### PR TITLE
Zone Insights

### DIFF
--- a/src/components/Skeletons/DataOverview.vue
+++ b/src/components/Skeletons/DataOverview.vue
@@ -521,4 +521,52 @@ span[class*="kuma-io-"] {
   }
 
 }
+
+// some reusable styles
+
+.overview-title {
+  font-size: var(--type-lg);
+  font-weight: 500;
+  margin: 0 0 var(--spacing-md) 0;
+  color: var(--tblack-85);
+}
+
+.overview-sub-title {
+  font-size: var(--type-md);
+  font-weight: 500;
+  // text-transform: uppercase;
+  // color: var(--gray-3);
+  margin: 0 0 var(--spacing-xs) 0;
+}
+
+.overview-tertiary-title {
+  font-size: var(--type-sm);
+  font-weight: 500;
+  text-transform: uppercase;
+  color: var(--gray-3);
+  margin: var(--spacing-xs) 0;
+}
+
+.overview-group-list {
+
+}
+
+.overview-stat-grid {
+  display: grid;
+  margin: var(--spacing-md) 0 0 0;
+
+  @media (min-width: 1140px) {
+    grid-template-columns: repeat(3, 1fr);
+    grid-gap: 10px 20px;
+  }
+}
+
+.overview-stack {
+
+  &:not(:last-of-type) {
+    padding: 0 0 var(--spacing-xl) 0;
+    margin: 0 0 var(--spacing-xl) 0;
+    border-bottom: 1px solid var(--gray-4);
+  }
+}
 </style>

--- a/src/components/Utils/LoaderCard.vue
+++ b/src/components/Utils/LoaderCard.vue
@@ -1,17 +1,15 @@
 <template>
-  <div class="label-list">
+  <div class="loader-card">
     <div
       v-if="isReady"
-      class="label-list-content"
+      class="loader-card-content"
     >
       <KCard
         v-if="!isLoading && !isEmpty"
         border-variant="noBorder"
       >
         <template slot="body">
-          <div class="label-list__col-wrapper multi-col">
-            <slot />
-          </div>
+          <slot />
         </template>
       </KCard>
     </div>
