### PR TITLE
fix(*) allow to open notification modal when onboarding enabled

### DIFF
--- a/src/components/NotificationManager/NotificationManager.vue
+++ b/src/components/NotificationManager/NotificationManager.vue
@@ -112,7 +112,7 @@ export default {
     },
 
     shouldRenderAlert() {
-      return !this.alertClosed && this.amountOfActions > 0
+      return !this.alertClosed && !this.showOnboarding && this.amountOfActions > 0
     },
 
     hasAnyAction() {

--- a/src/views/Shell.vue
+++ b/src/views/Shell.vue
@@ -4,8 +4,8 @@
 
     <main class="main-content">
       <div class="page">
+        <NotificationManager />
         <OnboardingNotification v-if="showOnboarding" />
-        <NotificationManager v-else />
         <Breadcrumbs />
         <router-view />
       </div>

--- a/src/views/__snapshots__/Shell.spec.ts.snap
+++ b/src/views/__snapshots__/Shell.spec.ts.snap
@@ -850,6 +850,8 @@ exports[`Shell.vue renders component with route 1`] = `
           <!---->
         </div>
          
+        <!---->
+         
         <div>
           <ul
             class="krumbs"


### PR DESCRIPTION
### Summary

Fix bug which doesn't allow to open notification when onboarding alert displayed. 

Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>