### PR TITLE
feat(services) Internal and External services in the GUI

### DIFF
--- a/src/components/Sidebar/menu.js
+++ b/src/components/Sidebar/menu.js
@@ -58,6 +58,12 @@ export default [
               title: true
             },
             {
+              name: 'Internal',
+              link: 'internal-services',
+              title: false,
+              nested: true
+            },
+            {
               name: 'External',
               link: 'external-services',
               title: false,

--- a/src/components/Sidebar/menu.js
+++ b/src/components/Sidebar/menu.js
@@ -54,6 +54,16 @@ export default [
               nested: true
             },
             {
+              name: 'Services',
+              title: true
+            },
+            {
+              name: 'External',
+              link: 'external-services',
+              title: false,
+              nested: true
+            },
+            {
               name: 'Policies',
               title: true
             },

--- a/src/router.js
+++ b/src/router.js
@@ -215,6 +215,16 @@ export default (store) => {
             breadcrumb: 'Gateway Data Plane Proxies'
           }
         },
+        // internal services
+        {
+          path: 'internal-services',
+          name: 'internal-services',
+          component: () => import(/* webpackChunkName: "dataplanes-gateway" */ '@/views/Entities/InternalServices'),
+          meta: {
+            title: 'Internal Services',
+            breadcrumb: 'Internal Services'
+          }
+        },
         // external services
         {
           path: 'external-services',

--- a/src/router.js
+++ b/src/router.js
@@ -215,6 +215,16 @@ export default (store) => {
             breadcrumb: 'Gateway Data Plane Proxies'
           }
         },
