### PR TITLE
chore(ci): uses a bigger resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
   check:
     docker:
       - image: *circleci_node_image
+    resource_class: large
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Uses large instead of small for the `check` job to avoid the `build` step to frequently be killed with an out-of-memory error.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>