### PR TITLE
Refactor/use mesh insights in overview

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ import configUrl from '@/configUrl'
 
 /** amCharts */
 import * as am4core from '@amcharts/amcharts4/core'
+import am4themesAnimated from '@amcharts/amcharts4/themes/animated';
 
 /** Kongponents */
 import './kongponents'
@@ -69,6 +70,8 @@ import '@/assets/styles/transitions.scss'
 Vue.use(VueMeta)
 
 Vue.config.productionTip = false
+
+am4core.useTheme(am4themesAnimated);
 
 /**
  * APP SETUP

--- a/src/services/kuma.js
+++ b/src/services/kuma.js
@@ -325,4 +325,18 @@ export default class Kuma {
   getServiceInsight (name, service, params) {
     return this.client.get(`/meshes/${name}/service-insights/${service}`, { params })
   }
+
+  /**
+   * Mesh Insights
+   */
+
+  // Get all Mesh Insights
+  getAllMeshInsights (params) {
+    return this.client.get('/mesh-insights', { params })
+  }
+
+  // Get a single Mesh Insight
+  getMeshInsight (name, params) {
+    return this.client.get(`/mesh-insights/${name}`, { params })
+  }
 }

--- a/src/services/kuma.js
+++ b/src/services/kuma.js
@@ -336,7 +336,7 @@ export default class Kuma {
   }
 
   // Get a single Mesh Insight
-  getMeshInsight (name, params) {
+  getMeshInsights (name, params) {
     return this.client.get(`/mesh-insights/${name}`, { params })
   }
 }

--- a/src/services/restClient.js
+++ b/src/services/restClient.js
@@ -87,16 +87,9 @@ export default class RestClient {
     const opts = await options || {}
     const url = await path
     const client = await this.client
+    const { statusText } = await client.get(url, opts)
 
-    return client.get(url, opts)
-      .then(response => {
-        return response.statusText
-      })
-      .catch(error => {
-        console.error(error)
-
-        return error
-      })
+    return statusText
   }
 
   /** fetch all Kuma API endpoints */
