### PR TITLE
fix(*) missing last items in sidebar

### DIFF
--- a/src/components/Sidebar/Subnav.vue
+++ b/src/components/Sidebar/Subnav.vue
@@ -77,7 +77,7 @@ export default {
   position: fixed;
   left: var(--sidebarCollapsedWidth);
   width: var(--subnavWidth);
-  height: 100%;
+  height: calc(100vh - 3rem - 10px); // -10px because of items padding
   border-left: 1px solid var(--steal-300);
   background-color: var(--white);
   transition: width 200ms ease-out;


### PR DESCRIPTION
So far if your screen was not able to show all elements and you needed
scroll, last elements were "cut" and not visible in the menu (even if
you tried to scroll to them)

This fix is not perfect as there is too much trickery/calculations going
on and to properly fix that it would involve full rewrite of sidebar
components, but it should work for now.

Signed-off-by: Bart Smykla <bartek@smykla.com>