### PR TITLE
feat(*) disable onboarding when no requirement fulfilled to display it

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,7 +40,7 @@ export default {
     },
   },
   data() {
-    return { loading: true, timeount: null }
+    return { loading: true, timeout: null }
   },
   computed: {
     ...mapState({
@@ -51,9 +51,9 @@ export default {
     }),
   },
   watch: {
-    globalLoading: function (val) {
+    globalLoading: function (loading) {
       this.timeout = setTimeout(() => {
-        this.loading = val
+        this.loading = loading
       }, 200)
     },
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,23 +36,36 @@ export default {
     title: 'Home',
     titleTemplate: `%s | ${process.env.VUE_APP_NAMESPACE}`,
     htmlAttrs: {
-      lang: 'en'
-    }
+      lang: 'en',
+    },
+  },
+  data() {
+    return { loading: true, timeount: null }
   },
   computed: {
     ...mapState({
-      loading: state => state.globalLoading
+      globalLoading: (state) => state.globalLoading,
     }),
     ...mapGetters({
-      status: 'config/getStatus'
-    })
+      status: 'config/getStatus',
+    }),
   },
-  beforeMount () {
+  watch: {
+    globalLoading: function (val) {
+      this.timeout = setTimeout(() => {
+        this.loading = val
+      }, 200)
+    },
+  },
+  beforeMount() {
     this.bootstrap()
   },
+  destroyed() {
+    clearTimeout(this.timeout)
+  },
   methods: {
-    ...mapActions(['bootstrap'])
-  }
+    ...mapActions(['bootstrap']),
+  },
 }
 </script>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,7 @@ function VUE_APP () {
   Vue.prototype.$api = kuma
 
   const store = new Vuex.Store(Store(kuma))
-  const router = Router()
+  const router = Router(store)
 
   new Vue({
     store,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -172,6 +172,12 @@ export default (api: Kuma): Module<RootInterface, RootInterface> => ({
     getSupportedVersions: ({ supportedVersions }) => supportedVersions,
     getSupportedVersionsFetching: ({ supportedVersionsFetching }) => supportedVersionsFetching,
     getSupportedVersionsFailed: ({ supportedVersionsFailed }) => supportedVersionsFailed,
+    showOnboarding: ({ totalDataplaneCount, meshes }) => {
+      const onlyDefaultMesh = meshes.total === 1 && meshes.items[0].name === 'default'
+      const noDataplane = totalDataplaneCount === 0
+
+      return noDataplane && onlyDefaultMesh
+    }
   },
   mutations: {
     SET_ONBOARDING_STATUS: (state, status) => (state.onboardingComplete = status),

--- a/src/views/Shell.vue
+++ b/src/views/Shell.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapGetters } from 'vuex'
 import Sidebar from '@/components/Sidebar/Sidebar'
 import OnboardingCheck from '@/components/Utils/OnboardingCheck'
 import Breadcrumbs from '@/components/Breadcrumbs.vue'
@@ -26,16 +26,9 @@ export default {
     OnboardingCheck,
   },
   computed: {
-    ...mapState({
-      dpCount: 'totalDataplaneCount',
-      meshes: 'meshes',
+    ...mapGetters({
+      showOnboarding: 'showOnboarding',
     }),
-    showOnboarding() {
-      const onlyDefaultMesh = this.meshes.total === 1 && this.meshes.items[0].name === 'default'
-      const noDataplane = this.dpCount === 0
-
-      return noDataplane && onlyDefaultMesh
-    },
   },
 }
 </script>


### PR DESCRIPTION
### Summary
We no longer want to display onboarding for users which already have fulfilled the condition to display onboarding popup. 

So we are redirecting into onboarding view only if the user has default mesh and no dataplanes and did not seen already the onboarding view. In any other case we are no longer redirecting into onboarding and if user try to open that page it will be redirected into global overview.

### Explanation of changes 

As right now we have to wait in the router to make sure we can check condition if the page should be displayed or not (so we need to wait till all bootstrap action will be resolved, and `globalLoading` will change into `false`) it caused a flash of the blank screen after loading is finished (movie below). To avoid that I provided a delay on change on loading in `App.vue` to make sure that all calculations done in routing will be finished after that. It is something that will be changed in the future after we change the onboarding.

#### Without delay

https://user-images.githubusercontent.com/16152347/128845079-cf9f697d-0df7-4e77-b338-c6f1548cde67.mov

#### With delay 

https://user-images.githubusercontent.com/16152347/128845369-fb5228c1-f92c-4b14-8bd0-fd790438fd07.mov





Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>