### PR TITLE
fix: not calling all entities endpoints correctly

### DIFF
--- a/src/utils/tableDataUtils.spec.ts
+++ b/src/utils/tableDataUtils.spec.ts
@@ -8,6 +8,7 @@ describe('tableDataUtils', () => {
     params = {
       getSingleEntity: jest.fn().mockResolvedValue({}),
       getAllEntities: jest.fn().mockResolvedValue({}),
+      getAllEntitiesFromPath: jest.fn().mockResolvedValue({}),
       getAllEntitiesFromMesh: jest.fn().mockResolvedValue({}),
       mesh: 'all',
       query: null,

--- a/src/utils/tableDataUtils.ts
+++ b/src/utils/tableDataUtils.ts
@@ -16,6 +16,7 @@ const getItems = (response: { total: number; items: TableItem[] }): TableItem[] 
 function getAPICallFunction({
   getSingleEntity,
   getAllEntities,
+  getAllEntitiesFromPath,
   getAllEntitiesFromMesh,
   path,
   mesh,
@@ -34,8 +35,14 @@ function getAPICallFunction({
     return getSingleEntity({ mesh, path, name: query }, params)
   }
 
-  if (!mesh || mesh === 'all') {
-    return getAllEntities({ path }, params)
+  const isAllEntities = !mesh || mesh === 'all'
+
+  if (getAllEntities && isAllEntities) {
+    return getAllEntities(params)
+  }
+
+  if (getAllEntitiesFromPath && isAllEntities) {
+    return getAllEntitiesFromPath({ path }, params)
   }
 
   if (getAllEntitiesFromMesh && mesh) {
@@ -48,6 +55,7 @@ function getAPICallFunction({
 export async function getTableData({
   getSingleEntity,
   getAllEntities,
+  getAllEntitiesFromPath,
   getAllEntitiesFromMesh,
   path,
   mesh,
@@ -59,6 +67,7 @@ export async function getTableData({
   const response = await getAPICallFunction({
     getSingleEntity,
     getAllEntities,
+    getAllEntitiesFromPath,
     getAllEntitiesFromMesh,
     path,
     mesh,

--- a/src/utils/tableDataUtils.types.ts
+++ b/src/utils/tableDataUtils.types.ts
@@ -3,7 +3,10 @@ export interface TableDataParams {
     options: { mesh?: string | null, path?: string, name?: string | null },
     params: { size: number, offset: string | null },
   ) => any
-  getAllEntities: (
+  getAllEntities?: (
+    params: { size: number, offset: string | null }
+  ) => any
+  getAllEntitiesFromPath?: (
     options: { path?: string },
     params: { size: number, offset: string | null }
   ) => any

--- a/src/views/Policies/PolicyView.vue
+++ b/src/views/Policies/PolicyView.vue
@@ -243,7 +243,7 @@ export default {
       try {
         const { data, next } = await getTableData({
           getSingleEntity: Kuma.getSinglePolicyEntity.bind(Kuma),
-          getAllEntities: Kuma.getAllPolicyEntities.bind(Kuma),
+          getAllEntitiesFromPath: Kuma.getAllPolicyEntities.bind(Kuma),
           getAllEntitiesFromMesh: Kuma.getAllPolicyEntitiesFromMesh.bind(Kuma),
           path,
           mesh,


### PR DESCRIPTION
Fixes a bug with not calling endpoints retrieving all entities correctly. The query parameters for the endpoints wouldn’t always be passed to the underlying request library leading to issues like showing all dataplanes instead of just those of a specific type.

Fixes #352.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>