### PR TITLE
fix: making repeated requests to zones+insights

### DIFF
--- a/src/data-planes/components/DataPlaneDetails.vue
+++ b/src/data-planes/components/DataPlaneDetails.vue
@@ -211,7 +211,6 @@ import {
   DataPlaneOverview,
 } from '@/types'
 import {
-  checkKumaDpAndZoneVersionsMismatch,
   compatibilityKind,
   COMPATIBLE,
   dpTags,
@@ -223,7 +222,6 @@ import {
 } from '@/dataplane'
 import { KUMA_ZONE_TAG_NAME, PRODUCT_NAME } from '@/consts'
 import { stripTimes } from '@/helpers'
-import Kuma from '@/services/kuma'
 import { useStore } from '@/store/store'
 import AccordionItem from '@/components/Accordion/AccordionItem.vue'
 import AccordionList from '@/components/Accordion/AccordionList.vue'
@@ -321,7 +319,7 @@ const kumaDocsVersion = computed(() => {
 
 const filteredTabs = computed(() => warnings.value.length === 0 ? tabs.filter((tab) => tab.hash !== '#warnings') : tabs)
 
-async function setWarnings() {
+function setWarnings() {
   const subscriptions = props.dataPlaneOverview.dataplaneInsight.subscriptions
 
   if (subscriptions.length === 0 || !('version' in subscriptions[0])) {
@@ -344,18 +342,12 @@ async function setWarnings() {
     const tags = dpTags(props.dataPlane)
     const zoneTag = tags.find(tag => tag.label === KUMA_ZONE_TAG_NAME)
 
-    if (zoneTag === undefined) {
-      return
-    }
-
-    const zoneOverview = await Kuma.getZoneOverview({ name: zoneTag.value })
-
-    const { compatible, payload } = checkKumaDpAndZoneVersionsMismatch(version.kumaDp.version, zoneOverview)
-
-    if (!compatible) {
+    if (zoneTag && typeof version.kumaDp.kumaCpCompatible === 'boolean' && !version.kumaDp.kumaCpCompatible) {
       warnings.value.push({
         kind: INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS,
-        payload,
+        payload: {
+          kumaDp: version.kumaDp.version,
+        },
       })
     }
   }

--- a/src/data-planes/components/DataPlaneDetails.vue
+++ b/src/data-planes/components/DataPlaneDetails.vue
@@ -221,8 +221,9 @@ import {
   INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS,
   parseMTLSData,
 } from '@/dataplane'
-import { PRODUCT_NAME } from '@/consts'
+import { KUMA_ZONE_TAG_NAME, PRODUCT_NAME } from '@/consts'
 import { stripTimes } from '@/helpers'
+import Kuma from '@/services/kuma'
 import { useStore } from '@/store/store'
 import AccordionItem from '@/components/Accordion/AccordionItem.vue'
 import AccordionList from '@/components/Accordion/AccordionList.vue'
@@ -341,7 +342,15 @@ async function setWarnings() {
 
   if (isMulticluster) {
     const tags = dpTags(props.dataPlane)
-    const { compatible, payload } = await checkKumaDpAndZoneVersionsMismatch(tags, version.kumaDp.version)
+    const zoneTag = tags.find(tag => tag.label === KUMA_ZONE_TAG_NAME)
+
+    if (zoneTag === undefined) {
+      return
+    }
+
+    const zoneOverview = await Kuma.getZoneOverview({ name: zoneTag.value })
+
+    const { compatible, payload } = checkKumaDpAndZoneVersionsMismatch(version.kumaDp.version, zoneOverview)
 
     if (!compatible) {
       warnings.value.push({

--- a/src/dataplane.ts
+++ b/src/dataplane.ts
@@ -10,7 +10,6 @@ import {
   DiscoverySubscription,
   LabelValue,
   Version,
-  ZoneOverview,
 } from '@/types'
 
 type TODO = any
@@ -163,24 +162,6 @@ export function getItemStatusFromInsight(item: TODO = {}): { status: typeof ONLI
 
   return {
     status: status(),
-  }
-}
-
-export function checkKumaDpAndZoneVersionsMismatch(dpVersion: string, zoneOverview: ZoneOverview): { compatible: boolean, payload?: { zoneVersion: string, kumaDp: string } } {
-  const subscriptions = zoneOverview.zoneInsight.subscriptions ?? []
-
-  if (subscriptions.length === 0) {
-    return { compatible: true }
-  }
-
-  const lastSubscription = subscriptions[subscriptions.length - 1]
-
-  return {
-    compatible: dpVersion === lastSubscription.version.kumaCp.version,
-    payload: {
-      zoneVersion: lastSubscription.version.kumaCp.version,
-      kumaDp: dpVersion,
-    },
   }
 }
 

--- a/src/views/Entities/components/WarningDefault.vue
+++ b/src/views/Entities/components/WarningDefault.vue
@@ -4,14 +4,11 @@
   </span>
 </template>
 
-<script>
-export default {
-  name: 'WarningDefault',
-  props: {
-    payload: {
-      type: [String, Object],
-      required: true,
-    },
+<script lang="ts" setup>
+defineProps({
+  payload: {
+    type: [String, Object],
+    required: true,
   },
-}
+})
 </script>

--- a/src/views/Entities/components/WarningEnvoyIncompatible.vue
+++ b/src/views/Entities/components/WarningEnvoyIncompatible.vue
@@ -1,20 +1,14 @@
 <template>
   <span>
-    Envoy (<strong>{{ payload.envoy }}</strong>) is
-    unsupported by the current version of Kuma DP
-    (<strong>{{ payload.kumaDp }}</strong>)
-    [Requirements: <strong> {{ payload.requirements }}</strong>]
+    Envoy (<strong>{{ payload.envoy }}</strong>) is unsupported by the current version of Kuma DP (<strong>{{ payload.kumaDp }}</strong>) [Requirements: <strong> {{ payload.requirements }}</strong>].
   </span>
 </template>
 
-<script>
-export default {
-  name: 'WarningEnvoyIncompatible',
-  props: {
-    payload: {
-      type: Object,
-      required: true,
-    },
+<script lang="ts" setup>
+defineProps({
+  payload: {
+    type: Object,
+    required: true,
   },
-}
+})
 </script>

--- a/src/views/Entities/components/WarningUnsupportedKumaDPVersion.vue
+++ b/src/views/Entities/components/WarningUnsupportedKumaDPVersion.vue
@@ -4,14 +4,11 @@
   </span>
 </template>
 
-<script>
-export default {
-  name: 'WarningUnsupportedKumaDPVersion',
-  props: {
-    payload: {
-      type: Object,
-      required: true,
-    },
+<script lang="ts" setup>
+defineProps({
+  payload: {
+    type: Object,
+    required: true,
   },
-}
+})
 </script>

--- a/src/views/Entities/components/WarningZoneAndGlobalCPSVersionsIncompatible.vue
+++ b/src/views/Entities/components/WarningZoneAndGlobalCPSVersionsIncompatible.vue
@@ -5,14 +5,11 @@
   </span>
 </template>
 
-<script>
-export default {
-  name: 'WarningZoneAndGlobalCPSVersionsIncompatible',
-  props: {
-    payload: {
-      type: Object,
-      required: true,
-    },
+<script lang="ts" setup>
+defineProps({
+  payload: {
+    type: Object,
+    required: true,
   },
-}
+})
 </script>

--- a/src/views/Entities/components/WarningZoneAndKumaDPVersionsIncompatible.vue
+++ b/src/views/Entities/components/WarningZoneAndKumaDPVersionsIncompatible.vue
@@ -1,18 +1,14 @@
 <template>
   <span>
-    There is mismatch between versions of Kuma DP (<strong>{{ payload.kumaDp }}</strong>)
-    and the Zone CP (<strong>{{ payload.zoneVersion }}</strong>)
+    There is a mismatch between versions of Kuma DP (<strong>{{ payload.kumaDp }}</strong>) and the Zone CP.
   </span>
 </template>
 
-<script>
-export default {
-  name: 'WarningZoneAndKumaDPVersionsIncompatible',
-  props: {
-    payload: {
-      type: Object,
-      required: true,
-    },
+<script lang="ts" setup>
+defineProps({
+  payload: {
+    type: Object,
+    required: true,
   },
-}
+})
 </script>


### PR DESCRIPTION
Fixes an issue with making repeated (and often duplicated) requests to the `zones+insights/:zone` API endpoint in the data plane list view. This happened because of version incompatibility checks. <del>Now, the the general zones overview is fetched before processing individual data planes which is generally better because data planes, if they are associated to a zone, don’t often have unique zones making the size of the response of the `zones+insights` endpoint smaller than the the added sizes of one `zones+insights/:zone` response **per data plane** (which often have the same zone)</del><ins>The API requests to the zone insights endpoint have been removed completely because the data plane insight data already contains knowledge of CP version incompatibilities which we now rely on</ins>.

Fixes #398.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>