### PR TITLE
fix: display dp tags

### DIFF
--- a/src/dataplane.js
+++ b/src/dataplane.js
@@ -1,0 +1,55 @@
+/*
+dpTags takes a Dataplane received from backend and construct the list of tags in form of array of objects with label and value.
+It flattens common tags so we don't display them twice.
+
+Example:
+
+type: Dataplane
+mesh: default
+name: cluster-1.ingress-01
+networking:
+  inbound:
+    - port: 1234
+      tags:
+        kuma.io/service: backend
+        version: 1
+    - port: 1235
+      tags:
+        kuma.io/service: backend-api
+        version: 1
+
+Will produce:
+[
+  { label: 'kuma.io/service', value: 'backend'},
+  { label: 'kuma.io/service', value: 'backend-api'},
+  { label: 'version', value: '1'},
+]
+ */
+export function dpTags (dataplane) {
+  let tags = []
+
+  const inbounds = dataplane.networking.inbound || null
+  if (inbounds) {
+    tags = inbounds.map(inbound => inbound.tags)
+      .flatMap(tags => Object.entries(tags))
+      .map(tagPair => tagPair[0] + '=' + tagPair[1])
+  }
+
+  // gateway data plane has no inbounds, but has tags embedded in gateway branch
+  const gateway = dataplane.networking.gateway || null
+  if (gateway) {
+    tags = Object.entries(gateway.tags)
+      .map(tagPair => tagPair[0] + '=' + tagPair[1])
+  }
+
+  tags = Array.from(new Set(tags)) // remove duplicates
+
+  return tags.map(function (tagPair) {
+    const pairSplit = tagPair.split('=')
+
+    return {
+      label: pairSplit[0],
+      value: pairSplit[1]
+    }
+  })
+}

--- a/src/dataplane.js
+++ b/src/dataplane.js
@@ -31,25 +31,25 @@ export function dpTags (dataplane) {
   const inbounds = dataplane.networking.inbound || null
   if (inbounds) {
     tags = inbounds.map(inbound => inbound.tags)
-      .flatMap(tags => Object.entries(tags))
-      .map(tagPair => tagPair[0] + '=' + tagPair[1])
+      .flatMap(Object.entries)
+      .map(([key, value]) => key + '=' + value)
   }
 
   // gateway data plane has no inbounds, but has tags embedded in gateway branch
   const gateway = dataplane.networking.gateway || null
   if (gateway) {
     tags = Object.entries(gateway.tags)
-      .map(tagPair => tagPair[0] + '=' + tagPair[1])
+      .map(([key, value]) => key + '=' + value)
   }
 
   tags = Array.from(new Set(tags)) // remove duplicates
 
   return tags.map(function (tagPair) {
-    const pairSplit = tagPair.split('=')
+    const [key, value] = tagPair.split('=')
 
     return {
-      label: pairSplit[0],
-      value: pairSplit[1]
+      label: key,
+      value: value
     }
   })
 }

