### PR TITLE
bug(*) fix issue on safari with wrongly displayed buttons

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -9,3 +9,7 @@ body {
   font-family: var(--base-font-family);
   /* font-size: var(--base-font-size); */
 }
+
+button, [type=button], [type=reset], [type=submit] {
+  -webkit-appearance: none;
+  }


### PR DESCRIPTION
It fixes a bug reported in: https://github.com/kumahq/kuma-gui/issues/183
Because tailwind set default appearance in Safari we need to disable it to allow us doing changes to how buttons look like.

Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>