### PR TITLE
chore: avoid crash in dataplane policies tab

### DIFF
--- a/src/components/DataplanePolicies/DataplanePolicies.vue
+++ b/src/components/DataplanePolicies/DataplanePolicies.vue
@@ -167,14 +167,19 @@ export default {
       this.isLoading = true
 
       try {
-        const { items, total } = await Kuma.getDataplanePolicies({
+        const { items, total, kind } = await Kuma.getDataplanePolicies({
           mesh: this.mesh,
           dppName: this.dppName,
         })
 
-        this.processItems(items)
-        this.hasItems = total > 0
-        this.items = items
+        // TODO: https://github.com/kumahq/kuma-gui/issues/351
+        // Stops processing responses from the dataplane policies endpoint that are in a new format
+        // because this code isn’t able to correctly process mesh gateway dataplanes.
+        if (kind === undefined || kind === 'SidecarDataplane') {
+          this.processItems(items)
+          this.items = items
+          this.hasItems = total > 0
+        }
       } catch (e) {
         console.error(e)
         this.hasError = true

--- a/src/services/mock/responses/dataplane-policies.json
+++ b/src/services/mock/responses/dataplane-policies.json
@@ -1,4 +1,5 @@
 {
+  "kind": "SidecarDataplane",
   "total": 6,
   "items": [
     {


### PR DESCRIPTION
Changes the dataplane policies tab to not crash when receiving data associated to mesh gateway dataplanes whose API responses use a wholly different format than what the current code is able to process.

Related to #351.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>