### PR TITLE
feat(policies) add documentation link

### DIFF
--- a/src/components/DocumentationLink/DocumentationLink.spec.ts
+++ b/src/components/DocumentationLink/DocumentationLink.spec.ts
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/vue'
+import DocumentationLink from './DocumentationLink.vue'
+
+describe('DocumentationLink.vue', () => {
+  it('renders snapshot', () => {
+    const { container } = render(DocumentationLink, { props: { href: 'https://kuma.io/docs/1.3.2/policies/timeout/' } })
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/components/DocumentationLink/DocumentationLink.vue
+++ b/src/components/DocumentationLink/DocumentationLink.vue
@@ -1,0 +1,39 @@
+<template>
+  <KButton
+    class="docs-link"
+    appearance="secondary"
+    size="small"
+    target="_blank"
+    :to="href"
+  >
+    <template v-slot:icon>
+      <KIcon
+        view-box="0 0 14 14"
+        icon="externalLink"
+      />
+    </template>
+    Documentation
+  </KButton>
+</template>
+
+<script>
+export default {
+  name: 'Documentation',
+  props: {
+    href: {
+      type: String,
+      required: true,
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.docs-link {
+  cursor: pointer;
+  position: absolute;
+
+  top: -48px;
+  right: -4px;
+}
+</style>

--- a/src/components/DocumentationLink/__snapshots__/DocumentationLink.spec.ts.snap
+++ b/src/components/DocumentationLink/__snapshots__/DocumentationLink.spec.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DocumentationLink.vue renders snapshot 1`] = `
+<div>
+  <a
+    class="k-button docs-link small secondary"
+    data-v-38fa8ecf=""
+    href="https://kuma.io/docs/1.3.2/policies/timeout/"
+    target="_blank"
+    type="button"
+  >
+    <svg
+      class="kong-icon kong-icon-externalLink"
+      data-v-38fa8ecf=""
+      data-v-a7c9c1d2=""
+      height="12"
+      role="img"
+      viewBox="0 0 14 14"
+      width="12"
+    >
+      <title
+        data-v-a7c9c1d2=""
+      >
+        externalLink
+      </title>
+      <g
+        data-v-a7c9c1d2=""
+      >
+        <path
+          d="M8.24308 1.5C7.83269 1.5 7.5 1.16710138 7.5.75c0-.41421356.33823-.75.74308-.75h3.00568C11.6666 0 12 .336341 12 .75123866v3.00567786C12 4.1673102 11.6671 4.5 11.25 4.5c-.41421 0-.75-.3382314-.75-.74308348V2.625L6.53246 6.59254c-.28982.2898217-.76955.2953689-1.06202.0029022l-.06588-.0658844c-.29098-.2909742-.29117-.7679483.0029-1.0620178L9.375 1.5H8.24308zm-6.74753 0C.67089 1.5 0 2.1695784 0 2.99554521v7.50890959C0 11.3291147.66958 12 1.49555 12h7.5089C9.82911 12 10.5 11.3304216 10.5 10.5044548V6.75H9v3.75H1.5V3h3.75V1.5H1.49555z"
+          data-v-a7c9c1d2=""
+          fill="#000"
+          fill-opacity=".25"
+          fill-rule="evenodd"
+        />
+      </g>
+    </svg>
+    
+  Documentation
+
+  </a>
+</div>
+`;

--- a/src/views/Policies/CircuitBreakers.vue
+++ b/src/views/Policies/CircuitBreakers.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="circuit-breakers">
+  <div class="circuit-breakers relative">
+    <DocumentationLink :href="docsURL" />
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -91,6 +92,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { getSome, stripTimes } from '@/helpers'
 import { getTableData } from '@/utils/tableDataUtils'
 import Kuma from '@/services/kuma'
@@ -101,6 +103,7 @@ import Tabs from '@/components/Utils/Tabs'
 import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
@@ -116,6 +119,7 @@ export default {
     YamlView,
     LabelList,
     PolicyConnections,
+    DocumentationLink,
   },
   data() {
     return {
@@ -155,6 +159,14 @@ export default {
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }
+  },
+  computed: {
+    ...mapGetters({
+      version: 'config/getVersion',
+    }),
+    docsURL() {
+      return `https://kuma.io/docs/${this.version}/policies/circuit-breaker/`
+    },
   },
   watch: {
     $route(to, from) {

--- a/src/views/Policies/FaultInjections.vue
+++ b/src/views/Policies/FaultInjections.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="fault-injections">
+  <div class="fault-injections relative">
+    <DocumentationLink :href="docsURL" />
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -93,6 +94,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { getSome, stripTimes } from '@/helpers'
 import { getTableData } from '@/utils/tableDataUtils'
 import Kuma from '@/services/kuma'
@@ -103,6 +105,7 @@ import Tabs from '@/components/Utils/Tabs'
 import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
@@ -118,6 +121,7 @@ export default {
     YamlView,
     LabelList,
     PolicyConnections,
+    DocumentationLink,
   },
   data() {
     return {
@@ -157,6 +161,14 @@ export default {
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }
+  },
+  computed: {
+    ...mapGetters({
+      version: 'config/getVersion',
+    }),
+    docsURL() {
+      return `https://kuma.io/docs/${this.version}/policies/fault-injection/`
+    },
   },
   watch: {
     $route(to, from) {

--- a/src/views/Policies/HealthChecks.vue
+++ b/src/views/Policies/HealthChecks.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="health-checks">
+  <div class="health-checks relative">
+    <DocumentationLink :href="docsURL" />
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -90,6 +91,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { getSome, stripTimes } from '@/helpers'
 import Kuma from '@/services/kuma'
 import { getTableData } from '@/utils/tableDataUtils'
@@ -100,6 +102,7 @@ import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
@@ -115,6 +118,7 @@ export default {
     YamlView,
     LabelList,
     PolicyConnections,
+    DocumentationLink,
   },
   data() {
     return {
@@ -154,6 +158,14 @@ export default {
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }
+  },
+  computed: {
+    ...mapGetters({
+      version: 'config/getVersion',
+    }),
+    docsURL() {
+      return `https://kuma.io/docs/${this.version}/policies/health-check/`
+    },
   },
   watch: {
     $route(to, from) {

--- a/src/views/Policies/ProxyTemplates.vue
+++ b/src/views/Policies/ProxyTemplates.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="proxy-templates">
+  <div class="proxy-templates relative">
+    <DocumentationLink :href="docsURL" />
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -90,6 +91,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { getSome, stripTimes } from '@/helpers'
 import Kuma from '@/services/kuma'
 import { getTableData } from '@/utils/tableDataUtils'
@@ -100,6 +102,7 @@ import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
@@ -115,6 +118,7 @@ export default {
     YamlView,
     LabelList,
     PolicyConnections,
+    DocumentationLink,
   },
   data() {
     return {
@@ -154,6 +158,14 @@ export default {
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }
+  },
+  computed: {
+    ...mapGetters({
+      version: 'config/getVersion',
+    }),
+    docsURL() {
+      return `https://kuma.io/docs/${this.version}/policies/proxy-template/`
+    },
   },
   watch: {
     $route(to, from) {

--- a/src/views/Policies/RateLimits.vue
+++ b/src/views/Policies/RateLimits.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="ratelimits">
+  <div class="ratelimits relative">
+    <DocumentationLink :href="docsURL" />
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -90,6 +91,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { getSome, stripTimes } from '@/helpers'
 import Kuma from '@/services/kuma'
 import { getTableData } from '@/utils/tableDataUtils'
@@ -100,6 +102,7 @@ import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
@@ -115,6 +118,7 @@ export default {
     YamlView,
     LabelList,
     PolicyConnections,
+    DocumentationLink,
   },
   data() {
     return {
@@ -154,6 +158,14 @@ export default {
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }
+  },
+  computed: {
+    ...mapGetters({
+      version: 'config/getVersion',
+    }),
+    docsURL() {
+      return `https://kuma.io/docs/${this.version}/policies/rate-limit/`
+    },
   },
   watch: {
     $route(to, from) {

--- a/src/views/Policies/Retries.vue
+++ b/src/views/Policies/Retries.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="retries">
+  <div class="retries relative">
+    <DocumentationLink :href="docsURL" />
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -89,6 +90,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { getSome, stripTimes } from '@/helpers'
 import Kuma from '@/services/kuma'
 import { getTableData } from '@/utils/tableDataUtils'
@@ -99,6 +101,7 @@ import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import LabelList from '@/components/Utils/LabelList'
+import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
@@ -114,6 +117,7 @@ export default {
     YamlView,
     LabelList,
     PolicyConnections,
+    DocumentationLink,
   },
   data() {
     return {
@@ -153,6 +157,14 @@ export default {
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }
+  },
+  computed: {
+    ...mapGetters({
+      version: 'config/getVersion',
+    }),
+    docsURL() {
+      return `https://kuma.io/docs/${this.version}/policies/retry/`
+    },
   },
   watch: {
     $route(to, from) {

--- a/src/views/Policies/Timeouts.vue
+++ b/src/views/Policies/Timeouts.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="timeouts">
+  <div class="timeouts relative">
+    <DocumentationLink :href="docsURL" />
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -89,6 +90,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { getSome, stripTimes } from '@/helpers'
 import Kuma from '@/services/kuma'
 import { getTableData } from '@/utils/tableDataUtils'
@@ -99,6 +101,7 @@ import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
@@ -114,6 +117,7 @@ export default {
     YamlView,
     LabelList,
     PolicyConnections,
+    DocumentationLink,
   },
   data() {
     return {
@@ -153,6 +157,14 @@ export default {
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }
+  },
+  computed: {
+    ...mapGetters({
+      version: 'config/getVersion',
+    }),
+    docsURL() {
+      return `https://kuma.io/docs/${this.version}/policies/timeout/`
+    },
   },
   watch: {
     $route(to, from) {

--- a/src/views/Policies/TrafficLogs.vue
+++ b/src/views/Policies/TrafficLogs.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="traffic-logs">
+  <div class="traffic-logs relative">
+    <DocumentationLink :href="docsURL" />
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -89,6 +90,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { getSome, stripTimes } from '@/helpers'
 import Kuma from '@/services/kuma'
 import { getTableData } from '@/utils/tableDataUtils'
@@ -100,6 +102,7 @@ import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
+import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 
 export default {
   name: 'TrafficLogs',
@@ -114,6 +117,7 @@ export default {
     YamlView,
     LabelList,
     PolicyConnections,
+    DocumentationLink,
   },
   data() {
     return {
@@ -153,6 +157,14 @@ export default {
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }
+  },
+  computed: {
+    ...mapGetters({
+      version: 'config/getVersion',
+    }),
+    docsURL() {
+      return `https://kuma.io/docs/${this.version}/policies/traffic-log/`
+    },
   },
   watch: {
     $route(to, from) {

--- a/src/views/Policies/TrafficPermissions.vue
+++ b/src/views/Policies/TrafficPermissions.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="traffic-permissions">
+  <div class="traffic-permissions relative">
+    <DocumentationLink :href="docsURL" />
     <div
       v-if="securityWarning"
       class="mb-4"
@@ -118,6 +119,7 @@ import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
@@ -133,6 +135,7 @@ export default {
     YamlView,
     LabelList,
     PolicyConnections,
+    DocumentationLink,
   },
   data() {
     return {
@@ -177,7 +180,11 @@ export default {
   computed: {
     ...mapGetters({
       environment: 'config/getEnvironment',
+      version: 'config/getVersion',
     }),
+    docsURL() {
+      return `https://kuma.io/docs/${this.version}/policies/traffic-permissions/`
+    },
   },
   watch: {
     $route(to, from) {

--- a/src/views/Policies/TrafficRoutes.vue
+++ b/src/views/Policies/TrafficRoutes.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="traffic-routes">
+  <div class="traffic-routes relative">
+    <DocumentationLink :href="docsURL" />
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -89,6 +90,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { getSome, stripTimes } from '@/helpers'
 import Kuma from '@/services/kuma'
 import { getTableData } from '@/utils/tableDataUtils'
@@ -99,6 +101,7 @@ import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
@@ -114,6 +117,7 @@ export default {
     YamlView,
     LabelList,
     PolicyConnections,
+    DocumentationLink,
   },
   data() {
     return {
@@ -153,6 +157,14 @@ export default {
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }
+  },
+  computed: {
+    ...mapGetters({
+      version: 'config/getVersion',
+    }),
+    docsURL() {
+      return `https://kuma.io/docs/${this.version}/policies/traffic-route/`
+    },
   },
   watch: {
     $route(to, from) {

--- a/src/views/Policies/TrafficTraces.vue
+++ b/src/views/Policies/TrafficTraces.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="traffic-traces">
+  <div class="traffic-traces relative">
+    <DocumentationLink :href="docsURL" />
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -89,6 +90,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { getSome, stripTimes } from '@/helpers'
 import Kuma from '@/services/kuma'
 import { getTableData } from '@/utils/tableDataUtils'
@@ -99,6 +101,7 @@ import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
+import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
@@ -114,6 +117,7 @@ export default {
     YamlView,
     LabelList,
     PolicyConnections,
+    DocumentationLink,
   },
   data() {
     return {
@@ -153,6 +157,14 @@ export default {
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
     }
+  },
+  computed: {
+    ...mapGetters({
+      version: 'config/getVersion',
+    }),
+    docsURL() {
+      return `https://kuma.io/docs/${this.version}/policies/traffic-trace/`
+    },
   },
   watch: {
     $route(to, from) {


### PR DESCRIPTION
It will finish #273 and provide a button that opens documentation related to selected policy in the new window.

![Screenshot 2022-01-18 at 15 15 42](https://user-images.githubusercontent.com/16152347/149954043-45107ff3-018a-4da8-89ec-40271b607b37.png)

Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>

