### PR TITLE
feat(*) allw use of patterns in supported versions

### DIFF
--- a/src/dataplane.ts
+++ b/src/dataplane.ts
@@ -218,7 +218,20 @@ export function checkVersionsCompatibility (
     return { kind: INCOMPATIBLE_WRONG_FORMAT }
   }
 
-  const requirements: TODO = kumaDp[kumaDpVersion]
+  const versionKeys = Object.keys(kumaDp)
+  let requirements: TODO = kumaDp[kumaDpVersion]
+
+  if (!requirements) {
+    for (let i = 0; i < versionKeys.length; i++) {
+      const currentVersion = versionKeys[i]
+
+      if (satisfies(kumaDpVersion, currentVersion)) {
+        requirements = kumaDp[currentVersion]
+
+        break
+      }
+    }
+  }
 
   if (!requirements) {
     return {


### PR DESCRIPTION
With this changes, API endpoint with supported versions can return not only explicitly specified full versions, but also things like:
```
    "1.1.*": {
      "envoy": "~1.17.0"
    }
```