### PR TITLE
refactor(linters): reworks linter setup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,161 +1,27 @@
-// http://eslint.org/docs/user-guide/configuring
+/** @typedef {import('eslint').ESLint.ConfigData} Config */
 
-module.exports = {
+/** @type {Config} */ const config = {
   root: true,
-
   parserOptions: {
     parser: '@typescript-eslint/parser',
     sourceType: 'module',
   },
-
   env: {
     browser: true,
     es6: true,
   },
-
-  extends: ['eslint:recommended', 'plugin:vue/vue3-recommended', 'standard', '@vue/typescript'],
-
-  // required to lint *.vue files
   plugins: ['vue', 'import', '@typescript-eslint'],
-
+  extends: ['eslint:recommended', 'plugin:vue/vue3-recommended', 'standard', '@vue/typescript'],
   rules: {
     indent: 'off',
     '@typescript-eslint/indent': ['error', 2],
-    'arrow-parens': 0,
-    'generator-star-spacing': 0,
-    'object-property-newline': 'error',
-    'lines-between-class-members': ['error', 'always'],
-    'padding-line-between-statements': [
-      'error',
-      { blankLine: 'always', prev: ['block', 'block-like'], next: '*' },
-      { blankLine: 'always', prev: '*', next: 'return' },
-      { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
-      {
-        blankLine: 'any',
-        prev: ['const', 'let', 'var'],
-        next: ['const', 'let', 'var', 'if'],
-      },
-      { blankLine: 'always', prev: 'directive', next: '*' },
-      { blankLine: 'any', prev: 'directive', next: 'directive' },
-    ],
-    curly: 'error',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
-    'no-mixed-operators': 'off',
-    'no-useless-escape': 'off',
-    'no-async-promise-executor': 'off',
-    // Vue-specific
-    'vue/no-use-v-if-with-v-for': 'off',
-    'vue/no-v-html': 'off',
-    'comma-dangle': 'off',
-    'space-before-function-paren': 'off',
-    semi: 'off',
-
-    '@typescript-eslint/array-type': [
-      'error',
-      {
-        default: 'array',
-      },
-    ],
-    '@typescript-eslint/explicit-member-accessibility': [
-      'error',
-      {
-        accessibility: 'explicit',
-      },
-    ],
-    '@typescript-eslint/member-ordering': 'error',
-    '@typescript-eslint/no-dynamic-delete': 'error',
-    '@typescript-eslint/no-empty-function': 'off',
-    '@typescript-eslint/no-empty-interface': 'error',
-    '@typescript-eslint/no-explicit-any': 'warn',
-    '@typescript-eslint/no-floating-promises': 'off',
-    '@typescript-eslint/no-misused-new': 'error',
-    '@typescript-eslint/no-namespace': 'error',
-    '@typescript-eslint/no-non-null-assertion': 'error',
-    '@typescript-eslint/no-require-imports': 'warn',
-    '@typescript-eslint/no-shadow': [
-      'warn',
-      {
-        hoist: 'all',
-      },
-    ],
-    '@typescript-eslint/no-this-alias': 'error',
-    '@typescript-eslint/no-unused-expressions': 'error',
-    '@typescript-eslint/prefer-function-type': 'error',
-    '@typescript-eslint/promise-function-async': 'off',
-    '@typescript-eslint/unified-signatures': 'error',
-    'arrow-body-style': ['error', 'as-needed'],
-    'constructor-super': 'error',
-    'eol-last': 'error',
-    eqeqeq: ['error', 'smart'],
-    'guard-for-in': 'error',
-    'id-blacklist': 'off',
-    'id-match': 'off',
-    'import/no-deprecated': 'warn',
-    'import/order': 'error',
-    'max-len': [
-      'warn',
-      {
-        code: 120,
-        ignoreStrings: true,
-        ignoreTemplateLiterals: true,
-      },
-    ],
-    'no-bitwise': 'error',
-    'no-caller': 'error',
-    'no-cond-assign': 'error',
-    'no-console': [
-      'error',
-      {
-        allow: [
-          'log',
-          'warn',
-          'info',
-          'debug',
-          'dir',
-          'timeLog',
-          'assert',
-          'clear',
-          'count',
-          'countReset',
-          'group',
-          'groupEnd',
-          'table',
-          'dirxml',
-          'error',
-          'groupCollapsed',
-          'Console',
-          'profile',
-          'profileEnd',
-          'timeStamp',
-          'context',
-        ],
-      },
-    ],
-    'no-duplicate-case': 'error',
-    'no-duplicate-imports': 'error',
-    'no-empty': 'off',
-    'no-empty-function': 'off',
-    'no-eval': 'error',
-    'no-fallthrough': 'error',
-    'no-magic-numbers': [
-      'warn', // TODO: label numbers and into error quickly
-      {
-        ignore: [-1, 0, 1],
-      },
-    ],
-    'no-new-wrappers': 'error',
-    'no-param-reassign': 'error',
-    'no-sequences': 'error',
-    'no-shadow': 'warn',
-    'no-sparse-arrays': 'error',
-    'no-template-curly-in-string': 'error',
-    'no-throw-literal': 'error',
-    'no-undef-init': 'error',
-    'no-underscore-dangle': 'off',
-    'no-unused-expressions': 'error',
-    'no-var': 'error',
-    'prefer-const': 'error',
-    'prefer-template': 'error',
-    radix: 'error',
+    'comma-dangle': ['error', 'always-multiline'],
+    'space-before-function-paren': ['error', {
+      anonymous: 'always',
+      named: 'never',
+      asyncArrow: 'always',
+    }],
   },
 }
+
+module.exports = config

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "singleQuote": true,
-  "trailingComma": "all",
-  "semi": false,
-  "printWidth": 120
-}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,10 @@
+/** @typedef {import('prettier').Config} Config */
+
+/** @type {Config} */ const config = {
+  singleQuote: true,
+  trailingComma: 'all',
+  semi: false,
+  printWidth: 120,
+}
+
+module.exports = config

--- a/src/components/CodeBlock.vue
+++ b/src/components/CodeBlock.vue
@@ -1,15 +1,17 @@
 <template>
+  <!-- eslint-disable vue/no-v-html -->
   <pre
     class="code-block"
     :class="`language-${language}`"
     data-testid="code-block"
   ><code v-html="highlightedCode" /></pre>
+  <!-- eslint-enable vue/no-v-html -->
 </template>
 
 <script lang="ts" setup>
 import { computed } from 'vue'
 
-import { highlightCode } from '@/utils/highlight-code';
+import { highlightCode } from '@/utils/highlight-code'
 
 const props = defineProps<{
   language: string

--- a/src/components/DataplanePolicies/DataplanePolicies.spec.ts
+++ b/src/components/DataplanePolicies/DataplanePolicies.spec.ts
@@ -65,7 +65,7 @@ describe('DataplanePolicies.vue', () => {
   })
 
   it('renders error', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => { }); // silence console errors
+    jest.spyOn(console, 'error').mockImplementation(() => { }) // silence console errors
 
     server.use(
       rest.get('http://localhost/meshes/:mesh/dataplanes/:dataplaneName/policies', (req, res, ctx) =>

--- a/src/components/DataplanePolicies/DataplanePolicies.vue
+++ b/src/components/DataplanePolicies/DataplanePolicies.vue
@@ -191,7 +191,6 @@ export default {
       for (const item of items) {
         item.policyTypes = {}
 
-        // eslint-disable-next-line guard-for-in
         for (const policyType in item.matchedPolicies) {
           const policy = this.policiesByType[policyType]
 

--- a/src/components/EnvoyClusters/EnvoyClusters.spec.ts
+++ b/src/components/EnvoyClusters/EnvoyClusters.spec.ts
@@ -53,7 +53,7 @@ describe('EnvoyClusters.vue', () => {
   })
 
   it('renders error', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => { }); // silence console errors
+    jest.spyOn(console, 'error').mockImplementation(() => { }) // silence console errors
 
     server.use(
       rest.get('http://localhost/meshes/:mesh/dataplanes/:dataplaneName/clusters', (req, res, ctx) =>

--- a/src/components/EnvoyStats/EnvoyStats.spec.ts
+++ b/src/components/EnvoyStats/EnvoyStats.spec.ts
@@ -53,7 +53,7 @@ describe('EnvoyStats.vue', () => {
   })
 
   it('renders error', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => { }); // silence console errors
+    jest.spyOn(console, 'error').mockImplementation(() => { }) // silence console errors
 
     server.use(
       rest.get('http://localhost/meshes/:mesh/dataplanes/:dataplaneName/stats', (req, res, ctx) =>

--- a/src/components/NotificationManager/NotificationManager.spec.ts
+++ b/src/components/NotificationManager/NotificationManager.spec.ts
@@ -33,7 +33,7 @@ function renderComponent({ meshes, selectedMesh = 'all' }: { meshes: any, select
         KCard,
         KIcon,
         KModal,
-      }
+      },
     },
   })
 }

--- a/src/components/NotificationManager/NotificationManager.vue
+++ b/src/components/NotificationManager/NotificationManager.vue
@@ -67,7 +67,7 @@
       <template #body-content>
         <AllMeshesNotifications
           v-if="isAllMeshesView"
-          @meshSelected="changeMesh($event)"
+          @mesh-selected="changeMesh($event)"
         />
         <SingleMeshNotifications v-else />
       </template>

--- a/src/components/NotificationManager/components/AllMeshesNotifications.vue
+++ b/src/components/NotificationManager/components/AllMeshesNotifications.vue
@@ -59,7 +59,7 @@ import { mapGetters } from 'vuex'
 export default {
   name: 'AllMeshesNotifications',
 
-  emits: ['meshSelected'],
+  emits: ['mesh-selected'],
 
   data() {
     return {
@@ -76,7 +76,7 @@ export default {
   },
   methods: {
     meshSelected(name) {
-      this.$emit('meshSelected', name)
+      this.$emit('mesh-selected', name)
     },
     calculateActions(meshActions) {
       const allActions = Object.values(meshActions)

--- a/src/components/Sidebar/AppSidebar.spec.ts
+++ b/src/components/Sidebar/AppSidebar.spec.ts
@@ -27,7 +27,7 @@ function renderComponent() {
     global: {
       plugins: [router, store],
       stubs: {
-        'router-link': RouterLinkStub
+        'router-link': RouterLinkStub,
       },
       components: {
         KAlert,

--- a/src/components/Sidebar/AppSidebar.vue
+++ b/src/components/Sidebar/AppSidebar.vue
@@ -24,6 +24,7 @@
             v-if="item.iconCustom && !item.icon"
             #item-icon
           >
+            <!-- eslint-disable-next-line vue/no-v-html -->
             <div v-html="item.iconCustom" />
           </template>
         </NavItem>
@@ -82,7 +83,7 @@ export default {
   computed: {
     ...mapState({
       selectedMesh: (state) => state.selectedMesh,
-      policies: (state) => state.policies
+      policies: (state) => state.policies,
     }),
 
     ...mapGetters({

--- a/src/components/Sidebar/NavItem.spec.ts
+++ b/src/components/Sidebar/NavItem.spec.ts
@@ -35,7 +35,7 @@ function renderComponent() {
       plugins: [router, store],
       components: {
         KIcon,
-      }
+      },
     },
   })
 }

--- a/src/components/Skeletons/DataOverview.vue
+++ b/src/components/Skeletons/DataOverview.vue
@@ -293,7 +293,7 @@ export default {
     },
   },
 
-  emits: ['tableAction', 'refresh', 'loadData'],
+  emits: ['table-action', 'refresh', 'load-data'],
 
   data() {
     return {
@@ -336,22 +336,22 @@ export default {
   methods: {
     tableRowHandler(e, row, type) {
       this.selectedRow = row.name
-      this.$emit('tableAction', row)
+      this.$emit('table-action', row)
     },
     onRefreshButtonClick() {
       this.$emit('refresh')
-      this.$emit('loadData', this.pageOffset)
+      this.$emit('load-data', this.pageOffset)
       datadogLogs.logger.info(datadogLogEvents.TABLE_REFRESH_BUTTON_CLICKED)
     },
     goToPreviousPage() {
       this.pageOffset -= this.pageSize
 
-      this.$emit('loadData', this.pageOffset)
+      this.$emit('load-data', this.pageOffset)
     },
     goToNextPage() {
       this.pageOffset += this.pageSize
 
-      this.$emit('loadData', this.pageOffset)
+      this.$emit('load-data', this.pageOffset)
     },
   },
 }

--- a/src/components/Skeletons/__snapshots__/DataOverview.spec.ts.snap
+++ b/src/components/Skeletons/__snapshots__/DataOverview.spec.ts.snap
@@ -33,7 +33,7 @@ Object {
       },
     ],
   ],
-  "loadData": Array [
+  "load-data": Array [
     Array [
       12,
     ],

--- a/src/components/Utils/TabsWidget.vue
+++ b/src/components/Utils/TabsWidget.vue
@@ -123,7 +123,7 @@ export default {
     },
   },
 
-  emits: ['onTabChange'],
+  emits: ['on-tab-change'],
 
   data() {
     return {
@@ -151,7 +151,7 @@ export default {
           newTab,
         },
       })
-      this.$emit('onTabChange', newTab)
+      this.$emit('on-tab-change', newTab)
     },
   },
 }

--- a/src/components/XdsConfiguration/XdsConfiguration.spec.ts
+++ b/src/components/XdsConfiguration/XdsConfiguration.spec.ts
@@ -41,7 +41,7 @@ describe('XdsConfiguration.vue', () => {
   })
 
   it('renders error', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => { }); // silence console errors
+    jest.spyOn(console, 'error').mockImplementation(() => { }) // silence console errors
 
     server.use(
       rest.get('http://localhost/meshes/:mesh/dataplanes/:dataplaneName/xds', (req, res, ctx) =>

--- a/src/components/__snapshots__/CodeBlock.spec.ts.snap
+++ b/src/components/__snapshots__/CodeBlock.spec.ts.snap
@@ -1,9 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CodeBlock matches snapshot 1`] = `
+<!-- eslint-disable vue/no-v-html -->
 <pre class="code-block language-json" data-testid="code-block"><code><span class="token punctuation">{</span>
           <span class="token property">"key"</span><span class="token operator">:</span> <span class="token string">"value"</span>
         <span class="token punctuation">}</span></code></pre>
+<!-- eslint-enable vue/no-v-html -->
 `;
 
-exports[`CodeBlock renders plaintext on unknown language 1`] = `<pre class="code-block language-python" data-testid="code-block"><code>print("Hello, world!")</code></pre>`;
+exports[`CodeBlock renders plaintext on unknown language 1`] = `
+<!-- eslint-disable vue/no-v-html -->
+<pre class="code-block language-python" data-testid="code-block"><code>print("Hello, world!")</code></pre>
+<!-- eslint-enable vue/no-v-html -->
+`;

--- a/src/dataplane.ts
+++ b/src/dataplane.ts
@@ -263,12 +263,12 @@ export function compatibilityKind(version: { kumaDp: TODO, envoy: TODO }) {
       payload: {
         envoy: envoyVersion,
         kumaDp: kumaDpVersion,
-      }
+      },
     }
   }
 
   return {
-    kind: COMPATIBLE
+    kind: COMPATIBLE,
   }
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -194,7 +194,7 @@ export function getSome(original: TODO, desired: TODO) {
  * @param {String} url
  */
 export function stripUrl(url: string) {
-  const regex = /([^\/]+$)/g
+  const regex = /([^/]+$)/g
   const match = url.match(regex)?.[0]
 
   return match

--- a/src/jest-replace-attribute-snapshot-serializer.ts
+++ b/src/jest-replace-attribute-snapshot-serializer.ts
@@ -10,7 +10,7 @@ const processedValues = new Set()
 
 export function replaceAttributesSnapshotSerializer(
   attributes: string[],
-  uuid = DEFAULT_UUID
+  uuid = DEFAULT_UUID,
 ): jest.SnapshotSerializerPlugin {
   return {
     /**

--- a/src/mixins/PieChart.js
+++ b/src/mixins/PieChart.js
@@ -77,7 +77,6 @@ export default {
   },
   computed: {
     defaultConfig() {
-      // eslint-disable-next-line @typescript-eslint/no-this-alias
       const self = this
 
       return {

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -357,7 +357,6 @@ export async function setupRouter() {
    */
 
   router.beforeEach(async (to, from, next) => {
-    // eslint-disable-next-line no-unmodified-loop-condition
     // This below is to make sure the inital calls have been fulfilled and it does not try to
     // access any route before it will be resolved
     while (store.getters.globalLoading) {

--- a/src/services/mocks.ts
+++ b/src/services/mocks.ts
@@ -136,7 +136,7 @@ const regexMatcher = (req: RestRequest, res: ResponseComposition, ctx: RestConte
 const setupHandlers = (apiURL: string): RestHandler[] => {
   const getApiPath = (path: string) => `${apiURL}${path.replace(/\+/g, '\\+').replace(/\?/g, '\\?')}`
   const handlers = mockFilenameBasePaths.map((path: string) => rest.get(
-    getApiPath(path), (req, res, ctx) => res(ctx.json(requireMockFile(`${path}.json`)))
+    getApiPath(path), (req, res, ctx) => res(ctx.json(requireMockFile(`${path}.json`))),
   ))
 
   handlers.push(

--- a/src/shims-svg.d.ts
+++ b/src/shims-svg.d.ts
@@ -1,5 +1,5 @@
 declare module '*.svg' {
-  import Vue, { VueConstructor } from 'vue';
-  const content: VueConstructor<Vue>;
-  export default content;
+  import Vue, { VueConstructor } from 'vue'
+  const content: VueConstructor<Vue>
+  export default content
 }

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,5 +1,5 @@
 declare module '*.vue' {
-  import { DefineComponent } from 'vue';
-  const component: DefineComponent<{}, {}, any>;
-  export default component;
+  import { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
 }

--- a/src/store/modules/config/config.spec.ts
+++ b/src/store/modules/config/config.spec.ts
@@ -55,7 +55,7 @@ describe('config module', () => {
           tagline: 'Other',
           version: '0.0.0-preview.abcd1234',
           kumaDocsVersion: 'dev',
-        }
+        },
       ],
       [
         {
@@ -67,7 +67,7 @@ describe('config module', () => {
           tagline: 'Other',
           version: '1.6.0-preview.abcd1234',
           kumaDocsVersion: '1.6.0',
-        }
+        },
       ],
       [
         {
@@ -79,7 +79,7 @@ describe('config module', () => {
           tagline: 'Kuma',
           version: '1.5.3',
           kumaDocsVersion: '1.5.1',
-        }
+        },
       ],
       [
         {
@@ -90,7 +90,7 @@ describe('config module', () => {
           tagline: 'Kuma',
           version: '1.5.3',
           kumaDocsVersion: 'latest',
-        }
+        },
       ],
     ])('tests getInfo action', async (getInfoResponse, expectedState) => {
       jest.spyOn(Kuma, 'getInfo').mockImplementation(() => Promise.resolve(getInfoResponse))

--- a/src/store/modules/notifications/notifications.spec.ts
+++ b/src/store/modules/notifications/notifications.spec.ts
@@ -13,7 +13,7 @@ describe('notifications module', () => {
           creationTime: '0001-01-01T00:00:00Z',
           modificationTime: '0001-01-01T00:00:00Z',
           type: 'Mesh',
-        }
+        },
       ]
       store.state.selectedMesh = 'web-to-backend.kuma-system'
 

--- a/src/views/Entities/MeshesView.spec.ts
+++ b/src/views/Entities/MeshesView.spec.ts
@@ -29,7 +29,7 @@ describe('MeshesView.vue', () => {
         stubs: {
           'router-link': RouterLinkStub,
         },
-      }
+      },
     })
 
     await screen.findByText(/Mesh: default/)

--- a/src/views/Entities/MeshesView.vue
+++ b/src/views/Entities/MeshesView.vue
@@ -9,8 +9,8 @@
         :table-data="tableData"
         :table-data-is-empty="tableDataIsEmpty"
         :next="next"
-        @tableAction="tableAction"
-        @loadData="loadData($event)"
+        @table-action="tableAction"
+        @load-data="loadData($event)"
       >
         <template #additionalControls>
           <KButton

--- a/src/views/Entities/ZoneEgresses.vue
+++ b/src/views/Entities/ZoneEgresses.vue
@@ -9,8 +9,8 @@
         :table-data="tableData"
         :table-data-is-empty="isEmpty"
         :next="next"
-        @tableAction="tableAction"
-        @loadData="loadData($event)"
+        @table-action="tableAction"
+        @load-data="loadData($event)"
       >
         <template #additionalControls>
           <KButton
@@ -144,7 +144,7 @@ export default {
     SubscriptionDetails,
     SubscriptionHeader,
     EntityURLControl,
-    XdsConfiguration
+    XdsConfiguration,
   },
 
   data() {

--- a/src/views/Entities/ZoneIngresses.vue
+++ b/src/views/Entities/ZoneIngresses.vue
@@ -12,8 +12,8 @@
         :table-data="tableData"
         :table-data-is-empty="isEmpty"
         :next="next"
-        @tableAction="tableAction"
-        @loadData="loadData($event)"
+        @table-action="tableAction"
+        @load-data="loadData($event)"
       >
         <template #additionalControls>
           <KButton
@@ -151,7 +151,7 @@ export default {
     SubscriptionHeader,
     MultizoneInfo,
     EntityURLControl,
-    XdsConfiguration
+    XdsConfiguration,
   },
 
   data() {

--- a/src/views/Entities/ZonesView.vue
+++ b/src/views/Entities/ZonesView.vue
@@ -13,8 +13,8 @@
         :table-data-is-empty="tableDataIsEmpty"
         :show-warnings="tableData.data.some((item) => item.withWarnings)"
         :next="next"
-        @tableAction="tableAction"
-        @loadData="loadData($event)"
+        @table-action="tableAction"
+        @load-data="loadData($event)"
       >
         <template #additionalControls>
           <KButton

--- a/src/views/Entities/partial/DataplanesView.vue
+++ b/src/views/Entities/partial/DataplanesView.vue
@@ -9,8 +9,8 @@
       :table-data-is-empty="tableDataIsEmpty"
       :show-warnings="tableData.data.some((item) => item.withWarnings)"
       :next="next"
-      @tableAction="tableAction"
-      @loadData="loadData($event)"
+      @table-action="tableAction"
+      @load-data="loadData($event)"
     >
       <template #additionalControls>
         <KButton
@@ -536,7 +536,7 @@ export default {
             envoyVersion: '-',
             selectedTime: NaN,
             selectedUpdateTime: NaN,
-            version: {}
+            version: {},
           },
         )
 

--- a/src/views/Entities/partial/ServicesView.vue
+++ b/src/views/Entities/partial/ServicesView.vue
@@ -9,8 +9,8 @@
         :table-data="tableData"
         :table-data-is-empty="tableDataIsEmpty"
         :next="next"
-        @tableAction="tableAction"
-        @loadData="loadData($event)"
+        @table-action="tableAction"
+        @load-data="loadData($event)"
       >
         >
         <template #additionalControls>

--- a/src/views/Onboarding/WelcomeView.spec.ts
+++ b/src/views/Onboarding/WelcomeView.spec.ts
@@ -36,7 +36,7 @@ function renderComponent(environment: string) {
       stubs: {
         routerLink: RouterLinkStub,
       },
-    }
+    },
   })
 }
 

--- a/src/views/Onboarding/__snapshots__/AddNewServicesCode.spec.ts.snap
+++ b/src/views/Onboarding/__snapshots__/AddNewServicesCode.spec.ts.snap
@@ -134,6 +134,8 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
                       id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                     >
                       
+                      
+                      <!-- eslint-disable vue/no-v-html -->
                       <pre
                         class="code-block language-bash"
                         data-testid="code-block"
@@ -142,6 +144,8 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
                           https://github.com/kumahq/kuma-counter-demo/
                         </code>
                       </pre>
+                      <!-- eslint-enable vue/no-v-html -->
+                      
                       
                     </div>
                     <!---->

--- a/src/views/Onboarding/components/OnboardingNavigation.spec.ts
+++ b/src/views/Onboarding/components/OnboardingNavigation.spec.ts
@@ -18,7 +18,7 @@ function renderComponent(props: any) {
         KButton,
       },
       stubs: {
-        'router-link': RouterLinkStub
+        'router-link': RouterLinkStub,
       },
       mocks: {
         $router: {

--- a/src/views/OverviewView.spec.ts
+++ b/src/views/OverviewView.spec.ts
@@ -44,7 +44,7 @@ describe('OverviewView.vue', () => {
         components: {
           KCard,
         },
-      }
+      },
     })
 
     expect(wrapper.element).toMatchSnapshot()

--- a/src/views/Policies/PolicyView.spec.ts
+++ b/src/views/Policies/PolicyView.spec.ts
@@ -21,7 +21,7 @@ async function createWrapper(props = {}) {
           params: {},
         },
       },
-    }
+    },
   })
 }
 

--- a/src/views/Policies/PolicyView.vue
+++ b/src/views/Policies/PolicyView.vue
@@ -39,8 +39,8 @@
         :table-data="tableData"
         :table-data-is-empty="tableDataIsEmpty"
         :next="next"
-        @tableAction="getEntity"
-        @loadData="loadData($event)"
+        @table-action="getEntity"
+        @load-data="loadData($event)"
       >
         >
         <template #additionalControls>

--- a/src/views/Wizard/components/EntityScanner.vue
+++ b/src/views/Wizard/components/EntityScanner.vue
@@ -96,7 +96,7 @@ export default {
     },
   },
 
-  emits: ['hideSiblings'],
+  emits: ['hide-siblings'],
 
   data() {
     return {
@@ -141,7 +141,7 @@ export default {
           this.isRunning = false
           this.isComplete = true
 
-          this.$emit('hideSiblings', true)
+          this.$emit('hide-siblings', true)
         }
       }, this.interval)
     },

--- a/src/views/Wizard/views/DataplaneKubernetes.vue
+++ b/src/views/Wizard/views/DataplaneKubernetes.vue
@@ -533,7 +533,7 @@
               :should-start="true"
               :has-error="scanError"
               :can-complete="scanFound"
-              @hideSiblings="hideSiblings"
+              @hide-siblings="hideSiblings"
             >
               <template #loading-title>
                 <h3>Searching&hellip;</h3>

--- a/src/views/Wizard/views/DataplaneUniversal.vue
+++ b/src/views/Wizard/views/DataplaneUniversal.vue
@@ -306,7 +306,7 @@
               :should-start="true"
               :has-error="scanError"
               :can-complete="scanFound"
-              @hideSiblings="hideSiblings"
+              @hide-siblings="hideSiblings"
             >
               <!-- loading -->
               <template #loading-title>

--- a/src/views/Wizard/views/Mesh.vue
+++ b/src/views/Wizard/views/Mesh.vue
@@ -442,7 +442,7 @@
                 :loaders="false"
                 :tabs="tabs"
                 :initial-tab-override="environment"
-                @onTabChange="onTabChange"
+                @on-tab-change="onTabChange"
               >
                 <template #kubernetes>
                   <CodeView
@@ -467,7 +467,7 @@
               :should-start="true"
               :has-error="scanError"
               :can-complete="scanFound"
-              @hideSiblings="hideSiblings"
+              @hide-siblings="hideSiblings"
             >
               <!-- loading -->
               <template #loading-title>

--- a/src/views/Wizard/views/__snapshots__/DataplaneUniversal.spec.ts.snap
+++ b/src/views/Wizard/views/__snapshots__/DataplaneUniversal.spec.ts.snap
@@ -260,6 +260,8 @@ exports[`DataplaneUniversal.vue passes whole wizzard and render yaml 1`] = `
                                       id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                                     >
                                       
+                                      
+                                      <!-- eslint-disable vue/no-v-html -->
                                       <pre
                                         class="code-block language-bash"
                                         data-testid="code-block"
@@ -285,6 +287,8 @@ exports[`DataplaneUniversal.vue passes whole wizzard and render yaml 1`] = `
                                            kuma-token-testMesh-4fzzzxtestMesh
                                         </code>
                                       </pre>
+                                      <!-- eslint-enable vue/no-v-html -->
+                                      
                                       
                                     </div>
                                     <!---->
@@ -399,6 +403,8 @@ exports[`DataplaneUniversal.vue passes whole wizzard and render yaml 1`] = `
                                       id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                                     >
                                       
+                                      
+                                      <!-- eslint-disable vue/no-v-html -->
                                       <pre
                                         class="code-block language-bash"
                                         data-testid="code-block"
@@ -467,6 +473,8 @@ networking:
                                           kuma-token-testMesh-4fzzzxtestMesh
                                         </code>
                                       </pre>
+                                      <!-- eslint-enable vue/no-v-html -->
+                                      
                                       
                                     </div>
                                     <!---->

--- a/src/views/Wizard/views/__snapshots__/Mesh.spec.ts.snap
+++ b/src/views/Wizard/views/__snapshots__/Mesh.spec.ts.snap
@@ -306,6 +306,8 @@ exports[`Mesh.vue passes whole wizzard and render yaml 1`] = `
                                       id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                                     >
                                       
+                                      
+                                      <!-- eslint-disable vue/no-v-html -->
                                       <pre
                                         class="code-block language-bash"
                                         data-testid="code-block"
@@ -367,6 +369,8 @@ metrics:
                                            -
                                         </code>
                                       </pre>
+                                      <!-- eslint-enable vue/no-v-html -->
+                                      
                                       
                                     </div>
                                     <!---->

--- a/vue.config.js
+++ b/vue.config.js
@@ -31,7 +31,7 @@ const webpack = require('webpack')
     plugins: [
       new webpack.ProvidePlugin({
         process: 'process/browser',
-      })
+      }),
     ],
     resolve: {
       fallback: {


### PR DESCRIPTION
Reworks the linter setup to use only a minimal set of project-specific rules. We already use reliable and well-curated linter rule presets. We should rely on them as much as possible. Alternatively, we could maintain our own rule preset, but then we shouldn’t use third party presets.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>