### PR TITLE
Kuma API location revisions

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 NODE_ENV=development
 VUE_APP_MOCK_API_ENABLED=false
-VUE_APP_KUMA_CONFIG=/dev-api-config.json
+VUE_APP_KUMA_CONFIG=http://localhost:5681/config

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,3 @@
 NODE_ENV=production
 VUE_APP_MOCK_API_ENABLED=false
-VUE_APP_KUMA_CONFIG=/config
+VUE_APP_KUMA_CONFIG=../config

--- a/src/main.js
+++ b/src/main.js
@@ -66,7 +66,7 @@ function SETUP_VUE_APP () {
   axios
     .get(process.env.VUE_APP_KUMA_CONFIG)
     .then(response => {
-      const apiUrl = response.data.apiUrl
+      const apiUrl = response.data.guiServer.apiServerUrl
       const kumaEnv = response.data.environment
 
       const storedKumaEnv = localStorage.getItem('kumaEnv') !== null


### PR DESCRIPTION
This PR changes the location from which the API endpoint is fetched. This PR depends on [#915](https://github.com/kumahq/kuma/pull/915) in the Kuma repository.

Prior to this change, we were fetching the Kuma GUI config from `:5683`. This condenses things down so that the GUI and the API are fetched from the same location, with the GUI being served from `:5681/gui/` and the API being fetched from `:5681/`.