### PR TITLE
chore: remove meshgateway experimental flag

### DIFF
--- a/src/components/Sidebar/Sidebar.spec.ts
+++ b/src/components/Sidebar/Sidebar.spec.ts
@@ -11,9 +11,9 @@ describe('Sidebar.vue', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('renders mesh gateways when flag applied', () => {
+  it('renders mesh gateways', () => {
     renderWithVuex(Sidebar, {
-      store: { modules: { config: { state: { clientConfig: { experimental: { meshGateway: true } } } } } },
+      store: { },
       routes: [],
     })
 

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.ts.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.ts.snap
@@ -623,6 +623,66 @@ exports[`Sidebar.vue renders snapshot 1`] = `
       </div>
       <div
         class="nav-item is-menu-item"
+        data-testid="mesh-gateway-routes"
+        parent="policies"
+      >
+        <a
+          aria-current="page"
+          class="router-link-exact-active router-link-active"
+          href="#/"
+        >
+          <!---->
+           
+          <div
+            class="nav-link"
+          >
+            
+        Mesh Gateway Routes
+
+        
+            <span
+              class="amount amount--empty"
+            >
+              
+
+          0
+        
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="nav-item is-menu-item"
+        data-testid="mesh-gateways"
+        parent="policies"
+      >
+        <a
+          aria-current="page"
+          class="router-link-exact-active router-link-active"
+          href="#/"
+        >
+          <!---->
+           
+          <div
+            class="nav-link"
+          >
+            
+        Mesh Gateways
+
+        
+            <span
+              class="amount amount--empty"
+            >
+              
+
+          0
+        
+            </span>
+          </div>
+        </a>
+      </div>
+      <div
+        class="nav-item is-menu-item"
         data-testid="proxy-templates"
         parent="policies"
       >

--- a/src/components/Sidebar/menu.ts
+++ b/src/components/Sidebar/menu.ts
@@ -1,6 +1,6 @@
 import { RawLocation } from 'vue-router'
 import meshIcon from '@/assets/images/icon-service-mesh.svg'
-import { POLICY_MAP, FEATURE_FLAG } from '@/consts'
+import { POLICY_MAP } from '@/consts'
 
 type TODO = any
 type KIconType = 'gearFilled'
@@ -199,7 +199,6 @@ const menu: MenuSection[] = [
                 title: false,
                 parent: 'policies',
                 insightsFieldAccessor: 'mesh.policies.MeshGateway',
-                featureFlags: [FEATURE_FLAG.GATEWAY],
               },
               {
                 name: POLICY_MAP.MeshGatewayRoute.title,
@@ -207,7 +206,6 @@ const menu: MenuSection[] = [
                 title: false,
                 parent: 'policies',
                 insightsFieldAccessor: 'mesh.policies.MeshGatewayRoute',
-                featureFlags: [FEATURE_FLAG.GATEWAY],
               },
             ].sort((a, b) => (a.name < b.name ? -1 : 1)),
           ],

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -66,6 +66,4 @@ export const POLICY_MAP = {
   },
 }
 
-export const FEATURE_FLAG = {
-  GATEWAY: 'meshGateway',
-}
+export const FEATURE_FLAG = {}

--- a/src/services/mock/responses/config.json
+++ b/src/services/mock/responses/config.json
@@ -86,9 +86,7 @@
     "tlsKeyFile": "/Users/tomasz.wylezek/.kuma/kuma-cp.key"
   },
   "environment": "universal",
-  "experimental": {
-    "meshGateway": true
-  },
+  "experimental": {},
   "general": {
     "dnsCacheTTL": "10s",
     "tlsCertFile": "/Users/tomasz.wylezek/.kuma/kuma-cp.crt",

--- a/src/store/modules/config/config.ts
+++ b/src/store/modules/config/config.ts
@@ -1,6 +1,5 @@
 import Kuma from '@/services/kuma'
 import { ActionTree, GetterTree, MutationTree } from 'vuex'
-import { FEATURE_FLAG } from '@/consts'
 import { RootInterface } from '../..'
 import { ConfigInterface } from './config.types'
 
@@ -26,15 +25,7 @@ const getters: GetterTree<ConfigInterface, RootInterface> = {
   getTagline: state => state.tagline,
   getVersion: state => state.version,
   getConfigurationType: state => state.clientConfig?.store?.type,
-  featureFlags: state => {
-    const featureFlags = []
-
-    if (state.clientConfig?.experimental?.meshGateway) {
-      featureFlags.push(FEATURE_FLAG.GATEWAY)
-    }
-
-    return featureFlags
-  },
+  featureFlags: state => ([]),
 
   getMulticlusterStatus: (state, getters) => {
     // is Kuma running in Multi-Zone mode?

--- a/src/store/modules/config/config.types.ts
+++ b/src/store/modules/config/config.types.ts
@@ -106,10 +106,6 @@ export interface DpServer {
   tlsKeyFile: string
 }
 
-export interface Experimental {
-  meshGateway: boolean
-}
-
 export interface General {
   dnsCacheTTL: string
   tlsCertFile: string
@@ -348,7 +344,7 @@ export interface ClientConfigInterface {
   dpServer: DpServer
   environment: string
   general: General
-  experimental: Experimental
+  experimental: {}
   guiServer: GuiServer
   metrics: Metrics
   mode: string

--- a/src/views/Entities/Meshes.vue
+++ b/src/views/Entities/Meshes.vue
@@ -165,7 +165,7 @@ import DataOverview from '@/components/Skeletons/DataOverview'
 import Tabs from '@/components/Utils/Tabs'
 import YamlView from '@/components/Skeletons/YamlView'
 import LabelList from '@/components/Utils/LabelList'
-import { PAGE_SIZE_DEFAULT, POLICY_MAP, FEATURE_FLAG } from '@/consts'
+import { PAGE_SIZE_DEFAULT, POLICY_MAP } from '@/consts'
 
 export default {
   name: 'Meshes',
@@ -297,18 +297,14 @@ export default {
           title: POLICY_MAP.Timeout.title,
           value: policies.Timeout.total,
         },
-        ...this.featureFlags.includes(FEATURE_FLAG.GATEWAY)
-          ? [
-            {
-              title: POLICY_MAP.MeshGateway.title,
-              value: policies.MeshGateway.total,
-            },
-            {
-              title: POLICY_MAP.MeshGatewayRoute.title,
-              value: policies.MeshGatewayRoute.total,
-            },
-          ]
-          : [],
+        {
+          title: POLICY_MAP.MeshGateway.title,
+          value: policies.MeshGateway.total,
+        },
+        {
+          title: POLICY_MAP.MeshGatewayRoute.title,
+          value: policies.MeshGatewayRoute.total,
+        },
       ]
     },
     countCols() {

--- a/src/views/Entities/__snapshots__/Meshes.spec.ts.snap
+++ b/src/views/Entities/__snapshots__/Meshes.spec.ts.snap
@@ -594,6 +594,44 @@ exports[`Meshes.vue renders snapshot with Resource tab 1`] = `
                             </li>
                           </ul>
                         </div>
+                        <div
+                          data-v-0029352b=""
+                        >
+                          <ul
+                            data-v-0029352b=""
+                          >
+                            <li
+                              data-v-0029352b=""
+                            >
+                              <h4
+                                data-v-0029352b=""
+                              >
+                                Mesh Gateways
+                              </h4>
+                               
+                              <p
+                                data-v-0029352b=""
+                              >
+                                1
+                              </p>
+                            </li>
+                            <li
+                              data-v-0029352b=""
+                            >
+                              <h4
+                                data-v-0029352b=""
+                              >
+                                Mesh Gateway Routes
+                              </h4>
+                               
+                              <p
+                                data-v-0029352b=""
+                              >
+                                1
+                              </p>
+                            </li>
+                          </ul>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/views/__snapshots__/Shell.spec.ts.snap
+++ b/src/views/__snapshots__/Shell.spec.ts.snap
@@ -662,6 +662,66 @@ exports[`Shell.vue renders component with route 1`] = `
           </div>
           <div
             class="nav-item is-menu-item"
+            data-testid="mesh-gateway-routes"
+            parent="policies"
+          >
+            <a
+              aria-current="page"
+              class="router-link-exact-active router-link-active"
+              href="#/"
+            >
+              <!---->
+               
+              <div
+                class="nav-link"
+              >
+                
+        Mesh Gateway Routes
+
+        
+                <span
+                  class="amount amount--empty"
+                >
+                  
+
+          0
+        
+                </span>
+              </div>
+            </a>
+          </div>
+          <div
+            class="nav-item is-menu-item"
+            data-testid="mesh-gateways"
+            parent="policies"
+          >
+            <a
+              aria-current="page"
+              class="router-link-exact-active router-link-active"
+              href="#/"
+            >
+              <!---->
+               
+              <div
+                class="nav-link"
+              >
+                
+        Mesh Gateways
+
+        
+                <span
+                  class="amount amount--empty"
+                >
+                  
+
+          0
+        
+                </span>
+              </div>
+            </a>
+          </div>
+          <div
+            class="nav-item is-menu-item"
             data-testid="proxy-templates"
             parent="policies"
           >


### PR DESCRIPTION
As meshgateway is now available without the need of experimental
flag (flag was even removed) we should display routes related
to it by default

Closes https://github.com/kumahq/kuma-gui/issues/328

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?: 👍 
