### PR TITLE
fix: incorrectly detecting onboarding states

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -9,7 +9,7 @@
   <template v-else>
     <AppHeader />
 
-    <div v-if="shouldShowOnboarding">
+    <div v-if="route.meta.onboardingProcess">
       <router-view />
     </div>
 
@@ -30,7 +30,7 @@
 
         <NotificationManager />
 
-        <AppOnboardingNotification v-if="shouldShowOnboarding" />
+        <AppOnboardingNotification v-if="shouldSuggestOnboarding" />
 
         <AppBreadcrumbs />
 
@@ -82,7 +82,7 @@ const timeout = ref<number | null>(null)
  * (e.g. `src/app/policies/PolicyView.vue` which is used by some dozen policy routes).
  */
 const routeKey = computed(() => route.meta.shouldReRender ? route.path : 'default')
-const shouldShowOnboarding = computed(() => store.getters['onboarding/showOnboarding'])
+const shouldSuggestOnboarding = computed(() => store.getters['onboarding/showOnboarding'])
 const isWideContent = computed(() => typeof route.name === 'string' && ['data-plane-list-view'].includes(route.name))
 
 watch(() => store.state.globalLoading, function (globalLoading) {


### PR DESCRIPTION
Fixes a few issues with when and how to show the onboarding process. Now, when a user navigates to an onboarding route, they only get redirected to the home page if they already completed onboarding (even by skipping it) *and* they have a basic setup (e.g. data planes). Similarly, we only redirect users who haven’t completed the onboarding *if* they don’t have a basic setup already.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
