### PR TITLE
feat(*) add new command to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "author": "Kong",
   "scripts": {
     "serve": "yarn vue-cli-service serve",
+    "prebuild": "yarn msw:cleanup",
     "build": "yarn vue-cli-service build --mode production",
+    "build:ci": "yarn vue-cli-service build",
     "test:unit": "yarn vue-cli-service test:unit -i",
     "test:e2e": "yarn vue-cli-service test:e2e",
     "lint": "yarn vue-cli-service lint",
     "msw:cleanup": "rm -f public/mockServiceWorker.js",
-    "prebuild": "yarn msw:cleanup",
     "test:unit:watch": "vue-cli-service test:unit --watch -i"
   },
   "dependencies": {


### PR DESCRIPTION
### Summary
To have an option to use netlify and build an app we need to have a build which contains service worker which provides `msw` option to mock request.
That's the reason why this PR provides new command `build:ci` which builds an app in development mode.

Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>