### PR TITLE
fix: route data being shown in configurations

### DIFF
--- a/src/api/mock-data/policies.json
+++ b/src/api/mock-data/policies.json
@@ -2,114 +2,138 @@
   "policies": [
     {
       "name": "CircuitBreaker",
-      "pluralDisplayName": "Circuit Breakers",
-      "singularDisplayName": "Circuit Breaker",
-      "readOnly": true,
+      "readOnly": false,
       "path": "circuit-breakers",
+      "singularDisplayName": "Circuit Breaker",
+      "pluralDisplayName": "Circuit Breakers",
       "isExperimental": false
     },
     {
       "name": "FaultInjection",
-      "pluralDisplayName": "Fault Injections",
-      "singularDisplayName": "Fault Injection",
-      "readOnly": true,
+      "readOnly": false,
       "path": "fault-injections",
+      "singularDisplayName": "Fault Injection",
+      "pluralDisplayName": "Fault Injections",
       "isExperimental": false
     },
     {
       "name": "HealthCheck",
-      "pluralDisplayName": "Health Checks",
-      "singularDisplayName": "Health Check",
-      "readOnly": true,
+      "readOnly": false,
       "path": "health-checks",
+      "singularDisplayName": "Health Check",
+      "pluralDisplayName": "Health Checks",
+      "isExperimental": false
+    },
+    {
+      "name": "MeshAccessLog",
+      "readOnly": false,
+      "path": "meshaccesslogs",
+      "singularDisplayName": "Mesh Access Log",
+      "pluralDisplayName": "Mesh Access Logs",
       "isExperimental": false
     },
     {
       "name": "MeshGateway",
-      "pluralDisplayName": "Mesh Gateways",
-      "singularDisplayName": "Mesh Gateway",
-      "readOnly": true,
+      "readOnly": false,
       "path": "meshgateways",
+      "singularDisplayName": "Mesh Gateway",
+      "pluralDisplayName": "Mesh Gateways",
       "isExperimental": true
     },
     {
       "name": "MeshGatewayRoute",
-      "pluralDisplayName": "Mesh Gateway Routes",
-      "singularDisplayName": "Mesh Gateway Route",
-      "readOnly": true,
+      "readOnly": false,
       "path": "meshgatewayroutes",
+      "singularDisplayName": "Mesh Gateway Route",
+      "pluralDisplayName": "Mesh Gateway Routes",
       "isExperimental": true
     },
     {
+      "name": "MeshTrace",
+      "readOnly": false,
+      "path": "meshtraces",
+      "singularDisplayName": "Mesh Trace",
+      "pluralDisplayName": "Mesh Traces",
+      "isExperimental": false
+    },
+    {
+      "name": "MeshTrafficPermission",
+      "readOnly": false,
+      "path": "meshtrafficpermissions",
+      "singularDisplayName": "Mesh Traffic Permission",
+      "pluralDisplayName": "Mesh Traffic Permissions",
+      "isExperimental": false
+    },
+    {
       "name": "ProxyTemplate",
-      "pluralDisplayName": "Proxy Templates",
-      "singularDisplayName": "Proxy Template",
-      "readOnly": true,
+      "readOnly": false,
       "path": "proxytemplates",
+      "singularDisplayName": "Proxy Template",
+      "pluralDisplayName": "Proxy Templates",
       "isExperimental": false
     },
     {
       "name": "RateLimit",
-      "pluralDisplayName": "Rate Limits",
-      "singularDisplayName": "Rate Limit",
-      "readOnly": true,
+      "readOnly": false,
       "path": "rate-limits",
+      "singularDisplayName": "Rate Limit",
+      "pluralDisplayName": "Rate Limits",
       "isExperimental": false
     },
     {
       "name": "Retry",
-      "pluralDisplayName": "Retries",
-      "singularDisplayName": "Retry",
-      "readOnly": true,
+      "readOnly": false,
       "path": "retries",
+      "singularDisplayName": "Retry",
+      "pluralDisplayName": "Retries",
       "isExperimental": false
     },
     {
       "name": "Timeout",
-      "pluralDisplayName": "Timeouts",
-      "singularDisplayName": "Timeout",
-      "readOnly": true,
+      "readOnly": false,
       "path": "timeouts",
+      "singularDisplayName": "Timeout",
+      "pluralDisplayName": "Timeouts",
       "isExperimental": false
     },
     {
       "name": "TrafficLog",
-      "pluralDisplayName": "Traffic Logs",
-      "singularDisplayName": "Traffic Log",
-      "readOnly": true,
+      "readOnly": false,
       "path": "traffic-logs",
+      "singularDisplayName": "Traffic Log",
+      "pluralDisplayName": "Traffic Logs",
       "isExperimental": false
     },
     {
       "name": "TrafficPermission",
-      "pluralDisplayName": "Traffic Permissions",
-      "singularDisplayName": "Traffic Permission",
-      "readOnly": true,
+      "readOnly": false,
       "path": "traffic-permissions",
+      "singularDisplayName": "Traffic Permission",
+      "pluralDisplayName": "Traffic Permissions",
       "isExperimental": false
     },
     {
       "name": "TrafficRoute",
-      "pluralDisplayName": "Traffic Routes",
-      "singularDisplayName": "Traffic Route",
-      "readOnly": true,
+      "readOnly": false,
       "path": "traffic-routes",
+      "singularDisplayName": "Traffic Route",
+      "pluralDisplayName": "Traffic Routes",
       "isExperimental": false
     },
     {
       "name": "TrafficTrace",
-      "pluralDisplayName": "Traffic Traces",
-      "singularDisplayName": "Traffic Trace",
-      "readOnly": true,
+      "readOnly": false,
       "path": "traffic-traces",
+      "singularDisplayName": "Traffic Trace",
+      "pluralDisplayName": "Traffic Traces",
       "isExperimental": false
     },
     {
-      "name": "VirtualOutbounds",
-      "pluralDisplayName": "Virtual Outbounds",
-      "singularDisplayName": "Virtual Outbound",
-      "readOnly": true,
+      "name": "VirtualOutbound",
+      "readOnly": false,
       "path": "virtual-outbounds",
+      "singularDisplayName": "Virtual Outbound",
+      "pluralDisplayName": "Virtual Outbounds",
       "isExperimental": false
     }
   ]

