### PR TITLE
refactor(*) cleanup of vuex store

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -28,38 +28,11 @@ export default (): Module<RootInterface, RootInterface> => ({
     meshes: {},
     dataplanes: [],
     selectedMesh: 'all', // shows all meshes on initial load
-    totalMeshCount: 0,
-    totalInternalServiceCount: 0,
-    totalExternalServiceCount: 0,
     totalDataplaneCount: 0,
-    totalHealthCheckCount: 0,
-    totalProxyTemplateCount: 0,
-    totalTrafficLogCount: 0,
-    totalTrafficPermissionCount: 0,
-    totalTrafficRouteCount: 0,
-    totalTrafficTraceCount: 0,
-    totalFaultInjectionCount: 0,
-    totalCircuitBreakerCount: 0,
-    totalRateLimitCount: 0,
-    totalRetryCount: 0,
-    totalTimeoutCount: 0,
+
     totalDataplaneList: [],
     anyDataplanesOffline: null,
-    // from mesh
-    totalHealthCheckCountFromMesh: 0,
-    totalProxyTemplateCountFromMesh: 0,
-    totalTrafficLogCountFromMesh: 0,
-    totalTrafficPermissionCountFromMesh: 0,
-    totalTrafficRouteCountFromMesh: 0,
-    totalTrafficTraceCountFromMesh: 0,
-    totalFaultInjectionCountFromMesh: 0,
-    totalCircuitBreakerCountFromMesh: 0,
-    totalInternalServiceCountFromMesh: 0,
-    totalExternalServiceCountFromMesh: 0,
-    totalDataplaneCountFromMesh: 0,
-    totalRateLimitCountFromMesh: 0,
-    totalRetryCountFromMesh: 0,
-    totalTimeoutCountFromMesh: 0,
+
     version: '',
     itemQueryNamespace: 'item',
     totalClusters: 0,
@@ -114,55 +87,17 @@ export default (): Module<RootInterface, RootInterface> => ({
     getDataplanes: state => state.dataplanes,
     getDataplanesList: state => state.totalDataplaneList,
     getAnyDpOffline: state => state.anyDataplanesOffline,
-    // total counts for all meshes
-    getTotalMeshCount: state => state.totalMeshCount,
-    getTotalInternalServiceCount: state => state.totalInternalServiceCount,
-    getTotalExternalServiceCount: state => state.totalExternalServiceCount,
-    getTotalDataplaneCount: state => state.totalDataplaneCount,
-    getTotalHealthCheckCount: state => state.totalHealthCheckCount,
-    getTotalProxyTemplateCount: state => state.totalProxyTemplateCount,
-    getTotalTrafficLogCount: state => state.totalTrafficLogCount,
-    getTotalTrafficPermissionCount: state => state.totalTrafficPermissionCount,
-    getTotalTrafficRouteCount: state => state.totalTrafficRouteCount,
-    getTotalTrafficTraceCount: state => state.totalTrafficTraceCount,
-    getTotalFaultInjectionCount: state => state.totalFaultInjectionCount,
-    getTotalCircuitBreakerCount: state => state.totalCircuitBreakerCount,
-    getTotalRateLimitCount: state => state.totalRateLimitCount,
-    getTotalRetryCount: state => state.totalRetryCount,
-    getTotalTimeoutCount: state => state.totalTimeoutCount,
-    // total counts per single mesh
-    getTotalInternalServiceCountFromMesh: state => state.totalInternalServiceCountFromMesh,
-    getTotalExternalServiceCountFromMesh: state => state.totalExternalServiceCountFromMesh,
-    getTotalDataplaneCountFromMesh: state => state.totalDataplaneCountFromMesh,
-    getTotalTrafficRoutesCountFromMesh: state => state.totalTrafficRouteCountFromMesh,
-    getTotalTrafficPermissionsCountFromMesh: state => state.totalTrafficPermissionCountFromMesh,
-    getTotalHealthChecksCountFromMesh: state => state.totalHealthCheckCountFromMesh,
-    getTotalProxyTemplatesCountFromMesh: state => state.totalProxyTemplateCountFromMesh,
-    getTotalTrafficLogsFromMesh: state => state.totalTrafficLogCountFromMesh,
-    getTotalTrafficTracesCountFromMesh: state => state.totalTrafficTraceCountFromMesh,
-    getTotalFaultInjectionsCountFromMesh: state => state.totalFaultInjectionCountFromMesh,
-    getTotalCircuitBreakersCountFromMesh: state => state.totalCircuitBreakerCountFromMesh,
-    getTotalRateLimitCountFromMesh: state => state.totalRateLimitCountFromMesh,
-    getTotalRetryCountFromMesh: state => state.totalRetryCountFromMesh,
-    getTotalTimeoutCountFromMesh: state => state.totalTimeoutCountFromMesh,
 
     getItemQueryNamespace: state => state.itemQueryNamespace,
     getClusterCount: state => state.totalClusters,
-    getServiceInsightsFromMesh: ({ serviceInsights }) => filterResourceByMesh(serviceInsights),
-    getExternalServicesFromMesh: ({ externalServices }) => filterResourceByMesh(externalServices),
     getMeshInsight: state => state.meshInsight,
     getMeshInsightsFetching: state => state.meshInsightsFetching,
-    getServiceInsightsFetching: state => state.serviceInsightsFetching,
-    getExternalServicesFetching: state => state.externalServicesFetching,
-    getResourceFetching: ({ meshInsightsFetching, serviceInsightsFetching, externalServicesFetching }) =>
-      meshInsightsFetching || serviceInsightsFetching || externalServicesFetching,
     getServiceResourcesFetching: ({ serviceInsightsFetching, externalServicesFetching }) =>
       serviceInsightsFetching || externalServicesFetching,
     getChart: ({ overviewCharts }) => (chartName: string) => overviewCharts[chartName],
     getZonesInsightsFetching: ({ zonesInsightsFetching }) => zonesInsightsFetching,
     getSupportedVersions: ({ supportedVersions }) => supportedVersions,
     getSupportedVersionsFetching: ({ supportedVersionsFetching }) => supportedVersionsFetching,
-    getSupportedVersionsFailed: ({ supportedVersionsFailed }) => supportedVersionsFailed,
     showOnboarding: ({ totalDataplaneCount, meshes }) => {
       const onlyDefaultMesh = meshes.total === 1 && meshes.items[0].name === 'default'
       const noDataplane = totalDataplaneCount === 0
@@ -176,36 +111,8 @@ export default (): Module<RootInterface, RootInterface> => ({
     FETCH_ALL_MESHES: (state, meshes) => (state.meshes = meshes),
     FETCH_DATAPLANES_FROM_MESH: (state, dataplanes) => (state.dataplanes = dataplanes),
     SET_SELECTED_MESH: (state, mesh) => (state.selectedMesh = mesh),
-    SET_TOTAL_MESH_COUNT: (state, count) => (state.totalMeshCount = count),
     SET_TOTAL_DATAPLANE_COUNT: (state, count) => (state.totalDataplaneCount = count),
-    SET_TOTAL_INTERNAL_SERVICE_COUNT: (state, count) => (state.totalInternalServiceCount = count),
-    SET_TOTAL_EXTERNAL_SERVICE_COUNT: (state, count) => (state.totalExternalServiceCount = count),
-    SET_TOTAL_HEALTH_CHECK_COUNT: (state, count) => (state.totalHealthCheckCount = count),
-    SET_TOTAL_PROXY_TEMPLATE_COUNT: (state, count) => (state.totalProxyTemplateCount = count),
-    SET_TOTAL_TRAFFIC_LOG_COUNT: (state, count) => (state.totalTrafficLogCount = count),
-    SET_TOTAL_TRAFFIC_PERMISSION_COUNT: (state, count) => (state.totalTrafficPermissionCount = count),
-    SET_TOTAL_TRAFFIC_ROUTE_COUNT: (state, count) => (state.totalTrafficRouteCount = count),
-    SET_TOTAL_TRAFFIC_TRACE_COUNT: (state, count) => (state.totalTrafficTraceCount = count),
     SET_TOTAL_DP_LIST: (state, dataplanes) => (state.totalDataplaneList = dataplanes),
-    SET_TOTAL_FAULT_INJECTION_COUNT: (state, count) => (state.totalFaultInjectionCount = count),
-    SET_TOTAL_CIRCUIT_BREAKER_COUNT: (state, count) => (state.totalCircuitBreakerCount = count),
-    SET_TOTAL_RATE_LIMIT_COUNT: (state, count) => (state.totalRateLimitCount = count),
-    SET_TOTAL_RETRY_COUNT: (state, count) => (state.totalRetryCount = count),
-    SET_TOTAL_TIMEOUT_COUNT: (state, count) => (state.totalTimeoutCount = count),
-    SET_TOTAL_DATAPLANE_COUNT_FROM_MESH: (state, count) => (state.totalDataplaneCountFromMesh = count),
-    SET_TOTAL_INTERNAL_SERVICE_COUNT_FROM_MESH: (state, count) => (state.totalInternalServiceCountFromMesh = count),
-    SET_TOTAL_EXTERNAL_SERVICE_COUNT_FROM_MESH: (state, count) => (state.totalExternalServiceCountFromMesh = count),
-    SET_TOTAL_HEALTH_CHECK_COUNT_FROM_MESH: (state, count) => (state.totalHealthCheckCountFromMesh = count),
-    SET_TOTAL_PROXY_TEMPLATE_COUNT_FROM_MESH: (state, count) => (state.totalProxyTemplateCountFromMesh = count),
-    SET_TOTAL_TRAFFIC_LOG_COUNT_FROM_MESH: (state, count) => (state.totalTrafficLogCountFromMesh = count),
-    SET_TOTAL_TRAFFIC_PERMISSION_COUNT_FROM_MESH: (state, count) => (state.totalTrafficPermissionCountFromMesh = count),
-    SET_TOTAL_TRAFFIC_ROUTE_COUNT_FROM_MESH: (state, count) => (state.totalTrafficRouteCountFromMesh = count),
-    SET_TOTAL_TRAFFIC_TRACE_COUNT_FROM_MESH: (state, count) => (state.totalTrafficTraceCountFromMesh = count),
-    SET_TOTAL_FAULT_INJECTION_COUNT_FROM_MESH: (state, count) => (state.totalFaultInjectionCountFromMesh = count),
-    SET_TOTAL_CIRCUIT_BREAKER_COUNT_FROM_MESH: (state, count) => (state.totalCircuitBreakerCountFromMesh = count),
-    SET_TOTAL_RATE_LIMIT_COUNT_FROM_MESH: (state, count) => (state.totalRateLimitCountFromMesh = count),
-    SET_TOTAL_RETRY_COUNT_FROM_MESH: (state, count) => (state.totalRetryCountFromMesh = count),
-    SET_TOTAL_TIMEOUT_COUNT_FROM_MESH: (state, count) => (state.totalTimeoutCountFromMesh = count),
     SET_TOTAL_CLUSTER_COUNT: (state, count) => (state.totalClusters = count),
     SET_ANY_DP_OFFLINE: (state, status) => (state.anyDataplanesOffline = status),
 
@@ -307,17 +214,6 @@ export default (): Module<RootInterface, RootInterface> => ({
         })
     },
 
-    // fetch all dataplanes from a specific mesh
-    fetchDataplanesFromMesh({ commit }, mesh: string) {
-      return Kuma.getAllDataplanesFromMesh(mesh)
-        .then(response => {
-          commit('FETCH_DATAPLANES_FROM_MESH', response)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
     // update the selected mesh
     updateSelectedMesh({ commit }, mesh) {
       commit('SET_SELECTED_MESH', mesh)
@@ -325,9 +221,6 @@ export default (): Module<RootInterface, RootInterface> => ({
 
     /**
      * Total Counts (for all items)
-     *
-     * Setting the `size` to 1 on these requests prevents
-     * the unneeded listing of max 100 items.
      */
 
     // get total clusters (Zones) when in multicluster (or "Multi-Zone") mode
@@ -339,53 +232,6 @@ export default (): Module<RootInterface, RootInterface> => ({
       })
     },
 
-    // get the total number of meshes
-    fetchMeshTotalCount({ commit, state }) {
-      const params = {
-        size: state.meshPageSize,
-      }
-
-      return Kuma.getAllMeshes(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_MESH_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of internal services present
-    fetchInternalServiceTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllServiceInsights(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_INTERNAL_SERVICE_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of external services present
-    fetchExternalServiceTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllExternalServices(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_EXTERNAL_SERVICE_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
     // get the total number of dataplanes present
     fetchDataplaneTotalCount({ commit }) {
       const params = { size: 1 }
@@ -395,385 +241,6 @@ export default (): Module<RootInterface, RootInterface> => ({
           const total = response.total
 
           commit('SET_TOTAL_DATAPLANE_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of health checks present
-    fetchHealthCheckTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllHealthChecks(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_HEALTH_CHECK_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of proxy templates present
-    fetchProxyTemplateTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllProxyTemplates(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_PROXY_TEMPLATE_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of traffic logs present
-    fetchTrafficLogTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllTrafficLogs(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_TRAFFIC_LOG_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of traffic permissions present
-    fetchTrafficPermissionTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllTrafficPermissions(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_TRAFFIC_PERMISSION_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of traffic routes present
-    fetchTrafficRouteTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllTrafficRoutes(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_TRAFFIC_ROUTE_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of traffic traces present
-    fetchTrafficTraceTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllTrafficTraces(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_TRAFFIC_TRACE_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of fault injections present
-    fetchFaultInjectionTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllFaultInjections(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_FAULT_INJECTION_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of circuit breakers present
-    fetchCircuitBreakerTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllCircuitBreakers(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_CIRCUIT_BREAKER_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of rate limits present
-    fetchRateLimitTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllRateLimits(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_RATE_LIMIT_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of retries present
-    fetchRetryTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllRetries(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_RETRY_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of timeouts present
-    fetchTimeoutTotalCount({ commit }) {
-      const params = { size: 1 }
-
-      return Kuma.getAllTimeouts(params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_TIMEOUT_COUNT', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    /**
-     * Total counts (per mesh)
-     */
-
-    // get the total number of internal services from a specific mesh
-    fetchInternalServiceTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllServiceInsightsFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_INTERNAL_SERVICE_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of external services from a specific mesh
-    fetchExternalServiceTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllExternalServicesFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_EXTERNAL_SERVICE_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of dataplanes from a specific mesh
-    fetchDataplaneTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllDataplanesFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_DATAPLANE_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of health checks from a specific mesh
-    fetchHealthCheckTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllHealthChecksFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_HEALTH_CHECK_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of proxy templates from a specific mesh
-    fetchProxyTemplateTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllProxyTemplatesFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_PROXY_TEMPLATE_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of traffic logs from a specific mesh
-    fetchTrafficLogTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllTrafficLogsFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_TRAFFIC_LOG_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of traffic permissions from a specific mesh
-    fetchTrafficPermissionTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllTrafficPermissionsFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_TRAFFIC_PERMISSION_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of traffic routes from a specific mesh
-    fetchTrafficRouteTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllTrafficRoutesFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_TRAFFIC_ROUTE_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of traffic traces from a specific mesh
-    fetchTrafficTraceTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllTrafficTracesFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_TRAFFIC_TRACE_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of fault injections from a specific mesh
-    fetchFaultInjectionTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllFaultInjectionsFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_FAULT_INJECTION_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of circuit breakers from a specific mesh
-    fetchCircuitBreakerTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllCircuitBreakersFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_CIRCUIT_BREAKER_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of rate limits from a specific mesh
-    fetchRateLimitTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllRateLimitsFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_RATE_LIMIT_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of retries from a specific mesh
-    fetchRetryTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllRetriesFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_RETRY_COUNT_FROM_MESH', total)
-        })
-        .catch(error => {
-          console.error(error)
-        })
-    },
-
-    // get the total number of timeouts from a specific mesh
-    fetchTimeoutTotalCountFromMesh({ commit }, mesh) {
-      const params = { size: 1 }
-
-      return Kuma.getAllTimeoutsFromMesh(mesh, params)
-        .then(response => {
-          const total = response.total
-
-          commit('SET_TOTAL_TIMEOUT_COUNT_FROM_MESH', total)
         })
         .catch(error => {
           console.error(error)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -92,12 +92,17 @@ export default (): Module<RootInterface, RootInterface> => ({
     getClusterCount: state => state.totalClusters,
     getMeshInsight: state => state.meshInsight,
     getMeshInsightsFetching: state => state.meshInsightsFetching,
+    getServiceInsightsFetching: state => state.serviceInsightsFetching,
+    getExternalServicesFetching: state => state.externalServicesFetching,
+    getResourceFetching: ({ meshInsightsFetching, serviceInsightsFetching, externalServicesFetching }) =>
+      meshInsightsFetching || serviceInsightsFetching || externalServicesFetching,
     getServiceResourcesFetching: ({ serviceInsightsFetching, externalServicesFetching }) =>
       serviceInsightsFetching || externalServicesFetching,
     getChart: ({ overviewCharts }) => (chartName: string) => overviewCharts[chartName],
     getZonesInsightsFetching: ({ zonesInsightsFetching }) => zonesInsightsFetching,
     getSupportedVersions: ({ supportedVersions }) => supportedVersions,
     getSupportedVersionsFetching: ({ supportedVersionsFetching }) => supportedVersionsFetching,
+    getSupportedVersionsFailed: ({ supportedVersionsFailed }) => supportedVersionsFailed,
     showOnboarding: ({ totalDataplaneCount, meshes }) => {
       const onlyDefaultMesh = meshes.total === 1 && meshes.items[0].name === 'default'
       const noDataplane = totalDataplaneCount === 0

--- a/src/store/reducers/mesh-insights.ts
+++ b/src/store/reducers/mesh-insights.ts
@@ -20,7 +20,7 @@ const sumDataplanes = (curr: DataPlaneStats = {}, next: DataPlaneStats = {}) => 
   }
 }
 
-const getInitialPolicies = () => ({
+export const getInitialPolicies = () => ({
   CircuitBreaker: {
     total: 0,
   },

--- a/src/views/Entities/Meshes.vue
+++ b/src/views/Entities/Meshes.vue
@@ -169,7 +169,7 @@
 <script>
 import { mapState } from 'vuex'
 import Kuma from '@/services/kuma'
-import { getEmptyInsight } from '@/store/reducers/mesh-insights'
+import { getEmptyInsight, getInitialPolicies } from '@/store/reducers/mesh-insights'
 import { datadogLogs } from '@datadog/browser-logs'
 import { datadogLogEvents } from '@/datadogEvents'
 import { getSome, humanReadableDate, rawReadableDate, getOffset, stripTimes } from '@/helpers'
@@ -268,6 +268,11 @@ export default {
         dataplanes: { total },
       } = this.meshInsight
 
+      const allPolicies = {
+        ...getInitialPolicies(),
+        ...policies,
+      }
+
       return [
         {
           title: 'Data plane proxies',
@@ -275,47 +280,47 @@ export default {
         },
         {
           title: 'Circuit Breakers',
-          value: policies.CircuitBreaker?.total,
+          value: allPolicies.CircuitBreaker.total,
         },
         {
           title: 'Fault Injections',
-          value: policies.FaultInjection?.total,
+          value: allPolicies.FaultInjection.total,
         },
         {
           title: 'Health Checks',
-          value: policies.HealthCheck?.total,
+          value: allPolicies.HealthCheck.total,
         },
         {
           title: 'Proxy Templates',
-          value: policies.ProxyTemplate?.total,
+          value: allPolicies.ProxyTemplate.total,
         },
         {
           title: 'Traffic Logs',
-          value: policies.TrafficLog?.total,
+          value: allPolicies.TrafficLog.total,
         },
         {
           title: 'Traffic Permissions',
-          value: policies.TrafficPermission?.total,
+          value: allPolicies.TrafficPermission.total,
         },
         {
           title: 'Traffic Routes',
-          value: policies.TrafficRoute?.total,
+          value: allPolicies.TrafficRoute.total,
         },
         {
           title: 'Traffic Traces',
-          value: policies.TrafficTrace?.total,
+          value: allPolicies.TrafficTrace.total,
         },
         {
           title: 'Rate Limits',
-          value: policies.RateLimit?.total,
+          value: allPolicies.RateLimit.total,
         },
         {
           title: 'Retries',
-          value: policies.Retry?.total,
+          value: allPolicies.Retry.total,
         },
         {
           title: 'Timeouts',
-          value: policies.Timeout?.total,
+          value: allPolicies.Timeout.total,
         },
       ]
     },


### PR DESCRIPTION
### Sumary

As we introduced `mesh-insights` some time ago, there is no longer a need to request for each policy/dataplanes etc. independently, as we can retrieve it from aggregated data.
Because of that, it allows us to remove a lot of code and simplify the logic.



Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>