### PR TITLE
feat(policies): more user friendly inspection of policies

### DIFF
--- a/src/components/DataplanePolicies/DataplanePolicies.spec.ts
+++ b/src/components/DataplanePolicies/DataplanePolicies.spec.ts
@@ -14,7 +14,7 @@ describe('DataplanePolicies.vue', () => {
       routes: [],
     })
 
-    await userEvent.click(await screen.findByText('192.168.0.1:80:81'))
+    await userEvent.click(await screen.findByText('web'))
 
     expect(container).toMatchSnapshot()
   })

--- a/src/components/DataplanePolicies/DataplanePolicies.vue
+++ b/src/components/DataplanePolicies/DataplanePolicies.vue
@@ -17,11 +17,25 @@
             <template v-slot:accordion-header>
               <div class="flex items-center justify-between">
                 <div>
-                  <p class="text-lg">
-                    {{ item.name }}
+                  <p
+                    v-if="item.type === 'dataplane'"
+                    class="text-lg"
+                  >
+                    Dataplane
+                  </p>
+                  <p
+                    v-if="item.type !== 'dataplane'"
+                    class="text-lg"
+                  >
+                    {{ item.service }}
                   </p>
                   <p class="subtitle">
-                    {{ item.type }}
+                    <span v-if="item.type === 'inbound' || item.type === 'outbound'">
+                      {{ item.type }} {{ item.name }}
+                    </span>
+                    <span v-if="item.type === 'service' || item.type === 'dataplane'">
+                      {{ item.type }}
+                    </span>
 
                     <KPop
                       width="300"
