### PR TITLE
refactor: uses vue router’s history mode

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,8 +41,11 @@
   testMatch: [
     '**/src/**/*.spec.(js|ts)',
   ],
-  setupFilesAfterEnv: [
+  setupFiles: [
     '<rootDir>/jest/jest-setup.ts',
+  ],
+  setupFilesAfterEnv: [
+    '<rootDir>/jest/jest-setup-after-env.ts',
   ],
 }
 

--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -8,13 +8,19 @@ import { config } from '@vue/test-utils'
 
 import { replaceAttributesSnapshotSerializer } from './jest-replace-attribute-snapshot-serializer'
 import { createRouter } from '../src/router/router'
+import { store, storeKey } from '../src/store/store'
 import { setupMockServer } from '../src/api/setupMockServer'
 
 /**
- * Adds the application’s router to vue test utils so that tests don’t have to set-up a new router instance on their own.
+ * Adds the application’s router to vue test utils. This way tests don’t have to set-up a new router instance on their own.
  */
 const router = createRouter()
 config.global.plugins.push(router)
+
+/**
+ * Adds the application’s Vuex store to vue test utils. This way tests don’t have to set-up a new store instance on their own.
+ */
+config.global.plugins.push([store, storeKey])
 
 /**
  * amcharts need SVGPathElement defined for our tests to work.

--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -1,0 +1,52 @@
+import '@testing-library/jest-dom/extend-expect'
+import '@testing-library/jest-dom'
+
+// Polyfills `window.fetch` for Jest because it runs in a Node environment where fetch isn’t available. It initially looked like this would change with Node.js 18, but that is not so.
+import 'isomorphic-fetch'
+
+import { config } from '@vue/test-utils'
+
+import { replaceAttributesSnapshotSerializer } from './jest-replace-attribute-snapshot-serializer'
+import { createRouter } from '../src/router/router'
+import { setupMockServer } from '../src/api/setupMockServer'
+
+/**
+ * Adds the application’s router to vue test utils so that tests don’t have to set-up a new router instance on their own.
+ */
+const router = createRouter()
+config.global.plugins.push(router)
+
+/**
+ * amcharts need SVGPathElement defined for our tests to work.
+ *
+ * See: https://github.com/amcharts/amcharts4/issues/1387
+ */
+Object.defineProperty(window, 'SVGPathElement', { value: class extends HTMLElement { } })
+
+/**
+ * Kongponents uses generated UUIDs for several attribute values.
+ * This breaks the project’s snapshot tests since they’re based on fully-mounted components
+ * which also includes those from external sources like Kongponents.
+ *
+ * In order to stabilize the tests which otherwise fail because the attribute values are different every run,
+ * we use a custom snapshot serializer to replace those attribute values with one fixed value.
+ */
+expect.addSnapshotSerializer(replaceAttributesSnapshotSerializer([
+  'id',
+  'aria-describedby',
+  'aria-labelledby',
+  'aria-controls',
+  'data-tableid',
+]))
+
+const server = setupMockServer(import.meta.env.VITE_KUMA_API_SERVER_URL)
+
+// Establish API mocking before all tests.
+beforeAll(() => server.listen())
+// Reset any request handlers that we may add during the tests,
+// so they don't affect other tests.
+afterEach(() => server.resetHandlers())
+// Clean up after the tests are finished.
+afterAll(() => server.close())
+
+export { router, server }

--- a/jest/jest-setup.ts
+++ b/jest/jest-setup.ts
@@ -22,19 +22,7 @@ dotenv.config()
 Object.defineProperty(window, 'SVGPathElement', { value: class extends HTMLElement { } })
 
 /**
- * Kongponents v6 uses a call to `crypto.getRandomValues` which isn’t implemented in jsdom by default.
- * To make the tests run, we supply it via Node’s `crypto` library.
- *
- * See: https://github.com/jsdom/jsdom/issues/1612
- */
-Object.defineProperty(global.self, 'crypto', {
-  value: {
-    getRandomValues: (array: []) => require('crypto').randomBytes(array.length),
-  },
-})
-
-/**
- * Kongponents v6 uses generated UUIDs for several attribute values.
+ * Kongponents uses generated UUIDs for several attribute values.
  * This breaks the project’s snapshot tests since they’re based on fully-mounted components
  * which also includes those from external sources like Kongponents.
  *

--- a/jest/jest-setup.ts
+++ b/jest/jest-setup.ts
@@ -1,50 +1,8 @@
-import '@testing-library/jest-dom/extend-expect'
-import '@testing-library/jest-dom'
-
-// Polyfills `window.fetch` for Jest because it runs in a Node environment where fetch isn’t available. It initially looked like this would change with Node.js 18, but that is not so.
-import 'isomorphic-fetch'
-
 import dotenv from 'dotenv'
-
-import { replaceAttributesSnapshotSerializer } from './jest-replace-attribute-snapshot-serializer'
-import { setupMockServer } from '../src/api/setupMockServer'
 
 /**
  * Ensures the tests run with the project’s environment variables being available.
+ *
+ * It’s important to run the environment variable setup as part of a Jest setup file and before a Jest setup after env file because the latter might statically import a file that makes use of environment variables which wouldn’t be correctly resolved at the time the static imports executed.
  */
 dotenv.config()
-
-/**
- * amcharts need SVGPathElement defined for our tests to work.
- *
- * See: https://github.com/amcharts/amcharts4/issues/1387
- */
-Object.defineProperty(window, 'SVGPathElement', { value: class extends HTMLElement { } })
-
-/**
- * Kongponents uses generated UUIDs for several attribute values.
- * This breaks the project’s snapshot tests since they’re based on fully-mounted components
- * which also includes those from external sources like Kongponents.
- *
- * In order to stabilize the tests which otherwise fail because the attribute values are different every run,
- * we use a custom snapshot serializer to replace those attribute values with one fixed value.
- */
-expect.addSnapshotSerializer(replaceAttributesSnapshotSerializer([
-  'id',
-  'aria-describedby',
-  'aria-labelledby',
-  'aria-controls',
-  'data-tableid',
-]))
-
-const server = setupMockServer(import.meta.env.VITE_KUMA_API_SERVER_URL)
-
-// Establish API mocking before all tests.
-beforeAll(() => server.listen())
-// Reset any request handlers that we may add during the tests,
-// so they don't affect other tests.
-afterEach(() => server.resetHandlers())
-// Clean up after the tests are finished.
-afterAll(() => server.close())
-
-export { server }

