### PR TITLE
feat(sidebar) reorganise items in sidebar

### DIFF
--- a/src/components/Sidebar/menu.ts
+++ b/src/components/Sidebar/menu.ts
@@ -44,7 +44,16 @@ const menu: MenuSection[] = [
               link: 'global-overview',
             },
             {
+              name: 'Meshes',
+              link: 'mesh-child',
+              pathFlip: true,
+            },
+            {
               name: 'Zones',
+              title: true,
+            },
+            {
+              name: 'Zone CPs',
               link: 'zones',
               // root: true
               // multicluster: true
@@ -56,11 +65,6 @@ const menu: MenuSection[] = [
               // multicluster: true
             },
             {
-              name: 'Meshes',
-              link: 'mesh-child',
-              pathFlip: true,
-            },
-            {
               name: 'Services',
               title: true,
             },
@@ -68,13 +72,11 @@ const menu: MenuSection[] = [
               name: 'Internal',
               link: 'internal-services',
               title: false,
-              nested: true,
             },
             {
               name: 'External',
               link: 'external-services',
               title: false,
-              nested: true,
             },
             {
               name: 'Data plane proxies',

--- a/src/store/modules/sidebar.ts
+++ b/src/store/modules/sidebar.ts
@@ -2,19 +2,12 @@ import menu from '@/components/Sidebar/menu'
 
 type Menu = typeof menu
 export interface SidebarState {
-  menu: typeof menu
+  menu: Menu
 }
 
 const state = { menu }
 
-const mutations = {
-  setMenu(state: SidebarState, menu: Menu) {
-    state.menu = menu
-  },
-}
-
 export default {
   namespaced: true,
   state,
-  mutations,
 }

--- a/src/views/__snapshots__/Shell.spec.ts.snap
+++ b/src/views/__snapshots__/Shell.spec.ts.snap
@@ -175,48 +175,6 @@ exports[`Shell.vue renders component with route 1`] = `
         </div>
         <div
           class="nav-item is-menu-item"
-        >
-           
-          <a
-            aria-current="page"
-            class="router-link-exact-active router-link-active"
-            href="#/"
-          >
-            <!---->
-             
-            <div
-              class="nav-link"
-            >
-              
-        Zones
-      
-            </div>
-             
-          </a>
-        </div>
-        <div
-          class="nav-item is-menu-item"
-        >
-           
-          <a
-            aria-current="page"
-            class="router-link-exact-active router-link-active"
-            href="#/"
-          >
-            <!---->
-             
-            <div
-              class="nav-link"
-            >
-              
-        Zone Ingresses
-      
-            </div>
-             
-          </a>
-        </div>
-        <div
-          class="nav-item is-menu-item"
           pathflip="true"
         >
            
@@ -255,6 +213,73 @@ exports[`Shell.vue renders component with route 1`] = `
                 class="text-uppercase"
               >
                 
+        Zones
+      
+              </span>
+            </div>
+             
+          </a>
+        </div>
+        <div
+          class="nav-item is-menu-item"
+        >
+           
+          <a
+            aria-current="page"
+            class="router-link-exact-active router-link-active"
+            href="#/"
+          >
+            <!---->
+             
+            <div
+              class="nav-link"
+            >
+              
+        Zone CPs
+      
+            </div>
+             
+          </a>
+        </div>
+        <div
+          class="nav-item is-menu-item"
+        >
+           
+          <a
+            aria-current="page"
+            class="router-link-exact-active router-link-active"
+            href="#/"
+          >
+            <!---->
+             
+            <div
+              class="nav-link"
+            >
+              
+        Zone Ingresses
+      
+            </div>
+             
+          </a>
+        </div>
+        <div
+          class="nav-item is-menu-item is-title"
+        >
+           
+          <a
+            aria-current="page"
+            class="router-link-exact-active router-link-active"
+            href="#/"
+          >
+            <!---->
+             
+            <div
+              class="title-text"
+            >
+              <span
+                class="text-uppercase"
+              >
+                
         Services
       
               </span>
@@ -263,7 +288,7 @@ exports[`Shell.vue renders component with route 1`] = `
           </a>
         </div>
         <div
-          class="nav-item is-menu-item is-nested"
+          class="nav-item is-menu-item"
         >
            
           <a
@@ -284,7 +309,7 @@ exports[`Shell.vue renders component with route 1`] = `
           </a>
         </div>
         <div
-          class="nav-item is-menu-item is-nested"
+          class="nav-item is-menu-item"
         >
            
           <a


### PR DESCRIPTION
### Summary

Small cleanup of items in the sidebar.
(Add zones and zone ingresses into Zone section, move meshes into Overview section, change fotn size of services, Rename Zones into Zone Cps)


#### Before
![Screenshot 2021-10-07 at 15 31 45](https://user-images.githubusercontent.com/16152347/136396200-4efef3da-c9f4-492a-9f15-1f8b62d84c83.png)


#### After

![Screenshot 2021-10-07 at 15 44 41](https://user-images.githubusercontent.com/16152347/136396690-fdc08e08-bafa-4a1c-aabe-a4adabad41d7.png)


Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>