@@ -98,6 +112,7 @@ const POLICY_TYPE_SUBTITLE = {
   inbound: 'Policies applied on incoming connection on address',
   outbound: 'Policies applied on outgoing connection to the address',
   service: 'Policies applied on outgoing connections to service',
+  dataplane: 'Policies applied on all incoming and outgoing connections to the selected data plane proxy',
 }
 
 export default {

--- a/src/components/DataplanePolicies/DataplanePolicies.vue
+++ b/src/components/DataplanePolicies/DataplanePolicies.vue
@@ -33,7 +33,7 @@
                     <span v-if="item.type === 'inbound' || item.type === 'outbound'">
                       {{ item.type }} {{ item.name }}
                     </span>
-                    <span v-if="item.type === 'service' || item.type === 'dataplane'">
+                    <span v-else-if="item.type === 'service' || item.type === 'dataplane'">
                       {{ item.type }}
                     </span>
 

--- a/src/components/DataplanePolicies/__snapshots__/DataplanePolicies.spec.ts.snap
+++ b/src/components/DataplanePolicies/__snapshots__/DataplanePolicies.spec.ts.snap
@@ -48,8 +48,6 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                   
                       </span>
                        
-                      <!---->
-                       
                       <div
                         data-v-3cb990b6=""
                       >
@@ -240,8 +238,6 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                   
                       </span>
                        
-                      <!---->
-                       
                       <div
                         data-v-3cb990b6=""
                       >
@@ -344,8 +340,6 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                     <p
                       class="subtitle"
                     >
-                      <!---->
-                       
                       <span>
                         
                     service
@@ -454,8 +448,6 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                     <p
                       class="subtitle"
                     >
-                      <!---->
-                       
                       <span>
                         
                     service
@@ -564,8 +556,6 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                     <p
                       class="subtitle"
                     >
-                      <!---->
-                       
                       <span>
                         
                     service
@@ -674,8 +664,6 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                     <p
                       class="subtitle"
                     >
-                      <!---->
-                       
                       <span>
                         
                     service
@@ -784,8 +772,6 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                     <p
                       class="subtitle"
                     >
-                      <!---->
-                       
                       <span>
                         
                     dataplane

--- a/src/components/DataplanePolicies/__snapshots__/DataplanePolicies.spec.ts.snap
+++ b/src/components/DataplanePolicies/__snapshots__/DataplanePolicies.spec.ts.snap
@@ -29,21 +29,27 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                   class="flex items-center justify-between"
                 >
                   <div>
+                    <!---->
+                     
                     <p
                       class="text-lg"
                     >
                       
-                  192.168.0.1:80:81
+                  web
                 
                     </p>
                      
                     <p
                       class="subtitle"
                     >
-                      
-                  inbound
-
+                      <span>
+                        
+                    inbound 192.168.0.1:80:81
                   
+                      </span>
+                       
+                      <!---->
+                       
                       <div
                         data-v-3cb990b6=""
                       >
@@ -215,21 +221,27 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                   class="flex items-center justify-between"
                 >
                   <div>
+                    <!---->
+                     
                     <p
                       class="text-lg"
                     >
                       
-                  192.168.0.2:8080
+                  backend
                 
                     </p>
                      
                     <p
                       class="subtitle"
                     >
-                      
-                  outbound
-
+                      <span>
+                        
+                    outbound 192.168.0.2:8080
                   
+                      </span>
+                       
+                      <!---->
+                       
                       <div
                         data-v-3cb990b6=""
                       >
@@ -319,6 +331,8 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                   class="flex items-center justify-between"
                 >
                   <div>
+                    <!---->
+                     
                     <p
                       class="text-lg"
                     >
@@ -330,10 +344,14 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                     <p
                       class="subtitle"
                     >
-                      
-                  service
-
+                      <!---->
+                       
+                      <span>
+                        
+                    service
                   
+                      </span>
+                       
                       <div
                         data-v-3cb990b6=""
                       >
@@ -423,6 +441,8 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                   class="flex items-center justify-between"
                 >
                   <div>
+                    <!---->
+                     
                     <p
                       class="text-lg"
                     >
@@ -434,10 +454,14 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                     <p
                       class="subtitle"
                     >
-                      
-                  service
-
+                      <!---->
+                       
+                      <span>
+                        
+                    service
                   
+                      </span>
+                       
                       <div
                         data-v-3cb990b6=""
                       >
@@ -527,6 +551,8 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                   class="flex items-center justify-between"
                 >
                   <div>
+                    <!---->
+                     
                     <p
                       class="text-lg"
                     >
@@ -538,10 +564,124 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                     <p
                       class="subtitle"
                     >
-                      
-                  service
-
+                      <!---->
+                       
+                      <span>
+                        
+                    service
                   
+                      </span>
+                       
+                      <div
+                        data-v-3cb990b6=""
+                      >
+                        <svg
+                          class="kong-icon ml-1 kong-icon-help"
+                          data-v-3cb990b6=""
+                          data-v-a7c9c1d2=""
+                          height="12"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="12"
+                        >
+                          <title
+                            data-v-a7c9c1d2=""
+                          >
+                            help
+                          </title>
+                          <g
+                            data-v-a7c9c1d2=""
+                          >
+                            <path
+                              d="M0 8c0 2.1217.842855 4.1566 2.34315 5.6569C3.84344 15.1571 5.87827 16 8 16c2.1217 0 4.1566-.8429 5.6569-2.3431C15.1571 12.1566 16 10.1217 16 8c0-2.12173-.8429-4.15656-2.3431-5.65685C12.1566.842855 10.1217 0 8 0 5.87827 0 3.84344.842855 2.34315 2.34315.842855 3.84344 0 5.87827 0 8"
+                              data-v-a7c9c1d2=""
+                              fill="#A3BBCC"
+                            />
+                            <path
+                              d="M7.0645 10.0342c0-.63807.0774-1.14617.2324-1.52447.1549-.3782.4375-.7496.8476-1.11422.4147-.36914.6905-.66764.8272-.89551.1367-.23242.2051-.47624.2051-.73144 0-.77019-.3555-1.15528-1.0665-1.15528-.3372 0-.6083.10482-.8134.31446-.2005.20507-.30537.48991-.31448.85449H5c.00911-.87044.28939-1.55176.84082-2.04395C6.39681 3.2461 7.1533 3 8.1103 3c.9662 0 1.7159.2347 2.2491.7041.5332.46485.7998 1.12338.7998 1.97559 0 .38737-.0866.75423-.2598 1.10059-.1732.34179-.4762.72233-.9092 1.14155l-.5537.5264c-.3463.3327-.5446.7223-.5947 1.169l-.0273.41697h-1.75zm-.19829 2.0986c0-.3054.10254-.556.30759-.752.2097-.2005.4763-.3007.7998-.3007.3236 0 .5879.1002.793.3007.2096.196.3145.4466.3145.752 0 .3008-.1026.5491-.3077.7451-.2005.196-.4671.2939-.7998.2939-.3327 0-.6015-.0979-.8066-.2939-.20053-.196-.30079-.4443-.30079-.7451z"
+                              data-v-a7c9c1d2=""
+                              fill="#fff"
+                            />
+                          </g>
+                        </svg>
+                        <transition-stub
+                          data-v-3cb990b6=""
+                          name="fade"
+                        >
+                          <div
+                            class="k-popover"
+                            data-v-3cb990b6=""
+                            style="width: 300px; display: none;"
+                          >
+                            <!---->
+                            <div
+                              class="k-popover-content"
+                              data-v-3cb990b6=""
+                            >
+                              <div>
+                                
+                        Policies applied on outgoing connections to service
+                      
+                              </div>
+                            </div>
+                          </div>
+                        </transition-stub>
+                      </div>
+                    </p>
+                  </div>
+                   
+                  <div
+                    class="flex flex-wrap justify-end"
+                  >
+                    <div
+                      class="k-badge truncate mr-2 mb-2 kbadge-default"
+                      data-v-07ccd633=""
+                    >
+                      
+                  HealthCheck
+                
+                    </div>
+                  </div>
+                </div>
+              </button>
+               
+              <transition-stub
+                name="accordion"
+              >
+                <!---->
+              </transition-stub>
+            </li>
+            <li
+              class="relative border-b py-2"
+            >
+              <button
+                class="accordion-item-header"
+              >
+                <div
+                  class="flex items-center justify-between"
+                >
+                  <div>
+                    <!---->
+                     
+                    <p
+                      class="text-lg"
+                    >
+                      
+                  web-api
+                
+                    </p>
+                     
+                    <p
+                      class="subtitle"
+                    >
+                      <!---->
+                       
+                      <span>
+                        
+                    service
+                  
+                      </span>
+                       
                       <div
                         data-v-3cb990b6=""
                       >
@@ -635,17 +775,23 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                       class="text-lg"
                     >
                       
-                  web
+                  Dataplane
                 
                     </p>
+                     
+                    <!---->
                      
                     <p
                       class="subtitle"
                     >
-                      
-                  service
-
+                      <!---->
+                       
+                      <span>
+                        
+                    dataplane
                   
+                      </span>
+                       
                       <div
                         data-v-3cb990b6=""
                       >
@@ -694,7 +840,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                             >
                               <div>
                                 
-                        Policies applied on outgoing connections to service
+                        Policies applied on all incoming and outgoing connections to the selected data plane proxy
                       
                               </div>
                             </div>
@@ -712,7 +858,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                       data-v-07ccd633=""
                     >
                       
-                  HealthCheck
+                  TrafficTrace
                 
                     </div>
                   </div>

--- a/src/services/mock/responses/dataplane-policies.json
+++ b/src/services/mock/responses/dataplane-policies.json
@@ -243,8 +243,8 @@
     },
     {
       "type": "service",
-      "name": "web",
-      "service": "web",
+      "name": "web-api",
+      "service": "web-api",
       "matchedPolicies": {
         "HealthCheck": [
           {

--- a/src/services/mock/responses/dataplane-policies.json
+++ b/src/services/mock/responses/dataplane-policies.json
@@ -3,6 +3,7 @@
   "items": [
     {
       "type": "inbound",
+      "service": "web",
       "name": "192.168.0.1:80:81",
       "matchedPolicies": {
         "FaultInjection": [
@@ -91,6 +92,7 @@
     {
       "type": "outbound",
       "name": "192.168.0.2:8080",
+      "service": "backend",
       "matchedPolicies": {
         "Timeout": [
           {
@@ -134,6 +136,7 @@
     {
       "type": "service",
       "name": "gateway",
+      "service": "gateway",
       "matchedPolicies": {
         "HealthCheck": [
           {
@@ -169,6 +172,7 @@
     {
       "type": "service",
       "name": "postgres",
+      "service": "postgres",
       "matchedPolicies": {
         "HealthCheck": [
           {
@@ -204,6 +208,7 @@
     {
       "type": "service",
       "name": "redis",
+      "service": "redis",
       "matchedPolicies": {
         "HealthCheck": [
           {
@@ -239,6 +244,7 @@
     {
       "type": "service",
       "name": "web",
+      "service": "web",
       "matchedPolicies": {
         "HealthCheck": [
           {
@@ -267,6 +273,29 @@
               "unhealthyThreshold": 11,
               "healthyThreshold": 9
             }
+          }
+        ]
+      }
+    },
+    {
+      "type": "dataplane",
+      "name": "",
+      "service": "",
+      "matchedPolicies": {
+        "TrafficTrace": [
+          {
+            "type": "TrafficTrace",
+            "mesh": "default",
+            "name": "foo-bar-baz-123",
+            "creationTime": "0001-01-01T00:00:00Z",
+            "modificationTime": "0001-01-01T00:00:00Z",
+            "sources": [
+              {
+                "match": {
+                  "kuma.io/service": "*"
+                }
+              }
+            ]
           }
         ]
       }


### PR DESCRIPTION
Instead of cryptic listeners addresses, we added `service` field to API so we can display it in the GUI. I pushed inbound/outbound address to subtitle.

Also, `dataplane` type of attachment was not handled. Name and Service, in this case, is empty, so we want to just display `Dataplane`.

![Screenshot 2022-01-31 at 10 19 03](https://user-images.githubusercontent.com/5459824/151768219-8b1c57ab-16ee-45ed-a78d-6150b68ef66b.png)

