### PR TITLE
feat(gateways) add gateway policies

### DIFF
--- a/src/components/DataplanePolicies/DataplanePolicies.vue
+++ b/src/components/DataplanePolicies/DataplanePolicies.vue
@@ -1,5 +1,5 @@
 <template>
-  <Fetcher
+  <StatusInfo
     :has-error="hasError"
     :is-loading="isLoading"
     :is-empty="!hasItems"
@@ -84,13 +84,13 @@
         </Accordion>
       </template>
     </kcard>
-  </Fetcher>
+  </StatusInfo>
 </template>
 
 <script>
 import { POLICY_MAP } from '@/consts'
 import Kuma from '@/services/kuma'
-import Fetcher from '@/components/Utils/Fetcher'
+import StatusInfo from '@/components/Utils/StatusInfo'
 import Accordion from '@/components/Accordion/Accordion'
 import AccordionItem from '@/components/Accordion/AccordionItem'
 
@@ -103,7 +103,7 @@ const POLICY_TYPE_SUBTITLE = {
 export default {
   name: 'DataplanePolicies',
   components: {
-    Fetcher,
+    StatusInfo,
     Accordion,
     AccordionItem,
   },

--- a/src/components/Sidebar/Sidebar.spec.ts
+++ b/src/components/Sidebar/Sidebar.spec.ts
@@ -11,6 +11,16 @@ describe('Sidebar.vue', () => {
     expect(container).toMatchSnapshot()
   })
 
+  it('renders gateways when flag applied', () => {
+    renderWithVuex(Sidebar, {
+      store: { modules: { config: { state: { clientConfig: { experimental: { gateway: true } } } } } },
+      routes: [],
+    })
+
+    expect(screen.getByTestId('gateways')).toBeInTheDocument()
+    expect(screen.getByTestId('gateway-routes')).toBeInTheDocument()
+  })
+
   it('refetch data after change of mesh', async () => {
     renderWithVuex(Sidebar, {
       routes: [

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script>
-import { mapState, mapActions } from 'vuex'
+import { mapState, mapActions, mapGetters } from 'vuex'
 import NavItem from '@/components/Sidebar/NavItem'
 import Subnav from '@/components/Sidebar/Subnav'
 import MeshSelector from '@/components/Utils/MeshSelector'
@@ -74,7 +74,7 @@ export default {
       toggleWorkspaces: false,
       isHovering: false,
       subnavIsExpanded: true,
-      menu,
+      menu: menu,
     }
   },
 
@@ -82,12 +82,23 @@ export default {
     ...mapState({
       selectedMesh: (state) => state.selectedMesh,
     }),
+    ...mapGetters({
+      featureFlags: 'config/featureFlags',
+    }),
     titleNavItems() {
       return this.menu.find((i) => i.position === 'top').items
     },
 
     topNavItems() {
-      return this.menu.find((i) => i.position === 'top').items[0].subNav.items
+      return this.menu
+        .find((i) => i.position === 'top')
+        .items[0].subNav.items.filter((menuItem) => {
+          if (!menuItem.featureFlags) {
+            return true
+          }
+
+          return menuItem.featureFlags.every((featureFlag) => this.featureFlags.includes(featureFlag))
+        })
     },
 
     bottomNavItems() {

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -74,7 +74,7 @@ export default {
       toggleWorkspaces: false,
       isHovering: false,
       subnavIsExpanded: true,
-      menu: menu,
+      menu,
     }
   },
 

--- a/src/components/Sidebar/menu.ts
+++ b/src/components/Sidebar/menu.ts
@@ -1,6 +1,6 @@
 import { RawLocation } from 'vue-router'
 import meshIcon from '@/assets/images/icon-service-mesh.svg'
-import { POLICY_MAP } from '@/consts'
+import { POLICY_MAP, FEATURE_FLAG } from '@/consts'
 
 type TODO = any
 type KIconType = 'gearFilled'
@@ -14,6 +14,7 @@ export interface MenuNavItem {
   parent?: string
   pathFlip?: boolean
   insightsFieldAccessor?: string
+  featureFlags?: string[]
 }
 
 export interface MenuItem {
@@ -190,6 +191,22 @@ const menu: MenuSection[] = [
                 title: false,
                 parent: 'policies',
                 insightsFieldAccessor: 'mesh.policies.Timeout',
+              },
+              {
+                name: POLICY_MAP.Gateway.title,
+                link: POLICY_MAP.Gateway.route,
+                title: false,
+                parent: 'policies',
+                insightsFieldAccessor: 'mesh.policies.Gateway',
+                featureFlags: [FEATURE_FLAG.GATEWAY],
+              },
+              {
+                name: POLICY_MAP.GatewayRoute.title,
+                link: POLICY_MAP.GatewayRoute.route,
+                title: false,
+                parent: 'policies',
+                insightsFieldAccessor: 'mesh.policies.GatewayRoute',
+                featureFlags: [FEATURE_FLAG.GATEWAY],
               },
             ].sort((a, b) => (a.name < b.name ? -1 : 1)),
           ],

--- a/src/components/Utils/StatusInfo.vue
+++ b/src/components/Utils/StatusInfo.vue
@@ -63,7 +63,7 @@
 
 <script>
 export default {
-  name: 'Fetcher',
+  name: 'StatusInfo',
   props: {
     isLoading: {
       type: Boolean,

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -56,4 +56,16 @@ export const POLICY_MAP = {
     title: 'Timeouts',
     route: 'timeouts',
   },
+  Gateway: {
+    title: 'Gateways',
+    route: 'gateways',
+  },
+  GatewayRoute: {
+    title: 'Gateway Routes',
+    route: 'gateway-routes',
+  },
+}
+
+export const FEATURE_FLAG = {
+  GATEWAY: 'gateway',
 }

--- a/src/dataplane.ts
+++ b/src/dataplane.ts
@@ -102,7 +102,7 @@ getStatus takes DataplaneInsight and returns map of versions
  */
 
 export function getVersions(dataplaneInsight: DataplaneInsight): Record<string, string> | null {
-  if (!dataplaneInsight.subscriptions.length) {
+  if (!dataplaneInsight.subscriptions?.length) {
     return null
   }
 
@@ -236,7 +236,9 @@ export function getDataplaneType(dataplane: { networking: { gateway?: TODO } } =
   const { gateway } = networking
 
   if (gateway) {
-    return 'Gateway'
+    const type = gateway?.type ? ` / ${gateway.type}` : ''
+
+    return `Gateway${type}`
   }
 
   return 'Standard'

--- a/src/router.ts
+++ b/src/router.ts
@@ -295,6 +295,25 @@ export default (store: Store<RootInterface>) => {
                   },
                   component: () => import(/* webpackChunkName: "timeouts" */ '@/views/Policies/Timeouts.vue'),
                 },
+                // gateways
+                {
+                  path: POLICY_MAP.Gateway.route,
+                  name: POLICY_MAP.Gateway.route,
+                  meta: {
+                    title: POLICY_MAP.Gateway.title,
+                  },
+                  component: () => import(/* webpackChunkName: "gateways" */ '@/views/Policies/Gateways.vue'),
+                },
+                // gateway routes
+                {
+                  path: POLICY_MAP.GatewayRoute.route,
+                  name: POLICY_MAP.GatewayRoute.route,
+                  meta: {
+                    title: POLICY_MAP.GatewayRoute.title,
+                  },
+                  component: () =>
+                    import(/* webpackChunkName: "gateway-routes" */ '@/views/Policies/GatewayRoutes.vue'),
+                },
               ],
             },
           ],

--- a/src/services/kuma.ts
+++ b/src/services/kuma.ts
@@ -359,6 +359,44 @@ class Kuma {
   }
 
   /**
+   * Gateways
+   */
+
+  // get all gateway
+  public getAllGateways(params?: any) {
+    return this.client.get('/gateways', { params })
+  }
+
+  // get all gateways from mesh
+  public getAllGatewaysFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
+    return this.client.get(`/meshes/${mesh}/gateways`, { params })
+  }
+
+  // get timeout details
+  public getGateway({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
+    return this.client.get(`/meshes/${mesh}/gateways/${name}`, { params })
+  }
+
+  /**
+   * Gateway routes
+   */
+
+  // get all gateway routes
+  public getAllGatewayRoutes(params?: any) {
+    return this.client.get('/gateway-routes', { params })
+  }
+
+  // get all gateway routes from mesh
+  public getAllGatewayRoutesFromMesh({ mesh }: ApiDefaultOptions = defaultOptions, params?: any) {
+    return this.client.get(`/meshes/${mesh}/gateway-routes`, { params })
+  }
+
+  // get timeout details
+  public getGatewayRoute({ mesh, name }: ApiDefaultOptions = defaultOptions, params?: any) {
+    return this.client.get(`/meshes/${mesh}/gateway-routes/${name}`, { params })
+  }
+
+  /**
    * External Services
    */
 

--- a/src/services/mock/responses/config.json
+++ b/src/services/mock/responses/config.json
@@ -1,8 +1,31 @@
 {
+  "access": {
+    "static": {
+      "adminResources": {
+        "groups": ["mesh-system:admin"],
+        "users": ["mesh-system:admin"]
+      },
+      "generateDpToken": {
+        "groups": ["mesh-system:admin"],
+        "users": ["mesh-system:admin"]
+      },
+      "generateUserToken": {
+        "groups": ["mesh-system:admin"],
+        "users": ["mesh-system:admin"]
+      }
+    },
+    "type": "static"
+  },
   "apiServer": {
     "auth": {
-      "allowFromLocalhost": true,
       "clientCertsDir": ""
+    },
+    "authn": {
+      "localhostIsAdmin": true,
+      "tokens": {
+        "bootstrapAdminToken": true
+      },
+      "type": "tokens"
     },
     "corsAllowedDomains": [".*"],
     "http": {
@@ -20,7 +43,6 @@
     "readOnly": false
   },
   "bootstrapServer": {
-    "apiVersion": "v3",
     "params": {
       "adminAccessLogPath": "/dev/null",
       "adminAddress": "127.0.0.1",
@@ -40,7 +62,8 @@
   "dnsServer": {
     "CIDR": "240.0.0.0/4",
     "domain": "mesh",
-    "port": 5653
+    "port": 5653,
+    "serviceVipEnabled": true
   },
   "dpServer": {
     "auth": {
@@ -63,6 +86,9 @@
     "tlsKeyFile": "/Users/tomasz.wylezek/.kuma/kuma-cp.key"
   },
   "environment": "universal",
+  "experimental": {
+    "gateway": true
+  },
   "general": {
     "dnsCacheTTL": "10s",
     "tlsCertFile": "/Users/tomasz.wylezek/.kuma/kuma-cp.crt",
@@ -74,7 +100,6 @@
   },
   "metrics": {
     "dataplane": {
-      "enabled": true,
       "idleTimeout": "5m0s",
       "subscriptionLimit": 2
     },
@@ -83,7 +108,6 @@
       "minResyncTimeout": "1s"
     },
     "zone": {
-      "enabled": true,
       "idleTimeout": "5m0s",
       "subscriptionLimit": 10
     }
@@ -183,7 +207,8 @@
         "virtualProbesEnabled": true,
         "virtualProbesPort": 9000
       },
-      "marshalingCacheExpirationTime": "5m0s"
+      "marshalingCacheExpirationTime": "5m0s",
+      "serviceAccountName": "system:serviceaccount:kuma-system:kuma-control-plane"
     },
     "universal": {
       "dataplaneCleanupAge": "72h0m0s"
@@ -201,8 +226,8 @@
       "connectionTimeout": 5,
       "dbName": "kuma",
       "host": "127.0.0.1",
-      "maxIdleConnections": 0,
-      "maxOpenConnections": 0,
+      "maxIdleConnections": 50,
+      "maxOpenConnections": 50,
       "maxReconnectInterval": "1m0s",
       "minReconnectInterval": "10s",
       "password": "*****",

--- a/src/services/mock/responses/dataplanes+insights.json
+++ b/src/services/mock/responses/dataplanes+insights.json
@@ -442,7 +442,8 @@
             "tags": {
               "kuma.io/service": "gateway",
               "kuma.io/zone": "cluster-1"
-            }
+            },
+            "type": "BUILTIN"
           },
           "outbound": [
             {

--- a/src/services/mock/responses/dataplanes+insights__only-gateways.json
+++ b/src/services/mock/responses/dataplanes+insights__only-gateways.json
@@ -14,7 +14,8 @@
             "tags": {
               "kuma.io/service": "gateway",
               "kuma.io/zone": "cluster-1"
-            }
+            },
+            "type": "BUILTIN"
           },
           "outbound": [
             {

--- a/src/services/mock/responses/gateway-routes.json
+++ b/src/services/mock/responses/gateway-routes.json
@@ -1,0 +1,43 @@
+{
+  "total": 1,
+  "items": [
+    {
+      "type": "GatewayRoute",
+      "mesh": "default",
+      "name": "edge-gateway",
+      "creationTime": "2022-01-25T13:58:29.381342+01:00",
+      "modificationTime": "2022-01-25T13:58:29.381342+01:00",
+      "selectors": [
+        {
+          "match": {
+            "kuma.io/service": "edge-gateway"
+          }
+        }
+      ],
+      "conf": {
+        "http": {
+          "rules": [
+            {
+              "matches": [
+                {
+                  "path": {
+                    "match": "PREFIX",
+                    "value": "/"
+                  }
+                }
+              ],
+              "backends": [
+                {
+                  "destination": {
+                    "kuma.io/service": "echo-service"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "next": null
+}

--- a/src/services/mock/responses/gateways.json
+++ b/src/services/mock/responses/gateways.json
@@ -1,0 +1,32 @@
+{
+  "total": 1,
+  "items": [
+    {
+      "type": "Gateway",
+      "mesh": "default",
+      "name": "edge-gateway",
+      "creationTime": "2022-01-25T13:55:51.798701+01:00",
+      "modificationTime": "2022-01-25T13:55:51.798701+01:00",
+      "selectors": [
+        {
+          "match": {
+            "kuma.io/service": "edge-gateway"
+          }
+        }
+      ],
+      "conf": {
+        "listeners": [
+          {
+            "hostname": "foo.example.com",
+            "port": 8080,
+            "protocol": "HTTP",
+            "tags": {
+              "port": "http/8080"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "next": null
+}

--- a/src/services/mock/responses/mesh-insights.json
+++ b/src/services/mock/responses/mesh-insights.json
@@ -42,6 +42,12 @@
         },
         "Timeout": {
           "total": 1
+        },
+        "Gateway": {
+          "total": 1
+        },
+        "GatewayRoute": {
+          "total": 1
         }
       },
       "dpVersions": {

--- a/src/services/mock/responses/mesh-insights/default.json
+++ b/src/services/mock/responses/mesh-insights/default.json
@@ -30,6 +30,12 @@
     },
     "TrafficRoute": {
       "total": 5
+    },
+    "Gateway": {
+      "total": 1
+    },
+    "GatewayRoute": {
+      "total": 1
     }
   },
   "dpVersions": {

--- a/src/services/mock/responses/meshes/default/gateway-routes.json
+++ b/src/services/mock/responses/meshes/default/gateway-routes.json
@@ -1,0 +1,43 @@
+{
+  "total": 1,
+  "items": [
+    {
+      "type": "GatewayRoute",
+      "mesh": "default",
+      "name": "edge-gateway",
+      "creationTime": "2022-01-25T13:58:29.381342+01:00",
+      "modificationTime": "2022-01-25T13:58:29.381342+01:00",
+      "selectors": [
+        {
+          "match": {
+            "kuma.io/service": "edge-gateway"
+          }
+        }
+      ],
+      "conf": {
+        "http": {
+          "rules": [
+            {
+              "matches": [
+                {
+                  "path": {
+                    "match": "PREFIX",
+                    "value": "/"
+                  }
+                }
+              ],
+              "backends": [
+                {
+                  "destination": {
+                    "kuma.io/service": "echo-service"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "next": null
+}

--- a/src/services/mock/responses/meshes/default/gateway-routes/edge-gateway.json
+++ b/src/services/mock/responses/meshes/default/gateway-routes/edge-gateway.json
@@ -1,0 +1,37 @@
+{
+  "type": "GatewayRoute",
+  "mesh": "default",
+  "name": "edge-gateway",
+  "creationTime": "2022-01-25T13:58:29.381342+01:00",
+  "modificationTime": "2022-01-25T13:58:29.381342+01:00",
+  "selectors": [
+    {
+      "match": {
+        "kuma.io/service": "edge-gateway"
+      }
+    }
+  ],
+  "conf": {
+    "http": {
+      "rules": [
+        {
+          "matches": [
+            {
+              "path": {
+                "match": "PREFIX",
+                "value": "/"
+              }
+            }
+          ],
+          "backends": [
+            {
+              "destination": {
+                "kuma.io/service": "echo-service"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/services/mock/responses/meshes/default/gateways.json
+++ b/src/services/mock/responses/meshes/default/gateways.json
@@ -1,0 +1,32 @@
+{
+  "total": 1,
+  "items": [
+    {
+      "type": "Gateway",
+      "mesh": "default",
+      "name": "edge-gateway",
+      "creationTime": "2022-01-25T13:55:51.798701+01:00",
+      "modificationTime": "2022-01-25T13:55:51.798701+01:00",
+      "selectors": [
+        {
+          "match": {
+            "kuma.io/service": "edge-gateway"
+          }
+        }
+      ],
+      "conf": {
+        "listeners": [
+          {
+            "hostname": "foo.example.com",
+            "port": 8080,
+            "protocol": "HTTP",
+            "tags": {
+              "port": "http/8080"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "next": null
+}

--- a/src/services/mock/responses/meshes/default/gateways/edge-gateway.json
+++ b/src/services/mock/responses/meshes/default/gateways/edge-gateway.json
@@ -1,0 +1,26 @@
+{
+  "type": "Gateway",
+  "mesh": "default",
+  "name": "edge-gateway",
+  "creationTime": "2022-01-25T13:55:51.798701+01:00",
+  "modificationTime": "2022-01-25T13:55:51.798701+01:00",
+  "selectors": [
+    {
+      "match": {
+        "kuma.io/service": "edge-gateway"
+      }
+    }
+  ],
+  "conf": {
+    "listeners": [
+      {
+        "hostname": "foo.example.com",
+        "port": 8080,
+        "protocol": "HTTP",
+        "tags": {
+          "port": "http/8080"
+        }
+      }
+    ]
+  }
+}

--- a/src/services/mocks.ts
+++ b/src/services/mocks.ts
@@ -48,6 +48,14 @@ const mockFilenameBasePaths: string[] = [
   'meshes/default/dataplanes/gateway-dp-87qntx',
   'meshes/default/dataplanes/dataplane-test-456',
 
+  'gateways',
+  'meshes/default/gateways',
+  'meshes/default/gateways/edge-gateway',
+
+  'gateway-routes',
+  'meshes/default/gateway-routes',
+  'meshes/default/gateway-routes/edge-gateway',
+
   'meshes/default/traffic-traces',
   'meshes/default/traffic-traces/tt-1',
   'meshes/default/traffic-traces/traffic-trace-02',

--- a/src/store/modules/config/config.ts
+++ b/src/store/modules/config/config.ts
@@ -1,5 +1,6 @@
 import Kuma from '@/services/kuma'
 import { ActionTree, GetterTree, MutationTree } from 'vuex'
+import { FEATURE_FLAG } from '@/consts'
 import { RootInterface } from '../..'
 import { ConfigInterface } from './config.types'
 
@@ -25,6 +26,16 @@ const getters: GetterTree<ConfigInterface, RootInterface> = {
   getTagline: state => state.tagline,
   getVersion: state => state.version,
   getConfigurationType: state => state.clientConfig?.store?.type,
+  featureFlags: state => {
+    const featureFlags = []
+
+    if (state.clientConfig?.experimental?.gateway) {
+      featureFlags.push(FEATURE_FLAG.GATEWAY)
+    }
+
+    return featureFlags
+  },
+
   getMulticlusterStatus: (state, getters) => {
     // is Kuma running in Multi-Zone mode?
 

--- a/src/store/modules/config/config.types.ts
+++ b/src/store/modules/config/config.types.ts
@@ -1,9 +1,30 @@
 import { Module } from 'vuex'
 import { RootInterface } from '../..'
 
+export interface AccessScope {
+  groups: String[]
+  users: String[]
+}
+
+export interface Access {
+  static: {
+    adminResources: AccessScope
+    generateDpToken: AccessScope
+    generateUserToken: AccessScope
+  }
+  type: string
+}
+
 export interface Auth {
-  allowFromLocalhost: boolean
   clientCertsDir: string
+}
+
+export interface Authn {
+  localhostIsAdmin: boolean
+  tokens: {
+    bootstrapAdminToken: boolean
+  }
+  type: string
 }
 
 export interface Http {
@@ -22,6 +43,7 @@ export interface Https {
 
 export interface ApiServer {
   auth: Auth
+  authn: Authn
   corsAllowedDomains: string[]
   http: Http
   https: Https
@@ -38,7 +60,6 @@ export interface Params {
 }
 
 export interface BootstrapServer {
-  apiVersion: string
   params: Params
 }
 
@@ -55,6 +76,7 @@ export interface DnsServer {
   CIDR: string
   domain: string
   port: number
+  serviceVipEnabled: boolean
 }
 
 export interface Auth2 {
@@ -84,6 +106,10 @@ export interface DpServer {
   tlsKeyFile: string
 }
 
+export interface Experimental {
+  gateway: boolean
+}
+
 export interface General {
   dnsCacheTTL: string
   tlsCertFile: string
@@ -96,7 +122,7 @@ export interface GuiServer {
 }
 
 export interface Dataplane {
-  enabled: boolean
+  idleTimeout: string
   subscriptionLimit: number
 }
 
@@ -106,7 +132,7 @@ export interface Mesh {
 }
 
 export interface Zone {
-  enabled: boolean
+  idleTimeout: string
   subscriptionLimit: number
 }
 
@@ -247,6 +273,7 @@ export interface Kubernetes {
   controlPlaneServiceName: string
   injector: Injector
   marshalingCacheExpirationTime: string
+  serviceAccountName: string
 }
 
 export interface Universal {
@@ -312,6 +339,7 @@ export interface XdsServer {
 }
 
 export interface ClientConfigInterface {
+  access: Access
   apiServer: ApiServer
   bootstrapServer: BootstrapServer
   defaults: Defaults
@@ -320,6 +348,7 @@ export interface ClientConfigInterface {
   dpServer: DpServer
   environment: string
   general: General
+  experimental: Experimental
   guiServer: GuiServer
   metrics: Metrics
   mode: string

--- a/src/store/modules/sidebar/sidebar.spec.ts
+++ b/src/store/modules/sidebar/sidebar.spec.ts
@@ -25,6 +25,8 @@ describe('sidebar module', () => {
               "policies": Object {
                 "CircuitBreaker": 0,
                 "FaultInjection": 2,
+                "Gateway": 1,
+                "GatewayRoute": 1,
                 "HealthCheck": 7,
                 "ProxyTemplate": 0,
                 "RateLimit": 0,

--- a/src/store/modules/sidebar/sidebar.ts
+++ b/src/store/modules/sidebar/sidebar.ts
@@ -36,10 +36,13 @@ const state: SidebarInterface = {
         RateLimit: 0,
         Retry: 0,
         Timeout: 0,
+        Gateway: 0,
+        GatewayRoute: 0,
       },
     },
   },
 }
+
 const mutations: MutationTree<SidebarInterface> = {
   SET_GLOBAL_INSIGHTS: (state, globalInsights) => (state.insights.global = globalInsights),
   SET_MESH_INSIGHTS: (state, meshInsight) => (state.insights.mesh = meshInsight),

--- a/src/store/modules/sidebar/sidebar.types.ts
+++ b/src/store/modules/sidebar/sidebar.types.ts
@@ -30,6 +30,8 @@ export interface SidebarInterface {
         RateLimit: number
         Retry: number
         Timeout: number
+        Gateway: number
+        GatewayRoute: number
       }
     }
   }

--- a/src/store/modules/sidebar/util.spec.ts
+++ b/src/store/modules/sidebar/util.spec.ts
@@ -15,6 +15,8 @@ describe('sidebar utils', () => {
           "policies": Object {
             "CircuitBreaker": 0,
             "FaultInjection": 0,
+            "Gateway": 0,
+            "GatewayRoute": 0,
             "HealthCheck": 0,
             "ProxyTemplate": 0,
             "RateLimit": 0,
@@ -171,6 +173,8 @@ describe('sidebar utils', () => {
           "policies": Object {
             "CircuitBreaker": 0,
             "FaultInjection": 0,
+            "Gateway": 0,
+            "GatewayRoute": 0,
             "HealthCheck": 0,
             "ProxyTemplate": 0,
             "RateLimit": 0,

--- a/src/store/modules/sidebar/utils.ts
+++ b/src/store/modules/sidebar/utils.ts
@@ -42,6 +42,8 @@ export function calculateMeshInsights(rawMeshInsights: { items: MeshInsight[] })
         RateLimit: 0,
         Retry: 0,
         Timeout: 0,
+        Gateway: 0,
+        GatewayRoute: 0,
       },
     },
   )

--- a/src/store/reducers/__snapshots__/mesh-insights.spec.ts.snap
+++ b/src/store/reducers/__snapshots__/mesh-insights.spec.ts.snap
@@ -19,6 +19,12 @@ Object {
     "FaultInjection": Object {
       "total": 0,
     },
+    "Gateway": Object {
+      "total": 0,
+    },
+    "GatewayRoute": Object {
+      "total": 0,
+    },
     "HealthCheck": Object {
       "total": 0,
     },
@@ -89,6 +95,12 @@ Object {
       "total": 0,
     },
     "FaultInjection": Object {
+      "total": 0,
+    },
+    "Gateway": Object {
+      "total": 0,
+    },
+    "GatewayRoute": Object {
       "total": 0,
     },
     "HealthCheck": Object {
@@ -169,6 +181,12 @@ Object {
     "FaultInjection": Object {
       "total": 0,
     },
+    "Gateway": Object {
+      "total": 0,
+    },
+    "GatewayRoute": Object {
+      "total": 0,
+    },
     "HealthCheck": Object {
       "total": 0,
     },
@@ -223,6 +241,12 @@ Object {
       "total": 0,
     },
     "FaultInjection": Object {
+      "total": 0,
+    },
+    "Gateway": Object {
+      "total": 0,
+    },
+    "GatewayRoute": Object {
       "total": 0,
     },
     "HealthCheck": Object {

--- a/src/store/reducers/mesh-insights.ts
+++ b/src/store/reducers/mesh-insights.ts
@@ -54,6 +54,12 @@ export const getInitialPolicies = () => ({
   Timeout: {
     total: 0,
   },
+  Gateway: {
+    total: 0,
+  },
+  GatewayRoute: {
+    total: 0,
+  },
 })
 
 const sumPolicies = (curr: any = getInitialPolicies(), next: any = {}) =>

--- a/src/views/Entities/Meshes.vue
+++ b/src/views/Entities/Meshes.vue
@@ -153,6 +153,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import Kuma from '@/services/kuma'
 import { getTableData } from '@/utils/tableDataUtils'
 import { getEmptyInsight, getInitialPolicies } from '@/store/reducers/mesh-insights'
@@ -164,7 +165,7 @@ import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
-import { PAGE_SIZE_DEFAULT, POLICY_MAP } from '@/consts'
+import { PAGE_SIZE_DEFAULT, POLICY_MAP, FEATURE_FLAG } from '@/consts'
 
 export default {
   name: 'Meshes',
@@ -233,6 +234,9 @@ export default {
     }
   },
   computed: {
+    ...mapGetters({
+      featureFlags: 'config/featureFlags',
+    }),
     counts() {
       const {
         policies: allPolicies,
@@ -293,6 +297,18 @@ export default {
           title: POLICY_MAP.Timeout.title,
           value: policies.Timeout.total,
         },
+        ...this.featureFlags.includes(FEATURE_FLAG.GATEWAY)
+          ? [
+            {
+              title: POLICY_MAP.Gateway.title,
+              value: policies.Gateway.total,
+            },
+            {
+              title: POLICY_MAP.GatewayRoute.title,
+              value: policies.GatewayRoute.total,
+            },
+          ]
+          : [],
       ]
     },
     countCols() {

--- a/src/views/Entities/partial/Dataplanes.vue
+++ b/src/views/Entities/partial/Dataplanes.vue
@@ -139,27 +139,29 @@
         </LabelList>
       </template>
       <template v-slot:insights>
-        <KCard border-variant="noBorder">
-          <template v-slot:body>
-            <Accordion :initially-open="0">
-              <AccordionItem
-                v-for="(value, key) in subscriptionsReversed"
-                :key="key"
-              >
-                <template v-slot:accordion-header>
-                  <SubscriptionHeader :details="value" />
-                </template>
+        <StatusInfo :is-empty="subscriptionsReversed.length === 0">
+          <KCard border-variant="noBorder">
+            <template v-slot:body>
+              <Accordion :initially-open="0">
+                <AccordionItem
+                  v-for="(value, key) in subscriptionsReversed"
+                  :key="key"
+                >
+                  <template v-slot:accordion-header>
+                    <SubscriptionHeader :details="value" />
+                  </template>
 
-                <template v-slot:accordion-content>
-                  <SubscriptionDetails
-                    :details="value"
-                    is-discovery-subscription
-                  />
-                </template>
-              </AccordionItem>
-            </Accordion>
-          </template>
-        </KCard>
+                  <template v-slot:accordion-content>
+                    <SubscriptionDetails
+                      :details="value"
+                      is-discovery-subscription
+                    />
+                  </template>
+                </AccordionItem>
+              </Accordion>
+            </template>
+          </KCard>
+        </StatusInfo>
       </template>
       <template v-slot:dpp-policies>
         <DataplanePolicies
@@ -248,6 +250,7 @@ import Accordion from '@/components/Accordion/Accordion'
 import AccordionItem from '@/components/Accordion/AccordionItem'
 import { getTableData } from '@/utils/tableDataUtils'
 import DataplanePolicies from '@/components/DataplanePolicies/DataplanePolicies'
+import StatusInfo from '@/components/Utils/StatusInfo'
 import SubscriptionDetails from '../components/SubscriptionDetails'
 import SubscriptionHeader from '../components/SubscriptionHeader'
 
@@ -266,6 +269,7 @@ export default {
     SubscriptionDetails,
     SubscriptionHeader,
     DataplanePolicies,
+    StatusInfo,
   },
   props: {
     nsBackButtonRoute: {
@@ -351,6 +355,7 @@ export default {
         headers: [],
         data: [],
       },
+      subscriptionsReversed: [],
       entity: {},
       rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,

--- a/src/views/Entities/partial/__snapshots__/Dataplanes.spec.ts.snap
+++ b/src/views/Entities/partial/__snapshots__/Dataplanes.spec.ts.snap
@@ -808,7 +808,7 @@ exports[`Dataplanes.vue renders snapshot 1`] = `
                 <td
                   data-v-bfeabd48=""
                 >
-                  Gateway
+                  Gateway / BUILTIN
                 </td>
                 <td
                   data-v-bfeabd48=""

--- a/src/views/Policies/GatewayRoutes.spec.ts
+++ b/src/views/Policies/GatewayRoutes.spec.ts
@@ -1,0 +1,13 @@
+import { screen } from '@testing-library/vue'
+import renderWithVuex from '@/testUtils/renderWithVuex'
+import GatewayRoutes from './GatewayRoutes.vue'
+
+describe('GatewayRoutes.vue', () => {
+  it('renders warning', async () => {
+    renderWithVuex(GatewayRoutes)
+
+    expect(
+      screen.getByText(/this policy is experimental\. if you encountered any problem please open an/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/views/Policies/Gateways.vue
+++ b/src/views/Policies/Gateways.vue
@@ -1,6 +1,20 @@
 <template>
-  <div class="proxy-templates relative">
+  <div class="gateways relative">
     <DocumentationLink :href="docsURL" />
+    <div class="mb-4">
+      <KAlert appearance="warning">
+        <template v-slot:alertMessage>
+          <p>
+            <strong>Warning</strong> This policy is experimental. If you encountered any problem please open an
+            <a
+              href="https://github.com/kumahq/kuma/issues/new/choose"
+              target="_blank"
+              rel="noopener noreferrer"
+            >issue</a>
+          </p>
+        </template>
+      </KAlert>
+    </div>
     <FrameSkeleton>
       <DataOverview
         :page-size="pageSize"
@@ -8,7 +22,7 @@
         :is-loading="isLoading"
         :empty-state="empty_state"
         :table-data="tableData"
-        :table-data-is-empty="tableDataIsEmpty"
+        :table-data-is-empty="isEmpty"
         :next="next"
         @tableAction="tableAction"
         @loadData="loadData($event)"
@@ -21,12 +35,10 @@
             appearance="primary"
             size="small"
             :to="{
-              name: 'proxy-templates'
+              name: 'gateways',
             }"
           >
-            <span class="custom-control-icon">
-              &larr;
-            </span>
+            <span class="custom-control-icon"> &larr; </span>
             View All
           </KButton>
         </template>
@@ -40,7 +52,9 @@
       >
         <template v-slot:tabHeader>
           <div>
-            <h3>Proxy Template: {{ entity.name }}</h3>
+            <h3>
+              Gateway: {{ entity.name }}
+            </h3>
           </div>
           <div>
             <EntityURLControl
@@ -50,11 +64,7 @@
           </div>
         </template>
         <template v-slot:overview>
-          <LabelList
-            :has-error="entityHasError"
-            :is-loading="entityIsLoading"
-            :is-empty="entityIsEmpty"
-          >
+          <LabelList>
             <div>
               <ul>
                 <li
@@ -74,14 +84,12 @@
           <PolicyConnections
             :mesh="rawEntity.mesh"
             :policy-name="rawEntity.name"
-            policy-type="proxy-templates"
+            policy-type="gateways"
           />
         </template>
         <template v-slot:yaml>
           <YamlView
-            :has-error="entityHasError"
-            :is-loading="entityIsLoading"
-            :is-empty="entityIsEmpty"
+            lang="yaml"
             :content="rawEntity"
           />
         </template>
@@ -93,22 +101,22 @@
 <script>
 import { mapGetters } from 'vuex'
 import { getSome, stripTimes } from '@/helpers'
-import Kuma from '@/services/kuma'
 import { getTableData } from '@/utils/tableDataUtils'
+import Kuma from '@/services/kuma'
 import EntityURLControl from '@/components/Utils/EntityURLControl'
 import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
-import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import Tabs from '@/components/Utils/Tabs'
+import PolicyConnections from '@/components/PolicyConnections/PolicyConnections'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
 import DocumentationLink from '@/components/DocumentationLink/DocumentationLink.vue'
 import { PAGE_SIZE_DEFAULT } from '@/consts'
 
 export default {
-  name: 'ProxyTemplates',
+  name: 'Gateways',
   metaInfo: {
-    title: 'Proxy Templates',
+    title: 'Gateways',
   },
   components: {
     EntityURLControl,
@@ -125,13 +133,9 @@ export default {
       isLoading: true,
       isEmpty: false,
       hasError: false,
-      entityIsLoading: true,
-      entityIsEmpty: false,
-      entityHasError: false,
-      tableDataIsEmpty: false,
       empty_state: {
         title: 'No Data',
-        message: 'There are no Proxy Templates present.',
+        message: 'There are no Gateways present.',
       },
       tableData: {
         headers: [
@@ -154,6 +158,7 @@ export default {
         },
       ],
       entity: {},
+      rawData: [],
       rawEntity: {},
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
@@ -164,7 +169,7 @@ export default {
       version: 'config/getVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/proxy-template/`
+      return `https://kuma.io/docs/${this.version}/policies/gateway/`
     },
   },
   watch: {
@@ -179,7 +184,6 @@ export default {
     init() {
       this.loadData()
     },
-
     tableAction(ev) {
       const data = ev
 
@@ -194,9 +198,9 @@ export default {
 
       try {
         const { data, next } = await getTableData({
-          getSingleEntity: Kuma.getProxyTemplate.bind(Kuma),
-          getAllEntities: Kuma.getAllProxyTemplates.bind(Kuma),
-          getAllEntitiesFromMesh: Kuma.getAllProxyTemplatesFromMesh.bind(Kuma),
+          getSingleEntity: Kuma.getGateway.bind(Kuma),
+          getAllEntities: Kuma.getAllGateways.bind(Kuma),
+          getAllEntitiesFromMesh: Kuma.getAllGatewaysFromMesh.bind(Kuma),
           mesh,
           query,
           size: this.pageSize,
@@ -209,20 +213,14 @@ export default {
         // set table data
 
         if (data.length) {
-          this.tableData.data = data
-          this.tableDataIsEmpty = false
           this.isEmpty = false
+          this.rawData = data
+          this.tableData.data = data
 
-          const selected = ['type', 'name', 'mesh']
-          const selectedEntity = data[0]
-
-          this.entity = getSome(selectedEntity, selected)
-          this.rawEntity = stripTimes(selectedEntity)
+          this.getEntity({ name: data[0].name })
         } else {
           this.tableData.data = []
-          this.tableDataIsEmpty = true
           this.isEmpty = true
-          this.entityIsEmpty = true
         }
       } catch (error) {
         this.hasError = true
@@ -231,47 +229,14 @@ export default {
         console.error(error)
       } finally {
         this.isLoading = false
-        this.entityIsLoading = false
       }
     },
     getEntity(entity) {
-      this.entityIsLoading = true
-      this.entityIsEmpty = false
-      this.entityHasError = false
+      const selected = ['type', 'name', 'mesh']
+      const item = this.rawData.find((data) => data.name === entity.name)
 
-      const mesh = this.$route.params.mesh
-
-      if (entity) {
-        const entityMesh = mesh === 'all' ? entity.mesh : mesh
-
-        return Kuma.getProxyTemplate({ mesh: entityMesh, name: entity.name })
-          .then((response) => {
-            if (response) {
-              const selected = ['type', 'name', 'mesh']
-
-              this.entity = getSome(response, selected)
-              // this.rawEntity = response
-              this.rawEntity = stripTimes(response)
-            } else {
-              this.entity = {}
-              this.entityIsEmpty = true
-            }
-          })
-          .catch((error) => {
-            this.entityHasError = true
-            console.error(error)
-          })
-          .finally(() => {
-            setTimeout(() => {
-              this.entityIsLoading = false
-            }, process.env.VUE_APP_DATA_TIMEOUT)
-          })
-      } else {
-        setTimeout(() => {
-          this.entityIsEmpty = true
-          this.entityIsLoading = false
-        }, process.env.VUE_APP_DATA_TIMEOUT)
-      }
+      this.rawEntity = stripTimes(item)
+      this.entity = getSome(item, selected)
     },
   },
 }


### PR DESCRIPTION
### Summary

It will apply gateways policies. The policies will be available on the sidebar when the feature flag is turned on. Also adjust the Type column in Dataplanes view when there is Gateway DPP.

#### Gateway DPPs view
![Screenshot 2022-01-27 at 10 11 14](https://user-images.githubusercontent.com/16152347/151339789-e4987e31-42e1-416a-a343-b88a535cad40.png)

#### All DPPs view
![Screenshot 2022-01-27 at 10 11 18](https://user-images.githubusercontent.com/16152347/151339796-05c1f514-313d-49c0-b702-d2be1bdd7f32.png)

#### Gateway routes view
![Screenshot 2022-01-27 at 10 11 24](https://user-images.githubusercontent.com/16152347/151339801-ed4c4d75-eaf6-4815-aa80-26baedf5049f.png)

#### Gateways view
![Screenshot 2022-01-27 at 10 11 29](https://user-images.githubusercontent.com/16152347/151339804-8b53fe2e-61f6-4b35-8aac-342c23979015.png)

#### Sidebar view
![Screenshot 2022-01-27 at 11 19 55](https://user-images.githubusercontent.com/16152347/151339807-282ff2bb-4f65-4d1a-a3b0-1595bb640a92.png)

#### Mesh resources

![Screenshot 2022-01-27 at 11 52 28](https://user-images.githubusercontent.com/16152347/151345503-156cb1b0-f597-44c5-975b-50f42d4b05cf.png)




Signed-off-by: Tomasz Wylężek <tomwylezek@gmail.com>
