### PR TITLE
Chore/change endpoint

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,7 @@
 export const PRODUCT_NAME = process.env.VUE_APP_NAMESPACE
 export const PAGE_SIZE_DEFAULT = 12
 export const APP_WINDOW = window
+
+export const ONLINE = 'Online'
+export const OFFLINE = 'Offline'
+export const PARTIALLY_DEGRADED = 'Partially degraded'

--- a/src/dataplane.ts
+++ b/src/dataplane.ts
@@ -1,4 +1,5 @@
 import { humanReadableDate } from '@/helpers'
+import { ONLINE, OFFLINE, PARTIALLY_DEGRADED } from '@/consts'
 import { satisfies } from 'semver'
 import Kuma from '@/services/kuma'
 
@@ -89,14 +90,14 @@ export function getStatus(dataplane: DataPlane, dataplaneInsight: TODO = {}) {
     const allInboundsOnline = errors.length === 0
 
     if (!proxyOnline || allInboundsOffline) {
-      return 'Offline'
+      return OFFLINE
     }
 
     if (!allInboundsOnline) {
-      return 'Partially degraded'
+      return PARTIALLY_DEGRADED
     }
 
-    return 'Online'
+    return ONLINE
   }
 
   return {
@@ -106,10 +107,10 @@ export function getStatus(dataplane: DataPlane, dataplaneInsight: TODO = {}) {
 }
 
 /*
-getStatus takes ZoneIngressInsight and returns the status 'Online' or 'Offline'
+getItemStatusFromInsight takes object with subscriptions and returns the status 'Online' or 'Offline'
  */
-export function getZoneIngressStatus(zoneIngressInsight: TODO = {}) {
-  const subscriptions = zoneIngressInsight.subscriptions ? zoneIngressInsight.subscriptions : []
+export function getItemStatusFromInsight(item: TODO = {}): { status: typeof ONLINE | typeof OFFLINE } {
+  const subscriptions = item.subscriptions ? item.subscriptions : []
 
   const proxyOnline = subscriptions.some(
     (item: TODO) => item.connectTime && item.connectTime.length && !item.disconnectTime,
@@ -117,19 +118,15 @@ export function getZoneIngressStatus(zoneIngressInsight: TODO = {}) {
 
   const status = () => {
     if (proxyOnline) {
-      return 'Online'
+      return ONLINE
     }
 
-    return 'Offline'
+    return OFFLINE
   }
 
   return {
     status: status(),
   }
-}
-
-export function getStatusFromObject({ dataplane, dataplaneInsight }: { dataplane: DataPlane; dataplaneInsight: TODO }) {
-  return getStatus(dataplane, dataplaneInsight)
 }
 
 interface DataPlaneOverview {

--- a/src/dataplane.ts
+++ b/src/dataplane.ts
@@ -110,7 +110,7 @@ export function getStatus(dataplane: DataPlane, dataplaneInsight: TODO = {}) {
 getItemStatusFromInsight takes object with subscriptions and returns the status 'Online' or 'Offline'
  */
 export function getItemStatusFromInsight(item: TODO = {}): { status: typeof ONLINE | typeof OFFLINE } {
-  const subscriptions = item.subscriptions ? item.subscriptions : []
+  const { subscriptions = [] } = item
 
   const proxyOnline = subscriptions.some(
     (item: TODO) => item.connectTime && item.connectTime.length && !item.disconnectTime,

--- a/src/services/mock/responses/zones+insights.json
+++ b/src/services/mock/responses/zones+insights.json
@@ -1,5 +1,5 @@
 {
-  "total": 1,
+  "total": 4,
   "items": [
     {
       "type": "ZoneOverview",
@@ -157,6 +157,233 @@
                   "responsesAcknowledged": "1"
                 }
               }
+            },
+            "version": {
+              "kumaCp": {
+                "version": "1.0.0-rc2-211-g823fe8ce",
+                "gitTag": "1.0.0-rc2-211-g823fe8ce",
+                "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+                "buildDate": "2021-02-18T13:22:30Z"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "ZoneOverview",
+      "mesh": "default",
+      "name": "zone-1",
+      "creationTime": "2020-07-28T23:08:22.317322+07:00",
+      "modificationTime": "2020-07-28T23:08:22.317322+07:00",
+      "zone": {
+        "ingress": {
+          "address": "127.0.0.1:10000"
+        }
+      },
+      "zoneInsight": {
+        "subscriptions": [
+          {
+            "id": "466aa63b-70e8-4435-8bee-a7146e2cdf11",
+            "globalInstanceId": "66309679-ee95-4ea8-b17f-c715ca03bb38",
+            "connectTime": "2020-07-28T16:08:09.743141Z",
+            "disconnectTime": "2020-07-28T16:08:09.743194Z",
+            "status": {
+              "total": {}
+            },
+            "version": {
+              "kumaCp": {
+                "version": "1.2.0-rc2-211-g823fe8ce",
+                "gitTag": "1.0.0-rc2-211-g823fe8ce",
+                "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+                "buildDate": "2021-02-18T13:22:30Z"
+              }
+            }
+          },
+          {
+            "id": "f586f89c-2c4e-4f93-9a56-f0ea2ff010b7",
+            "globalInstanceId": "66309679-ee95-4ea8-b17f-c715ca03bb38",
+            "connectTime": "2020-07-28T16:08:24.760801Z",
+            "status": {
+              "lastUpdateTime": "2020-07-28T16:08:25.770774Z",
+              "total": {
+                "responsesSent": "11",
+                "responsesAcknowledged": "11"
+              },
+              "stat": {
+                "CircuitBreaker": {
+                  "responsesSent": "124",
+                  "responsesAcknowledged": "4509369"
+                },
+                "Dataplane": {
+                  "responsesSent": "9018614",
+                  "responsesAcknowledged": "13527859"
+                },
+                "FaultInjection": {
+                  "responsesSent": "18037104",
+                  "responsesAcknowledged": "22546349"
+                },
+                "HealthCheck": {
+                  "responsesSent": "27055594",
+                  "responsesAcknowledged": "31564839"
+                },
+                "Mesh": {
+                  "responsesSent": "36074084",
+                  "responsesAcknowledged": "40583329"
+                },
+                "ProxyTemplate": {
+                  "responsesSent": "45092574",
+                  "responsesAcknowledged": "49601819"
+                },
+                "Secret": {
+                  "responsesSent": "54111064",
+                  "responsesAcknowledged": "58620309"
+                },
+                "TrafficLog": {
+                  "responsesSent": "63129554",
+                  "responsesAcknowledged": "67638799"
+                },
+                "TrafficPermission": {
+                  "responsesSent": "72148044",
+                  "responsesAcknowledged": "76657289"
+                },
+                "TrafficRoute": {
+                  "responsesSent": "81166534",
+                  "responsesAcknowledged": "85675779"
+                },
+                "TrafficTrace": {
+                  "responsesSent": "90185024",
+                  "responsesAcknowledged": "94694269"
+                }
+              }
+            },
+            "version": {
+              "kumaCp": {
+                "version": "1.0.0-rc2-211-g823fe8ce",
+                "gitTag": "1.0.0-rc2-211-g823fe8ce",
+                "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+                "buildDate": "2021-02-18T13:22:30Z"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "ZoneOverview",
+      "mesh": "default",
+      "name": "zone-2",
+      "creationTime": "2018-07-17T16:05:36.995Z",
+      "modificationTime": "2019-07-17T18:08:41Z",
+      "zone": {
+        "ingress": {
+          "address": "192.168.1.2:1000"
+        }
+      },
+      "zoneInsight": {
+        "subscriptions": [
+          {
+            "id": "1",
+            "globalInstanceId": "node-001",
+            "connectTime": "2020-07-28T16:08:09.743141Z",
+            "status": {
+              "total": {}
+            },
+            "version": {
+              "kumaCp": {
+                "version": "1.0.0-rc2-211-g823fe8ce",
+                "gitTag": "1.0.0-rc2-211-g823fe8ce",
+                "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+                "buildDate": "2021-02-18T13:22:30Z"
+              }
+            }
+          },
+          {
+            "id": "2",
+            "globalInstanceId": "node-002",
+            "connectTime": "2020-07-28T16:08:09.743141Z",
+            "status": {
+              "total": {}
+            },
+            "version": {
+              "kumaCp": {
+                "version": "1.0.0-rc2-211-g823fe8ce",
+                "gitTag": "1.0.0-rc2-211-g823fe8ce",
+                "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+                "buildDate": "2021-02-18T13:22:30Z"
+              }
+            }
+          },
+          {
+            "id": "3",
+            "globalInstanceId": "node-003",
+            "connectTime": "2020-07-28T16:08:09.743141Z",
+            "status": {
+              "total": {}
+            },
+            "version": {
+              "kumaCp": {
+                "version": "1.0.0-rc2-211-g823fe8ce",
+                "gitTag": "1.0.0-rc2-211-g823fe8ce",
+                "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+                "buildDate": "2021-02-18T13:22:30Z"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "ZoneOverview",
+      "mesh": "default",
+      "name": "zone-3",
+      "creationTime": "2018-07-17T16:05:36.995Z",
+      "modificationTime": "2019-07-17T18:08:41Z",
+      "zone": {
+        "ingress": {
+          "address": "192.168.1.2:1000"
+        }
+      },
+      "zoneInsight": {
+        "subscriptions": [
+          {
+            "id": "1",
+            "globalInstanceId": "node-001",
+            "connectTime": "2020-07-28T16:08:09.743141Z",
+            "status": {
+              "total": {}
+            },
+            "version": {
+              "kumaCp": {
+                "version": "1.0.0-rc2-211-g823fe8ce",
+                "gitTag": "1.0.0-rc2-211-g823fe8ce",
+                "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+                "buildDate": "2021-02-18T13:22:30Z"
+              }
+            }
+          },
+          {
+            "id": "2",
+            "globalInstanceId": "node-002",
+            "connectTime": "2020-07-28T16:08:09.743141Z",
+            "status": {
+              "total": {}
+            },
+            "version": {
+              "kumaCp": {
+                "version": "1.0.0-rc2-211-g823fe8ce",
+                "gitTag": "1.0.0-rc2-211-g823fe8ce",
+                "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+                "buildDate": "2021-02-18T13:22:30Z"
+              }
+            }
+          },
+          {
+            "id": "3",
+            "globalInstanceId": "node-003",
+            "connectTime": "2020-07-28T16:08:09.743141Z",
+            "status": {
+              "total": {}
             },
             "version": {
               "kumaCp": {

--- a/src/services/mock/responses/zones+insights/cluster-1.json
+++ b/src/services/mock/responses/zones+insights/cluster-1.json
@@ -1,19 +1,19 @@
 {
   "type": "ZoneOverview",
   "name": "cluster-1",
-  "creationTime": "2021-02-19T11:58:05.898336+01:00",
-  "modificationTime": "2021-02-19T11:58:05.898336+01:00",
+  "creationTime": "2021-02-19T08:06:15.380674+01:00",
+  "modificationTime": "2021-02-19T08:06:15.380674+01:00",
   "zone": {
     "enabled": true
   },
   "zoneInsight": {
     "subscriptions": [
       {
-        "id": "4c4002d8-226b-4576-8f3c-21fe1ebfc928",
+        "id": "b21265cf-f856-4214-ad1b-42539c4b20a9",
         "globalInstanceId": "foobar",
-        "connectTime": "2021-02-19T10:58:05.898402Z",
+        "connectTime": "2021-02-19T07:06:15.380718Z",
         "status": {
-          "lastUpdateTime": "2021-02-19T10:58:06.902847Z",
+          "lastUpdateTime": "2021-02-19T07:06:16.384057Z",
           "total": {
             "responsesSent": "14",
             "responsesAcknowledged": "14"
@@ -79,7 +79,85 @@
         },
         "version": {
           "kumaCp": {
-            "version": "1.0.8",
+            "version": "1.0.0-rc2-211-g823fe8ce",
+            "gitTag": "1.0.0-rc2-211-g823fe8ce",
+            "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+            "buildDate": "2021-02-18T13:22:30Z"
+          }
+        }
+      },
+      {
+        "id": "3d3b7a11-e0f9-4f70-8cc9-2594318488d3",
+        "globalInstanceId": "MacBook-Pro-Bartlomiej.local-9e52",
+        "connectTime": "2021-02-19T07:07:15.535286Z",
+        "status": {
+          "lastUpdateTime": "2021-02-19T07:07:15.537654Z",
+          "total": {
+            "responsesSent": "14",
+            "responsesAcknowledged": "14"
+          },
+          "stat": {
+            "CircuitBreaker": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "Config": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "Dataplane": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "ExternalService": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "FaultInjection": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "HealthCheck": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "Mesh": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "ProxyTemplate": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "Retry": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "Secret": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "TrafficLog": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "TrafficPermission": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "TrafficRoute": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            },
+            "TrafficTrace": {
+              "responsesSent": "1",
+              "responsesAcknowledged": "1"
+            }
+          }
+        },
+        "version": {
+          "kumaCp": {
+            "version": "1.0.0-rc2-211-g823fe8ce",
             "gitTag": "1.0.0-rc2-211-g823fe8ce",
             "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
             "buildDate": "2021-02-18T13:22:30Z"

--- a/src/services/mock/responses/zones+insights/zone-1.json
+++ b/src/services/mock/responses/zones+insights/zone-1.json
@@ -18,6 +18,14 @@
         "disconnectTime": "2020-07-28T16:08:09.743194Z",
         "status": {
           "total": {}
+        },
+        "version": {
+          "kumaCp": {
+            "version": "1.2.0-rc2-211-g823fe8ce",
+            "gitTag": "1.0.0-rc2-211-g823fe8ce",
+            "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+            "buildDate": "2021-02-18T13:22:30Z"
+          }
         }
       },
       {
@@ -75,6 +83,14 @@
               "responsesSent": "90185024",
               "responsesAcknowledged": "94694269"
             }
+          }
+        },
+        "version": {
+          "kumaCp": {
+            "version": "1.0.0-rc2-211-g823fe8ce",
+            "gitTag": "1.0.0-rc2-211-g823fe8ce",
+            "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+            "buildDate": "2021-02-18T13:22:30Z"
           }
         }
       }

--- a/src/services/mock/responses/zones+insights/zone-2.json
+++ b/src/services/mock/responses/zones+insights/zone-2.json
@@ -13,15 +13,51 @@
     "subscriptions": [
       {
         "id": "1",
-        "globalInstanceId": "node-001"
+        "globalInstanceId": "node-001",
+        "connectTime": "2020-07-28T16:08:09.743141Z",
+        "status": {
+          "total": {}
+        },
+        "version": {
+          "kumaCp": {
+            "version": "1.0.0-rc2-211-g823fe8ce",
+            "gitTag": "1.0.0-rc2-211-g823fe8ce",
+            "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+            "buildDate": "2021-02-18T13:22:30Z"
+          }
+        }
       },
       {
         "id": "2",
-        "globalInstanceId": "node-002"
+        "globalInstanceId": "node-002",
+        "connectTime": "2020-07-28T16:08:09.743141Z",
+        "status": {
+          "total": {}
+        },
+        "version": {
+          "kumaCp": {
+            "version": "1.0.0-rc2-211-g823fe8ce",
+            "gitTag": "1.0.0-rc2-211-g823fe8ce",
+            "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+            "buildDate": "2021-02-18T13:22:30Z"
+          }
+        }
       },
       {
         "id": "3",
-        "globalInstanceId": "node-003"
+        "globalInstanceId": "node-003",
+        "connectTime": "2020-07-28T16:08:09.743141Z",
+        "status": {
+          "total": {}
+        },
+        "version": {
+          "kumaCp": {
+            "version": "1.0.0-rc2-211-g823fe8ce",
+            "gitTag": "1.0.0-rc2-211-g823fe8ce",
+            "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+            "buildDate": "2021-02-18T13:22:30Z"
+          }
+        }
       }
     ]
   }

--- a/src/services/mock/responses/zones+insights/zone-3.json
+++ b/src/services/mock/responses/zones+insights/zone-3.json
@@ -13,15 +13,51 @@
     "subscriptions": [
       {
         "id": "1",
-        "globalInstanceId": "node-001"
+        "globalInstanceId": "node-001",
+        "connectTime": "2020-07-28T16:08:09.743141Z",
+        "status": {
+          "total": {}
+        },
+        "version": {
+          "kumaCp": {
+            "version": "1.0.0-rc2-211-g823fe8ce",
+            "gitTag": "1.0.0-rc2-211-g823fe8ce",
+            "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+            "buildDate": "2021-02-18T13:22:30Z"
+          }
+        }
       },
       {
         "id": "2",
-        "globalInstanceId": "node-002"
+        "globalInstanceId": "node-002",
+        "connectTime": "2020-07-28T16:08:09.743141Z",
+        "status": {
+          "total": {}
+        },
+        "version": {
+          "kumaCp": {
+            "version": "1.0.0-rc2-211-g823fe8ce",
+            "gitTag": "1.0.0-rc2-211-g823fe8ce",
+            "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+            "buildDate": "2021-02-18T13:22:30Z"
+          }
+        }
       },
       {
         "id": "3",
-        "globalInstanceId": "node-003"
+        "globalInstanceId": "node-003",
+        "connectTime": "2020-07-28T16:08:09.743141Z",
+        "status": {
+          "total": {}
+        },
+        "version": {
+          "kumaCp": {
+            "version": "1.0.0-rc2-211-g823fe8ce",
+            "gitTag": "1.0.0-rc2-211-g823fe8ce",
+            "gitCommit": "823fe8cef6430a8f75e72a7224eb5a8ab571ec42",
+            "buildDate": "2021-02-18T13:22:30Z"
+          }
+        }
       }
     ]
   }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -456,7 +456,7 @@ export default (): Module<RootInterface, RootInterface> => ({
       let online = 0
 
       data.forEach((item: any): void => {
-        const status = getItemStatusFromInsight(item.zoneInsight).status
+        const { status } = getItemStatusFromInsight(item.zoneInsight)
 
         if (status === ONLINE) {
           online++

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -437,7 +437,6 @@ export default (): Module<RootInterface, RootInterface> => ({
           commit('SET_OVERVIEW_CHART_DATA', { chartName: 'zonesCPVersions', data: versionsData })
         }
       } catch (e) {
-        console.log(e)
         commit('SET_OVERVIEW_CHART_DATA', { chartName: 'zones', data: [] })
         commit('SET_OVERVIEW_CHART_DATA', { chartName: 'zonesCPVersions', data: [] })
       }

--- a/src/utils/tableDataUtils.spec.ts
+++ b/src/utils/tableDataUtils.spec.ts
@@ -23,6 +23,12 @@ describe('tableDataUtils', () => {
       expect(params.getAllEntities).toHaveBeenCalled()
     })
 
+    it('calls getAllEntities when no mesh provided', () => {
+      getTableData({ ...params, mesh: undefined })
+
+      expect(params.getAllEntities).toHaveBeenCalled()
+    })
+
     it('calls getAllEntitiesFromMesh', () => {
       getTableData({ ...params, mesh: 'default' })
 
@@ -37,6 +43,22 @@ describe('tableDataUtils', () => {
   })
 
   describe('handles reponses', () => {
+    it('when no corresponding function provided', async () => {
+      const response = await getTableData({
+        ...params,
+        mesh: 'default',
+        getSingleEntity: undefined,
+        getAllEntitiesFromMesh: undefined,
+      })
+
+      expect(response).toMatchInlineSnapshot(`
+        Object {
+          "data": Array [],
+          "next": false,
+        }
+      `)
+    })
+
     it('without data', async () => {
       const response = await getTableData(params)
 

--- a/src/utils/tableDataUtils.ts
+++ b/src/utils/tableDataUtils.ts
@@ -27,13 +27,17 @@ function getAPICallFunction({
     offset,
   }
 
-  if (mesh === 'all') {
+  if (!mesh || mesh === 'all') {
     return getAllEntities(params)
   } else if (getSingleEntity && query && query.length && mesh !== 'all') {
     return getSingleEntity(mesh, query, params)
   }
 
-  return getAllEntitiesFromMesh(mesh, params)
+  if (getAllEntitiesFromMesh) {
+    return getAllEntitiesFromMesh(mesh, params)
+  }
+
+  return Promise.resolve()
 }
 
 export async function getTableData({

--- a/src/utils/tableDataUtils.ts
+++ b/src/utils/tableDataUtils.ts
@@ -29,7 +29,9 @@ function getAPICallFunction({
 
   if (!mesh || mesh === 'all') {
     return getAllEntities(params)
-  } else if (getSingleEntity && query && query.length && mesh !== 'all') {
+  }
+
+  if (getSingleEntity && query && query.length && mesh !== 'all') {
     return getSingleEntity(mesh, query, params)
   }
 

--- a/src/utils/tableDataUtils.types.ts
+++ b/src/utils/tableDataUtils.types.ts
@@ -1,8 +1,8 @@
 export interface TableDataParams {
   getSingleEntity?: (mesh: string, query: string | null, params: { size: number; offset: string | null }) => any
   getAllEntities: (params: { size: number; offset: string | null }) => any
-  getAllEntitiesFromMesh: (mesh: string, params: { size: number; offset: string | null }) => any
-  mesh: string
+  getAllEntitiesFromMesh?: (mesh: string, params: { size: number; offset: string | null }) => any
+  mesh?: string
   size: number
   query?: string | null
   offset: string | null

--- a/src/views/Entities/ZoneIngresses.vue
+++ b/src/views/Entities/ZoneIngresses.vue
@@ -187,7 +187,7 @@ import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
 import LoaderCard from '@/components/Utils/LoaderCard'
 
-import { getZoneIngressStatus } from '@/dataplane'
+import { getItemStatusFromInsight } from '@/dataplane'
 import { PAGE_SIZE_DEFAULT, PRODUCT_NAME } from '@/consts'
 
 export default {
@@ -335,7 +335,7 @@ export default {
               items = items.map((item) => {
                 const { zoneIngressInsight = {} } = item
 
-                return { ...item, ...getZoneIngressStatus(zoneIngressInsight) }
+                return { ...item, ...getItemStatusFromInsight(zoneIngressInsight) }
               })
 
               // sort the table data by name and the mesh it's associated with

--- a/src/views/Entities/partial/Services.vue
+++ b/src/views/Entities/partial/Services.vue
@@ -94,7 +94,7 @@ import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
-import { PAGE_SIZE_DEFAULT } from '@/consts'
+import { OFFLINE, ONLINE, PARTIALLY_DEGRADED, PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
   name: 'Services',
@@ -228,14 +228,14 @@ export default {
 
         switch (entity.status) {
           case 'online':
-            entity.status = 'Online'
+            entity.status = ONLINE
             break
           case 'partially_degraded':
-            entity.status = 'Partially degraded'
+            entity.status = PARTIALLY_DEGRADED
             break
           case 'offline':
           default:
-            entity.status = 'Offline'
+            entity.status = OFFLINE
         }
 
         return entity


### PR DESCRIPTION
#### Summary
Previously we used `/status/zones` to get an overview of statutes of zones. But as we introduced `*-insights` then we should rely on them and use them to align all of our API usages. 

Also upgraded the mocks to be aligned with API responses and did some cleanup. 