### PR TITLE
(fix) fix insights values

### DIFF
--- a/src/services/mock/responses/mesh-insights.json
+++ b/src/services/mock/responses/mesh-insights.json
@@ -16,9 +16,6 @@
         "Secret": {
           "total": 6
         },
-        "ServiceInsight": {
-          "total": 11
-        },
         "TrafficPermission": {
           "total": 3
         },

--- a/src/store/reducers/__snapshots__/mesh-insights.spec.ts.snap
+++ b/src/store/reducers/__snapshots__/mesh-insights.spec.ts.snap
@@ -1,0 +1,257 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mesh-insights calls mergeInsightsReducer with an empty array 1`] = `
+Object {
+  "dataplanes": Object {
+    "online": 0,
+    "partiallyDegraded": 0,
+    "total": 0,
+  },
+  "dpVersions": Object {
+    "envoy": Object {},
+    "kumaDp": Object {},
+  },
+  "meshesTotal": 0,
+  "policies": Object {
+    "CircuitBreaker": Object {
+      "total": 0,
+    },
+    "FaultInjection": Object {
+      "total": 0,
+    },
+    "HealthCheck": Object {
+      "total": 0,
+    },
+    "ProxyTemplate": Object {
+      "total": 0,
+    },
+    "RateLimit": Object {
+      "total": 0,
+    },
+    "Retry": Object {
+      "total": 0,
+    },
+    "Timeout": Object {
+      "total": 0,
+    },
+    "TrafficLog": Object {
+      "total": 0,
+    },
+    "TrafficPermission": Object {
+      "total": 0,
+    },
+    "TrafficRoute": Object {
+      "total": 0,
+    },
+    "TrafficTrace": Object {
+      "total": 0,
+    },
+  },
+}
+`;
+
+exports[`mesh-insights calls mergeInsightsReducer with mesh insights array 1`] = `
+Object {
+  "dataplanes": Object {
+    "online": 6,
+    "partiallyDegraded": 10,
+    "total": 26,
+  },
+  "dpVersions": Object {
+    "envoy": Object {
+      "1.16.1": Object {
+        "online": 1,
+        "partiallyDegraded": 0,
+        "total": 8,
+      },
+      "1.16.2": Object {
+        "online": 1,
+        "partiallyDegraded": 0,
+        "total": 4,
+      },
+    },
+    "kumaDp": Object {
+      "1.0.4": Object {
+        "online": 4,
+        "partiallyDegraded": 0,
+        "total": 6,
+      },
+      "1.0.5": Object {
+        "online": 2,
+        "partiallyDegraded": 0,
+        "total": 2,
+      },
+    },
+  },
+  "meshesTotal": 5,
+  "policies": Object {
+    "CircuitBreaker": Object {
+      "total": 0,
+    },
+    "FaultInjection": Object {
+      "total": 0,
+    },
+    "HealthCheck": Object {
+      "total": 0,
+    },
+    "ProxyTemplate": Object {
+      "total": 0,
+    },
+    "RateLimit": Object {
+      "total": 0,
+    },
+    "Retry": Object {
+      "total": 0,
+    },
+    "Secret": Object {
+      "total": 12,
+    },
+    "ServiceInsight": Object {
+      "total": 22,
+    },
+    "Timeout": Object {
+      "total": 0,
+    },
+    "TrafficLog": Object {
+      "total": 0,
+    },
+    "TrafficPermission": Object {
+      "total": 6,
+    },
+    "TrafficRoute": Object {
+      "total": 10,
+    },
+    "TrafficTrace": Object {
+      "total": 0,
+    },
+  },
+}
+`;
+
+exports[`mesh-insights calls parseInsightReducer with mesh insights 1`] = `
+Object {
+  "dataplanes": Object {
+    "online": 3,
+    "partiallyDegraded": 5,
+    "total": 13,
+  },
+  "dpVersions": Object {
+    "envoy": Object {
+      "1.16.1": Object {
+        "online": 1,
+        "partiallyDegraded": 0,
+        "total": 8,
+      },
+      "1.16.2": Object {
+        "online": 1,
+        "partiallyDegraded": 0,
+        "total": 4,
+      },
+    },
+    "kumaDp": Object {
+      "1.0.4": Object {
+        "online": 2,
+        "partiallyDegraded": 0,
+        "total": 3,
+      },
+      "1.0.5": Object {
+        "online": 1,
+        "partiallyDegraded": 0,
+        "total": 1,
+      },
+    },
+  },
+  "meshesTotal": 1,
+  "policies": Object {
+    "CircuitBreaker": Object {
+      "total": 0,
+    },
+    "FaultInjection": Object {
+      "total": 0,
+    },
+    "HealthCheck": Object {
+      "total": 0,
+    },
+    "ProxyTemplate": Object {
+      "total": 0,
+    },
+    "RateLimit": Object {
+      "total": 0,
+    },
+    "Retry": Object {
+      "total": 0,
+    },
+    "Secret": Object {
+      "total": 6,
+    },
+    "ServiceInsight": Object {
+      "total": 11,
+    },
+    "Timeout": Object {
+      "total": 0,
+    },
+    "TrafficLog": Object {
+      "total": 0,
+    },
+    "TrafficPermission": Object {
+      "total": 3,
+    },
+    "TrafficRoute": Object {
+      "total": 5,
+    },
+    "TrafficTrace": Object {
+      "total": 0,
+    },
+  },
+}
+`;
+
+exports[`mesh-insights calls parseInsightReducer without any data 1`] = `
+Object {
+  "dataplanes": Object {
+    "online": 0,
+    "partiallyDegraded": 0,
+    "total": 0,
+  },
+  "dpVersions": Object {
+    "envoy": Object {},
+    "kumaDp": Object {},
+  },
+  "meshesTotal": 1,
+  "policies": Object {
+    "CircuitBreaker": Object {
+      "total": 0,
+    },
+    "FaultInjection": Object {
+      "total": 0,
+    },
+    "HealthCheck": Object {
+      "total": 0,
+    },
+    "ProxyTemplate": Object {
+      "total": 0,
+    },
+    "RateLimit": Object {
+      "total": 0,
+    },
+    "Retry": Object {
+      "total": 0,
+    },
+    "Timeout": Object {
+      "total": 0,
+    },
+    "TrafficLog": Object {
+      "total": 0,
+    },
+    "TrafficPermission": Object {
+      "total": 0,
+    },
+    "TrafficRoute": Object {
+      "total": 0,
+    },
+    "TrafficTrace": Object {
+      "total": 0,
+    },
+  },
+}
+`;

--- a/src/store/reducers/mesh-insights.spec.ts
+++ b/src/store/reducers/mesh-insights.spec.ts
@@ -1,0 +1,106 @@
+import { mergeInsightsReducer, parseInsightReducer } from './mesh-insights'
+
+describe('mesh-insights', () => {
+  const meshInsightObject = {
+    dataplanes: {
+      total: 13,
+      online: 3,
+      partiallyDegraded: 5,
+    },
+    policies: {
+      Secret: {
+        total: 6,
+      },
+      ServiceInsight: {
+        total: 11,
+      },
+      TrafficPermission: {
+        total: 3,
+      },
+      TrafficRoute: {
+        total: 5,
+      },
+    },
+    dpVersions: {
+      kumaDp: {
+        '1.0.4': {
+          total: 3,
+          online: 2,
+        },
+        '1.0.5': {
+          total: 1,
+          online: 1,
+        },
+      },
+      envoy: {
+        '1.16.2': {
+          total: 4,
+          online: 1,
+        },
+        '1.16.1': {
+          total: 8,
+          online: 1,
+        },
+      },
+    },
+  }
+
+  it('calls parseInsightReducer without any data', () => {
+    expect(parseInsightReducer()).toMatchSnapshot()
+  })
+
+  it('calls parseInsightReducer with mesh insights', () => {
+    expect(parseInsightReducer(meshInsightObject)).toMatchSnapshot()
+  })
+
+  it('calls mergeInsightsReducer with an empty array', () => {
+    expect(mergeInsightsReducer([])).toMatchSnapshot()
+  })
+
+  it('calls mergeInsightsReducer with mesh insights array', () => {
+    expect(
+      mergeInsightsReducer([
+        meshInsightObject,
+        {
+          policies: {
+            Secret: {
+              total: 6,
+            },
+            ServiceInsight: {
+              total: 11,
+            },
+            TrafficPermission: {
+              total: 3,
+            },
+            TrafficRoute: {
+              total: 5,
+            },
+          },
+        },
+
+        {
+          dataplanes: {
+            total: 13,
+            online: 3,
+            partiallyDegraded: 5,
+          },
+        },
+        {
+          dpVersions: {
+            kumaDp: {
+              '1.0.4': {
+                total: 3,
+                online: 2,
+              },
+              '1.0.5': {
+                total: 1,
+                online: 1,
+              },
+            },
+          },
+        },
+        { policies: {}, dataplanes: {}, dpVersions: {} },
+      ]),
+    ).toMatchSnapshot()
+  })
+})

--- a/src/store/reducers/mesh-insights.ts
+++ b/src/store/reducers/mesh-insights.ts
@@ -103,6 +103,18 @@ export function mergeInsightsReducer(insights: TODO = []) {
       policies: sumPolicies(acc.policies, insight.policies),
       dpVersions: sumVersions(acc.dpVersions, insight.dpVersions),
     }),
-    {},
+    {
+      meshesTotal: 0,
+      dataplanes: {
+        online: 0,
+        partiallyDegraded: 0,
+        total: 0,
+      },
+      policies: getInitialPolicies(),
+      dpVersions: {
+        kumaDp: {},
+        envoy: {},
+      },
+    },
   )
 }

--- a/src/views/Entities/Meshes.vue
+++ b/src/views/Entities/Meshes.vue
@@ -159,7 +159,7 @@
 <script>
 import { mapState } from 'vuex'
 import Kuma from '@/services/kuma'
-import { getEmptyInsight, getInitialPolicies } from '@/store/reducers/mesh-insights'
+import { getEmptyInsight } from '@/store/reducers/mesh-insights'
 import { datadogLogs } from '@datadog/browser-logs'
 import { datadogLogEvents } from '@/datadogEvents'
 import { getSome, humanReadableDate, rawReadableDate, stripTimes } from '@/helpers'
@@ -253,11 +253,6 @@ export default {
         dataplanes: { total },
       } = this.meshInsight
 
-      const allPolicies = {
-        ...getInitialPolicies(),
-        ...policies,
-      }
-
       return [
         {
           title: 'Data plane proxies',
@@ -265,47 +260,47 @@ export default {
         },
         {
           title: 'Circuit Breakers',
-          value: allPolicies.CircuitBreaker.total,
+          value: policies.CircuitBreaker.total,
         },
         {
           title: 'Fault Injections',
-          value: allPolicies.FaultInjection.total,
+          value: policies.FaultInjection.total,
         },
         {
           title: 'Health Checks',
-          value: allPolicies.HealthCheck.total,
+          value: policies.HealthCheck.total,
         },
         {
           title: 'Proxy Templates',
-          value: allPolicies.ProxyTemplate.total,
+          value: policies.ProxyTemplate.total,
         },
         {
           title: 'Traffic Logs',
-          value: allPolicies.TrafficLog.total,
+          value: policies.TrafficLog.total,
         },
         {
           title: 'Traffic Permissions',
-          value: allPolicies.TrafficPermission.total,
+          value: policies.TrafficPermission.total,
         },
         {
           title: 'Traffic Routes',
-          value: allPolicies.TrafficRoute.total,
+          value: policies.TrafficRoute.total,
         },
         {
           title: 'Traffic Traces',
-          value: allPolicies.TrafficTrace.total,
+          value: policies.TrafficTrace.total,
         },
         {
           title: 'Rate Limits',
-          value: allPolicies.RateLimit.total,
+          value: policies.RateLimit.total,
         },
         {
           title: 'Retries',
-          value: allPolicies.Retry.total,
+          value: policies.Retry.total,
         },
         {
           title: 'Timeouts',
-          value: allPolicies.Timeout.total,
+          value: policies.Timeout.total,
         },
       ]
     },

--- a/src/views/Overview.vue
+++ b/src/views/Overview.vue
@@ -100,7 +100,6 @@
 
 <script>
 import { mapActions, mapGetters } from 'vuex'
-import { getInitialPolicies } from '@/store/reducers/mesh-insights'
 import MetricGrid from '@/components/Metrics/MetricGrid.vue'
 import CardSkeleton from '@/components/Skeletons/CardSkeleton'
 import Resources from '@/components/Resources'
@@ -173,11 +172,6 @@ export default {
       const mesh = this.selectedMesh
       const { policies, meshesTotal } = this.meshInsight
 
-      const allPolicies = {
-        ...getInitialPolicies(),
-        ...policies,
-      }
-
       const tableData = [
         {
           metric: 'Meshes',
@@ -186,57 +180,57 @@ export default {
         },
         {
           metric: 'Circuit Breakers',
-          value: allPolicies.CircuitBreaker.total,
+          value: policies.CircuitBreaker.total,
           url: `/mesh/${mesh}/circuit-breakers`,
         },
         {
           metric: 'Fault Injections',
-          value: allPolicies.FaultInjection.total,
+          value: policies.FaultInjection.total,
           url: `/mesh/${mesh}/fault-injections`,
         },
         {
           metric: 'Health Checks',
-          value: allPolicies.HealthCheck.total,
+          value: policies.HealthCheck.total,
           url: `/mesh/${mesh}/health-checks`,
         },
         {
           metric: 'Proxy Templates',
-          value: allPolicies.ProxyTemplate.total,
+          value: policies.ProxyTemplate.total,
           url: `/mesh/${mesh}/proxy-templates`,
         },
         {
           metric: 'Traffic Logs',
-          value: allPolicies.TrafficLog.total,
+          value: policies.TrafficLog.total,
           url: `/mesh/${mesh}/traffic-logs`,
         },
         {
           metric: 'Traffic Permissions',
-          value: allPolicies.TrafficPermission.total,
+          value: policies.TrafficPermission.total,
           url: `/mesh/${mesh}/traffic-permissions`,
         },
         {
           metric: 'Traffic Routes',
-          value: allPolicies.TrafficRoute.total,
+          value: policies.TrafficRoute.total,
           url: `/mesh/${mesh}/traffic-routes`,
         },
         {
           metric: 'Traffic Traces',
-          value: allPolicies.TrafficTrace.total,
+          value: policies.TrafficTrace.total,
           url: `/mesh/${mesh}/traffic-traces`,
         },
         {
           metric: 'Rate Limits',
-          value: allPolicies.RateLimit.total,
+          value: policies.RateLimit.total,
           url: `/mesh/${mesh}/rate-limits`,
         },
         {
           metric: 'Retries',
-          value: allPolicies.Retry.total,
+          value: policies.Retry.total,
           url: `/mesh/${mesh}/retries`,
         },
         {
           metric: 'Timeouts',
-          value: allPolicies.Timeout.total,
+          value: policies.Timeout.total,
           url: `/mesh/${mesh}/timeouts`,
         },
       ]


### PR DESCRIPTION
### Summary

As the insights are generated only in 15 seconds interval it happends sometimes that `/meshes-insights` were returning an empty array, even if cp contains default mesh. Because of that some data were wrong and caused errors. 
This PR will fix that, provide constant initial data, which in case of empty response will return initially setup object which contain all necessary data.


Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>