### PR TITLE
Fix broken docs version links.

### DIFF
--- a/src/views/Entities/ZoneIngresses.vue
+++ b/src/views/Entities/ZoneIngresses.vue
@@ -16,7 +16,7 @@
       </template>
       <template v-slot:cta>
         <KButton
-          to="https://kuma.io/docs/0.6.0/documentation/deployments/"
+          :to="`https://kuma.io/docs/${globalCpVersion}/documentation/deployments/`"
           target="_blank"
           appearance="primary"
         >
@@ -264,6 +264,7 @@ export default {
   computed: {
     ...mapGetters({
       multicluster: 'config/getMulticlusterStatus',
+      globalCpVersion: 'config/getVersion',
     }),
     // If you need to test multicluster without actually having it enabled
     // in Kuma, uncomment this and comment out the mapGetters above.

--- a/src/views/Entities/Zones.vue
+++ b/src/views/Entities/Zones.vue
@@ -16,7 +16,7 @@
       </template>
       <template v-slot:cta>
         <KButton
-          to="https://kuma.io/docs/0.6.0/documentation/deployments/"
+          :to="`https://kuma.io/docs/${globalCpVersion}/documentation/deployments/`"
           target="_blank"
           appearance="primary"
         >

--- a/src/views/Entities/__snapshots__/Zones.spec.ts.snap
+++ b/src/views/Entities/__snapshots__/Zones.spec.ts.snap
@@ -876,7 +876,7 @@ exports[`Zones.vue renders snapshot when no multizone 1`] = `
             class="k-button primary"
             data-v-38fa8ecf=""
             data-v-7725326c=""
-            href="https://kuma.io/docs/0.6.0/documentation/deployments/"
+            href="https://kuma.io/docs/null/documentation/deployments/"
             target="_blank"
             type="button"
           >


### PR DESCRIPTION
Zone and ZoneIngresses both had hardcoded (and broken) docs links. Fixed these by grabbing the current version (similar to the way other components did).

Signed-off-by: John Harris <john.harris@konghq.com>