### PR TITLE
fix(data-planes): calling gateway type provided

### DIFF
--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -147,7 +147,7 @@ const dataPlaneTypes = [
   'All',
   'Standard',
   'Gateway (builtin)',
-  'Gateway (provided)',
+  'Gateway (delegated)',
 ]
 
 const route = useRoute()

--- a/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
+++ b/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
@@ -44,9 +44,9 @@ exports[`DataPlaneListView.vue matches snapshot 1`] = `
               Gateway (builtin)
             </option>
             <option
-              value="Gateway (provided)"
+              value="Gateway (delegated)"
             >
-              Gateway (provided)
+              Gateway (delegated)
             </option>
             
           </select>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -129,7 +129,7 @@ export type DataPlaneNetworking = {
   }[]
   gateway?: {
     tags: Record<string, string>
-    type?: 'builtin' | 'provided' | undefined
+    type?: 'builtin' | 'delegated' | undefined
   },
 }
 

--- a/src/utilities/dataplane.ts
+++ b/src/utilities/dataplane.ts
@@ -195,7 +195,7 @@ export function parseMTLSData(dataPlaneOverview: DataPlaneOverview): DataPlaneEn
 }
 
 /**
- * @returns `'Standard' | 'Gateway' | 'Gateway (builtin)' | 'Gateway (provided)'`
+ * @returns `'Standard' | 'Gateway' | 'Gateway (builtin)' | 'Gateway (delegated)'`
  */
 export function getDataplaneType(dataplane: { networking: DataPlaneNetworking }): string {
   const { gateway } = dataplane.networking


### PR DESCRIPTION
Fixes an issue where one of the gateway types was called "provided" instead of "delegated".

Fixes #437.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>