### PR TITLE
refactor: use @jest/globals

### DIFF
--- a/jest/jest-replace-attribute-snapshot-serializer.ts
+++ b/jest/jest-replace-attribute-snapshot-serializer.ts
@@ -1,3 +1,6 @@
+// Imports the appropriate plugin type from the library Jest uses for snapshot serialization.
+import { NewPlugin } from 'pretty-format'
+
 const DEFAULT_UUID = 'aaaabbbb-cccc-dddd-eeee-ffffffffffff'
 
 function hasUuidAttribute(element: Element, attribute: string): boolean {
@@ -11,7 +14,7 @@ const processedValues = new Set()
 export function replaceAttributesSnapshotSerializer(
   attributes: string[],
   uuid = DEFAULT_UUID,
-): jest.SnapshotSerializerPlugin {
+): NewPlugin {
   return {
     /**
      * Matches elements which haven’t been processed by this serializer before.
@@ -19,6 +22,7 @@ export function replaceAttributesSnapshotSerializer(
     test: (value) => value instanceof Element && !processedValues.has(value)
       ? attributes.some((attribute) => hasUuidAttribute(value, attribute))
       : false,
+
     /**
      * Replaces the attribute values of an element with a static value.
      */

--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -1,3 +1,5 @@
+import { afterAll, afterEach, beforeAll, expect } from '@jest/globals'
+
 // Polyfills `window.fetch` for Jest because it runs in a Node environment where fetch isn’t available. It initially looked like this would change with Node.js 18, but that is not so.
 import 'isomorphic-fetch'
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.18.6",
-    "@types/jest": "^29.2.2",
+    "@jest/globals": "^29.3.1",
     "@types/prismjs": "^1.26.0",
     "@types/semver": "^7.3.13",
     "@typescript-eslint/eslint-plugin": "^5.42.0",

--- a/src/api/makeRequest.spec.ts
+++ b/src/api/makeRequest.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, jest, test } from '@jest/globals'
+
 import { ApiError } from './ApiError'
 import { makeRequest } from './makeRequest'
 

--- a/src/app/App.spec.ts
+++ b/src/app/App.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import App from './App.vue'
@@ -25,9 +26,8 @@ function renderComponent(status: string) {
   })
 }
 
