### PR TITLE
Zones `next` handling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -114,7 +114,7 @@ export default {
             // fetch the config
             this.$store.dispatch('getConfig')
               .then(() => {
-                const mode = this.$store.getters.getConfig.mode.mode
+                const mode = this.$store.getters.getConfig.mode
 
                 /**
                  * Set Kuma's current mode in localStorage.

--- a/src/main.js
+++ b/src/main.js
@@ -110,11 +110,21 @@ function SETUP_VUE_APP () {
       /**
        * Always check the API URL and set it accordingly for the app to access.
        */
-      var apiUrl = response.data.guiServer.apiServerUrl
+      let apiUrl = response.data.guiServer.apiServerUrl
+
       if (apiUrl === '') {
         const url = window.location.href
 
-        apiUrl = url.substring(0, url.indexOf('/gui')) + '/'
+        /**
+         * If we're running in development mode, we have to ensure
+         * we fetch from the external Kuma API URL and not from the app
+         * root itself (since it runs from :8080).
+         */
+        if (process.env.NODE_ENV === 'development') {
+          apiUrl = process.env.VUE_APP_KUMA_CONFIG.replace('/config', '/')
+        } else {
+          apiUrl = url.substring(0, url.indexOf('/gui')) + '/'
+        }
       }
 
       localStorage.setItem('kumaApiUrl', apiUrl)

--- a/src/services/restClient.js
+++ b/src/services/restClient.js
@@ -49,7 +49,7 @@ export default class RestClient {
    * our app with the API URL endpoint and simple info.
    */
   static kumaClientConfig () {
-    const configUrl = `${localStorage.getItem('kumaApiUrl')}/config`
+    const configUrl = `${localStorage.getItem('kumaApiUrl')}config`
 
     return axios.create({
       baseURL: configUrl,
@@ -121,7 +121,7 @@ export default class RestClient {
   async getConfig () {
     const client = await this.clientConfig
 
-    return client.get('/')
+    return client.get('')
       .then(response => {
         const data = response.data
 

--- a/src/views/Entities/Zones.vue
+++ b/src/views/Entities/Zones.vue
@@ -273,8 +273,13 @@ export default {
       const getZoneStatus = () => {
         return endpoint
           .then(response => {
+            const nextCheck = response.next &&
+              response.next !== undefined &&
+              response.next !== null &&
+              response.next.length > 0
+
             // check to see if the `next` url is present
-            if (response.next && response.next !== null) {
+            if (nextCheck) {
               this.next = getOffset(response.next)
               this.hasNext = true
             } else {

--- a/src/views/Entities/Zones.vue
+++ b/src/views/Entities/Zones.vue
@@ -274,7 +274,7 @@ export default {
         return endpoint
           .then(response => {
             // check to see if the `next` url is present
-            if (response.next) {
+            if (response.next && response.next !== null) {
               this.next = getOffset(response.next)
               this.hasNext = true
             } else {


### PR DESCRIPTION
This fix addresses an issue where the `next` parameter in the Zones endpoint wasn't being handled properly.

### Additional items in this fix:

* Changed the way `mode` is fetched so that it aligns with the API changes to Kuma (`mode` used to be nested in `mode.mode` but this has changed to simply be `mode`)
* Added a check for development mode so that the GUI serves properly from `http://localhost:8080/` in this repo, but defaults to `http://[user-ip]/gui/` in production mode (from within Kuma itself)