### PR TITLE
fix(*) ExternalServices view when empty mtls block

### DIFF
--- a/src/views/Entities/ExternalServices.vue
+++ b/src/views/Entities/ExternalServices.vue
@@ -305,8 +305,11 @@ export default {
               }
 
               this.tableData.data = this.tableData.data.map(entity => {
-                entity.address = entity.networking.address
-                entity.tlsEnabled = entity.networking.tls.enabled ? 'Enabled' : 'Disabled'
+                const { networking = {} } = entity
+                const { tls = {} } = networking
+
+                entity.address = networking.address
+                entity.tlsEnabled = tls.enabled ? 'Enabled' : 'Disabled'
 
                 return entity
               })


### PR DESCRIPTION
GUI was crashing when received response with external service
without specified (even empty) `networking.mtls` block

Signed-off-by: Bart Smykla <bartek@smykla.com>