### PR TITLE
fix: accessing omitted items field

### DIFF
--- a/src/app/AppSidebar.vue
+++ b/src/app/AppSidebar.vue
@@ -30,7 +30,7 @@ import AppMeshSelector from './AppMeshSelector.vue'
 import AppNavItem from './AppNavItem.vue'
 import { getNavItems } from './getNavItems'
 
-const POLLING_INTERVAL_IN_SECONDS = 2
+const POLLING_INTERVAL_IN_SECONDS = 10
 
 const store = useStore()
 

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -430,7 +430,7 @@ async function loadData(offset: number): Promise<void> {
   try {
     const { items, next } = await Kuma.getAllDataplaneOverviewsFromMesh({ mesh }, { size, offset })
 
-    if (items.length > 0) {
+    if (Array.isArray(items) && items.length > 0) {
       items.sort(function (overviewA, overviewB) {
         if (overviewA.name === overviewB.name) {
           return overviewA.mesh > overviewB.mesh ? 1 : -1

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -85,17 +85,16 @@ async function loadData(offset: number): Promise<void> {
     const { items = [], next } = await Kuma.getAllServiceInsightsFromMesh({ mesh }, { size, offset })
     nextUrl.value = next
 
-    items.sort((itemA, itemB) => {
-      if (itemA.name > itemB.name) {
-        return 1
-      } else if (itemA.name < itemB.name) {
-        return -1
-      } else {
-        return itemA.mesh.localeCompare(itemB.mesh)
-      }
-    })
-
-    if (items.length > 0) {
+    if (Array.isArray(items) && items.length > 0) {
+      items.sort((itemA, itemB) => {
+        if (itemA.name > itemB.name) {
+          return 1
+        } else if (itemA.name < itemB.name) {
+          return -1
+        } else {
+          return itemA.mesh.localeCompare(itemB.mesh)
+        }
+      })
       setActiveServiceInsight(items[0])
       tableData.value.data = items.map((item) => processItem(item))
     } else {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -258,16 +258,18 @@ export const storeConfig: StoreOptions<State> = {
       try {
         const response = await Kuma.getAllMeshes(params)
 
-        response.items.sort((meshA, meshB) => {
-          // Prioritizes the mesh named “default”.
-          if (meshA.name === 'default') {
-            return -1
-          } else if (meshB.name === 'default') {
-            return 1
-          }
+        if (Array.isArray(response.items)) {
+          response.items.sort((meshA, meshB) => {
+            // Prioritizes the mesh named “default”.
+            if (meshA.name === 'default') {
+              return -1
+            } else if (meshB.name === 'default') {
+              return 1
+            }
 
-          return meshA.name.localeCompare(meshB.name)
-        })
+            return meshA.name.localeCompare(meshB.name)
+          })
+        }
 
         commit('SET_MESHES', response)
       } catch (error) {


### PR DESCRIPTION
Fixes a bug with accessing the `items` field in a response which is now omitted if empty.

Fixes the polling interval accidentally being set to 2 seconds from testing.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>