### PR TITLE
Prefixing Kuma native tags with `kuma.io`

### DIFF
--- a/src/components/Skeletons/DataOverview.vue
+++ b/src/components/Skeletons/DataOverview.vue
@@ -83,7 +83,7 @@
             >
               <span
                 class="entity-tags__label"
-                :class="`entity-tags__label--${item.label.toLowerCase()}`"
+                :class="`entity-tags__label--${item.label.toLowerCase().replace('kuma.io/','')}`"
               >
                 {{ item.label }}
               </span>

--- a/src/services/mock.js
+++ b/src/services/mock.js
@@ -172,7 +172,7 @@ export default class Mock {
               address: '10.0.0.1',
               gateway: {
                 tags: {
-                  service: 'kong'
+                  'kuma.io/service': 'kong'
                 }
               },
               outbound: {
@@ -199,7 +199,7 @@ export default class Mock {
                     app: 'kuma-demo-frontend',
                     env: 'prod',
                     'pod-template-hash': '69c9fd4bd',
-                    protocol: 'http',
+                    'kuma.io/protocol': 'http',
                     version: 'v8'
                   }
                 },
@@ -209,7 +209,7 @@ export default class Mock {
                     app: 'kuma-demo-backend',
                     env: 'prod',
                     'pod-template-hash': 'd7cb6b576',
-                    protocol: 'http',
+                    'kuma.io/protocol': 'http',
                     version: 'v0'
                   }
                 },
@@ -218,7 +218,7 @@ export default class Mock {
                   tags: {
                     app: 'postgres',
                     'pod-template-hash': '65df766577',
-                    protocol: 'tcp'
+                    'kuma.io/protocol': 'tcp'
                   }
                 },
                 {
@@ -226,7 +226,7 @@ export default class Mock {
                   tags: {
                     app: 'redis',
                     'pod-template-hash': '78ff699f7',
-                    protocol: 'tcp',
+                    'kuma.io/protocol': 'tcp',
                     role: 'master',
                     tier: 'backend'
                   }
@@ -256,7 +256,7 @@ export default class Mock {
                 app: 'kuma-demo-frontend',
                 env: 'prod',
                 'pod-template-hash': '69c9fd4bd',
-                protocol: 'http',
+                'kuma.io/protocol': 'http',
                 version: 'v8'
               }
             },
@@ -266,7 +266,7 @@ export default class Mock {
                 app: 'kuma-demo-backend',
                 env: 'prod',
                 'pod-template-hash': 'd7cb6b576',
-                protocol: 'http',
+                'kuma.io/protocol': 'http',
                 version: 'v0'
               }
             },
