### PR TITLE
feat(policies) add Affected DPPs tab for every policy

### DIFF
--- a/src/components/PolicyConnections/PolicyConnections.spec.ts
+++ b/src/components/PolicyConnections/PolicyConnections.spec.ts
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import { rest } from 'msw'
+import { server } from '@/jest-setup'
+import PolicyConnections from './PolicyConnections.vue'
+
+describe('PolicyConnections.vue', () => {
+  it('renders snapshot', async () => {
+    const { container } = render(PolicyConnections, {
+      props: {
+        mesh: 'foo',
+        policyType: 'foo',
+        policyName: 'foo',
+      },
+      routes: [{ name: 'dataplanes', path: '/' }],
+    })
+
+    await screen.findByText('frontend')
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('filters result', async () => {
+    render(PolicyConnections, {
+      props: {
+        mesh: 'foo',
+        policyType: 'foo',
+        policyName: 'foo',
+      },
+      routes: [{ name: 'dataplanes', path: '/' }],
+    })
+
+    await screen.findByText('frontend')
+
+    expect(screen.getAllByTestId('dataplane-name').length).toBe(3)
+
+    await userEvent.type(screen.getByRole('textbox'), 'b')
+
+    expect(screen.getAllByTestId('dataplane-name').length).toBe(2)
+  })
+
+  it('renders loading', () => {
+    render(PolicyConnections, {
+      props: {
+        mesh: 'foo',
+        policyType: 'foo',
+        policyName: 'foo',
+      },
+      routes: [{ name: 'dataplanes', path: '/' }],
+    })
+
+    expect(screen.getByText('spinner')).toBeInTheDocument()
+  })
+
+  it('renders error', async () => {
+    server.use(
+      rest.get(' http://localhost/meshes/:mesh/:policyType/:policyName/dataplanes', (req, res, ctx) =>
+        res(ctx.status(500), ctx.json({})),
+      ),
+    )
+
+    render(PolicyConnections, {
+      props: {
+        mesh: 'foo',
+        policyType: 'foo',
+        policyName: 'foo',
+      },
+      routes: [{ name: 'dataplanes', path: '/' }],
+    })
+
+    expect(await screen.findByText(/An error has occurred while trying to load this data./)).toBeInTheDocument()
+  })
+
+  it('renders no item', async () => {
+    server.use(
+      rest.get(' http://localhost/meshes/:mesh/:policyType/:policyName/dataplanes', (req, res, ctx) =>
+        res(ctx.status(200), ctx.json({ total: 0, items: [] })),
+      ),
+    )
+
+    render(PolicyConnections, {
+      props: {
+        mesh: 'foo',
+        policyType: 'foo',
+        policyName: 'foo',
+      },
+      routes: [{ name: 'dataplanes', path: '/' }],
+    })
+
+    expect(await screen.findByText(/There is no data to display./)).toBeInTheDocument()
+  })
+})

--- a/src/components/PolicyConnections/PolicyConnections.vue
+++ b/src/components/PolicyConnections/PolicyConnections.vue
@@ -1,0 +1,108 @@
+
+<template>
+  <div>
+    <LabelList
+      :has-error="hasError"
+      :is-loading="isLoading"
+      :is-empty="!hasDataplanes"
+    >
+      <ul>
+        <li>
+          <h4>Dataplanes</h4>
+          <input
+            id="dataplane-search"
+            v-model="searchInput"
+            type="text"
+            class="k-input mb-4"
+            placeholder="Filter by name"
+            required
+          >
+          <p
+            v-for="(dataplane, key) in filteredDataplanes"
+            :key="key"
+            class="my-1"
+            data-testid="dataplane-name"
+          >
+            <router-link :to="{ name: 'dataplanes', query: {ns: dataplane.dataplane.name}, params: {mesh: dataplane.dataplane.mesh} }">
+              {{ dataplane.dataplane.name }}
+            </router-link>
+          </p>
+        </li>
+      </ul>
+    </LabelList>
+  </div>
+</template>
+
+<script>
+import Kuma from '@/services/kuma'
+import LabelList from '@/components/Utils/LabelList'
+
+export default {
+  name: 'PolicyConnections',
+  components: {
+    LabelList,
+  },
+  props: {
+    mesh: {
+      type: String,
+      required: true,
+    },
+    policyType: {
+      type: String,
+      required: true,
+    },
+    policyName: {
+      type: String,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      hasDataplanes: false,
+      isLoading: true,
+      hasError: false,
+      dataplanes: [],
+      searchInput: '',
+    }
+  },
+  computed: {
+    filteredDataplanes() {
+      const lowerCasedInput = this.searchInput.toLowerCase()
+
+      return this.dataplanes.filter(({ dataplane: { name } }) => name.toLowerCase().includes(lowerCasedInput))
+    },
+  },
+  watch: {
+    policyName() {
+      this.fetchPolicyConntections()
+    },
+  },
+  mounted() {
+    this.fetchPolicyConntections()
+  },
+
+  methods: {
+    async fetchPolicyConntections() {
+      this.hasError = false
+      this.isLoading = true
+
+      try {
+        const { items, total } = await Kuma.getPolicyConnections({
+          mesh: this.mesh,
+          policyType: this.policyType,
+          policyName: this.policyName,
+        })
+
+        this.hasDataplanes = total > 0
+
+        this.dataplanes = items
+      } catch (e) {
+        this.hasError = true
+      } finally {
+        this.isLoading = false
+      }
+    },
+  },
+}
+</script>

--- a/src/components/PolicyConnections/__snapshots__/PolicyConnections.spec.ts.snap
+++ b/src/components/PolicyConnections/__snapshots__/PolicyConnections.spec.ts.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PolicyConnections.vue renders snapshot 1`] = `
+<div>
+  <div>
+    <div>
+      <div
+        class="label-list-content"
+      >
+        <div
+          class="kong-card noBorder"
+          data-v-0029352b=""
+        >
+          <!---->
+          <!---->
+          <div
+            class="k-card-body"
+            data-v-0029352b=""
+          >
+            <div
+              class="label-list__col-wrapper multi-col"
+              data-v-0029352b=""
+            >
+              <ul
+                data-v-0029352b=""
+              >
+                <li
+                  data-v-0029352b=""
+                >
+                  <h4
+                    data-v-0029352b=""
+                  >
+                    Dataplanes
+                  </h4>
+                   
+                  <input
+                    class="k-input mb-4"
+                    data-v-0029352b=""
+                    id="dataplane-search"
+                    placeholder="Filter by name"
+                    required="required"
+                    type="text"
+                  />
+                   
+                  <p
+                    class="my-1"
+                    data-testid="dataplane-name"
+                    data-v-0029352b=""
+                  >
+                    <a
+                      class=""
+                      data-v-0029352b=""
+                      href="#/?ns=backend"
+                    >
+                      
+            backend
+          
+                    </a>
+                  </p>
+                  <p
+                    class="my-1"
+                    data-testid="dataplane-name"
+                    data-v-0029352b=""
+                  >
+                    <a
+                      class=""
+                      data-v-0029352b=""
+                      href="#/?ns=db"
+                    >
+                      
+            db
+          
+                    </a>
+                  </p>
+                  <p
+                    class="my-1"
+                    data-testid="dataplane-name"
+                    data-v-0029352b=""
+                  >
+                    <a
+                      class=""
+                      data-v-0029352b=""
+                      href="#/?ns=frontend"
+                    >
+                      
+            frontend
+          
+                    </a>
+                  </p>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+       
+      <!---->
+       
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</div>
+`;

--- a/src/services/kuma.ts
+++ b/src/services/kuma.ts
@@ -422,6 +422,18 @@ class Kuma {
   public getGlobalInsights(params?: any) {
     return this.client.get('/global-insights')
   }
+
+  /**
+   * Policy connections
+   */
+
+  // Get policy dpps connections
+  public getPolicyConnections(
+    { mesh, policyType, policyName }: { mesh: string; policyType: string; policyName: string },
+    params?: any,
+  ) {
+    return this.client.get(`/meshes/${mesh}/${policyType}/${policyName}/dataplanes`, { params })
+  }
 }
 
 export default new Kuma()

--- a/src/services/mock/responses/policy-connections.json
+++ b/src/services/mock/responses/policy-connections.json
@@ -1,0 +1,42 @@
+{
+  "total": 2,
+  "items": [
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "backend"
+      },
+      "attachments": [
+        {
+          "type": "inbound",
+          "name": "192.168.0.1:80:81"
+        }
+      ]
+    },
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "db"
+      },
+      "attachments": [
+        {
+          "type": "inbound",
+          "name": "192.168.0.1:80:81"
+        }
+      ]
+    },
+    {
+      "dataplane": {
+        "mesh": "default",
+        "name": "frontend"
+      },
+      "attachments": [
+        {
+          "type": "inbound",
+          "name": "192.168.0.1:80:81"
+        }
+      ]
+    }
+  ],
+  "next": null
+}

--- a/src/services/mocks.ts
+++ b/src/services/mocks.ts
@@ -158,6 +158,12 @@ const setupHandlers = (apiURL: string): RestHandler[] => {
     }),
   )
 
+  handlers.push(
+    rest.get(`${apiURL}meshes/:mesh/:policyType/:policyName/dataplanes`, (req, res, ctx) =>
+      res(ctx.json(requireMockFile('policy-connections.json'))),
+    ),
+  )
+
   return handlers
 }
 

--- a/src/views/Entities/Meshes.vue
+++ b/src/views/Entities/Meshes.vue
@@ -225,7 +225,7 @@ export default {
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
       itemsPerCol: 3,

--- a/src/views/Entities/partial/Dataplanes.vue
+++ b/src/views/Entities/partial/Dataplanes.vue
@@ -340,7 +340,7 @@ export default {
         data: [],
       },
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
       shownTLSTab: false,

--- a/src/views/Entities/partial/Services.vue
+++ b/src/views/Entities/partial/Services.vue
@@ -150,7 +150,7 @@ export default {
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }

--- a/src/views/Policies/CircuitBreakers.spec.ts
+++ b/src/views/Policies/CircuitBreakers.spec.ts
@@ -1,0 +1,36 @@
+import { screen } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
+import renderWithVuex from '@/testUtils/renderWithVuex'
+import Kuma from '@/services/kuma'
+import CircuitBreakers from './CircuitBreakers.vue'
+
+describe('CircuitBreakers.vue', () => {
+  it('calls getPolicyConnections only when select the tab', async () => {
+    jest.spyOn(Kuma, 'getPolicyConnections')
+    const { debug } = renderWithVuex(CircuitBreakers)
+
+    await screen.findByText(/Circuit Breaker: cb1/)
+
+    expect(Kuma.getPolicyConnections).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByText(/Affected DPPs/))
+
+    await screen.findByText(/backend/)
+
+    expect(Kuma.getPolicyConnections).toHaveBeenCalledWith({
+      mesh: 'default',
+      policyName: 'cb1',
+      policyType: 'circuit-breakers',
+    })
+
+    await userEvent.click(await screen.findByText(/cb2/))
+
+    await screen.findByText(/Circuit Breaker: cb2/)
+
+    expect(Kuma.getPolicyConnections).toHaveBeenCalledWith({
+      mesh: 'default',
+      policyName: 'cb2',
+      policyType: 'circuit-breakers',
+    })
+  })
+})

--- a/src/views/Policies/CircuitBreakers.vue
+++ b/src/views/Policies/CircuitBreakers.vue
@@ -69,6 +69,13 @@
             </div>
           </LabelList>
         </template>
+        <template v-slot:affected-dpps>
+          <PolicyConnections
+            :mesh="rawEntity.mesh"
+            :policy-name="rawEntity.name"
+            policy-type="circuit-breakers"
+          />
+        </template>
         <template v-slot:yaml>
           <YamlView
             lang="yaml"
@@ -91,6 +98,7 @@ import EntityURLControl from '@/components/Utils/EntityURLControl'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
@@ -107,6 +115,7 @@ export default {
     Tabs,
     YamlView,
     LabelList,
+    PolicyConnections,
   },
   data() {
     return {
@@ -135,13 +144,14 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
+        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
           hash: '#yaml',
           title: 'YAML',
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }

--- a/src/views/Policies/FaultInjections.vue
+++ b/src/views/Policies/FaultInjections.vue
@@ -71,6 +71,13 @@
             </div>
           </LabelList>
         </template>
+        <template v-slot:affected-dpps>
+          <PolicyConnections
+            :mesh="rawEntity.mesh"
+            :policy-name="rawEntity.name"
+            policy-type="fault-injections"
+          />
+        </template>
         <template v-slot:yaml>
           <YamlView
             lang="yaml"
@@ -93,6 +100,7 @@ import EntityURLControl from '@/components/Utils/EntityURLControl'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
@@ -109,6 +117,7 @@ export default {
     Tabs,
     YamlView,
     LabelList,
+    PolicyConnections,
   },
   data() {
     return {
@@ -137,13 +146,14 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
+        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
           hash: '#yaml',
           title: 'YAML',
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }

--- a/src/views/Policies/HealthChecks.vue
+++ b/src/views/Policies/HealthChecks.vue
@@ -69,6 +69,13 @@
             </div>
           </LabelList>
         </template>
+        <template v-slot:affected-dpps>
+          <PolicyConnections
+            :mesh="rawEntity.mesh"
+            :policy-name="rawEntity.name"
+            policy-type="health-checks"
+          />
+        </template>
         <template v-slot:yaml>
           <YamlView
             :has-error="entityHasError"
@@ -89,6 +96,7 @@ import { getTableData } from '@/utils/tableDataUtils'
 import EntityURLControl from '@/components/Utils/EntityURLControl'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
@@ -106,6 +114,7 @@ export default {
     Tabs,
     YamlView,
     LabelList,
+    PolicyConnections,
   },
   data() {
     return {
@@ -134,13 +143,14 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
+        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
           hash: '#yaml',
           title: 'YAML',
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }

--- a/src/views/Policies/ProxyTemplates.vue
+++ b/src/views/Policies/ProxyTemplates.vue
@@ -69,6 +69,13 @@
             </div>
           </LabelList>
         </template>
+        <template v-slot:affected-dpps>
+          <PolicyConnections
+            :mesh="rawEntity.mesh"
+            :policy-name="rawEntity.name"
+            policy-type="proxy-templates"
+          />
+        </template>
         <template v-slot:yaml>
           <YamlView
             :has-error="entityHasError"
@@ -89,6 +96,7 @@ import { getTableData } from '@/utils/tableDataUtils'
 import EntityURLControl from '@/components/Utils/EntityURLControl'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
@@ -106,6 +114,7 @@ export default {
     Tabs,
     YamlView,
     LabelList,
+    PolicyConnections,
   },
   data() {
     return {
@@ -134,13 +143,14 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
+        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
           hash: '#yaml',
           title: 'YAML',
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }

--- a/src/views/Policies/RateLimits.vue
+++ b/src/views/Policies/RateLimits.vue
@@ -69,6 +69,13 @@
             </div>
           </LabelList>
         </template>
+        <template v-slot:affected-dpps>
+          <PolicyConnections
+            :mesh="rawEntity.mesh"
+            :policy-name="rawEntity.name"
+            policy-type="rate-limits"
+          />
+        </template>
         <template v-slot:yaml>
           <YamlView
             :has-error="entityHasError"
@@ -89,6 +96,7 @@ import { getTableData } from '@/utils/tableDataUtils'
 import EntityURLControl from '@/components/Utils/EntityURLControl'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
@@ -106,6 +114,7 @@ export default {
     Tabs,
     YamlView,
     LabelList,
+    PolicyConnections,
   },
   data() {
     return {
@@ -134,13 +143,14 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
+        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
           hash: '#yaml',
           title: 'YAML',
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }

--- a/src/views/Policies/Retries.vue
+++ b/src/views/Policies/Retries.vue
@@ -76,6 +76,13 @@
             :content="rawEntity"
           />
         </template>
+        <template v-slot:affected-dpps>
+          <PolicyConnections
+            :mesh="rawEntity.mesh"
+            :policy-name="rawEntity.name"
+            policy-type="retries"
+          />
+        </template>
       </Tabs>
     </FrameSkeleton>
   </div>
@@ -90,6 +97,7 @@ import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import LabelList from '@/components/Utils/LabelList'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
@@ -105,6 +113,7 @@ export default {
     Tabs,
     YamlView,
     LabelList,
+    PolicyConnections,
   },
   data() {
     return {
@@ -133,13 +142,14 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
+        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
           hash: '#yaml',
           title: 'YAML',
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }

--- a/src/views/Policies/Timeouts.vue
+++ b/src/views/Policies/Timeouts.vue
@@ -68,6 +68,13 @@
             </div>
           </LabelList>
         </template>
+        <template v-slot:affected-dpps>
+          <PolicyConnections
+            :mesh="rawEntity.mesh"
+            :policy-name="rawEntity.name"
+            policy-type="timeouts"
+          />
+        </template>
         <template v-slot:yaml>
           <YamlView
             :has-error="entityHasError"
@@ -88,6 +95,7 @@ import { getTableData } from '@/utils/tableDataUtils'
 import EntityURLControl from '@/components/Utils/EntityURLControl'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
@@ -105,6 +113,7 @@ export default {
     Tabs,
     YamlView,
     LabelList,
+    PolicyConnections,
   },
   data() {
     return {
@@ -133,13 +142,14 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
+        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
           hash: '#yaml',
           title: 'YAML',
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }

--- a/src/views/Policies/TrafficLogs.vue
+++ b/src/views/Policies/TrafficLogs.vue
@@ -68,6 +68,13 @@
             </div>
           </LabelList>
         </template>
+        <template v-slot:affected-dpps>
+          <PolicyConnections
+            :mesh="rawEntity.mesh"
+            :policy-name="rawEntity.name"
+            policy-type="traffic-logs"
+          />
+        </template>
         <template v-slot:yaml>
           <YamlView
             :has-error="entityHasError"
@@ -87,6 +94,7 @@ import Kuma from '@/services/kuma'
 import { getTableData } from '@/utils/tableDataUtils'
 import EntityURLControl from '@/components/Utils/EntityURLControl'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
@@ -105,6 +113,7 @@ export default {
     Tabs,
     YamlView,
     LabelList,
+    PolicyConnections,
   },
   data() {
     return {
@@ -133,13 +142,14 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
+        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
           hash: '#yaml',
           title: 'YAML',
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }

--- a/src/views/Policies/TrafficPermissions.vue
+++ b/src/views/Policies/TrafficPermissions.vue
@@ -86,6 +86,13 @@
             </div>
           </LabelList>
         </template>
+        <template v-slot:affected-dpps>
+          <PolicyConnections
+            :mesh="rawEntity.mesh"
+            :policy-name="rawEntity.name"
+            policy-type="traffic-permissions"
+          />
+        </template>
         <template v-slot:yaml>
           <YamlView
             :has-error="entityHasError"
@@ -106,6 +113,7 @@ import { getTableData } from '@/utils/tableDataUtils'
 import { getSome, stripTimes } from '@/helpers'
 import EntityURLControl from '@/components/Utils/EntityURLControl'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
@@ -124,6 +132,7 @@ export default {
     Tabs,
     YamlView,
     LabelList,
+    PolicyConnections,
   },
   data() {
     return {
@@ -152,13 +161,14 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
+        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
           hash: '#yaml',
           title: 'YAML',
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
       securityWarning: false,

--- a/src/views/Policies/TrafficRoutes.vue
+++ b/src/views/Policies/TrafficRoutes.vue
@@ -68,6 +68,13 @@
             </div>
           </LabelList>
         </template>
+        <template v-slot:affected-dpps>
+          <PolicyConnections
+            :mesh="rawEntity.mesh"
+            :policy-name="rawEntity.name"
+            policy-type="traffic-routes"
+          />
+        </template>
         <template v-slot:yaml>
           <YamlView
             :has-error="entityHasError"
@@ -88,6 +95,7 @@ import { getTableData } from '@/utils/tableDataUtils'
 import EntityURLControl from '@/components/Utils/EntityURLControl'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
@@ -105,6 +113,7 @@ export default {
     Tabs,
     YamlView,
     LabelList,
+    PolicyConnections,
   },
   data() {
     return {
@@ -133,13 +142,14 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
+        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
           hash: '#yaml',
           title: 'YAML',
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }

--- a/src/views/Policies/TrafficTraces.vue
+++ b/src/views/Policies/TrafficTraces.vue
@@ -68,6 +68,13 @@
             </div>
           </LabelList>
         </template>
+        <template v-slot:affected-dpps>
+          <PolicyConnections
+            :mesh="rawEntity.mesh"
+            :policy-name="rawEntity.name"
+            policy-type="traffic-traces"
+          />
+        </template>
         <template v-slot:yaml>
           <YamlView
             :has-error="entityHasError"
@@ -88,6 +95,7 @@ import { getTableData } from '@/utils/tableDataUtils'
 import EntityURLControl from '@/components/Utils/EntityURLControl'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
@@ -105,6 +113,7 @@ export default {
     Tabs,
     YamlView,
     LabelList,
+    PolicyConnections,
   },
   data() {
     return {
@@ -133,13 +142,14 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
+        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
           hash: '#yaml',
           title: 'YAML',
         },
       ],
       entity: {},
-      rawEntity: null,
+      rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }


### PR DESCRIPTION
### Summary

Provide a new tab "Affected DPPs" for every policy which contains all dpps (and direct link to them) which are affected by the selected policy.


![Screenshot 2022-01-13 at 14 54 20](https://user-images.githubusercontent.com/16152347/149342969-805db6f1-e74b-4664-bc54-6715b2806b07.png)
![Screenshot 2022-01-13 at 14 54 26](https://user-images.githubusercontent.com/16152347/149342973-a8224a1b-6da1-4c6e-bc6c-2b031f98ef03.png)


Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>

