### PR TITLE
feat(*) add services to overview

### DIFF
--- a/src/components/Metrics/MetricGrid.vue
+++ b/src/components/Metrics/MetricGrid.vue
@@ -13,7 +13,13 @@
           v-if="metric.value !== null"
           :key="index"
           :data-testid="metric.metric | formatTestId"
-          :class="metric.status"
+          :class="[
+            metric.status,
+            {
+              'metric--third-in-row': (index + 1) % 3 === 0,
+              'metric--in-last-row': index + metrics.length % 3 >= metrics.length
+            }
+          ]"
           class="metric"
         >
           <router-link
@@ -148,8 +154,12 @@ export default {
     @media (min-width: 841px) {
       border-right: var(--border);
 
-      &:nth-child(3n) {
+      &.metric--third-in-row {
         border-right: 0;
+      }
+
+      &.metric--in-last-row {
+        border-bottom: 0;
       }
     }
 
@@ -220,22 +230,6 @@ export default {
 
       .metric-value {
         color: #D90000;
-      }
-    }
-  }
-
-  @media (min-width: 841px) {
-    &.metric-count--odd {
-
-      .metric:nth-last-child(-n+2) {
-        border-bottom: 0;
-      }
-    }
-
-    &.metric-count--even {
-
-      .metric:nth-last-child(-n+3) {
-        border-bottom: 0;
       }
     }
   }

--- a/src/components/Sidebar/menu.js
+++ b/src/components/Sidebar/menu.js
@@ -27,6 +27,22 @@ export default [
               pathFlip: true
             },
             {
+              name: 'Services',
+              title: true
+            },
+            {
+              name: 'Internal',
+              link: 'internal-services',
+              title: false,
+              nested: true
+            },
+            {
+              name: 'External',
+              link: 'external-services',
+              title: false,
+              nested: true
+            },
+            {
               name: 'Data plane proxies',
               title: true
             },
@@ -50,22 +66,6 @@ export default [
             {
               name: 'Gateway',
               link: 'gateway-dataplanes',
-              title: false,
-              nested: true
-            },
-            {
-              name: 'Services',
-              title: true
-            },
-            {
-              name: 'Internal',
-              link: 'internal-services',
-              title: false,
-              nested: true
-            },
-            {
-              name: 'External',
-              link: 'external-services',
               title: false,
               nested: true
             },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -23,6 +23,8 @@ export default (api) => {
       dataplanes: [],
       selectedMesh: 'all', // shows all meshes on initial load
       totalMeshCount: 0,
+      totalInternalServiceCount: 0,
+      totalExternalServiceCount: 0,
       totalDataplaneCount: 0,
       totalHealthCheckCount: 0,
       totalProxyTemplateCount: 0,
@@ -43,6 +45,8 @@ export default (api) => {
       totalTrafficTraceCountFromMesh: 0,
       totalFaultInjectionCountFromMesh: 0,
       totalCircuitBreakerCountFromMesh: 0,
+      totalInternalServiceCountFromMesh: 0,
+      totalExternalServiceCountFromMesh: 0,
       totalDataplaneCountFromMesh: 0,
       tagline: null,
       version: null,
@@ -63,6 +67,8 @@ export default (api) => {
       getAnyDpOffline: (state) => state.anyDataplanesOffline,
       // total counts for all meshes
       getTotalMeshCount: (state) => state.totalMeshCount,
+      getTotalInternalServiceCount: (state) => state.totalInternalServiceCount,
+      getTotalExternalServiceCount: (state) => state.totalExternalServiceCount,
       getTotalDataplaneCount: (state) => state.totalDataplaneCount,
       getTotalHealthCheckCount: (state) => state.totalHealthCheckCount,
       getTotalProxyTemplateCount: (state) => state.totalProxyTemplateCount,
@@ -73,6 +79,8 @@ export default (api) => {
       getTotalFaultInjectionCount: (state) => state.totalFaultInjectionCount,
       getTotalCircuitBreakerCount: (state) => state.totalCircuitBreakerCount,
       // total counts per single mesh
+      getTotalInternalServiceCountFromMesh: (state) => state.totalInternalServiceCountFromMesh,
+      getTotalExternalServiceCountFromMesh: (state) => state.totalExternalServiceCountFromMesh,
       getTotalDataplaneCountFromMesh: (state) => state.totalDataplaneCountFromMesh,
       getTotalTrafficRoutesCountFromMesh: (state) => state.totalTrafficRouteCountFromMesh,
       getTotalTrafficPermissionsCountFromMesh: (state) => state.totalTrafficPermissionCountFromMesh,
@@ -119,6 +127,8 @@ export default (api) => {
       SET_SELECTED_MESH: (state, mesh) => (state.selectedMesh = mesh),
       SET_TOTAL_MESH_COUNT: (state, count) => (state.totalMeshCount = count),
       SET_TOTAL_DATAPLANE_COUNT: (state, count) => (state.totalDataplaneCount = count),
+      SET_TOTAL_INTERNAL_SERVICE_COUNT: (state, count) => (state.totalInternalServiceCount = count),
+      SET_TOTAL_EXTERNAL_SERVICE_COUNT: (state, count) => (state.totalExternalServiceCount = count),
       SET_TOTAL_HEALTH_CHECK_COUNT: (state, count) => (state.totalHealthCheckCount = count),
       SET_TOTAL_PROXY_TEMPLATE_COUNT: (state, count) => (state.totalProxyTemplateCount = count),
       SET_TOTAL_TRAFFIC_LOG_COUNT: (state, count) => (state.totalTrafficLogCount = count),
@@ -129,6 +139,8 @@ export default (api) => {
       SET_TOTAL_FAULT_INJECTION_COUNT: (state, count) => (state.totalFaultInjectionCount = count),
       SET_TOTAL_CIRCUIT_BREAKER_COUNT: (state, count) => (state.totalCircuitBreakerCount = count),
       SET_TOTAL_DATAPLANE_COUNT_FROM_MESH: (state, count) => (state.totalDataplaneCountFromMesh = count),
+      SET_TOTAL_INTERNAL_SERVICE_COUNT_FROM_MESH: (state, count) => (state.totalInternalServiceCountFromMesh = count),
+      SET_TOTAL_EXTERNAL_SERVICE_COUNT_FROM_MESH: (state, count) => (state.totalExternalServiceCountFromMesh = count),
       SET_TOTAL_HEALTH_CHECK_COUNT_FROM_MESH: (state, count) => (state.totalHealthCheckCountFromMesh = count),
       SET_TOTAL_PROXY_TEMPLATE_COUNT_FROM_MESH: (state, count) => (state.totalProxyTemplateCountFromMesh = count),
       SET_TOTAL_TRAFFIC_LOG_COUNT_FROM_MESH: (state, count) => (state.totalTrafficLogCountFromMesh = count),
@@ -213,6 +225,36 @@ export default (api) => {
             const total = response.total
 
             commit('SET_TOTAL_MESH_COUNT', total)
+          })
+          .catch(error => {
+            console.error(error)
+          })
+      },
+
+      // get the total number of internal services present
+      fetchInternalServiceTotalCount ({ commit }) {
+        const params = { size: 1 }
+
+        return api.getAllServiceInsights(params)
+          .then(response => {
+            const total = response.total
+
+            commit('SET_TOTAL_INTERNAL_SERVICE_COUNT', total)
+          })
+          .catch(error => {
+            console.error(error)
+          })
+      },
+
+      // get the total number of external services present
+      fetchExternalServiceTotalCount ({ commit }) {
+        const params = { size: 1 }
+
+        return api.getAllExternalServices(params)
+          .then(response => {
+            const total = response.total
+
+            commit('SET_TOTAL_EXTERNAL_SERVICE_COUNT', total)
           })
           .catch(error => {
             console.error(error)
@@ -357,6 +399,36 @@ export default (api) => {
       /**
        * Total counts (per mesh)
        */
+
+      // get the total number of internal services from a specific mesh
+      fetchInternalServiceTotalCountFromMesh ({ commit }, mesh) {
+        const params = { size: 1 }
+
+        return api.getAllServiceInsightsFromMesh(mesh, params)
+          .then(response => {
+            const total = response.total
+
+            commit('SET_TOTAL_INTERNAL_SERVICE_COUNT_FROM_MESH', total)
+          })
+          .catch(error => {
+            console.error(error)
+          })
+      },
+
+      // get the total number of external services from a specific mesh
+      fetchExternalServiceTotalCountFromMesh ({ commit }, mesh) {
+        const params = { size: 1 }
+
+        return api.getAllExternalServicesFromMesh(mesh, params)
+          .then(response => {
+            const total = response.total
+
+            commit('SET_TOTAL_EXTERNAL_SERVICE_COUNT_FROM_MESH', total)
+          })
+          .catch(error => {
+            console.error(error)
+          })
+      },
 
       // get the total number of dataplanes from a specific mesh
       fetchDataplaneTotalCountFromMesh ({ commit }, mesh) {

--- a/src/views/Overview.vue
+++ b/src/views/Overview.vue
@@ -99,6 +99,8 @@ export default {
         storeVals = {
           meshCount: state.totalMeshCount,
           dataplaneCount: state.totalDataplaneCount,
+          internalServiceCount: state.totalInternalServiceCount,
+          externalServiceCount: state.totalExternalServiceCount,
           faultInjectionCount: state.totalFaultInjectionCount,
           healthCheckCount: state.totalHealthCheckCount,
           proxyTemplateCount: state.totalProxyTemplateCount,
@@ -111,6 +113,8 @@ export default {
       } else {
         storeVals = {
           dataplaneCount: state.totalDataplaneCountFromMesh,
+          internalServiceCount: state.totalInternalServiceCountFromMesh,
+          externalServiceCount: state.totalExternalServiceCountFromMesh,
           faultInjectionCount: state.totalFaultInjectionCountFromMesh,
           healthCheckCount: state.totalHealthCheckCountFromMesh,
           proxyTemplateCount: state.totalProxyTemplateCountFromMesh,
@@ -127,6 +131,16 @@ export default {
           metric: 'Meshes',
           value: storeVals.meshCount,
           url: `/meshes/${this.selectedMesh}`
+        },
+        {
+          metric: 'Internal Services',
+          value: storeVals.internalServiceCount,
+          url: `/${this.selectedMesh}/internal-services`
+        },
+        {
+          metric: 'External Services',
+          value: storeVals.externalServiceCount,
+          url: `/${this.selectedMesh}/external-services`
         },
         {
           metric: 'Data Plane Proxies',
@@ -236,6 +250,8 @@ export default {
         actions = [
           'fetchTotalClusterCount',
           'fetchMeshTotalCount',
+          'fetchInternalServiceTotalCount',
+          'fetchExternalServiceTotalCount',
           'fetchDataplaneTotalCount',
           'fetchHealthCheckTotalCount',
           'fetchProxyTemplateTotalCount',
@@ -256,6 +272,8 @@ export default {
         // load the total counts just for that selected mesh
         actions = [
           'fetchTotalClusterCount',
+          'fetchInternalServiceTotalCountFromMesh',
+          'fetchExternalServiceTotalCountFromMesh',
           'fetchDataplaneTotalCountFromMesh',
           'fetchHealthCheckTotalCountFromMesh',
           'fetchProxyTemplateTotalCountFromMesh',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3358,15 +3358,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001038, caniuse-lite@^1.0.30001039:
-  version "1.0.30001040"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001040.tgz#103fc8e6eb1d7397e95134cd0e996743353d58ea"
-  integrity sha512-Ep0tEPeI5wCvmJNrXjE3etgfI+lkl1fTDU6Y3ZH1mhrjkPlVI9W4pcKbMo+BQLpEWKVYYp2EmYaRsqpPC3k7lQ==
-
-caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001111:
-  version "1.0.30001117"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz#69a9fae5d480eaa9589f7641a83842ad396d17c4"
-  integrity sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001038, caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001111:
+  version "1.0.30001165"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz"
+  integrity sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Added cards with numbers of internal and external services in dataplane
overviews + moved services block at top of `DATA PLANE PROXIES` section
in the sidebar.

Here are the screens reflecting the changes:
<img width="2560" alt="Screenshot 2020-12-08 at 16 53 44" src="https://user-images.githubusercontent.com/11655498/101507290-b1645980-3976-11eb-816d-cc9e19a52d80.png">
<img width="2560" alt="Screenshot 2020-12-08 at 16 53 01" src="https://user-images.githubusercontent.com/11655498/101507303-b45f4a00-3976-11eb-99c1-8978473a3ed9.png">


Signed-off-by: Bart Smykla <bartek@smykla.com>