### PR TITLE
fix: bundles being referenced relative to document root

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import svgLoader from 'vite-svg-loader'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: './',
   server: {
     port: 8080,
   },


### PR DESCRIPTION
Fixes an issue with bundles being injected in the resulting index.html relative to the document root (`/`) which breaks the GUI when served from a path that’s not the document root (e.g. being served on `/gui`).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>