### PR TITLE
fix(*) properly create share url

### DIFF
--- a/src/components/Utils/EntityURLControl.spec.ts
+++ b/src/components/Utils/EntityURLControl.spec.ts
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import EntityURLControl from './EntityURLControl.vue'
+
+describe('EntityURLControl.vue', () => {
+  it('renders snapshot', () => {
+    const { container } = render(EntityURLControl, {
+      mocks: {
+        $route: {
+          params: {
+            mesh: 'default',
+          },
+        },
+      },
+      props: {
+        name: 'foo',
+      },
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('display custom message', () => {
+    render(EntityURLControl, {
+      mocks: {
+        $route: {
+          params: {
+            mesh: 'default',
+          },
+        },
+      },
+      props: {
+        name: 'foo',
+        copyButtonText: 'copy',
+      },
+    })
+
+    expect(screen.getByText('copy')).toBeInTheDocument()
+  })
+
+  it("dosen't render for mesh all", () => {
+    render(EntityURLControl, {
+      mocks: {
+        $route: {
+          params: {
+            mesh: 'all',
+          },
+        },
+      },
+      props: {
+        name: 'foo',
+      },
+    })
+
+    expect(screen.queryByTestId('entity-url-control')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/Utils/EntityURLControl.vue
+++ b/src/components/Utils/EntityURLControl.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="entity-url-control">
-    <KClipboardProvider
-      v-if="shouldDisplay"
-      v-slot="{ copyToClipboard }"
-    >
+  <div
+    v-if="shouldDisplay"
+    data-testid="entity-url-control"
+  >
+    <KClipboardProvider v-slot="{ copyToClipboard }">
       <KPop placement="bottom">
         <KButton
           appearance="secondary"
           size="small"
-          @click="() => { copyToClipboard(url) }"
+          @click="() => { copyToClipboard(shareUrl) }"
         >
           <template v-slot:icon>
             <KIcon
@@ -28,13 +28,11 @@
   </div>
 </template>
 
-<script lang="ts">
-import Vue from 'vue'
-
-export default Vue.extend({
+<script >
+export default {
   name: 'EntityURLControl',
   props: {
-    url: {
+    name: {
       type: String,
       required: true,
     },
@@ -48,7 +46,12 @@ export default Vue.extend({
     },
   },
   computed: {
-    shouldDisplay(): boolean {
+    shareUrl() {
+      const urlRoot = `${window.location.href.replace(window.location.hash, '')}#`
+
+      return `${urlRoot}${this.$route.fullPath}?ns=${this.name}`
+    },
+    shouldDisplay() {
       const mesh = this.$route.params.mesh || null
 
       // we only want to display the copy button when the user has filtered
@@ -60,5 +63,5 @@ export default Vue.extend({
       return false
     },
   },
-})
+}
 </script>

--- a/src/components/Utils/__snapshots__/EntityURLControl.spec.ts.snap
+++ b/src/components/Utils/__snapshots__/EntityURLControl.spec.ts.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EntityURLControl.vue renders snapshot 1`] = `
+<div>
+  <div
+    data-testid="entity-url-control"
+  >
+    <div
+      data-v-3cb990b6=""
+    >
+      <button
+        class="k-button small secondary"
+        data-v-38fa8ecf=""
+        data-v-3cb990b6=""
+        type="button"
+      >
+        <svg
+          class="kong-icon kong-icon-externalLink"
+          data-v-38fa8ecf=""
+          data-v-a7c9c1d2=""
+          height="12"
+          role="img"
+          viewBox="0 0 16 16"
+          width="12"
+        >
+          <title
+            data-v-a7c9c1d2=""
+          >
+            externalLink
+          </title>
+          <g
+            data-v-a7c9c1d2=""
+          >
+            <path
+              d="M8.24308 1.5C7.83269 1.5 7.5 1.16710138 7.5.75c0-.41421356.33823-.75.74308-.75h3.00568C11.6666 0 12 .336341 12 .75123866v3.00567786C12 4.1673102 11.6671 4.5 11.25 4.5c-.41421 0-.75-.3382314-.75-.74308348V2.625L6.53246 6.59254c-.28982.2898217-.76955.2953689-1.06202.0029022l-.06588-.0658844c-.29098-.2909742-.29117-.7679483.0029-1.0620178L9.375 1.5H8.24308zm-6.74753 0C.67089 1.5 0 2.1695784 0 2.99554521v7.50890959C0 11.3291147.66958 12 1.49555 12h7.5089C9.82911 12 10.5 11.3304216 10.5 10.5044548V6.75H9v3.75H1.5V3h3.75V1.5H1.49555z"
+              data-v-a7c9c1d2=""
+              fill="#000"
+              fill-opacity=".25"
+              fill-rule="evenodd"
+            />
+          </g>
+        </svg>
+        
+        Copy URL
+      
+      </button>
+      <transition-stub
+        data-v-3cb990b6=""
+        name="fade"
+      >
+        <div
+          class="k-popover"
+          data-v-3cb990b6=""
+          style="width: 200px; display: none;"
+        >
+          <!---->
+          <div
+            class="k-popover-content"
+            data-v-3cb990b6=""
+          >
+            <div>
+              <p>
+                URL copied to clipboard!
+              </p>
+            </div>
+          </div>
+        </div>
+      </transition-stub>
+    </div>
+  </div>
+</div>
+`;

--- a/src/views/Entities/Meshes.vue
+++ b/src/views/Entities/Meshes.vue
@@ -38,9 +38,6 @@
           <div>
             <h3>{{ tabGroupTitle }}</h3>
           </div>
-          <!-- <div>
-            <EntityURLControl :url="shareUrl" />
-          </div> -->
         </template>
         <template v-slot:overview>
           <LabelList
@@ -163,7 +160,6 @@ import { getEmptyInsight, getInitialPolicies } from '@/store/reducers/mesh-insig
 import { datadogLogs } from '@datadog/browser-logs'
 import { datadogLogEvents } from '@/datadogEvents'
 import { getSome, humanReadableDate, rawReadableDate, stripTimes } from '@/helpers'
-// import EntityURLControl from '@/components/Utils/EntityURLControl'
 import sortEntities from '@/mixins/EntitySorter'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
@@ -178,7 +174,6 @@ export default {
     title: 'Meshes',
   },
   components: {
-    // EntityURLControl,
     FrameSkeleton,
     DataOverview,
     Tabs,
@@ -311,19 +306,6 @@ export default {
     },
     countCols() {
       return Math.ceil(this.counts.length / this.itemsPerCol)
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}/#`
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Entities/partial/Dataplanes.vue
+++ b/src/views/Entities/partial/Dataplanes.vue
@@ -51,7 +51,7 @@
           <h3>{{ tabGroupTitle }}</h3>
         </div>
         <div>
-          <EntityURLControl :url="shareUrl" />
+          <EntityURLControl :name="entity.name" />
         </div>
       </template>
       <template v-slot:overview>
@@ -328,24 +328,6 @@ export default {
       const storedVersion = this.$store.getters.getVersion
 
       return storedVersion !== null ? storedVersion : 'latest'
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}/#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (entity.basicData) {
-          if (this.$route.query.ns) {
-            return this.$route.fullPath
-          }
-
-          return `${urlRoot}${this.$route.fullPath}?ns=${entity.basicData.name}`
-        }
-
-        return null
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Entities/partial/Services.vue
+++ b/src/views/Entities/partial/Services.vue
@@ -42,7 +42,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -177,20 +177,6 @@ export default {
       const entity = this.formatForCLI(this.rawEntity)
 
       return entity
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Policies/CircuitBreakers.vue
+++ b/src/views/Policies/CircuitBreakers.vue
@@ -40,7 +40,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -161,20 +161,6 @@ export default {
       } else {
         return null
       }
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Policies/FaultInjections.vue
+++ b/src/views/Policies/FaultInjections.vue
@@ -42,7 +42,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -163,20 +163,6 @@ export default {
       } else {
         return null
       }
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Policies/HealthChecks.vue
+++ b/src/views/Policies/HealthChecks.vue
@@ -42,7 +42,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -162,20 +162,6 @@ export default {
       } else {
         return null
       }
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Policies/ProxyTemplates.vue
+++ b/src/views/Policies/ProxyTemplates.vue
@@ -42,7 +42,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -162,20 +162,6 @@ export default {
       } else {
         return null
       }
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Policies/RateLimits.vue
+++ b/src/views/Policies/RateLimits.vue
@@ -42,7 +42,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -162,20 +162,6 @@ export default {
       } else {
         return null
       }
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Policies/Retries.vue
+++ b/src/views/Policies/Retries.vue
@@ -41,7 +41,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -161,20 +161,6 @@ export default {
       } else {
         return null
       }
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Policies/Timeouts.vue
+++ b/src/views/Policies/Timeouts.vue
@@ -41,7 +41,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -161,20 +161,6 @@ export default {
       } else {
         return null
       }
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Policies/TrafficLogs.vue
+++ b/src/views/Policies/TrafficLogs.vue
@@ -41,7 +41,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -161,20 +161,6 @@ export default {
       } else {
         return null
       }
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Policies/TrafficPermissions.vue
+++ b/src/views/Policies/TrafficPermissions.vue
@@ -59,7 +59,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -184,20 +184,6 @@ export default {
       } else {
         return null
       }
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Policies/TrafficRoutes.vue
+++ b/src/views/Policies/TrafficRoutes.vue
@@ -41,7 +41,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -161,20 +161,6 @@ export default {
       } else {
         return null
       }
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {

--- a/src/views/Policies/TrafficTraces.vue
+++ b/src/views/Policies/TrafficTraces.vue
@@ -41,7 +41,7 @@
             <h3>{{ tabGroupTitle }}</h3>
           </div>
           <div>
-            <EntityURLControl :url="shareUrl" />
+            <EntityURLControl :name="entity.name" />
           </div>
         </template>
         <template v-slot:overview>
@@ -161,20 +161,6 @@ export default {
       } else {
         return null
       }
-    },
-    shareUrl() {
-      const urlRoot = `${window.location.origin}#`
-      const entity = this.entity
-
-      const shareUrl = () => {
-        if (this.$route.query.ns) {
-          return this.$route.fullPath
-        }
-
-        return `${urlRoot}${this.$route.fullPath}?ns=${entity.name}`
-      }
-
-      return shareUrl()
     },
   },
   watch: {


### PR DESCRIPTION
### Summary

Previously when clicked on  copy url (attachment) it copied wrong URL (http://localhost:5681#/mesh/default/circuit-breakers?ns=circuit-breaker-all-default)

Right now it should copy the proper URL which allows sharing link to a specific resource.

![Screenshot 2021-11-10 at 14 12 56](https://user-images.githubusercontent.com/16152347/141119450-f1162517-c657-49ea-bd64-a1e7654d1af8.png)



Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>