--- a/src/app/__snapshots__/AppSidebar.spec.ts.snap
+++ b/src/app/__snapshots__/AppSidebar.spec.ts.snap
@@ -155,6 +155,24 @@ exports[`AppSidebar.vue renders snapshot 1`] = `
       
       <div
         class="nav-item"
+        data-testid="meshaccesslogs"
+        title="false"
+      >
+        <a
+          class="nav-link"
+        >
+          Mesh Access Logs 
+          <span
+            class="amount amount--empty"
+          >
+            0
+          </span>
+        </a>
+      </div>
+      
+      
+      <div
+        class="nav-item"
         data-testid="meshgatewayroutes"
         title="false"
       >
@@ -180,6 +198,42 @@ exports[`AppSidebar.vue renders snapshot 1`] = `
           class="nav-link"
         >
           Mesh Gateways 
+          <span
+            class="amount amount--empty"
+          >
+            0
+          </span>
+        </a>
+      </div>
+      
+      
+      <div
+        class="nav-item"
+        data-testid="meshtraces"
+        title="false"
+      >
+        <a
+          class="nav-link"
+        >
+          Mesh Traces 
+          <span
+            class="amount amount--empty"
+          >
+            0
+          </span>
+        </a>
+      </div>
+      
+      
+      <div
+        class="nav-item"
+        data-testid="meshtrafficpermissions"
+        title="false"
+      >
+        <a
+          class="nav-link"
+        >
+          Mesh Traffic Permissions 
           <span
             class="amount amount--empty"
           >

--- a/src/app/policies/views/PolicyView.vue
+++ b/src/app/policies/views/PolicyView.vue
@@ -238,11 +238,11 @@ async function loadData(offset: number = 0): Promise<void> {
       tableDataIsEmpty.value = false
       isEmpty.value = false
 
-      const selected = ['type', 'name', 'mesh']
-      const selectedEntity = items[0]
-
-      entity.value = getSome(selectedEntity, selected)
-      rawEntity.value = stripTimes(selectedEntity)
+      await getEntity({
+        mesh: items[0].mesh,
+        name: items[0].name,
+        path,
+      })
     } else {
       tableData.value.data = []
       tableDataIsEmpty.value = true
@@ -281,7 +281,7 @@ function processEntity(entity: PolicyEntity): any {
   return processedEntity
 }
 
-async function getEntity(selectedEntity: any): Promise<void> {
+async function getEntity(selectedEntity: { mesh: string, path: string, name: string }): Promise<void> {
   entityHasError.value = false
   entityIsLoading.value = true
   entityIsEmpty.value = false

--- a/src/store/reducers/__snapshots__/mesh-insights.spec.ts.snap
+++ b/src/store/reducers/__snapshots__/mesh-insights.spec.ts.snap
@@ -22,10 +22,19 @@ exports[`mesh-insights calls mergeInsightsReducer with an empty array 1`] = `
     "HealthCheck": {
       "total": 0,
     },
+    "MeshAccessLog": {
+      "total": 0,
+    },
     "MeshGateway": {
       "total": 0,
     },
     "MeshGatewayRoute": {
+      "total": 0,
+    },
+    "MeshTrace": {
+      "total": 0,
+    },
+    "MeshTrafficPermission": {
       "total": 0,
     },
     "ProxyTemplate": {
@@ -50,6 +59,9 @@ exports[`mesh-insights calls mergeInsightsReducer with an empty array 1`] = `
       "total": 0,
     },
     "TrafficTrace": {
+      "total": 0,
+    },
+    "VirtualOutbound": {
       "total": 0,
     },
   },
@@ -100,10 +112,19 @@ exports[`mesh-insights calls mergeInsightsReducer with mesh insights array 1`] =
     "HealthCheck": {
       "total": 0,
     },
+    "MeshAccessLog": {
+      "total": 0,
+    },
     "MeshGateway": {
       "total": 0,
     },
     "MeshGatewayRoute": {
+      "total": 0,
+    },
+    "MeshTrace": {
+      "total": 0,
+    },
+    "MeshTrafficPermission": {
       "total": 0,
     },
     "ProxyTemplate": {
@@ -134,6 +155,9 @@ exports[`mesh-insights calls mergeInsightsReducer with mesh insights array 1`] =
       "total": 10,
     },
     "TrafficTrace": {
+      "total": 0,
+    },
+    "VirtualOutbound": {
       "total": 0,
     },
   },