-
 describe('App.vue', () => {
-  it('renders main view when successful', async () => {
+  test('renders main view when successful', async () => {
     const wrapper = renderComponent('OK')
     store.dispatch('bootstrap')
 
@@ -38,7 +38,7 @@ describe('App.vue', () => {
     expect(wrapper.html()).toContain('Create a virtual mesh')
   })
 
-  it('fails to renders basic view', async () => {
+  test('fails to renders basic view', async () => {
     const wrapper = renderComponent('ERROR')
     store.dispatch('bootstrap')
 

--- a/src/app/AppLoadingBar.spec.ts
+++ b/src/app/AppLoadingBar.spec.ts
@@ -1,3 +1,4 @@
+import { afterAll, beforeAll, describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, shallowMount } from '@vue/test-utils'
 
 import AppLoadingBar from './AppLoadingBar.vue'
@@ -15,13 +16,13 @@ describe('AppLoadingBar', () => {
     jest.useRealTimers()
   })
 
-  it('renders snapshot at the beginning', () => {
+  test('renders snapshot at the beginning', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('checks if width is max of 100% size', async () => {
+  test('checks if width is max of 100% size', async () => {
     const wrapper = renderComponent()
 
     jest.advanceTimersByTime(1500)

--- a/src/app/AppNavItem.spec.ts
+++ b/src/app/AppNavItem.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import AppNavItem from './AppNavItem.vue'
@@ -15,13 +16,13 @@ function renderComponent() {
 }
 
 describe('AppNavItem.vue', () => {
-  it('renders snapshot with link to selected mesh', () => {
+  test('renders snapshot with link to selected mesh', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it.each([
+  test.each([
     [0, '0'],
     [20, '20'],
     [200, '99+'],

--- a/src/app/AppOnboardingNotification.spec.ts
+++ b/src/app/AppOnboardingNotification.spec.ts
@@ -1,9 +1,10 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import AppOnboardingNotification from './AppOnboardingNotification.vue'
 
 describe('AppOnboardingNotification', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = mount(AppOnboardingNotification)
 
     expect(wrapper.element).toMatchSnapshot()

--- a/src/app/AppSidebar.spec.ts
+++ b/src/app/AppSidebar.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 
 import AppSidebar from './AppSidebar.vue'
@@ -16,20 +17,20 @@ async function renderComponent() {
 }
 
 describe('AppSidebar.vue', () => {
-  it('renders snapshot', async () => {
+  test('renders snapshot', async () => {
     const wrapper = await renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders mesh gateways', async () => {
+  test('renders mesh gateways', async () => {
     const wrapper = await renderComponent()
 
     expect(wrapper.find('[data-testid="meshgateways"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="meshgatewayroutes"]').exists()).toBe(true)
   })
 
-  it('refetch data after change of mesh', async () => {
+  test('refetch data after change of mesh', async () => {
     store.state.selectedMesh = 'hello-world'
     store.state.meshes.total = 1
     store.state.meshes.items = [

--- a/src/app/common/AccordionList.spec.ts
+++ b/src/app/common/AccordionList.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import AccordionList from './AccordionList.vue'
@@ -41,13 +42,13 @@ function renderComponent(props = {}) {
 }
 
 describe('AccordionList.vue', () => {
-  it('renders snapshot at the beginning', () => {
+  test('renders snapshot at the beginning', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders with opened second panel and switch opened panel on click', async () => {
+  test('renders with opened second panel and switch opened panel on click', async () => {
     const wrapper = renderComponent({ initiallyOpen: 1 })
 
     expect(wrapper.find('[data-testid="accordion-item-content"]').html()).toContain('Content 2')
@@ -59,7 +60,7 @@ describe('AccordionList.vue', () => {
     expect(wrapper.find('[data-testid="accordion-item-content"]').html()).toContain('Content 1')
   })
 
-  it('renders initally two opened accordion', async () => {
+  test('renders initally two opened accordion', async () => {
     const wrapper = renderComponent({
       initiallyOpen: [0, 1],
       multipleOpen: true,
@@ -68,7 +69,7 @@ describe('AccordionList.vue', () => {
     expect(wrapper.findAll('[data-testid="accordion-item-content"]').length).toBe(2)
   })
 
-  it('renders initally two closed accordions and open it', async () => {
+  test('renders initally two closed accordions and open it', async () => {
     const wrapper = renderComponent({ multipleOpen: true })
 
     expect(wrapper.findAll('[data-testid="accordion-item-content"]').length).toBe(0)

--- a/src/app/common/DataOverview.spec.ts
+++ b/src/app/common/DataOverview.spec.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 import { datadogLogs } from '@datadog/browser-logs'
 
@@ -23,7 +24,7 @@ describe('DataOverview.vue', () => {
     (datadogLogs.logger.info as jest.MockedFunction<any>).mockClear()
   })
 
-  it('renders basic snapshot', () => {
+  test('renders basic snapshot', () => {
     const wrapper = renderComponent({
       tableData: {
         headers: [],
@@ -34,7 +35,7 @@ describe('DataOverview.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders additional scoped slot', async () => {
+  test('renders additional scoped slot', async () => {
     const wrapper = renderComponent({
       tableData: {
         headers: [
@@ -53,7 +54,7 @@ describe('DataOverview.vue', () => {
     expect(wrapper.find('table').element).toMatchSnapshot()
   })
 
-  it('renders pagination and react on click', async () => {
+  test('renders pagination and react on click', async () => {
     const wrapper = renderComponent({
       next: true,
       tableData: {
@@ -80,7 +81,7 @@ describe('DataOverview.vue', () => {
     expect(wrapper.find('[data-testid="pagination-previous-button"]').exists()).toBe(false)
   })
 
-  it('refresh page on second page', async () => {
+  test('refresh page on second page', async () => {
     const wrapper = renderComponent({
       next: true,
       tableData: {
@@ -100,7 +101,7 @@ describe('DataOverview.vue', () => {
     expect(datadogLogs.logger.info).toMatchSnapshot()
   })
 
-  it('renders all custom templates for data', async () => {
+  test('renders all custom templates for data', async () => {
     const wrapper = renderComponent({
       showWarnings: true,
       tableData: {

--- a/src/app/common/DocumentationLink.spec.ts
+++ b/src/app/common/DocumentationLink.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import DocumentationLink from './DocumentationLink.vue'
@@ -11,7 +12,7 @@ function renderComponent() {
 }
 
 describe('DocumentationLink.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()

--- a/src/app/common/EnvoyData.spec.ts
+++ b/src/app/common/EnvoyData.spec.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 import { rest } from 'msw'
 
@@ -20,7 +21,7 @@ describe('EnvoyData.vue', () => {
     document.body.innerHTML = ''
   })
 
-  it('renders snapshot', async () => {
+  test('renders snapshot', async () => {
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + 'meshes/:mesh/dataplanes/:dataplaneName/clusters', (req, res, ctx) =>
         res(ctx.status(200), ctx.json('')),
@@ -35,7 +36,7 @@ describe('EnvoyData.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders loading', () => {
+  test('renders loading', () => {
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + 'meshes/:mesh/dataplanes/:dataplaneName/clusters', (req, res, ctx) =>
         res(ctx.status(200), ctx.json('')),
@@ -51,7 +52,7 @@ describe('EnvoyData.vue', () => {
     wrapper.unmount()
   })
 
-  it('renders error', async () => {
+  test('renders error', async () => {
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + 'meshes/:mesh/dataplanes/:dataplaneName/clusters', (req, res, ctx) =>
         res(ctx.status(500), ctx.json('')),

--- a/src/app/common/NotificationIcon.spec.ts
+++ b/src/app/common/NotificationIcon.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import NotificationIcon from './NotificationIcon.vue'
@@ -7,13 +8,13 @@ function renderComponent() {
 }
 
 describe('NotificationIcon.vue', () => {
-  it('renders snapshot', async () => {
+  test('renders snapshot', async () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders icon without notification number', async () => {
+  test('renders icon without notification number', async () => {
     const wrapper = renderComponent()
 
     expect(wrapper.find('[data-testid="notification-amount"]').exists()).toBe(false)

--- a/src/app/common/PaginationWidget.spec.ts
+++ b/src/app/common/PaginationWidget.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, jest, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 import { datadogLogs } from '@datadog/browser-logs'
 
@@ -12,13 +13,13 @@ function renderComponent(props = {}) {
 }
 
 describe('PaginationWidget.vue', () => {
-  it('renders nothing if no next or prev props provided', () => {
+  test('renders nothing if no next or prev props provided', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders pagination', () => {
+  test('renders pagination', () => {
     const wrapper = renderComponent({
       hasPrevious: true,
       hasNext: true,
@@ -27,7 +28,7 @@ describe('PaginationWidget.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('calls buttons', async () => {
+  test('calls buttons', async () => {
     const wrapper = renderComponent({
       hasPrevious: true,
       hasNext: true,

--- a/src/app/common/TabsWidget.spec.ts
+++ b/src/app/common/TabsWidget.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import TabsWidget from './TabsWidget.vue'
@@ -13,7 +14,7 @@ function renderComponent(props: any) {
 }
 
 describe('TabsWidget.vue', () => {
-  it('renders basic snapshot', () => {
+  test('renders basic snapshot', () => {
     const wrapper = renderComponent({
       tabs: [
         {
@@ -32,7 +33,7 @@ describe('TabsWidget.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('switches tabs on click', async () => {
+  test('switches tabs on click', async () => {
     const wrapper = renderComponent({
       tabs: [
         {
@@ -52,7 +53,7 @@ describe('TabsWidget.vue', () => {
     expect(wrapper.find('#panel-1').html()).toContain('Kubernetes')
   })
 
-  it('renders with initally selected tab', () => {
+  test('renders with initally selected tab', () => {
     const wrapper = renderComponent({
       tabs: [
         {

--- a/src/app/common/UpgradeCheck.spec.ts
+++ b/src/app/common/UpgradeCheck.spec.ts
@@ -1,10 +1,11 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import UpgradeCheck from './UpgradeCheck.vue'
 import { store } from '@/store/store'
 
 describe('UpgradeCheck.vue', () => {
-  it('renders snapshot', async () => {
+  test('renders snapshot', async () => {
     store.state.config.tagline = import.meta.env.VITE_NAMESPACE
 
     const wrapper = mount(UpgradeCheck)

--- a/src/app/common/charts/DonutChart.spec.ts
+++ b/src/app/common/charts/DonutChart.spec.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DonutChart from './DonutChart.vue'
@@ -24,7 +25,7 @@ describe('DonutChart.vue', () => {
     document.body.innerHTML = ''
   })
 
-  it('renders chart', async () => {
+  test('renders chart', async () => {
     const wrapper = renderComponent()
 
     await flushPromises()

--- a/src/app/data-planes/components/DataPlaneDetails.spec.ts
+++ b/src/app/data-planes/components/DataPlaneDetails.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneDetails from './DataPlaneDetails.vue'

--- a/src/app/data-planes/components/DataPlaneEntitySummary.spec.ts
+++ b/src/app/data-planes/components/DataPlaneEntitySummary.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneEntitySummary from './DataPlaneEntitySummary.vue'

--- a/src/app/data-planes/components/DataplanePolicies.spec.ts
+++ b/src/app/data-planes/components/DataplanePolicies.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
 import { rest } from 'msw'
 
@@ -19,7 +20,7 @@ async function renderComponent(props = {}) {
 }
 
 describe('DataplanePolicies.vue', () => {
-  it('renders snapshot', async () => {
+  test('renders snapshot', async () => {
     const wrapper = await renderComponent({
       dataPlane: {
         mesh: 'foo',
@@ -35,7 +36,7 @@ describe('DataplanePolicies.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders loading', async () => {
+  test('renders loading', async () => {
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + 'meshes/:mesh/dataplanes/:dataplaneName/policies', (req, res, ctx) =>
         res(ctx.status(200), ctx.json({ total: 0, items: [] })),
@@ -53,7 +54,7 @@ describe('DataplanePolicies.vue', () => {
     expect(wrapper.find('[data-testid="loading-block"]').exists()).toBe(true)
   })
 
-  it('renders error', async () => {
+  test('renders error', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => { }) // silence console errors
 
     server.use(
@@ -75,7 +76,7 @@ describe('DataplanePolicies.vue', () => {
     expect(wrapper.html()).toContain('An error has occurred while trying to load this data.')
   })
 
-  it('renders no item', async () => {
+  test('renders no item', async () => {
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + 'meshes/:mesh/dataplanes/:dataplaneName/policies', (req, res, ctx) =>
         res(ctx.status(200), ctx.json({ total: 0, items: [] })),

--- a/src/app/data-planes/views/DataPlaneListView.spec.ts
+++ b/src/app/data-planes/views/DataPlaneListView.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneListView from './DataPlaneListView.vue'

--- a/src/app/main-overview/views/MainOverviewView.spec.ts
+++ b/src/app/main-overview/views/MainOverviewView.spec.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import MainOverviewView from './MainOverviewView.vue'
@@ -15,7 +16,7 @@ describe('MainOverviewView.vue', () => {
     document.body.innerHTML = ''
   })
 
-  it('renders basic snapshot', () => {
+  test('renders basic snapshot', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()

--- a/src/app/notification-manager/components/LoggingNotification.spec.ts
+++ b/src/app/notification-manager/components/LoggingNotification.spec.ts
@@ -1,9 +1,10 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import LoggingNotification from './LoggingNotification.vue'
 
 describe('LoggingNotification.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = mount(LoggingNotification)
 
     expect(wrapper.element).toMatchSnapshot()

--- a/src/app/notification-manager/components/MetricsNotification.spec.ts
+++ b/src/app/notification-manager/components/MetricsNotification.spec.ts
@@ -1,9 +1,10 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import MetricsNotification from './MetricsNotification.vue'
 
 describe('MetricsNotification.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = mount(MetricsNotification)
 
     expect(wrapper.element).toMatchSnapshot()

--- a/src/app/notification-manager/components/MtlsNotification.spec.ts
+++ b/src/app/notification-manager/components/MtlsNotification.spec.ts
@@ -1,9 +1,10 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import MtlsNotification from './MtlsNotification.vue'
 
 describe('MtlsNotification.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = mount(MtlsNotification)
 
     expect(wrapper.element).toMatchSnapshot()

--- a/src/app/notification-manager/components/NotificationManager.spec.ts
+++ b/src/app/notification-manager/components/NotificationManager.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import NotificationManager from './NotificationManager.vue'
@@ -11,7 +12,7 @@ function renderComponent({ meshes, selectedMesh }: { meshes: any, selectedMesh: 
 }
 
 describe('NotificationManager.vue', () => {
-  it('renders snapshot with information that there are actions which user may take', () => {
+  test('renders snapshot with information that there are actions which user may take', () => {
     const wrapper = renderComponent({
       selectedMesh: 'test-mesh',
       meshes: {
@@ -22,7 +23,7 @@ describe('NotificationManager.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it("doesn't render notification info after it's closed", async () => {
+  test("doesn't render notification info after it's closed", async () => {
     const wrapper = renderComponent({
       selectedMesh: 'test-mesh',
       meshes: {
@@ -34,7 +35,7 @@ describe('NotificationManager.vue', () => {
     expect(wrapper.find('[data-testid="notification-info"]').exists()).toBe(false)
   })
 
-  it('renders single mesh notification modal', async () => {
+  test('renders single mesh notification modal', async () => {
     const wrapper = renderComponent({
       selectedMesh: 'test-mesh',
       meshes: {

--- a/src/app/notification-manager/components/TracingNotification.spec.ts
+++ b/src/app/notification-manager/components/TracingNotification.spec.ts
@@ -1,9 +1,10 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import TracingNotification from './TracingNotification.vue'
 
 describe('TracingNotification.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = mount(TracingNotification)
 
     expect(wrapper.element).toMatchSnapshot()

--- a/src/app/onboarding/components/OnboardingHeading.spec.ts
+++ b/src/app/onboarding/components/OnboardingHeading.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import OnboardingHeading from './OnboardingHeading.vue'
@@ -12,7 +13,7 @@ function renderComponent() {
 }
 
 describe('OnboardingHeading.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()

--- a/src/app/onboarding/components/OnboardingNavigation.spec.ts
+++ b/src/app/onboarding/components/OnboardingNavigation.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount, RouterLinkStub } from '@vue/test-utils'
 
 import OnboardingNavigation from './OnboardingNavigation.vue'
@@ -15,7 +16,7 @@ function renderComponent(props = {}) {
 }
 
 describe('OnboardingNavigation.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = renderComponent({
       previousStep: 'foo',
       nextStep: 'bar',
@@ -24,7 +25,7 @@ describe('OnboardingNavigation.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('displays different next step title', () => {
+  test('displays different next step title', () => {
     const wrapper = renderComponent({
       previousStep: 'foo',
       nextStep: 'bar',
@@ -34,7 +35,7 @@ describe('OnboardingNavigation.vue', () => {
     expect(wrapper.html()).toContain('nextStepTitle')
   })
 
-  it('display disabled next button', () => {
+  test('display disabled next button', () => {
     const wrapper = renderComponent({
       previousStep: 'foo',
       nextStep: 'bar',
@@ -44,7 +45,7 @@ describe('OnboardingNavigation.vue', () => {
     expect(wrapper.find('[data-testid="onboarding-next-button"]').attributes('disabled')).toBe('true')
   })
 
-  it('doesn\'t display previous step', () => {
+  test('doesn\'t display previous step', () => {
     const wrapper = renderComponent({
       nextStep: 'bar',
     })
@@ -52,7 +53,7 @@ describe('OnboardingNavigation.vue', () => {
     expect(wrapper.html()).not.toContain('Back')
   })
 
-  it('changes step to previous', async () => {
+  test('changes step to previous', async () => {
     const wrapper = renderComponent({
       previousStep: 'foo',
       nextStep: 'bar',
@@ -65,7 +66,7 @@ describe('OnboardingNavigation.vue', () => {
     expect(store.state.onboarding.step).toBe('foo')
   })
 
-  it('calls skip onboarding', async () => {
+  test('calls skip onboarding', async () => {
     const wrapper = renderComponent({
       previousStep: 'foo',
       nextStep: 'bar',

--- a/src/app/onboarding/views/AddNewServices.spec.ts
+++ b/src/app/onboarding/views/AddNewServices.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import AddNewServices from './AddNewServices.vue'
@@ -7,13 +8,13 @@ function renderComponent() {
 }
 
 describe('AddNewServices.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('changes selected box', async () => {
+  test('changes selected box', async () => {
     const wrapper = renderComponent()
 
     const boxes = wrapper.findAll('[data-testid="box"]')

--- a/src/app/onboarding/views/AddNewServicesCode.spec.ts
+++ b/src/app/onboarding/views/AddNewServicesCode.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import AddNewServicesCode from './AddNewServicesCode.vue'
@@ -8,7 +9,7 @@ function renderComponent() {
 }
 
 describe('AddNewServicesCode.vue', () => {
-  it('renders snapshot', async () => {
+  test('renders snapshot', async () => {
     const wrapper = renderComponent()
 
     await flushPromises()
@@ -16,7 +17,7 @@ describe('AddNewServicesCode.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('detects resources on call and allow to proceed', async () => {
+  test('detects resources on call and allow to proceed', async () => {
     const wrapper = renderComponent()
 
     await flushPromises()
@@ -26,7 +27,7 @@ describe('AddNewServicesCode.vue', () => {
     expect(wrapper.find('[data-testid="loading"]').exists()).toBe(false)
   })
 
-  it('refetch resources if any not available', async () => {
+  test('refetch resources if any not available', async () => {
     jest.useFakeTimers()
     jest
       .spyOn(kumaApi, 'getAllDataplanes')

--- a/src/app/onboarding/views/CompletedView.spec.ts
+++ b/src/app/onboarding/views/CompletedView.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import CompletedView from './CompletedView.vue'
@@ -7,7 +8,7 @@ function renderComponent() {
 }
 
 describe('CompletedView.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()

--- a/src/app/onboarding/views/ConfigurationTypes.spec.ts
+++ b/src/app/onboarding/views/ConfigurationTypes.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import ConfigurationTypes from './ConfigurationTypes.vue'
@@ -22,13 +23,13 @@ function renderComponent(mode = 'standalone') {
 }
 
 describe('ConfigurationTypes.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders multizone previous step', () => {
+  test('renders multizone previous step', () => {
     const wrapper = renderComponent('global')
 
     expect(wrapper.html()).toContain('onboarding-multi-zone')

--- a/src/app/onboarding/views/CreateMesh.spec.ts
+++ b/src/app/onboarding/views/CreateMesh.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import CreateMesh from './CreateMesh.vue'
@@ -22,7 +23,7 @@ function renderComponent(mode = 'standalone') {
 }
 
 describe('CreateMesh.vue', () => {
-  it('renders snapshot', async () => {
+  test('renders snapshot', async () => {
     const wrapper = renderComponent()
 
     await flushPromises()
@@ -30,7 +31,7 @@ describe('CreateMesh.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders multizone next step', () => {
+  test('renders multizone next step', () => {
     const wrapper = renderComponent('global')
 
     expect(wrapper.html()).toContain('onboarding-multi-zone')

--- a/src/app/onboarding/views/DataplanesOverview.spec.ts
+++ b/src/app/onboarding/views/DataplanesOverview.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataplanesOverview from './DataplanesOverview.vue'
@@ -7,7 +8,7 @@ function renderComponent() {
 }
 
 describe('DataplanesOverview.vue', () => {
-  it('renders snapshot', async () => {
+  test('renders snapshot', async () => {
     const wrapper = renderComponent()
 
     expect(wrapper.find('[data-testid="loading"]').exists()).toBe(true)

--- a/src/app/onboarding/views/DeploymentTypes.spec.ts
+++ b/src/app/onboarding/views/DeploymentTypes.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import DeploymentTypes from './DeploymentTypes.vue'
@@ -8,13 +9,13 @@ function renderComponent() {
 }
 
 describe('DeploymentTypes.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('changes selected graph', async () => {
+  test('changes selected graph', async () => {
     const wrapper = renderComponent()
 
     const multiZoneRadioButton = wrapper.find('[data-testid="onboarding-multi-zone-radio-button"]')

--- a/src/app/onboarding/views/MultiZoneView.spec.ts
+++ b/src/app/onboarding/views/MultiZoneView.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import MultiZoneView from './MultiZoneView.vue'
@@ -8,13 +9,13 @@ function renderComponent() {
 }
 
 describe('MultiZoneView.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = renderComponent()
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('detects resources on call and allow to proceed', async () => {
+  test('detects resources on call and allow to proceed', async () => {
     const wrapper = renderComponent()
 
     await flushPromises()
@@ -25,7 +26,7 @@ describe('MultiZoneView.vue', () => {
     expect(wrapper.find('[data-testid="loading"]').exists()).toBe(false)
   })
 
-  it('refetch resources if any not available', async () => {
+  test('refetch resources if any not available', async () => {
     jest.useFakeTimers()
     jest
       .spyOn(kumaApi, 'getAllZoneIngressOverviews')

--- a/src/app/onboarding/views/WelcomeView.spec.ts
+++ b/src/app/onboarding/views/WelcomeView.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import WelcomeView from './WelcomeView.vue'
@@ -13,13 +14,13 @@ function renderComponent(environment: string) {
 }
 
 describe('WelcomeView.vue', () => {
-  it('renders snapshot', () => {
+  test('renders snapshot', () => {
     const wrapper = renderComponent('universal')
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders Kubernetess', () => {
+  test('renders Kubernetess', () => {
     const wrapper = renderComponent('kubernetess')
 
     expect(wrapper.html()).toContain('Kubernetes')

--- a/src/app/policies/components/PolicyConnections.spec.ts
+++ b/src/app/policies/components/PolicyConnections.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 import { rest } from 'msw'
 
@@ -9,7 +10,7 @@ function renderComponent(props = {}) {
 }
 
 describe('PolicyConnections.vue', () => {
-  it('renders snapshot', async () => {
+  test('renders snapshot', async () => {
     const wrapper = renderComponent({
       mesh: 'foo',
       policyType: 'foo',
@@ -23,7 +24,7 @@ describe('PolicyConnections.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('filters result', async () => {
+  test('filters result', async () => {
     const wrapper = renderComponent({
       mesh: 'foo',
       policyType: 'foo',
@@ -42,7 +43,7 @@ describe('PolicyConnections.vue', () => {
     expect(wrapper.findAll('[data-testid="dataplane-name"]').length).toBe(2)
   })
 
-  it('renders loading', () => {
+  test('renders loading', () => {
     const wrapper = renderComponent({
       mesh: 'foo',
       policyType: 'foo',
@@ -52,7 +53,7 @@ describe('PolicyConnections.vue', () => {
     expect(wrapper.find('[data-testid="loading-block"]').exists()).toBe(true)
   })
 
-  it('renders error', async () => {
+  test('renders error', async () => {
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + 'meshes/:mesh/:policyType/:policyName/dataplanes', (req, res, ctx) =>
         res(ctx.status(500), ctx.json({})),
@@ -70,7 +71,7 @@ describe('PolicyConnections.vue', () => {
     expect(wrapper.html()).toContain('An error has occurred while trying to load this data.')
   })
 
-  it('renders no item', async () => {
+  test('renders no item', async () => {
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + 'meshes/:mesh/:policyType/:policyName/dataplanes', (req, res, ctx) =>
         res(ctx.status(200), ctx.json({ total: 0, items: [] })),

--- a/src/app/policies/views/PolicyView.spec.ts
+++ b/src/app/policies/views/PolicyView.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import PolicyView from './PolicyView.vue'

--- a/src/app/services/components/ExternalServiceDetails.spec.ts
+++ b/src/app/services/components/ExternalServiceDetails.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { shallowMount } from '@vue/test-utils'
 
 import ExternalServiceDetails from './ExternalServiceDetails.vue'

--- a/src/app/services/components/ServiceDetails.spec.ts
+++ b/src/app/services/components/ServiceDetails.spec.ts
@@ -1,3 +1,4 @@
+import { beforeAll, describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, shallowMount } from '@vue/test-utils'
 
 import ServiceDetails from './ServiceDetails.vue'

--- a/src/app/services/components/ServiceInsightDetails.spec.ts
+++ b/src/app/services/components/ServiceInsightDetails.spec.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import ServiceInsightDetails from './ServiceInsightDetails.vue'

--- a/src/app/wizard/views/DataplaneUniversal.spec.ts
+++ b/src/app/wizard/views/DataplaneUniversal.spec.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 import { rest } from 'msw'
 
@@ -14,7 +15,7 @@ describe('DataplaneUniversal.vue', () => {
     jest.spyOn(global.Math, 'random').mockReturnValue(0.123456789)
   })
 
-  it('passes whole wizzard and render yaml', async () => {
+  test('passes whole wizzard and render yaml', async () => {
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + 'meshes/:mesh/dataplanes/:dataplaneName', (req, res, ctx) =>
         res(ctx.status(200), ctx.json({ name: 'hi' })),

--- a/src/app/wizard/views/Mesh.spec.ts
+++ b/src/app/wizard/views/Mesh.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { DOMWrapper, flushPromises, mount, VueWrapper } from '@vue/test-utils'
 
 import Mesh from './Mesh.vue'
@@ -34,7 +35,7 @@ async function doStep(wrapper: VueWrapper<any>, nextButton: DOMWrapper<any>, ena
 }
 
 describe('Mesh.vue', () => {
-  it('passes whole wizzard and render yaml', async () => {
+  test('passes whole wizzard and render yaml', async () => {
     const wrapper = renderComponent('global')
 
     const nextButton = wrapper.find('[data-testid="next-step-button"]')

--- a/src/app/zones/views/ZoneEgresses.spec.ts
+++ b/src/app/zones/views/ZoneEgresses.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import ZoneEgresses from './ZoneEgresses.vue'
@@ -13,7 +14,7 @@ function renderComponent(mode = 'standalone') {
 }
 
 describe('ZoneEgresses.vue', () => {
-  it('renders snapshot when no multizone', async () => {
+  test('renders snapshot when no multizone', async () => {
     const wrapper = renderComponent()
 
     await flushPromises()
@@ -23,7 +24,7 @@ describe('ZoneEgresses.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders snapshot when multizone', async () => {
+  test('renders snapshot when multizone', async () => {
     const wrapper = renderComponent('global')
 
     await flushPromises()
@@ -33,7 +34,7 @@ describe('ZoneEgresses.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders zoneegress insights', async () => {
+  test('renders zoneegress insights', async () => {
     const wrapper = renderComponent('global')
 
     await flushPromises()

--- a/src/app/zones/views/ZoneIngresses.spec.ts
+++ b/src/app/zones/views/ZoneIngresses.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import ZoneIngresses from './ZoneIngresses.vue'
@@ -13,7 +14,7 @@ function renderComponent(mode = 'standalone') {
 }
 
 describe('ZoneIngresses.vue', () => {
-  it('renders snapshot when no multizone', async () => {
+  test('renders snapshot when no multizone', async () => {
     const wrapper = renderComponent()
 
     await flushPromises()
@@ -21,7 +22,7 @@ describe('ZoneIngresses.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders snapshot when multizone', async () => {
+  test('renders snapshot when multizone', async () => {
     const wrapper = renderComponent('global')
 
     await flushPromises()
@@ -31,7 +32,7 @@ describe('ZoneIngresses.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders zoneingress insights', async () => {
+  test('renders zoneingress insights', async () => {
     const wrapper = renderComponent('global')
 
     await flushPromises()

--- a/src/app/zones/views/ZonesView.spec.ts
+++ b/src/app/zones/views/ZonesView.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import ZonesView from './ZonesView.vue'
@@ -13,7 +14,7 @@ function renderComponent(mode = 'standalone') {
 }
 
 describe('ZonesView.vue', () => {
-  it('renders snapshot when no multizone', async () => {
+  test('renders snapshot when no multizone', async () => {
     const wrapper = renderComponent()
 
     await flushPromises()
@@ -21,7 +22,7 @@ describe('ZonesView.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders snapshot when multizone', async () => {
+  test('renders snapshot when multizone', async () => {
     const wrapper = renderComponent('global')
 
     await flushPromises()
@@ -32,7 +33,7 @@ describe('ZonesView.vue', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  it('renders config of multizone', async () => {
+  test('renders config of multizone', async () => {
     const wrapper = renderComponent('global')
 
     await flushPromises()
@@ -43,7 +44,7 @@ describe('ZonesView.vue', () => {
     expect(wrapper.html()).toContain('adminAccessLogPath')
   })
 
-  it('renders zone insights', async () => {
+  test('renders zone insights', async () => {
     const wrapper = renderComponent('global')
 
     await flushPromises()

--- a/src/store/modules/config/config.spec.ts
+++ b/src/store/modules/config/config.spec.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+
 import { rest } from 'msw'
 
 import configModule from './config'
@@ -6,7 +8,7 @@ import { kumaApi } from '@/api/kumaApi'
 
 describe('config module', () => {
   describe('getters', () => {
-    it('tests getStatus getter', () => {
+    test('tests getStatus getter', () => {
       const state: any = {
         status: 'foo',
       }
@@ -16,7 +18,7 @@ describe('config module', () => {
       expect(result).toBe('foo')
     })
 
-    it('tests getMulticlusterStatus getter when global mode', () => {
+    test('tests getMulticlusterStatus getter when global mode', () => {
       const getters = {
         getMode: 'global',
       }
@@ -26,7 +28,7 @@ describe('config module', () => {
       expect(result).toBe(true)
     })
 
-    it('tests getMulticlusterStatus getter when standalone', () => {
+    test('tests getMulticlusterStatus getter when standalone', () => {
       const getters = {
         getMode: 'standalone',
       }
@@ -42,7 +44,7 @@ describe('config module', () => {
       jest.restoreAllMocks()
     })
 
-    it('tests getStatus action', async () => {
+    test('tests getStatus action', async () => {
       server.use(rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL, (req, res, ctx) => res(ctx.status(200))))
 
       const state: any = {
@@ -60,7 +62,7 @@ describe('config module', () => {
       expect(result).toBe('OK')
     })
 
-    it.each([
+    test.each([
       [
         {
           tagline: 'Other',
@@ -147,7 +149,7 @@ describe('config module', () => {
   })
 
   describe('mutations', () => {
-    it('tests SET_CONFIG_DATA mutation', () => {
+    test('tests SET_CONFIG_DATA mutation', () => {
       const userConfig = { foo: 'bar' }
 
       const state: any = {

--- a/src/store/modules/notifications/notifications.spec.ts
+++ b/src/store/modules/notifications/notifications.spec.ts
@@ -1,8 +1,10 @@
+import { describe, expect, test } from '@jest/globals'
+
 import notificationsModule from './notifications'
 
 describe('notifications module', () => {
   describe('getters', () => {
-    it('tests singleMeshNotificationItems getter ', () => {
+    test('tests singleMeshNotificationItems getter ', () => {
       const rootState: any = {
         selectedMesh: 'web-to-backend.kuma-system',
         meshes: {
@@ -55,7 +57,7 @@ describe('notifications module', () => {
 `)
     })
 
-    it('tests meshNotificationItemMapWithAction getter', () => {
+    test('tests meshNotificationItemMapWithAction getter', () => {
       const rootState: any = {
         meshes: {
           items: [
@@ -105,7 +107,7 @@ describe('notifications module', () => {
 `)
     })
 
-    it('tests amountOfActions getter', () => {
+    test('tests amountOfActions getter', () => {
       const rootState: any = {
         meshes: {
           items: [

--- a/src/store/modules/sidebar/sidebar.spec.ts
+++ b/src/store/modules/sidebar/sidebar.spec.ts
@@ -1,8 +1,10 @@
+import { describe, expect, test } from '@jest/globals'
+
 import sidebarModule from './sidebar'
 
 describe('sidebar module', () => {
   describe('actions', () => {
-    it('tests getInsights action', async () => {
+    test('tests getInsights action', async () => {
       const rootState: any = {
         selectedMesh: 'default',
       }

--- a/src/store/modules/sidebar/util.spec.ts
+++ b/src/store/modules/sidebar/util.spec.ts
@@ -1,8 +1,10 @@
+import { describe, expect, test } from '@jest/globals'
+
 import { calculateMeshInsights, calculateGlobalInsights } from './utils'
 
 describe('sidebar utils', () => {
   describe('calculateMeshInsights', () => {
-    it('when no item', async () => {
+    test('when no item', async () => {
       const meshInsight = calculateMeshInsights({ items: [] })
 
       expect(meshInsight).toMatchInlineSnapshot(`
@@ -21,7 +23,7 @@ describe('sidebar utils', () => {
 }
 `)
     })
-    it('when several items', async () => {
+    test('when several items', async () => {
       const meshInsight = calculateMeshInsights({
         items: [
           {
@@ -173,7 +175,7 @@ describe('sidebar utils', () => {
   })
 
   describe('calculateGlobalInsights', () => {
-    it('when no item', async () => {
+    test('when no item', async () => {
       const meshInsight = calculateGlobalInsights({
         type: 'GlobalInsights',
         creationTime: '123',
@@ -183,7 +185,7 @@ describe('sidebar utils', () => {
       expect(meshInsight).toMatchInlineSnapshot('{}')
     })
 
-    it('when several items', async () => {
+    test('when several items', async () => {
       const meshInsight = calculateGlobalInsights({
         type: 'GlobalInsights',
         creationTime: '2018-07-17T16:05:36.995Z',

--- a/src/store/reducers/mesh-insights.spec.ts
+++ b/src/store/reducers/mesh-insights.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from '@jest/globals'
+
 import { mergeInsightsReducer, parseInsightReducer } from './mesh-insights'
 
 describe('mesh-insights', () => {
@@ -45,19 +47,19 @@ describe('mesh-insights', () => {
     },
   }
 
-  it('calls parseInsightReducer without any data', () => {
+  test('calls parseInsightReducer without any data', () => {
     expect(parseInsightReducer()).toMatchSnapshot()
   })
 
-  it('calls parseInsightReducer with mesh insights', () => {
+  test('calls parseInsightReducer with mesh insights', () => {
     expect(parseInsightReducer(meshInsightObject)).toMatchSnapshot()
   })
 
-  it('calls mergeInsightsReducer with an empty array', () => {
+  test('calls mergeInsightsReducer with an empty array', () => {
     expect(mergeInsightsReducer([])).toMatchSnapshot()
   })
 
-  it('calls mergeInsightsReducer with mesh insights array', () => {
+  test('calls mergeInsightsReducer with mesh insights array', () => {
     expect(
       mergeInsightsReducer([
         meshInsightObject,

--- a/src/utilities/getAppBaseUrl.spec.ts
+++ b/src/utilities/getAppBaseUrl.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from '@jest/globals'
+
 import { getAppBaseUrl } from './getAppBaseUrl'
 
 describe('getAppBaseUrl', () => {

--- a/src/utilities/getAppGuiPath.spec.ts
+++ b/src/utilities/getAppGuiPath.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from '@jest/globals'
+
 import { getAppGuiPath } from './getAppGuiPath'
 
 describe('getAppGuiPath', () => {

--- a/src/utilities/helpers.spec.ts
+++ b/src/utilities/helpers.spec.ts
@@ -1,16 +1,18 @@
+import { describe, expect, jest, test } from '@jest/globals'
+
 import { DISABLED } from '@/constants'
 import { getZoneDpServerAuthType, fetchAllResources } from './helpers'
 import { ZoneOverview } from '@/types/index.d'
 
 describe('helpers', () => {
   describe('getZoneDpServerAuthType', () => {
-    it(`returns ${DISABLED} when no subscriptions`, () => {
+    test(`returns ${DISABLED} when no subscriptions`, () => {
       expect(getZoneDpServerAuthType(({ zoneInsight: { subscriptions: [] } } as unknown) as ZoneOverview)).toBe(
         DISABLED,
       )
     })
 
-    it(`returns ${DISABLED} when subscription does not have auth in config`, () => {
+    test(`returns ${DISABLED} when subscription does not have auth in config`, () => {
       expect(
         getZoneDpServerAuthType(({
           zoneInsight: {
@@ -24,7 +26,7 @@ describe('helpers', () => {
       ).toBe(DISABLED)
     })
 
-    it('returns dp auth type when subscriptions available', () => {
+    test('returns dp auth type when subscriptions available', () => {
       const type = 'authType'
 
       expect(
@@ -40,7 +42,7 @@ describe('helpers', () => {
       ).toBe(type)
     })
 
-    it(`returns ${DISABLED} type when subscriptions available but no config`, () => {
+    test(`returns ${DISABLED} type when subscriptions available but no config`, () => {
       const type = DISABLED
 
       expect(
@@ -54,28 +56,29 @@ describe('helpers', () => {
   })
 
   describe('fetchAllResources', () => {
-    it('throws an error when broken call', () => {
-      const brokenRequest = jest.fn().mockImplementation(() => {
+    test('throws an error when broken call', () => {
+      const brokenRequest = jest.fn(() => {
         throw new Error()
       })
 
       expect(() => fetchAllResources({ callEndpoint: brokenRequest })).rejects.toThrow(Error)
     })
 
-    it('returns aggregared data', async () => {
+    test('returns aggregared data', async () => {
       const request = jest
         .fn()
-        .mockResolvedValueOnce({
+        .mockReturnValueOnce(Promise.resolve({
           next: true,
           items: new Array(500).fill(''),
           total: 501,
-        })
-        .mockResolvedValueOnce({
+        }))
+        .mockReturnValueOnce(Promise.resolve({
           next: false,
           items: [''],
           total: 501,
-        })
+        }))
 
+      // @ts-expect-error
       const response = (await fetchAllResources({ callEndpoint: request }))
 
       expect(response.items.length).toBe(501)

--- a/src/utilities/highlightElement.spec.ts
+++ b/src/utilities/highlightElement.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from '@jest/globals'
+
 import { _highlightCode, highlightElement, AvailableLanguages } from './highlightElement'
 
 const highlightCodeTestCases: Array<[{ language: AvailableLanguages, code: string }, string]> = [

--- a/src/utilities/reformatYaml.spec.ts
+++ b/src/utilities/reformatYaml.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from '@jest/globals'
+
 import { reformatYaml } from './reformatYaml'
 
 describe('reformatYaml', () => {

--- a/src/utilities/tableDataUtils.spec.ts
+++ b/src/utilities/tableDataUtils.spec.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+
 import { getTableData } from './tableDataUtils'
 import { TableDataParams } from './tableDataUtils.types'
 
@@ -6,10 +8,10 @@ describe('tableDataUtils', () => {
 
   beforeEach(() => {
     params = {
-      getSingleEntity: jest.fn().mockResolvedValue({}),
-      getAllEntities: jest.fn().mockResolvedValue({}),
-      getAllEntitiesFromPath: jest.fn().mockResolvedValue({}),
-      getAllEntitiesFromMesh: jest.fn().mockResolvedValue({}),
+      getSingleEntity: jest.fn().mockReturnValue(Promise.resolve({})),
+      getAllEntities: jest.fn().mockReturnValue(Promise.resolve({})),
+      getAllEntitiesFromPath: jest.fn().mockReturnValue(Promise.resolve({})),
+      getAllEntitiesFromMesh: jest.fn().mockReturnValue(Promise.resolve({})),
       query: null,
       size: 10,
       offset: null,
@@ -17,25 +19,25 @@ describe('tableDataUtils', () => {
   })
 
   describe('calls proper function based on parameters', () => {
-    it('calls getAllEntities', () => {
+    test('calls getAllEntities', () => {
       getTableData(params)
 
       expect(params.getAllEntities).toHaveBeenCalled()
     })
 
-    it('calls getAllEntities when no mesh provided', () => {
+    test('calls getAllEntities when no mesh provided', () => {
       getTableData({ ...params, mesh: undefined })
 
       expect(params.getAllEntities).toHaveBeenCalled()
     })
 
-    it('calls getAllEntitiesFromMesh', () => {
+    test('calls getAllEntitiesFromMesh', () => {
       getTableData({ ...params, mesh: 'test-mesh' })
 
       expect(params.getAllEntitiesFromMesh).toHaveBeenCalled()
     })
 
-    it('calls getSingleEntity', () => {
+    test('calls getSingleEntity', () => {
       getTableData({ ...params, query: 'foo', mesh: 'test-mesh' })
 
       expect(params.getSingleEntity).toHaveBeenCalled()
@@ -43,7 +45,7 @@ describe('tableDataUtils', () => {
   })
 
   describe('handles reponses', () => {
-    it('when no corresponding function provided', async () => {
+    test('when no corresponding function provided', async () => {
       const response = await getTableData({
         ...params,
         mesh: 'test-mesh',
@@ -59,7 +61,7 @@ describe('tableDataUtils', () => {
 `)
     })
 
-    it('without data', async () => {
+    test('without data', async () => {
       const response = await getTableData(params)
 
       expect(response).toMatchInlineSnapshot(`
@@ -72,8 +74,8 @@ describe('tableDataUtils', () => {
 `)
     })
 
-    it('with single data', async () => {
-      params.getAllEntities = jest.fn().mockResolvedValue({ mesh: 'foo', name: 'bar' })
+    test('with single data', async () => {
+      params.getAllEntities = jest.fn().mockReturnValue(Promise.resolve({ mesh: 'foo', name: 'bar' }))
       const response = await getTableData(params)
 
       expect(response).toMatchInlineSnapshot(`
@@ -89,15 +91,15 @@ describe('tableDataUtils', () => {
 `)
     })
 
-    it('with multiple data', async () => {
-      params.getAllEntities = jest.fn().mockResolvedValue({
+    test('with multiple data', async () => {
+      params.getAllEntities = jest.fn().mockReturnValue(Promise.resolve({
         items: [
           { mesh: 'foo', name: 'bar' },
           { mesh: 'bar', name: 'foo' },
         ],
         total: 2,
         next: 'http://?offset=2',
-      })
+      }))
       const response = await getTableData(params)
 
       expect(response).toMatchInlineSnapshot(`
@@ -117,12 +119,12 @@ describe('tableDataUtils', () => {
 `)
     })
 
-    it('with empty array of items', async () => {
-      params.getAllEntities = jest.fn().mockResolvedValue({
+    test('with empty array of items', async () => {
+      params.getAllEntities = jest.fn().mockReturnValue(Promise.resolve({
         items: [],
         total: 0,
         next: null,
-      })
+      }))
       const response = await getTableData(params)
 
       expect(response).toMatchInlineSnapshot(`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1147,10 +1147,27 @@
     "@types/node" "*"
     jest-mock "^29.2.2"
 
+"@jest/environment@^29.3.1":
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.3.1.tgz#eb039f726d5fcd14698acd072ac6576d41cfcaa6"
+  integrity sha512-pMmvfOPmoa1c1QpfFW0nXYtNLpofqo4BrCIk6f2kW4JFeNlHV2t3vd+3iDLf31e2ot2Mec0uqZfmI+U0K2CFag==
+  dependencies:
+    "@jest/fake-timers" "^29.3.1"
+    "@jest/types" "^29.3.1"
+    "@types/node" "*"
+    jest-mock "^29.3.1"
+
 "@jest/expect-utils@^29.2.2":
   version "29.2.2"
   resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.2.2.tgz#460a5b5a3caf84d4feb2668677393dd66ff98665"
   integrity sha512-vwnVmrVhTmGgQzyvcpze08br91OL61t9O0lJMDyb6Y/D8EKQ9V7rGUb/p7PDt0GPzK0zFYqXWFo4EO2legXmkg==
+  dependencies:
+    jest-get-type "^29.2.0"
+
+"@jest/expect-utils@^29.3.1":
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.3.1.tgz#531f737039e9b9e27c42449798acb5bba01935b6"
+  integrity sha512-wlrznINZI5sMjwvUoLVk617ll/UYfGIZNxmbU+Pa7wmkL4vYzhV9R2pwVqUh4NWWuLQWkI8+8mOkxs//prKQ3g==
   dependencies:
     jest-get-type "^29.2.0"
 
@@ -1161,6 +1178,14 @@
   dependencies:
     expect "^29.2.2"
     jest-snapshot "^29.2.2"
+
+"@jest/expect@^29.3.1":
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.3.1.tgz#456385b62894349c1d196f2d183e3716d4c6a6cd"
+  integrity sha512-QivM7GlSHSsIAWzgfyP8dgeExPRZ9BIe2LsdPyEhCGkZkoyA+kGsoIzbKAfZCvvRzfZioKwPtCZIt5SaoxYCvg==
+  dependencies:
+    expect "^29.3.1"
+    jest-snapshot "^29.3.1"
 
 "@jest/fake-timers@^29.2.2":
   version "29.2.2"
@@ -1174,6 +1199,18 @@
     jest-mock "^29.2.2"
     jest-util "^29.2.1"
 
+"@jest/fake-timers@^29.3.1":
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.3.1.tgz#b140625095b60a44de820876d4c14da1aa963f67"
+  integrity sha512-iHTL/XpnDlFki9Tq0Q1GGuVeQ8BHZGIYsvCO5eN/O/oJaRzofG9Xndd9HuSDBI/0ZS79pg0iwn07OMTQ7ngF2A==
+  dependencies:
+    "@jest/types" "^29.3.1"
+    "@sinonjs/fake-timers" "^9.1.2"
+    "@types/node" "*"
+    jest-message-util "^29.3.1"
+    jest-mock "^29.3.1"
+    jest-util "^29.3.1"
+
 "@jest/globals@^29.2.2":
   version "29.2.2"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.2.2.tgz#205ff1e795aa774301c2c0ba0be182558471b845"
@@ -1183,6 +1220,16 @@
     "@jest/expect" "^29.2.2"
     "@jest/types" "^29.2.1"
     jest-mock "^29.2.2"
+
+"@jest/globals@^29.3.1":
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.3.1.tgz#92be078228e82d629df40c3656d45328f134a0c6"
+  integrity sha512-cTicd134vOcwO59OPaB6AmdHQMCtWOe+/DitpTZVxWgMJ+YvXL1HNAmPyiGbSHmF/mXVBkvlm8YYtQhyHPnV6Q==
+  dependencies:
+    "@jest/environment" "^29.3.1"
+    "@jest/expect" "^29.3.1"
+    "@jest/types" "^29.3.1"
+    jest-mock "^29.3.1"
 
 "@jest/reporters@^29.2.2":
   version "29.2.2"
@@ -1271,10 +1318,43 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.1"
 
+"@jest/transform@^29.3.1":
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.3.1.tgz#1e6bd3da4af50b5c82a539b7b1f3770568d6e36d"
+  integrity sha512-8wmCFBTVGYqFNLWfcOWoVuMuKYPUBTnTMDkdvFtAYELwDOl9RGwOsvQWGPFxDJ8AWY9xM/8xCXdqmPK3+Q5Lug==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@jest/types" "^29.3.1"
+    "@jridgewell/trace-mapping" "^0.3.15"
+    babel-plugin-istanbul "^6.1.1"
+    chalk "^4.0.0"
+    convert-source-map "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.3.1"
+    jest-regex-util "^29.2.0"
+    jest-util "^29.3.1"
+    micromatch "^4.0.4"
+    pirates "^4.0.4"
+    slash "^3.0.0"
+    write-file-atomic "^4.0.1"
+
 "@jest/types@^29.2.1":
   version "29.2.1"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.2.1.tgz#ec9c683094d4eb754e41e2119d8bdaef01cf6da0"
   integrity sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==
+  dependencies:
+    "@jest/schemas" "^29.0.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
+"@jest/types@^29.3.1":
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.3.1.tgz#7c5a80777cb13e703aeec6788d044150341147e3"
+  integrity sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==
   dependencies:
     "@jest/schemas" "^29.0.0"
     "@types/istanbul-lib-coverage" "^2.0.0"
@@ -1487,14 +1567,6 @@
   integrity sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==
   dependencies:
     "@types/istanbul-lib-report" "*"
-
-"@types/jest@^29.2.2":
-  version "29.2.2"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.2.2.tgz#874e7dc6702fa6a3fe6107792aa98636dcc480b4"
-  integrity sha512-og1wAmdxKoS71K2ZwSVqWPX6OVn3ihZ6ZT2qvZvZQm90lJVDyXIjYcu4Khx2CNIeaFv12rOU/YObOsI3VOkzog==
-  dependencies:
-    expect "^29.0.0"
-    pretty-format "^29.0.0"
 
 "@types/js-levenshtein@^1.1.1":
   version "1.1.1"
@@ -2531,6 +2603,11 @@ convert-source-map@^1.4.0, convert-source-map@^1.5.1, convert-source-map@^1.6.0,
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
 
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
 cookie@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
@@ -2874,6 +2951,11 @@ diff-sequences@^29.2.0:
   version "29.2.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.2.0.tgz#4c55b5b40706c7b5d2c5c75999a50c56d214e8f6"
   integrity sha512-413SY5JpYeSBZxmenGEmCVQ8mCgtFJF0w9PROdaS6z987XC2Pd2GOKqOITLtMftmyFZqgtCOb/QA7/Z3ZXfzIw==
+
+diff-sequences@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.3.1.tgz#104b5b95fe725932421a9c6e5b4bef84c3f2249e"
+  integrity sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -3583,7 +3665,7 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expect@^29.0.0, expect@^29.2.2:
+expect@^29.2.2:
   version "29.2.2"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.2.2.tgz#ba2dd0d7e818727710324a6e7f13dd0e6d086106"
   integrity sha512-hE09QerxZ5wXiOhqkXy5d2G9ar+EqOyifnCXCpMNu+vZ6DG9TJ6CO2c2kPDSLqERTTWrO7OZj8EkYHQqSd78Yw==
@@ -3593,6 +3675,17 @@ expect@^29.0.0, expect@^29.2.2:
     jest-matcher-utils "^29.2.2"
     jest-message-util "^29.2.1"
     jest-util "^29.2.1"
+
+expect@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.3.1.tgz#92877aad3f7deefc2e3f6430dd195b92295554a6"
+  integrity sha512-gGb1yTgU30Q0O/tQq+z30KBWv24ApkMgFUpvKBkyLUBL68Wv8dHdJxTBZFl/iT8K/bqDHvUYRH6IIN3rToopPA==
+  dependencies:
+    "@jest/expect-utils" "^29.3.1"
+    jest-get-type "^29.2.0"
+    jest-matcher-utils "^29.3.1"
+    jest-message-util "^29.3.1"
+    jest-util "^29.3.1"
 
 ext@^1.1.2:
   version "1.7.0"
@@ -4439,6 +4532,16 @@ jest-diff@^29.2.1:
     jest-get-type "^29.2.0"
     pretty-format "^29.2.1"
 
+jest-diff@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.3.1.tgz#d8215b72fed8f1e647aed2cae6c752a89e757527"
+  integrity sha512-vU8vyiO7568tmin2lA3r2DP8oRvzhvRcD4DjpXc6uGveQodyk7CKLhQlCSiwgx3g0pFaE88/KLZ0yaTWMc4Uiw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.3.1"
+    jest-get-type "^29.2.0"
+    pretty-format "^29.3.1"
+
 jest-docblock@^29.2.0:
   version "29.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.2.0.tgz#307203e20b637d97cee04809efc1d43afc641e82"
@@ -4507,6 +4610,25 @@ jest-haste-map@^29.2.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-haste-map@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.3.1.tgz#af83b4347f1dae5ee8c2fb57368dc0bb3e5af843"
+  integrity sha512-/FFtvoG1xjbbPXQLFef+WSU4yrc0fc0Dds6aRPBojUid7qlPqZvxdUBA03HW0fnVHXVCnCdkuoghYItKNzc/0A==
+  dependencies:
+    "@jest/types" "^29.3.1"
+    "@types/graceful-fs" "^4.1.3"
+    "@types/node" "*"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.9"
+    jest-regex-util "^29.2.0"
+    jest-util "^29.3.1"
+    jest-worker "^29.3.1"
+    micromatch "^4.0.4"
+    walker "^1.0.8"
+  optionalDependencies:
+    fsevents "^2.3.2"
+
 jest-leak-detector@^29.2.1:
   version "29.2.1"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.2.1.tgz#ec551686b7d512ec875616c2c3534298b1ffe2fc"
@@ -4525,6 +4647,16 @@ jest-matcher-utils@^29.2.2:
     jest-get-type "^29.2.0"
     pretty-format "^29.2.1"
 
+jest-matcher-utils@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.3.1.tgz#6e7f53512f80e817dfa148672bd2d5d04914a572"
+  integrity sha512-fkRMZUAScup3txIKfMe3AIZZmPEjWEdsPJFK3AIy5qRohWqQFg1qrmKfYXR9qEkNc7OdAu2N4KPHibEmy4HPeQ==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^29.3.1"
+    jest-get-type "^29.2.0"
+    pretty-format "^29.3.1"
+
 jest-message-util@^29.2.1:
   version "29.2.1"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.2.1.tgz#3a51357fbbe0cc34236f17a90d772746cf8d9193"
@@ -4540,6 +4672,21 @@ jest-message-util@^29.2.1:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-message-util@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.3.1.tgz#37bc5c468dfe5120712053dd03faf0f053bd6adb"
+  integrity sha512-lMJTbgNcDm5z+6KDxWtqOFWlGQxD6XaYwBqHR8kmpkP+WWWG90I35kdtQHY67Ay5CSuydkTBbJG+tH9JShFCyA==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^29.3.1"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^29.3.1"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-mock@^29.2.2:
   version "29.2.2"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.2.2.tgz#9045618b3f9d27074bbcf2d55bdca6a5e2e8bca7"
@@ -4548,6 +4695,15 @@ jest-mock@^29.2.2:
     "@jest/types" "^29.2.1"
     "@types/node" "*"
     jest-util "^29.2.1"
+
+jest-mock@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.3.1.tgz#60287d92e5010979d01f218c6b215b688e0f313e"
+  integrity sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==
+  dependencies:
+    "@jest/types" "^29.3.1"
+    "@types/node" "*"
+    jest-util "^29.3.1"
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
@@ -4674,6 +4830,36 @@ jest-snapshot@^29.2.2:
     pretty-format "^29.2.1"
     semver "^7.3.5"
 
+jest-snapshot@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.3.1.tgz#17bcef71a453adc059a18a32ccbd594b8cc4e45e"
+  integrity sha512-+3JOc+s28upYLI2OJM4PWRGK9AgpsMs/ekNryUV0yMBClT9B1DF2u2qay8YxcQd338PPYSFNb0lsar1B49sLDA==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@babel/generator" "^7.7.2"
+    "@babel/plugin-syntax-jsx" "^7.7.2"
+    "@babel/plugin-syntax-typescript" "^7.7.2"
+    "@babel/traverse" "^7.7.2"
+    "@babel/types" "^7.3.3"
+    "@jest/expect-utils" "^29.3.1"
+    "@jest/transform" "^29.3.1"
+    "@jest/types" "^29.3.1"
+    "@types/babel__traverse" "^7.0.6"
+    "@types/prettier" "^2.1.5"
+    babel-preset-current-node-syntax "^1.0.0"
+    chalk "^4.0.0"
+    expect "^29.3.1"
+    graceful-fs "^4.2.9"
+    jest-diff "^29.3.1"
+    jest-get-type "^29.2.0"
+    jest-haste-map "^29.3.1"
+    jest-matcher-utils "^29.3.1"
+    jest-message-util "^29.3.1"
+    jest-util "^29.3.1"
+    natural-compare "^1.4.0"
+    pretty-format "^29.3.1"
+    semver "^7.3.5"
+
 jest-transform-stub@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz#19018b0851f7568972147a5d60074b55f0225a7d"
@@ -4685,6 +4871,18 @@ jest-util@^29.0.0, jest-util@^29.2.1:
   integrity sha512-P5VWDj25r7kj7kl4pN2rG/RN2c1TLfYYYZYULnS/35nFDjBai+hBeo3MDrYZS7p6IoY3YHZnt2vq4L6mKnLk0g==
   dependencies:
     "@jest/types" "^29.2.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
+jest-util@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.3.1.tgz#1dda51e378bbcb7e3bc9d8ab651445591ed373e1"
+  integrity sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==
+  dependencies:
+    "@jest/types" "^29.3.1"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
@@ -4724,6 +4922,16 @@ jest-worker@^29.2.1:
   dependencies:
     "@types/node" "*"
     jest-util "^29.2.1"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
+jest-worker@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.3.1.tgz#e9462161017a9bb176380d721cab022661da3d6b"
+  integrity sha512-lY4AnnmsEWeiXirAIA0c9SDPbuCBq8IYuDVL8PMm0MZ2PEs2yPvRA/J64QBXuZp7CYKrDM/rmNrc9/i3KJQncw==
+  dependencies:
+    "@types/node" "*"
+    jest-util "^29.3.1"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
@@ -5609,10 +5817,19 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
-pretty-format@^29.0.0, pretty-format@^29.2.1:
+pretty-format@^29.2.1:
   version "29.2.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.2.1.tgz#86e7748fe8bbc96a6a4e04fa99172630907a9611"
   integrity sha512-Y41Sa4aLCtKAXvwuIpTvcFBkyeYp2gdFWzXGA+ZNES3VwURIB165XO/z7CjETwzCCS53MjW/rLMyyqEnTtaOfA==
+  dependencies:
+    "@jest/schemas" "^29.0.0"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
+pretty-format@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.3.1.tgz#1841cac822b02b4da8971dacb03e8a871b4722da"
+  integrity sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==
   dependencies:
     "@jest/schemas" "^29.0.0"
     ansi-styles "^5.0.0"


### PR DESCRIPTION
Uses the package @jest/globals to explicitly import global Jest symbols and removes the global type definitions for jest.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>