### PR TITLE
fix(*) fix wrong dp type

### DIFF
--- a/src/views/Entities/GatewayDataplanes.vue
+++ b/src/views/Entities/GatewayDataplanes.vue
@@ -21,9 +21,6 @@ export default {
         gateway: true,
       },
       emptyStateMsg: 'There are no Gateway data plane proxies present.',
-      getDataplaneType () {
-        return 'Gateway'
-      },
     }
   },
 }

--- a/src/views/Entities/StandardDataplanes.vue
+++ b/src/views/Entities/StandardDataplanes.vue
@@ -2,7 +2,6 @@
   <div class="standard-dataplanes">
     <Dataplanes
       :dataplane-api-params="{ gateway: false, ingress: false }"
-      :get-dataplane-type="getDataplaneType"
       empty-state-msg="There are no Standard data plane proxies present."
     />
   </div>
@@ -18,11 +17,6 @@ export default {
   },
   components: {
     Dataplanes,
-  },
-  methods: {
-    getDataplaneType () {
-      return 'Standard'
-    }
   },
 }
 </script>


### PR DESCRIPTION
The issue was because we weren't passing `dataplane` param into the function. After it has been provided, the issue is gone.
Also, it will remove `getDataplaneType` from being a prop as we have a generic function that is handling that behaviour properly.
Also removed `addDataFields` as it was doing nothing and did a small refactor following the boy scout rule.


Screenshots:
### All dps
![Screenshot 2021-07-09 at 10 37 15](https://user-images.githubusercontent.com/16152347/125049843-b1117580-e0a1-11eb-87d5-de7d573843d0.png)

### Standard dps
![Screenshot 2021-07-09 at 10 37 22](https://user-images.githubusercontent.com/16152347/125049853-b373cf80-e0a1-11eb-88e4-97b51f57133b.png)

### Gateway dps
![Screenshot 2021-07-09 at 10 37 27](https://user-images.githubusercontent.com/16152347/125049855-b40c6600-e0a1-11eb-8a30-bec686948a07.png)


Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>