### PR TITLE
chore(*) fix dataplane token command

### DIFF
--- a/src/views/Wizard/views/DataplaneUniversal.vue
+++ b/src/views/Wizard/views/DataplaneUniversal.vue
@@ -582,7 +582,7 @@ export default {
     generateDpTokenCodeOutput () {
       const { meshName, univDataplaneId } = this.validate
 
-      const cmdStructure = `kumactl generate dataplane-token --dataplane=${univDataplaneId} > kuma-token-${univDataplaneId}`
+      const cmdStructure = `kumactl generate dataplane-token --name=${univDataplaneId} > kuma-token-${univDataplaneId}`
 
       return cmdStructure
     },


### PR DESCRIPTION
Fix the dataplane token command. The `--dataplane` flag ought to be
`--name`.

This fixes #168.

Signed-off-by: James Peach <james.peach@konghq.com>