### PR TITLE
Fix hardcoded docs links.

### DIFF
--- a/src/views/Entities/ZoneIngresses.spec.ts
+++ b/src/views/Entities/ZoneIngresses.spec.ts
@@ -9,6 +9,7 @@ jest.mock('@/helpers', () => {
   return {
     __esModule: true,
     ...originalModule,
+    humanReadableDate: (data: string) => data,
     rawReadableDate: (data: string) => data,
   }
 })

--- a/src/views/Entities/Zones.spec.ts
+++ b/src/views/Entities/Zones.spec.ts
@@ -9,6 +9,7 @@ jest.mock('@/helpers', () => {
   return {
     __esModule: true,
     ...originalModule,
+    humanReadableDate: (data: string) => data,
     rawReadableDate: (data: string) => data,
   }
 })

--- a/src/views/Entities/__snapshots__/ZoneIngresses.spec.ts.snap
+++ b/src/views/Entities/__snapshots__/ZoneIngresses.spec.ts.snap
@@ -451,7 +451,7 @@ exports[`ZoneIngresses.vue renders snapshot when no multizone 1`] = `
             class="k-button primary"
             data-v-38fa8ecf=""
             data-v-567e03f2=""
-            href="https://kuma.io/docs/0.6.0/documentation/deployments/"
+            href="https://kuma.io/docs/null/documentation/deployments/"
             target="_blank"
             type="button"
           >

--- a/src/views/Entities/__snapshots__/ZoneIngresses.spec.ts.snap
+++ b/src/views/Entities/__snapshots__/ZoneIngresses.spec.ts.snap
@@ -604,7 +604,7 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                                 Last Connected:
                               </strong>
                                
-        on 7/13/2021
+        2021-07-13T08:41:04.556796688Z
       
                             </li>
                              

--- a/src/views/Entities/__snapshots__/Zones.spec.ts.snap
+++ b/src/views/Entities/__snapshots__/Zones.spec.ts.snap
@@ -1164,7 +1164,7 @@ exports[`Zones.vue renders zone insights 1`] = `
                                 Last Connected:
                               </strong>
                                
-        on 2/18/2021
+        2021-02-19T07:11:15.535286Z
       
                             </li>
                              
@@ -1751,7 +1751,7 @@ exports[`Zones.vue renders zone insights 1`] = `
                                 Last Connected:
                               </strong>
                                
-        on 7/28/2020
+        2020-07-28T16:18:09.743141Z
       
                             </li>
                              
@@ -1760,7 +1760,7 @@ exports[`Zones.vue renders zone insights 1`] = `
                                 Last Disconnected:
                               </strong>
                                
-        on 7/28/2020
+        2020-07-28T16:18:09.743194Z
       
                             </li>
                           </ul>

--- a/src/views/Entities/__snapshots__/Zones.spec.ts.snap
+++ b/src/views/Entities/__snapshots__/Zones.spec.ts.snap
@@ -915,7 +915,7 @@ exports[`Zones.vue renders snapshot when no multizone 1`] = `
             class="k-button primary"
             data-v-38fa8ecf=""
             data-v-567e03f2=""
-            href="https://kuma.io/docs/0.6.0/documentation/deployments/"
+            href="https://kuma.io/docs/null/documentation/deployments/"
             target="_blank"
             type="button"
           >
@@ -1164,7 +1164,7 @@ exports[`Zones.vue renders zone insights 1`] = `
                                 Last Connected:
                               </strong>
                                
-        on 2/19/2021
+        on 2/18/2021
       
                             </li>
                              

--- a/src/views/Entities/components/MultizoneInfo.vue
+++ b/src/views/Entities/components/MultizoneInfo.vue
@@ -15,7 +15,7 @@
     </template>
     <template v-slot:cta>
       <KButton
-        to="https://kuma.io/docs/0.6.0/documentation/deployments/"
+        :to="`https://kuma.io/docs/${version}/documentation/deployments/`"
         target="_blank"
         appearance="primary"
       >
@@ -26,6 +26,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { PRODUCT_NAME } from '@/consts'
 export default {
   name: 'MultizoneInfo',
@@ -33,6 +34,11 @@ export default {
     return {
       productName: PRODUCT_NAME,
     }
+  },
+  computed: {
+    ...mapGetters({
+      version: 'config/getVersion',
+    }),
   },
 }
 </script>


### PR DESCRIPTION
Zone and ZoneIngresses both had hardcoded (and broken) docs links. Fixed these by grabbing the current version (similar to the way other components did).

Signed-off-by: John Harris john.harris@konghq.com