### PR TITLE
feat(dataoverview) Add possibility to add custom slots into dataoverview

### DIFF
--- a/src/components/Skeletons/DataOverview.spec.ts
+++ b/src/components/Skeletons/DataOverview.spec.ts
@@ -23,6 +23,30 @@ describe('DataOverview.vue', () => {
     expect(container).toMatchSnapshot()
   })
 
+  it('renders additional scoped slot', () => {
+    render(DataOverview, {
+      propsData: {
+        tableData: {
+          headers: [{ key: 'custom', hideLabel: true }],
+          data: [
+            {
+              custom: ['custom', 'vaues', 'in', 'an', 'array'],
+            },
+          ],
+        },
+      },
+      scopedSlots: {
+        custom: `
+        <ul>
+          <li v-for="item in props.rowValue" :key="item">{{item}}</li>
+        </ul>
+        `,
+      },
+    })
+
+    expect(screen.getByRole('table')).toMatchSnapshot()
+  })
+
   it('renders pagination and react on click', async () => {
     render(DataOverview, {
       propsData: {

--- a/src/components/Skeletons/DataOverview.vue
+++ b/src/components/Skeletons/DataOverview.vue
@@ -51,6 +51,18 @@
           is-clickable
           @row:click="tableRowHandler"
         >
+          <!-- Custom slots provided by parent -->
+          <template
+            v-for="slot in customSlots"
+            v-slot:[slot]="{ rowValue, row }"
+          >
+            <slot
+              :name="slot"
+              :row-value="rowValue"
+              :row="row"
+            />
+          </template>
+
           <!-- status -->
           <template v-slot:status="{ rowValue }">
             <div
@@ -288,6 +300,9 @@ export default {
     }
   },
   computed: {
+    customSlots() {
+      return this.tableData.headers.map(({ key }) => key).filter((key) => this.$scopedSlots[key])
+    },
     isReady() {
       return !this.isEmpty && !this.hasError && !this.isLoading
     },

--- a/src/components/Skeletons/__snapshots__/DataOverview.spec.ts.snap
+++ b/src/components/Skeletons/__snapshots__/DataOverview.spec.ts.snap
@@ -39,6 +39,69 @@ exports[`DataOverview.vue refresh page on second page 2`] = `
 }
 `;
 
+exports[`DataOverview.vue renders additional scoped slot 1`] = `
+<table
+  class="k-table micro-table has-hover is-clickable"
+  data-v-bfeabd48=""
+>
+  <thead
+    data-v-bfeabd48=""
+  >
+    <tr
+      data-v-bfeabd48=""
+    >
+      <th
+        class=""
+        data-v-bfeabd48=""
+      >
+        <!---->
+      </th>
+    </tr>
+  </thead>
+  <tbody
+    data-v-bfeabd48=""
+  >
+    <tr
+      data-v-bfeabd48=""
+    >
+      <td
+        data-v-bfeabd48=""
+      >
+        <ul
+          data-v-bfeabd48=""
+        >
+          <li
+            data-v-bfeabd48=""
+          >
+            custom
+          </li>
+          <li
+            data-v-bfeabd48=""
+          >
+            vaues
+          </li>
+          <li
+            data-v-bfeabd48=""
+          >
+            in
+          </li>
+          <li
+            data-v-bfeabd48=""
+          >
+            an
+          </li>
+          <li
+            data-v-bfeabd48=""
+          >
+            array
+          </li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`DataOverview.vue renders all custom templates for data 1`] = `
 <div>
   <div


### PR DESCRIPTION
### Summary

Previously when we wanted to add a custom "display" for any key, we had to add it into DataOverview which caused enormous growth of that component. The change will allow passing slot through it - so instead of having all in DataOverview we will be able to leave dependency in a place where it's needed.

Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>