### PR TITLE
fix: Show correct 'ctl command in mesh wizard code block

### DIFF
--- a/src/app/wizard/views/Mesh.spec.ts
+++ b/src/app/wizard/views/Mesh.spec.ts
@@ -61,12 +61,12 @@ describe('Mesh.vue', () => {
     // test that the cli command is correct depending
     // on which tab you clicked
     const kubeTab = wrapper.find('#kubernetes-tab a')
-    const uniCode = wrapper.find('[data-test-codeblock="universal"]')
+    const uniCode = wrapper.find('[data-testid="universal"]')
     expect(uniCode.html()).toContain('kumactl')
 
     await kubeTab.trigger('click')
 
-    const kubeCode = wrapper.find('[data-test-codeblock="kubernetes"]')
+    const kubeCode = wrapper.find('[data-testid="kubernetes"]')
     expect(kubeCode.html()).toContain('kubectl')
   })
 })

--- a/src/app/wizard/views/Mesh.spec.ts
+++ b/src/app/wizard/views/Mesh.spec.ts
@@ -55,8 +55,18 @@ describe('Mesh.vue', () => {
     await doStep(wrapper, nextButton, 'mesh-metrics-enabled', ['mesh-metrics-backend-name'])
 
     await flushPromises()
-    expect(wrapper.html()).toContain('kumactl apply')
 
     expect(wrapper.element).toMatchSnapshot()
+
+    // test that the cli command is correct depending
+    // on which tab you clicked
+    const kubeTab = wrapper.find('#kubernetes-tab a')
+    const uniCode = wrapper.find('[data-test-codeblock="universal"]')
+    expect(uniCode.html()).toContain('kumactl')
+
+    await kubeTab.trigger('click')
+
+    const kubeCode = wrapper.find('[data-test-codeblock="kubernetes"]')
+    expect(kubeCode.html()).toContain('kubectl')
   })
 })

--- a/src/app/wizard/views/Mesh.vue
+++ b/src/app/wizard/views/Mesh.vue
@@ -499,7 +499,7 @@
                 <template #kubernetes>
                   <CodeBlock
                     id="code-block-kubernetes-command"
-                    data-test-codeblock="kubernetes"
+                    data-testid="kubernetes"
                     language="bash"
                     :code="codeOutput"
                   />
@@ -507,7 +507,7 @@
                 <template #universal>
                   <CodeBlock
                     id="code-block-universal-command"
-                    data-test-codeblock="universal"
+                    data-testid="universal"
                     language="bash"
                     :code="codeOutput"
                   />

--- a/src/app/wizard/views/Mesh.vue
+++ b/src/app/wizard/views/Mesh.vue
@@ -499,6 +499,7 @@
                 <template #kubernetes>
                   <CodeBlock
                     id="code-block-kubernetes-command"
+                    data-test-codeblock="kubernetes"
                     language="bash"
                     :code="codeOutput"
                   />
@@ -506,6 +507,7 @@
                 <template #universal>
                   <CodeBlock
                     id="code-block-universal-command"
+                    data-test-codeblock="universal"
                     language="bash"
                     :code="codeOutput"
                   />
@@ -866,8 +868,11 @@ export default {
       // Mesh yaml creation
       let meshYaml
 
+      let ctl
+
       if (this.selectedTab === '#kubernetes') {
         // Kubernetes
+        ctl = 'kubectl'
         meshYaml = {
           apiVersion: 'kuma.io/v1alpha1',
           kind: 'Mesh',
@@ -881,6 +886,7 @@ export default {
         }
       } else {
         // Universal
+        ctl = 'kumactl'
         meshYaml = {
           type: 'Mesh',
           name: newData.meshName,
@@ -888,7 +894,7 @@ export default {
         }
       }
 
-      return formatForCLI(meshYaml, '" | kumactl apply -f -')
+      return formatForCLI(meshYaml, `" | ${ctl} apply -f -`)
     },
     nextDisabled() {
       const {

--- a/src/app/wizard/views/__snapshots__/Mesh.spec.ts.snap
+++ b/src/app/wizard/views/__snapshots__/Mesh.spec.ts.snap
@@ -209,6 +209,7 @@ exports[`Mesh.vue passes whole wizzard and render yaml 1`] = `
                           
                           <div
                             class="k-code-block code-block"
+                            data-test-codeblock="universal"
                             data-testid="k-code-block"
                             data-v-034f9b55=""
                             id="code-block-universal-command"

--- a/src/app/wizard/views/__snapshots__/Mesh.spec.ts.snap
+++ b/src/app/wizard/views/__snapshots__/Mesh.spec.ts.snap
@@ -209,8 +209,7 @@ exports[`Mesh.vue passes whole wizzard and render yaml 1`] = `
                           
                           <div
                             class="k-code-block code-block"
-                            data-test-codeblock="universal"
-                            data-testid="k-code-block"
+                            data-testid="universal"
                             data-v-034f9b55=""
                             id="code-block-universal-command"
                             style="--maxLineNumberWidth: 2ch;"


### PR DESCRIPTION
Makes the command dynamic depending on which tab you have selected, plus
adds some data-test-* attributes for testing purposes

Fixes https://github.com/kumahq/kuma-gui/issues/451

Signed-off-by: John Cowen <john.cowen@konghq.com>
