### PR TITLE
fix: pagination not working correctly

### DIFF
--- a/src/api/mock-data/meshes/default/circuit-breakers.json
+++ b/src/api/mock-data/meshes/default/circuit-breakers.json
@@ -98,5 +98,5 @@
       }
     }
   ],
-  "next": null
+  "next": "http://localhost:5681/meshes/default/circuit-breakers?offset=1"
 }

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -400,11 +400,12 @@ async function parseData(dataPlaneOverview: DataPlaneOverview) {
 }
 
 async function loadData(offset: number): Promise<void> {
-  isLoading.value = true
   pageOffset.value = offset
-
   // Puts the offset parameter in the URL so it can be retrieved when the user reloads the page.
   patchQueryParam('offset', offset > 0 ? offset : null)
+
+  isLoading.value = true
+
   const mesh = route.params.mesh as string
   const size = PAGE_SIZE
 

--- a/src/app/policies/views/PolicyView.vue
+++ b/src/app/policies/views/PolicyView.vue
@@ -35,6 +35,7 @@
         :table-data="tableData"
         :table-data-is-empty="tableDataIsEmpty"
         :next="nextUrl"
+        :page-offset="pageOffset"
         @table-action="getEntity"
         @load-data="loadData"
       >
@@ -137,6 +138,7 @@ import PolicyConnections from '../components/PolicyConnections.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
 import YamlView from '@/app/common/YamlView.vue'
 import { PolicyEntity, TableHeader } from '@/types/index.d'
+import { patchQueryParam } from '@/utilities/patchQueryParam'
 
 const tabs = [
   {
@@ -157,6 +159,12 @@ const props = defineProps({
     type: String,
     required: true,
   },
+
+  offset: {
+    type: Number,
+    required: false,
+    default: 0,
+  },
 })
 
 const isLoading = ref(true)
@@ -169,6 +177,7 @@ const tableDataIsEmpty = ref(false)
 const entity = ref<any>({})
 const rawEntity = ref<Omit<PolicyEntity, 'creationTime' | 'modificationTime'> | null>(null)
 const nextUrl = ref<string | null>(null)
+const pageOffset = ref(props.offset)
 
 const tableData = ref<{ headers: TableHeader[], data: any[] }>({
   headers: [
@@ -202,12 +211,16 @@ watch(() => route.params.mesh, function () {
   tableDataIsEmpty.value = false
   error.value = null
 
-  loadData()
+  loadData(0)
 })
 
-loadData()
+loadData(props.offset)
 
-async function loadData(offset: number = 0): Promise<void> {
+async function loadData(offset: number): Promise<void> {
+  pageOffset.value = offset
+  // Puts the offset parameter in the URL so it can be retrieved when the user reloads the page.
+  patchQueryParam('offset', offset > 0 ? offset : null)
+
   isLoading.value = true
   error.value = null
 

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -10,6 +10,7 @@
         :table-data="tableData"
         :table-data-is-empty="tableData.data.length === 0"
         :next="nextUrl"
+        :page-offset="pageOffset"
         @table-action="setActiveServiceInsight"
         @load-data="loadData"
       />
@@ -36,6 +37,7 @@ import ServiceDetails from '../components/ServiceDetails.vue'
 import { kumaApi } from '@/api/kumaApi'
 import { STATUS } from '@/constants'
 import { ServiceInsight, TableHeader } from '@/types/index.d'
+import { patchQueryParam } from '@/utilities/patchQueryParam'
 
 const headers: TableHeader[] = [
   { label: 'Service', key: 'name' },
@@ -54,9 +56,18 @@ const EMPTY_STATE = {
 
 const route = useRoute()
 
+const props = defineProps({
+  offset: {
+    type: Number,
+    required: false,
+    default: 0,
+  },
+})
+
 const isLoading = ref(true)
 const error = ref<Error | null>(null)
 const nextUrl = ref<string | null>(null)
+const pageOffset = ref(props.offset)
 const serviceInsight = ref<{ name: string, mesh: string, serviceType?: 'internal' | 'external' | 'gateway_builtin' | 'gateway_delegated' } | null>(null)
 const tableData = ref<{ headers: TableHeader[], data: any[] }>({
   headers,
@@ -72,9 +83,13 @@ watch(() => route.params.mesh, function () {
   loadData(0)
 })
 
-loadData(0)
+loadData(props.offset)
 
 async function loadData(offset: number): Promise<void> {
+  pageOffset.value = offset
+  // Puts the offset parameter in the URL so it can be retrieved when the user reloads the page.
+  patchQueryParam('offset', offset > 0 ? offset : null)
+
   isLoading.value = true
   error.value = null
 

--- a/src/app/zones/views/ZoneEgresses.vue
+++ b/src/app/zones/views/ZoneEgresses.vue
@@ -10,6 +10,7 @@
         :table-data="tableData"
         :table-data-is-empty="isEmpty"
         :next="next"
+        :page-offset="pageOffset"
         @table-action="tableAction"
         @load-data="loadData($event)"
       >
@@ -129,6 +130,7 @@ import LabelList from '@/app/common/LabelList.vue'
 import SubscriptionDetails from '@/app/common/subscriptions/SubscriptionDetails.vue'
 import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
+import { patchQueryParam } from '@/utilities/patchQueryParam'
 
 export default {
   name: 'ZoneEgresses',
@@ -145,6 +147,14 @@ export default {
     TabsWidget,
     KButton,
     KCard,
+  },
+
+  props: {
+    offset: {
+      type: Number,
+      required: false,
+      default: 0,
+    },
   },
 
   data() {
@@ -192,8 +202,10 @@ export default {
       pageSize: PAGE_SIZE_DEFAULT,
       next: null,
       subscriptionsReversed: [],
+      pageOffset: this.offset,
     }
   },
+
   watch: {
     $route() {
       // Ensures basic state is reset when switching meshes using the mesh selector.
@@ -201,16 +213,15 @@ export default {
       this.isEmpty = false
       this.error = null
 
-      this.init()
+      this.loadData(0)
     },
   },
+
   beforeMount() {
-    this.init()
+    this.loadData(this.offset)
   },
+
   methods: {
-    init() {
-      this.loadData()
-    },
     tableAction(ev) {
       const data = ev
 
@@ -218,7 +229,11 @@ export default {
       this.getEntity(data)
     },
 
-    async loadData(offset = '0') {
+    async loadData(offset) {
+      this.pageOffset = offset
+      // Puts the offset parameter in the URL so it can be retrieved when the user reloads the page.
+      patchQueryParam('offset', offset > 0 ? offset : null)
+
       this.isLoading = true
       this.isEmpty = false
 

--- a/src/router/getLastParameter.ts
+++ b/src/router/getLastParameter.ts
@@ -1,0 +1,11 @@
+import { LocationQueryValue } from 'vue-router'
+
+export function getLastNumberParameter(param: LocationQueryValue | LocationQueryValue[], defaultValue: number = 0): number {
+  const lastParam = getLastParameter(param)
+  return lastParam !== undefined ? parseInt(lastParam) : defaultValue
+}
+
+export function getLastParameter(param: LocationQueryValue | LocationQueryValue[]): string | undefined {
+  const paramList = Array.isArray(param) ? param : [param]
+  return paramList[paramList.length - 1] ?? undefined
+}

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -1,5 +1,6 @@
 import { createRouter as createVueRouter, createWebHistory, NavigationGuard, Router, RouteRecordRaw } from 'vue-router'
 
+import { getLastNumberParameter } from './getLastParameter'
 import { store } from '@/store/store'
 import { PolicyDefinition } from '@/types/index.d'
 import { ClientStorage } from '@/utilities/ClientStorage'
@@ -13,9 +14,10 @@ function getPolicyRoutes(policies: PolicyDefinition[]): RouteRecordRaw[] {
       shouldReRender: true,
       title: policy.pluralDisplayName,
     },
-    props: {
+    props: (route) => ({
       policyPath: policy.path,
-    },
+      offset: getLastNumberParameter(route.query.offset),
+    }),
     component: () => import('@/app/policies/views/PolicyView.vue'),
   }))
 }
@@ -55,6 +57,9 @@ export function createRouter(policyDefinitions: PolicyDefinition[] = []): Router
       meta: {
         title: 'Zones',
       },
+      props: (route) => ({
+        offset: getLastNumberParameter(route.query.offset),
+      }),
       component: () => import('@/app/zones/views/ZonesView.vue'),
     },
     {
@@ -63,6 +68,9 @@ export function createRouter(policyDefinitions: PolicyDefinition[] = []): Router
       meta: {
         title: 'Zone ingresses',
       },
+      props: (route) => ({
+        offset: getLastNumberParameter(route.query.offset),
+      }),
       component: () => import('@/app/zones/views/ZoneIngresses.vue'),
     },
     {
@@ -71,6 +79,9 @@ export function createRouter(policyDefinitions: PolicyDefinition[] = []): Router
       meta: {
         title: 'Zone egresses',
       },
+      props: (route) => ({
+        offset: getLastNumberParameter(route.query.offset),
+      }),
       component: () => import('@/app/zones/views/ZoneEgresses.vue'),
     },
     {
@@ -93,15 +104,10 @@ export function createRouter(policyDefinitions: PolicyDefinition[] = []): Router
               meta: {
                 title: 'Data plane proxies',
               },
-              props(route) {
-                const offsets = Array.isArray(route.query.offset) ? route.query.offset : [route.query.offset]
-                const offset = parseInt(offsets[offsets.length - 1] ?? '0') || 0
-
-                return {
-                  name: route.query.name,
-                  offset,
-                }
-              },
+              props: (route) => ({
+                name: route.query.name,
+                offset: getLastNumberParameter(route.query.offset),
+              }),
               component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
             },
             {
@@ -125,6 +131,9 @@ export function createRouter(policyDefinitions: PolicyDefinition[] = []): Router
               meta: {
                 title: 'Services',
               },
+              props: (route) => ({
+                offset: getLastNumberParameter(route.query.offset),
+              }),
               component: () => import('@/app/services/views/ServiceListView.vue'),
             },
             {


### PR DESCRIPTION
Fixes pagination not working correctly on some pages.

Adds the logic for persisting the pagination offset in the URL so reloading reloads the page the user was on.

Fixes #441.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>