### PR TITLE
feat: moves YAML tab content into overview tab

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,9 +17,12 @@
   plugins: ['vue', 'import', '@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:vue/vue3-recommended', 'standard', '@vue/typescript'],
   rules: {
+    // Turns off some non-TypeScript rules in favor of their specific TypeScript rules to avoid false negatives:
     indent: 'off',
-    'func-call-spacing': 'off',
     '@typescript-eslint/indent': ['error', 2],
+    'func-call-spacing': 'off',
+    '@typescript-eslint/func-call-spacing': 'error',
+
     '@typescript-eslint/no-unused-vars': ['warn', {
       argsIgnorePattern: '^_',
       ignoreRestSiblings: true,

--- a/src/app/services/components/ExternalServiceDetails.spec.ts
+++ b/src/app/services/components/ExternalServiceDetails.spec.ts
@@ -1,3 +1,4 @@
+import { createRouter, createWebHashHistory } from 'vue-router'
 import { mount, RouterLinkStub } from '@vue/test-utils'
 
 import ExternalServiceDetails from './ExternalServiceDetails.vue'
@@ -6,6 +7,17 @@ import { createExternalService } from '@/test-data/createExternalService'
 
 const externalService = createExternalService()
 
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: { template: 'TestComponent' },
+    },
+  ],
+})
+
 function renderComponent(props = {}) {
   return mount(ExternalServiceDetails, {
     props: {
@@ -13,7 +25,7 @@ function renderComponent(props = {}) {
       ...props,
     },
     global: {
-      plugins: [[store, storeKey]],
+      plugins: [router, [store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },
@@ -26,10 +38,6 @@ describe('ExternalServiceDetails', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.html()).toContain('httpbin.org:80')
-
-    const yamlTab = wrapper.find('#yaml-tab')
-    await yamlTab.trigger('click')
-
     expect(wrapper.html()).toContain('kuma.io/service')
     expect(wrapper.html()).toContain('httpbin')
   })

--- a/src/app/services/components/ExternalServiceDetails.vue
+++ b/src/app/services/components/ExternalServiceDetails.vue
@@ -1,75 +1,62 @@
 <template>
-  <TabsWidget
-    :tabs="tabs"
-    initial-tab-override="overview"
-  >
-    <template #tabHeader>
-      <div>
-        <h3>
-          Service: {{ processedExternalService.name }}
-        </h3>
+  <div class="entity-summary entity-section-list">
+    <h3 class="entity-title">
+      <span class="kutil-sr-only">Service:</span>
+
+      <router-link :to="externalServiceRoute">
+        {{ externalService.name }}
+      </router-link>
+
+      <EntityURLControl
+        v-if="route.name !== externalServiceRoute.name"
+        :route="externalServiceRoute"
+      />
+    </h3>
+
+    <section>
+      <div class="definition">
+        <span>Mesh:</span>
+        <span>{{ externalService.mesh }}</span>
       </div>
 
-      <div>
-        <EntityURLControl
-          :route="{
-            name: 'external-service-detail-view',
-            params: {
-              service: processedExternalService.name,
-              mesh: processedExternalService.mesh,
-            }
-          }"
+      <div class="definition">
+        <span>Address:</span>
+        <span>{{ props.externalService.networking.address }}</span>
+      </div>
+
+      <div class="definition">
+        <span>TLD:</span>
+        <span>{{ props.externalService.networking.tls.enabled ? 'Enabled' : 'Disabled' }}</span>
+      </div>
+    </section>
+
+    <section v-if="tags.length > 0">
+      <h4>Tags</h4>
+
+      <div class="tag-list">
+        <EntityTag
+          v-for="(tag, index) in tags"
+          :key="index"
+          :tag="tag"
         />
       </div>
-    </template>
+    </section>
 
-    <template #overview>
-      <LabelList>
-        <div>
-          <ul>
-            <li
-              v-for="(value, prop) in processedExternalService"
-              :key="prop"
-            >
-              <h4>{{ prop }}</h4>
-
-              <template v-if="prop === 'tags' && typeof value !== 'string'">
-                <div class="entity-tag-list">
-                  <EntityTag
-                    v-for="(tag, index) in value"
-                    :key="index"
-                    :tag="tag"
-                  />
-                </div>
-              </template>
-
-              <template v-else>
-                {{ value }}
-              </template>
-            </li>
-          </ul>
-        </div>
-      </LabelList>
-    </template>
-
-    <template #yaml>
-      <div class="config-wrapper">
-        <YamlView :content="rawExternalService" />
-      </div>
-    </template>
-  </TabsWidget>
+    <YamlView :content="rawExternalService" />
+  </div>
 </template>
 
 <script lang="ts" setup>
 import { computed, PropType } from 'vue'
+import { useRoute } from 'vue-router'
 
 import { ExternalService } from '@/types'
 import { stripTimes } from '@/helpers'
 import EntityTag from '@/components/EntityTag/EntityTag.vue'
 import EntityURLControl from '@/components/Utils/EntityURLControl.vue'
-import LabelList from '@/components/Utils/LabelList.vue'
-import TabsWidget from '@/components/Utils/TabsWidget.vue'
 import YamlView from '@/components/Skeletons/YamlView.vue'
+
+const route = useRoute()
 
 const props = defineProps({
   externalService: {
@@ -78,38 +65,71 @@ const props = defineProps({
   },
 })
 
-const tabs = [
-  {
-    hash: '#overview',
-    title: 'Overview',
+const externalServiceRoute = computed(() => ({
+  name: 'external-service-detail-view',
+  params: {
+    service: props.externalService.name,
+    mesh: props.externalService.mesh,
   },
-  {
-    hash: '#yaml',
-    title: 'YAML',
-  },
-]
-
-const processedExternalService = computed(() => {
-  const { name, mesh } = props.externalService
-  const tags = Object.entries(props.externalService.tags).map(([label, value]) => ({ label, value }))
-
-  const address = props.externalService.networking.address
-  const tls = props.externalService.networking.tls.enabled ? 'Enabled' : 'Disabled'
-
-  return { name, mesh, tags, address, tls }
-})
-
+}))
+const tags = computed(() => Object.entries(props.externalService.tags).map(([label, value]) => ({ label, value })))
 const rawExternalService = computed(() => stripTimes(props.externalService))
 </script>
 
 <style lang="scss" scoped>
-.entity-tag-list {
+h3, h4 {
+  margin-bottom: var(--spacing-xs);
+}
+
+h3 {
+  font-size: 1.4em;
+}
+
+h4 {
+  font-size: 1.25em;
+}
+
+.entity-section-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md) var(--spacing-xl);
+}
+
+.entity-title {
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+.definition {
+  display: grid;
+  grid-template-columns: 10ch 1fr;
+  grid-gap: var(--spacing-md);
+}
+
+.tag-list {
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-xxs);
 }
 
-.config-wrapper {
-  padding: var(--spacing-md);
+.status::before {
+  content: '';
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: var(--spacing-xs);
+  border: 4px solid currentColor;
+  border-radius: 50%;
+}
+
+.status--success {
+  color: var(--green-400);
+}
+
+.status--warning {
+  color: var(--yellow-500);
+}
+
+.status--danger {
+  color:  var(--red-600);
 }
 </style>

--- a/src/app/services/components/ServiceDetails.vue
+++ b/src/app/services/components/ServiceDetails.vue
@@ -1,24 +1,22 @@
 <template>
-  <div class="component-frame">
-    <LoadingBlock v-if="isLoading" />
+  <LoadingBlock v-if="isLoading" />
 
-    <ErrorBlock
-      v-else-if="error !== null"
-      :error="error"
-    />
+  <ErrorBlock
+    v-else-if="error !== null"
+    :error="error"
+  />
 
-    <ServiceInsightDetails
-      v-else-if="serviceInsight !== null"
-      :service-insight="serviceInsight"
-    />
+  <ServiceInsightDetails
+    v-else-if="serviceInsight !== null"
+    :service-insight="serviceInsight"
+  />
 
-    <ExternalServiceDetails
-      v-else-if="externalService !== null"
-      :external-service="externalService"
-    />
+  <ExternalServiceDetails
+    v-else-if="externalService !== null"
+    :external-service="externalService"
+  />
 
-    <EmptyBlock v-else />
-  </div>
+  <EmptyBlock v-else />
 </template>
 
 <script lang="ts" setup>

--- a/src/app/services/components/ServiceInsightDetails.spec.ts
+++ b/src/app/services/components/ServiceInsightDetails.spec.ts
@@ -1,3 +1,4 @@
+import { createRouter, createWebHashHistory } from 'vue-router'
 import { mount, RouterLinkStub } from '@vue/test-utils'
 
 import ServiceInsightDetails from './ServiceInsightDetails.vue'
@@ -6,6 +7,17 @@ import { createServiceInsight } from '@/test-data/createServiceInsight'
 
 const serviceInsight = createServiceInsight()
 
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: { template: 'TestComponent' },
+    },
+  ],
+})
+
 function renderComponent(props = {}) {
   return mount(ServiceInsightDetails, {
     props: {
@@ -13,7 +25,7 @@ function renderComponent(props = {}) {
       ...props,
     },
     global: {
-      plugins: [[store, storeKey]],
+      plugins: [router, [store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },
@@ -26,10 +38,6 @@ describe('ServiceInsightDetails', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.html()).toContain('Total: 2 (online: 1)')
-
-    const yamlTab = wrapper.find('#yaml-tab')
-    await yamlTab.trigger('click')
-
     expect(wrapper.html()).toContain('status')
     expect(wrapper.html()).toContain('partially_degraded')
   })

--- a/src/app/services/components/ServiceList.vue
+++ b/src/app/services/components/ServiceList.vue
@@ -15,6 +15,7 @@
 
     <ServiceDetails
       v-if="activeEntity !== null"
+      class="service-details"
       :type="activeEntity.type"
       :name="activeEntity.name"
       :mesh="activeEntity.mesh"
@@ -170,3 +171,9 @@ function setActiveEntity(entity: { type: 'ServiceInsight' | 'ExternalService', n
   activeEntity.value = entity
 }
 </script>
+
+<style lang="scss" scoped>
+.service-details {
+  padding: var(--spacing-md);
+}
+</style>

--- a/src/app/services/views/ExternalServiceDetailView.vue
+++ b/src/app/services/views/ExternalServiceDetailView.vue
@@ -1,5 +1,6 @@
 <template>
   <ServiceDetails
+    class="service-details component-frame"
     type="ExternalService"
     :name="(route.params.service as string)"
     :mesh="(route.params.mesh as string)"
@@ -17,3 +18,9 @@ const store = useStore()
 
 store.dispatch('updatePageTitle', route.params.service)
 </script>
+
+<style lang="scss" scoped>
+.service-details {
+  padding: var(--spacing-md);
+}
+</style>

--- a/src/app/services/views/ServiceInsightDetailView.vue
+++ b/src/app/services/views/ServiceInsightDetailView.vue
@@ -1,5 +1,6 @@
 <template>
   <ServiceDetails
+    class="service-details component-frame"
     type="ServiceInsight"
     :name="(route.params.service as string)"
     :mesh="(route.params.mesh as string)"
@@ -17,3 +18,9 @@ const store = useStore()
 
 store.dispatch('updatePageTitle', route.params.service)
 </script>
+
+<style lang="scss" scoped>
+.service-details {
+  padding: var(--spacing-md);
+}
+</style>

--- a/src/components/Skeletons/DataOverview.vue
+++ b/src/components/Skeletons/DataOverview.vue
@@ -475,12 +475,6 @@ export default {
   color: var(--yellow-500);
 }
 
-.entity-tag-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-xxs);
-}
-
 .data-table-action-link {
   padding: 0;
 }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -12,7 +12,7 @@ export const KUMA_ZONE_TAG_NAME = 'kuma.io/zone'
 
 export const FEATURE_FLAG = {}
 
-export const STATUS = {
+export const STATUS: Record<string, { title: string, appearance: string }> = {
   partially_degraded: {
     title: 'Partially degraded',
     appearance: 'warning',

--- a/src/data-planes/components/DataPlaneDetails.vue
+++ b/src/data-planes/components/DataPlaneDetails.vue
@@ -58,23 +58,25 @@
         </div>
 
         <div>
-          <h4>Tags</h4>
+          <template v-if="dataPlaneTags.length > 0">
+            <h4>Tags</h4>
 
-          <p>
-            <span
-              v-for="(tag, index) in dataPlaneTags"
-              :key="index"
-              class="tag-cols"
-            >
-              <span>
-                {{ tag.label }}:
-              </span>
+            <p>
+              <span
+                v-for="(tag, index) in dataPlaneTags"
+                :key="index"
+                class="tag-cols"
+              >
+                <span>
+                  {{ tag.label }}:
+                </span>
 
-              <span>
-                {{ tag.value }}
+                <span>
+                  {{ tag.value }}
+                </span>
               </span>
-            </span>
-          </p>
+            </p>
+          </template>
 
           <template v-if="dataPlaneVersions">
             <h4>Versions</h4>
@@ -97,6 +99,10 @@
           </template>
         </div>
       </LabelList>
+
+      <div class="config-wrapper">
+        <YamlView :content="rawDataPlane" />
+      </div>
     </template>
 
     <template #insights>
@@ -189,12 +195,6 @@
       </LabelList>
     </template>
 
-    <template #yaml>
-      <div class="config-wrapper">
-        <YamlView :content="rawDataPlane" />
-      </div>
-    </template>
-
     <template #warnings>
       <WarningsWidget :warnings="warnings" />
     </template>
@@ -281,10 +281,6 @@ const tabs = [
     title: 'Certificate Insights',
   },
   {
-    hash: '#yaml',
-    title: 'YAML',
-  },
-  {
     hash: '#warnings',
     title: 'Warnings',
   },
@@ -325,11 +321,13 @@ const kumaDocsVersion = computed(() => {
 const filteredTabs = computed(() => warnings.value.length === 0 ? tabs.filter((tab) => tab.hash !== '#warnings') : tabs)
 
 async function setWarnings() {
-  if (props.dataPlaneOverview.dataplaneInsight.subscriptions.length === 0) {
+  const subscriptions = props.dataPlaneOverview.dataplaneInsight.subscriptions
+
+  if (subscriptions.length === 0 || !('version' in subscriptions[0])) {
     return
   }
 
-  const version = props.dataPlaneOverview.dataplaneInsight.subscriptions[0].version
+  const version = subscriptions[0].version
 
   if (version.kumaDp && version.envoy) {
     const compatibility = compatibilityKind(version)
@@ -369,6 +367,8 @@ setWarnings()
 }
 
 .config-wrapper {
-  padding: var(--spacing-md);
+  padding-right: var(--spacing-md);
+  padding-left: var(--spacing-md);
+  padding-bottom: var(--spacing-md);
 }
 </style>

--- a/src/data-planes/components/DataPlaneEntitySummary.spec.ts
+++ b/src/data-planes/components/DataPlaneEntitySummary.spec.ts
@@ -1,27 +1,10 @@
-import { createStore } from 'vuex'
 import { mount, RouterLinkStub } from '@vue/test-utils'
 
 import DataPlaneEntitySummary from './DataPlaneEntitySummary.vue'
+import { store, storeKey } from '@/store/store'
 import { createDataPlaneOverview } from '@/test-data/createDataPlaneOverview'
 
 const dataPlaneOverview = createDataPlaneOverview()
-
-const store = createStore({
-  modules: {
-    config: {
-      namespaced: true,
-      state: {
-        clientConfig: {
-          mode: 'global',
-          environment: 'universal',
-        },
-      },
-      getters: {
-        getEnvironment: (state) => state.clientConfig?.environment,
-      },
-    },
-  },
-})
 
 function renderComponent(props = {}) {
   return mount(DataPlaneEntitySummary, {
@@ -30,7 +13,7 @@ function renderComponent(props = {}) {
       ...props,
     },
     global: {
-      plugins: [store],
+      plugins: [[store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },

--- a/src/data-planes/components/DataPlaneEntitySummary.vue
+++ b/src/data-planes/components/DataPlaneEntitySummary.vue
@@ -33,7 +33,7 @@
     <section v-if="dataPlaneTags.length > 0">
       <h4>Tags</h4>
 
-      <div class="entity-tag-list">
+      <div class="tag-list">
         <EntityTag
           v-for="(tag, index) in dataPlaneTags"
           :key="index"
@@ -137,6 +137,7 @@ import { computed, PropType } from 'vue'
 import { KIcon } from '@kong/kongponents'
 
 import { DataPlaneOverview, DataPlaneStatus } from '@/types'
+import { STATUS } from '@/consts'
 import { rawReadableDate } from '@/helpers'
 import EntityTag from '@/components/EntityTag/EntityTag.vue'
 import YamlView from '@/components/Skeletons/YamlView.vue'
@@ -149,10 +150,10 @@ const props = defineProps({
   },
 })
 
-const BADGE_APPEARANCE_MAP: Record<DataPlaneStatus, string> = {
-  Online: 'success',
-  Offline: 'danger',
-  'Partially degraded': 'warning',
+const STATUS_KEYWORD: Record<DataPlaneStatus, string> = {
+  'Partially degraded': 'partially_degraded',
+  Offline: 'offline',
+  Online: 'online',
 }
 
 const dataPlane = computed(() => {
@@ -202,10 +203,7 @@ const subscriptionWrappers = computed(() => {
 const status = computed(() => {
   const { status: title } = getStatus(props.dataPlaneOverview.dataplane, props.dataPlaneOverview.dataplaneInsight)
 
-  return {
-    title,
-    appearance: BADGE_APPEARANCE_MAP[title],
-  }
+  return STATUS[STATUS_KEYWORD[title]]
 })
 
 const dependencies = computed(() => {
@@ -291,7 +289,7 @@ h5 {
   gap: var(--spacing-md);
 }
 
-.entity-tag-list {
+.tag-list {
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-xxs);

--- a/src/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
+++ b/src/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
@@ -237,24 +237,6 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
             
           </a>
         </li>
-        <li
-          aria-controls="panel-7"
-          aria-selected="false"
-          class="tab-item"
-          data-v-6bcd6661=""
-          id="yaml-tab"
-          role="tab"
-          tabindex="0"
-        >
-          <a
-            class="tab-link"
-            data-v-6bcd6661=""
-          >
-            
-            YAML
-            
-          </a>
-        </li>
         
       </ul>
       
@@ -342,6 +324,7 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                       </ul>
                     </div>
                     <div>
+                      
                       <h4>
                         Tags
                       </h4>
@@ -369,6 +352,7 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                         </span>
                         
                       </p>
+                      
                       
                       <h4>
                         Versions
@@ -416,6 +400,397 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                 <!---->
               </div>
             </section>
+          </div>
+        </div>
+        <div
+          class="config-wrapper"
+        >
+          <div
+            class="yaml-view"
+          >
+            <div
+              class="yaml-view-content"
+            >
+              <div
+                class="k-tabs"
+                data-v-6bcd6661=""
+              >
+                <ul
+                  aria-label="ktabs"
+                  data-v-6bcd6661=""
+                  role="tablist"
+                >
+                  
+                  <li
+                    aria-controls="panel-0"
+                    aria-selected="true"
+                    class="active tab-item"
+                    data-v-6bcd6661=""
+                    id="universal-tab"
+                    role="tab"
+                    tabindex="0"
+                  >
+                    <a
+                      class="tab-link"
+                      data-v-6bcd6661=""
+                    >
+                      
+                      Universal
+                      
+                    </a>
+                  </li>
+                  <li
+                    aria-controls="panel-1"
+                    aria-selected="false"
+                    class="tab-item"
+                    data-v-6bcd6661=""
+                    id="kubernetes-tab"
+                    role="tab"
+                    tabindex="0"
+                  >
+                    <a
+                      class="tab-link"
+                      data-v-6bcd6661=""
+                    >
+                      
+                      Kubernetes
+                      
+                    </a>
+                  </li>
+                  
+                </ul>
+                
+                <div
+                  aria-labelledby="universal-tab"
+                  class="tab-container"
+                  data-v-6bcd6661=""
+                  id="panel-0"
+                  role="tabpanel"
+                  tabindex="0"
+                >
+                  
+                  <div
+                    class="code-block"
+                  >
+                    <!-- eslint-disable vue/no-v-html -->
+                    <pre
+                      class="code-block__code language-yaml"
+                      data-testid="code-block"
+                    >
+                      <code>
+                        <span
+                          class="token key atrule"
+                        >
+                          type
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         Dataplane
+
+                        <span
+                          class="token key atrule"
+                        >
+                          mesh
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         default
+
+                        <span
+                          class="token key atrule"
+                        >
+                          name
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         backend
+
+                        <span
+                          class="token key atrule"
+                        >
+                          networking
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         
+  
+                        <span
+                          class="token key atrule"
+                        >
+                          address
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         127.0.0.1
+  
+                        <span
+                          class="token key atrule"
+                        >
+                          inbound
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         
+    
+                        <span
+                          class="token punctuation"
+                        >
+                          -
+                        </span>
+                         
+                        <span
+                          class="token key atrule"
+                        >
+                          port
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         
+                        <span
+                          class="token number"
+                        >
+                          7776
+                        </span>
+                        
+      
+                        <span
+                          class="token key atrule"
+                        >
+                          servicePort
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         
+                        <span
+                          class="token number"
+                        >
+                          7777
+                        </span>
+                        
+      
+                        <span
+                          class="token key atrule"
+                        >
+                          serviceAddress
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         127.0.0.1
+      
+                        <span
+                          class="token key atrule"
+                        >
+                          tags
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         
+        
+                        <span
+                          class="token key atrule"
+                        >
+                          kuma.io/protocol
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         http
+        
+                        <span
+                          class="token key atrule"
+                        >
+                          kuma.io/service
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         backend
+  
+                        <span
+                          class="token key atrule"
+                        >
+                          outbound
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         
+    
+                        <span
+                          class="token punctuation"
+                        >
+                          -
+                        </span>
+                         
+                        <span
+                          class="token key atrule"
+                        >
+                          port
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         
+                        <span
+                          class="token number"
+                        >
+                          10001
+                        </span>
+                        
+      
+                        <span
+                          class="token key atrule"
+                        >
+                          tags
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         
+        
+                        <span
+                          class="token key atrule"
+                        >
+                          kuma.io/service
+                        </span>
+                        <span
+                          class="token punctuation"
+                        >
+                          :
+                        </span>
+                         frontend
+                      </code>
+                    </pre>
+                    <!-- eslint-enable vue/no-v-html -->
+                    
+                    <div
+                      aria-controls="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                      aria-expanded="false"
+                      data-v-9bbde9b2=""
+                      id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                      role="button"
+                    >
+                      
+                      <button
+                        class="code-block__copy-button"
+                        type="button"
+                      >
+                        <span
+                          class="kong-icon-copy kong-icon"
+                          data-v-637de6fa=""
+                        >
+                          <svg
+                            height="16"
+                            viewBox="0 0 32 32"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            <title>
+                              Copy
+                            </title>
+                            
+  
+                            <path
+                              d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
+                              fill="#A3BBCC"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        <span
+                          class="kutil-sr-only"
+                        >
+                          Copy
+                        </span>
+                      </button>
+                      
+                      <transition-stub
+                        data-v-9bbde9b2=""
+                      >
+                        <div
+                          class="k-popover"
+                          data-v-9bbde9b2=""
+                          id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                          role="region"
+                          style="width: 200px; max-width: 350px; max-height: auto; display: none;"
+                        >
+                          <!---->
+                          <div
+                            class="k-popover-content"
+                            data-v-9bbde9b2=""
+                          >
+                            
+                            <p>
+                              Code copied to clipboard
+                            </p>
+                            
+                          </div>
+                          <!---->
+                        </div>
+                      </transition-stub>
+                    </div>
+                    
+                  </div>
+                  
+                </div>
+                <div
+                  aria-labelledby="kubernetes-tab"
+                  class="tab-container"
+                  data-v-6bcd6661=""
+                  id="panel-1"
+                  role="tabpanel"
+                  tabindex="0"
+                >
+                  <!---->
+                </div>
+                
+              </div>
+            </div>
           </div>
         </div>
         
@@ -476,16 +851,6 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
         class="tab-container"
         data-v-6bcd6661=""
         id="panel-6"
-        role="tabpanel"
-        tabindex="0"
-      >
-        <!---->
-      </div>
-      <div
-        aria-labelledby="yaml-tab"
-        class="tab-container"
-        data-v-6bcd6661=""
-        id="panel-7"
         role="tabpanel"
         tabindex="0"
       >

--- a/src/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
+++ b/src/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
@@ -39,7 +39,7 @@ exports[`DataPlaneEntitySummary matches snapshot 1`] = `
       Tags
     </h4>
     <div
-      class="entity-tag-list"
+      class="tag-list"
     >
       
       <span

--- a/src/data-planes/views/DataPlaneListView.spec.ts
+++ b/src/data-planes/views/DataPlaneListView.spec.ts
@@ -1,47 +1,26 @@
-import { createStore } from 'vuex'
+import { createRouter, createWebHashHistory } from 'vue-router'
 import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 
 import DataPlaneListView from './DataPlaneListView.vue'
-import Kuma from '@/services/kuma'
+import { store, storeKey } from '@/store/store'
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: { template: 'TestComponent' },
+    },
+  ],
+})
 
 async function renderComponent() {
-  const { policies } = await Kuma.getPolicies()
-  const policiesByType = policies.reduce((obj, policy) => Object.assign(obj, { [policy.name]: policy }), {})
-
-  const store = createStore({
-    modules: {
-      config: {
-        namespaced: true,
-        state: {
-          tagline: 'Kuma',
-          clientConfig: {
-            mode: 'global',
-            environment: 'universal',
-          },
-        },
-        getters: {
-          getTagline: (state) => state.tagline,
-          getEnvironment: (state) => state.clientConfig?.environment,
-          getMulticlusterStatus: () => false,
-        },
-      },
-    },
-    state: {
-      policiesByType,
-    },
-  })
+  await store.dispatch('fetchPolicies')
 
   const wrapper = mount(DataPlaneListView, {
     global: {
-      plugins: [store],
-      mocks: {
-        $route: {
-          params: {
-            mesh: 'all',
-          },
-          query: {},
-        },
-      },
+      plugins: [router, [store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },

--- a/src/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
+++ b/src/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
@@ -2203,7 +2203,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
           Tags
         </h4>
         <div
-          class="entity-tag-list"
+          class="tag-list"
         >
           
           <span

--- a/src/dataplane.ts
+++ b/src/dataplane.ts
@@ -53,6 +53,7 @@ export function dpTags(dataplane: { networking: DataPlaneNetworking }): LabelVal
 
   if (dataplane.networking.inbound) {
     tags = dataplane.networking.inbound
+      .filter((inbound) => 'tags' in inbound)
       .flatMap((inbound) => Object.entries(inbound.tags))
       .map(([key, value]) => `${key}=${value}`)
   }
@@ -112,25 +113,28 @@ export function getStatus(dataplane: { networking: DataPlaneNetworking }, datapl
 getStatus takes DataplaneInsight and returns map of versions
  */
 
-export function getVersions(dataplaneInsight: DataPlaneInsight): Record<string, string> | null {
-  if (!dataplaneInsight.subscriptions?.length) {
+export function getVersions(dataPlaneInsight: DataPlaneInsight): Record<string, string> | null {
+  if (dataPlaneInsight.subscriptions.length === 0) {
     return null
   }
 
   const versions: Record<string, string> = {}
 
-  const lastSubscription: DiscoverySubscription =
-    dataplaneInsight.subscriptions[dataplaneInsight.subscriptions.length - 1]
+  const lastSubscription: DiscoverySubscription = dataPlaneInsight.subscriptions[dataPlaneInsight.subscriptions.length - 1]
 
-  if (lastSubscription.version?.envoy) {
+  if (lastSubscription.version === undefined) {
+    return null
+  }
+
+  if (lastSubscription.version.envoy) {
     versions.envoy = lastSubscription.version.envoy.version
   }
 
-  if (lastSubscription.version?.kumaDp) {
+  if (lastSubscription.version.kumaDp) {
     versions.kumaDp = lastSubscription.version.kumaDp.version
   }
 
-  if (lastSubscription.version?.dependencies) {
+  if (lastSubscription.version.dependencies) {
     Object.entries(lastSubscription.version.dependencies).forEach(([key, value]) => {
       versions[key] = value
     })

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -31,7 +31,6 @@ export async function setupRouter() {
       alias: '/:pathMatch(.*)*',
       meta: {
         title: 'Item not found',
-        excludeAsBreadcrumb: true,
       },
       component: () => import('@/views/NotFound.vue'),
     },
@@ -54,7 +53,6 @@ export async function setupRouter() {
           component: () => import('@/views/DiagnosticsView.vue'),
           meta: {
             title: 'Diagnostics',
-            breadcrumb: 'Diagnostics',
             hideSubnav: true,
           },
         },
@@ -92,7 +90,6 @@ export async function setupRouter() {
           name: 'all-meshes',
           meta: {
             title: 'Meshes',
-            breadcrumb: 'Meshes',
             parent: 'global-overview',
           },
           redirect: {
@@ -108,6 +105,7 @@ export async function setupRouter() {
               meta: {
                 title: 'Meshes',
                 parent: 'all-meshes',
+                breadcrumbTitleParam: 'mesh',
               },
               component: () => import('@/views/Entities/MeshesView.vue'),
             },
@@ -118,7 +116,6 @@ export async function setupRouter() {
           name: 'mesh-individual',
           meta: {
             title: 'Mesh',
-            breadcrumb: 'Mesh',
           },
           redirect: {
             name: 'global-overview',
@@ -132,7 +129,6 @@ export async function setupRouter() {
               name: 'mesh',
               meta: {
                 title: 'Meshes',
-                breadcrumb: 'Meshes',
                 parent: 'all-meshes',
               },
               children: [
@@ -170,6 +166,7 @@ export async function setupRouter() {
                       meta: {
                         title: 'Data plane',
                         parent: 'data-plane-list-view',
+                        breadcrumbTitleParam: 'dataPlane',
                       },
                       component: () => import('@/data-planes/views/DataPlaneDetailView.vue'),
                     },
@@ -183,7 +180,6 @@ export async function setupRouter() {
                       name: 'service-insight-list-view',
                       meta: {
                         title: 'Internal services',
-                        breadcrumb: 'Internal services',
                       },
                       component: () => import('@/app/services/views/ServiceInsightListView.vue'),
                     },
@@ -193,6 +189,7 @@ export async function setupRouter() {
                       meta: {
                         title: 'Internal service',
                         parent: 'service-insight-list-view',
+                        breadcrumbTitleParam: 'service',
                       },
                       component: () => import('@/app/services/views/ServiceInsightDetailView.vue'),
                     },
@@ -206,7 +203,6 @@ export async function setupRouter() {
                       name: 'external-service-list-view',
                       meta: {
                         title: 'External services',
-                        breadcrumb: 'External services',
                       },
                       component: () => import('@/app/services/views/ExternalServiceListView.vue'),
                     },
@@ -216,6 +212,7 @@ export async function setupRouter() {
                       meta: {
                         title: 'External service',
                         parent: 'external-service-list-view',
+                        breadcrumbTitleParam: 'service',
                       },
                       component: () => import('@/app/services/views/ExternalServiceDetailView.vue'),
                     },
@@ -247,6 +244,7 @@ export async function setupRouter() {
           path: 'deployment-types',
           name: 'onboarding-deployment-types',
           meta: {
+            title: 'Deployment Types',
             onboardingProcess: true,
           },
           component: () => import('@/views/Onboarding/DeploymentTypes.vue'),
@@ -255,6 +253,7 @@ export async function setupRouter() {
           path: 'configuration-types',
           name: 'onboarding-configuration-types',
           meta: {
+            title: 'Configuration Types',
             onboardingProcess: true,
           },
           component: () => import('@/views/Onboarding/ConfigurationTypes.vue'),
@@ -263,6 +262,7 @@ export async function setupRouter() {
           path: 'multi-zone',
           name: 'onboarding-multi-zone',
           meta: {
+            title: 'Multizone',
             onboardingProcess: true,
           },
           component: () => import('@/views/Onboarding/MultiZoneView.vue'),
@@ -271,6 +271,7 @@ export async function setupRouter() {
           path: 'create-mesh',
           name: 'onboarding-create-mesh',
           meta: {
+            title: 'Create the Mesh',
             onboardingProcess: true,
           },
           component: () => import('@/views/Onboarding/CreateMesh.vue'),
@@ -279,6 +280,7 @@ export async function setupRouter() {
           path: 'add-services',
           name: 'onboarding-add-services',
           meta: {
+            title: 'Add new services',
             onboardingProcess: true,
           },
           component: () => import('@/views/Onboarding/AddNewServices.vue'),
@@ -287,6 +289,7 @@ export async function setupRouter() {
           path: 'add-services-code',
           name: 'onboarding-add-services-code',
           meta: {
+            title: 'Add new services',
             onboardingProcess: true,
           },
           component: () => import('@/views/Onboarding/AddNewServicesCode.vue'),
@@ -295,6 +298,7 @@ export async function setupRouter() {
           path: 'dataplanes-overview',
           name: 'onboarding-dataplanes-overview',
           meta: {
+            title: 'Data planes overview',
             onboardingProcess: true,
           },
           component: () => import('@/views/Onboarding/DataplanesOverview.vue'),
@@ -303,6 +307,7 @@ export async function setupRouter() {
           path: 'completed',
           name: 'onboarding-completed',
           meta: {
+            title: 'Completed',
             onboardingProcess: true,
           },
           component: () => import('@/views/Onboarding/CompletedView.vue'),
@@ -386,7 +391,7 @@ export async function setupRouter() {
 
     const showOnboarding = store.getters['onboarding/showOnboarding']
     const isCompleted = store.state.onboarding.isCompleted
-    const onboardingRoute = to.meta?.onboardingProcess
+    const onboardingRoute = to.meta.onboardingProcess
 
     // Redirects user to home page if they try to navigate to an onboarding route while having already completed onboarding.
     if (!showOnboarding && onboardingRoute) {

--- a/src/shims-vue-router.d.ts
+++ b/src/shims-vue-router.d.ts
@@ -2,7 +2,24 @@ import 'vue-router'
 
 declare module 'vue-router' {
   interface RouteMeta {
+    /**
+     * The title of a route which is used as the document title and the title shown in the breadcrumb navigation).
+     */
     title?: string
+
+    /**
+     * Sets a route’s parent route for displaying it in the breadcrumb and main navigation.
+     */
     parent?: string
+
+    /**
+     * Reads the breadcrumb title from the route parameter of the given name.
+     */
+    breadcrumbTitleParam?: string
+
+    /**
+     * Whether a route is part of the onboarding pages.
+     */
+    onboardingProcess?: boolean
   }
 }

--- a/src/views/Entities/MeshesView.spec.ts
+++ b/src/views/Entities/MeshesView.spec.ts
@@ -1,23 +1,18 @@
-import { createStore } from 'vuex'
 import { RouterLinkStub } from '@vue/test-utils'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { KAlert, KBadge, KButton, KCard, KClipboardProvider, KEmptyState, KIcon, KPop, KTable, KTabs } from '@kong/kongponents'
 
 import MeshesView from './MeshesView.vue'
-import Kuma from '@/services/kuma'
+import { store, storeKey } from '@/store/store'
 
 describe('MeshesView.vue', () => {
   it('renders snapshot with Resource tab', async () => {
-    const { policies } = await Kuma.getPolicies()
-    const store = createStore({
-      state: {
-        policies,
-      },
-    })
+    await store.dispatch('fetchPolicies')
+
     const { container } = render(MeshesView, {
       global: {
-        plugins: [store],
+        plugins: [[store, storeKey]],
         components: { KAlert, KBadge, KButton, KCard, KClipboardProvider, KEmptyState, KIcon, KPop, KTable, KTabs },
         mocks: {
           $route: {

--- a/src/views/Entities/MeshesView.vue
+++ b/src/views/Entities/MeshesView.vue
@@ -110,8 +110,7 @@
               </ul>
             </div>
           </LabelList>
-        </template>
-        <template #yaml>
+
           <div class="config-wrapper">
             <YamlView
               :has-error="entityHasError"
@@ -121,6 +120,7 @@
             />
           </div>
         </template>
+
         <template #resources>
           <LabelList
             :has-error="entityHasError"
@@ -204,10 +204,6 @@ export default {
         {
           hash: '#resources',
           title: 'Resources',
-        },
-        {
-          hash: '#yaml',
-          title: 'YAML',
         },
       ],
       entity: {},
@@ -457,6 +453,8 @@ export default {
 }
 
 .config-wrapper {
-  padding: var(--spacing-md);
+  padding-right: var(--spacing-md);
+  padding-left: var(--spacing-md);
+  padding-bottom: var(--spacing-md);
 }
 </style>

--- a/src/views/Entities/__snapshots__/MeshesView.spec.ts.snap
+++ b/src/views/Entities/__snapshots__/MeshesView.spec.ts.snap
@@ -362,24 +362,6 @@ exports[`MeshesView.vue renders snapshot with Resource tab 1`] = `
                   
                 </a>
               </li>
-              <li
-                aria-controls="panel-2"
-                aria-selected="false"
-                class="tab-item"
-                data-v-6bcd6661=""
-                id="yaml-tab"
-                role="tab"
-                tabindex="0"
-              >
-                <a
-                  class="tab-link"
-                  data-v-6bcd6661=""
-                >
-                  
-                  YAML
-                  
-                </a>
-              </li>
               
             </ul>
             
@@ -591,16 +573,6 @@ exports[`MeshesView.vue renders snapshot with Resource tab 1`] = `
               </div>
               
               
-            </div>
-            <div
-              aria-labelledby="yaml-tab"
-              class="tab-container"
-              data-v-6bcd6661=""
-              id="panel-2"
-              role="tabpanel"
-              tabindex="0"
-            >
-              <!---->
             </div>
             
           </div>

--- a/src/views/Onboarding/AddNewServices.vue
+++ b/src/views/Onboarding/AddNewServices.vue
@@ -61,11 +61,6 @@ export default {
     OnboardingPage,
     ServiceBox,
   },
-  metaInfo() {
-    return {
-      title: 'Add new services',
-    }
-  },
   computed: {
     ...mapGetters({
       onboardingMode: 'onboarding/getMode',

--- a/src/views/Onboarding/AddNewServicesCode.vue
+++ b/src/views/Onboarding/AddNewServicesCode.vue
@@ -99,11 +99,6 @@ export default {
     LoadingBox,
     KCard,
   },
-  metaInfo() {
-    return {
-      title: 'Add new services',
-    }
-  },
   data() {
     return {
       productName: PRODUCT_NAME,

--- a/src/views/Onboarding/CompletedView.vue
+++ b/src/views/Onboarding/CompletedView.vue
@@ -3,6 +3,7 @@
     <template #header>
       <OnboardingHeading title="Go to the dashboard" />
     </template>
+
     <template #content>
       <div class="flex justify-center">
         <img src="@/assets/images/kuma_gui.png">
@@ -20,22 +21,8 @@
   </OnboardingPage>
 </template>
 
-<script>
+<script lang="ts" setup>
 import OnboardingNavigation from '@/views/Onboarding/components/OnboardingNavigation.vue'
 import OnboardingHeading from '@/views/Onboarding/components/OnboardingHeading.vue'
 import OnboardingPage from '@/views/Onboarding/components/OnboardingPage.vue'
-
-export default {
-  name: 'CompletedView',
-  components: {
-    OnboardingNavigation,
-    OnboardingHeading,
-    OnboardingPage,
-  },
-  metaInfo() {
-    return {
-      title: 'Completed',
-    }
-  },
-}
 </script>

--- a/src/views/Onboarding/ConfigurationTypes.vue
+++ b/src/views/Onboarding/ConfigurationTypes.vue
@@ -60,11 +60,6 @@ export default {
     OnboardingHeading,
     OnboardingPage,
   },
-  metaInfo() {
-    return {
-      title: 'Configuration Types',
-    }
-  },
   data() {
     return { mode: 'kubernetes', productName: PRODUCT_NAME }
   },

--- a/src/views/Onboarding/CreateMesh.vue
+++ b/src/views/Onboarding/CreateMesh.vue
@@ -47,11 +47,6 @@ export default {
     OnboardingHeading,
     OnboardingPage,
   },
-  metaInfo() {
-    return {
-      title: 'Create the Mesh',
-    }
-  },
 
   data() {
     return {

--- a/src/views/Onboarding/DeploymentTypes.vue
+++ b/src/views/Onboarding/DeploymentTypes.vue
@@ -57,11 +57,6 @@ export default {
     OnboardingHeading,
     OnboardingPage,
   },
-  metaInfo() {
-    return {
-      title: 'Deployment Types',
-    }
-  },
   data() {
     return { mode: 'standalone', productName: PRODUCT_NAME }
   },

--- a/src/views/Onboarding/MultiZoneView.vue
+++ b/src/views/Onboarding/MultiZoneView.vue
@@ -88,11 +88,6 @@ export default {
     OnboardingPage,
     LoadingBox,
   },
-  metaInfo() {
-    return {
-      title: 'Multizone',
-    }
-  },
   data() {
     return {
       hasZones: false,

--- a/src/views/Onboarding/WelcomeView.vue
+++ b/src/views/Onboarding/WelcomeView.vue
@@ -52,11 +52,6 @@ export default {
     WelcomeAnimationSvg,
   },
 
-  metaInfo() {
-    return {
-      title: `Welcome to ${PRODUCT_NAME}!`,
-    }
-  },
   data() {
     return {
       productName: PRODUCT_NAME,

--- a/src/views/Onboarding/__snapshots__/CompletedView.spec.ts.snap
+++ b/src/views/Onboarding/__snapshots__/CompletedView.spec.ts.snap
@@ -32,9 +32,7 @@ exports[`CompletedView.vue renders snapshot 1`] = `
           <div
             class="flex justify-center"
           >
-            <img
-              src=""
-            />
+            <img />
           </div>
           
         </div>

--- a/src/views/OverviewView.vue
+++ b/src/views/OverviewView.vue
@@ -106,11 +106,6 @@ import { PRODUCT_NAME } from '@/consts'
 
 export default {
   name: 'OverviewView',
-  metaInfo() {
-    return {
-      title: this.$route.meta.title,
-    }
-  },
   components: {
     DonutChart,
     VersionsDonutChart,
@@ -155,12 +150,6 @@ export default {
     },
     envoyVersionsChart() {
       return this.getChart('envoyVersions')
-    },
-    pageTitle() {
-      const metaTitle = this.$route.meta.title
-      const mesh = this.selectedMesh
-
-      return mesh === 'all' ? `${metaTitle} for all Meshes` : `${metaTitle} for ${mesh}`
     },
     zonesForChart() {
       return this.multicluster ? this.$store.state.totalClusters : 1

--- a/src/views/Policies/PolicyView.spec.ts
+++ b/src/views/Policies/PolicyView.spec.ts
@@ -1,29 +1,32 @@
-import { createStore } from 'vuex'
+import { createRouter, createWebHashHistory } from 'vue-router'
 import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import { KAlert, KButton, KCard, KClipboardProvider, KEmptyState, KIcon, KPop, KTable, KTabs } from '@kong/kongponents'
 
 import PolicyView from './PolicyView.vue'
-import { storeConfig } from '@/store/index'
+import { store, storeKey } from '@/store/store'
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: { template: 'TestComponent' },
+    },
+  ],
+})
 
 async function createWrapper(props = {}) {
-  const store = createStore(storeConfig)
-
   await store.dispatch('fetchPolicies')
 
   return mount(PolicyView, {
     props,
     global: {
-      plugins: [store],
+      plugins: [router, [store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },
       components: { KAlert, KButton, KCard, KClipboardProvider, KEmptyState, KIcon, KPop, KTable, KTabs },
-      mocks: {
-        $route: {
-          query: {},
-          params: {},
-        },
-      },
     },
   })
 }

--- a/src/views/Policies/PolicyView.vue
+++ b/src/views/Policies/PolicyView.vue
@@ -100,6 +100,15 @@
               </ul>
             </div>
           </LabelList>
+
+          <div class="config-wrapper">
+            <YamlView
+              :has-error="entityHasError"
+              :is-loading="entityIsLoading"
+              :is-empty="entityIsEmpty"
+              :content="rawEntity"
+            />
+          </div>
         </template>
 
         <template #affected-dpps>
@@ -108,18 +117,6 @@
             :policy-name="rawEntity.name"
             :policy-type="policy.path"
           />
-        </template>
-
-        <template #yaml>
-          <div class="config-wrapper">
-            <YamlView
-              lang="yaml"
-              :has-error="entityHasError"
-              :is-loading="entityIsLoading"
-              :is-empty="entityIsEmpty"
-              :content="rawEntity"
-            />
-          </div>
         </template>
       </TabsWidget>
     </FrameSkeleton>
@@ -186,10 +183,9 @@ export default {
           hash: '#overview',
           title: 'Overview',
         },
-        { hash: '#affected-dpps', title: 'Affected DPPs' },
         {
-          hash: '#yaml',
-          title: 'YAML',
+          hash: '#affected-dpps',
+          title: 'Affected DPPs',
         },
       ],
       entity: {},
@@ -263,6 +259,21 @@ export default {
         // set table data
 
         if (data.length) {
+          for (const policy of data) {
+            if (!policy.mesh) {
+              continue
+            }
+
+            const meshRoute = {
+              name: 'mesh-child',
+              params: {
+                mesh: policy.mesh,
+              },
+            }
+
+            policy.meshRoute = meshRoute
+          }
+
           this.tableData.data = data
           this.tableDataIsEmpty = false
           this.isEmpty = false
@@ -327,6 +338,8 @@ export default {
 
 <style lang="scss" scoped>
 .config-wrapper {
-  padding: var(--spacing-md);
+  padding-right: var(--spacing-md);
+  padding-left: var(--spacing-md);
+  padding-bottom: var(--spacing-md);
 }
 </style>


### PR DESCRIPTION
## Changes

Moves the content of the YAML tab (universal and kubernetes configurations) into the overview tab so that they’re accessible more quickly.

Simplifies breadcrumbs component.

Resolves #386.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Screenshots

![image](https://user-images.githubusercontent.com/5774638/192793397-7d6d3f38-0e08-4cae-aeca-e43ce8808dc6.png)