### PR TITLE
feat: Add a GH Star button

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:ci": "cross-env VITE_MOCK_API_ENABLED=true VITE_FAKE_MULTIZONE=true yarn run build",
     "lint": "eslint --ext .js,.ts,.vue --fix .",
     "lint:lockfile": "lockfile-lint --path yarn.lock --allowed-hosts yarn --validate-https",
-    "test": "cross-env TZ=UTC jest",
+    "test": "cross-env TZ=UTC jest -i ./src/app/App.spec.ts",
     "test:watch": "yarn run test --watch"
   },
   "engines": {
@@ -30,6 +30,7 @@
     "semver-compare": "^1.0.0",
     "tailwindcss": "^3.2.2",
     "vue": "^3.2.41",
+    "vue-github-button": "^3.1.0",
     "vue-router": "^4.1.6",
     "vuex": "^4.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:ci": "cross-env VITE_MOCK_API_ENABLED=true VITE_FAKE_MULTIZONE=true yarn run build",
     "lint": "eslint --ext .js,.ts,.vue --fix .",
     "lint:lockfile": "lockfile-lint --path yarn.lock --allowed-hosts yarn --validate-https",
-    "test": "cross-env TZ=UTC jest -i ./src/app/App.spec.ts",
+    "test": "cross-env TZ=UTC jest",
     "test:watch": "yarn run test --watch"
   },
   "engines": {

--- a/src/app/App.spec.ts
+++ b/src/app/App.spec.ts
@@ -3,6 +3,10 @@ import { render, screen, waitForElementToBeRemoved } from '@testing-library/vue'
 import App from './App.vue'
 import { store } from '@/store/store'
 
+// jest can't import this module properly due to transpiling issues
+// mock this out with a blank element
+jest.mock('vue-github-button', () => ({ template: '<span />' }))
+
 function renderComponent(status: string) {
   store.state.globalLoading = true
   store.state.config.tagline = import.meta.env.VITE_NAMESPACE
@@ -13,10 +17,14 @@ function renderComponent(status: string) {
       stubs: {
         // Let’s not unnecessarily render all that chart markup.
         DonutChart: true,
+        // keeps the github-button as a <github-button> instead of a span in
+        // the snapshot so its as close to actual usage as possible
+        GithubButton: true,
       },
     },
   })
 }
+
 
 describe('App.vue', () => {
   it('renders main view when successful', async () => {

--- a/src/app/AppHeader.vue
+++ b/src/app/AppHeader.vue
@@ -10,6 +10,7 @@
       </router-link>
 
       <GithubButton
+        class="gh-star"
         href="https://github.com/kumahq/kuma"
         aria-label="Star kumahq/kuma on GitHub"
       >
@@ -102,6 +103,9 @@ const mode = computed(() => store.getters['config/getMulticlusterStatus'] ? 'Mul
 
 .logo-image {
   max-height: 36px;
+}
+.gh-star {
+  height: 20px;
 }
 
 .horizontal-list {

--- a/src/app/AppHeader.vue
+++ b/src/app/AppHeader.vue
@@ -9,6 +9,13 @@
         >
       </router-link>
 
+      <GithubButton
+        href="https://github.com/kumahq/kuma"
+        aria-label="Star kumahq/kuma on GitHub"
+      >
+        Star
+      </GithubButton>
+
       <div class="upgrade-check-wrapper">
         <UpgradeCheck />
       </div>
@@ -54,6 +61,7 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 import { KButton, KIcon, KPop } from '@kong/kongponents'
+import GithubButton from 'vue-github-button'
 
 import { useStore } from '@/store/store'
 import NotificationIcon from './common/NotificationIcon.vue'

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -19,6 +19,10 @@ exports[`App.vue fails to renders basic view 1`] = `
           class="logo-image"
         />
       </a>
+      <github-button-stub
+        aria-label="Star kumahq/kuma on GitHub"
+        href="https://github.com/kumahq/kuma"
+      />
       <div
         class="upgrade-check-wrapper"
       >

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -21,6 +21,7 @@ exports[`App.vue fails to renders basic view 1`] = `
       </a>
       <github-button-stub
         aria-label="Star kumahq/kuma on GitHub"
+        class="gh-star"
         href="https://github.com/kumahq/kuma"
       />
       <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -3947,6 +3947,11 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+github-buttons@^2.22.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/github-buttons/-/github-buttons-2.22.0.tgz#b2669f8504ce5496ab37b7ce53e8ed01db9818bc"
+  integrity sha512-N5bk01s1WgK1FVtoeSUVkRkJpkaSu8yHMPcjye+PTa0jsRjMRNrYqVLgpUf2RA5Kvec05DfHYAT6/68fwkdqPw==
+
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -6902,6 +6907,13 @@ vue-eslint-parser@^9.0.0, vue-eslint-parser@^9.0.1:
     esquery "^1.4.0"
     lodash "^4.17.21"
     semver "^7.3.6"
+
+vue-github-button@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vue-github-button/-/vue-github-button-3.1.0.tgz#a95751c43db68cb3ba790af1f63df7e3a2be6dae"
+  integrity sha512-S69NFalucetUW4AjMkLlHY/fgTWu6LEGEtehMewXRNLnjODhDvJj4lwt0u0BSPXLTDB+PLk1tWlwx3pw+ItLgQ==
+  dependencies:
+    github-buttons "^2.22.0"
 
 vue-router@^4.1.6:
   version "4.1.6"


### PR DESCRIPTION
Adds a standard GH star button next to the Kuma logo in the header

<img width="517" alt="Screenshot 2022-11-09 at 16 14 10" src="https://user-images.githubusercontent.com/554604/200884143-db571660-7888-4d05-a4d7-cdd3d1cdbb4e.png">

Probably worth noting this doesn't actually star the project only links to the repo on GH

Fixes https://github.com/kumahq/kuma-gui/issues/428 

Signed-off-by: John Cowen <john.cowen@konghq.com>