@@ -184,10 +208,19 @@ exports[`mesh-insights calls parseInsightReducer with mesh insights 1`] = `
     "HealthCheck": {
       "total": 0,
     },
+    "MeshAccessLog": {
+      "total": 0,
+    },
     "MeshGateway": {
       "total": 0,
     },
     "MeshGatewayRoute": {
+      "total": 0,
+    },
+    "MeshTrace": {
+      "total": 0,
+    },
+    "MeshTrafficPermission": {
       "total": 0,
     },
     "ProxyTemplate": {
@@ -220,6 +253,9 @@ exports[`mesh-insights calls parseInsightReducer with mesh insights 1`] = `
     "TrafficTrace": {
       "total": 0,
     },
+    "VirtualOutbound": {
+      "total": 0,
+    },
   },
 }
 `;
@@ -246,10 +282,19 @@ exports[`mesh-insights calls parseInsightReducer without any data 1`] = `
     "HealthCheck": {
       "total": 0,
     },
+    "MeshAccessLog": {
+      "total": 0,
+    },
     "MeshGateway": {
       "total": 0,
     },
     "MeshGatewayRoute": {
+      "total": 0,
+    },
+    "MeshTrace": {
+      "total": 0,
+    },
+    "MeshTrafficPermission": {
       "total": 0,
     },
     "ProxyTemplate": {
@@ -274,6 +319,9 @@ exports[`mesh-insights calls parseInsightReducer without any data 1`] = `
       "total": 0,
     },
     "TrafficTrace": {
+      "total": 0,
+    },
+    "VirtualOutbound": {
       "total": 0,
     },
   },

--- a/src/store/reducers/mesh-insights.ts
+++ b/src/store/reducers/mesh-insights.ts
@@ -21,45 +21,23 @@ const sumDataplanes = (curr: DataPlaneStats = {}, next: DataPlaneStats = {}) => 
 }
 
 export const getInitialPolicies = () => ({
-  CircuitBreaker: {
-    total: 0,
-  },
-  FaultInjection: {
-    total: 0,
-  },
-  HealthCheck: {
-    total: 0,
-  },
-  ProxyTemplate: {
-    total: 0,
-  },
-  TrafficLog: {
-    total: 0,
-  },
-  TrafficPermission: {
-    total: 0,
-  },
-  TrafficRoute: {
-    total: 0,
-  },
-  TrafficTrace: {
-    total: 0,
-  },
-  RateLimit: {
-    total: 0,
-  },
-  Retry: {
-    total: 0,
-  },
-  Timeout: {
-    total: 0,
-  },
-  MeshGateway: {
-    total: 0,
-  },
-  MeshGatewayRoute: {
-    total: 0,
-  },
+  CircuitBreaker: { total: 0 },
+  FaultInjection: { total: 0 },
+  HealthCheck: { total: 0 },
+  MeshAccessLog: { total: 0 },
+  MeshGateway: { total: 0 },
+  MeshGatewayRoute: { total: 0 },
+  MeshTrace: { total: 0 },
+  MeshTrafficPermission: { total: 0 },
+  ProxyTemplate: { total: 0 },
+  RateLimit: { total: 0 },
+  Retry: { total: 0 },
+  Timeout: { total: 0 },
+  TrafficLog: { total: 0 },
+  TrafficPermission: { total: 0 },
+  TrafficRoute: { total: 0 },
+  TrafficTrace: { total: 0 },
+  VirtualOutbound: { total: 0 },
 })
 
 const sumPolicies = (curr: any = getInitialPolicies(), next: any = {}) =>


### PR DESCRIPTION
Fixes an issue where internal route data was rendered as part of configurations.

Updates the mock data for policies.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>