--- a/src/dataplane.js
+++ b/src/dataplane.js
@@ -30,8 +30,7 @@ export function dpTags (dataplane) {
 
   const inbounds = dataplane.networking.inbound || null
   if (inbounds) {
-    tags = inbounds.map(inbound => inbound.tags)
-      .flatMap(Object.entries)
+    tags = inbounds.flatMap(inbound => Object.entries(inbound.tags))
       .map(([key, value]) => key + '=' + value)
   }
 
@@ -44,12 +43,6 @@ export function dpTags (dataplane) {
 
   tags = Array.from(new Set(tags)) // remove duplicates
 
-  return tags.map(function (tagPair) {
-    const [key, value] = tagPair.split('=')
-
-    return {
-      label: key,
-      value: value
-    }
-  })
+  return tags.map(tagPair => tagPair.split('='))
+    .map(([key, value]) => ({ label: key, value: value }))
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -393,22 +393,6 @@ export function cleanTag (tag) {
 }
 
 /**
- * removeDuplicates
- *
- * This removes duplicate objects from an array
- *
- * @param {Array} array
- * @param {String} key
- */
-export function dedupeObjects (array, key) {
-  return array.filter((obj, index, self) =>
-    index === self.findIndex((el) => (
-      el[key] === obj[key]
-    ))
-  )
-}
-
-/**
  * camelCaseToWords
  *
  * Converts camelcase to human-readable words in titlecase format
@@ -464,7 +448,6 @@ export default {
   getOffset,
   stripTimes,
   cleanTag,
-  dedupeObjects,
   camelCaseToWords,
   kebabCase
 }

--- a/src/views/Entities/GatewayDataplanes.vue
+++ b/src/views/Entities/GatewayDataplanes.vue
@@ -164,6 +164,7 @@ import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import { dpTags } from '@/dataplane'
 
 export default {
   name: 'GatewayDataplanes',
@@ -371,22 +372,7 @@ export default {
             /**
              * Handle our tag collection
              */
-
-            if (gateway) {
-              // gateway tags
-              const gatewayItems = gateway.tags || null
-
-              if (gatewayItems) {
-                Object.keys(gatewayItems).forEach(key => {
-                  tags.push({
-                    label: key,
-                    value: gatewayItems[key]
-                  })
-                })
-              }
-            } else {
-              tags = 'none'
-            }
+            tags = dpTags(response.dataplane)
 
             /**
              * Iterate through the subscriptions
@@ -618,91 +604,10 @@ export default {
                 return data
               }
 
-              // combine all tags into a single object
-              const fullTagSrc = () => {
-                const src = response.networking || null
-                const inbound = src.inbound || null
-                const gateway = src.gateway || null
-                const ingress = src.ingress || null
-
-                if (inbound || gateway || ingress) {
-                  const final = []
-
-                  // inbound tags
-                  if (inbound) {
-                    for (let i = 0; i < inbound.length; i++) {
-                      const rawTags = inbound[i].tags || null
-
-                      if (rawTags) {
-                        const tagKeys = Object.keys(rawTags)
-                        const tagVals = Object.values(rawTags)
-
-                        for (let x = 0; x < tagKeys.length; x++) {
-                          final.push({
-                            label: tagKeys[x],
-                            value: tagVals[x]
-                          })
-                        }
-                      }
-                    }
-                  }
-
-                  // gateway tags
-                  if (gateway) {
-                    const gatewayItems = gateway.tags || null
-
-                    if (gatewayItems) {
-                      for (let i = 0; i < Object.keys(gatewayItems).length; i++) {
-                        const tagKeys = Object.keys(gatewayItems)
-                        const tagVals = Object.values(gatewayItems)
-
-                        for (let x = 0; x < tagKeys.length; x++) {
-                          final.push({
-                            label: tagKeys[x],
-                            value: tagVals[x]
-                          })
-                        }
-                      }
-                    }
-                  }
-
-                  // ingress tags
-                  if (ingress) {
-                    for (let i = 0; i < ingress.length; i++) {
-                      const ingressTags = ingress[i].tags || null
-                      const ingressService = ingress[i].service || null
-
-                      if (ingressService) {
-                        final.push({
-                          label: 'service',
-                          value: ingressService
-                        })
-                      }
-
-                      if (ingressTags) {
-                        const tagKeys = Object.keys(ingressTags)
-                        const tagVals = Object.values(ingressTags)
-
-                        for (let x = 0; x < tagKeys.length; x++) {
-                          final.push({
-                            label: tagKeys[x],
-                            value: tagVals[x]
-                          })
-                        }
-                      }
-                    }
-                  }
-
-                  return final
-                }
-
-                return null
-              }
-
               const newEntity = async () => {
                 return {
                   basicData: { ...getSome(response, selected) },
-                  tags: { ...fullTagSrc() },
+                  tags: dpTags(response),
                   mtls: await getMTLSData()
                 }
               }

--- a/src/views/Entities/StandardDataplanes.vue
+++ b/src/views/Entities/StandardDataplanes.vue
@@ -155,7 +155,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import { getSome, humanReadableDate, getOffset, stripTimes, dedupeObjects } from '@/helpers'
+import { getSome, humanReadableDate, getOffset, stripTimes } from '@/helpers'
 import EntityURLControl from '@/components/Utils/EntityURLControl'
 import sortEntities from '@/mixins/EntitySorter'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
@@ -164,6 +164,7 @@ import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import { dpTags } from '@/dataplane'
 
 export default {
   name: 'StandardDataplanes',
@@ -371,22 +372,7 @@ export default {
             /**
              * Handle our tag collection
              */
-
-            if (inbound) {
-              // inbound tags
-              const inboundItems = inbound[0].tags || null
-
-              if (inboundItems) {
-                Object.keys(inboundItems).forEach(key => {
-                  tags.push({
-                    label: key,
-                    value: inboundItems[key]
-                  })
-                })
-              }
-            } else {
-              tags = 'none'
-            }
+            tags = dpTags(response.dataplane)
 
             /**
              * Iterate through the subscriptions
@@ -618,99 +604,10 @@ export default {
                 return data
               }
 
-              // combine all tags into a single object
-              const fullTagSrc = () => {
-                const src = response.networking || null
-                const inbound = src.inbound || null
-                const gateway = src.gateway || null
-                const ingress = src.ingress || null
-
-                if (inbound || gateway || ingress) {
-                  const inboundFinalTags = []
-                  const gatewayFinalTags = []
-                  const ingressFinalTags = []
-
-                  // inbound tags
-                  if (inbound) {
-                    for (let i = 0; i < inbound.length; i++) {
-                      const rawTags = inbound[i].tags || null
-
-                      if (rawTags) {
-                        const tagKeys = Object.keys(rawTags)
-                        const tagVals = Object.values(rawTags)
-
-                        for (let x = 0; x < tagKeys.length; x++) {
-                          inboundFinalTags.push({
-                            label: tagKeys[x],
-                            value: tagVals[x]
-                          })
-                        }
-                      }
-                    }
-                  }
-
-                  // gateway tags
-                  if (gateway) {
-                    const gatewayItems = gateway.tags || null
-
-                    if (gatewayItems) {
-                      for (let i = 0; i < Object.keys(gatewayItems).length; i++) {
-                        const tagKeys = Object.keys(gatewayItems)
-                        const tagVals = Object.values(gatewayItems)
-
-                        for (let x = 0; x < tagKeys.length; x++) {
-                          gatewayFinalTags.push({
-                            label: tagKeys[x],
-                            value: tagVals[x]
-                          })
-                        }
-                      }
-                    }
-                  }
-
-                  // ingress tags
-                  if (ingress) {
-                    for (let i = 0; i < ingress.length; i++) {
-                      const ingressTags = ingress[i].tags || null
-                      const ingressService = ingress[i].service || null
-
-                      if (ingressService) {
-                        ingressFinalTags.push({
-                          label: 'service',
-                          value: ingressService
-                        })
-                      }
-
-                      if (ingressTags) {
-                        const tagKeys = Object.keys(ingressTags)
-                        const tagVals = Object.values(ingressTags)
-
-                        for (let x = 0; x < tagKeys.length; x++) {
-                          ingressFinalTags.push({
-                            label: tagKeys[x],
-                            value: tagVals[x]
-                          })
-                        }
-                      }
-                    }
-                  }
-
-                  const final = [
-                    ...inboundFinalTags,
-                    ...gatewayFinalTags,
-                    ...ingressFinalTags
-                  ]
-
-                  return dedupeObjects(final, 'value')
-                }
-
-                return null
-              }
-
               const newEntity = async () => {
                 return {
                   basicData: { ...getSome(response, selected) },
-                  tags: { ...fullTagSrc() },
+                  tags: dpTags(response),
                   mtls: await getMTLSData()
                 }
               }


### PR DESCRIPTION
I noticed that tags in Ingress tab are broken so I looked into algorithm and noticed a couple of problems
* Ingress does not have tags in `networking.ingress.tags`, we should just list from the inbounds
* We cannot just take `inbound[0].tags` because they might be more tags
* There were two algorithms to display tags spread across 3 files, I created one function in `src/dataplane.js`

Some additional small stuff
* In ingress there should be no Certificate Insights in overview
* restored this one https://github.com/kumahq/kuma-gui/pull/82 because it was lost for some reason