### PR TITLE
fix: tracing having wrong sampling property location

### DIFF
--- a/src/views/Wizard/views/Mesh.vue
+++ b/src/views/Wizard/views/Mesh.vue
@@ -770,12 +770,12 @@ export default {
       if (hasTracing) {
         const tracingObj = schemaNew.tracing
 
-        tracingObj.backends[0].conf = {}
-
         tracingObj.defaultBackend = newData.meshTracingBackend
         tracingObj.backends[0].type = newData.meshTracingType || 'zipkin'
         tracingObj.backends[0].name = newData.meshTracingBackend
-        tracingObj.backends[0].conf.sampling = newData.meshTracingSampling || 100
+        tracingObj.backends[0].sampling = newData.meshTracingSampling || 100
+
+        tracingObj.backends[0].conf = {}
         tracingObj.backends[0].conf.url = newData.meshTracingZipkinURL
       }
 

--- a/src/views/Wizard/views/__snapshots__/Mesh.spec.ts.snap
+++ b/src/views/Wizard/views/__snapshots__/Mesh.spec.ts.snap
@@ -335,8 +335,8 @@ tracing:
   backends: 
     - name: fake-name
       type: zipkin
+      sampling: 99.9
       conf: 
-        sampling: 99.9
         url: fake-name
 logging: 
   backends: 


### PR DESCRIPTION
Fixes an issue with the mesh creation wizard creating an incorrect traffic tracing policy with the `sampling` property being under `conf`.

Fixes #334.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>