### PR TITLE
fix(charts) check if there is chart logo before

### DIFF
--- a/src/mixins/PieChart.js
+++ b/src/mixins/PieChart.js
@@ -381,10 +381,12 @@ export default {
         window.series = this.series
       }
 
-      this.chart.logo.disabled = !this.displayAmChartsLogo
+      if (this.chart.logo) {
+        this.chart.logo.disabled = !this.displayAmChartsLogo
 
-      if (this.displayAmChartsLogo) {
-        this.chart.logo.properties.align = 'right'
+        if (this.displayAmChartsLogo) {
+          this.chart.logo.properties.align = 'right'
+        }
       }
 
       this.series.labels.template.disabled = this.hideSliceLabels


### PR DESCRIPTION
If there is a license for amcharts provided, there is no `this.chart.logo` present