@@ -74,12 +72,8 @@
 
 <script>
 export default {
-  name: 'LabelList',
+  name: 'LoaderCard',
   props: {
-    items: {
-      type: Object,
-      default: null
-    },
     title: {
       type: String,
       default: null
@@ -106,104 +100,11 @@ export default {
 </script>
 
 <style lang="scss">
-.label-list-content {
-
-  .kong-card {
-    margin-bottom: 0 !important;
-  }
-}
-
-.label-list {
+.loader-card {
 
 }
 
-.label-list__col-wrapper {
+.loader-card-content {
 
-  h1, h2, h3, h4, h5, h6 {
-    font-size: var(--type-sm);
-    font-weight: 500;
-    text-transform: uppercase;
-    color: var(--gray-3);
-    margin-bottom: var(--spacing-xs);
-  }
-
-  ul {
-
-    li {
-      display: block;
-      overflow: hidden;
-
-      &:not(:last-of-type) {
-        margin-bottom: var(--spacing-md);
-      }
-    }
-  }
-
-  @media screen and (min-width: 1024px) {
-    &.multi-col {
-      display: flex;
-
-      > * {
-        // flex: 1 0 0;
-        flex-grow: 1;
-        flex-basis: 33.333333%;
-
-        &:not(:last-of-type) {
-          margin-right: var(--spacing-md);
-        }
-      }
-    }
-  }
-}
-
-.label-list__items__value {
-  // font-size: var(--type-sm);
-  // font-family: var(--font-family-mono);
-}
-
-// Tag columns
-
-.tag-cols {
-  display: grid;
-  grid-auto-flow: column dense;
-  grid-gap: 10px;
-  grid-template-columns: 1fr 2fr;
-
-  span:first-of-type {
-    min-width: 80px;
-    font-weight: 700;
-    text-align: right;
-  }
-
-  span:last-of-type {
-
-  }
-}
-
-.tag-cols__label {
-  min-width: 80px;
-  font-weight: 700;
-  text-align: right;
-}
-
-.tag-cols__value {
-
-}
-
-// Label columns
-
-.label-cols {
-  display: flex;
-  align-items: stretch;
-
-  span:first-of-type {
-
-    &:after {
-      display: inline-block;
-      content: "/";
-      margin: 0 3px 0 1px;
-      color: #999;
-    }
-  }
 }
 </style>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -408,6 +408,21 @@ export function dedupeObjects (array, key) {
   )
 }
 
+/**
+ * camelCaseToWords
+ *
+ * Converts camelcase to human-readable words in titlecase format
+ *
+ * @param {String} str
+ */
+export function camelCaseToWords (str) {
+  const search = /^[a-z]+|[A-Z][a-z]*/g
+
+  return str.match(search).map((x) => {
+    return x[0].toUpperCase() + x.substr(1).toLowerCase()
+  }).join(' ')
+}
+
 export default {
   forEach,
   decodeJWT,
@@ -430,5 +445,6 @@ export default {
   getOffset,
   stripTimes,
   cleanTag,
-  dedupeObjects
+  dedupeObjects,
+  camelCaseToWords
 }

--- a/src/services/mock.js
+++ b/src/services/mock.js
@@ -147,7 +147,7 @@ export default class Mock {
         items: [
           {
             mesh: 'default',
-            name: 'hello-world-foobar-002',
+            name: 'gateway-dp-87qntx',
             networking: {},
             type: 'Dataplane'
           },
@@ -166,7 +166,7 @@ export default class Mock {
         items: [
           {
             mesh: 'default',
-            name: 'hello-world-foobar-002',
+            name: 'gateway-dp-87qntx',
             type: 'Dataplane',
             networking: {
               address: '10.0.0.1',
@@ -490,53 +490,16 @@ export default class Mock {
         name: 'ingress-dp-test-123',
         dataplane: {
           networking: {
-            address: '192.168.64.8',
+            address: '10.0.0.1',
             inbound: [
               {
-                port: 10001
-              }
-            ],
-            ingress: [
-              {
-                'kuma.io/service': 'frontend.kuma-demo.svc:8080',
+                port: 10000,
+                servicePort: 9000,
                 tags: {
-                  app: 'kuma-demo-frontend',
-                  env: 'prod',
-                  'pod-template-hash-super-long-title': '69c9fd4bd',
-                  'kuma.io/protocol': 'http',
-                  version: 'v8',
-                  'some-duplicate-tag': '1234567890'
-                }
-              },
-              {
-                'kuma.io/service': 'backend.kuma-demo.svc:3001',
-                tags: {
-                  app: 'kuma-demo-backend',
-                  env: 'prod',
-                  'pod-template-hash': 'd7cb6b576',
-                  'kuma.io/protocol': 'http',
-                  version: 'v0',
-                  'some-duplicate-tag': '1234567890'
-                }
-              },
-              {
-                'kuma.io/service': 'postgres.kuma-demo.svc:5432',
-                tags: {
-                  app: 'postgres',
-                  'pod-template-hash': '65df766577',
-                  'kuma.io/protocol': 'tcp',
-                  'some-duplicate-tag': '1234567890'
-                }
-              },
-              {
-                'kuma.io/service': 'redis.kuma-demo.svc:6379',
-                tags: {
-                  app: 'redis',
-                  'pod-template-hash': '78ff699f7',
-                  'kuma.io/protocol': 'tcp',
-                  role: 'master',
-                  tier: 'backend',
-                  'some-duplicate-tag': '1234567890'
+                  env: 'dev',
+                  'kuma.io/service': 'kuma-example-backend',
+                  tag01: 'value01',
+                  reallyLongTagLabelHere: 'a-really-long-tag-value-here'
                 }
               }
             ]
@@ -569,7 +532,12 @@ export default class Mock {
                 rds: {}
               }
             }
-          ]
+          ],
+          mTLS: {
+            certificateExpirationTime: '2020-05-11T16:53:55Z',
+            lastCertificateRegeneration: '2020-05-11T16:53:40.862241Z',
+            certificateRegenerations: 2
+          }
         }
       })
       .onGet('/meshes/default/dataplanes+insights/dataplane-test-456')
@@ -648,11 +616,11 @@ export default class Mock {
           ]
         }
       })
-      .onGet('/meshes/default/dataplanes/hello-world-foobar-002')
+      .onGet('/meshes/default/dataplanes/gateway-dp-87qntx')
       .reply(200, {
         type: 'Dataplane',
         mesh: 'default',
-        name: 'hello-world-foobar-002',
+        name: 'gateway-dp-87qntx',
         creationTime: '2020-06-02T09:33:09.208372-04:00',
         modificationTime: '2020-06-02T09:33:09.208372-04:00',
         networking: {
@@ -729,63 +697,6 @@ export default class Mock {
               }
             }
           ]
-        }
-      })
-      .onGet('/meshes/default/dataplanes+insights/hello-world-foobar-002')
-      .reply(200, {
-        type: 'DataplaneOverview',
-        mesh: 'default',
-        name: 'hello-world-foobar-002',
-        dataplane: {
-          networking: {
-            address: '10.0.0.1',
-            inbound: [
-              {
-                port: 10000,
-                servicePort: 9000,
-                tags: {
-                  env: 'dev',
-                  'kuma.io/service': 'kuma-example-backend',
-                  tag01: 'value01',
-                  reallyLongTagLabelHere: 'a-really-long-tag-value-here'
-                }
-              }
-            ]
-          }
-        },
-        dataplaneInsight: {
-          subscriptions: [
-            {
-              id: '426fe0d8-f667-11e9-b081-acde48001122',
-              controlPlaneInstanceId: '06070748-f667-11e9-b081-acde48001122',
-              connectTime: '2019-10-24T14:04:56.820350Z',
-              status: {
-                lastUpdateTime: '2019-10-24T14:04:57.832482Z',
-                total: {
-                  responsesSent: '3',
-                  responsesAcknowledged: '3'
-                },
-                cds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                eds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                lds: {
-                  responsesSent: '1',
-                  responsesAcknowledged: '1'
-                },
-                rds: {}
-              }
-            }
-          ],
-          mTLS: {
-            certificateExpirationTime: '2020-05-11T16:53:55Z',
-            lastCertificateRegeneration: '2020-05-11T16:53:40.862241Z',
-            certificateRegenerations: 2
-          }
         }
       })
       .onGet('/meshes/default/traffic-traces')
@@ -2585,80 +2496,79 @@ export default class Mock {
             type: 'ZoneOverview',
             mesh: 'default',
             name: 'zone-1',
-            creationTime: '2018-07-17T16:05:36.995Z',
-            modificationTime: '2019-07-17T18:08:41Z',
+            creationTime: '2020-07-28T23:08:22.317322+07:00',
+            modificationTime: '2020-07-28T23:08:22.317322+07:00',
             zone: {
               ingress: {
-                address: '192.168.1.1:1000'
+                address: '127.0.0.1:10000'
               }
             },
             zoneInsight: {
               subscriptions: [
                 {
-                  id: '1',
-                  globalInstanceId: 'node-001',
-                  connectTime: '2018-07-17T16:05:36.995Z',
+                  id: '466aa63b-70e8-4435-8bee-a7146e2cdf11',
+                  globalInstanceId: '66309679-ee95-4ea8-b17f-c715ca03bb38',
+                  connectTime: '2020-07-28T16:08:09.743141Z',
+                  disconnectTime: '2020-07-28T16:08:09.743194Z',
                   status: {
-                    total: {
-                      responsesSent: '22',
-                      responsesRejected: '11'
-                    },
-                    stat: {
-                      CircuitBreaker: {
-                        responsesSent: '2',
-                        responsesRejected: '1'
-                      },
-                      FaultInjection: {
-                        responsesSent: '2',
-                        responsesRejected: '1'
-                      },
-                      HealthCheck: {
-                        responsesSent: '2',
-                        responsesRejected: '1'
-                      },
-                      Ingress: {
-                        responsesSent: '2',
-                        responsesRejected: '1'
-                      },
-                      Mesh: {
-                        responsesSent: '2',
-                        responsesRejected: '1'
-                      },
-                      ProxyTemplate: {
-                        responsesSent: '2',
-                        responsesRejected: '1'
-                      },
-                      Secret: {
-                        responsesSent: '2',
-                        responsesRejected: '1'
-                      },
-                      TrafficLog: {
-                        responsesSent: '2',
-                        responsesRejected: '1'
-                      },
-                      TrafficPermission: {
-                        responsesSent: '2',
-                        responsesRejected: '1'
-                      },
-                      TrafficRoute: {
-                        responsesSent: '2',
-                        responsesRejected: '1'
-                      },
-                      TrafficTrace: {
-                        responsesSent: '2',
-                        responsesRejected: '1'
-                      }
-                    }
+                    total: {}
                   }
                 },
                 {
-                  id: '2',
-                  globalInstanceId: 'node-002',
-                  connectTime: '2019-07-17T16:05:36.995Z',
+                  id: 'f586f89c-2c4e-4f93-9a56-f0ea2ff010b7',
+                  globalInstanceId: '66309679-ee95-4ea8-b17f-c715ca03bb38',
+                  connectTime: '2020-07-28T16:08:24.760801Z',
                   status: {
+                    lastUpdateTime: '2020-07-28T16:08:25.770774Z',
                     total: {
-                      responsesSent: '20',
-                      responsesRejected: '2'
+                      responsesSent: '11',
+                      responsesAcknowledged: '11'
+                    },
+                    stat: {
+                      CircuitBreaker: {
+                        responsesSent: '124',
+                        responsesAcknowledged: '4509369'
+                      },
+                      Dataplane: {
+                        responsesSent: '9018614',
+                        responsesAcknowledged: '13527859'
+                      },
+                      FaultInjection: {
+                        responsesSent: '18037104',
+                        responsesAcknowledged: '22546349'
+                      },
+                      HealthCheck: {
+                        responsesSent: '27055594',
+                        responsesAcknowledged: '31564839'
+                      },
+                      Mesh: {
+                        responsesSent: '36074084',
+                        responsesAcknowledged: '40583329'
+                      },
+                      ProxyTemplate: {
+                        responsesSent: '45092574',
+                        responsesAcknowledged: '49601819'
+                      },
+                      Secret: {
+                        responsesSent: '54111064',
+                        responsesAcknowledged: '58620309'
+                      },
+                      TrafficLog: {
+                        responsesSent: '63129554',
+                        responsesAcknowledged: '67638799'
+                      },
+                      TrafficPermission: {
+                        responsesSent: '72148044',
+                        responsesAcknowledged: '76657289'
+                      },
+                      TrafficRoute: {
+                        responsesSent: '81166534',
+                        responsesAcknowledged: '85675779'
+                      },
+                      TrafficTrace: {
+                        responsesSent: '90185024',
+                        responsesAcknowledged: '94694269'
+                      }
                     }
                   }
                 }
@@ -2729,80 +2639,79 @@ export default class Mock {
         type: 'ZoneOverview',
         mesh: 'default',
         name: 'zone-1',
-        creationTime: '2018-07-17T16:05:36.995Z',
-        modificationTime: '2019-07-17T18:08:41Z',
+        creationTime: '2020-07-28T23:08:22.317322+07:00',
+        modificationTime: '2020-07-28T23:08:22.317322+07:00',
         zone: {
           ingress: {
-            address: '192.168.1.1:1000'
+            address: '127.0.0.1:10000'
           }
         },
         zoneInsight: {
           subscriptions: [
             {
-              id: '1',
-              globalInstanceId: 'node-001',
-              connectTime: '2018-07-17T16:05:36.995Z',
+              id: '466aa63b-70e8-4435-8bee-a7146e2cdf11',
+              globalInstanceId: '66309679-ee95-4ea8-b17f-c715ca03bb38',
+              connectTime: '2020-07-28T16:08:09.743141Z',
+              disconnectTime: '2020-07-28T16:08:09.743194Z',
               status: {
-                total: {
-                  responsesSent: '22',
-                  responsesRejected: '11'
-                },
-                stat: {
-                  CircuitBreaker: {
-                    responsesSent: '2',
-                    responsesRejected: '1'
-                  },
-                  FaultInjection: {
-                    responsesSent: '2',
-                    responsesRejected: '1'
-                  },
-                  HealthCheck: {
-                    responsesSent: '2',
-                    responsesRejected: '1'
-                  },
-                  Ingress: {
-                    responsesSent: '2',
-                    responsesRejected: '1'
-                  },
-                  Mesh: {
-                    responsesSent: '2',
-                    responsesRejected: '1'
-                  },
-                  ProxyTemplate: {
-                    responsesSent: '2',
-                    responsesRejected: '1'
-                  },
-                  Secret: {
-                    responsesSent: '2',
-                    responsesRejected: '1'
-                  },
-                  TrafficLog: {
-                    responsesSent: '2',
-                    responsesRejected: '1'
-                  },
-                  TrafficPermission: {
-                    responsesSent: '2',
-                    responsesRejected: '1'
-                  },
-                  TrafficRoute: {
-                    responsesSent: '2',
-                    responsesRejected: '1'
-                  },
-                  TrafficTrace: {
-                    responsesSent: '2',
-                    responsesRejected: '1'
-                  }
-                }
+                total: {}
               }
             },
             {
-              id: '2',
-              globalInstanceId: 'node-002',
-              connectTime: '2019-07-17T16:05:36.995Z',
+              id: 'f586f89c-2c4e-4f93-9a56-f0ea2ff010b7',
+              globalInstanceId: '66309679-ee95-4ea8-b17f-c715ca03bb38',
+              connectTime: '2020-07-28T16:08:24.760801Z',
               status: {
+                lastUpdateTime: '2020-07-28T16:08:25.770774Z',
                 total: {
-                  responsesSent: '20',
-                  responsesRejected: '2'
+                  responsesSent: '11',
+                  responsesAcknowledged: '11'
+                },
+                stat: {
+                  CircuitBreaker: {
+                    responsesSent: '124',
+                    responsesAcknowledged: '4509369'
+                  },
+                  Dataplane: {
+                    responsesSent: '9018614',
+                    responsesAcknowledged: '13527859'
+                  },
+                  FaultInjection: {
+                    responsesSent: '18037104',
+                    responsesAcknowledged: '22546349'
+                  },
+                  HealthCheck: {
+                    responsesSent: '27055594',
+                    responsesAcknowledged: '31564839'
+                  },
+                  Mesh: {
+                    responsesSent: '36074084',
+                    responsesAcknowledged: '40583329'
+                  },
+                  ProxyTemplate: {
+                    responsesSent: '45092574',
+                    responsesAcknowledged: '49601819'
+                  },
+                  Secret: {
+                    responsesSent: '54111064',
+                    responsesAcknowledged: '58620309'
+                  },
+                  TrafficLog: {
+                    responsesSent: '63129554',
+                    responsesAcknowledged: '67638799'
+                  },
+                  TrafficPermission: {
+                    responsesSent: '72148044',
+                    responsesAcknowledged: '76657289'
+                  },
+                  TrafficRoute: {
+                    responsesSent: '81166534',
+                    responsesAcknowledged: '85675779'
+                  },
+                  TrafficTrace: {
+                    responsesSent: '90185024',
+                    responsesAcknowledged: '94694269'
+                  }
                 }
               }
             }

--- a/src/views/Entities/Dataplanes.vue
+++ b/src/views/Entities/Dataplanes.vue
@@ -105,15 +105,6 @@
             </div>
           </LabelList>
         </template>
-        <template slot="yaml">
-          <YamlView
-            :title="entityOverviewTitle"
-            :has-error="entityHasError"
-            :is-loading="entityIsLoading"
-            :is-empty="entityIsEmpty"
-            :content="rawEntity"
-          />
-        </template>
         <template slot="mtls">
           <LabelList
             :has-error="entityHasError"
@@ -147,6 +138,15 @@
               </template>
             </KAlert>
           </LabelList>
+        </template>
+        <template slot="yaml">
+          <YamlView
+            :title="entityOverviewTitle"
+            :has-error="entityHasError"
+            :is-loading="entityIsLoading"
+            :is-empty="entityIsEmpty"
+            :content="rawEntity"
+          />
         </template>
       </Tabs>
     </FrameSkeleton>
@@ -273,9 +273,6 @@ export default {
       }
 
       return shareUrl()
-    },
-    dedupedTags () {
-
     }
   },
   watch: {

--- a/src/views/Entities/Zones.vue
+++ b/src/views/Entities/Zones.vue
@@ -95,6 +95,80 @@
             </div>
           </LabelList>
         </template>
+        <template slot="insights">
+          <LoaderCard
+            :has-error="entityHasError"
+            :is-loading="entityIsLoading"
+            :is-empty="entityIsEmpty"
+          >
+            <div v-if="rawEntity">
+              <div
+                v-for="(value, key) in rawEntity.zoneInsight.subscriptions"
+                :key="key"
+                class="overview-stack"
+              >
+                <h4 class="overview-title">
+                  ID: <span class="mono">{{ value.id }}</span>
+                </h4>
+
+                <div v-if="value.globalInstanceId || value.connectTime || value.disconnectTime">
+                  <h5 class="overview-tertiary-title">
+                    General Information:
+                  </h5>
+                  <ul>
+                    <li v-if="value.globalInstanceId">
+                      <strong>Global Instance ID:</strong>&nbsp;
+                      <span class="mono">{{ value.globalInstanceId }}</span>
+                    </li>
+                    <li v-if="value.connectTime">
+                      <strong>Last Connected:</strong>&nbsp;
+                      {{ value.connectTime | readableDate }}
+                    </li>
+                    <li v-if="value.disconnectTime">
+                      <strong>Last Disconnected:</strong>&nbsp;
+                      {{ value.disconnectTime | readableDate }}
+                    </li>
+                  </ul>
+                </div>
+
+                <ul
+                  v-if="value.status.stat"
+                  class="overview-stat-grid"
+                >
+                  <li
+                    v-for="(item, label) in value.status.stat"
+                    :key="label"
+                  >
+                    <h6 class="overview-tertiary-title">
+                      {{ label | humanReadable }}:
+                    </h6>
+                    <ul>
+                      <li
+                        v-for="(k, v) in item"
+                        :key="v"
+                      >
+                        <strong>{{ v | humanReadable }}:</strong>&nbsp;
+                        <span class="mono">{{ k | formatValue | formatError }}</span>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+                <KAlert
+                  v-else
+                  appearance="info"
+                  class="mt-4"
+                >
+                  <template slot="alertIcon">
+                    <KIcon icon="portal" />
+                  </template>
+                  <template slot="alertMessage">
+                    There are no Policy statistics for <strong>{{ value.id }}</strong>
+                  </template>
+                </KAlert>
+              </div>
+            </div>
+          </LoaderCard>
+        </template>
         <template slot="yaml">
           <YamlView
             :title="entityOverviewTitle"
@@ -111,7 +185,7 @@
 
 <script>
 import { mapState, mapGetters } from 'vuex'
-import { humanReadableDate, getOffset, getSome, stripTimes } from '@/helpers'
+import { humanReadableDate, getOffset, getSome, stripTimes, camelCaseToWords } from '@/helpers'
 import sortEntities from '@/mixins/EntitySorter'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import PageHeader from '@/components/Utils/PageHeader.vue'
@@ -121,6 +195,7 @@ import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import LoaderCard from '@/components/Utils/LoaderCard'
 
 export default {
   name: 'Zones',
@@ -135,14 +210,25 @@ export default {
     DataOverview,
     Tabs,
     YamlView,
-    LabelList
+    LabelList,
+    LoaderCard
   },
   filters: {
     formatValue (value) {
-      return value ? value.toLocaleString('en').toString() : 0
+      return value ? parseInt(value).toLocaleString('en').toString() : 0
     },
     readableDate (value) {
       return humanReadableDate(value)
+    },
+    humanReadable (value) {
+      return camelCaseToWords(value)
+    },
+    formatError (value) {
+      if (value === '--') {
+        return 'error calculating'
+      }
+
+      return value
     }
   },
   mixins: [
@@ -159,7 +245,7 @@ export default {
       tableDataIsEmpty: false,
       empty_state: {
         title: 'No Data',
-        message: 'There are no Meshes present.'
+        message: 'There are no Zones present.'
       },
       tableData: {
         headers: [
@@ -174,6 +260,10 @@ export default {
         {
           hash: '#overview',
           title: 'Overview'
+        },
+        {
+          hash: '#insights',
+          title: 'Zone Insights'
         },
         {
           hash: '#yaml',
@@ -273,10 +363,7 @@ export default {
       const getZoneStatus = () => {
         return endpoint
           .then(response => {
-            const nextCheck = response.next &&
-              response.next !== undefined &&
-              response.next !== null &&
-              response.next.length > 0
+            const nextCheck = (response && response.next) ? response.next : false
 
             // check to see if the `next` url is present
             if (nextCheck) {
@@ -288,7 +375,7 @@ export default {
 
             const items = response
 
-            if (items.length > 0) {
+            if (items && items.length > 0) {
               // rewrite the status column to be more human-readable
               items.forEach(i => {
                 const status = (i.active === false)


### PR DESCRIPTION
These changes expand on the Zones view considerably. On the Zones page (`http://localhost:8080/#/zones` -- must be running Kuma in Multi-Zone mode to test), there is now a new tab titled "Zone Insights" that shows subscription information, global instance ID, connect and disconnect times, etc.

## Screenshot
![](https://p124.p4.n0.cdn.getcloudapp.com/items/v1u2YWgN/Screen%20Shot%202020-08-20%20at%205.08.42%20PM.png?source=viewer&v=467392e0c99616479e293f55e4f4f1ac)

The amount of information displayed can be scaled back accordingly.