### PR TITLE
fix dataplane to view url in k8's onboarding

### DIFF
--- a/src/views/Wizard/views/DataplaneKubernetes.vue
+++ b/src/views/Wizard/views/DataplaneKubernetes.vue
@@ -748,9 +748,6 @@ export default {
           name: 'dataplanes',
           params: {
             mesh: fields.meshName
-          },
-          query: {
-            ns: fields.k8sNamespaceSelection
           }
         }
       }


### PR DESCRIPTION
After done with the k8's data plane setup there is a link to redirect to `/dataplanes`, the redirection URL has an additional `namespace` paramwhich upon redirection fails to load data on the data plane page. so, removed the param
Signed-off-by: Tharun <rajendrantharun@live.com>