### PR TITLE
fix(restClient) status fetching

### DIFF
--- a/src/services/restClient.ts
+++ b/src/services/restClient.ts
@@ -97,9 +97,9 @@ export default class RestClient {
     const opts = await options || {}
     const url = await path
     const client = await this.client
-    const { statusText } = await client.get(url, opts)
+    const { status } = await client.get(url, opts)
 
-    return statusText
+    return status === 200 ? 'OK' : null
   }
 
   /** fetch all Kuma API endpoints */


### PR DESCRIPTION
According to specification of `fetch` API (in refs), field
`statusText` will be empty in `HTTP 2`, and it was causing problems
as there is inconsistency and everything was working fine
in Firefox, as it looks like they are not following
very strictly this part of the specification and even in `HTTP 2`
this field was equal `OK`, but it was not working on Chrome

refs.
https://fetch.spec.whatwg.org/#concept-response-status-message