### PR TITLE
bug(*) missing service info

### DIFF
--- a/src/services/mock/responses/external-services.json
+++ b/src/services/mock/responses/external-services.json
@@ -3,8 +3,32 @@
   "items": [
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
+      "creationTime": "2021-02-02T10:59:26.640498+01:00",
+      "modificationTime": "2021-02-02T10:59:26.640498+01:00",
+      "networking": {
+        "address": "httpbin.org:80",
+        "tls": {
+          "enabled": true,
+          "clientCert": {
+            "secret": "clientCert"
+          },
+          "clientKey": {
+            "secret": "clientKey"
+          },
+          "allowRenegotiation": false
+        }
+      },
+      "tags": {
+        "kuma.io/protocol": "http",
+        "kuma.io/service": "httpbin"
+      }
+    },
+    {
+      "type": "ExternalService",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -18,8 +42,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -33,8 +57,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -48,8 +72,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -63,8 +87,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -78,8 +102,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -93,8 +117,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -108,8 +132,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -123,8 +147,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -138,8 +162,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -153,8 +177,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -168,8 +192,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -183,8 +207,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -198,8 +222,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -213,8 +237,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {
@@ -228,23 +252,8 @@
     },
     {
       "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
-      "creationTime": "2021-02-02T10:59:26.640498+01:00",
-      "modificationTime": "2021-02-02T10:59:26.640498+01:00",
-      "networking": {
-        "address": "httpbin.org:80",
-        "tls": {}
-      },
-      "tags": {
-        "kuma.io/protocol": "http",
-        "kuma.io/service": "httpbin"
-      }
-    },
-    {
-      "type": "ExternalService",
-      "mesh": "foo",
-      "name": "httpbin2",
+      "mesh": "default",
+      "name": "httpbin",
       "creationTime": "2021-02-02T10:59:26.640498+01:00",
       "modificationTime": "2021-02-02T10:59:26.640498+01:00",
       "networking": {

--- a/src/views/Entities/partial/Services.vue
+++ b/src/views/Entities/partial/Services.vue
@@ -212,7 +212,7 @@ export default {
     getService(mesh, query, params) {
       return this.name === 'Internal Services'
         ? Kuma.getServiceInsight(mesh, query, params)
-        : Kuma.getAllExternalServices(mesh, query, params)
+        : Kuma.getExternalService(mesh, query, params)
     },
     getServiceFromMesh(mesh) {
       return this.name === 'Internal Services'


### PR DESCRIPTION
### Summary

In https://github.com/kumahq/kuma/issues/2728 it was reported that external services are not displayed properly.
The reason behind it was the part of refactoring which was done in https://github.com/kumahq/kuma-gui/pull/193 where the typo made it call the wrong endpoint. This PR fixes that issue.


![Screenshot 2021-09-06 at 09 30 47](https://user-images.githubusercontent.com/16152347/132177618-d43fd92d-4451-4fb8-96bb-1818e869e254.png)
![Screenshot 2021-09-06 at 09 30 50](https://user-images.githubusercontent.com/16152347/132177624-838556ad-0480-45ff-a3da-3bdfa37545d0.png)

Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>