### PR TITLE
Table overflow fix

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 NODE_ENV=development
-VUE_APP_MOCK_API_ENABLED=false
+VUE_APP_MOCK_API_ENABLED=true
 VUE_APP_KUMA_CONFIG=http://localhost:5681/config
 
 # if you want to emulate Multi-Zone mode, set this to true

--- a/src/components/Skeletons/DataOverview.vue
+++ b/src/components/Skeletons/DataOverview.vue
@@ -468,6 +468,8 @@ span[class*="kuma-io-"] {
 }
 
 .data-overview-table {
+  // this accounts for super long table widths
+  overflow-x: auto;
 
   @media (max-width: 1110px) {
     overflow-x: scroll;

--- a/src/services/mock.js
+++ b/src/services/mock.js
@@ -367,6 +367,10 @@ export default class Mock {
           ],
           ingress: [
             {
+              publicAddress: '192.168.0.123',
+              publicPort: 1234,
+            },
+            {
               'kuma.io/service': 'frontend.kuma-demo.svc:8080',
               tags: {
                 app: 'kuma-demo-frontend',
@@ -430,6 +434,10 @@ export default class Mock {
                 ],
                 ingress: [
                   {
+                    publicAddress: '192.168.0.123',
+                    publicPort: 1234,
+                  },
+                  {
                     'kuma.io/service': 'frontend.kuma-demo.svc:8080',
                     tags: {
                       app: 'kuma-demo-frontend',
@@ -490,6 +498,10 @@ export default class Mock {
                   }
                 ],
                 ingress: [
+                  {
+                    publicAddress: '192.168.0.123',
+                    publicPort: 1234,
+                  },
                   {
                     'kuma.io/service': 'frontend.kuma-demo.svc:8080',
                     tags: {
@@ -558,7 +570,11 @@ export default class Mock {
                   reallyLongTagLabelHere: 'a-really-long-tag-value-here'
                 }
               }
-            ]
+            ],
+            ingress: {
+              publicAddress: '192.168.0.123',
+              publicPort: 1234,
+            }
           }
         },
         dataplaneInsight: {
@@ -610,6 +626,10 @@ export default class Mock {
               }
             ],
             ingress: [
+              {
+                publicAddress: '192.168.0.123',
+                publicPort: 1234,
+              },
               {
                 'kuma.io/service': 'frontend.kuma-demo.svc:8080',
                 tags: {
@@ -710,6 +730,10 @@ export default class Mock {
             }
           ],
           ingress: [
+            {
+              publicAddress: '192.168.0.123',
+              publicPort: 1234,
+            },
             {
               'kuma.io/service': 'frontend.kuma-demo.svc:8080',
               tags: {


### PR DESCRIPTION
This change adds horizontal scrolling on the DataOverview table container for instances where they are super wide. This will prevent the tables from jutting out of their parent container.