### PR TITLE
fix dataplane entity views data load

### DIFF
--- a/src/views/Entities/GatewayDataplanes.vue
+++ b/src/views/Entities/GatewayDataplanes.vue
@@ -318,10 +318,7 @@ export default {
       const mesh = this.$route.params.mesh || null
       const query = this.$route.query.ns || null
 
-      // we only need the offset if there is a size added
       const params = {
-        size: this.pageSize,
-        offset: this.pageOffset,
         gateway: true
       }
 

--- a/src/views/Entities/IngressDataplanes.vue
+++ b/src/views/Entities/IngressDataplanes.vue
@@ -319,10 +319,7 @@ export default {
       const mesh = this.$route.params.mesh || null
       const query = this.$route.query.ns || null
 
-      // we only need the offset if there is a size added
       const params = {
-        size: this.pageSize,
-        offset: this.pageOffset,
         ingress: true
       }
 

--- a/src/views/Entities/StandardDataplanes.vue
+++ b/src/views/Entities/StandardDataplanes.vue
@@ -319,8 +319,6 @@ export default {
       const query = this.$route.query.ns || null
 
       const params = {
-        size: this.pageSize,
-        offset: this.pageOffset,
         gateway: false,
         ingress: false
       }


### PR DESCRIPTION
Currently, Kuma rest API not supports filtering and pagination at the same time. This causes API calls to fail for dp views. 
So, removed pageSize from the API params.