### PR TITLE
fix(wizzard) remove ca option from wizzard

### DIFF
--- a/src/views/Wizard/views/Mesh.vue
+++ b/src/views/Wizard/views/Mesh.vue
@@ -106,9 +106,6 @@
                   <option value="provided">
                     provided
                   </option>
-                  <option value="vault">
-                    vault
-                  </option>
                 </select>
                 <p class="help">
                   If you've enabled mTLS, you must select a CA.


### PR DESCRIPTION
Remove ca option from wizzard which is not available.


Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>


