### PR TITLE
Remote CP endpoint revisions

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 NODE_ENV=development
-VUE_APP_MOCK_API_ENABLED=false
+VUE_APP_MOCK_API_ENABLED=true
 VUE_APP_KUMA_CONFIG=/dev-api-config.json

--- a/src/services/kuma.js
+++ b/src/services/kuma.js
@@ -39,9 +39,14 @@ export default class Kuma {
    * Multicluster
    */
 
-  // get local CPs
-  getLocalCPs (params) {
-    return this.client.get('/status/clusters', { params })
+  // Zone status
+  getZoneStatus (params) {
+    return this.client.get('/status/zones', { params })
+  }
+
+  // Zones
+  getZones (params) {
+    return this.client.get('/zones', { params })
   }
 
   /**

--- a/src/services/mock.js
+++ b/src/services/mock.js
@@ -2309,30 +2309,74 @@ export default class Mock {
           }
         }
       })
-      // Remote CPs
-      .onGet('/status/clusters')
+      // Zone status
+      .onGet('/status/zones')
       .reply(200, [
         {
-          active: false,
-          name: 'http://127.0.0.1:5681',
-          url: 'http://172.18.0.1:5681'
+          name: 'zone-1',
+          url: '192.168.0.1:1000',
+          active: false
         },
         {
-          active: true,
-          name: 'http://172.18.0.2:5681',
-          url: 'http://172.18.0.2:5681'
+          name: 'zone-2',
+          url: '192.168.0.1:1000',
+          active: true
         },
         {
-          active: false,
-          name: 'http://172.18.0.3:5681',
-          url: 'http://172.18.0.3:5681'
+          name: 'zone-3',
+          url: '192.168.0.1:1000',
+          active: false
         }
       ])
-      // config
-      .onGet('/config')
-      .reply(200, {
-        mode: 'global'
-      })
+      // Zones
+      .onGet('/zones')
+      .reply(200, [
+        {
+          total: 1,
+          items: [
+            {
+              type: 'Zone',
+              name: 'zone-1',
+              creationTime: '2020-07-22T19:37:28.442793+03:00',
+              modificationTime: '2020-07-22T19:37:28.442793+03:00',
+              ingress: {
+                address: '192.168.0.1:1000'
+              }
+            }
+          ],
+          next: null
+        }
+      ])
+      // .onGet('/zones/zone-1')
+      // .reply(200, {
+      //   type: 'Zone',
+      //   name: 'zone-1',
+      //   creationTime: '2020-07-22T19:37:28.442793+03:00',
+      //   modificationTime: '2020-07-22T19:37:28.442793+03:00',
+      //   ingress: {
+      //     address: '192.168.0.1:1000'
+      //   }
+      // })
+      // .onGet('/zones/zone-2')
+      // .reply(200, {
+      //   type: 'Zone',
+      //   name: 'zone-2',
+      //   creationTime: '2020-07-22T19:37:28.442793+03:00',
+      //   modificationTime: '2020-07-22T19:37:28.442793+03:00',
+      //   ingress: {
+      //     address: '192.168.0.1:1000'
+      //   }
+      // })
+      // .onGet('/zones/zone-3')
+      // .reply(200, {
+      //   type: 'Zone',
+      //   name: 'zone-3',
+      //   creationTime: '2020-07-22T19:37:28.442793+03:00',
+      //   modificationTime: '2020-07-22T19:37:28.442793+03:00',
+      //   ingress: {
+      //     address: '192.168.0.1:1000'
+      //   }
+      // })
       .onAny()
       .passThrough()
   }

--- a/src/views/Entities/RemoteCP.vue
+++ b/src/views/Entities/RemoteCP.vue
@@ -172,12 +172,9 @@ export default {
     ...mapState({
       mesh: 'selectedMesh'
     }),
-    // ...mapGetters({
-    //   multicluster: 'getMulticlusterStatus'
-    // }),
-    multicluster () {
-      return true
-    },
+    ...mapGetters({
+      multicluster: 'getMulticlusterStatus'
+    }),
     pageTitle () {
       const metaTitle = this.$route.meta.title
 

--- a/src/views/Entities/RemoteCP.vue
+++ b/src/views/Entities/RemoteCP.vue
@@ -172,9 +172,12 @@ export default {
     ...mapState({
       mesh: 'selectedMesh'
     }),
-    ...mapGetters({
-      multicluster: 'getMulticlusterStatus'
-    }),
+    // ...mapGetters({
+    //   multicluster: 'getMulticlusterStatus'
+    // }),
+    multicluster () {
+      return true
+    },
     pageTitle () {
       const metaTitle = this.$route.meta.title
 
@@ -238,9 +241,9 @@ export default {
       this.isLoading = true
       this.isEmpty = false
 
-      const endpoint = this.$api.getLocalCPs()
+      const endpoint = this.$api.getZoneStatus()
 
-      const getLocalCPs = () => {
+      const getZoneStatus = () => {
         return endpoint
           .then(response => {
             // check to see if the `next` url is present
@@ -301,7 +304,7 @@ export default {
           })
       }
 
-      getLocalCPs()
+      getZoneStatus()
     },
     getEntity (entity) {
       this.entityIsLoading = true


### PR DESCRIPTION
This is dependent upon [#921](https://github.com/kumahq/kuma/pull/921) in the Kuma repository.

I've renamed the REST API commands so that they're more in line with the naming in Kuma. I've also added 2 mock endpoints so that these changes can be tested locally if there are no zones created in Kuma (mocks can be disabled in `.env.development` -- the app must be restarted for this change to take effect).

Right now, the Remote CPs page is only fetching data from `http://localhost:5681/status/zones`.