--- a/src/api/mocks.ts
+++ b/src/api/mocks.ts
@@ -10,12 +10,13 @@ async function loadMockFile(importFn: () => Promise<any>): Promise<any> {
 
 function getBaseInfo(): Info {
   return {
-    hostname: 'Tomaszs-MacBook-Pro-16-inch-2019',
+    hostname: 'control-plane-5d94cb99c6-rzr96',
     tagline: import.meta.env.VITE_NAMESPACE,
     version: '1.7.1',
     basedOnKuma: '1.7.1',
-    instanceId: 'Tomaszs-MacBook-Pro-16-inch-2019-c2a8',
-    clusterId: 'ea1c9d9d-9722-4fda-8051-67e6fe0ad1b4',
+    instanceId: 'control-plane-5d94cb99c6-rzr96-ca19',
+    clusterId: 'b3c42481-0681-4da7-a276-c1fd4ed3c7a1',
+    gui: 'The gui is available at /gui',
   }
 }
 

--- a/src/api/mocks.ts
+++ b/src/api/mocks.ts
@@ -32,13 +32,13 @@ const mockFileImports: Array<[string, () => Promise<any>]> = [
   ['service-insights', () => import('./mock-data/service-insights.json')],
 
   ['zones', () => import('./mock-data/zones.json')],
-  ['zones+insights', () => import('./mock-data/zones+insights.json')],
-  ['zones+insights/zone-1', () => import('./mock-data/zones+insights/zone-1.json')],
-  ['zones+insights/zone-2', () => import('./mock-data/zones+insights/zone-2.json')],
-  ['zones+insights/zone-3', () => import('./mock-data/zones+insights/zone-3.json')],
-  ['zones+insights/cluster-1', () => import('./mock-data/zones+insights/cluster-1.json')],
+  ['zones\\+insights', () => import('./mock-data/zones+insights.json')],
+  ['zones\\+insights/zone-1', () => import('./mock-data/zones+insights/zone-1.json')],
+  ['zones\\+insights/zone-2', () => import('./mock-data/zones+insights/zone-2.json')],
+  ['zones\\+insights/zone-3', () => import('./mock-data/zones+insights/zone-3.json')],
+  ['zones\\+insights/cluster-1', () => import('./mock-data/zones+insights/cluster-1.json')],
   ['zoneingresses/:zoneIngressName/xds', () => import('./mock-data/dataplane-xds.json')],
-  ['zoneingresses+insights', () => import('./mock-data/zoneingresses+insights.json')],
+  ['zoneingresses\\+insights', () => import('./mock-data/zoneingresses+insights.json')],
   ['zoneegresses/:zoneEgressName/xds', () => import('./mock-data/dataplane-xds.json')],
   ['zoneegressoverviews', () => import('./mock-data/zoneegressoverviews.json')],
 
@@ -64,17 +64,17 @@ const mockFileImports: Array<[string, () => Promise<any>]> = [
   ['meshes/default/dataplanes/frontend', () => import('./mock-data/meshes/default/dataplanes/frontend.json')],
   ['meshes/default/dataplanes/ingress-dp-test-123', () => import('./mock-data/meshes/default/dataplanes/ingress-dp-test-123.json')],
   ['meshes/default/dataplanes/no-subscriptions', () => import('./mock-data/meshes/default/dataplanes/no-subscriptions.json')],
-  ['meshes/default/dataplanes+insights', () => import('./mock-data/meshes/default/dataplanes+insights.json')],
-  ['meshes/default/dataplanes+insights/backend', () => import('./mock-data/meshes/default/dataplanes+insights/backend.json')],
-  ['meshes/default/dataplanes+insights/cluster-1.backend-02', () => import('./mock-data/meshes/default/dataplanes+insights/cluster-1.backend-02.json')],
-  ['meshes/default/dataplanes+insights/cluster-1.backend-03', () => import('./mock-data/meshes/default/dataplanes+insights/cluster-1.backend-03.json')],
-  ['meshes/default/dataplanes+insights/cluster-1.gateway-01', () => import('./mock-data/meshes/default/dataplanes+insights/cluster-1.gateway-01.json')],
-  ['meshes/default/dataplanes+insights/cluster-1.ingress-02', () => import('./mock-data/meshes/default/dataplanes+insights/cluster-1.ingress-02.json')],
-  ['meshes/default/dataplanes+insights/dataplane-test-456', () => import('./mock-data/meshes/default/dataplanes+insights/dataplane-test-456.json')],
-  ['meshes/default/dataplanes+insights/db', () => import('./mock-data/meshes/default/dataplanes+insights/db.json')],
-  ['meshes/default/dataplanes+insights/frontend', () => import('./mock-data/meshes/default/dataplanes+insights/frontend.json')],
-  ['meshes/default/dataplanes+insights/ingress-dp-test-123', () => import('./mock-data/meshes/default/dataplanes+insights/ingress-dp-test-123.json')],
-  ['meshes/default/dataplanes+insights/no-subscriptions', () => import('./mock-data/meshes/default/dataplanes+insights/no-subscriptions.json')],
+  ['meshes/default/dataplanes\\+insights', () => import('./mock-data/meshes/default/dataplanes+insights.json')],
+  ['meshes/default/dataplanes\\+insights/backend', () => import('./mock-data/meshes/default/dataplanes+insights/backend.json')],
+  ['meshes/default/dataplanes\\+insights/cluster-1.backend-02', () => import('./mock-data/meshes/default/dataplanes+insights/cluster-1.backend-02.json')],
+  ['meshes/default/dataplanes\\+insights/cluster-1.backend-03', () => import('./mock-data/meshes/default/dataplanes+insights/cluster-1.backend-03.json')],
+  ['meshes/default/dataplanes\\+insights/cluster-1.gateway-01', () => import('./mock-data/meshes/default/dataplanes+insights/cluster-1.gateway-01.json')],
+  ['meshes/default/dataplanes\\+insights/cluster-1.ingress-02', () => import('./mock-data/meshes/default/dataplanes+insights/cluster-1.ingress-02.json')],
+  ['meshes/default/dataplanes\\+insights/dataplane-test-456', () => import('./mock-data/meshes/default/dataplanes+insights/dataplane-test-456.json')],
+  ['meshes/default/dataplanes\\+insights/db', () => import('./mock-data/meshes/default/dataplanes+insights/db.json')],
+  ['meshes/default/dataplanes\\+insights/frontend', () => import('./mock-data/meshes/default/dataplanes+insights/frontend.json')],
+  ['meshes/default/dataplanes\\+insights/ingress-dp-test-123', () => import('./mock-data/meshes/default/dataplanes+insights/ingress-dp-test-123.json')],
+  ['meshes/default/dataplanes\\+insights/no-subscriptions', () => import('./mock-data/meshes/default/dataplanes+insights/no-subscriptions.json')],
   ['meshes/default/service-insights/backend', () => import('./mock-data/meshes/default/service-insights/backend.json')],
   ['meshes/default/service-insights/ingress', () => import('./mock-data/meshes/default/service-insights/ingress.json')],
   ['meshes/default/service-insights/redis', () => import('./mock-data/meshes/default/service-insights/redis.json')],
@@ -116,7 +116,7 @@ const mockFileImports: Array<[string, () => Promise<any>]> = [
 
   ['meshes/hello-world', () => import('./mock-data/meshes/hello-world.json')],
   ['meshes/hello-world/dataplanes', () => import('./mock-data/meshes/hello-world/dataplanes.json')],
-  ['meshes/hello-world/dataplanes+insights', () => import('./mock-data/meshes/hello-world/dataplanes+insights.json')],
+  ['meshes/hello-world/dataplanes\\+insights', () => import('./mock-data/meshes/hello-world/dataplanes+insights.json')],
   ['meshes/hello-world/health-checks/hello-health-check', () => import('./mock-data/meshes/hello-world/health-checks/hello-health-check.json')],
   ['meshes/hello-world/proxytemplates', () => import('./mock-data/meshes/hello-world/proxytemplates.json')],
   ['meshes/hello-world/proxytemplates/pt-123', () => import('./mock-data/meshes/hello-world/proxytemplates/pt-123.json')],
@@ -127,7 +127,7 @@ const mockFileImports: Array<[string, () => Promise<any>]> = [
 
   ['meshes/kong-mania-12', () => import('./mock-data/meshes/kong-mania-12.json')],
   ['meshes/kong-mania-12/dataplanes', () => import('./mock-data/meshes/kong-mania-12/dataplanes.json')],
-  ['meshes/kong-mania-12/dataplanes+insights', () => import('./mock-data/meshes/kong-mania-12/dataplanes+insights.json')],
+  ['meshes/kong-mania-12/dataplanes\\+insights', () => import('./mock-data/meshes/kong-mania-12/dataplanes+insights.json')],
   ['meshes/kong-mania-12/external-services', () => import('./mock-data/meshes/kong-mania-12/external-services.json')],
   ['meshes/kong-mania-12/health-checks/testing-health-checks', () => import('./mock-data/meshes/kong-mania-12/health-checks/testing-health-checks.json')],
   ['meshes/kong-mania-12/health-checks/web-to-banana', () => import('./mock-data/meshes/kong-mania-12/health-checks/web-to-banana.json')],
@@ -160,7 +160,7 @@ export function setupHandlers(url: string): RestHandler[] {
   const origin = url.replace(/\/+$/, '')
 
   function getApiPath(path: string = '') {
-    const escapedPath = path.replace(/\+/g, '\\+').replace(/\?/g, '\\?').replace(/^\/+/, '')
+    const escapedPath = path.replace(/^\/+/, '')
 
     return [origin, escapedPath].filter((segment) => segment !== '').join('/')
   }
@@ -172,7 +172,7 @@ export function setupHandlers(url: string): RestHandler[] {
   handlers.push(rest.get(getApiPath(), (_req, res, ctx) => res(ctx.json(getBaseInfo()))))
 
   handlers.push(
-    rest.get(getApiPath('dataplanes+insights'), async (req, res, ctx) => {
+    rest.get(getApiPath('dataplanes\\+insights'), async (req, res, ctx) => {
       const gateway = req.url.searchParams.get('gateway')
 
       let data

--- a/src/app/App.spec.ts
+++ b/src/app/App.spec.ts
@@ -1,20 +1,10 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
-import { RouterLinkStub } from '@vue/test-utils'
 import { render, screen, waitForElementToBeRemoved } from '@testing-library/vue'
 
 import App from './App.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 function renderComponent(status: string) {
   store.state.globalLoading = true
@@ -25,7 +15,8 @@ function renderComponent(status: string) {
     global: {
       plugins: [router, [store, storeKey]],
       stubs: {
-        'router-link': RouterLinkStub,
+        // Let’s not unnecessarily render all that chart markup.
+        DonutChart: true,
       },
     },
   })
@@ -38,7 +29,7 @@ describe('App.vue', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'))
 
-    expect(screen.getByText('TestComponent')).toBeInTheDocument()
+    expect(screen.getByText('Create a virtual mesh')).toBeInTheDocument()
   })
 
   it('fails to renders basic view', async () => {

--- a/src/app/App.spec.ts
+++ b/src/app/App.spec.ts
@@ -1,10 +1,7 @@
 import { render, screen, waitForElementToBeRemoved } from '@testing-library/vue'
 
 import App from './App.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-
-const router = createRouter()
 
 function renderComponent(status: string) {
   store.state.globalLoading = true
@@ -13,7 +10,7 @@ function renderComponent(status: string) {
 
   return render(App, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
       stubs: {
         // Let’s not unnecessarily render all that chart markup.
         DonutChart: true,

--- a/src/app/App.spec.ts
+++ b/src/app/App.spec.ts
@@ -1,7 +1,7 @@
 import { render, screen, waitForElementToBeRemoved } from '@testing-library/vue'
 
 import App from './App.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 
 function renderComponent(status: string) {
   store.state.globalLoading = true
@@ -10,7 +10,6 @@ function renderComponent(status: string) {
 
   return render(App, {
     global: {
-      plugins: [[store, storeKey]],
       stubs: {
         // Let’s not unnecessarily render all that chart markup.
         DonutChart: true,

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -78,7 +78,7 @@ const isLoading = ref(store.state.globalLoading)
 const routeKey = computed(() => route.meta.shouldReRender ? route.path : 'NONE')
 const shouldShowAppError = computed(() => store.state.config.status !== 'OK')
 const shouldSuggestOnboarding = computed(() => store.getters['onboarding/showOnboarding'])
-const shouldShowNotificationManager = computed(() => !shouldSuggestOnboarding.value && store.getters['notifications/amountOfActions'] > 0)
+const shouldShowNotificationManager = computed(() => store.getters['notifications/amountOfActions'] > 0)
 const isWideContent = computed(() => typeof route.name === 'string' && ['data-plane-list-view', 'service-list-view'].includes(route.name))
 
 watch(() => store.state.globalLoading, function (globalLoading) {

--- a/src/app/AppHeader.vue
+++ b/src/app/AppHeader.vue
@@ -36,7 +36,7 @@
         {{ store.state.config.tagline }} <b>{{ store.state.config.version }}</b> on <b>{{ environmentName }}</b> ({{ mode }})
       </p>
 
-      <NotificationIcon />
+      <NotificationIcon v-if="shouldShowNotificationManager" />
 
       <router-link :to="{ name: 'diagnostics' }">
         <KIcon
@@ -61,6 +61,7 @@ import UpgradeCheck from './common/UpgradeCheck.vue'
 
 const store = useStore()
 
+const shouldShowNotificationManager = computed(() => store.getters['notifications/amountOfActions'] > 0)
 const environmentName = computed(() => {
   const environment = store.getters['config/getEnvironment']
 

--- a/src/app/AppNavItem.spec.ts
+++ b/src/app/AppNavItem.spec.ts
@@ -1,10 +1,7 @@
 import { mount } from '@vue/test-utils'
 
 import AppNavItem from './AppNavItem.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-
-const router = createRouter()
 
 function renderComponent() {
   return mount(AppNavItem, {
@@ -15,7 +12,7 @@ function renderComponent() {
       insightsFieldAccessor: 'mesh.dataplanes.total',
     },
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/AppNavItem.spec.ts
+++ b/src/app/AppNavItem.spec.ts
@@ -1,24 +1,10 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
 import { mount } from '@vue/test-utils'
 
 import AppNavItem from './AppNavItem.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-    {
-      path: '/mesh/:mesh/data-planes',
-      name: 'data-plane-list-view',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 function renderComponent() {
   return mount(AppNavItem, {

--- a/src/app/AppNavItem.spec.ts
+++ b/src/app/AppNavItem.spec.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils'
 
 import AppNavItem from './AppNavItem.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 
 function renderComponent() {
   return mount(AppNavItem, {
@@ -10,9 +10,6 @@ function renderComponent() {
       routeName: 'data-plane-list-view',
       usesMeshParam: true,
       insightsFieldAccessor: 'mesh.dataplanes.total',
-    },
-    global: {
-      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/AppOnboardingNotification.spec.ts
+++ b/src/app/AppOnboardingNotification.spec.ts
@@ -1,15 +1,10 @@
 import { mount } from '@vue/test-utils'
 
-import { store, storeKey } from '@/store/store'
 import AppOnboardingNotification from './AppOnboardingNotification.vue'
 
 describe('AppOnboardingNotification', () => {
   it('renders snapshot', () => {
-    const wrapper = mount(AppOnboardingNotification, {
-      global: {
-        plugins: [[store, storeKey]],
-      },
-    })
+    const wrapper = mount(AppOnboardingNotification)
 
     expect(wrapper.element).toMatchSnapshot()
   })

--- a/src/app/AppSidebar.spec.ts
+++ b/src/app/AppSidebar.spec.ts
@@ -3,14 +3,13 @@ import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 
 import AppSidebar from './AppSidebar.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 
 async function renderComponent() {
   await store.dispatch('fetchPolicies')
 
   return render(AppSidebar, {
     global: {
-      plugins: [[store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },

--- a/src/app/AppSidebar.spec.ts
+++ b/src/app/AppSidebar.spec.ts
@@ -1,26 +1,12 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
 import { RouterLinkStub } from '@vue/test-utils'
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 
 import AppSidebar from './AppSidebar.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-    {
-      path: '/mesh/:mesh',
-      name: 'mesh-detail-view',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 async function renderComponent() {
   await store.dispatch('fetchPolicies')

--- a/src/app/AppSidebar.spec.ts
+++ b/src/app/AppSidebar.spec.ts
@@ -3,17 +3,14 @@ import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 
 import AppSidebar from './AppSidebar.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-
-const router = createRouter()
 
 async function renderComponent() {
   await store.dispatch('fetchPolicies')
 
   return render(AppSidebar, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -9,7 +9,11 @@ exports[`App.vue fails to renders basic view 1`] = `
     <div
       class="horizontal-list"
     >
-      <a>
+      <a
+        aria-current="page"
+        class="router-link-active router-link-exact-active"
+        href="/"
+      >
         <img
           alt="Kuma Logo"
           class="logo-image"
@@ -143,7 +147,10 @@ exports[`App.vue fails to renders basic view 1`] = `
           4
         </span>
       </button>
-      <a>
+      <a
+        class=""
+        href="/diagnostics"
+      >
         <span
           class="kong-icon-gearFilled kong-icon"
           data-v-71cfcfc4=""
@@ -197,7 +204,9 @@ exports[`App.vue fails to renders basic view 1`] = `
           data-testid="home"
         >
           <a
-            class="nav-link nav-link--is-active"
+            aria-current="page"
+            class="router-link-active router-link-exact-active nav-link nav-link--is-active"
+            href="/"
           >
             Home 
             <!--v-if-->
@@ -268,6 +277,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         >
           <a
             class="nav-link"
+            href="/mesh/default"
           >
             Overview 
             <!--v-if-->
@@ -281,6 +291,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         >
           <a
             class="nav-link"
+            href="/mesh/default/services"
           >
             Services 
             <span
@@ -298,6 +309,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         >
           <a
             class="nav-link"
+            href="/mesh/default/data-planes"
           >
             Data Plane Proxies 
             <span
@@ -437,7 +449,363 @@ exports[`App.vue fails to renders basic view 1`] = `
         <div
           class="transition-root"
         >
-          TestComponent
+          
+          <div
+            class="chart-container mt-16"
+          >
+            <!--v-if-->
+            <!--v-if-->
+            <donut-chart-stub
+              class="chart chart-1/3"
+              data="[object Object]"
+              displayamchartslogo="false"
+              emptysubtitle="NO"
+              hideslicelabels="false"
+              isloading="true"
+              reversetitles="false"
+              savechart="false"
+              title="[object Object]"
+            />
+            <donut-chart-stub
+              class="chart chart-1/3"
+              data="[object Object],[object Object]"
+              displayamchartslogo="false"
+              emptysubtitle="NO"
+              hideslicelabels="false"
+              isloading="true"
+              reversetitles="false"
+              savechart="true"
+              title="[object Object]"
+            />
+            <donut-chart-stub
+              class="chart chart-1/3"
+              data="[object Object],[object Object]"
+              displayamchartslogo="false"
+              emptysubtitle="NO"
+              hideslicelabels="false"
+              isloading="true"
+              reversetitles="false"
+              savechart="false"
+              title="[object Object]"
+            />
+            <donut-chart-stub
+              class="chart chart-1/2 chart-offset-left-1/6"
+              data="[object Object],[object Object],[object Object],[object Object]"
+              displayamchartslogo="false"
+              emptysubtitle="NOT FOUND"
+              hideslicelabels="false"
+              isloading="true"
+              reversetitles="true"
+              savechart="false"
+              subtitleprops="[object Object]"
+              title="KUMA DP"
+              titleprops="[object Object]"
+            />
+            <donut-chart-stub
+              class="chart chart-1/2 chart-offset-right-1/6"
+              data="[object Object],[object Object],[object Object],[object Object],[object Object]"
+              displayamchartslogo="true"
+              emptysubtitle="NOT FOUND"
+              hideslicelabels="false"
+              isloading="true"
+              reversetitles="true"
+              savechart="false"
+              subtitleprops="[object Object]"
+              title="ENVOY"
+              titleprops="[object Object]"
+            />
+          </div>
+          <div
+            class="resource-list mt-8"
+          >
+            <section
+              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              aria-label="Create a virtual mesh"
+              class="border kong-card"
+              data-v-1f0d90ac=""
+            >
+              <div
+                class="k-card-header d-flex mb-3"
+                data-v-1f0d90ac=""
+              >
+                <!---->
+                <div
+                  class="k-card-title mb-3"
+                  data-v-1f0d90ac=""
+                >
+                  <h4
+                    data-v-1f0d90ac=""
+                  >
+                    
+                    Create a virtual mesh
+                    
+                  </h4>
+                </div>
+                <div
+                  class="k-card-actions"
+                  data-v-1f0d90ac=""
+                >
+                  
+                  
+                </div>
+              </div>
+              <!---->
+              <div
+                class="k-card-content d-flex"
+                data-v-1f0d90ac=""
+              >
+                <div
+                  class="k-card-body"
+                  data-v-1f0d90ac=""
+                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                >
+                  
+                  <p>
+                     We can create multiple isolated Mesh resources (i.e. per application/
+                    <wbr />
+                    team/
+                    <wbr />
+                    business unit). 
+                  </p>
+                  <div
+                    class="resource-list-actions mt-4"
+                  >
+                    <a
+                      class="medium rounded primary k-button"
+                      data-v-6f773baa=""
+                      href="/wizard/mesh"
+                      type="button"
+                    >
+                      
+                      <!---->
+                      
+                      
+                       Create mesh 
+                      
+                      <!---->
+                    </a>
+                  </div>
+                  
+                </div>
+                <!---->
+              </div>
+            </section>
+            <section
+              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              aria-label="Connect data plane proxies"
+              class="border kong-card"
+              data-v-1f0d90ac=""
+            >
+              <div
+                class="k-card-header d-flex mb-3"
+                data-v-1f0d90ac=""
+              >
+                <!---->
+                <div
+                  class="k-card-title mb-3"
+                  data-v-1f0d90ac=""
+                >
+                  <h4
+                    data-v-1f0d90ac=""
+                  >
+                    
+                    Connect data plane proxies
+                    
+                  </h4>
+                </div>
+                <div
+                  class="k-card-actions"
+                  data-v-1f0d90ac=""
+                >
+                  
+                  
+                </div>
+              </div>
+              <!---->
+              <div
+                class="k-card-content d-flex"
+                data-v-1f0d90ac=""
+              >
+                <div
+                  class="k-card-body"
+                  data-v-1f0d90ac=""
+                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                >
+                  
+                  <p>
+                     We need a data plane proxy for each replica of our services within a Mesh resource. 
+                  </p>
+                  <div
+                    class="resource-list-actions mt-4"
+                  >
+                    <a
+                      class="medium rounded primary k-button"
+                      data-v-6f773baa=""
+                      href="/wizard/universal-dataplane"
+                      type="button"
+                    >
+                      
+                      <!---->
+                      
+                      
+                       Get started 
+                      
+                      <!---->
+                    </a>
+                  </div>
+                  
+                </div>
+                <!---->
+              </div>
+            </section>
+            <section
+              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              aria-label="Apply Kuma policies"
+              class="border kong-card"
+              data-v-1f0d90ac=""
+            >
+              <div
+                class="k-card-header d-flex mb-3"
+                data-v-1f0d90ac=""
+              >
+                <!---->
+                <div
+                  class="k-card-title mb-3"
+                  data-v-1f0d90ac=""
+                >
+                  <h4
+                    data-v-1f0d90ac=""
+                  >
+                    
+                    Apply Kuma policies
+                    
+                  </h4>
+                </div>
+                <div
+                  class="k-card-actions"
+                  data-v-1f0d90ac=""
+                >
+                  
+                  
+                </div>
+              </div>
+              <!---->
+              <div
+                class="k-card-content d-flex"
+                data-v-1f0d90ac=""
+              >
+                <div
+                  class="k-card-body"
+                  data-v-1f0d90ac=""
+                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                >
+                  
+                  <p>
+                     We can apply Kuma policies to secure, observe, route and manage the Mesh and its data plane proxies. 
+                  </p>
+                  <div
+                    class="resource-list-actions mt-4"
+                  >
+                    <a
+                      class="medium rounded primary k-button"
+                      data-v-6f773baa=""
+                      href="https://kuma.io/policies/?utm_source=Kuma&utm_medium=Kuma-GUI"
+                      type="button"
+                    >
+                      
+                      <!---->
+                      
+                      
+                       Explore policies 
+                      
+                      <!---->
+                    </a>
+                  </div>
+                  
+                </div>
+                <!---->
+              </div>
+            </section>
+            <section
+              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              aria-label="Resources"
+              class="border kong-card"
+              data-v-1f0d90ac=""
+            >
+              <div
+                class="k-card-header d-flex mb-3"
+                data-v-1f0d90ac=""
+              >
+                <!---->
+                <div
+                  class="k-card-title mb-3"
+                  data-v-1f0d90ac=""
+                >
+                  <h4
+                    data-v-1f0d90ac=""
+                  >
+                    
+                    Resources
+                    
+                  </h4>
+                </div>
+                <div
+                  class="k-card-actions"
+                  data-v-1f0d90ac=""
+                >
+                  
+                  
+                </div>
+              </div>
+              <!---->
+              <div
+                class="k-card-content d-flex"
+                data-v-1f0d90ac=""
+              >
+                <div
+                  class="k-card-body"
+                  data-v-1f0d90ac=""
+                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                >
+                  
+                  <p>
+                     Join the Kuma community and ask questions: 
+                  </p>
+                  <ul>
+                    
+                    <li>
+                      <a
+                        href="https://kuma.io/docs/1.7.x/?utm_source=Kuma&utm_medium=Kuma-GUI"
+                        target="_blank"
+                      >
+                        Kuma Documentation
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://kuma-mesh.slack.com/?utm_source=Kuma&utm_medium=Kuma-GUI"
+                        target="_blank"
+                      >
+                        Kuma Community Chat
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://github.com/kumahq/kuma?utm_source=Kuma&utm_medium=Kuma-GUI"
+                        target="_blank"
+                      >
+                        Kuma GitHub Repository
+                      </a>
+                    </li>
+                    
+                  </ul>
+                  
+                </div>
+                <!---->
+              </div>
+            </section>
+          </div>
+          
         </div>
       </transition-stub>
     </main>

--- a/src/app/__snapshots__/AppNavItem.spec.ts.snap
+++ b/src/app/__snapshots__/AppNavItem.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`AppNavItem.vue renders snapshot with link to selected mesh 1`] = `
 >
   <a
     class="nav-link"
-    href="#/mesh/default/data-planes"
+    href="/mesh/default/data-planes"
   >
     All 
     <span

--- a/src/app/__snapshots__/AppOnboardingNotification.spec.ts.snap
+++ b/src/app/__snapshots__/AppOnboardingNotification.spec.ts.snap
@@ -31,10 +31,10 @@ exports[`AppOnboardingNotification renders snapshot 1`] = `
              We've detected that you don't have any data plane proxies running yet. We've created an onboarding process to help you! 
           </div>
           <div>
-            <router-link
+            <a
               class="small rounded primary k-button action-button"
               data-v-6f773baa=""
-              to="[object Object]"
+              href="/onboarding/welcome"
               type="button"
             >
               
@@ -44,7 +44,7 @@ exports[`AppOnboardingNotification renders snapshot 1`] = `
                Get started 
               
               <!---->
-            </router-link>
+            </a>
           </div>
         </div>
         

--- a/src/app/common/DataOverview.spec.ts
+++ b/src/app/common/DataOverview.spec.ts
@@ -1,18 +1,19 @@
-import { flushPromises, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises } from '@vue/test-utils'
 import { render, screen } from '@testing-library/vue'
 import { datadogLogs } from '@datadog/browser-logs'
 import userEvent from '@testing-library/user-event'
 
 import DataOverview from './DataOverview.vue'
+import { createRouter } from '@/router/router'
+
+const router = createRouter()
 
 jest.mock('@datadog/browser-logs')
 
 function renderComponent(props = {}) {
   return render(DataOverview, {
     global: {
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
+      plugins: [router],
     },
     props,
     slots: {

--- a/src/app/common/DataOverview.spec.ts
+++ b/src/app/common/DataOverview.spec.ts
@@ -4,17 +4,11 @@ import { datadogLogs } from '@datadog/browser-logs'
 import userEvent from '@testing-library/user-event'
 
 import DataOverview from './DataOverview.vue'
-import { createRouter } from '@/router/router'
-
-const router = createRouter()
 
 jest.mock('@datadog/browser-logs')
 
 function renderComponent(props = {}) {
   return render(DataOverview, {
-    global: {
-      plugins: [router],
-    },
     props,
     slots: {
       custom: `

--- a/src/app/common/EntityURLControl.spec.ts
+++ b/src/app/common/EntityURLControl.spec.ts
@@ -1,15 +1,12 @@
 import { render, screen } from '@testing-library/vue'
 
 import EntityURLControl from './EntityURLControl.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-
-const router = createRouter()
 
 function renderComponent(props: any) {
   return render(EntityURLControl, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
     props,
   })

--- a/src/app/common/EntityURLControl.spec.ts
+++ b/src/app/common/EntityURLControl.spec.ts
@@ -1,31 +1,15 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
 import { render, screen } from '@testing-library/vue'
 
 import EntityURLControl from './EntityURLControl.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 function renderComponent(props: any) {
   return render(EntityURLControl, {
     global: {
       plugins: [router, [store, storeKey]],
-      mocks: {
-        $route: {
-          params: {
-            mesh: 'test-mesh',
-          },
-        },
-      },
     },
     props,
   })

--- a/src/app/common/EntityURLControl.spec.ts
+++ b/src/app/common/EntityURLControl.spec.ts
@@ -1,13 +1,9 @@
 import { render, screen } from '@testing-library/vue'
 
 import EntityURLControl from './EntityURLControl.vue'
-import { store, storeKey } from '@/store/store'
 
-function renderComponent(props: any) {
+function renderComponent(props = {}) {
   return render(EntityURLControl, {
-    global: {
-      plugins: [[store, storeKey]],
-    },
     props,
   })
 }

--- a/src/app/common/EnvoyData.spec.ts
+++ b/src/app/common/EnvoyData.spec.ts
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/vue'
 import { rest } from 'msw'
 
 import EnvoyData from './EnvoyData.vue'
-import { server } from '@/../jest/jest-setup'
+import { server } from '@/../jest/jest-setup-after-env'
 
 function renderComponent(props = {}) {
   return render(EnvoyData, {

--- a/src/app/common/NotificationIcon.spec.ts
+++ b/src/app/common/NotificationIcon.spec.ts
@@ -1,14 +1,9 @@
 import { mount } from '@vue/test-utils'
 
 import NotificationIcon from './NotificationIcon.vue'
-import { store, storeKey } from '@/store/store'
 
 function renderComponent() {
-  return mount(NotificationIcon, {
-    global: {
-      plugins: [[store, storeKey]],
-    },
-  })
+  return mount(NotificationIcon)
 }
 
 describe('NotificationIcon.vue', () => {

--- a/src/app/common/UpgradeCheck.spec.ts
+++ b/src/app/common/UpgradeCheck.spec.ts
@@ -1,17 +1,13 @@
 import { render } from '@testing-library/vue'
 
 import UpgradeCheck from './UpgradeCheck.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 
 describe('UpgradeCheck.vue', () => {
   it('renders snapshot', async () => {
     store.state.config.tagline = import.meta.env.VITE_NAMESPACE
 
-    const { container, findByText } = render(UpgradeCheck, {
-      global: {
-        plugins: [[store, storeKey]],
-      },
-    })
+    const { container, findByText } = render(UpgradeCheck)
 
     await findByText('Update')
     expect(container).toMatchSnapshot()

--- a/src/app/common/charts/DonutChart.spec.ts
+++ b/src/app/common/charts/DonutChart.spec.ts
@@ -1,17 +1,9 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
 import { render, screen } from '@testing-library/vue'
-import DonutChart from './DonutChart.vue'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+import DonutChart from './DonutChart.vue'
+import { createRouter } from '@/router/router'
+
+const router = createRouter()
 
 describe('DonutChart.vue', () => {
   it('renders chart', async () => {

--- a/src/app/common/charts/DonutChart.spec.ts
+++ b/src/app/common/charts/DonutChart.spec.ts
@@ -1,16 +1,10 @@
 import { render, screen } from '@testing-library/vue'
 
 import DonutChart from './DonutChart.vue'
-import { createRouter } from '@/router/router'
-
-const router = createRouter()
 
 describe('DonutChart.vue', () => {
   it('renders chart', async () => {
     render(DonutChart, {
-      global: {
-        plugins: [router],
-      },
       props: {
         data: [
           {

--- a/src/app/data-planes/components/DataPlaneDetails.spec.ts
+++ b/src/app/data-planes/components/DataPlaneDetails.spec.ts
@@ -1,21 +1,12 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
-import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneDetails from './DataPlaneDetails.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { createDataPlane } from '@/test-data/createDataPlane'
 import { createDataPlaneOverview } from '@/test-data/createDataPlaneOverview'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 const dataPlane = createDataPlane()
 const dataPlaneOverview = createDataPlaneOverview()
@@ -31,9 +22,6 @@ async function renderComponent(props = {}) {
     },
     global: {
       plugins: [router, [store, storeKey]],
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
     },
   })
 }

--- a/src/app/data-planes/components/DataPlaneDetails.spec.ts
+++ b/src/app/data-planes/components/DataPlaneDetails.spec.ts
@@ -1,12 +1,9 @@
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneDetails from './DataPlaneDetails.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { createDataPlane } from '@/test-data/createDataPlane'
 import { createDataPlaneOverview } from '@/test-data/createDataPlaneOverview'
-
-const router = createRouter()
 
 const dataPlane = createDataPlane()
 const dataPlaneOverview = createDataPlaneOverview()
@@ -21,7 +18,7 @@ async function renderComponent(props = {}) {
       ...props,
     },
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/data-planes/components/DataPlaneDetails.spec.ts
+++ b/src/app/data-planes/components/DataPlaneDetails.spec.ts
@@ -1,7 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneDetails from './DataPlaneDetails.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { createDataPlane } from '@/test-data/createDataPlane'
 import { createDataPlaneOverview } from '@/test-data/createDataPlaneOverview'
 
@@ -16,9 +16,6 @@ async function renderComponent(props = {}) {
       dataPlane,
       dataPlaneOverview,
       ...props,
-    },
-    global: {
-      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/data-planes/components/DataPlaneEntitySummary.spec.ts
+++ b/src/app/data-planes/components/DataPlaneEntitySummary.spec.ts
@@ -1,13 +1,10 @@
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneEntitySummary from './DataPlaneEntitySummary.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { createDataPlaneOverview } from '@/test-data/createDataPlaneOverview'
 
 const dataPlaneOverview = createDataPlaneOverview()
-
-const router = createRouter()
 
 function renderComponent(props = {}) {
   return mount(DataPlaneEntitySummary, {
@@ -16,7 +13,7 @@ function renderComponent(props = {}) {
       ...props,
     },
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/data-planes/components/DataPlaneEntitySummary.spec.ts
+++ b/src/app/data-planes/components/DataPlaneEntitySummary.spec.ts
@@ -1,7 +1,6 @@
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneEntitySummary from './DataPlaneEntitySummary.vue'
-import { store, storeKey } from '@/store/store'
 import { createDataPlaneOverview } from '@/test-data/createDataPlaneOverview'
 
 const dataPlaneOverview = createDataPlaneOverview()
@@ -11,9 +10,6 @@ function renderComponent(props = {}) {
     props: {
       dataPlaneOverview,
       ...props,
-    },
-    global: {
-      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/data-planes/components/DataPlaneEntitySummary.spec.ts
+++ b/src/app/data-planes/components/DataPlaneEntitySummary.spec.ts
@@ -1,10 +1,13 @@
-import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneEntitySummary from './DataPlaneEntitySummary.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { createDataPlaneOverview } from '@/test-data/createDataPlaneOverview'
 
 const dataPlaneOverview = createDataPlaneOverview()
+
+const router = createRouter()
 
 function renderComponent(props = {}) {
   return mount(DataPlaneEntitySummary, {
@@ -13,10 +16,7 @@ function renderComponent(props = {}) {
       ...props,
     },
     global: {
-      plugins: [[store, storeKey]],
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
+      plugins: [router, [store, storeKey]],
     },
   })
 }

--- a/src/app/data-planes/components/DataplanePolicies.spec.ts
+++ b/src/app/data-planes/components/DataplanePolicies.spec.ts
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import DataplanePolicies from './DataplanePolicies.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { server } from '@/../jest/jest-setup-after-env'
 
 async function renderComponent(props = {}) {
@@ -12,7 +12,6 @@ async function renderComponent(props = {}) {
 
   return render(DataplanePolicies, {
     global: {
-      plugins: [[store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },

--- a/src/app/data-planes/components/DataplanePolicies.spec.ts
+++ b/src/app/data-planes/components/DataplanePolicies.spec.ts
@@ -4,15 +4,18 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import DataplanePolicies from './DataplanePolicies.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { server } from '@/../jest/jest-setup'
+
+const router = createRouter()
 
 async function renderComponent(props = {}) {
   await store.dispatch('fetchPolicies')
 
   return render(DataplanePolicies, {
     global: {
-      plugins: [[store, storeKey]],
+      plugins: [router, [store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },

--- a/src/app/data-planes/components/DataplanePolicies.spec.ts
+++ b/src/app/data-planes/components/DataplanePolicies.spec.ts
@@ -4,18 +4,15 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import DataplanePolicies from './DataplanePolicies.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-import { server } from '@/../jest/jest-setup'
-
-const router = createRouter()
+import { server } from '@/../jest/jest-setup-after-env'
 
 async function renderComponent(props = {}) {
   await store.dispatch('fetchPolicies')
 
   return render(DataplanePolicies, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },

--- a/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
@@ -13,7 +13,10 @@ exports[`DataPlaneEntitySummary matches snapshot 1`] = `
       >
         Data plane proxy:
       </span>
-      <a>
+      <a
+        class=""
+        href="/mesh/test-mesh/data-planes/backend"
+      >
         backend
       </a>
       <div

--- a/src/app/data-planes/views/DataPlaneListView.spec.ts
+++ b/src/app/data-planes/views/DataPlaneListView.spec.ts
@@ -1,7 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneListView from './DataPlaneListView.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { router } from '@/../jest/jest-setup-after-env'
 
 async function renderComponent() {
@@ -10,11 +10,7 @@ async function renderComponent() {
 
   await store.dispatch('fetchPolicies')
 
-  const wrapper = mount(DataPlaneListView, {
-    global: {
-      plugins: [[store, storeKey]],
-    },
-  })
+  const wrapper = mount(DataPlaneListView)
 
   await flushPromises()
 

--- a/src/app/data-planes/views/DataPlaneListView.spec.ts
+++ b/src/app/data-planes/views/DataPlaneListView.spec.ts
@@ -1,19 +1,10 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
-import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneListView from './DataPlaneListView.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: '<TestComponent>' },
-    },
-  ],
-})
+const router = createRouter()
 
 async function renderComponent() {
   router.currentRoute.value.name = 'home'
@@ -23,9 +14,6 @@ async function renderComponent() {
   const wrapper = mount(DataPlaneListView, {
     global: {
       plugins: [router, [store, storeKey]],
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
     },
   })
 

--- a/src/app/data-planes/views/DataPlaneListView.spec.ts
+++ b/src/app/data-planes/views/DataPlaneListView.spec.ts
@@ -1,19 +1,18 @@
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneListView from './DataPlaneListView.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-
-const router = createRouter()
+import { router } from '@/../jest/jest-setup-after-env'
 
 async function renderComponent() {
   router.currentRoute.value.name = 'home'
   router.currentRoute.value.params.mesh = 'default'
+
   await store.dispatch('fetchPolicies')
 
   const wrapper = mount(DataPlaneListView, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 

--- a/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
+++ b/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
@@ -417,6 +417,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
           class="medium rounded primary k-button add-dp-button"
           data-testid="data-plane-create-data-plane-button"
           data-v-6f773baa=""
+          href="/wizard/kubernetes-dataplane"
           type="button"
         >
           
@@ -703,7 +704,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/backend"
+                      >
                         backend
                       </a>
                       
@@ -713,7 +717,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default"
+                      >
                         default
                       </a>
                       
@@ -731,7 +738,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/services/backend"
+                      >
                         backend
                       </a>
                       
@@ -772,6 +782,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       <a
                         class="medium rounded btn-link k-button detail-link"
                         data-v-6f773baa=""
+                        href="/mesh/default/data-planes/backend"
                         type="button"
                       >
                         
@@ -840,7 +851,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/cluster-1.backend-02"
+                      >
                         cluster-1.backend-02
                       </a>
                       
@@ -850,7 +864,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default"
+                      >
                         default
                       </a>
                       
@@ -868,7 +885,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/services/backend"
+                      >
                         backend
                       </a>
                       
@@ -909,6 +929,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       <a
                         class="medium rounded btn-link k-button detail-link"
                         data-v-6f773baa=""
+                        href="/mesh/default/data-planes/cluster-1.backend-02"
                         type="button"
                       >
                         
@@ -977,7 +998,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/cluster-1.backend-03"
+                      >
                         cluster-1.backend-03
                       </a>
                       
@@ -987,7 +1011,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default"
+                      >
                         default
                       </a>
                       
@@ -1005,7 +1032,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/services/backend"
+                      >
                         backend
                       </a>
                       
@@ -1046,6 +1076,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       <a
                         class="medium rounded btn-link k-button detail-link"
                         data-v-6f773baa=""
+                        href="/mesh/default/data-planes/cluster-1.backend-03"
                         type="button"
                       >
                         
@@ -1114,7 +1145,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/cluster-1.gateway-01"
+                      >
                         cluster-1.gateway-01
                       </a>
                       
@@ -1124,7 +1158,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default"
+                      >
                         default
                       </a>
                       
@@ -1142,7 +1179,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/services/gateway"
+                      >
                         gateway
                       </a>
                       
@@ -1183,6 +1223,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       <a
                         class="medium rounded btn-link k-button detail-link"
                         data-v-6f773baa=""
+                        href="/mesh/default/data-planes/cluster-1.gateway-01"
                         type="button"
                       >
                         
@@ -1251,7 +1292,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/cluster-1.ingress-02"
+                      >
                         cluster-1.ingress-02
                       </a>
                       
@@ -1261,7 +1305,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default"
+                      >
                         default
                       </a>
                       
@@ -1279,7 +1326,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/services/ingress"
+                      >
                         ingress
                       </a>
                       
@@ -1320,6 +1370,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       <a
                         class="medium rounded btn-link k-button detail-link"
                         data-v-6f773baa=""
+                        href="/mesh/default/data-planes/cluster-1.ingress-02"
                         type="button"
                       >
                         
@@ -1388,7 +1439,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/dataplane-test-456"
+                      >
                         dataplane-test-456
                       </a>
                       
@@ -1398,7 +1452,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default"
+                      >
                         default
                       </a>
                       
@@ -1416,7 +1473,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/services/kuma-example-backend"
+                      >
                         kuma-example-backend
                       </a>
                       
@@ -1457,6 +1517,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       <a
                         class="medium rounded btn-link k-button detail-link"
                         data-v-6f773baa=""
+                        href="/mesh/default/data-planes/dataplane-test-456"
                         type="button"
                       >
                         
@@ -1525,7 +1586,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/db"
+                      >
                         db
                       </a>
                       
@@ -1535,7 +1599,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default"
+                      >
                         default
                       </a>
                       
@@ -1553,7 +1620,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/services/db"
+                      >
                         db
                       </a>
                       
@@ -1594,6 +1664,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       <a
                         class="medium rounded btn-link k-button detail-link"
                         data-v-6f773baa=""
+                        href="/mesh/default/data-planes/db"
                         type="button"
                       >
                         
@@ -1662,7 +1733,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/frontend"
+                      >
                         frontend
                       </a>
                       
@@ -1672,7 +1746,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default"
+                      >
                         default
                       </a>
                       
@@ -1690,7 +1767,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/services/frontend"
+                      >
                         frontend
                       </a>
                       
@@ -1731,6 +1811,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       <a
                         class="medium rounded btn-link k-button detail-link"
                         data-v-6f773baa=""
+                        href="/mesh/default/data-planes/frontend"
                         type="button"
                       >
                         
@@ -1838,7 +1919,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/ingress-dp-test-123"
+                      >
                         ingress-dp-test-123
                       </a>
                       
@@ -1848,7 +1932,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default"
+                      >
                         default
                       </a>
                       
@@ -1866,7 +1953,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/services/kuma-example-backend"
+                      >
                         kuma-example-backend
                       </a>
                       
@@ -1907,6 +1997,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       <a
                         class="medium rounded btn-link k-button detail-link"
                         data-v-6f773baa=""
+                        href="/mesh/default/data-planes/ingress-dp-test-123"
                         type="button"
                       >
                         
@@ -1975,7 +2066,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/no-subscriptions"
+                      >
                         no-subscriptions
                       </a>
                       
@@ -1985,7 +2079,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default"
+                      >
                         default
                       </a>
                       
@@ -2003,7 +2100,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       data-v-4f741344=""
                     >
                       
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/services/no-subscriptions"
+                      >
                         no-subscriptions
                       </a>
                       
@@ -2044,6 +2144,7 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
                       <a
                         class="medium rounded btn-link k-button detail-link"
                         data-v-6f773baa=""
+                        href="/mesh/default/data-planes/no-subscriptions"
                         type="button"
                       >
                         
@@ -2133,7 +2234,10 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
           >
             Data plane proxy:
           </span>
-          <a>
+          <a
+            class=""
+            href="/mesh/default/data-planes/backend"
+          >
             backend
           </a>
           <div

--- a/src/app/main-overview/views/MainOverviewView.spec.ts
+++ b/src/app/main-overview/views/MainOverviewView.spec.ts
@@ -1,7 +1,6 @@
 import { mount, RouterLinkStub } from '@vue/test-utils'
 
 import MainOverviewView from './MainOverviewView.vue'
-import { store, storeKey } from '@/store/store'
 
 describe('MainOverviewView.vue', () => {
   it('renders basic snapshot', () => {
@@ -11,7 +10,6 @@ describe('MainOverviewView.vue', () => {
       // which is only possible if the element is actually in the DOM.
       attachTo: document.body,
       global: {
-        plugins: [[store, storeKey]],
         stubs: {
           'router-link': RouterLinkStub,
         },

--- a/src/app/main-overview/views/MainOverviewView.spec.ts
+++ b/src/app/main-overview/views/MainOverviewView.spec.ts
@@ -1,10 +1,7 @@
 import { mount, RouterLinkStub } from '@vue/test-utils'
 
 import MainOverviewView from './MainOverviewView.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-
-const router = createRouter()
 
 describe('MainOverviewView.vue', () => {
   it('renders basic snapshot', () => {
@@ -14,7 +11,7 @@ describe('MainOverviewView.vue', () => {
       // which is only possible if the element is actually in the DOM.
       attachTo: document.body,
       global: {
-        plugins: [router, [store, storeKey]],
+        plugins: [[store, storeKey]],
         stubs: {
           'router-link': RouterLinkStub,
         },

--- a/src/app/main-overview/views/MainOverviewView.spec.ts
+++ b/src/app/main-overview/views/MainOverviewView.spec.ts
@@ -1,32 +1,13 @@
 import { mount, RouterLinkStub } from '@vue/test-utils'
-import { createRouter, createWebHashHistory } from 'vue-router'
 
 import MainOverviewView from './MainOverviewView.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
+
+const router = createRouter()
 
 describe('MainOverviewView.vue', () => {
   it('renders basic snapshot', () => {
-    const router = createRouter({
-      history: createWebHashHistory(),
-      routes: [
-        {
-          path: '/',
-          name: 'home',
-          component: { template: 'TestComponent' },
-        },
-        {
-          path: '/zones',
-          name: 'zones',
-          component: { template: 'TestComponent' },
-        },
-        {
-          path: '/mesh/:mesh/data-planes',
-          name: 'data-plane-list-view',
-          component: { template: 'TestComponent' },
-        },
-      ],
-    })
-
     const wrapper = mount(MainOverviewView, {
       // This is necessary to correctly suppress the amcharts “Chart was not disposed” warning.
       // Its detection logic relies on finding an elements root node

--- a/src/app/notification-manager/components/LoggingNotification.spec.ts
+++ b/src/app/notification-manager/components/LoggingNotification.spec.ts
@@ -1,15 +1,10 @@
 import { mount } from '@vue/test-utils'
 
-import { store, storeKey } from '@/store/store'
 import LoggingNotification from './LoggingNotification.vue'
 
 describe('LoggingNotification.vue', () => {
   it('renders snapshot', () => {
-    const wrapper = mount(LoggingNotification, {
-      global: {
-        plugins: [[store, storeKey]],
-      },
-    })
+    const wrapper = mount(LoggingNotification)
 
     expect(wrapper.element).toMatchSnapshot()
   })

--- a/src/app/notification-manager/components/MetricsNotification.spec.ts
+++ b/src/app/notification-manager/components/MetricsNotification.spec.ts
@@ -1,15 +1,10 @@
 import { mount } from '@vue/test-utils'
 
-import { store, storeKey } from '@/store/store'
 import MetricsNotification from './MetricsNotification.vue'
 
 describe('MetricsNotification.vue', () => {
   it('renders snapshot', () => {
-    const wrapper = mount(MetricsNotification, {
-      global: {
-        plugins: [[store, storeKey]],
-      },
-    })
+    const wrapper = mount(MetricsNotification)
 
     expect(wrapper.element).toMatchSnapshot()
   })

--- a/src/app/notification-manager/components/MtlsNotification.spec.ts
+++ b/src/app/notification-manager/components/MtlsNotification.spec.ts
@@ -1,15 +1,10 @@
 import { mount } from '@vue/test-utils'
 
-import { store, storeKey } from '@/store/store'
 import MtlsNotification from './MtlsNotification.vue'
 
 describe('MtlsNotification.vue', () => {
   it('renders snapshot', () => {
-    const wrapper = mount(MtlsNotification, {
-      global: {
-        plugins: [[store, storeKey]],
-      },
-    })
+    const wrapper = mount(MtlsNotification)
 
     expect(wrapper.element).toMatchSnapshot()
   })

--- a/src/app/notification-manager/components/NotificationManager.spec.ts
+++ b/src/app/notification-manager/components/NotificationManager.spec.ts
@@ -1,19 +1,10 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
 import { mount } from '@vue/test-utils'
 
-import { store, storeKey } from '@/store/store'
 import NotificationManager from './NotificationManager.vue'
+import { createRouter } from '@/router/router'
+import { store, storeKey } from '@/store/store'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 function renderComponent({ meshes, selectedMesh }: { meshes: any, selectedMesh: string }) {
   store.state.meshes = meshes

--- a/src/app/notification-manager/components/NotificationManager.spec.ts
+++ b/src/app/notification-manager/components/NotificationManager.spec.ts
@@ -1,10 +1,7 @@
 import { mount } from '@vue/test-utils'
 
 import NotificationManager from './NotificationManager.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-
-const router = createRouter()
 
 function renderComponent({ meshes, selectedMesh }: { meshes: any, selectedMesh: string }) {
   store.state.meshes = meshes
@@ -12,7 +9,7 @@ function renderComponent({ meshes, selectedMesh }: { meshes: any, selectedMesh: 
 
   return mount(NotificationManager, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/notification-manager/components/NotificationManager.spec.ts
+++ b/src/app/notification-manager/components/NotificationManager.spec.ts
@@ -1,17 +1,13 @@
 import { mount } from '@vue/test-utils'
 
 import NotificationManager from './NotificationManager.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 
 function renderComponent({ meshes, selectedMesh }: { meshes: any, selectedMesh: string }) {
   store.state.meshes = meshes
   store.state.selectedMesh = selectedMesh
 
-  return mount(NotificationManager, {
-    global: {
-      plugins: [[store, storeKey]],
-    },
-  })
+  return mount(NotificationManager)
 }
 
 describe('NotificationManager.vue', () => {

--- a/src/app/notification-manager/components/TracingNotification.spec.ts
+++ b/src/app/notification-manager/components/TracingNotification.spec.ts
@@ -1,15 +1,10 @@
 import { mount } from '@vue/test-utils'
 
-import { store, storeKey } from '@/store/store'
 import TracingNotification from './TracingNotification.vue'
 
 describe('TracingNotification.vue', () => {
   it('renders snapshot', () => {
-    const wrapper = mount(TracingNotification, {
-      global: {
-        plugins: [[store, storeKey]],
-      },
-    })
+    const wrapper = mount(TracingNotification)
 
     expect(wrapper.element).toMatchSnapshot()
   })

--- a/src/app/onboarding/components/OnboardingNavigation.spec.ts
+++ b/src/app/onboarding/components/OnboardingNavigation.spec.ts
@@ -3,13 +3,12 @@ import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 
 import OnboardingNavigation from './OnboardingNavigation.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 
 function renderComponent(props: any) {
   return render(OnboardingNavigation, {
     props,
     global: {
-      plugins: [[store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },

--- a/src/app/onboarding/components/OnboardingNavigation.spec.ts
+++ b/src/app/onboarding/components/OnboardingNavigation.spec.ts
@@ -3,16 +3,13 @@ import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 
 import OnboardingNavigation from './OnboardingNavigation.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-
-const router = createRouter()
 
 function renderComponent(props: any) {
   return render(OnboardingNavigation, {
     props,
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
       },

--- a/src/app/onboarding/components/OnboardingNavigation.spec.ts
+++ b/src/app/onboarding/components/OnboardingNavigation.spec.ts
@@ -3,20 +3,18 @@ import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 
 import OnboardingNavigation from './OnboardingNavigation.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
+
+const router = createRouter()
 
 function renderComponent(props: any) {
   return render(OnboardingNavigation, {
     props,
     global: {
-      plugins: [[store, storeKey]],
+      plugins: [router, [store, storeKey]],
       stubs: {
         'router-link': RouterLinkStub,
-      },
-      mocks: {
-        $router: {
-          push: () => undefined,
-        },
       },
     },
   })

--- a/src/app/onboarding/views/AddNewServices.spec.ts
+++ b/src/app/onboarding/views/AddNewServices.spec.ts
@@ -2,14 +2,9 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import AddNewServices from './AddNewServices.vue'
-import { store, storeKey } from '@/store/store'
 
 function renderComponent() {
-  return render(AddNewServices, {
-    global: {
-      plugins: [[store, storeKey]],
-    },
-  })
+  return render(AddNewServices)
 }
 
 describe('AddNewServices.vue', () => {

--- a/src/app/onboarding/views/AddNewServices.spec.ts
+++ b/src/app/onboarding/views/AddNewServices.spec.ts
@@ -1,17 +1,16 @@
-import { RouterLinkStub } from '@vue/test-utils'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import AddNewServices from './AddNewServices.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
+
+const router = createRouter()
 
 function renderComponent() {
   return render(AddNewServices, {
     global: {
-      plugins: [[store, storeKey]],
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
+      plugins: [router, [store, storeKey]],
     },
   })
 }

--- a/src/app/onboarding/views/AddNewServices.spec.ts
+++ b/src/app/onboarding/views/AddNewServices.spec.ts
@@ -2,15 +2,12 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import AddNewServices from './AddNewServices.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-
-const router = createRouter()
 
 function renderComponent() {
   return render(AddNewServices, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/onboarding/views/AddNewServicesCode.spec.ts
+++ b/src/app/onboarding/views/AddNewServicesCode.spec.ts
@@ -3,15 +3,12 @@ import { render, screen } from '@testing-library/vue'
 
 import AddNewServicesCode from './AddNewServicesCode.vue'
 import { kumaApi } from '@/api/kumaApi'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-
-const router = createRouter()
 
 function renderComponent() {
   return render(AddNewServicesCode, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/onboarding/views/AddNewServicesCode.spec.ts
+++ b/src/app/onboarding/views/AddNewServicesCode.spec.ts
@@ -3,14 +3,9 @@ import { render, screen } from '@testing-library/vue'
 
 import AddNewServicesCode from './AddNewServicesCode.vue'
 import { kumaApi } from '@/api/kumaApi'
-import { store, storeKey } from '@/store/store'
 
 function renderComponent() {
-  return render(AddNewServicesCode, {
-    global: {
-      plugins: [[store, storeKey]],
-    },
-  })
+  return render(AddNewServicesCode)
 }
 
 describe('AddNewServicesCode.vue', () => {

--- a/src/app/onboarding/views/AddNewServicesCode.spec.ts
+++ b/src/app/onboarding/views/AddNewServicesCode.spec.ts
@@ -1,17 +1,17 @@
-import { flushPromises, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises } from '@vue/test-utils'
 import { render, screen } from '@testing-library/vue'
 
 import AddNewServicesCode from './AddNewServicesCode.vue'
 import { kumaApi } from '@/api/kumaApi'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
+
+const router = createRouter()
 
 function renderComponent() {
   return render(AddNewServicesCode, {
     global: {
-      plugins: [[store, storeKey]],
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
+      plugins: [router, [store, storeKey]],
     },
   })
 }

--- a/src/app/onboarding/views/CompletedView.spec.ts
+++ b/src/app/onboarding/views/CompletedView.spec.ts
@@ -1,15 +1,15 @@
-import { RouterLinkStub } from '@vue/test-utils'
 import { render } from '@testing-library/vue'
 
 import CompletedView from './CompletedView.vue'
+import { createRouter } from '@/router/router'
+
+const router = createRouter()
 
 describe('CompletedView.vue', () => {
   it('renders snapshot', () => {
     const { container } = render(CompletedView, {
       global: {
-        stubs: {
-          'router-link': RouterLinkStub,
-        },
+        plugins: [router],
       },
     })
 

--- a/src/app/onboarding/views/CompletedView.spec.ts
+++ b/src/app/onboarding/views/CompletedView.spec.ts
@@ -1,17 +1,10 @@
 import { render } from '@testing-library/vue'
 
 import CompletedView from './CompletedView.vue'
-import { createRouter } from '@/router/router'
-
-const router = createRouter()
 
 describe('CompletedView.vue', () => {
   it('renders snapshot', () => {
-    const { container } = render(CompletedView, {
-      global: {
-        plugins: [router],
-      },
-    })
+    const { container } = render(CompletedView)
 
     expect(container).toMatchSnapshot()
   })

--- a/src/app/onboarding/views/ConfigurationTypes.spec.ts
+++ b/src/app/onboarding/views/ConfigurationTypes.spec.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/vue'
 
 import ConfigurationTypes from './ConfigurationTypes.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
@@ -11,7 +11,6 @@ function renderComponent(mode = 'standalone') {
 
   return render(ConfigurationTypes, {
     global: {
-      plugins: [[store, storeKey]],
       stubs: {
         'router-link': {
           props: ['to'],

--- a/src/app/onboarding/views/CreateMesh.spec.ts
+++ b/src/app/onboarding/views/CreateMesh.spec.ts
@@ -2,7 +2,7 @@ import { flushPromises } from '@vue/test-utils'
 import { render, screen } from '@testing-library/vue'
 
 import CreateMesh from './CreateMesh.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
@@ -12,7 +12,6 @@ function renderComponent(mode = 'standalone') {
 
   return render(CreateMesh, {
     global: {
-      plugins: [[store, storeKey]],
       stubs: {
         routerLink: {
           props: ['to'],

--- a/src/app/onboarding/views/DeploymentTypes.spec.ts
+++ b/src/app/onboarding/views/DeploymentTypes.spec.ts
@@ -3,12 +3,10 @@ import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 
 import DeploymentTypes from './DeploymentTypes.vue'
-import { store, storeKey } from '@/store/store'
 
 function renderComponent() {
   return render(DeploymentTypes, {
     global: {
-      plugins: [[store, storeKey]],
       stubs: {
         routerLink: RouterLinkStub,
       },

--- a/src/app/onboarding/views/MultiZoneView.spec.ts
+++ b/src/app/onboarding/views/MultiZoneView.spec.ts
@@ -3,14 +3,9 @@ import { render, screen } from '@testing-library/vue'
 
 import MultiZoneView from './MultiZoneView.vue'
 import { kumaApi } from '@/api/kumaApi'
-import { store, storeKey } from '@/store/store'
 
 function renderComponent() {
-  return render(MultiZoneView, {
-    global: {
-      plugins: [[store, storeKey]],
-    },
-  })
+  return render(MultiZoneView)
 }
 
 describe('MultiZoneView.vue', () => {

--- a/src/app/onboarding/views/WelcomeView.spec.ts
+++ b/src/app/onboarding/views/WelcomeView.spec.ts
@@ -2,7 +2,7 @@ import { RouterLinkStub } from '@vue/test-utils'
 import { render } from '@testing-library/vue'
 
 import WelcomeView from './WelcomeView.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
@@ -12,9 +12,8 @@ function renderComponent(environment: string) {
 
   return render(WelcomeView, {
     global: {
-      plugins: [[store, storeKey]],
       stubs: {
-        routerLink: RouterLinkStub,
+        'router-link': RouterLinkStub,
       },
     },
   })

--- a/src/app/onboarding/views/__snapshots__/AddNewServices.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/AddNewServices.spec.ts.snap
@@ -93,6 +93,7 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
         <a
           class="medium rounded primary k-button navigation-button navigation-button--back"
           data-v-6f773baa=""
+          href="/onboarding/create-mesh"
           type="button"
         >
           
@@ -123,6 +124,7 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
             <a
               class="medium rounded primary k-button navigation-button navigation-button--next"
               data-v-6f773baa=""
+              href="/onboarding/add-services-code"
               type="button"
             >
               

--- a/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
@@ -222,6 +222,7 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
         <a
           class="medium rounded primary k-button navigation-button navigation-button--back"
           data-v-6f773baa=""
+          href="/onboarding/add-services"
           type="button"
         >
           
@@ -252,6 +253,7 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
             <a
               class="medium rounded primary k-button navigation-button navigation-button--next"
               data-v-6f773baa=""
+              href="/onboarding/dataplanes-overview"
               type="button"
             >
               

--- a/src/app/onboarding/views/__snapshots__/CompletedView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/CompletedView.spec.ts.snap
@@ -50,6 +50,7 @@ exports[`CompletedView.vue renders snapshot 1`] = `
             <a
               class="medium rounded primary k-button navigation-button navigation-button--next"
               data-v-6f773baa=""
+              href="/"
               type="button"
             >
               

--- a/src/app/onboarding/views/__snapshots__/MultiZoneView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/MultiZoneView.spec.ts.snap
@@ -133,10 +133,10 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
       <div
         class="mt-4 flex items-center flex-col sm:flex-row justify-between"
       >
-        <router-link
+        <a
           class="medium rounded primary k-button navigation-button navigation-button--back"
           data-v-6f773baa=""
-          to="[object Object]"
+          href="/onboarding/configuration-types"
           type="button"
         >
           
@@ -146,7 +146,7 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
            Back 
           
           <!---->
-        </router-link>
+        </a>
         <div>
           <button
             class="small rounded btn-link k-button skip-button"
@@ -164,11 +164,11 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
           <span
             class="inline-block cursor-not-allowed"
           >
-            <router-link
+            <a
               class="medium rounded primary k-button navigation-button navigation-button--next"
               data-v-6f773baa=""
               disabled="true"
-              to="[object Object]"
+              href="/onboarding/create-mesh"
               type="button"
             >
               
@@ -178,7 +178,7 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
               Next
               
               <!---->
-            </router-link>
+            </a>
           </span>
         </div>
       </div>

--- a/src/app/policies/components/PolicyConnections.spec.ts
+++ b/src/app/policies/components/PolicyConnections.spec.ts
@@ -3,16 +3,10 @@ import userEvent from '@testing-library/user-event'
 import { rest } from 'msw'
 
 import PolicyConnections from './PolicyConnections.vue'
-import { createRouter } from '@/router/router'
-import { server } from '@/../jest/jest-setup'
-
-const router = createRouter()
+import { server } from '@/../jest/jest-setup-after-env'
 
 function renderComponent(props = {}) {
   return render(PolicyConnections, {
-    global: {
-      plugins: [router],
-    },
     props,
   })
 }

--- a/src/app/policies/components/PolicyConnections.spec.ts
+++ b/src/app/policies/components/PolicyConnections.spec.ts
@@ -1,17 +1,17 @@
-import { RouterLinkStub } from '@vue/test-utils'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import { rest } from 'msw'
 
 import PolicyConnections from './PolicyConnections.vue'
+import { createRouter } from '@/router/router'
 import { server } from '@/../jest/jest-setup'
+
+const router = createRouter()
 
 function renderComponent(props = {}) {
   return render(PolicyConnections, {
     global: {
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
+      plugins: [router],
     },
     props,
   })

--- a/src/app/policies/components/__snapshots__/PolicyConnections.spec.ts.snap
+++ b/src/app/policies/components/__snapshots__/PolicyConnections.spec.ts.snap
@@ -45,7 +45,10 @@ exports[`PolicyConnections.vue renders snapshot 1`] = `
                       class="my-1"
                       data-testid="dataplane-name"
                     >
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/backend"
+                      >
                         backend
                       </a>
                     </p>
@@ -53,7 +56,10 @@ exports[`PolicyConnections.vue renders snapshot 1`] = `
                       class="my-1"
                       data-testid="dataplane-name"
                     >
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/db"
+                      >
                         db
                       </a>
                     </p>
@@ -61,7 +67,10 @@ exports[`PolicyConnections.vue renders snapshot 1`] = `
                       class="my-1"
                       data-testid="dataplane-name"
                     >
-                      <a>
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/frontend"
+                      >
                         frontend
                       </a>
                     </p>

--- a/src/app/policies/views/PolicyView.spec.ts
+++ b/src/app/policies/views/PolicyView.spec.ts
@@ -1,10 +1,8 @@
 import { flushPromises, mount } from '@vue/test-utils'
 
 import PolicyView from './PolicyView.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-
-const router = createRouter()
+import { router } from '@/../jest/jest-setup-after-env'
 
 async function createWrapper(props = {}) {
   router.currentRoute.value.name = 'home'
@@ -14,7 +12,7 @@ async function createWrapper(props = {}) {
   return mount(PolicyView, {
     props,
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/policies/views/PolicyView.spec.ts
+++ b/src/app/policies/views/PolicyView.spec.ts
@@ -1,19 +1,10 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
-import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 
 import PolicyView from './PolicyView.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 async function createWrapper(props = {}) {
   router.currentRoute.value.name = 'home'
@@ -24,9 +15,6 @@ async function createWrapper(props = {}) {
     props,
     global: {
       plugins: [router, [store, storeKey]],
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
     },
   })
 }

--- a/src/app/policies/views/PolicyView.spec.ts
+++ b/src/app/policies/views/PolicyView.spec.ts
@@ -1,7 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils'
 
 import PolicyView from './PolicyView.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { router } from '@/../jest/jest-setup-after-env'
 
 async function createWrapper(props = {}) {
@@ -11,9 +11,6 @@ async function createWrapper(props = {}) {
 
   return mount(PolicyView, {
     props,
-    global: {
-      plugins: [[store, storeKey]],
-    },
   })
 }
 

--- a/src/app/services/components/ExternalServiceDetails.spec.ts
+++ b/src/app/services/components/ExternalServiceDetails.spec.ts
@@ -1,22 +1,13 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
-import { shallowMount, RouterLinkStub } from '@vue/test-utils'
+import { shallowMount } from '@vue/test-utils'
 
 import ExternalServiceDetails from './ExternalServiceDetails.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { createExternalService } from '@/test-data/createExternalService'
 
 const externalService = createExternalService()
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 function renderComponent(props = {}) {
   return shallowMount(ExternalServiceDetails, {
@@ -26,9 +17,6 @@ function renderComponent(props = {}) {
     },
     global: {
       plugins: [router, [store, storeKey]],
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
     },
   })
 }

--- a/src/app/services/components/ExternalServiceDetails.spec.ts
+++ b/src/app/services/components/ExternalServiceDetails.spec.ts
@@ -1,7 +1,6 @@
 import { shallowMount } from '@vue/test-utils'
 
 import ExternalServiceDetails from './ExternalServiceDetails.vue'
-import { store, storeKey } from '@/store/store'
 import { createExternalService } from '@/test-data/createExternalService'
 
 const externalService = createExternalService()
@@ -11,9 +10,6 @@ function renderComponent(props = {}) {
     props: {
       externalService,
       ...props,
-    },
-    global: {
-      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/services/components/ExternalServiceDetails.spec.ts
+++ b/src/app/services/components/ExternalServiceDetails.spec.ts
@@ -1,13 +1,10 @@
 import { shallowMount } from '@vue/test-utils'
 
 import ExternalServiceDetails from './ExternalServiceDetails.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { createExternalService } from '@/test-data/createExternalService'
 
 const externalService = createExternalService()
-
-const router = createRouter()
 
 function renderComponent(props = {}) {
   return shallowMount(ExternalServiceDetails, {
@@ -16,7 +13,7 @@ function renderComponent(props = {}) {
       ...props,
     },
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/services/components/ServiceInsightDetails.spec.ts
+++ b/src/app/services/components/ServiceInsightDetails.spec.ts
@@ -1,7 +1,6 @@
 import { mount } from '@vue/test-utils'
 
 import ServiceInsightDetails from './ServiceInsightDetails.vue'
-import { store, storeKey } from '@/store/store'
 import { createServiceInsight } from '@/test-data/createServiceInsight'
 
 const serviceInsight = createServiceInsight()
@@ -12,9 +11,6 @@ function renderComponent(props = {}) {
     props: {
       serviceInsight,
       ...props,
-    },
-    global: {
-      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/services/components/ServiceInsightDetails.spec.ts
+++ b/src/app/services/components/ServiceInsightDetails.spec.ts
@@ -1,13 +1,10 @@
 import { mount } from '@vue/test-utils'
 
 import ServiceInsightDetails from './ServiceInsightDetails.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { createServiceInsight } from '@/test-data/createServiceInsight'
 
 const serviceInsight = createServiceInsight()
-
-const router = createRouter()
 
 function renderComponent(props = {}) {
   return mount(ServiceInsightDetails, {
@@ -17,7 +14,7 @@ function renderComponent(props = {}) {
       ...props,
     },
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/services/components/ServiceInsightDetails.spec.ts
+++ b/src/app/services/components/ServiceInsightDetails.spec.ts
@@ -1,22 +1,13 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
-import { mount, RouterLinkStub } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 
 import ServiceInsightDetails from './ServiceInsightDetails.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { createServiceInsight } from '@/test-data/createServiceInsight'
 
 const serviceInsight = createServiceInsight()
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 function renderComponent(props = {}) {
   return mount(ServiceInsightDetails, {
@@ -27,9 +18,6 @@ function renderComponent(props = {}) {
     },
     global: {
       plugins: [router, [store, storeKey]],
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
     },
   })
 }

--- a/src/app/wizard/views/DataplaneUniversal.spec.ts
+++ b/src/app/wizard/views/DataplaneUniversal.spec.ts
@@ -1,27 +1,13 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
 import { rest } from 'msw'
 import { render } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import DataplaneUniversal from './DataplaneUniversal.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { server } from '@/../jest/jest-setup'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-    {
-      path: '/create-mesh',
-      name: 'create-mesh',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 describe('DataplaneUniversal.vue', () => {
   beforeEach(() => {

--- a/src/app/wizard/views/DataplaneUniversal.spec.ts
+++ b/src/app/wizard/views/DataplaneUniversal.spec.ts
@@ -3,11 +3,8 @@ import { render } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import DataplaneUniversal from './DataplaneUniversal.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
-import { server } from '@/../jest/jest-setup'
-
-const router = createRouter()
+import { server } from '@/../jest/jest-setup-after-env'
 
 describe('DataplaneUniversal.vue', () => {
   beforeEach(() => {
@@ -39,7 +36,7 @@ describe('DataplaneUniversal.vue', () => {
 
     const { container, getByText, getByDisplayValue, getByLabelText, findByText } = render(DataplaneUniversal, {
       global: {
-        plugins: [router, [store, storeKey]],
+        plugins: [[store, storeKey]],
       },
     })
 

--- a/src/app/wizard/views/DataplaneUniversal.spec.ts
+++ b/src/app/wizard/views/DataplaneUniversal.spec.ts
@@ -3,7 +3,7 @@ import { render } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import DataplaneUniversal from './DataplaneUniversal.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { server } from '@/../jest/jest-setup-after-env'
 
 describe('DataplaneUniversal.vue', () => {
@@ -34,11 +34,7 @@ describe('DataplaneUniversal.vue', () => {
       },
     ]
 
-    const { container, getByText, getByDisplayValue, getByLabelText, findByText } = render(DataplaneUniversal, {
-      global: {
-        plugins: [[store, storeKey]],
-      },
-    })
+    const { container, getByText, getByDisplayValue, getByLabelText, findByText } = render(DataplaneUniversal)
 
     const select = <HTMLInputElement>getByDisplayValue('Select an existing Mesh…')
     const nextButton = getByText(/Next ›/i).closest('button')

--- a/src/app/wizard/views/Mesh.spec.ts
+++ b/src/app/wizard/views/Mesh.spec.ts
@@ -2,12 +2,9 @@ import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 
 import Mesh from './Mesh.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
-
-const router = createRouter()
 
 function renderComponent(mode = 'standalone') {
   store.state.config.tagline = import.meta.env.VITE_NAMESPACE
@@ -17,7 +14,7 @@ function renderComponent(mode = 'standalone') {
 
   return render(Mesh, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/wizard/views/Mesh.spec.ts
+++ b/src/app/wizard/views/Mesh.spec.ts
@@ -1,27 +1,13 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 
 import Mesh from './Mesh.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-    {
-      path: '/create-mesh',
-      name: 'create-mesh',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 function renderComponent(mode = 'standalone') {
   store.state.config.tagline = import.meta.env.VITE_NAMESPACE

--- a/src/app/wizard/views/Mesh.spec.ts
+++ b/src/app/wizard/views/Mesh.spec.ts
@@ -2,7 +2,7 @@ import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
 
 import Mesh from './Mesh.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
@@ -12,11 +12,7 @@ function renderComponent(mode = 'standalone') {
   const clientConfig: ClientConfigInterface = { ...config, mode }
   store.state.config.clientConfig = clientConfig
 
-  return render(Mesh, {
-    global: {
-      plugins: [[store, storeKey]],
-    },
-  })
+  return render(Mesh)
 }
 
 describe('Mesh.vue', () => {

--- a/src/app/zones/views/ZoneEgresses.spec.ts
+++ b/src/app/zones/views/ZoneEgresses.spec.ts
@@ -3,12 +3,9 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import ZoneEgresses from './ZoneEgresses.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
-
-const router = createRouter()
 
 jest.mock('@/utilities/helpers', () => {
   const originalModule = jest.requireActual('@/utilities/helpers')
@@ -27,7 +24,7 @@ function renderComponent(mode = 'standalone') {
 
   return render(ZoneEgresses, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/zones/views/ZoneEgresses.spec.ts
+++ b/src/app/zones/views/ZoneEgresses.spec.ts
@@ -1,23 +1,14 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
-import { flushPromises, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises } from '@vue/test-utils'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import ZoneEgresses from './ZoneEgresses.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 jest.mock('@/utilities/helpers', () => {
   const originalModule = jest.requireActual('@/utilities/helpers')
@@ -37,14 +28,6 @@ function renderComponent(mode = 'standalone') {
   return render(ZoneEgresses, {
     global: {
       plugins: [router, [store, storeKey]],
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
-      mocks: {
-        $route: {
-          query: {},
-        },
-      },
     },
   })
 }

--- a/src/app/zones/views/ZoneEgresses.spec.ts
+++ b/src/app/zones/views/ZoneEgresses.spec.ts
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import ZoneEgresses from './ZoneEgresses.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
@@ -22,11 +22,7 @@ function renderComponent(mode = 'standalone') {
   const clientConfig: ClientConfigInterface = { ...config, mode }
   store.state.config.clientConfig = clientConfig
 
-  return render(ZoneEgresses, {
-    global: {
-      plugins: [[store, storeKey]],
-    },
-  })
+  return render(ZoneEgresses)
 }
 
 describe('ZoneEgresses.vue', () => {

--- a/src/app/zones/views/ZoneIngresses.spec.ts
+++ b/src/app/zones/views/ZoneIngresses.spec.ts
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import ZoneIngresses from './ZoneIngresses.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
@@ -22,11 +22,7 @@ function renderComponent(mode = 'standalone') {
   const clientConfig: ClientConfigInterface = { ...config, mode }
   store.state.config.clientConfig = clientConfig
 
-  return render(ZoneIngresses, {
-    global: {
-      plugins: [[store, storeKey]],
-    },
-  })
+  return render(ZoneIngresses)
 }
 
 describe('ZoneIngresses.vue', () => {

--- a/src/app/zones/views/ZoneIngresses.spec.ts
+++ b/src/app/zones/views/ZoneIngresses.spec.ts
@@ -3,12 +3,9 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import ZoneIngresses from './ZoneIngresses.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
-
-const router = createRouter()
 
 jest.mock('@/utilities/helpers', () => {
   const originalModule = jest.requireActual('@/utilities/helpers')
@@ -27,7 +24,7 @@ function renderComponent(mode = 'standalone') {
 
   return render(ZoneIngresses, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/app/zones/views/ZoneIngresses.spec.ts
+++ b/src/app/zones/views/ZoneIngresses.spec.ts
@@ -1,23 +1,14 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
-import { flushPromises, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises } from '@vue/test-utils'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import ZoneIngresses from './ZoneIngresses.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 jest.mock('@/utilities/helpers', () => {
   const originalModule = jest.requireActual('@/utilities/helpers')
@@ -37,14 +28,6 @@ function renderComponent(mode = 'standalone') {
   return render(ZoneIngresses, {
     global: {
       plugins: [router, [store, storeKey]],
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
-      mocks: {
-        $route: {
-          query: {},
-        },
-      },
     },
   })
 }

--- a/src/app/zones/views/ZonesView.spec.ts
+++ b/src/app/zones/views/ZonesView.spec.ts
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import ZonesView from './ZonesView.vue'
-import { store, storeKey } from '@/store/store'
+import { store } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
@@ -21,11 +21,7 @@ function renderComponent(mode = 'standalone') {
   const clientConfig: ClientConfigInterface = { ...config, mode }
   store.state.config.clientConfig = clientConfig
 
-  return render(ZonesView, {
-    global: {
-      plugins: [[store, storeKey]],
-    },
-  })
+  return render(ZonesView)
 }
 
 describe('ZonesView.vue', () => {

--- a/src/app/zones/views/ZonesView.spec.ts
+++ b/src/app/zones/views/ZonesView.spec.ts
@@ -1,23 +1,13 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
-import { RouterLinkStub } from '@vue/test-utils'
 import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import ZonesView from './ZonesView.vue'
+import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    {
-      path: '/',
-      name: 'home',
-      component: { template: 'TestComponent' },
-    },
-  ],
-})
+const router = createRouter()
 
 jest.mock('@/utilities/helpers', () => {
   const originalModule = jest.requireActual('@/utilities/helpers')
@@ -37,14 +27,6 @@ function renderComponent(mode = 'standalone') {
   return render(ZonesView, {
     global: {
       plugins: [router, [store, storeKey]],
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
-      mocks: {
-        $route: {
-          query: {},
-        },
-      },
     },
   })
 }

--- a/src/app/zones/views/ZonesView.spec.ts
+++ b/src/app/zones/views/ZonesView.spec.ts
@@ -2,12 +2,9 @@ import { render, screen } from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 
 import ZonesView from './ZonesView.vue'
-import { createRouter } from '@/router/router'
 import { store, storeKey } from '@/store/store'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
-
-const router = createRouter()
 
 jest.mock('@/utilities/helpers', () => {
   const originalModule = jest.requireActual('@/utilities/helpers')
@@ -26,7 +23,7 @@ function renderComponent(mode = 'standalone') {
 
   return render(ZonesView, {
     global: {
-      plugins: [router, [store, storeKey]],
+      plugins: [[store, storeKey]],
     },
   })
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { addLicense, useTheme } from '@amcharts/amcharts4/core'
 import am4themesAnimated from '@amcharts/amcharts4/themes/animated'
 
 import App from './app/App.vue'
-import { setupRouter } from './router/router'
+import { createRouter } from './router/router'
 import { storeKey, store } from './store/store'
 import { setupDatadog } from './utilities/setupDatadog'
 import { kumaApi } from './api/kumaApi'
@@ -47,11 +47,14 @@ async function initializeVue() {
 
   app.use(store, storeKey)
 
-  // Fetches basic resources before setting up the router and mounting the application.
-  // This is mainly needed to properly redirect users to the onboarding flow in the appropriate scenarios.
-  await store.dispatch('bootstrap')
+  await Promise.all([
+    // Fetches basic resources before setting up the router and mounting the application. This is mainly needed to properly redirect users to the onboarding flow in the appropriate scenarios.
+    store.dispatch('bootstrap'),
+    // Loads available policies in order to populate the necessary routes.
+    store.dispatch('fetchPolicies'),
+  ])
 
-  const router = await setupRouter()
+  const router = await createRouter(store.state.policies)
 
   app.use(router)
 

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHashHistory, NavigationGuard, RouteRecordRaw } from 'vue-router'
+import { createRouter as createVueRouter, createWebHistory, NavigationGuard, Router, RouteRecordRaw } from 'vue-router'
 
 import { store } from '@/store/store'
 import { PolicyDefinition } from '@/types/index.d'
@@ -19,10 +19,8 @@ function getPolicyRoutes(policies: PolicyDefinition[]): RouteRecordRaw[] {
   }))
 }
 
-export async function setupRouter() {
-  // Loads available policies in order to populate the necessary routes.
-  await store.dispatch('fetchPolicies')
-  const policyRoutes = getPolicyRoutes(store.state.policies)
+export function createRouter(policyDefinitions: PolicyDefinition[] = []): Router {
+  const policyRoutes = getPolicyRoutes(policyDefinitions)
 
   const routes: readonly RouteRecordRaw[] = [
     {
@@ -283,8 +281,8 @@ export async function setupRouter() {
     },
   ]
 
-  const router = createRouter({
-    history: createWebHashHistory(import.meta.env.BASE_URL),
+  const router = createVueRouter({
+    history: createWebHistory(import.meta.env.BASE_URL),
     routes,
   })
 

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -286,10 +286,22 @@ export function createRouter(policyDefinitions: PolicyDefinition[] = []): Router
     routes,
   })
 
+  router.beforeEach(redirectOldHashHistoryUrlPaths)
   router.beforeEach(updateSelectedMeshGuard)
   router.beforeEach(onboardingRouteGuard)
 
   return router
+}
+
+/**
+ * Redirects navigations to old hash history-style URL paths.
+ */
+const redirectOldHashHistoryUrlPaths: NavigationGuard = function (to, _from, next) {
+  if (to.fullPath.startsWith('/#/')) {
+    next(to.fullPath.substring(2))
+  } else {
+    next()
+  }
 }
 
 /**

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -126,8 +126,7 @@ const initialState: BareRootState = {
 
 export interface State extends BareRootState {
   /**
-   * Explicitly adds the types for all modules here
-   * because the created store for some reason doesn’t have module types at all.
+   * Explicitly adds the types for all modules here because the created store doesn’t have module types at all.
    */
   config: ConfigInterface
   sidebar: SidebarInterface
@@ -143,11 +142,10 @@ export const storeConfig: StoreOptions<State> = {
     onboarding,
   },
   // Note: *Technically*, `initialState` here doesn’t hold all properties from `State`. All module state is missing. However, the module state MUST NOT be made optional in `State` as otherwise, it will be considered as optional when accessing, for example, `store.state.config.status`.
-  state: initialState as State,
+  state: () => initialState as State,
   getters: {
     globalLoading: state => state.globalLoading,
     getMeshList: state => state.meshes,
-
     getItemQueryNamespace: state => state.itemQueryNamespace,
     getMeshInsight: state => state.meshInsight,
     getMeshInsightsFetching: state => state.meshInsightsFetching,

--- a/src/store/modules/config/config.spec.ts
+++ b/src/store/modules/config/config.spec.ts
@@ -69,6 +69,7 @@ describe('config module', () => {
           hostname: '',
           instanceId: '',
           clusterId: '',
+          gui: '',
         },
         {
           tagline: 'Other',
@@ -84,6 +85,7 @@ describe('config module', () => {
           hostname: '',
           instanceId: '',
           clusterId: '',
+          gui: '',
         },
         {
           tagline: 'Other',
@@ -99,6 +101,7 @@ describe('config module', () => {
           hostname: '',
           instanceId: '',
           clusterId: '',
+          gui: '',
         },
         {
           tagline: import.meta.env.VITE_NAMESPACE,
@@ -113,6 +116,7 @@ describe('config module', () => {
           hostname: '',
           instanceId: '',
           clusterId: '',
+          gui: '',
         },
         {
           tagline: import.meta.env.VITE_NAMESPACE,

--- a/src/store/modules/config/config.ts
+++ b/src/store/modules/config/config.ts
@@ -1,6 +1,6 @@
 import { ActionTree, GetterTree, MutationTree } from 'vuex'
 
-import { State } from '../../index'
+import { State } from '../../storeConfig'
 import { ConfigInterface, ClientConfigInterface } from './config.types'
 import { kumaApi } from '@/api/kumaApi'
 

--- a/src/store/modules/config/config.ts
+++ b/src/store/modules/config/config.ts
@@ -29,24 +29,16 @@ const getters: GetterTree<ConfigInterface, State> = {
   getVersion: state => state.version,
   getKumaDocsVersion: state => state.kumaDocsVersion,
   getConfigurationType: state => state.clientConfig?.store?.type,
-
   getMulticlusterStatus: (_state, getters) => {
-    // is Kuma running in Multi-Zone mode?
-
-    let status
-
     if (import.meta.env.DEV && import.meta.env.VITE_FAKE_MULTIZONE === 'true') {
-      status = true
-
       console.warn(
         '%c ✨You are currently faking Multi-Zone mode.',
         'background: black; color: white; display: block; padding: 0.25rem;',
       )
-    } else {
-      status = getters.getMode === 'global'
+      return true
     }
 
-    return status
+    return getters.getMode === 'global'
   },
 }
 
@@ -57,6 +49,7 @@ const actions: ActionTree<ConfigInterface, State> = {
 
     return Promise.all([infoPromise, configPromise])
   },
+
   // get the general Kuma config (this differs from the API config endpoint)
   getConfig({ commit }) {
     return kumaApi.getConfig().then((response) => {
@@ -100,7 +93,7 @@ const actions: ActionTree<ConfigInterface, State> = {
 
 const configModule = {
   namespaced: true,
-  state: initialConfigState,
+  state: () => initialConfigState,
   getters,
   mutations,
   actions,

--- a/src/store/modules/notifications/notifications.spec.ts
+++ b/src/store/modules/notifications/notifications.spec.ts
@@ -1,23 +1,38 @@
-import { createStore } from 'vuex'
+// import { createStore } from 'vuex'
 
-import { storeConfig, State } from '../../index'
-
-const store = createStore<State>(storeConfig)
+// import { storeConfig, State } from '../../index'
+import notificationsModule from './notifications'
 
 describe('notifications module', () => {
   describe('getters', () => {
     it('tests singleMeshNotificationItems getter ', () => {
-      store.state.meshes.items = [
-        {
-          name: 'web-to-backend.kuma-system',
-          creationTime: '0001-01-01T00:00:00Z',
-          modificationTime: '0001-01-01T00:00:00Z',
-          type: 'Mesh',
+      const rootState: any = {
+        selectedMesh: 'web-to-backend.kuma-system',
+        meshes: {
+          items: [
+            {
+              name: 'web-to-backend.kuma-system',
+              creationTime: '0001-01-01T00:00:00Z',
+              modificationTime: '0001-01-01T00:00:00Z',
+              type: 'Mesh',
+            },
+          ],
         },
-      ]
-      store.state.selectedMesh = 'web-to-backend.kuma-system'
+      }
+      const getters = {
+        meshNotificationItemMap: {
+          'web-to-backend.kuma-system': {
+            hasLogging: false,
+            hasMtls: false,
+            hasMetrics: false,
+            hasTracing: false,
+          },
+        },
+      }
 
-      expect(store.getters['notifications/singleMeshNotificationItems']).toMatchInlineSnapshot(`
+      const result = notificationsModule.getters.singleMeshNotificationItems(notificationsModule.state(), getters, rootState, undefined)
+
+      expect(result).toMatchInlineSnapshot(`
 [
   {
     "component": "MetricsNotification",
@@ -44,27 +59,44 @@ describe('notifications module', () => {
     })
 
     it('tests meshNotificationItemMapWithAction getter', () => {
-      store.state.meshes.items = [
-        {
-          name: 'test-1',
-          creationTime: '0001-01-01T00:00:00Z',
-          modificationTime: '0001-01-01T00:00:00Z',
-          type: 'Mesh',
-          logging: {},
-          mtls: {},
-          tracing: {},
-          metrics: {},
+      const rootState: any = {
+        meshes: {
+          items: [
+            {
+              name: 'test-1',
+              creationTime: '0001-01-01T00:00:00Z',
+              modificationTime: '0001-01-01T00:00:00Z',
+              type: 'Mesh',
+              logging: {},
+              mtls: {},
+              tracing: {},
+              metrics: {},
+            },
+            {
+              name: 'test-2',
+              creationTime: '0001-01-01T00:00:00Z',
+              modificationTime: '0001-01-01T00:00:00Z',
+              type: 'Mesh',
+              mtls: {},
+            },
+          ],
         },
-        {
-          name: 'test-2',
-          creationTime: '0001-01-01T00:00:00Z',
-          modificationTime: '0001-01-01T00:00:00Z',
-          type: 'Mesh',
-          mtls: {},
-        },
-      ]
+      }
 
-      expect(store.getters['notifications/meshNotificationItemMapWithAction']).toMatchInlineSnapshot(`
+      const getters = {
+        meshNotificationItemMap: {
+          'test-2': {
+            hasLogging: false,
+            hasMtls: true,
+            hasMetrics: false,
+            hasTracing: false,
+          },
+        },
+      }
+
+      const result = notificationsModule.getters.meshNotificationItemMapWithAction(notificationsModule.state(), getters, rootState, undefined)
+
+      expect(result).toMatchInlineSnapshot(`
 {
   "test-2": {
     "hasLogging": false,
@@ -77,24 +109,47 @@ describe('notifications module', () => {
     })
 
     it('tests amountOfActions getter', () => {
-      store.state.meshes.items = [
-        {
-          name: 'test-1',
-          creationTime: '0001-01-01T00:00:00Z',
-          modificationTime: '0001-01-01T00:00:00Z',
-          type: 'Mesh',
-          logging: {},
+      const rootState: any = {
+        meshes: {
+          items: [
+            {
+              name: 'test-1',
+              creationTime: '0001-01-01T00:00:00Z',
+              modificationTime: '0001-01-01T00:00:00Z',
+              type: 'Mesh',
+              logging: {},
+            },
+            {
+              name: 'test-2',
+              creationTime: '0001-01-01T00:00:00Z',
+              modificationTime: '0001-01-01T00:00:00Z',
+              type: 'Mesh',
+              mtls: {},
+            },
+          ],
         },
-        {
-          name: 'test-2',
-          creationTime: '0001-01-01T00:00:00Z',
-          modificationTime: '0001-01-01T00:00:00Z',
-          type: 'Mesh',
-          mtls: {},
-        },
-      ]
+      }
 
-      expect(store.getters['notifications/amountOfActions']).toBe(2)
+      const getters = {
+        meshNotificationItemMapWithAction: {
+          'test-1': {
+            hasLogging: false,
+            hasMetrics: false,
+            hasMtls: false,
+            hasTracing: false,
+          },
+          'test-2': {
+            hasLogging: false,
+            hasMetrics: false,
+            hasMtls: true,
+            hasTracing: false,
+          },
+        },
+      }
+
+      const result = notificationsModule.getters.amountOfActions(notificationsModule.state(), getters, rootState, undefined)
+
+      expect(result).toBe(2)
     })
   })
 })

--- a/src/store/modules/notifications/notifications.spec.ts
+++ b/src/store/modules/notifications/notifications.spec.ts
@@ -1,6 +1,3 @@
-// import { createStore } from 'vuex'
-
-// import { storeConfig, State } from '../../index'
 import notificationsModule from './notifications'
 
 describe('notifications module', () => {

--- a/src/store/modules/notifications/notifications.ts
+++ b/src/store/modules/notifications/notifications.ts
@@ -100,7 +100,7 @@ const actions: ActionTree<NotificationsInterface, State> = {
 
 const notificationsModule = {
   namespaced: true,
-  state: initialNotificationsState,
+  state: () => initialNotificationsState,
   getters,
   mutations,
   actions,

--- a/src/store/modules/notifications/notifications.ts
+++ b/src/store/modules/notifications/notifications.ts
@@ -1,6 +1,6 @@
 import { ActionTree, GetterTree, MutationTree } from 'vuex'
 
-import { State } from '../../index'
+import { State } from '../../storeConfig'
 import { NotificationsInterface, NotificationItem, MeshNotificationItem } from './notifications.types'
 import { Mesh } from '@/types/index.d'
 

--- a/src/store/modules/onboarding/onboarding.ts
+++ b/src/store/modules/onboarding/onboarding.ts
@@ -1,5 +1,5 @@
 import { ActionTree, GetterTree, MutationTree } from 'vuex'
-import { State } from '../../index'
+import { State } from '../../storeConfig'
 import { OnboardingInterface } from './onboarding.types'
 import { ClientStorage } from '@/utilities/ClientStorage'
 

--- a/src/store/modules/onboarding/onboarding.ts
+++ b/src/store/modules/onboarding/onboarding.ts
@@ -47,7 +47,7 @@ const actions: ActionTree<OnboardingInterface, State> = {
 
 const onboardingModule = {
   namespaced: true,
-  state: initialOnboardingState,
+  state: () => initialOnboardingState,
   getters,
   mutations,
   actions,

--- a/src/store/modules/sidebar/sidebar.spec.ts
+++ b/src/store/modules/sidebar/sidebar.spec.ts
@@ -1,15 +1,26 @@
-import { createStore } from 'vuex'
-
-import { storeConfig, State } from '../../index'
+import sidebarModule from './sidebar'
 
 describe('sidebar module', () => {
   describe('actions', () => {
     it('tests getInsights action', async () => {
-      const store = createStore<State>(storeConfig)
+      const rootState: any = {
+        selectedMesh: 'default',
+      }
+      const state: any = sidebarModule.state()
 
-      await store.dispatch('sidebar/getInsights')
+      function commit(type: string, status: any): void {
+        sidebarModule.mutations[type](state, status)
+      }
 
-      expect(store.state.sidebar).toMatchInlineSnapshot(`
+      function dispatch(type: string): void {
+        // @ts-ignore I can’t be bothered to battle Vuex’s loose types right now.
+        return sidebarModule.actions[type]({ commit, state, rootState })
+      }
+
+      // @ts-ignore I can’t be bothered to battle Vuex’s loose types right now.
+      await sidebarModule.actions.getInsights({ dispatch })
+
+      expect(state).toMatchInlineSnapshot(`
 {
   "insights": {
     "global": {

--- a/src/store/modules/sidebar/sidebar.ts
+++ b/src/store/modules/sidebar/sidebar.ts
@@ -69,7 +69,7 @@ const actions: ActionTree<SidebarInterface, State> = {
 
 const sidebarModule = {
   namespaced: true,
-  state: initialSidebarState,
+  state: () => initialSidebarState,
   getters,
   mutations,
   actions,

--- a/src/store/modules/sidebar/sidebar.ts
+++ b/src/store/modules/sidebar/sidebar.ts
@@ -1,6 +1,6 @@
 import { ActionTree, GetterTree, MutationTree } from 'vuex'
 
-import { State } from '../../index'
+import { State } from '../../storeConfig'
 import { calculateMeshInsights, calculateGlobalInsights } from './utils'
 import { SidebarInterface } from './sidebar.types'
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,7 +1,7 @@
 import { InjectionKey } from 'vue'
 import { createStore, useStore as useVuexStore, Store } from 'vuex'
 
-import { storeConfig, State } from './index'
+import { storeConfig, State } from './storeConfig'
 
 export const storeKey: InjectionKey<Store<State>> = Symbol('store')
 

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -20,6 +20,9 @@ import { Mesh, PolicyDefinition } from '@/types/index.d'
 
 type TODO = any
 
+/**
+ * The root state of the application’s Vuex store minus all module state.
+ */
 interface BareRootState {
   menu: null
   globalLoading: boolean
@@ -124,10 +127,12 @@ const initialState: BareRootState = {
   policiesByType: {},
 }
 
+/**
+ * The root state of the application’s Vuex store including all module state.
+ *
+ * Module state is explicitly added because creating a store using modules needs it. By default, Vuex’s types for stores with namespaced modules will be incorrect.
+ */
 export interface State extends BareRootState {
-  /**
-   * Explicitly adds the types for all modules here because the created store doesn’t have module types at all.
-   */
   config: ConfigInterface
   sidebar: SidebarInterface
   notifications: NotificationsInterface
@@ -141,7 +146,7 @@ export const storeConfig: StoreOptions<State> = {
     notifications,
     onboarding,
   },
-  // Note: *Technically*, `initialState` here doesn’t hold all properties from `State`. All module state is missing. However, the module state MUST NOT be made optional in `State` as otherwise, it will be considered as optional when accessing, for example, `store.state.config.status`.
+  // Explicitly asserts `initialState` to be of type `State` (which includes module state) even though `initialSate` doesn’t include module state. This is necessary because otherwise the result of creating a store from `storeConfig` and `State` will be a store (i.e. `Store<State>`) that, according to its type, is missing all module state which it actually doesn’t. Vuex’s types aren’t complete and don’t account for this scenario. Without this workaround, accessing module state without a type guard would always produce a TypeScript error.
   state: () => initialState as State,
   getters: {
     globalLoading: state => state.globalLoading,
@@ -165,8 +170,6 @@ export const storeConfig: StoreOptions<State> = {
     SET_SELECTED_MESH: (state, mesh) => (state.selectedMesh = mesh),
     SET_TOTAL_DATAPLANE_COUNT: (state, count) => (state.totalDataplaneCount = count),
     SET_TOTAL_CLUSTER_COUNT: (state, count) => (state.totalClusters = count),
-
-    // NEW
     SET_INTERNAL_SERVICE_SUMMARY: (state, { items = [] } = {}) => {
       const { serviceSummary } = state
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -20,6 +20,7 @@ export type Info = {
   basedOnKuma?: string
   instanceId: string
   clusterId: string
+  gui: string
 }
 
 export interface KDSSubscription {

--- a/src/utilities/patchQueryParam.ts
+++ b/src/utilities/patchQueryParam.ts
@@ -1,38 +1,16 @@
 /**
- * Patches the query parameters when using vue router’s hash mode for navigation using the History API.
+ * Patches the query parameters when using vue router’s history mode for navigation.
  *
- * This is a hack. It’s necessary because vue router’s hash mode doesn’t provide a mechanism for manipulating the URL’s query parameters without also triggering a navigation.
+ * @param value sets/updates `name` if value if is a string or number; otherwise, deletes `name`.
  */
 export function patchQueryParam(name: string, value: string | number | null | undefined): void {
-  const state = window.history.state
-
-  if (state === null) {
-    return
-  }
-
-  const queryStart = state.current.indexOf('?')
-  const queryString = queryStart > -1 ? state.current.substring(queryStart) : ''
-  const params = new URLSearchParams(queryString)
+  const url = new URL(window.location.href)
 
   if (value !== null && value !== undefined) {
-    params.set(name, String(value))
-  } else if (params.has(name)) {
-    params.delete(name)
+    url.searchParams.set(name, String(value))
+  } else if (url.searchParams.has(name)) {
+    url.searchParams.delete(name)
   }
 
-  const newQueryString = params.toString()
-  const completeQueryString = newQueryString === '' ? '' : '?' + newQueryString
-
-  let newCurrent = ''
-  if (queryStart > -1) {
-    newCurrent = state.current.substring(0, queryStart) + completeQueryString
-  } else {
-    newCurrent = state.current + completeQueryString
-  }
-
-  if (state.current !== newCurrent) {
-    const updatedState = Object.assign({}, state)
-    updatedState.current = newCurrent
-    window.history.replaceState(updatedState, '', '#' + newCurrent)
-  }
+  window.history.replaceState({ path: url.href }, '', url.href)
 }


### PR DESCRIPTION
Switches from hash history mode to web history mode. Most notably this changes the GUI to have true URL paths without a `/#/` segment which allows us to use fragment identifiers ourselves.

Moves the vue router boilerplate to a Jest setup after env file which allows us to remove it from all tests.

Moves the vuex boilerplate to a Jest setup after env file which allows us to remove it from all tests.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>