### PR TITLE
fix(zoneegress): show zoneegress instances in standalone mode

### DIFF
--- a/src/views/Entities/ZoneEgresses.spec.ts
+++ b/src/views/Entities/ZoneEgresses.spec.ts
@@ -15,8 +15,13 @@ jest.mock('@/helpers', () => {
 })
 
 describe('ZoneEgresses.vue', () => {
-  it('renders snapshot when no multizone', () => {
-    const { container } = renderWithVuex(ZoneEgresses, { routes: [] })
+  it('renders snapshot when no multizone', async () => {
+    const { container } = renderWithVuex(ZoneEgresses, {
+      routes: [],
+      store: { modules: { config: { state: { clientConfig: { mode: 'global' } } } } },
+    })
+
+    await screen.findByText(/ZoneEgressOverview/)
 
     expect(container).toMatchSnapshot()
   })

--- a/src/views/Entities/ZoneEgresses.vue
+++ b/src/views/Entities/ZoneEgresses.vue
@@ -1,111 +1,104 @@
 <template>
   <div class="zoneegresses">
-    <MultizoneInfo v-if="multicluster === false" />
-
-    <!-- Zone CPs information for when Multicluster is enabled -->
-    <FrameSkeleton v-else>
-      <DataOverview
-        :page-size="pageSize"
-        :has-error="hasError"
-        :is-loading="isLoading"
-        :empty-state="empty_state"
-        :table-data="tableData"
-        :table-data-is-empty="isEmpty"
-        :next="next"
-        @tableAction="tableAction"
-        @loadData="loadData($event)"
-      >
-        <template v-slot:additionalControls>
-          <KButton
-            v-if="$route.query.ns"
-            class="back-button"
-            appearance="primary"
-            size="small"
-            :to="{
+    <DataOverview
+      :page-size="pageSize"
+      :has-error="hasError"
+      :is-loading="isLoading"
+      :empty-state="empty_state"
+      :table-data="tableData"
+      :table-data-is-empty="isEmpty"
+      :next="next"
+      @tableAction="tableAction"
+      @loadData="loadData($event)"
+    >
+      <template v-slot:additionalControls>
+        <KButton
+          v-if="$route.query.ns"
+          class="back-button"
+          appearance="primary"
+          size="small"
+          :to="{
             name: 'zoneegresses'
-            }"
-          >
-            <span class="custom-control-icon">
-              &larr;
-            </span>
-            View All
-          </KButton>
-        </template>
-      </DataOverview>
-      <Tabs
-        v-if="isEmpty === false"
-        :has-error="hasError"
-        :is-loading="isLoading"
-        :tabs="tabs"
-        initial-tab-override="overview"
-      >
-        <template v-slot:tabHeader>
+          }"
+        >
+          <span class="custom-control-icon">
+            &larr;
+          </span>
+          View All
+        </KButton>
+      </template>
+    </DataOverview>
+    <Tabs
+      v-if="isEmpty === false"
+      :has-error="hasError"
+      :is-loading="isLoading"
+      :tabs="tabs"
+      initial-tab-override="overview"
+    >
+      <template v-slot:tabHeader>
+        <div>
+          <h3> Zone Egress: {{ entity.name }}</h3>
+        </div>
+        <div>
+          <EntityURLControl :name="entity.name" />
+        </div>
+      </template>
+      <template v-slot:overview>
+        <LabelList>
           <div>
-            <h3> Zone Egress: {{ entity.name }}</h3>
+            <ul>
+              <li
+                v-for="(value, key) in entity"
+                :key="key"
+              >
+                <h4 v-if="value">
+                  {{ key }}
+                </h4>
+                <p>
+                  {{ value }}
+                </p>
+              </li>
+            </ul>
           </div>
-          <div>
-            <EntityURLControl :name="entity.name" />
-          </div>
-        </template>
-        <template v-slot:overview>
-          <LabelList>
-            <div>
-              <ul>
-                <li
-                  v-for="(value, key) in entity"
-                  :key="key"
-                >
-                  <h4 v-if="value">
-                    {{ key }}
-                  </h4>
-                  <p>
-                    {{ value }}
-                  </p>
-                </li>
-              </ul>
-            </div>
-          </LabelList>
-        </template>
-        <template v-slot:insights>
-          <KCard border-variant="noBorder">
-            <template v-slot:body>
-              <Accordion :initially-open="0">
-                <AccordionItem
-                  v-for="(value, key) in subscriptionsReversed"
-                  :key="key"
-                >
-                  <template v-slot:accordion-header>
-                    <SubscriptionHeader :details="value" />
-                  </template>
+        </LabelList>
+      </template>
+      <template v-slot:insights>
+        <KCard border-variant="noBorder">
+          <template v-slot:body>
+            <Accordion :initially-open="0">
+              <AccordionItem
+                v-for="(value, key) in subscriptionsReversed"
+                :key="key"
+              >
+                <template v-slot:accordion-header>
+                  <SubscriptionHeader :details="value" />
+                </template>
 
-                  <template v-slot:accordion-content>
-                    <SubscriptionDetails
-                      :details="value"
-                      is-discovery-subscription
-                    />
-                  </template>
-                </AccordionItem>
-              </Accordion>
-            </template>
-          </KCard>
-        </template>
-        <template v-slot:xds-configuration>
-          <XdsConfiguration
-            :zone-egress-name="entity.name"
-          />
-        </template>
-      </Tabs>
-    </FrameSkeleton>
+                <template v-slot:accordion-content>
+                  <SubscriptionDetails
+                    :details="value"
+                    is-discovery-subscription
+                  />
+                </template>
+              </AccordionItem>
+            </Accordion>
+          </template>
+        </KCard>
+      </template>
+      <template v-slot:xds-configuration>
+        <XdsConfiguration
+          :zone-egress-name="entity.name"
+        />
+      </template>
+    </Tabs>
   </div>
 </template>
 
 <script>
 import get from 'lodash/get'
-import { mapGetters } from 'vuex'
 import { getTableData } from '@/utils/tableDataUtils'
 import { getSome } from '@/helpers'
 import Kuma from '@/services/kuma'
-import FrameSkeleton from '@/components/Skeletons/FrameSkeleton'
 import DataOverview from '@/components/Skeletons/DataOverview'
 import EntityURLControl from '@/components/Utils/EntityURLControl'
 import Tabs from '@/components/Utils/Tabs'
@@ -120,12 +113,10 @@ import AccordionItem from '@/components/Accordion/AccordionItem'
 
 import SubscriptionDetails from './components/SubscriptionDetails'
 import SubscriptionHeader from './components/SubscriptionHeader'
-import MultizoneInfo from './components/MultizoneInfo'
 
 export default {
   name: 'ZoneEgresses',
   components: {
-    FrameSkeleton,
     DataOverview,
     Tabs,
     LabelList,
@@ -133,7 +124,6 @@ export default {
     AccordionItem,
     SubscriptionDetails,
     SubscriptionHeader,
-    MultizoneInfo,
     EntityURLControl,
     XdsConfiguration
   },
@@ -180,11 +170,6 @@ export default {
       subscriptionsReversed: [],
     }
   },
-  computed: {
-    ...mapGetters({
-      multicluster: 'config/getMulticlusterStatus',
-    }),
-  },
   watch: {
     $route() {
       this.init()
@@ -195,9 +180,7 @@ export default {
   },
   methods: {
     init() {
-      if (this.multicluster) {
-        this.loadData()
-      }
+      this.loadData()
     },
     tableAction(ev) {
       const data = ev

--- a/src/views/Entities/__snapshots__/ZoneEgresses.spec.ts.snap
+++ b/src/views/Entities/__snapshots__/ZoneEgresses.spec.ts.snap
@@ -6,159 +6,151 @@ exports[`ZoneEgresses.vue renders snapshot when multizone 1`] = `
     class="zoneegresses"
   >
     <div
-      class="component-frame"
+      class="data-overview"
+      data-testid="data-overview"
     >
       <div
-        class="data-overview"
-        data-testid="data-overview"
+        class="data-table-controls mb-2"
       >
-        <div
-          class="data-table-controls mb-2"
-        >
-           
-          <button
-            class="k-button ml-2 refresh-button small primary"
-            data-v-38fa8ecf=""
-            type="button"
-          >
-            <div
-              class="refresh-icon"
-              data-v-38fa8ecf=""
-            >
-              <svg
-                data-v-38fa8ecf=""
-                viewBox="0 0 36 36"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  data-v-38fa8ecf=""
-                  fill="#fff"
-                  fill-rule="nonzero"
-                >
-                  <path
-                    d="M18 5.5a12.465 12.465 0 00-8.118 2.995 1.5 1.5 0 001.847 2.363l.115-.095A9.437 9.437 0 0118 8.5l.272.004a9.487 9.487 0 019.07 7.75l.04.246H25a.5.5 0 00-.416.777l4 6a.5.5 0 00.832 0l4-6 .04-.072A.5.5 0 0033 16.5h-2.601l-.017-.15C29.567 10.2 24.294 5.5 18 5.5zM2.584 18.723l-.04.072A.5.5 0 003 19.5h2.6l.018.15C6.433 25.8 11.706 30.5 18 30.5c3.013 0 5.873-1.076 8.118-2.995a1.5 1.5 0 00-1.847-2.363l-.115.095A9.437 9.437 0 0118 27.5l-.272-.004a9.487 9.487 0 01-9.07-7.75l-.041-.246H11a.5.5 0 00.416-.777l-4-6a.5.5 0 00-.832 0l-4 6z"
-                    data-v-38fa8ecf=""
-                  />
-                </g>
-              </svg>
-            </div>
-             
-            <span
-              data-v-38fa8ecf=""
-            >
-              Refresh
-            </span>
-          </button>
-        </div>
          
-        <div
-          class="data-overview-content"
+        <button
+          class="k-button ml-2 refresh-button small primary"
+          data-v-38fa8ecf=""
+          type="button"
         >
           <div
-            class="data-overview-table"
+            class="refresh-icon"
+            data-v-38fa8ecf=""
           >
-            <table
-              class="k-table micro-table has-hover is-clickable"
+            <svg
+              data-v-38fa8ecf=""
+              viewBox="0 0 36 36"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                data-v-38fa8ecf=""
+                fill="#fff"
+                fill-rule="nonzero"
+              >
+                <path
+                  d="M18 5.5a12.465 12.465 0 00-8.118 2.995 1.5 1.5 0 001.847 2.363l.115-.095A9.437 9.437 0 0118 8.5l.272.004a9.487 9.487 0 019.07 7.75l.04.246H25a.5.5 0 00-.416.777l4 6a.5.5 0 00.832 0l4-6 .04-.072A.5.5 0 0033 16.5h-2.601l-.017-.15C29.567 10.2 24.294 5.5 18 5.5zM2.584 18.723l-.04.072A.5.5 0 003 19.5h2.6l.018.15C6.433 25.8 11.706 30.5 18 30.5c3.013 0 5.873-1.076 8.118-2.995a1.5 1.5 0 00-1.847-2.363l-.115.095A9.437 9.437 0 0118 27.5l-.272-.004a9.487 9.487 0 01-9.07-7.75l-.041-.246H11a.5.5 0 00.416-.777l-4-6a.5.5 0 00-.832 0l-4 6z"
+                  data-v-38fa8ecf=""
+                />
+              </g>
+            </svg>
+          </div>
+           
+          <span
+            data-v-38fa8ecf=""
+          >
+            Refresh
+          </span>
+        </button>
+      </div>
+       
+      <div
+        class="data-overview-content"
+      >
+        <div
+          class="data-overview-table"
+        >
+          <table
+            class="k-table micro-table has-hover is-clickable"
+            data-v-bfeabd48=""
+          >
+            <thead
               data-v-bfeabd48=""
             >
-              <thead
+              <tr
                 data-v-bfeabd48=""
               >
-                <tr
+                <th
+                  class=""
                   data-v-bfeabd48=""
                 >
-                  <th
-                    class=""
-                    data-v-bfeabd48=""
-                  >
-                    <!---->
-                  </th>
-                  <th
-                    class=""
-                    data-v-bfeabd48=""
-                  >
-                     Status 
-                  </th>
-                  <th
-                    class=""
-                    data-v-bfeabd48=""
-                  >
-                     Name 
-                  </th>
-                </tr>
-              </thead>
-              <tbody
+                  <!---->
+                </th>
+                <th
+                  class=""
+                  data-v-bfeabd48=""
+                >
+                   Status 
+                </th>
+                <th
+                  class=""
+                  data-v-bfeabd48=""
+                >
+                   Name 
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              data-v-bfeabd48=""
+            >
+              <tr
                 data-v-bfeabd48=""
               >
-                <tr
+                <td
                   data-v-bfeabd48=""
                 >
-                  <td
+                  <a
+                    class="data-table-action-link is-active"
                     data-v-bfeabd48=""
                   >
-                    <a
-                      class="data-table-action-link is-active"
+                    <span
+                      class="action-link__active-state"
                       data-v-bfeabd48=""
                     >
+                      
+              ✓
+              
                       <span
-                        class="action-link__active-state"
+                        class="sr-only"
                         data-v-bfeabd48=""
                       >
                         
-              ✓
-              
-                        <span
-                          class="sr-only"
-                          data-v-bfeabd48=""
-                        >
-                          
                 Selected
               
-                        </span>
                       </span>
-                    </a>
-                  </td>
-                  <td
+                    </span>
+                  </a>
+                </td>
+                <td
+                  data-v-bfeabd48=""
+                >
+                  <div
+                    class="entity-status"
                     data-v-bfeabd48=""
                   >
-                    <div
-                      class="entity-status"
+                    <span
+                      class="entity-status__dot"
+                      data-v-bfeabd48=""
+                    />
+                     
+                    <span
+                      class="entity-status__label"
                       data-v-bfeabd48=""
                     >
-                      <span
-                        class="entity-status__dot"
-                        data-v-bfeabd48=""
-                      />
-                       
-                      <span
-                        class="entity-status__label"
-                        data-v-bfeabd48=""
-                      >
-                        Online
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    data-v-bfeabd48=""
-                  >
-                    zoneegress-1
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                      Online
+                    </span>
+                  </div>
+                </td>
+                <td
+                  data-v-bfeabd48=""
+                >
+                  zoneegress-1
+                </td>
+              </tr>
+            </tbody>
+          </table>
+           
+          <div
+            class="pagination"
+          >
+            <!---->
              
-            <div
-              class="pagination"
-            >
-              <!---->
-               
-              <!---->
-            </div>
+            <!---->
           </div>
-           
-          <!---->
-           
-          <!---->
         </div>
          
         <!---->
@@ -166,263 +158,267 @@ exports[`ZoneEgresses.vue renders snapshot when multizone 1`] = `
         <!---->
       </div>
        
-      <div
-        class="tab-container"
-        data-testid="tab-container"
+      <!---->
+       
+      <!---->
+    </div>
+     
+    <div
+      class="tab-container"
+      data-testid="tab-container"
+    >
+      <header
+        class="tab__header"
       >
-        <header
-          class="tab__header"
-        >
-          <div>
-            <h3>
-               Zone Egress: zoneegress-1
-            </h3>
-          </div>
-           
-          <div>
+        <div>
+          <h3>
+             Zone Egress: zoneegress-1
+          </h3>
+        </div>
+         
+        <div>
+          <div
+            data-testid="entity-url-control"
+          >
             <div
-              data-testid="entity-url-control"
+              data-v-3cb990b6=""
             >
-              <div
+              <button
+                class="k-button small secondary"
+                data-v-38fa8ecf=""
                 data-v-3cb990b6=""
+                type="button"
               >
-                <button
-                  class="k-button small secondary"
+                <svg
+                  class="kong-icon kong-icon-externalLink"
                   data-v-38fa8ecf=""
-                  data-v-3cb990b6=""
-                  type="button"
+                  data-v-a7c9c1d2=""
+                  height="12"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="12"
                 >
-                  <svg
-                    class="kong-icon kong-icon-externalLink"
-                    data-v-38fa8ecf=""
+                  <title
                     data-v-a7c9c1d2=""
-                    height="12"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="12"
                   >
-                    <title
+                    externalLink
+                  </title>
+                  <g
+                    data-v-a7c9c1d2=""
+                  >
+                    <path
+                      d="M8.24308 1.5C7.83269 1.5 7.5 1.16710138 7.5.75c0-.41421356.33823-.75.74308-.75h3.00568C11.6666 0 12 .336341 12 .75123866v3.00567786C12 4.1673102 11.6671 4.5 11.25 4.5c-.41421 0-.75-.3382314-.75-.74308348V2.625L6.53246 6.59254c-.28982.2898217-.76955.2953689-1.06202.0029022l-.06588-.0658844c-.29098-.2909742-.29117-.7679483.0029-1.0620178L9.375 1.5H8.24308zm-6.74753 0C.67089 1.5 0 2.1695784 0 2.99554521v7.50890959C0 11.3291147.66958 12 1.49555 12h7.5089C9.82911 12 10.5 11.3304216 10.5 10.5044548V6.75H9v3.75H1.5V3h3.75V1.5H1.49555z"
                       data-v-a7c9c1d2=""
-                    >
-                      externalLink
-                    </title>
-                    <g
-                      data-v-a7c9c1d2=""
-                    >
-                      <path
-                        d="M8.24308 1.5C7.83269 1.5 7.5 1.16710138 7.5.75c0-.41421356.33823-.75.74308-.75h3.00568C11.6666 0 12 .336341 12 .75123866v3.00567786C12 4.1673102 11.6671 4.5 11.25 4.5c-.41421 0-.75-.3382314-.75-.74308348V2.625L6.53246 6.59254c-.28982.2898217-.76955.2953689-1.06202.0029022l-.06588-.0658844c-.29098-.2909742-.29117-.7679483.0029-1.0620178L9.375 1.5H8.24308zm-6.74753 0C.67089 1.5 0 2.1695784 0 2.99554521v7.50890959C0 11.3291147.66958 12 1.49555 12h7.5089C9.82911 12 10.5 11.3304216 10.5 10.5044548V6.75H9v3.75H1.5V3h3.75V1.5H1.49555z"
-                        data-v-a7c9c1d2=""
-                        fill="#000"
-                        fill-opacity=".25"
-                        fill-rule="evenodd"
-                      />
-                    </g>
-                  </svg>
-                  
+                      fill="#000"
+                      fill-opacity=".25"
+                      fill-rule="evenodd"
+                    />
+                  </g>
+                </svg>
+                
         Copy URL
       
-                </button>
-                <transition-stub
-                  data-v-3cb990b6=""
-                  name="fade"
-                >
-                  <div
-                    class="k-popover"
-                    data-v-3cb990b6=""
-                    style="width: 200px; display: none;"
-                  >
-                    <!---->
-                    <div
-                      class="k-popover-content"
-                      data-v-3cb990b6=""
-                    >
-                      <div>
-                        <p>
-                          URL copied to clipboard!
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </transition-stub>
-              </div>
-            </div>
-          </div>
-        </header>
-         
-        <div
-          class="tab__content-container"
-        >
-          <div
-            class="k-tabs"
-            data-v-a38b664a=""
-          >
-            <ul
-              aria-label="ktabs"
-              data-v-a38b664a=""
-              role="tablist"
-            >
-              <li
-                aria-controls="panel-0"
-                aria-selected="true"
-                class="tab-item active"
-                data-v-a38b664a=""
-                id="overview-tab"
-                role="tab"
-                tabindex="0"
-              >
-                <a
-                  class="tab-link"
-                  data-v-a38b664a=""
-                >
-                  Overview
-                </a>
-              </li>
-              <li
-                aria-controls="panel-1"
-                aria-selected="false"
-                class="tab-item"
-                data-v-a38b664a=""
-                id="insights-tab"
-                role="tab"
-                tabindex="0"
-              >
-                <a
-                  class="tab-link"
-                  data-v-a38b664a=""
-                >
-                  Zone Egress Insights
-                </a>
-              </li>
-              <li
-                aria-controls="panel-2"
-                aria-selected="false"
-                class="tab-item"
-                data-v-a38b664a=""
-                id="xds-configuration-tab"
-                role="tab"
-                tabindex="0"
-              >
-                <a
-                  class="tab-link"
-                  data-v-a38b664a=""
-                >
-                  XDS Configuration
-                </a>
-              </li>
-            </ul>
-            <div
-              aria-labelledby="overview-tab"
-              class="tab-container"
-              data-v-a38b664a=""
-              id="panel-0"
-              role="tabpanel"
-              tabindex="0"
-            >
-              <div
-                data-v-a38b664a=""
+              </button>
+              <transition-stub
+                data-v-3cb990b6=""
+                name="fade"
               >
                 <div
-                  class="label-list-content"
+                  class="k-popover"
+                  data-v-3cb990b6=""
+                  style="width: 200px; display: none;"
                 >
+                  <!---->
                   <div
-                    class="kong-card noBorder"
+                    class="k-popover-content"
+                    data-v-3cb990b6=""
+                  >
+                    <div>
+                      <p>
+                        URL copied to clipboard!
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </transition-stub>
+            </div>
+          </div>
+        </div>
+      </header>
+       
+      <div
+        class="tab__content-container"
+      >
+        <div
+          class="k-tabs"
+          data-v-a38b664a=""
+        >
+          <ul
+            aria-label="ktabs"
+            data-v-a38b664a=""
+            role="tablist"
+          >
+            <li
+              aria-controls="panel-0"
+              aria-selected="true"
+              class="tab-item active"
+              data-v-a38b664a=""
+              id="overview-tab"
+              role="tab"
+              tabindex="0"
+            >
+              <a
+                class="tab-link"
+                data-v-a38b664a=""
+              >
+                Overview
+              </a>
+            </li>
+            <li
+              aria-controls="panel-1"
+              aria-selected="false"
+              class="tab-item"
+              data-v-a38b664a=""
+              id="insights-tab"
+              role="tab"
+              tabindex="0"
+            >
+              <a
+                class="tab-link"
+                data-v-a38b664a=""
+              >
+                Zone Egress Insights
+              </a>
+            </li>
+            <li
+              aria-controls="panel-2"
+              aria-selected="false"
+              class="tab-item"
+              data-v-a38b664a=""
+              id="xds-configuration-tab"
+              role="tab"
+              tabindex="0"
+            >
+              <a
+                class="tab-link"
+                data-v-a38b664a=""
+              >
+                XDS Configuration
+              </a>
+            </li>
+          </ul>
+          <div
+            aria-labelledby="overview-tab"
+            class="tab-container"
+            data-v-a38b664a=""
+            id="panel-0"
+            role="tabpanel"
+            tabindex="0"
+          >
+            <div
+              data-v-a38b664a=""
+            >
+              <div
+                class="label-list-content"
+              >
+                <div
+                  class="kong-card noBorder"
+                  data-v-0029352b=""
+                >
+                  <!---->
+                  <!---->
+                  <div
+                    class="k-card-body"
                     data-v-0029352b=""
                   >
-                    <!---->
-                    <!---->
                     <div
-                      class="k-card-body"
+                      class="label-list__col-wrapper multi-col"
                       data-v-0029352b=""
                     >
                       <div
-                        class="label-list__col-wrapper multi-col"
                         data-v-0029352b=""
                       >
-                        <div
+                        <ul
                           data-v-0029352b=""
                         >
-                          <ul
+                          <li
                             data-v-0029352b=""
                           >
-                            <li
+                            <h4
                               data-v-0029352b=""
                             >
-                              <h4
-                                data-v-0029352b=""
-                              >
-                                
-                  type
-                
-                              </h4>
-                               
-                              <p
-                                data-v-0029352b=""
-                              >
-                                
-                  ZoneEgressOverview
-                
-                              </p>
-                            </li>
-                            <li
+                              
+                type
+              
+                            </h4>
+                             
+                            <p
                               data-v-0029352b=""
                             >
-                              <h4
-                                data-v-0029352b=""
-                              >
-                                
-                  name
-                
-                              </h4>
-                               
-                              <p
-                                data-v-0029352b=""
-                              >
-                                
-                  zoneegress-1
-                
-                              </p>
-                            </li>
-                          </ul>
-                        </div>
+                              
+                ZoneEgressOverview
+              
+                            </p>
+                          </li>
+                          <li
+                            data-v-0029352b=""
+                          >
+                            <h4
+                              data-v-0029352b=""
+                            >
+                              
+                name
+              
+                            </h4>
+                             
+                            <p
+                              data-v-0029352b=""
+                            >
+                              
+                zoneegress-1
+              
+                            </p>
+                          </li>
+                        </ul>
                       </div>
                     </div>
                   </div>
                 </div>
-                 
-                <!---->
-                 
-                <!---->
-                 
-                <!---->
               </div>
-            </div>
-            <div
-              aria-labelledby="insights-tab"
-              class="tab-container"
-              data-v-a38b664a=""
-              id="panel-1"
-              role="tabpanel"
-              tabindex="0"
-            >
+               
               <!---->
-            </div>
-            <div
-              aria-labelledby="xds-configuration-tab"
-              class="tab-container"
-              data-v-a38b664a=""
-              id="panel-2"
-              role="tabpanel"
-              tabindex="0"
-            >
+               
+              <!---->
+               
               <!---->
             </div>
           </div>
+          <div
+            aria-labelledby="insights-tab"
+            class="tab-container"
+            data-v-a38b664a=""
+            id="panel-1"
+            role="tabpanel"
+            tabindex="0"
+          >
+            <!---->
+          </div>
+          <div
+            aria-labelledby="xds-configuration-tab"
+            class="tab-container"
+            data-v-a38b664a=""
+            id="panel-2"
+            role="tabpanel"
+            tabindex="0"
+          >
+            <!---->
+          </div>
+        </div>
+         
+        <div>
+          <!---->
            
-          <div>
-            <!---->
-             
-            <!---->
-          </div>
+          <!---->
         </div>
       </div>
     </div>
@@ -436,89 +432,420 @@ exports[`ZoneEgresses.vue renders snapshot when no multizone 1`] = `
     class="zoneegresses"
   >
     <div
-      class="empty-state-wrapper"
-      data-v-567e03f2=""
+      class="data-overview"
+      data-testid="data-overview"
     >
       <div
-        class="empty-state-title"
-        data-v-567e03f2=""
+        class="data-table-controls mb-2"
       >
-        <!---->
-        <h5
-          data-v-567e03f2=""
+         
+        <button
+          class="k-button ml-2 refresh-button small primary"
+          data-v-38fa8ecf=""
+          type="button"
         >
-          <svg
-            class="kong-icon kong-icon--centered kong-icon-dangerCircle"
-            data-v-567e03f2=""
-            data-v-a7c9c1d2=""
-            height="42"
-            role="img"
-            viewBox="0 0 16 16"
-            width="42"
-          >
-            <title
-              data-v-a7c9c1d2=""
-            >
-              dangerCircle
-            </title>
-            <g
-              data-v-a7c9c1d2=""
-            >
-              <path
-                d="M0,8a8,8 0 1,0 16,0a8,8 0 1,0 -16,0"
-                data-v-a7c9c1d2=""
-                fill="#BFBFBF"
-              />
-              <path
-                d="M9 11v2H7v-2h2zm0-8v6.5H7V3h2z"
-                data-v-a7c9c1d2=""
-                fill="#FFF"
-                id="preserveColor"
-              />
-            </g>
-          </svg>
-          
-    Kuma is running in Standalone mode.
-  
-        </h5>
-      </div>
-      <div
-        class="empty-state-content"
-        data-v-567e03f2=""
-      >
-        <p
-          data-v-567e03f2=""
-        >
-          <p
-            data-v-567e03f2=""
-          >
-            
-      To access this page, you must be running in 
-            <strong
-              data-v-567e03f2=""
-            >
-              Multi-Zone
-            </strong>
-             mode.
-    
-          </p>
-        </p>
-        <p
-          data-v-567e03f2=""
-        >
-          <a
-            class="k-button primary"
+          <div
+            class="refresh-icon"
             data-v-38fa8ecf=""
-            data-v-567e03f2=""
-            href="https://kuma.io/docs/null/documentation/deployments/"
-            target="_blank"
-            type="button"
           >
-            
-      Learn More
-    
-          </a>
-        </p>
+            <svg
+              data-v-38fa8ecf=""
+              viewBox="0 0 36 36"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                data-v-38fa8ecf=""
+                fill="#fff"
+                fill-rule="nonzero"
+              >
+                <path
+                  d="M18 5.5a12.465 12.465 0 00-8.118 2.995 1.5 1.5 0 001.847 2.363l.115-.095A9.437 9.437 0 0118 8.5l.272.004a9.487 9.487 0 019.07 7.75l.04.246H25a.5.5 0 00-.416.777l4 6a.5.5 0 00.832 0l4-6 .04-.072A.5.5 0 0033 16.5h-2.601l-.017-.15C29.567 10.2 24.294 5.5 18 5.5zM2.584 18.723l-.04.072A.5.5 0 003 19.5h2.6l.018.15C6.433 25.8 11.706 30.5 18 30.5c3.013 0 5.873-1.076 8.118-2.995a1.5 1.5 0 00-1.847-2.363l-.115.095A9.437 9.437 0 0118 27.5l-.272-.004a9.487 9.487 0 01-9.07-7.75l-.041-.246H11a.5.5 0 00.416-.777l-4-6a.5.5 0 00-.832 0l-4 6z"
+                  data-v-38fa8ecf=""
+                />
+              </g>
+            </svg>
+          </div>
+           
+          <span
+            data-v-38fa8ecf=""
+          >
+            Refresh
+          </span>
+        </button>
+      </div>
+       
+      <div
+        class="data-overview-content"
+      >
+        <div
+          class="data-overview-table"
+        >
+          <table
+            class="k-table micro-table has-hover is-clickable"
+            data-v-bfeabd48=""
+          >
+            <thead
+              data-v-bfeabd48=""
+            >
+              <tr
+                data-v-bfeabd48=""
+              >
+                <th
+                  class=""
+                  data-v-bfeabd48=""
+                >
+                  <!---->
+                </th>
+                <th
+                  class=""
+                  data-v-bfeabd48=""
+                >
+                   Status 
+                </th>
+                <th
+                  class=""
+                  data-v-bfeabd48=""
+                >
+                   Name 
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              data-v-bfeabd48=""
+            >
+              <tr
+                data-v-bfeabd48=""
+              >
+                <td
+                  data-v-bfeabd48=""
+                >
+                  <a
+                    class="data-table-action-link is-active"
+                    data-v-bfeabd48=""
+                  >
+                    <span
+                      class="action-link__active-state"
+                      data-v-bfeabd48=""
+                    >
+                      
+              ✓
+              
+                      <span
+                        class="sr-only"
+                        data-v-bfeabd48=""
+                      >
+                        
+                Selected
+              
+                      </span>
+                    </span>
+                  </a>
+                </td>
+                <td
+                  data-v-bfeabd48=""
+                >
+                  <div
+                    class="entity-status"
+                    data-v-bfeabd48=""
+                  >
+                    <span
+                      class="entity-status__dot"
+                      data-v-bfeabd48=""
+                    />
+                     
+                    <span
+                      class="entity-status__label"
+                      data-v-bfeabd48=""
+                    >
+                      Online
+                    </span>
+                  </div>
+                </td>
+                <td
+                  data-v-bfeabd48=""
+                >
+                  zoneegress-1
+                </td>
+              </tr>
+            </tbody>
+          </table>
+           
+          <div
+            class="pagination"
+          >
+            <!---->
+             
+            <!---->
+          </div>
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+     
+    <div
+      class="tab-container"
+      data-testid="tab-container"
+    >
+      <header
+        class="tab__header"
+      >
+        <div>
+          <h3>
+             Zone Egress: zoneegress-1
+          </h3>
+        </div>
+         
+        <div>
+          <div
+            data-testid="entity-url-control"
+          >
+            <div
+              data-v-3cb990b6=""
+            >
+              <button
+                class="k-button small secondary"
+                data-v-38fa8ecf=""
+                data-v-3cb990b6=""
+                type="button"
+              >
+                <svg
+                  class="kong-icon kong-icon-externalLink"
+                  data-v-38fa8ecf=""
+                  data-v-a7c9c1d2=""
+                  height="12"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="12"
+                >
+                  <title
+                    data-v-a7c9c1d2=""
+                  >
+                    externalLink
+                  </title>
+                  <g
+                    data-v-a7c9c1d2=""
+                  >
+                    <path
+                      d="M8.24308 1.5C7.83269 1.5 7.5 1.16710138 7.5.75c0-.41421356.33823-.75.74308-.75h3.00568C11.6666 0 12 .336341 12 .75123866v3.00567786C12 4.1673102 11.6671 4.5 11.25 4.5c-.41421 0-.75-.3382314-.75-.74308348V2.625L6.53246 6.59254c-.28982.2898217-.76955.2953689-1.06202.0029022l-.06588-.0658844c-.29098-.2909742-.29117-.7679483.0029-1.0620178L9.375 1.5H8.24308zm-6.74753 0C.67089 1.5 0 2.1695784 0 2.99554521v7.50890959C0 11.3291147.66958 12 1.49555 12h7.5089C9.82911 12 10.5 11.3304216 10.5 10.5044548V6.75H9v3.75H1.5V3h3.75V1.5H1.49555z"
+                      data-v-a7c9c1d2=""
+                      fill="#000"
+                      fill-opacity=".25"
+                      fill-rule="evenodd"
+                    />
+                  </g>
+                </svg>
+                
+        Copy URL
+      
+              </button>
+              <transition-stub
+                data-v-3cb990b6=""
+                name="fade"
+              >
+                <div
+                  class="k-popover"
+                  data-v-3cb990b6=""
+                  style="width: 200px; display: none;"
+                >
+                  <!---->
+                  <div
+                    class="k-popover-content"
+                    data-v-3cb990b6=""
+                  >
+                    <div>
+                      <p>
+                        URL copied to clipboard!
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </transition-stub>
+            </div>
+          </div>
+        </div>
+      </header>
+       
+      <div
+        class="tab__content-container"
+      >
+        <div
+          class="k-tabs"
+          data-v-a38b664a=""
+        >
+          <ul
+            aria-label="ktabs"
+            data-v-a38b664a=""
+            role="tablist"
+          >
+            <li
+              aria-controls="panel-0"
+              aria-selected="true"
+              class="tab-item active"
+              data-v-a38b664a=""
+              id="overview-tab"
+              role="tab"
+              tabindex="0"
+            >
+              <a
+                class="tab-link"
+                data-v-a38b664a=""
+              >
+                Overview
+              </a>
+            </li>
+            <li
+              aria-controls="panel-1"
+              aria-selected="false"
+              class="tab-item"
+              data-v-a38b664a=""
+              id="insights-tab"
+              role="tab"
+              tabindex="0"
+            >
+              <a
+                class="tab-link"
+                data-v-a38b664a=""
+              >
+                Zone Egress Insights
+              </a>
+            </li>
+            <li
+              aria-controls="panel-2"
+              aria-selected="false"
+              class="tab-item"
+              data-v-a38b664a=""
+              id="xds-configuration-tab"
+              role="tab"
+              tabindex="0"
+            >
+              <a
+                class="tab-link"
+                data-v-a38b664a=""
+              >
+                XDS Configuration
+              </a>
+            </li>
+          </ul>
+          <div
+            aria-labelledby="overview-tab"
+            class="tab-container"
+            data-v-a38b664a=""
+            id="panel-0"
+            role="tabpanel"
+            tabindex="0"
+          >
+            <div
+              data-v-a38b664a=""
+            >
+              <div
+                class="label-list-content"
+              >
+                <div
+                  class="kong-card noBorder"
+                  data-v-0029352b=""
+                >
+                  <!---->
+                  <!---->
+                  <div
+                    class="k-card-body"
+                    data-v-0029352b=""
+                  >
+                    <div
+                      class="label-list__col-wrapper multi-col"
+                      data-v-0029352b=""
+                    >
+                      <div
+                        data-v-0029352b=""
+                      >
+                        <ul
+                          data-v-0029352b=""
+                        >
+                          <li
+                            data-v-0029352b=""
+                          >
+                            <h4
+                              data-v-0029352b=""
+                            >
+                              
+                type
+              
+                            </h4>
+                             
+                            <p
+                              data-v-0029352b=""
+                            >
+                              
+                ZoneEgressOverview
+              
+                            </p>
+                          </li>
+                          <li
+                            data-v-0029352b=""
+                          >
+                            <h4
+                              data-v-0029352b=""
+                            >
+                              
+                name
+              
+                            </h4>
+                             
+                            <p
+                              data-v-0029352b=""
+                            >
+                              
+                zoneegress-1
+              
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+               
+              <!---->
+               
+              <!---->
+               
+              <!---->
+            </div>
+          </div>
+          <div
+            aria-labelledby="insights-tab"
+            class="tab-container"
+            data-v-a38b664a=""
+            id="panel-1"
+            role="tabpanel"
+            tabindex="0"
+          >
+            <!---->
+          </div>
+          <div
+            aria-labelledby="xds-configuration-tab"
+            class="tab-container"
+            data-v-a38b664a=""
+            id="panel-2"
+            role="tabpanel"
+            tabindex="0"
+          >
+            <!---->
+          </div>
+        </div>
+         
+        <div>
+          <!---->
+           
+          <!---->
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Zone Egress can be deployed in standalone mode, but GUI doesn't present data if the mode is different than multizone. Removed part of the code that was responsible for that and now the user is allowed to see zone egress instances in standalone mode.