### PR TITLE
chore: renames backend table header to storage type

### DIFF
--- a/src/views/Entities/ZonesView.vue
+++ b/src/views/Entities/ZonesView.vue
@@ -196,7 +196,7 @@ export default {
           { label: 'Status', key: 'status' },
           { label: 'Name', key: 'name' },
           { label: 'Zone CP Version', key: 'zoneCpVersion' },
-          { label: 'Backend', key: 'backend' },
+          { label: 'Storage type', key: 'storeType' },
           { label: 'Ingress', key: 'hasIngress' },
           { label: 'Egress', key: 'hasEgress' },
           { key: 'warnings', hideLabel: true },
@@ -276,7 +276,7 @@ export default {
     parseData(entity) {
       const { zoneInsight = {}, name } = entity
       let zoneCpVersion = '-'
-      let backend = ''
+      let storeType = ''
       let cpCompat = true
 
       if (zoneInsight.subscriptions && zoneInsight.subscriptions.length) {
@@ -287,7 +287,7 @@ export default {
 
             cpCompat = kumaCpGlobalCompatible
             if (item.config) {
-              backend = JSON.parse(item.config).store.type
+              storeType = JSON.parse(item.config).store.type
             }
           }
         })
@@ -297,7 +297,7 @@ export default {
         ...entity,
         status: getItemStatusFromInsight(zoneInsight).status,
         zoneCpVersion,
-        backend,
+        storeType,
         hasIngress: this.zonesWithIngress.has(name) ? 'Yes' : 'No',
         hasEgress: this.zonesWithEgress.has(name) ? 'Yes' : 'No',
         withWarnings: !cpCompat,

--- a/src/views/Entities/__snapshots__/ZonesView.spec.ts.snap
+++ b/src/views/Entities/__snapshots__/ZonesView.spec.ts.snap
@@ -173,7 +173,7 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
                             class=""
                             data-v-77421f6a=""
                           >
-                            Backend
+                            Storage type
                           </span>
                           
                           <!---->


### PR DESCRIPTION
Renames the “Backend” table header in the Zones CPs table to “Storage type”.

Fixes #306.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>