### PR TITLE
bug(*) set proper route on click

### DIFF
--- a/src/components/Sidebar/NavItem.spec.ts
+++ b/src/components/Sidebar/NavItem.spec.ts
@@ -1,0 +1,23 @@
+import renderWithVuex from '@/testUtils/renderWithVuex'
+import TestComponent from '@/testUtils/TestComponent.vue'
+import NavItem from './NavItem.vue'
+
+describe('NavItem.vue', () => {
+  it('renders snapshot with link to selected mesh', async () => {
+    const { container } = renderWithVuex(NavItem, {
+      routes: [
+        {
+          path: '/:mesh/default',
+          name: 'default',
+          component: TestComponent,
+        },
+      ],
+      propsData: {
+        name: 'Default',
+        link: 'default',
+      },
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/components/Sidebar/NavItem.vue
+++ b/src/components/Sidebar/NavItem.vue
@@ -53,6 +53,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { datadogLogs } from '@datadog/browser-logs'
 import { datadogLogEvents } from '@/datadogEvents'
 
@@ -103,8 +104,13 @@ export default {
     }
   },
   computed: {
+    ...mapGetters({
+      selectedMesh: 'getSelectedMesh',
+    }),
     routerLink() {
-      const params = !this.subNav && Object.keys(this.$route?.params || {}).length > 0 ? this.$route?.params : undefined
+      const params = {
+        mesh: this.selectedMesh,
+      }
 
       const link = () => {
         if (this.link) {

--- a/src/components/Sidebar/__snapshots__/NavItem.spec.ts.snap
+++ b/src/components/Sidebar/__snapshots__/NavItem.spec.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavItem.vue renders snapshot with link to selected mesh 1`] = `
+<div>
+  <div
+    class="nav-item is-menu-item"
+  >
+     
+    <a
+      class=""
+      href="#/all/default"
+    >
+      <!---->
+       
+      <div
+        class="nav-link"
+      >
+        
+        Default
+      
+      </div>
+       
+    </a>
+  </div>
+</div>
+`;

--- a/src/components/Utils/MeshSelector.vue
+++ b/src/components/Utils/MeshSelector.vue
@@ -35,6 +35,8 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   name: 'MeshSelector',
   props: {
@@ -44,12 +46,9 @@ export default {
     },
   },
   computed: {
-    selectedMesh() {
-      const stored = localStorage.getItem('selectedMesh')
-      const query = this.$route.params.mesh
-
-      return stored || query
-    },
+    ...mapGetters({
+      selectedMesh: 'getSelectedMesh',
+    }),
   },
   methods: {
     changeMesh(event) {


### PR DESCRIPTION
### Summary
When we open a page on "zones" or "zone ingress" and then refresh and change from "all meshes" into a different one and try to access some other page - we will be redirected to overview with URL pointing to "all" instead of specific mesh and with wrong data displayed.

### Bug video
https://user-images.githubusercontent.com/16152347/129707151-d800757c-eaf1-450a-9ff7-7b2b24213b03.mov


### Fixed

https://user-images.githubusercontent.com/16152347/129707535-91b1f1f1-64a7-46d2-8b7f-df8938d2d568.mov




Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>