### PR TITLE
fix: incorrect version path in docs URLs

### DIFF
--- a/src/components/NotificationManager/components/LoggingNotification.spec.ts
+++ b/src/components/NotificationManager/components/LoggingNotification.spec.ts
@@ -4,7 +4,7 @@ import LoggingNotification from './LoggingNotification.vue'
 describe('LoggingNotification.vue', () => {
   it('renders snapshot', () => {
     const { container } = renderWithVuex(LoggingNotification, {
-      store: { modules: { config: { state: { version: '1.2.0' } } } },
+      store: { modules: { config: { state: { kumaDocsVersion: '1.2.0' } } } },
     })
 
     expect(container).toMatchSnapshot()

--- a/src/components/NotificationManager/components/LoggingNotification.vue
+++ b/src/components/NotificationManager/components/LoggingNotification.vue
@@ -7,7 +7,7 @@
     <ul class="list-disc pl-4">
       <li>
         <a
-          :href="`https://kuma.io/docs/${version}/policies/traffic-log/`"
+          :href="`https://kuma.io/docs/${kumaDocsVersion}/policies/traffic-log/`"
           target="_blank"
         >
           Traffic Log policy documentation
@@ -23,7 +23,7 @@ export default {
   name: 'LoggingNotification',
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
   },
 }

--- a/src/components/NotificationManager/components/MetricsNotification.spec.ts
+++ b/src/components/NotificationManager/components/MetricsNotification.spec.ts
@@ -4,7 +4,7 @@ import MetricsNotification from './MetricsNotification.vue'
 describe('MetricsNotification.vue', () => {
   it('renders snapshot', () => {
     const { container } = renderWithVuex(MetricsNotification, {
-      store: { modules: { config: { state: { version: '1.2.0' } } } },
+      store: { modules: { config: { state: { kumaDocsVersion: '1.2.0' } } } },
     })
 
     expect(container).toMatchSnapshot()

--- a/src/components/NotificationManager/components/MetricsNotification.vue
+++ b/src/components/NotificationManager/components/MetricsNotification.vue
@@ -7,7 +7,7 @@
     <ul class="list-disc pl-4">
       <li>
         <a
-          :href="`https://kuma.io/docs/${version}/policies/traffic-metrics/`"
+          :href="`https://kuma.io/docs/${kumaDocsVersion}/policies/traffic-metrics/`"
           target="_blank"
         >
           Traffic Metrics policy documentation
@@ -23,7 +23,7 @@ export default {
   name: 'MetricsNotification',
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
   },
 }

--- a/src/components/NotificationManager/components/MtlsNotification.spec.ts
+++ b/src/components/NotificationManager/components/MtlsNotification.spec.ts
@@ -4,7 +4,7 @@ import MtlsNotification from './MtlsNotification.vue'
 describe('MtlsNotification.vue', () => {
   it('renders snapshot', () => {
     const { container } = renderWithVuex(MtlsNotification, {
-      store: { modules: { config: { state: { version: '1.2.0' } } } },
+      store: { modules: { config: { state: { kumaDocsVersion: '1.2.0' } } } },
     })
 
     expect(container).toMatchSnapshot()

--- a/src/components/NotificationManager/components/MtlsNotification.vue
+++ b/src/components/NotificationManager/components/MtlsNotification.vue
@@ -9,7 +9,7 @@
     <ul class="list-disc pl-4">
       <li>
         <a
-          :href="`https://kuma.io/docs/${version}/security/certificates/`"
+          :href="`https://kuma.io/docs/${kumaDocsVersion}/security/certificates/`"
           target="_blank"
         >
           Secure access across services
@@ -17,7 +17,7 @@
       </li>
       <li>
         <a
-          :href="`https://kuma.io/docs/${version}/policies/mutual-tls/`"
+          :href="`https://kuma.io/docs/${kumaDocsVersion}/policies/mutual-tls/`"
           target="_blank"
         >
           Mutual TLS
@@ -25,7 +25,7 @@
       </li>
       <li>
         <a
-          :href="`https://kuma.io/docs/${version}/policies/traffic-permissions/`"
+          :href="`https://kuma.io/docs/${kumaDocsVersion}/policies/traffic-permissions/`"
           target="_blank"
         >
           Traffic Permissions policy documentation
@@ -42,7 +42,7 @@ export default {
 
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
   },
 }

--- a/src/components/NotificationManager/components/OnboardingNotification.spec.ts
+++ b/src/components/NotificationManager/components/OnboardingNotification.spec.ts
@@ -4,7 +4,7 @@ import OnboardingNotification from './OnboardingNotification.vue'
 describe('OnboardingNotification.vue', () => {
   it('renders snapshot', () => {
     const { container } = renderWithVuex(OnboardingNotification, {
-      store: { modules: { config: { state: { version: '1.2.0' } } } },
+      store: { modules: { config: { state: { kumaDocsVersion: '1.2.0' } } } },
       routes: [],
     })
 

--- a/src/components/NotificationManager/components/TracingNotification.spec.ts
+++ b/src/components/NotificationManager/components/TracingNotification.spec.ts
@@ -4,7 +4,7 @@ import TracingNotification from './TracingNotification.vue'
 describe('TracingNotification.vue', () => {
   it('renders snapshot', () => {
     const { container } = renderWithVuex(TracingNotification, {
-      store: { modules: { config: { state: { version: '1.2.0' } } } },
+      store: { modules: { config: { state: { kumaDocsVersion: '1.2.0' } } } },
     })
 
     expect(container).toMatchSnapshot()

--- a/src/components/NotificationManager/components/TracingNotification.vue
+++ b/src/components/NotificationManager/components/TracingNotification.vue
@@ -7,7 +7,7 @@
     <ul class="list-disc pl-4">
       <li>
         <a
-          :href="`https://kuma.io/docs/${version}/policies/traffic-trace/`"
+          :href="`https://kuma.io/docs/${kumaDocsVersion}/policies/traffic-trace/`"
           target="_blank"
         >
           Traffic Trace policy documentation
@@ -24,7 +24,7 @@ export default {
 
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
   },
 }

--- a/src/components/Resources.vue
+++ b/src/components/Resources.vue
@@ -1,6 +1,6 @@
 <template>
   <KCard
-    v-if="version"
+    v-if="resourceLinks.length > 0"
     title="Resources"
   >
     <template v-slot:body>
@@ -34,18 +34,18 @@ export default {
   }),
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     resourceLinks() {
-      const storedVersion = this.version
-      const versionOutput = storedVersion !== null ? storedVersion : 'latest'
+      const storedVersion = this.kumaDocsVersion
+      const kumaDocsVersion = storedVersion !== null ? storedVersion : 'latest'
 
       const utmSource = process.env.VUE_APP_UTM
 
       if (storedVersion) {
         return [
           {
-            link: `https://kuma.io/docs/${versionOutput}/${utmSource}`,
+            link: `https://kuma.io/docs/${kumaDocsVersion}/${utmSource}`,
             label: `${process.env.VUE_APP_NAMESPACE} Documentation`,
           },
           {
@@ -59,7 +59,7 @@ export default {
         ]
       }
 
-      return false
+      return []
     },
   },
 }

--- a/src/components/Utils/UpgradeCheck.spec.ts
+++ b/src/components/Utils/UpgradeCheck.spec.ts
@@ -4,7 +4,7 @@ import UpgradeCheck from './UpgradeCheck.vue'
 describe('UpgradeCheck.vue', () => {
   it('renders snapshot', async () => {
     const { container, findByText } = renderWithVuex(UpgradeCheck, {
-      store: { modules: { config: { state: { version: '1.2.0', tagline: 'Kuma' } } } },
+      store: { modules: { config: { state: { kumaDocsVersion: '1.2.0', tagline: 'Kuma' } } } },
     })
 
     await findByText('Update')

--- a/src/store/modules/config/config.ts
+++ b/src/store/modules/config/config.ts
@@ -7,6 +7,7 @@ const state: ConfigInterface = {
   status: null,
   tagline: null,
   version: null,
+  kumaDocsVersion: 'latest',
   clientConfig: null,
 }
 
@@ -15,6 +16,7 @@ const mutations: MutationTree<ConfigInterface> = {
   SET_STATUS: (state, status) => (state.status = status),
   SET_TAGLINE: (state, tagline) => (state.tagline = tagline),
   SET_VERSION: (state, version) => (state.version = version),
+  SET_KUMA_DOCS_VERSION: (state, kumaDocsVersion) => (state.kumaDocsVersion = kumaDocsVersion),
 }
 
 const getters: GetterTree<ConfigInterface, RootInterface> = {
@@ -24,6 +26,7 @@ const getters: GetterTree<ConfigInterface, RootInterface> = {
   getMode: state => state.clientConfig?.mode,
   getTagline: state => state.tagline,
   getVersion: state => state.version,
+  getKumaDocsVersion: state => state.kumaDocsVersion,
   getConfigurationType: state => state.clientConfig?.store?.type,
   featureFlags: state => ([]),
 
@@ -74,6 +77,20 @@ const actions: ActionTree<ConfigInterface, RootInterface> = {
       .then(response => {
         commit('SET_TAGLINE', response.tagline)
         commit('SET_VERSION', response.version)
+
+        let kumaDocsVersion = 'latest'
+        if ('basedOnKuma' in response) {
+          const suffixIndex = response.basedOnKuma.indexOf('-preview.')
+          if (suffixIndex !== -1) {
+            const basedOnKumaStripped = response.basedOnKuma.substring(0, suffixIndex)
+
+            kumaDocsVersion = basedOnKumaStripped === '0.0.0' ? 'dev' : basedOnKumaStripped
+          } else {
+            kumaDocsVersion = response.basedOnKuma
+          }
+        }
+
+        commit('SET_KUMA_DOCS_VERSION', kumaDocsVersion)
       })
       .catch(error => {
         console.error(error)

--- a/src/store/modules/config/config.types.ts
+++ b/src/store/modules/config/config.types.ts
@@ -362,6 +362,7 @@ export interface ConfigInterface {
   status: string | null
   tagline: string | null
   version: string | null
+  kumaDocsVersion: string
 }
 
 export type ConfigType = Module<ConfigInterface, RootInterface>

--- a/src/views/Entities/__snapshots__/ZoneIngresses.spec.ts.snap
+++ b/src/views/Entities/__snapshots__/ZoneIngresses.spec.ts.snap
@@ -562,7 +562,7 @@ exports[`ZoneIngresses.vue renders snapshot when no multizone 1`] = `
             class="k-button primary"
             data-v-38fa8ecf=""
             data-v-567e03f2=""
-            href="https://kuma.io/docs/null/documentation/deployments/"
+            href="https://kuma.io/docs/latest/documentation/deployments/"
             target="_blank"
             type="button"
           >

--- a/src/views/Entities/__snapshots__/Zones.spec.ts.snap
+++ b/src/views/Entities/__snapshots__/Zones.spec.ts.snap
@@ -960,7 +960,7 @@ exports[`Zones.vue renders snapshot when no multizone 1`] = `
             class="k-button primary"
             data-v-38fa8ecf=""
             data-v-567e03f2=""
-            href="https://kuma.io/docs/null/documentation/deployments/"
+            href="https://kuma.io/docs/latest/documentation/deployments/"
             target="_blank"
             type="button"
           >

--- a/src/views/Entities/components/MultizoneInfo.vue
+++ b/src/views/Entities/components/MultizoneInfo.vue
@@ -15,7 +15,7 @@
     </template>
     <template v-slot:cta>
       <KButton
-        :to="`https://kuma.io/docs/${version}/documentation/deployments/`"
+        :to="`https://kuma.io/docs/${kumaDocsVersion}/documentation/deployments/`"
         target="_blank"
         appearance="primary"
       >
@@ -37,7 +37,7 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
   },
 }

--- a/src/views/Entities/partial/Dataplanes.vue
+++ b/src/views/Entities/partial/Dataplanes.vue
@@ -210,7 +210,7 @@
             <template v-slot:alertMessage>
               This data plane proxy does not yet have mTLS configured &mdash;
               <a
-                :href="`https://kuma.io/docs/${version}/documentation/security/#certificates`"
+                :href="`https://kuma.io/docs/${kumaDocsVersion}/documentation/security/#certificates`"
                 class="external-link"
                 target="_blank"
               >
@@ -415,8 +415,8 @@ export default {
         return { name: 'kubernetes-dataplane' }
       }
     },
-    version() {
-      const storedVersion = this.$store.getters.getVersion
+    kumaDocsVersion() {
+      const storedVersion = this.$store.getters.getKumaDocsVersion
 
       return storedVersion !== null ? storedVersion : 'latest'
     },

--- a/src/views/Onboarding/MultiZone.vue
+++ b/src/views/Onboarding/MultiZone.vue
@@ -105,10 +105,10 @@ export default {
       return this.hasZoneIngresses && this.hasZones
     },
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     documentationLink() {
-      return `https://kuma.io/docs/${this.version}/deployments/multi-zone/#zone-control-plane`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/deployments/multi-zone/#zone-control-plane`
     },
   },
 

--- a/src/views/Onboarding/__snapshots__/MultiZone.spec.ts.snap
+++ b/src/views/Onboarding/__snapshots__/MultiZone.spec.ts.snap
@@ -69,11 +69,11 @@ exports[`MultiZone.vue renders snapshot 1`] = `
               <a
                 class="external-link-code-block"
                 data-v-0029352b=""
-                href="https://kuma.io/docs/null/deployments/multi-zone/#zone-control-plane"
+                href="https://kuma.io/docs/latest/deployments/multi-zone/#zone-control-plane"
                 target="_blank"
               >
                 
-          https://kuma.io/docs/null/deployments/multi-zone/#zone-control-plane
+          https://kuma.io/docs/latest/deployments/multi-zone/#zone-control-plane
         
               </a>
             </div>

--- a/src/views/Policies/CircuitBreakers.vue
+++ b/src/views/Policies/CircuitBreakers.vue
@@ -162,10 +162,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/circuit-breaker/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/circuit-breaker/`
     },
   },
   watch: {

--- a/src/views/Policies/FaultInjections.vue
+++ b/src/views/Policies/FaultInjections.vue
@@ -164,10 +164,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/fault-injection/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/fault-injection/`
     },
   },
   watch: {

--- a/src/views/Policies/HealthChecks.vue
+++ b/src/views/Policies/HealthChecks.vue
@@ -161,10 +161,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/health-check/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/health-check/`
     },
   },
   watch: {

--- a/src/views/Policies/MeshGatewayRoutes.vue
+++ b/src/views/Policies/MeshGatewayRoutes.vue
@@ -166,10 +166,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/meshgatewayroute/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/meshgatewayroute/`
     },
   },
   watch: {

--- a/src/views/Policies/MeshGateways.vue
+++ b/src/views/Policies/MeshGateways.vue
@@ -166,10 +166,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/meshgateway/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/meshgateway/`
     },
   },
   watch: {

--- a/src/views/Policies/ProxyTemplates.vue
+++ b/src/views/Policies/ProxyTemplates.vue
@@ -161,10 +161,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/proxy-template/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/proxy-template/`
     },
   },
   watch: {

--- a/src/views/Policies/RateLimits.vue
+++ b/src/views/Policies/RateLimits.vue
@@ -161,10 +161,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/rate-limit/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/rate-limit/`
     },
   },
   watch: {

--- a/src/views/Policies/Retries.vue
+++ b/src/views/Policies/Retries.vue
@@ -160,10 +160,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/retry/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/retry/`
     },
   },
   watch: {

--- a/src/views/Policies/Timeouts.vue
+++ b/src/views/Policies/Timeouts.vue
@@ -160,10 +160,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/timeout/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/timeout/`
     },
   },
   watch: {

--- a/src/views/Policies/TrafficLogs.vue
+++ b/src/views/Policies/TrafficLogs.vue
@@ -160,10 +160,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/traffic-log/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/traffic-log/`
     },
   },
   watch: {

--- a/src/views/Policies/TrafficPermissions.vue
+++ b/src/views/Policies/TrafficPermissions.vue
@@ -180,10 +180,10 @@ export default {
   computed: {
     ...mapGetters({
       environment: 'config/getEnvironment',
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/traffic-permissions/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/traffic-permissions/`
     },
   },
   watch: {

--- a/src/views/Policies/TrafficRoutes.vue
+++ b/src/views/Policies/TrafficRoutes.vue
@@ -160,10 +160,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/traffic-route/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/traffic-route/`
     },
   },
   watch: {

--- a/src/views/Policies/TrafficTraces.vue
+++ b/src/views/Policies/TrafficTraces.vue
@@ -160,10 +160,10 @@ export default {
   },
   computed: {
     ...mapGetters({
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
     }),
     docsURL() {
-      return `https://kuma.io/docs/${this.version}/policies/traffic-trace/`
+      return `https://kuma.io/docs/${this.kumaDocsVersion}/policies/traffic-trace/`
     },
   },
   watch: {

--- a/src/views/Wizard/views/Mesh.vue
+++ b/src/views/Wizard/views/Mesh.vue
@@ -527,7 +527,7 @@
           </p>
           <p>
             <a
-              :href="`https://kuma.io/docs/${version}/policies/mesh/${utm}`"
+              :href="`https://kuma.io/docs/${kumaDocsVersion}/policies/mesh/${utm}`"
               target="_blank"
             >
               Learn More
@@ -662,7 +662,7 @@ export default {
   computed: {
     ...mapGetters({
       title: 'config/getTagline',
-      version: 'config/getVersion',
+      kumaDocsVersion: 'config/getKumaDocsVersion',
       environment: 'config/getEnvironment',
     }),
 

--- a/src/views/Wizard/views/__snapshots__/Mesh.spec.ts.snap
+++ b/src/views/Wizard/views/__snapshots__/Mesh.spec.ts.snap
@@ -548,7 +548,7 @@ metrics:
                
               <p>
                 <a
-                  href="https://kuma.io/docs/null/policies/mesh/?utm_source=Kuma&utm_medium=Kuma-GUI"
+                  href="https://kuma.io/docs/latest/policies/mesh/?utm_source=Kuma&utm_medium=Kuma-GUI"
                   target="_blank"
                 >
                   

--- a/src/views/__snapshots__/Overview.spec.ts.snap
+++ b/src/views/__snapshots__/Overview.spec.ts.snap
@@ -2179,7 +2179,88 @@ exports[`Overview.vue renders basic snapshot 1`] = `
       </div>
        
       <div>
-        <!---->
+        <div
+          class="kong-card card-item border"
+          data-v-0029352b=""
+        >
+          <div
+            class="k-card-header mb-4"
+            data-v-0029352b=""
+          >
+            <div
+              class="k-card-title"
+              data-v-0029352b=""
+            >
+              <h4
+                data-v-0029352b=""
+              >
+                Resources
+              </h4>
+            </div>
+            <div
+              class="k-card-actions"
+              data-v-0029352b=""
+            />
+          </div>
+          <!---->
+          <div
+            class="k-card-body"
+            data-v-0029352b=""
+          >
+            <p
+              data-v-0029352b=""
+            >
+              
+      Join the Kuma community and ask questions:
+    
+            </p>
+             
+            <ul
+              class="resource-list"
+              data-v-0029352b=""
+            >
+              <li
+                data-v-0029352b=""
+              >
+                <a
+                  data-v-0029352b=""
+                  href="https://kuma.io/docs/latest/?utm_source=Kuma&utm_medium=Kuma-GUI"
+                  target="_blank"
+                >
+                  
+          Kuma Documentation
+        
+                </a>
+              </li>
+              <li
+                data-v-0029352b=""
+              >
+                <a
+                  data-v-0029352b=""
+                  href="https://kuma-mesh.slack.com/?utm_source=Kuma&utm_medium=Kuma-GUI"
+                  target="_blank"
+                >
+                  
+          Kuma Community Chat
+        
+                </a>
+              </li>
+              <li
+                data-v-0029352b=""
+              >
+                <a
+                  data-v-0029352b=""
+                  href="https://github.com/kumahq/kuma?utm_source=Kuma&utm_medium=Kuma-GUI"
+                  target="_blank"
+                >
+                  
+          Kuma GitHub Repository
+        
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes URLs to the Kuma documentation website in cases where implementations of the open core versions have a version that differs from the underlying Kuma version.

Introduces a new `kumaDocsVersion` state which is derived from the `basedOnKuma` field found in the API response for `/`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