@@ -275,7 +275,7 @@ export default class Mock {
               tags: {
                 app: 'postgres',
                 'pod-template-hash': '65df766577',
-                protocol: 'tcp'
+                'kuma.io/protocol': 'tcp'
               }
             },
             {
@@ -283,7 +283,7 @@ export default class Mock {
               tags: {
                 app: 'redis',
                 'pod-template-hash': '78ff699f7',
-                protocol: 'tcp',
+                'kuma.io/protocol': 'tcp',
                 role: 'master',
                 tier: 'backend'
               }
@@ -307,39 +307,39 @@ export default class Mock {
           ],
           ingress: [
             {
-              service: 'frontend.kuma-demo.svc:8080',
+              'kuma.io/service': 'frontend.kuma-demo.svc:8080',
               tags: {
                 app: 'kuma-demo-frontend',
                 env: 'prod',
                 'pod-template-hash': '69c9fd4bd',
-                protocol: 'http',
+                'kuma.io/protocol': 'http',
                 version: 'v8'
               }
             },
             {
-              service: 'backend.kuma-demo.svc:3001',
+              'kuma.io/service': 'backend.kuma-demo.svc:3001',
               tags: {
                 app: 'kuma-demo-backend',
                 env: 'prod',
                 'pod-template-hash': 'd7cb6b576',
-                protocol: 'http',
+                'kuma.io/protocol': 'http',
                 version: 'v0'
               }
             },
             {
-              service: 'postgres.kuma-demo.svc:5432',
+              'kuma.io/service': 'postgres.kuma-demo.svc:5432',
               tags: {
                 app: 'postgres',
                 'pod-template-hash': '65df766577',
-                protocol: 'tcp'
+                'kuma.io/protocol': 'tcp'
               }
             },
             {
-              service: 'redis.kuma-demo.svc:6379',
+              'kuma.io/service': 'redis.kuma-demo.svc:6379',
               tags: {
                 app: 'redis',
                 'pod-template-hash': '78ff699f7',
-                protocol: 'tcp',
+                'kuma.io/protocol': 'tcp',
                 role: 'master',
                 tier: 'backend'
               }
@@ -366,39 +366,39 @@ export default class Mock {
                 ],
                 ingress: [
                   {
-                    service: 'frontend.kuma-demo.svc:8080',
+                    'kuma.io/service': 'frontend.kuma-demo.svc:8080',
                     tags: {
                       app: 'kuma-demo-frontend',
                       env: 'prod',
                       'pod-template-hash': '69c9fd4bd',
-                      protocol: 'http',
+                      'kuma.io/protocol': 'http',
                       version: 'v8'
                     }
                   },
                   {
-                    service: 'backend.kuma-demo.svc:3001',
+                    'kuma.io/service': 'backend.kuma-demo.svc:3001',
                     tags: {
                       app: 'kuma-demo-backend',
                       env: 'prod',
                       'pod-template-hash': 'd7cb6b576',
-                      protocol: 'http',
+                      'kuma.io/protocol': 'http',
                       version: 'v0'
                     }
                   },
                   {
-                    service: 'postgres.kuma-demo.svc:5432',
+                    'kuma.io/service': 'postgres.kuma-demo.svc:5432',
                     tags: {
                       app: 'postgres',
                       'pod-template-hash': '65df766577',
-                      protocol: 'tcp'
+                      'kuma.io/protocol': 'tcp'
                     }
                   },
                   {
-                    service: 'redis.kuma-demo.svc:6379',
+                    'kuma.io/service': 'redis.kuma-demo.svc:6379',
                     tags: {
                       app: 'redis',
                       'pod-template-hash': '78ff699f7',
-                      protocol: 'tcp',
+                      'kuma.io/protocol': 'tcp',
                       role: 'master',
                       tier: 'backend'
                     }
@@ -425,39 +425,39 @@ export default class Mock {
             ],
             ingress: [
               {
-                service: 'frontend.kuma-demo.svc:8080',
+                'kuma.io/service': 'frontend.kuma-demo.svc:8080',
                 tags: {
                   app: 'kuma-demo-frontend',
                   env: 'prod',
                   'pod-template-hash': '69c9fd4bd',
-                  protocol: 'http',
+                  'kuma.io/protocol': 'http',
                   version: 'v8'
                 }
               },
               {
-                service: 'backend.kuma-demo.svc:3001',
+                'kuma.io/service': 'backend.kuma-demo.svc:3001',
                 tags: {
                   app: 'kuma-demo-backend',
                   env: 'prod',
                   'pod-template-hash': 'd7cb6b576',
-                  protocol: 'http',
+                  'kuma.io/protocol': 'http',
                   version: 'v0'
                 }
               },
               {
-                service: 'postgres.kuma-demo.svc:5432',
+                'kuma.io/service': 'postgres.kuma-demo.svc:5432',
                 tags: {
                   app: 'postgres',
                   'pod-template-hash': '65df766577',
-                  protocol: 'tcp'
+                  'kuma.io/protocol': 'tcp'
                 }
               },
               {
-                service: 'redis.kuma-demo.svc:6379',
+                'kuma.io/service': 'redis.kuma-demo.svc:6379',
                 tags: {
                   app: 'redis',
                   'pod-template-hash': '78ff699f7',
-                  protocol: 'tcp',
+                  'kuma.io/protocol': 'tcp',
                   role: 'master',
                   tier: 'backend'
                 }
@@ -510,7 +510,7 @@ export default class Mock {
               servicePort: 9000,
               tags: {
                 env: 'dev',
-                service: 'kuma-example-backend',
+                'kuma.io/service': 'kuma-example-backend',
                 tag01: 'value01',
                 reallyLongTagLabelHere: 'a-really-long-tag-value-here'
               }
@@ -532,7 +532,7 @@ export default class Mock {
                 servicePort: 9000,
                 tags: {
                   env: 'dev',
-                  service: 'kuma-example-backend',
+                  'kuma.io/service': 'kuma-example-backend',
                   tag01: 'value01',
                   reallyLongTagLabelHere: 'a-really-long-tag-value-here'
                 }

--- a/src/views/Wizard/views/DataplaneKubernetes.vue
+++ b/src/views/Wizard/views/DataplaneKubernetes.vue
@@ -623,7 +623,7 @@ networking:
   - port: 10000
     servicePort: 9000
     tags:
-      service: echo</pre>
+      kuma.io/service: echo</pre>
           </code>
         </template>
       </StepSkeleton>
@@ -633,7 +633,7 @@ networking:
 
 <script>
 import { mapGetters } from 'vuex'
-import { rejectKeys } from '@/views/Wizard/helpers'
+// import { rejectKeys } from '@/views/Wizard/helpers'
 import updateStorage from '@/views/Wizard/mixins/updateStorage'
 import FormatForCLI from '@/mixins/FormatForCLI'
 import FormFragment from '@/views/Wizard/components/FormFragment'
@@ -642,9 +642,6 @@ import StepSkeleton from '@/views/Wizard/components/StepSkeleton'
 import Switcher from '@/views/Wizard/components/Switcher'
 import CodeView from '@/components/Skeletons/CodeView'
 // import Scanner from '@/views/Wizard/components/Scanner'
-
-// schema for building code output
-// import meshSchema from '@/views/Wizard/schemas/Mesh'
 
 // schema for building code output (TBD)
 import dataplaneSchema from '@/views/Wizard/schemas/DataplaneKubernetes'

--- a/src/views/Wizard/views/DataplaneUniversal.vue
+++ b/src/views/Wizard/views/DataplaneUniversal.vue
@@ -591,7 +591,7 @@ export default {
           address: univDataplaneNetworkAddress,
           gateway: {
             tags: {
-              service: univDataplaneServiceName
+              'kuma.io/service': univDataplaneServiceName
             }
           }
         }

--- a/src/views/Wizard/views/DataplaneUniversal.vue
+++ b/src/views/Wizard/views/DataplaneUniversal.vue
@@ -420,7 +420,7 @@ networking:
   - port: 10000
     servicePort: 9000
     tags:
-      service: echo</pre>
+      kuma.io/service: echo</pre>
           </code>
         </template>
       </StepSkeleton>
@@ -576,8 +576,8 @@ export default {
               port: univDataplaneNetworkDPPort,
               servicePort: univDataplaneNetworkServicePort,
               tags: {
-                service: univDataplaneServiceName,
-                protocol: univDataplaneNetworkProtocol
+                'kuma.io/service': univDataplaneServiceName,
+                'kuma.io/protocol': univDataplaneNetworkProtocol
               }
             }
           ]


### PR DESCRIPTION
This PR depends on [#910](https://github.com/kumahq/kuma/pull/910) in the Kuma repository.

This PR makes the following changes to the native Kuma tags:

* `service` -> `kuma.io/service`
* `protocol` -> `kuma.io/protocol`

Both the Universal and Kubernetes Wizards are also updated to reflect these changes.

## Dataplanes view
![](https://p124.p4.n0.cdn.getcloudapp.com/items/Z4uYO180/Screen%20Shot%202020-07-22%20at%204.56.20%20PM.png?v=b74b97a100c8403531856043eb83deac)

## Universal Dataplane Wizard
![](https://p124.p4.n0.cdn.getcloudapp.com/items/qGuKkr2E/Screen%20Shot%202020-07-22%20at%204.57.56%20PM.png?v=b69f09d381e954d9ec4139bba4558b2b)