### PR TITLE
UTM strings for Google Analytics

### DIFF
--- a/.env
+++ b/.env
@@ -8,3 +8,5 @@ VUE_APP_SHOW_ENTERPRISE_BUTTON=true
 VUE_APP_LOGO=kuma-logo-new.svg
 VUE_APP_KUMA_DP_SERVER_URL=https://localhost:5678/
 VUE_APP_AMCHARTS_LICENSE=''
+# utm values
+VUE_APP_UTM=?utm_source=Kuma&utm_medium=Kuma-GUI

--- a/src/components/Resources.vue
+++ b/src/components/Resources.vue
@@ -40,7 +40,7 @@ export default {
         ? storedVersion
         : 'latest'
 
-      const utmSource = '?utm_source=Kuma-GUI'
+      const utmSource = process.env.VUE_APP_UTM
 
       if (storedVersion) {
         return [

--- a/src/components/Utils/EnterpriseBox.vue
+++ b/src/components/Utils/EnterpriseBox.vue
@@ -30,7 +30,7 @@ export default {
   name: 'EnterpriseBox',
   data () {
     return {
-      url: 'https://kuma.io/enterprise/?utm_source=Kuma-GUI'
+      url: `https://kuma.io/enterprise/${process.env.VUE_APP_UTM}`
     }
   },
 }

--- a/src/components/Utils/UpgradeCheck.vue
+++ b/src/components/Utils/UpgradeCheck.vue
@@ -34,7 +34,7 @@ export default {
   name: 'UpgradeCheck',
   data () {
     return {
-      url: `${process.env.VUE_APP_INSTALL_URL}?utm_source=Kuma-GUI`,
+      url: `${process.env.VUE_APP_INSTALL_URL}${process.env.VUE_APP_UTM}`,
       latestVerSrc: process.env.VUE_APP_VERSION_URL,
       latestVer: null,
       showNotice: false

--- a/src/views/Onboarding/Complete.vue
+++ b/src/views/Onboarding/Complete.vue
@@ -18,7 +18,7 @@
         </div>
         <div class="app-source-check__content px-2">
           <p>
-            <strong>Secure your traffic:</strong> by using the <a :href="`https://kuma.io/docs/${runningVersion}/policies/#mutual-tls?utm_source=Kuma-GUI`">mTLS policy</a>
+            <strong>Secure your traffic:</strong> by using the <a :href="`https://kuma.io/docs/${runningVersion}/policies/#mutual-tls${process.env.VUE_APP_UTM}`">mTLS policy</a>
           </p>
         </div>
       </div>
@@ -30,7 +30,7 @@
           >
         </div>
         <div class="app-source-check__content px-2">
-          <strong>Route your requests:</strong> by using the <a :href="`https://kuma.io/docs/${runningVersion}/policies/#traffic-route?utm_source=Kuma-GUI`">Traffic Route</a> policy
+          <strong>Route your requests:</strong> by using the <a :href="`https://kuma.io/docs/${runningVersion}/policies/#traffic-route${process.env.VUE_APP_UTM}`">Traffic Route</a> policy
         </div>
       </div>
       <div class="flex items-center">
@@ -41,7 +41,7 @@
           >
         </div>
         <div class="app-source-check__content px-2">
-          <p><strong>Log your traffic</strong>, by using the <a :href="`https://kuma.io/docs/${runningVersion}/policies/#traffic-log?utm_source=Kuma-GUI`">Traffic Log</a> policy</p>
+          <p><strong>Log your traffic</strong>, by using the <a :href="`https://kuma.io/docs/${runningVersion}/policies/#traffic-log${process.env.VUE_APP_UTM}`">Traffic Log</a> policy</p>
         </div>
       </div>
       <div class="flex items-center">
@@ -52,7 +52,7 @@
           >
         </div>
         <div class="app-source-check__content px-2">
-          <p><strong>Trace your traffic</strong>, by using the <a :href="`https://kuma.io/docs/${runningVersion}/policies/#traffic-trace?utm_source=Kuma-GUI`">Traffic Trace</a> policy</p>
+          <p><strong>Trace your traffic</strong>, by using the <a :href="`https://kuma.io/docs/${runningVersion}/policies/#traffic-trace${process.env.VUE_APP_UTM}`">Traffic Trace</a> policy</p>
         </div>
       </div>
       <div class="flex items-center">
@@ -63,7 +63,7 @@
           >
         </div>
         <div class="app-source-check__content px-2">
-          <p><strong>Inject Fault</strong>, by using the <a :href="`https://kuma.io/docs/${runningVersion}/policies/#fault-injections?utm_source=Kuma-GUI`">Fault Injection</a> policy</p>
+          <p><strong>Inject Fault</strong>, by using the <a :href="`https://kuma.io/docs/${runningVersion}/policies/#fault-injections${process.env.VUE_APP_UTM}`">Fault Injection</a> policy</p>
         </div>
       </div>
       <div class="flex items-center">
@@ -74,7 +74,7 @@
           >
         </div>
         <div class="app-source-check__content px-2">
-          <p><strong>And you can do <a :href="`https://kuma.io/docs/${runningVersion}/policies/?utm_source=Kuma-GUI`">much more</a>!</strong></p>
+          <p><strong>And you can do <a :href="`https://kuma.io/docs/${runningVersion}/policies/${process.env.VUE_APP_UTM}`">much more</a>!</strong></p>
         </div>
       </div>
     </div>

--- a/src/views/Overview.vue
+++ b/src/views/Overview.vue
@@ -82,7 +82,7 @@
       <div>
         <CardSkeleton
           class="card-item"
-          card-action-route="https://kuma.io/policies/?utm_source=Kuma-GUI"
+          :card-action-route="cardActionPoliciesRoute"
           :card-title="`Apply ${title} policies`"
           card-action-button-text="Explore Policies"
         >
@@ -135,6 +135,9 @@ export default {
       areServicesLoading: 'getServiceResourcesFetching',
       getChart: 'getChart',
     }),
+    cardActionPoliciesRoute () {
+      return `https://kuma.io/policies/${process.env.VUE_APP_UTM}`
+    },
     dataplanesChart () {
       return this.getChart('dataplanes')
     },

--- a/src/views/Wizard/views/Mesh.vue
+++ b/src/views/Wizard/views/Mesh.vue
@@ -589,7 +589,7 @@
           </p>
           <p>
             <a
-              :href="`https://kuma.io/docs/${version}/policies/mesh/?utm_source=Kuma-GUI`"
+              :href="`https://kuma.io/docs/${version}/policies/mesh/${process.env.VUE_APP_UTM}`"
               target="_blank"
             >
               Learn More


### PR DESCRIPTION
I've added the UTM strings `utm_source` and `utm_medium` to URLs that go to the Kuma website from within the GUI so that we can track these events accordingly in Google Analytics.