@@ -105,30 +98,16 @@ export default class RestClient {
     // const url = this.buildUrl(path)
     const url = await path
     const client = await this.client
+    const { data } = await client.get(url, opts)
 
-    return client.get(url, opts)
-      .then(response => {
-        const data = response.data
-
-        return data
-      })
-      .catch(error => {
-        console.error(error)
-      })
+    return data
   }
 
   /** fetch all Kuma API endpoints */
   async getConfig () {
     const client = await this.clientConfig
+    const { data } = await client.get('')
 
-    return client.get('')
-      .then(response => {
-        const data = response.data
-
-        return data
-      })
-      .catch(error => {
-        console.error(error)
-      })
+    return data
   }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -55,7 +55,7 @@ export default (api) => {
       totalDataplaneCountFromMesh: 0,
       totalRetryCountFromMesh: 0,
       tagline: null,
-      version: null,
+      version: '',
       status: null,
       selectedTab: '#overview',
       selectedTableRow: null,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -68,6 +68,7 @@ export default (api) => {
       dataplaneInsights: [],
       serviceInsights: [],
       externalServices: [],
+      meshInsights: [],
     },
     getters: {
       getOnboardingStatus: (state) => state.onboardingComplete,
@@ -227,6 +228,7 @@ export default (api) => {
       SET_DATAPLANE_INSIGHTS: (state, value) => (state.dataplaneInsights = value),
       SET_SERVICE_INSIGHTS: (state, value) => (state.serviceInsights = value),
       SET_EXTERNAL_SERVICES: (state, value) => (state.externalServices = value),
+      SET_MESH_INSIGHTS: (state, value) => (state.meshInsights = value),
     },
     actions: {
       // update the onboarding state
@@ -792,11 +794,8 @@ export default (api) => {
       },
 
       // NEW
-      async fetchDataplaneInsights ({ commit, state }, { mesh, ...otherParams } = {}) {
-        const callApi = mesh
-          ? params => api.getAllDataplaneOverviewsFromMesh(mesh, params)
-          : params => api.getAllDataplaneOverviews(params)
 
+      async fetchAllResources ({ commit, state }, { endpoint, mutation, ...otherParams }) {
         const { pageSize } = state
 
         try {
@@ -805,7 +804,7 @@ export default (api) => {
 
           while (true) {
             const params = { ...otherParams, size: pageSize, offset: offset++ }
-            const { items, next } = await callApi(params)
+            const { items, next } = await endpoint(params)
 
             if (items) {
               allItems = allItems.concat(items)
@@ -816,86 +815,46 @@ export default (api) => {
             }
           }
 
-          commit('SET_DATAPLANE_INSIGHTS', allItems)
+          commit(mutation, allItems)
         } catch (e) {
           console.error(e)
         }
       },
 
-      async fetchAllDataplaneInsights ({ commit, state }) {
-        const { pageSize } = state
-
-        try {
-          let offset = 0
-          let allItems = []
-
-          while (true) {
-            const params = { size: pageSize, offset: offset++ }
-            const { items, next } = await api.getAllDataplaneOverviews(params)
-
-            if (items) {
-              allItems = allItems.concat(items)
-            }
-
-            if (!next) {
-              break
-            }
-          }
-
-          commit('SET_DATAPLANE_INSIGHTS', allItems)
-        } catch (e) {
-          console.error(e)
+      fetchAllMeshInsights ({ dispatch }) {
+        const params = {
+          endpoint: (...params) => api.getAllMeshInsights(...params),
+          mutation: 'SET_MESH_INSIGHTS',
         }
+
+        return dispatch('fetchAllResources', params)
       },
 
-      async fetchAllServiceInsights ({ commit, state }) {
-        const { pageSize } = state
-
-        try {
-          let offset = 0
-          let allItems = []
-
-          while (true) {
-            const params = { size: pageSize, offset: offset++ }
-            const { items, next } = await api.getAllServiceInsights(params)
-
-            if (items) {
-              allItems = allItems.concat(items)
-            }
-
-            if (!next) {
-              break
-            }
-          }
-
-          commit('SET_SERVICE_INSIGHTS', allItems)
-        } catch (e) {
-          console.error(e)
+      fetchAllDataplaneInsights ({ dispatch }) {
+        const params = {
+          endpoint: (...params) => api.getAllDataplaneOverviews(...params),
+          mutation: 'SET_DATAPLANE_INSIGHTS',
         }
+
+        return dispatch('fetchAllResources', params)
       },
 
-      async fetchAllExternalServices ({ commit, state }) {
-        const { pageSize } = state
-
-        try {
-          let offset = 0
-          let allItems = []
-
-          while (true) {
-            const params = { size: pageSize, offset: offset++ }
-            const { items, next } = await api.getAllExternalServices(params)
-
-            allItems = allItems.concat(items)
-
-            if (!next) {
-              break
-            }
-          }
-
-          commit('SET_EXTERNAL_SERVICES', allItems)
-        } catch (e) {
-          console.error(e)
+      fetchAllServiceInsights ({ dispatch }) {
+        const params = {
+          endpoint: (...params) => api.getAllServiceInsights(...params),
+          mutation: 'SET_SERVICE_INSIGHTS',
         }
+
+        return dispatch('fetchAllResources', params)
+      },
+
+      async fetchAllExternalServices ({ dispatch }) {
+        const params = {
+          endpoint: (...params) => api.getAllExternalServices(...params),
+          mutation: 'SET_EXTERNAL_SERVICES',
+        }
+
+        return dispatch('fetchAllResources', params)
       },
 
       async fetchAllServices ({ dispatch }) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,9 +4,8 @@ import Vuex from 'vuex'
 import sidebar from '@/store/modules/sidebar'
 // import workspaces from '@/store/modules/workspaces'
 
-import { getStatus, getStatusFromObject } from '@/dataplane'
+import { getStatusFromObject } from '@/dataplane'
 import { filterResourceByMesh } from '@/helpers'
-import * as am4core from '@amcharts/amcharts4/core'
 
 Vue.use(Vuex)
 

--- a/src/store/reducers/mesh-insights.js
+++ b/src/store/reducers/mesh-insights.js
@@ -1,0 +1,91 @@
+const sumDataplanes = (curr = {}, next = {}) => {
+  const currOnline = curr.online || 0
+  const nextOnline = next.online || 0
+  const currOffline = curr.offline || 0
+  const nextOffline = next.offline || 0
+  const currTotal = curr.total || 0
+  const nextTotal = next.total || 0
+
+  return {
+    online: currOnline + nextOnline,
+    offline: currOffline + nextOffline,
+    total: currTotal + nextTotal,
+  }
+}
+
+const getInitialPolicies = () => ({
+  CircuitBreaker: {
+    total: 0,
+  },
+  FaultInjection: {
+    total: 0,
+  },
+  HealthCheck: {
+    total: 0,
+  },
+  ProxyTemplate: {
+    total: 0,
+  },
+  TrafficLog: {
+    total: 0,
+  },
+  TrafficPermission: {
+    total: 0,
+  },
+  TrafficRoute: {
+    total: 0,
+  },
+  TrafficTrace: {
+    total: 0,
+  },
+  Retry: {
+    total: 0,
+  },
+})
+
+const sumPolicies = (curr = getInitialPolicies(), next = {}) =>
+  Object.entries(next).reduce((acc, [name, stat]) => {
+    const currTotal = acc[name]
+      ? acc[name].total
+      : 0
+
+    return {
+      ...acc,
+      [name]: {
+        total: currTotal + stat.total,
+      },
+    }
+  }, curr)
+
+const sumDependencyVersion = (curr = {}, next = {}) =>
+  Object.entries(next).reduce((acc, [version, stat]) => ({
+    ...acc,
+    [version]: sumDataplanes(acc[version], stat),
+  }), curr)
+
+const sumVersions = (curr = {}, next = {}) => ({
+  kumaDp: sumDependencyVersion(curr.kumaDp, next.kumaDp),
+  envoy: sumDependencyVersion(curr.envoy, next.envoy),
+})
+
+export function getEmptyInsight () {
+  return {
+    meshesTotal: 0,
+    dataplanes: { online: 0, offline: 0, total: 0 },
+    policies: getInitialPolicies(),
+    dpVersions: { kumaDp: {}, envoy: {} }
+  }
+}
+
+export function parseInsightReducer (insight = {}) {
+  return mergeInsightsReducer([insight])
+}
+
+export function mergeInsightsReducer (insights = []) {
+  return insights.reduce((acc, insight) => ({
+    meshesTotal: insights.length,
+    dataplanes: sumDataplanes(acc.dataplanes, insight.dataplanes),
+    policies: sumPolicies(acc.policies, insight.policies),
+    dpVersions: sumVersions(acc.dpVersions, insight.dpVersions),
+  }), {})
+}

--- a/src/views/Overview.vue
+++ b/src/views/Overview.vue
@@ -67,8 +67,6 @@
 <script>
 import { mapGetters } from 'vuex'
 
-import 'vue-progress-path/dist/vue-progress-path.css'
-
 import MetricGrid from '@/components/Metrics/MetricGrid.vue'
 import CardSkeleton from '@/components/Skeletons/CardSkeleton'
 import Resources from '@/components/Resources'


### PR DESCRIPTION
- Refactored `fetch*` actions to remove duplicates
- Introduced new methods to call api endpoints for mesh insights
- Introduced `fetchAllMeshInsights` action + appropriate state
  and mutation
- Changed chained promises to fully use the `async/away` way,
  which was already being used but somehow mixed with raw promises
- Removed console.err when request failed from restClient,
  as it was not propagating errors higher and even failed
  request was marked as successful
- Fixed the type of store.version as it was failing in Header component
  as there was a data race
- Introduced concept of reducers (from react), a functions which are
  processing data in mutations.

  Maybe in the future, when the store will be divided into more
  modules, it would be good to get rid of reducers in favor of
  native Vue mutations, but currently it's much more readable
  to place these functions in one, separate file
- Introduced in state `meshInsightsFetching` property, which
  can be used in the future for some "loading" bar purposes
- Removed `dataplaneInsights` as they are currently unnecessary,
  as all data we were using it for are currently replaced by
  mesh insights
- Removed unnecessary mutations related to dataplane insights
- Refactored/fixed `fetchMeshInsights` action, which was wrong
  before as it is different, depending on mesh parameter
- Set default theme for amcharts charts to be animated
- Refactored `Overview` view to use mesh insights instead of multiple
  different endpoints

## Changes in charts

- Styles:
  - Restored radius on series
  - Added space (stroke/border) on series, which adds effect of
    white space between series
  - Because of removing top title, enlarged the chart

- Title/SumLabel:
  - Removed titles from top, and placed them inside instead of word
    `Total`
  - Set font color to main theme light `[rgba(41, 11, 83, 0.75)]`
  - Capitalized text
  - Set bold font weight for the amount number inside
- Labels:
  - Labels of series are now placed inside of series
  - Labels are now transparent for events, to not block clicks
  - Changed styles of series labels:
    - They are capitalized
    - They are white
    - Spacing between letters is set to 0.1em
- Tooltips:
  - Restored tooltips on non-disabled charts when hovering, with
    exception of `Zones` chart
  - Changed styles for tooltips:
    - Removed stroke
  - Tooltips now follows the cursor

- Other:
  - Introduced animation when charts initially load
  - Removed unused and unnecessary logic for setting `zIndex`
    property for charts
  - Change order of charts, now services are placed inside (second
    position), and dataplanes on the right (third position)


https://user-images.githubusercontent.com/11655498/105958876-7e3b6e00-607b-11eb-8da9-32b97b5ae31f.mov

Still missing:
- [ ] [Improve chart labels edge cases behaviour/look](https://github.com/kumahq/kuma-gui/pull/130)