### PR TITLE
refactor(api) change format

### DIFF
--- a/src/components/Sidebar/menu.ts
+++ b/src/components/Sidebar/menu.ts
@@ -12,7 +12,6 @@ export interface MenuNavItem {
   nested?: boolean
   parent?: string
   pathFlip?: boolean
-  params?: boolean
   insightsFieldAccessor?: string
 }
 
@@ -20,7 +19,6 @@ export interface MenuItem {
   name: string
   icon?: KIconType
   link?: string
-
   iconCustom?: TODO
   subNav?: {
     items: MenuNavItem[]
@@ -60,7 +58,6 @@ const menu: MenuSection[] = [
               name: 'Zone CPs',
               link: 'zones',
               insightsFieldAccessor: 'global.zones',
-              params: true,
               // root: true
               // multicluster: true
             },

--- a/src/components/Sidebar/menu.ts
+++ b/src/components/Sidebar/menu.ts
@@ -12,6 +12,7 @@ export interface MenuNavItem {
   nested?: boolean
   parent?: string
   pathFlip?: boolean
+  params?: boolean
   insightsFieldAccessor?: string
 }
 
@@ -19,6 +20,7 @@ export interface MenuItem {
   name: string
   icon?: KIconType
   link?: string
+
   iconCustom?: TODO
   subNav?: {
     items: MenuNavItem[]
@@ -58,6 +60,7 @@ const menu: MenuSection[] = [
               name: 'Zone CPs',
               link: 'zones',
               insightsFieldAccessor: 'global.zones',
+              params: true,
               // root: true
               // multicluster: true
             },

--- a/src/dataplane.ts
+++ b/src/dataplane.ts
@@ -160,7 +160,7 @@ export function getDataplaneInsight(dataplaneOverview: DataPlaneOverview) {
 }
 
 export async function checkKumaDpAndZoneVersionsMismatch(zoneName: string, dpVersion: string) {
-  const response = (await Kuma.getZoneOverview(zoneName)) || {}
+  const response = (await Kuma.getZoneOverview({ name: zoneName })) || {}
   const { zoneInsight = {} } = response
   const { subscriptions = [] } = zoneInsight
 

--- a/src/services/kuma.ts
+++ b/src/services/kuma.ts
@@ -48,8 +48,13 @@ class Kuma {
   }
 
   // Zones
-  public getZones(params?: any) {
+  public getZones(params: any) {
     return this.client.get('/zones', { params })
+  }
+
+  // Zones
+  public getZone({ name }: any = {}, params: any) {
+    return this.client.get(`/zones/${name}`, { params })
   }
 
   /**
@@ -62,7 +67,7 @@ class Kuma {
   }
 
   // Get a single Zone Insight/Overview
-  public getZoneOverview(name: string, params?: any) {
+  public getZoneOverview({ name }: any = {}, params: any) {
     return this.client.get(`/zones+insights/${name}`, { params })
   }
 
@@ -76,7 +81,7 @@ class Kuma {
   }
 
   // Get a single Zone Ingress Insight/Overview
-  public getZoneIngressOverview(name: string, params?: any) {
+  public getZoneIngressOverview({ name }: any = {}, params: any) {
     return this.client.get(`/zoneingresses+insights/${name}`, { params })
   }
 
@@ -90,7 +95,7 @@ class Kuma {
   }
 
   // get a single mesh
-  public getMesh(name: string, params?: any) {
+  public getMesh({ name }: any = {}, params: any) {
     return this.client.get(`/meshes/${name}`, { params })
   }
 
@@ -103,32 +108,32 @@ class Kuma {
   }
 
   // get a list of all dataplanes
-  public getAllDataplanesFromMesh(name: string, params?: any) {
-    return this.client.get(`/meshes/${name}/dataplanes`, { params })
+  public getAllDataplanesFromMesh({ mesh }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/dataplanes`, { params })
   }
 
   // get a single dataplane
-  public getDataplaneFromMesh(name: string, dataplane: string, params: any) {
-    return this.client.get(`/meshes/${name}/dataplanes/${dataplane}`, { params })
+  public getDataplaneFromMesh({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/dataplanes/${name}`, { params })
   }
 
   /**
    * Dataplane Overviews
    */
 
-  // get a specific dataplane overview from its associated mesh
-  public getDataplaneOverviewFromMesh(mesh: string, dataplane: string, params?: any) {
-    return this.client.get(`/meshes/${mesh}/dataplanes+insights/${dataplane}`, { params })
-  }
-
-  // get all dataplane overviews from a specific mesh
-  public getAllDataplaneOverviewsFromMesh(mesh: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/dataplanes+insights`, { params })
-  }
-
   // get all dataplane overviews
   public getAllDataplaneOverviews(params: any) {
     return this.client.get('/dataplanes+insights', { params })
+  }
+
+  // get all dataplane overviews from a specific mesh
+  public getAllDataplaneOverviewsFromMesh({ mesh }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/dataplanes+insights`, { params })
+  }
+
+  // get a specific dataplane overview from its associated mesh
+  public getDataplaneOverviewFromMesh({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/dataplanes+insights/${name}`, { params })
   }
 
   /**
@@ -141,13 +146,13 @@ class Kuma {
   }
 
   // get all traffic logs from mesh
-  public getAllTrafficLogsFromMesh(mesh: string, params: any) {
+  public getAllTrafficLogsFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/traffic-logs`, { params })
   }
 
   // get traffic log details
-  public getTrafficLog(mesh: string, trafficlog: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/traffic-logs/${trafficlog}`, { params })
+  public getTrafficLog({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/traffic-logs/${name}`, { params })
   }
 
   /**
@@ -160,13 +165,13 @@ class Kuma {
   }
 
   // get traffic permissions from mesh
-  public getAllTrafficPermissionsFromMesh(mesh: string, params: any) {
+  public getAllTrafficPermissionsFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/traffic-permissions`, { params })
   }
 
   // get traffic permission details
-  public getTrafficPermission(mesh: string, trafficpermission: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/traffic-permissions/${trafficpermission}`, { params })
+  public getTrafficPermission({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/traffic-permissions/${name}`, { params })
   }
 
   /**
@@ -179,13 +184,13 @@ class Kuma {
   }
 
   // get traffic routes from mesh
-  public getAllTrafficRoutesFromMesh(mesh: string, params: any) {
+  public getAllTrafficRoutesFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/traffic-routes`, { params })
   }
 
   // get traffic route details
-  public getTrafficRoute(mesh: string, trafficroute: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/traffic-routes/${trafficroute}`, { params })
+  public getTrafficRoute({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/traffic-routes/${name}`, { params })
   }
 
   /**
@@ -198,13 +203,13 @@ class Kuma {
   }
 
   // get traffic traces from mesh
-  public getAllTrafficTracesFromMesh(mesh: string, params: any) {
+  public getAllTrafficTracesFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/traffic-traces`, { params })
   }
 
   // get traffic trace details
-  public getTrafficTrace(mesh: string, traffictrace: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/traffic-traces/${traffictrace}`, { params })
+  public getTrafficTrace({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/traffic-traces/${name}`, { params })
   }
 
   /**
@@ -220,13 +225,13 @@ class Kuma {
   }
 
   // get all proxy templates from mesh
-  public getAllProxyTemplatesFromMesh(mesh: string, params: any) {
+  public getAllProxyTemplatesFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/proxytemplates`, { params })
   }
 
   // get proxy template details
-  public getProxyTemplate(mesh: string, proxytemplate: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/proxytemplates/${proxytemplate}`, { params })
+  public getProxyTemplate({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/proxytemplates/${name}`, { params })
   }
 
   /**
@@ -239,12 +244,12 @@ class Kuma {
   }
 
   // get all health checks from mesh
-  public getAllHealthChecksFromMesh(mesh: string, params: any) {
+  public getAllHealthChecksFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/health-checks`, { params })
   }
 
   // get health check details
-  public getHealthCheck(mesh: string, name: string, params: any) {
+  public getHealthCheck({ mesh, name }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/health-checks/${name}`, { params })
   }
 
@@ -258,13 +263,13 @@ class Kuma {
   }
 
   // get all fault injections from mesh
-  public getAllFaultInjectionsFromMesh(mesh: string, params: any) {
+  public getAllFaultInjectionsFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/fault-injections`, { params })
   }
 
   // get fault injection details
-  public getFaultInjection(mesh: string, faultinjection: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/fault-injections/${faultinjection}`, { params })
+  public getFaultInjection({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/fault-injections/${name}`, { params })
   }
 
   /**
@@ -277,13 +282,13 @@ class Kuma {
   }
 
   // get all circuit breakers from mesh
-  public getAllCircuitBreakersFromMesh(mesh: string, params: any) {
+  public getAllCircuitBreakersFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/circuit-breakers`, { params })
   }
 
   // get circuit breaker details
-  public getCircuitBreaker(mesh: string, circuitbreaker: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/circuit-breakers/${circuitbreaker}`, { params })
+  public getCircuitBreaker({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/circuit-breakers/${name}`, { params })
   }
 
   /**
@@ -296,13 +301,13 @@ class Kuma {
   }
 
   // get all rate limits from mesh
-  public getAllRateLimitsFromMesh(mesh: string, params: any) {
+  public getAllRateLimitsFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/rate-limits`, { params })
   }
 
   // get rate limit details
-  public getRateLimit(mesh: string, ratelimit: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/rate-limits/${ratelimit}`, { params })
+  public getRateLimit({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/rate-limits/${name}`, { params })
   }
 
   /**
@@ -315,13 +320,13 @@ class Kuma {
   }
 
   // get all retries from mesh
-  public getAllRetriesFromMesh(mesh: string, params: any) {
+  public getAllRetriesFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/retries`, { params })
   }
 
   // get retry details
-  public getRetry(mesh: string, retry: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/retries/${retry}`, { params })
+  public getRetry({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/retries/${name}`, { params })
   }
 
   /**
@@ -334,13 +339,13 @@ class Kuma {
   }
 
   // get all timeouts from mesh
-  public getAllTimeoutsFromMesh(mesh: string, params: any) {
+  public getAllTimeoutsFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/timeouts`, { params })
   }
 
   // get timeout details
-  public getTimeout(mesh: string, timeout: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/timeouts/${timeout}`, { params })
+  public getTimeout({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/timeouts/${name}`, { params })
   }
 
   /**
@@ -353,13 +358,13 @@ class Kuma {
   }
 
   // get all external services from mesh
-  public getAllExternalServicesFromMesh(mesh: string, params: any) {
+  public getAllExternalServicesFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/external-services`, { params })
   }
 
   // get external service details
-  public getExternalService(mesh: string, externalservice: string, params: any) {
-    return this.client.get(`/meshes/${mesh}/external-services/${externalservice}`, { params })
+  public getExternalService({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/external-services/${name}`, { params })
   }
 
   /**
@@ -372,13 +377,13 @@ class Kuma {
   }
 
   // get all services from mesh
-  public getAllServiceInsightsFromMesh(mesh: string, params: any) {
+  public getAllServiceInsightsFromMesh({ mesh }: any = {}, params: any) {
     return this.client.get(`/meshes/${mesh}/service-insights`, { params })
   }
 
   // get service details
-  public getServiceInsight(name: string, service: string, params: any) {
-    return this.client.get(`/meshes/${name}/service-insights/${service}`, { params })
+  public getServiceInsight({ mesh, name }: any = {}, params: any) {
+    return this.client.get(`/meshes/${mesh}/service-insights/${name}`, { params })
   }
 
   /**
@@ -391,11 +396,11 @@ class Kuma {
   }
 
   // Get a single Mesh Insight
-  public getMeshInsights(name: string, params?: any) {
+  public getMeshInsights({ name }: any = {}, params: any) {
     return this.client.get(`/mesh-insights/${name}`, { params })
   }
 
-  public getSupportedVersions(params?: any) {
+  public getSupportedVersions(params: any) {
     return this.client.get('/versions', { params })
   }
 
@@ -404,7 +409,7 @@ class Kuma {
    */
 
   // Get global insights
-  public getGlobalInsights() {
+  public getGlobalInsights(params: any) {
     return this.client.get('/global-insights')
   }
 }

--- a/src/services/kuma.ts
+++ b/src/services/kuma.ts
@@ -1,5 +1,15 @@
 import RestClient from '@/services/restClient'
 
+const defaultOptions = {
+  name: '',
+  mesh: '',
+}
+
+interface ApiDefaultOptions {
+  name?: string
+  mesh?: string
+}
+
 class Kuma {
   private client: RestClient
 
@@ -34,7 +44,7 @@ class Kuma {
   /**
    * Custom query
    */
-  public query(model: string, params: any) {
+  public query(model: string, params?: any) {
     return this.client.get(`/${model}`, { params })
   }
 
@@ -43,17 +53,17 @@ class Kuma {
    */
 
   // Zone status
-  public getZonesStatus(params: any) {
+  public getZonesStatus(params?: any) {
     return this.client.get('/status/zones', { params })
   }
 
   // Zones
-  public getZones(params: any) {
+  public getZones(params?: any) {
     return this.client.get('/zones', { params })
   }
 
   // Zones
-  public getZone({ name }: any = {}, params: any) {
+  public getZone({ name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/zones/${name}`, { params })
   }
 
@@ -62,12 +72,12 @@ class Kuma {
    */
 
   // Get all Zone Insights/Overviews
-  public getAllZoneOverviews(params: any) {
+  public getAllZoneOverviews(params?: any) {
     return this.client.get('/zones+insights', { params })
   }
 
   // Get a single Zone Insight/Overview
-  public getZoneOverview({ name }: any = {}, params: any) {
+  public getZoneOverview({ name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/zones+insights/${name}`, { params })
   }
 
@@ -76,12 +86,12 @@ class Kuma {
    */
 
   // Get all Zone Ingress Insights/Overviews
-  public getAllZoneIngressOverviews(params: any) {
+  public getAllZoneIngressOverviews(params?: any) {
     return this.client.get('/zoneingresses+insights', { params })
   }
 
   // Get a single Zone Ingress Insight/Overview
-  public getZoneIngressOverview({ name }: any = {}, params: any) {
+  public getZoneIngressOverview({ name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/zoneingresses+insights/${name}`, { params })
   }
 
@@ -90,12 +100,12 @@ class Kuma {
    */
 
   // get a list of all meshes
-  public getAllMeshes(params: any) {
+  public getAllMeshes(params?: any) {
     return this.client.get('/meshes', { params })
   }
 
   // get a single mesh
-  public getMesh({ name }: any = {}, params: any) {
+  public getMesh({ name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${name}`, { params })
   }
 
@@ -103,17 +113,17 @@ class Kuma {
    * Dataplanes
    */
 
-  public getAllDataplanes(params: any) {
+  public getAllDataplanes(params?: any) {
     return this.client.get('/dataplanes', { params })
   }
 
   // get a list of all dataplanes
-  public getAllDataplanesFromMesh({ mesh }: any = {}, params: any) {
+  public getAllDataplanesFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/dataplanes`, { params })
   }
 
   // get a single dataplane
-  public getDataplaneFromMesh({ mesh, name }: any = {}, params: any) {
+  public getDataplaneFromMesh({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/dataplanes/${name}`, { params })
   }
 
@@ -122,17 +132,17 @@ class Kuma {
    */
 
   // get all dataplane overviews
-  public getAllDataplaneOverviews(params: any) {
+  public getAllDataplaneOverviews(params?: any) {
     return this.client.get('/dataplanes+insights', { params })
   }
 
   // get all dataplane overviews from a specific mesh
-  public getAllDataplaneOverviewsFromMesh({ mesh }: any = {}, params: any) {
+  public getAllDataplaneOverviewsFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/dataplanes+insights`, { params })
   }
 
   // get a specific dataplane overview from its associated mesh
-  public getDataplaneOverviewFromMesh({ mesh, name }: any = {}, params: any) {
+  public getDataplaneOverviewFromMesh({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/dataplanes+insights/${name}`, { params })
   }
 
@@ -141,17 +151,17 @@ class Kuma {
    */
 
   // get all traffic logs
-  public getAllTrafficLogs(params: any) {
+  public getAllTrafficLogs(params?: any) {
     return this.client.get('/traffic-logs', { params })
   }
 
   // get all traffic logs from mesh
-  public getAllTrafficLogsFromMesh({ mesh }: any = {}, params: any) {
+  public getAllTrafficLogsFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/traffic-logs`, { params })
   }
 
   // get traffic log details
-  public getTrafficLog({ mesh, name }: any = {}, params: any) {
+  public getTrafficLog({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/traffic-logs/${name}`, { params })
   }
 
@@ -160,17 +170,17 @@ class Kuma {
    */
 
   // get traffic permissions
-  public getAllTrafficPermissions(params: any) {
+  public getAllTrafficPermissions(params?: any) {
     return this.client.get('/traffic-permissions', { params })
   }
 
   // get traffic permissions from mesh
-  public getAllTrafficPermissionsFromMesh({ mesh }: any = {}, params: any) {
+  public getAllTrafficPermissionsFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/traffic-permissions`, { params })
   }
 
   // get traffic permission details
-  public getTrafficPermission({ mesh, name }: any = {}, params: any) {
+  public getTrafficPermission({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/traffic-permissions/${name}`, { params })
   }
 
@@ -179,17 +189,17 @@ class Kuma {
    */
 
   // get all traffic routes
-  public getAllTrafficRoutes(params: any) {
+  public getAllTrafficRoutes(params?: any) {
     return this.client.get('/traffic-routes', { params })
   }
 
   // get traffic routes from mesh
-  public getAllTrafficRoutesFromMesh({ mesh }: any = {}, params: any) {
+  public getAllTrafficRoutesFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/traffic-routes`, { params })
   }
 
   // get traffic route details
-  public getTrafficRoute({ mesh, name }: any = {}, params: any) {
+  public getTrafficRoute({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/traffic-routes/${name}`, { params })
   }
 
@@ -198,17 +208,17 @@ class Kuma {
    */
 
   // get all traffic traces
-  public getAllTrafficTraces(params: any) {
+  public getAllTrafficTraces(params?: any) {
     return this.client.get('/traffic-traces', { params })
   }
 
   // get traffic traces from mesh
-  public getAllTrafficTracesFromMesh({ mesh }: any = {}, params: any) {
+  public getAllTrafficTracesFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/traffic-traces`, { params })
   }
 
   // get traffic trace details
-  public getTrafficTrace({ mesh, name }: any = {}, params: any) {
+  public getTrafficTrace({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/traffic-traces/${name}`, { params })
   }
 
@@ -217,7 +227,7 @@ class Kuma {
    */
 
   // get all proxy templates
-  public getAllProxyTemplates(params: any) {
+  public getAllProxyTemplates(params?: any) {
     return this.client.get('/proxytemplates', { params })
 
     // this may change to this:
@@ -225,12 +235,12 @@ class Kuma {
   }
 
   // get all proxy templates from mesh
-  public getAllProxyTemplatesFromMesh({ mesh }: any = {}, params: any) {
+  public getAllProxyTemplatesFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/proxytemplates`, { params })
   }
 
   // get proxy template details
-  public getProxyTemplate({ mesh, name }: any = {}, params: any) {
+  public getProxyTemplate({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/proxytemplates/${name}`, { params })
   }
 
@@ -239,17 +249,17 @@ class Kuma {
    */
 
   // get all health checks
-  public getAllHealthChecks(params: any) {
+  public getAllHealthChecks(params?: any) {
     return this.client.get('/health-checks', { params })
   }
 
   // get all health checks from mesh
-  public getAllHealthChecksFromMesh({ mesh }: any = {}, params: any) {
+  public getAllHealthChecksFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/health-checks`, { params })
   }
 
   // get health check details
-  public getHealthCheck({ mesh, name }: any = {}, params: any) {
+  public getHealthCheck({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/health-checks/${name}`, { params })
   }
 
@@ -258,17 +268,17 @@ class Kuma {
    */
 
   // get all fault injections
-  public getAllFaultInjections(params: any) {
+  public getAllFaultInjections(params?: any) {
     return this.client.get('/fault-injections', { params })
   }
 
   // get all fault injections from mesh
-  public getAllFaultInjectionsFromMesh({ mesh }: any = {}, params: any) {
+  public getAllFaultInjectionsFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/fault-injections`, { params })
   }
 
   // get fault injection details
-  public getFaultInjection({ mesh, name }: any = {}, params: any) {
+  public getFaultInjection({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/fault-injections/${name}`, { params })
   }
 
@@ -277,17 +287,17 @@ class Kuma {
    */
 
   // get all circuit breakers
-  public getAllCircuitBreakers(params: any) {
+  public getAllCircuitBreakers(params?: any) {
     return this.client.get('/circuit-breakers', { params })
   }
 
   // get all circuit breakers from mesh
-  public getAllCircuitBreakersFromMesh({ mesh }: any = {}, params: any) {
+  public getAllCircuitBreakersFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/circuit-breakers`, { params })
   }
 
   // get circuit breaker details
-  public getCircuitBreaker({ mesh, name }: any = {}, params: any) {
+  public getCircuitBreaker({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/circuit-breakers/${name}`, { params })
   }
 
@@ -296,17 +306,17 @@ class Kuma {
    */
 
   // get all rate limits
-  public getAllRateLimits(params: any) {
+  public getAllRateLimits(params?: any) {
     return this.client.get('/rate-limits', { params })
   }
 
   // get all rate limits from mesh
-  public getAllRateLimitsFromMesh({ mesh }: any = {}, params: any) {
+  public getAllRateLimitsFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/rate-limits`, { params })
   }
 
   // get rate limit details
-  public getRateLimit({ mesh, name }: any = {}, params: any) {
+  public getRateLimit({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/rate-limits/${name}`, { params })
   }
 
@@ -315,17 +325,17 @@ class Kuma {
    */
 
   // get all retries
-  public getAllRetries(params: any) {
+  public getAllRetries(params?: any) {
     return this.client.get('/retries', { params })
   }
 
   // get all retries from mesh
-  public getAllRetriesFromMesh({ mesh }: any = {}, params: any) {
+  public getAllRetriesFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/retries`, { params })
   }
 
   // get retry details
-  public getRetry({ mesh, name }: any = {}, params: any) {
+  public getRetry({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/retries/${name}`, { params })
   }
 
@@ -334,17 +344,17 @@ class Kuma {
    */
 
   // get all timeouts
-  public getAllTimeouts(params: any) {
+  public getAllTimeouts(params?: any) {
     return this.client.get('/timeouts', { params })
   }
 
   // get all timeouts from mesh
-  public getAllTimeoutsFromMesh({ mesh }: any = {}, params: any) {
+  public getAllTimeoutsFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/timeouts`, { params })
   }
 
   // get timeout details
-  public getTimeout({ mesh, name }: any = {}, params: any) {
+  public getTimeout({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/timeouts/${name}`, { params })
   }
 
@@ -353,17 +363,17 @@ class Kuma {
    */
 
   // get all external services
-  public getAllExternalServices(params: any) {
+  public getAllExternalServices(params?: any) {
     return this.client.get('/external-services', { params })
   }
 
   // get all external services from mesh
-  public getAllExternalServicesFromMesh({ mesh }: any = {}, params: any) {
+  public getAllExternalServicesFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/external-services`, { params })
   }
 
   // get external service details
-  public getExternalService({ mesh, name }: any = {}, params: any) {
+  public getExternalService({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/external-services/${name}`, { params })
   }
 
@@ -372,17 +382,17 @@ class Kuma {
    */
 
   // get all services
-  public getAllServiceInsights(params: any) {
+  public getAllServiceInsights(params?: any) {
     return this.client.get('/service-insights', { params })
   }
 
   // get all services from mesh
-  public getAllServiceInsightsFromMesh({ mesh }: any = {}, params: any) {
+  public getAllServiceInsightsFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/service-insights`, { params })
   }
 
   // get service details
-  public getServiceInsight({ mesh, name }: any = {}, params: any) {
+  public getServiceInsight({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/meshes/${mesh}/service-insights/${name}`, { params })
   }
 
@@ -391,16 +401,16 @@ class Kuma {
    */
 
   // Get all Mesh Insights
-  public getAllMeshInsights(params: any) {
+  public getAllMeshInsights(params?: any) {
     return this.client.get('/mesh-insights', { params })
   }
 
   // Get a single Mesh Insight
-  public getMeshInsights({ name }: any = {}, params: any) {
+  public getMeshInsights({ name }: ApiDefaultOptions = defaultOptions, params?: any) {
     return this.client.get(`/mesh-insights/${name}`, { params })
   }
 
-  public getSupportedVersions(params: any) {
+  public getSupportedVersions(params?: any) {
     return this.client.get('/versions', { params })
   }
 
@@ -409,7 +419,7 @@ class Kuma {
    */
 
   // Get global insights
-  public getGlobalInsights(params: any) {
+  public getGlobalInsights(params?: any) {
     return this.client.get('/global-insights')
   }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -446,8 +446,6 @@ export default (): Module<RootInterface, RootInterface> => ({
 
       let online = 0
 
-      console.log({ items })
-
       items.forEach((item: any): void => {
         const { status } = getItemStatusFromInsight(item.zoneInsight)
 

--- a/src/store/modules/sidebar/sidebar.ts
+++ b/src/store/modules/sidebar/sidebar.ts
@@ -66,7 +66,7 @@ const actions: ActionTree<SidebarInterface, RootInterface> = {
 
         meshInsightsRawData = await fetchAllResources<MeshInsight>(params)
       } else {
-        meshInsightsRawData = { items: [await Kuma.getMeshInsights(selectedMesh)], total: 1 }
+        meshInsightsRawData = { items: [await Kuma.getMeshInsights({ name: selectedMesh })], total: 1 }
       }
 
       meshInsights = calculateMeshInsights(meshInsightsRawData)

--- a/src/utils/tableDataUtils.spec.ts
+++ b/src/utils/tableDataUtils.spec.ts
@@ -40,6 +40,12 @@ describe('tableDataUtils', () => {
 
       expect(params.getSingleEntity).toHaveBeenCalled()
     })
+
+    it('calls getSingleEntity with mesh all', () => {
+      getTableData({ ...params, query: 'foo', mesh: 'all' })
+
+      expect(params.getSingleEntity).toHaveBeenCalled()
+    })
   })
 
   describe('handles reponses', () => {

--- a/src/utils/tableDataUtils.ts
+++ b/src/utils/tableDataUtils.ts
@@ -27,16 +27,16 @@ function getAPICallFunction({
     offset,
   }
 
+  if (getSingleEntity && query) {
+    return getSingleEntity({ mesh, name: query }, params)
+  }
+
   if (!mesh || mesh === 'all') {
     return getAllEntities(params)
   }
 
-  if (getSingleEntity && query && query.length && mesh !== 'all') {
-    return getSingleEntity(mesh, query, params)
-  }
-
-  if (getAllEntitiesFromMesh) {
-    return getAllEntitiesFromMesh(mesh, params)
+  if (getAllEntitiesFromMesh && mesh) {
+    return getAllEntitiesFromMesh({ mesh }, params)
   }
 
   return Promise.resolve()

--- a/src/utils/tableDataUtils.types.ts
+++ b/src/utils/tableDataUtils.types.ts
@@ -1,7 +1,10 @@
 export interface TableDataParams {
-  getSingleEntity?: (mesh: string, query: string | null, params: { size: number; offset: string | null }) => any
+  getSingleEntity?: (
+    options: { mesh?: string | null; name?: string | null },
+    params: { size: number; offset: string | null },
+  ) => any
   getAllEntities: (params: { size: number; offset: string | null }) => any
-  getAllEntitiesFromMesh?: (mesh: string, params: { size: number; offset: string | null }) => any
+  getAllEntitiesFromMesh?: (options: { mesh: string }, params: { size: number; offset: string | null }) => any
   mesh?: string
   size: number
   query?: string | null

--- a/src/views/Entities/Meshes.vue
+++ b/src/views/Entities/Meshes.vue
@@ -342,7 +342,7 @@ export default {
         offset,
       }
 
-      const endpoint = mesh === 'all' || !mesh ? Kuma.getAllMeshes(params) : Kuma.getMesh(mesh)
+      const endpoint = mesh === 'all' || !mesh ? Kuma.getAllMeshes(params) : Kuma.getMesh({ name: mesh })
 
       const getMeshes = () =>
         endpoint
@@ -406,10 +406,10 @@ export default {
       this.entityHasError = false
 
       if (entity && entity !== null) {
-        return Kuma.getMesh(entity.name)
+        return Kuma.getMesh({ name: entity.name })
           .then((response) => {
             if (response) {
-              Kuma.getMeshInsights(entity.name).then((meshInsightResponse) => {
+              Kuma.getMeshInsights({ name: entity.name }).then((meshInsightResponse) => {
                 this.meshInsight = meshInsightResponse
               })
 

--- a/src/views/Entities/ZoneIngresses.vue
+++ b/src/views/Entities/ZoneIngresses.vue
@@ -241,7 +241,7 @@ export default {
 
         try {
           // get the ZoneIngress details from the ZoneIngress Insights endpoint
-          const response = await Kuma.getZoneIngressOverview(entity.name)
+          const response = await Kuma.getZoneIngressOverview({ name: entity.name })
 
           const subscriptions = get(response, 'zoneIngressInsight.subscriptions', [])
 

--- a/src/views/Entities/Zones.vue
+++ b/src/views/Entities/Zones.vue
@@ -322,7 +322,7 @@ export default {
 
         try {
           // get the Zone details from the Zone Insights endpoint
-          const response = await Kuma.getZoneOverview(entity.name)
+          const response = await Kuma.getZoneOverview({ name: entity.name })
           const subscriptions = get(response, 'zoneInsight.subscriptions', [])
 
           this.entity = { ...getSome(response, selected), 'Authentication Type': getZoneDpServerAuthType(response) }

--- a/src/views/Entities/partial/Dataplanes.vue
+++ b/src/views/Entities/partial/Dataplanes.vue
@@ -404,10 +404,10 @@ export default {
         if (mesh === 'all') {
           return Kuma.getAllDataplaneOverviews(params)
         } else if (query && query.length && mesh !== 'all') {
-          return Kuma.getDataplaneOverviewFromMesh(mesh, query)
+          return Kuma.getDataplaneOverviewFromMesh({ mesh, name: query })
         }
 
-        return Kuma.getAllDataplaneOverviewsFromMesh(mesh, params)
+        return Kuma.getAllDataplaneOverviewsFromMesh({ mesh }, params)
       }
 
       /**
@@ -416,7 +416,7 @@ export default {
        */
       const dpFetcher = async (mesh, name, finalArr) => {
         try {
-          const response = await Kuma.getDataplaneOverviewFromMesh(mesh, name)
+          const response = await Kuma.getDataplaneOverviewFromMesh({ mesh, name })
           const { dataplane = {}, dataplaneInsight = {} } = response
           const { name: responseName = '', mesh: responseMesh = '' } = response
           const { subscriptions = [] } = dataplaneInsight
@@ -615,7 +615,7 @@ export default {
         const entityMesh = mesh === 'all' ? entity.mesh : mesh
 
         try {
-          const response = await Kuma.getDataplaneOverviewFromMesh(entityMesh, entity.name)
+          const response = await Kuma.getDataplaneOverviewFromMesh({ mesh: entityMesh, name: entity.name })
           const dataplane = getDataplane(response)
 
           if (dataplane) {

--- a/src/views/Entities/partial/Services.vue
+++ b/src/views/Entities/partial/Services.vue
@@ -195,13 +195,13 @@ export default {
     },
     getService(mesh, query, params) {
       return this.name === 'Internal Services'
-        ? Kuma.getServiceInsight(mesh, query, params)
-        : Kuma.getExternalService(mesh, query, params)
+        ? Kuma.getServiceInsight({ mesh, name: query }, params)
+        : Kuma.getExternalService({ mesh, name: query }, params)
     },
     getServiceFromMesh(mesh) {
       return this.name === 'Internal Services'
-        ? Kuma.getAllServiceInsightsFromMesh(mesh)
-        : Kuma.getAllExternalServicesFromMesh(mesh)
+        ? Kuma.getAllServiceInsightsFromMesh({ mesh })
+        : Kuma.getAllExternalServicesFromMesh({ mesh })
     },
     parseData(entity) {
       if (this.name === 'Internal Services') {

--- a/src/views/Policies/CircuitBreakers.vue
+++ b/src/views/Policies/CircuitBreakers.vue
@@ -235,7 +235,7 @@ export default {
       this.entityHasError = false
 
       if (entity) {
-        return Kuma.getCircuitBreaker(entity.mesh, entity.name)
+        return Kuma.getCircuitBreaker({ mesh: entity.mesh, name: entity.name })
           .then((response) => {
             if (response) {
               const selected = ['type', 'name', 'mesh']

--- a/src/views/Policies/FaultInjections.vue
+++ b/src/views/Policies/FaultInjections.vue
@@ -238,7 +238,7 @@ export default {
       if (entity) {
         const entityMesh = mesh === 'all' ? entity.mesh : mesh
 
-        return Kuma.getFaultInjection(entityMesh, entity.name)
+        return Kuma.getFaultInjection({ mesh: entityMesh, name: entity.name })
           .then((response) => {
             if (response) {
               const selected = ['type', 'name', 'mesh']

--- a/src/views/Policies/HealthChecks.vue
+++ b/src/views/Policies/HealthChecks.vue
@@ -241,7 +241,7 @@ export default {
       if (entity) {
         const entityMesh = mesh === 'all' ? entity.mesh : mesh
 
-        return Kuma.getHealthCheck(entityMesh, entity.name)
+        return Kuma.getHealthCheck({ mesh: entityMesh, name: entity.name })
           .then((response) => {
             if (response) {
               const selected = ['type', 'name', 'mesh']

--- a/src/views/Policies/ProxyTemplates.vue
+++ b/src/views/Policies/ProxyTemplates.vue
@@ -241,7 +241,7 @@ export default {
       if (entity) {
         const entityMesh = mesh === 'all' ? entity.mesh : mesh
 
-        return Kuma.getProxyTemplate(entityMesh, entity.name)
+        return Kuma.getProxyTemplate({ mesh: entityMesh, name: entity.name })
           .then((response) => {
             if (response) {
               const selected = ['type', 'name', 'mesh']

--- a/src/views/Policies/RateLimits.vue
+++ b/src/views/Policies/RateLimits.vue
@@ -239,7 +239,7 @@ export default {
       if (entity) {
         const entityMesh = mesh === 'all' ? entity.mesh : mesh
 
-        return Kuma.getRateLimit(entityMesh, entity.name)
+        return Kuma.getRateLimit({ mesh: entityMesh, name: entity.name })
           .then((response) => {
             if (response) {
               const selected = ['type', 'name', 'mesh']

--- a/src/views/Policies/Retries.vue
+++ b/src/views/Policies/Retries.vue
@@ -241,7 +241,7 @@ export default {
       if (entity) {
         const entityMesh = mesh === 'all' ? entity.mesh : mesh
 
-        return Kuma.getRetry(entityMesh, entity.name)
+        return Kuma.getRetry({ mesh: entityMesh, name: entity.name })
           .then((response) => {
             if (response) {
               const selected = ['type', 'name', 'mesh']

--- a/src/views/Policies/Timeouts.vue
+++ b/src/views/Policies/Timeouts.vue
@@ -239,7 +239,7 @@ export default {
       if (entity) {
         const entityMesh = mesh === 'all' ? entity.mesh : mesh
 
-        return Kuma.getTimeout(entityMesh, entity.name)
+        return Kuma.getTimeout({ mesh: entityMesh, name: entity.name })
           .then((response) => {
             if (response) {
               const selected = ['type', 'name', 'mesh']

--- a/src/views/Policies/TrafficLogs.vue
+++ b/src/views/Policies/TrafficLogs.vue
@@ -239,7 +239,7 @@ export default {
       if (entity) {
         const entityMesh = mesh === 'all' ? entity.mesh : mesh
 
-        return Kuma.getTrafficLog(entityMesh, entity.name)
+        return Kuma.getTrafficLog({ mesh: entityMesh, name: entity.name })
           .then((response) => {
             if (response) {
               const selected = ['type', 'name', 'mesh']

--- a/src/views/Policies/TrafficPermissions.vue
+++ b/src/views/Policies/TrafficPermissions.vue
@@ -262,7 +262,7 @@ export default {
       if (entity) {
         const entityMesh = mesh === 'all' ? entity.mesh : mesh
 
-        return Kuma.getTrafficPermission(entityMesh, entity.name)
+        return Kuma.getTrafficPermission({ mesh: entityMesh, name: entity.name })
           .then((response) => {
             if (response) {
               const selected = ['type', 'name', 'mesh']
@@ -298,7 +298,7 @@ export default {
       const entityMesh = mesh !== 'all' ? mesh : false
 
       if (entityMesh) {
-        return Kuma.getMesh(entityMesh).then((response) => {
+        return Kuma.getMesh({ name: entityMesh }).then((response) => {
           const { mtls } = response
 
           if (mtls?.enabledBackend?.length > 0) {

--- a/src/views/Policies/TrafficRoutes.vue
+++ b/src/views/Policies/TrafficRoutes.vue
@@ -239,7 +239,7 @@ export default {
       if (entity) {
         const entityMesh = mesh === 'all' ? entity.mesh : mesh
 
-        return Kuma.getTrafficRoute(entityMesh, entity.name)
+        return Kuma.getTrafficRoute({ mesh: entityMesh, name: entity.name })
           .then((response) => {
             if (response) {
               const selected = ['type', 'name', 'mesh']

--- a/src/views/Policies/TrafficTraces.vue
+++ b/src/views/Policies/TrafficTraces.vue
@@ -239,7 +239,7 @@ export default {
       if (entity) {
         const entityMesh = mesh === 'all' ? entity.mesh : mesh
 
-        return Kuma.getTrafficTrace(entityMesh, entity.name)
+        return Kuma.getTrafficTrace({ mesh: entityMesh, name: entity.name })
           .then((response) => {
             if (response) {
               const selected = ['type', 'name', 'mesh']

--- a/src/views/Wizard/views/DataplaneKubernetes.vue
+++ b/src/views/Wizard/views/DataplaneKubernetes.vue
@@ -814,7 +814,7 @@ export default {
       // do nothing if there is no Mesh nor Dataplane found
       if (!mesh || !dataplane) return
 
-      Kuma.getDataplaneFromMesh(mesh, dataplane)
+      Kuma.getDataplaneFromMesh({ mesh, name: dataplane })
         .then((response) => {
           if (response && response.name.length > 0) {
             this.isRunning = true

--- a/src/views/Wizard/views/DataplaneUniversal.vue
+++ b/src/views/Wizard/views/DataplaneUniversal.vue
@@ -663,7 +663,7 @@ export default {
       // do nothing if there is no Mesh nor Dataplane found
       if (!meshName || !univDataplaneId) return
 
-      Kuma.getDataplaneFromMesh(meshName, univDataplaneId)
+      Kuma.getDataplaneFromMesh({ mesh: meshName, name: univDataplaneId })
         .then((response) => {
           if (response && response.name.length > 0) {
             this.isRunning = true

--- a/src/views/Wizard/views/Mesh.vue
+++ b/src/views/Wizard/views/Mesh.vue
@@ -919,7 +919,7 @@ export default {
       // do nothing if there's nothing found
       if (!entity) return
 
-      Kuma.getMesh(entity)
+      Kuma.getMesh({ name: entity })
         .then((response) => {
           if (response && response.name.length > 0) {
             this.isRunning = true


### PR DESCRIPTION
### Summary

The reason of this refactor is to align the format of parameters in API calls.
This will allow to easy access a single entity (in case of share-url or one entity table view) no matter if it's mesh-related or not, whereas previously we were limited to mesh-related resources.