+        // external services
+        {
+          path: 'external-services',
+          name: 'external-services',
+          component: () => import(/* webpackChunkName: "dataplanes-gateway" */ '@/views/Entities/ExternalServices'),
+          meta: {
+            title: 'External Services',
+            breadcrumb: 'External Services'
+          }
+        },
         // traffic permissions
         {
           path: 'traffic-permissions',

--- a/src/services/kuma.js
+++ b/src/services/kuma.js
@@ -289,25 +289,21 @@ export default class Kuma {
   }
 
   /**
-   *
-   * NOTE:
-   * There are no endpoints yet for fetching service information.
-   * The below calls are placeholders for when those endpoints are added.
-   *
+   * Service Insights
    */
 
   // get all services
-  getAllServices (params) {
-    return this.client.get('/services', { params })
+  getAllServiceInsights (params) {
+    return this.client.get('/service-insights', { params })
   }
 
   // get all services from mesh
-  getAllServicesFromMesh (mesh, params) {
-    return this.client.get(`/meshes/${mesh}/services`, { params })
+  getAllServiceInsightsFromMesh (mesh, params) {
+    return this.client.get(`/meshes/${mesh}/service-insights`, { params })
   }
 
   // get service details
-  getService (name, service, params) {
-    return this.client.get(`/meshes/${name}/services/${service}`, { params })
+  getServiceInsight (name, service, params) {
+    return this.client.get(`/meshes/${name}/service-insights/${service}`, { params })
   }
 }

--- a/src/services/kuma.js
+++ b/src/services/kuma.js
@@ -270,6 +270,25 @@ export default class Kuma {
   }
 
   /**
+   * External Services
+   */
+
+  // get all external services
+  getAllExternalServices (params) {
+    return this.client.get('/external-services', { params })
+  }
+
+  // get all external services from mesh
+  getAllExternalServicesFromMesh (mesh, params) {
+    return this.client.get(`/meshes/${mesh}/external-services`, { params })
+  }
+
+  // get external service details
+  getExternalService (mesh, externalservice, params) {
+    return this.client.get(`/meshes/${mesh}/external-services/${externalservice}`, { params })
+  }
+
+  /**
    *
    * NOTE:
    * There are no endpoints yet for fetching service information.

--- a/src/views/Entities/ExternalServices.vue
+++ b/src/views/Entities/ExternalServices.vue
@@ -1,0 +1,374 @@
+<template>
+  <div class="external-services">
+    <FrameSkeleton>
+      <DataOverview
+        :page-size="pageSize"
+        :has-error="hasError"
+        :is-loading="isLoading"
+        :empty-state="empty_state"
+        :display-data-table="true"
+        :table-data="tableData"
+        :table-data-is-empty="tableDataIsEmpty"
+        table-data-function-text="View"
+        table-data-row="name"
+        @tableAction="tableAction"
+        @reloadData="loadData"
+      >
+        <template slot="additionalControls">
+          <KButton
+            v-if="this.$route.query.ns"
+            class="back-button"
+            appearance="primary"
+            size="small"
+            :to="{
+              name: 'external-services'
+            }"
+          >
+            <span class="custom-control-icon">
+              &larr;
+            </span>
+            View All
+          </KButton>
+        </template>
+        <template slot="pagination">
+          <Pagination
+            :has-previous="previous.length > 0"
+            :has-next="hasNext"
+            @next="goToNextPage"
+            @previous="goToPreviousPage"
+          />
+        </template>
+      </DataOverview>
+      <Tabs
+        v-if="isEmpty === false"
+        :has-error="hasError"
+        :is-loading="isLoading"
+        :tabs="tabs"
+        initial-tab-override="overview"
+      >
+        <template slot="tabHeader">
+          <div>
+            <h3>{{ tabGroupTitle }}</h3>
+          </div>
+          <div>
+            <EntityURLControl :url="shareUrl" />
+          </div>
+        </template>
+        <template slot="overview">
+          <LabelList
+            :has-error="entityHasError"
+            :is-loading="entityIsLoading"
+            :is-empty="entityIsEmpty"
+          >
+            <div>
+              <ul>
+                <li
+                  v-for="(val, key) in entity"
+                  :key="key"
+                >
+                  <h4>{{ key }}</h4>
+                  <p>
+                    {{ val }}
+                  </p>
+                </li>
+              </ul>
+            </div>
+          </LabelList>
+        </template>
+        <template slot="yaml">
+          <YamlView
+            lang="yaml"
+            :title="entityOverviewTitle"
+            :has-error="entityHasError"
+            :is-loading="entityIsLoading"
+            :is-empty="entityIsEmpty"
+            :content="rawEntity"
+          />
+        </template>
+      </Tabs>
+    </FrameSkeleton>
+  </div>
+</template>
+
+<script>
+import { getSome, stripTimes } from '@/helpers'
+import EntityURLControl from '@/components/Utils/EntityURLControl'
+import sortEntities from '@/mixins/EntitySorter'
+import FormatForCLI from '@/mixins/FormatForCLI'
+import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
+import Pagination from '@/components/Pagination'
+import DataOverview from '@/components/Skeletons/DataOverview'
+import Tabs from '@/components/Utils/Tabs'
+import YamlView from '@/components/Skeletons/YamlView'
+import LabelList from '@/components/Utils/LabelList'
+
+export default {
+  name: 'ExternalServices',
+  metaInfo: {
+    title: 'External Services'
+  },
+  components: {
+    EntityURLControl,
+    FrameSkeleton,
+    Pagination,
+    DataOverview,
+    Tabs,
+    YamlView,
+    LabelList
+  },
+  mixins: [
+    FormatForCLI,
+    sortEntities
+  ],
+  data () {
+    return {
+      isLoading: true,
+      isEmpty: false,
+      hasError: false,
+      entityIsLoading: true,
+      entityIsEmpty: false,
+      entityHasError: false,
+      tableDataIsEmpty: false,
+      empty_state: {
+        title: 'No Data',
+        message: 'There are no External Services present.'
+      },
+      tableData: {
+        headers: [
+          { key: 'actions', hideLabel: true },
+          { label: 'Name', key: 'name' },
+          { label: 'Mesh', key: 'mesh' },
+          { label: 'Address', key: 'address' },
+          { label: 'TLS', key: 'tlsEnabled' }
+        ],
+        data: []
+      },
+      tabs: [
+        {
+          hash: '#overview',
+          title: 'Overview'
+        },
+        {
+          hash: '#yaml',
+          title: 'YAML'
+        }
+      ],
+      entity: [],
+      rawEntity: null,
+      firstEntity: null,
+      pageSize: this.$pageSize,
+      pageOffset: null,
+      next: null,
+      hasNext: false,
+      previous: []
+    }
+  },
+  computed: {
+    tabGroupTitle () {
+      const entity = this.entity
+
+      if (entity) {
+        return `External Service: ${entity.name}`
+      } else {
+        return null
+      }
+    },
+    entityOverviewTitle () {
+      const entity = this.entity
+
+      if (entity) {
+        return `Entity Overview for ${entity.name}`
+      } else {
+        return null
+      }
+    },
+    formattedRawEntity () {
+      const entity = this.formatForCLI(this.rawEntity)
+
+      return entity
+    },
+    shareUrl () {
+      const urlRoot = `${window.location.origin}#`
+      const entity = this.entity
+
+      const shareUrl = () => {
+        if (this.$route.query.ns) {
+          return this.$route.fullPath
+        }
+
+        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
+      }
+
+      return shareUrl()
+    }
+  },
+  watch: {
+    '$route' (to, from) {
+      this.init()
+    }
+  },
+  beforeMount () {
+    this.init()
+  },
+  methods: {
+    init () {
+      this.loadData()
+    },
+    goToPreviousPage () {
+      this.pageOffset = this.previous.pop()
+      this.next = null
+
+      this.loadData()
+    },
+    goToNextPage () {
+      this.previous.push(this.pageOffset)
+      this.pageOffset = this.next
+      this.next = null
+
+      this.loadData()
+    },
+    tableAction (ev) {
+      const data = ev
+
+      // reset back to the first tab
+      this.$store.dispatch('updateSelectedTab', this.tabs[0].hash)
+
+      // set the active table row
+      this.$store.dispatch('updateSelectedTableRow', data.name)
+
+      // load the data into the tabs
+      this.getEntity(data)
+    },
+    loadData () {
+      this.isLoading = true
+
+      const mesh = this.$route.params.mesh || null
+      const query = this.$route.query.ns || null
+
+      const params = {
+        size: this.pageSize,
+        offset: this.pageOffset
+      }
+
+      const endpoint = () => {
+        if (mesh === 'all') {
+          return this.$api.getAllExternalServices(params)
+        } else if ((query && query.length) && mesh !== 'all') {
+          return this.$api.getExternalService(mesh, query, params)
+        }
+
+        return this.$api.getAllExternalServicesFromMesh(mesh)
+      }
+
+      const getExternalServices = () => {
+        return endpoint()
+          .then(response => {
+            const items = () => {
+              const r = response
+
+              if ('total' in r) {
+                if (r.total !== 0 && r.items && r.items.length > 0) {
+                  return this.sortEntities(r.items)
+                }
+
+                return null
+              }
+
+              return r
+            }
+
+            const entityList = items()
+
+            if (items()) {
+              const firstItem = query
+                ? entityList
+                : entityList[0]
+
+              // set the first item as the default for initial load
+              this.firstEntity = firstItem.name
+
+              // load the YAML entity for the first item on page load
+              this.getEntity(stripTimes(firstItem))
+
+              // set the selected table row for the first item on page load
+              this.$store.dispatch('updateSelectedTableRow', firstItem.name)
+
+              this.tableData.data = query
+                ? [entityList]
+                : entityList
+
+              this.tableData.data = this.tableData.data.map(entity => {
+                entity.address = entity.networking.address
+                entity.tlsEnabled = entity.networking.tls.enabled ? 'Enabled' : 'Disabled'
+
+                return entity
+              })
+
+              this.tableDataIsEmpty = false
+              this.isEmpty = false
+            } else {
+              this.tableData.data = []
+              this.tableDataIsEmpty = true
+              this.isEmpty = true
+
+              this.getEntity(null)
+            }
+          })
+          .catch(error => {
+            this.hasError = true
+            this.isEmpty = true
+
+            console.error(error)
+          })
+          .finally(() => {
+            setTimeout(() => {
+              this.isLoading = false
+            }, process.env.VUE_APP_DATA_TIMEOUT)
+          })
+      }
+
+      getExternalServices()
+    },
+    getEntity (entity) {
+      this.entityIsLoading = true
+      this.entityIsEmpty = false
+
+      const mesh = this.$route.params.mesh
+
+      if (entity && entity !== null) {
+        const entityMesh = (mesh === 'all')
+          ? entity.mesh
+          : mesh
+
+        return this.$api.getExternalService(entityMesh, entity.name)
+          .then(response => {
+            if (response) {
+              const selected = ['type', 'name', 'mesh']
+
+              this.entity = getSome(response, selected)
+              // this.rawEntity = response
+              this.rawEntity = stripTimes(response)
+            } else {
+              this.entity = null
+              this.entityIsEmpty = true
+            }
+          })
+          .catch(error => {
+            this.entityHasError = true
+            console.error(error)
+          })
+          .finally(() => {
+            setTimeout(() => {
+              this.entityIsLoading = false
+            }, process.env.VUE_APP_DATA_TIMEOUT)
+          })
+      } else {
+        setTimeout(() => {
+          this.entityIsEmpty = true
+          this.entityIsLoading = false
+        }, process.env.VUE_APP_DATA_TIMEOUT)
+      }
+    }
+  }
+}
+</script>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5459824/100870897-ab1a3d00-349f-11eb-82f5-62becd4a2f5c.png)
![image](https://user-images.githubusercontent.com/5459824/100870913-b2414b00-349f-11eb-97bc-182406efcc16.png)
![image](https://user-images.githubusercontent.com/5459824/100870933-bbcab300-349f-11eb-9f8b-b27c2da16773.png)

I did not implement `All` because
1) We don't have an endpoint to aggregate ServiceInsights and ExternalServices and support pagination etc.
2) What would be the columns in the list? "Online dataplanes" does not make sense on external services and address does not make sense for internal services

Overall it can be done but with much work which I'd argue give not that much value.

Views are essentially copy paste with renaming with this modification
```
              this.tableData.data = this.tableData.data.map(entity => {
                entity.address = entity.networking.address
                entity.tlsEnabled = entity.networking.tls.enabled ? 'Enabled' : 'Disabled'
                return entity
              })
```

```
              this.tableData.data = this.tableData.data.map(entity => {
                // API can skip the field if there is no stat
                entity.offline = entity.offline || 0
                entity.online = entity.online || 0
                entity.total = entity.total || 0
                entity.totalOnline = `${entity.online} / ${entity.total}`
                return entity
              })
```

to support custom columns in the list