### PR TITLE
refactor(dataoverview) extract tags

### DIFF
--- a/src/components/EntityTag/EntityTag.spec.ts
+++ b/src/components/EntityTag/EntityTag.spec.ts
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/vue'
+import EntityTag from './EntityTag.vue'
+
+describe('EntityTag.vue', () => {
+  it('renders basic snapshot', () => {
+    const { container } = render(EntityTag, {
+      props: {
+        tag: {
+          label: 'kuma.io/service',
+          value: 'backend',
+        },
+      },
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/components/EntityTag/EntityTag.vue
+++ b/src/components/EntityTag/EntityTag.vue
@@ -1,0 +1,97 @@
+<template>
+  <span class="entity-tag">
+    <span
+      class="entity-tag__label"
+      :class="`entity-tag__label--${cleanTagLabel(tag.label)}`"
+    >
+      {{ tag.label }}
+    </span>
+    <span
+      class="entity-tag__value"
+      :class="`entity-tag__value--${tag.value}`"
+    >
+      {{ tag.value }}
+    </span>
+  </span>
+</template>
+
+<script>
+export default {
+  name: 'EntityTag',
+  props: {
+    tag: {
+      type: Object,
+      required: true,
+    },
+  },
+  methods: {
+    cleanTagLabel(val) {
+      return val.toLowerCase().replace('.', '-').replace('/', '-')
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.entity-tag {
+  font-size: var(--type-xs);
+  background-color: #fff;
+  font-family: var(--font-family-mono);
+
+  &:not(:last-of-type) {
+    margin-right: 0.5rem;
+    margin-bottom: 0.25rem;
+  }
+
+  @media (max-width: 1136px) {
+    display: flex;
+    flex-direction: column;
+    font-size: 11px;
+
+    .entity-tag__label {
+      border-radius: 5px 5px 0 0;
+    }
+
+    .entity-tag__value {
+      border-radius: 0 0 5px 5px;
+    }
+  }
+
+  @media (min-width: 1137px) {
+    display: inline-flex;
+    align-tags: stretch;
+  }
+}
+
+.entity-tag__label {
+  --color: var(--blue-1);
+
+  position: relative;
+  background-color: var(--color);
+  color: #fff;
+  text-transform: uppercase;
+  border-radius: 5px 0 0 5px;
+  padding: 0.15rem 0.5rem;
+  // box-shadow: inset 0 0 0 1px var(--color);
+  box-shadow: inset 0 0 0 1px var(--color);
+}
+
+// this gives kuma-specific native tag a different color
+// to differentiate them from user-created tag.
+span[class*='kuma-io-'] {
+  --color: var(--brand-color-6);
+
+  background-color: var(--color);
+  box-shadow: inset 0 0 0 1px var(--color);
+}
+
+.entity-tag__value {
+  background-color: #fff;
+  border-radius: 0 5px 5px 0;
+  padding: 0.15rem 0.5rem 0.15rem 0.75rem;
+  color: #000;
+  font-weight: 500;
+  box-shadow: inset 0 0 0 1px #ccc;
+  // box-shadow: inset 0 0 0 1px currentColor;
+}
+</style>

--- a/src/components/EntityTag/__snapshots__/EntityTag.spec.ts.snap
+++ b/src/components/EntityTag/__snapshots__/EntityTag.spec.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EntityTag.vue renders basic snapshot 1`] = `
+<div>
+  <span
+    class="entity-tag"
+  >
+    <span
+      class="entity-tag__label entity-tag__label--kuma-io-service"
+    >
+      
+    kuma.io/service
+  
+    </span>
+     
+    <span
+      class="entity-tag__value entity-tag__value--backend"
+    >
+      
+    backend
+  
+    </span>
+  </span>
+</div>
+`;

--- a/src/components/Skeletons/DataOverview.vue
+++ b/src/components/Skeletons/DataOverview.vue
@@ -66,25 +66,11 @@
           </template>
           <!-- tags -->
           <template v-slot:tags="{ rowValue }">
-            <span
-              v-for="(item, key) in rowValue"
+            <EntityTag
+              v-for="(tag, key) in rowValue"
               :key="key"
-              class="entity-tags"
-              :class="`entity-tags--${key}`"
-            >
-              <span
-                class="entity-tags__label"
-                :class="`entity-tags__label--${cleanTagLabel(item.label)}`"
-              >
-                {{ item.label }}
-              </span>
-              <span
-                class="entity-tags__value"
-                :class="`entity-tags__value--${item.value}`"
-              >
-                {{ item.value }}
-              </span>
-            </span>
+              :tag="tag"
+            />
           </template>
           <!--- total Updates --->
           <template v-slot:totalUpdates="{ row }">
@@ -233,11 +219,13 @@
 import { datadogLogs } from '@datadog/browser-logs'
 import { datadogLogEvents } from '@/datadogEvents'
 import Pagination from '@/components/Pagination'
+import EntityTag from '@/components/EntityTag/EntityTag.vue'
 
 export default {
   name: 'DataOverview',
   components: {
     Pagination,
+    EntityTag,
   },
   props: {
     pageSize: {
@@ -315,9 +303,6 @@ export default {
       this.selectedRow = row.name
       this.$emit('tableAction', row)
     },
-    cleanTagLabel(val) {
-      return val.toLowerCase().replace('.', '-').replace('/', '-')
-    },
     onRefreshButtonClick() {
       this.$emit('refresh')
       this.$emit('loadData', this.pageOffset)
@@ -387,68 +372,6 @@ export default {
 .data-table-controls {
   text-align: right;
   padding: var(--spacing-sm) var(--spacing-sm) 0 var(--spacing-sm);
-}
-
-.entity-tags {
-  font-size: var(--type-xs);
-  background-color: #fff;
-  font-family: var(--font-family-mono);
-
-  &:not(:last-of-type) {
-    margin-right: 0.5rem;
-    margin-bottom: 0.25rem;
-  }
-
-  @media (max-width: 1136px) {
-    display: flex;
-    flex-direction: column;
-    font-size: 11px;
-
-    .entity-tags__label {
-      border-radius: 5px 5px 0 0;
-    }
-
-    .entity-tags__value {
-      border-radius: 0 0 5px 5px;
-    }
-  }
-
-  @media (min-width: 1137px) {
-    display: inline-flex;
-    align-items: stretch;
-  }
-}
-
-.entity-tags__label {
-  --color: var(--blue-1);
-
-  position: relative;
-  background-color: var(--color);
-  color: #fff;
-  text-transform: uppercase;
-  border-radius: 5px 0 0 5px;
-  padding: 0.15rem 0.5rem;
-  // box-shadow: inset 0 0 0 1px var(--color);
-  box-shadow: inset 0 0 0 1px var(--color);
-}
-
-// this gives kuma-specific native tags a different color
-// to differentiate them from user-created tags.
-span[class*='kuma-io-'] {
-  --color: var(--brand-color-6);
-
-  background-color: var(--color);
-  box-shadow: inset 0 0 0 1px var(--color);
-}
-
-.entity-tags__value {
-  background-color: #fff;
-  border-radius: 0 5px 5px 0;
-  padding: 0.15rem 0.5rem 0.15rem 0.75rem;
-  color: #000;
-  font-weight: 500;
-  box-shadow: inset 0 0 0 1px #ccc;
-  // box-shadow: inset 0 0 0 1px currentColor;
 }
 
 .data-overview-table {

--- a/src/components/Skeletons/__snapshots__/DataOverview.spec.ts.snap
+++ b/src/components/Skeletons/__snapshots__/DataOverview.spec.ts.snap
@@ -191,91 +191,83 @@ exports[`DataOverview.vue renders all custom templates for data 1`] = `
                 data-v-bfeabd48=""
               >
                 <span
-                  class="entity-tags entity-tags--0"
+                  class="entity-tag"
                   data-v-bfeabd48=""
                 >
                   <span
-                    class="entity-tags__label entity-tags__label--env"
-                    data-v-bfeabd48=""
+                    class="entity-tag__label entity-tag__label--env"
                   >
                     
-              env
-            
+    env
+  
                   </span>
                    
                   <span
-                    class="entity-tags__value entity-tags__value--dev"
-                    data-v-bfeabd48=""
+                    class="entity-tag__value entity-tag__value--dev"
                   >
                     
-              dev
-            
+    dev
+  
                   </span>
                 </span>
                 <span
-                  class="entity-tags entity-tags--1"
+                  class="entity-tag"
                   data-v-bfeabd48=""
                 >
                   <span
-                    class="entity-tags__label entity-tags__label--kuma-io-service"
-                    data-v-bfeabd48=""
+                    class="entity-tag__label entity-tag__label--kuma-io-service"
                   >
                     
-              kuma.io/service
-            
+    kuma.io/service
+  
                   </span>
                    
                   <span
-                    class="entity-tags__value entity-tags__value--kuma-example-backend"
-                    data-v-bfeabd48=""
+                    class="entity-tag__value entity-tag__value--kuma-example-backend"
                   >
                     
-              kuma-example-backend
-            
+    kuma-example-backend
+  
                   </span>
                 </span>
                 <span
-                  class="entity-tags entity-tags--2"
+                  class="entity-tag"
                   data-v-bfeabd48=""
                 >
                   <span
-                    class="entity-tags__label entity-tags__label--tag01"
-                    data-v-bfeabd48=""
+                    class="entity-tag__label entity-tag__label--tag01"
                   >
                     
-              tag01
-            
+    tag01
+  
                   </span>
                    
                   <span
-                    class="entity-tags__value entity-tags__value--value01"
-                    data-v-bfeabd48=""
+                    class="entity-tag__value entity-tag__value--value01"
                   >
                     
-              value01
-            
+    value01
+  
                   </span>
                 </span>
                 <span
-                  class="entity-tags entity-tags--3"
+                  class="entity-tag"
                   data-v-bfeabd48=""
                 >
                   <span
-                    class="entity-tags__label entity-tags__label--reallylongtaglabelhere"
-                    data-v-bfeabd48=""
+                    class="entity-tag__label entity-tag__label--reallylongtaglabelhere"
                   >
                     
-              reallyLongTagLabelHere
-            
+    reallyLongTagLabelHere
+  
                   </span>
                    
                   <span
-                    class="entity-tags__value entity-tags__value--a-really-long-tag-value-here"
-                    data-v-bfeabd48=""
+                    class="entity-tag__value entity-tag__value--a-really-long-tag-value-here"
                   >
                     
-              a-really-long-tag-value-here
-            
+    a-really-long-tag-value-here
+  
                   </span>
                 </span>
               </td>


### PR DESCRIPTION
### Summary

Previously we had tags hardcoded in DataOverview component. This PR will extract it, reducing size of that component and making it reusable in other places.



Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>