### PR TITLE
refactor: adds BaseGuiPath variable to index file

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,21 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <link rel="icon" href="/favicon.png" />
-    <title>Manager</title>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-    <script type="module" src="/src/main.ts"></script>
-  </head>
-  <body>
-    <noscript>
-      <strong>
-        We're sorry but this site doesn't work properly without JavaScript enabled. Please enable it to continue.
-      </strong>
-    </noscript>
+  <link rel="icon" href="/favicon.png" />
+  <title>Manager</title>
 
-    <div id="app"></div>
-  </body>
+  <script type="application/json" id="kuma-config">{{.}}</script>
+
+  <script type="module" src="/src/main.ts"></script>
+</head>
+
+<body>
+  <noscript>
+    <strong>
+      We're sorry but this site doesn't work properly without JavaScript enabled. Please enable it to continue.
+    </strong>
+  </noscript>
+
+  <div id="app"></div>
+</body>
+
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,23 +4,26 @@ import vue from '@vitejs/plugin-vue'
 import svgLoader from 'vite-svg-loader'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: './',
-  // For testing, you may set the base path to a less conventional value to resemble a real user environment more closely. Annoyingly, this currently **requires** the trailing slash to be added in the URL. Navigating to http://localhost:8080/dev/gui will **not** work; http://localhost:8080/dev/gui/ will. Issue: https://github.com/vitejs/vite/issues/9236
-  // base: '/dev/gui/',
-  server: {
-    port: 8080,
-  },
-  plugins: [
-    vue(),
-    svgLoader(),
-  ],
-  resolve: {
-    alias: {
-      /**
-       * Used to import files using, for example, '@/api/kumaApi'.
-       */
-      '@': path.resolve('./src'),
+export default defineConfig(function ({ mode }) {
+  return {
+    // Under no circumstances (except for the value `'./'`) should `base` be set to a value that doesn’t have a leading and trailing slash. Vite **will** always add a leading and trailing slash unless they’re present. For this reason, `{{.BaseGuiPath}}` must never have a leading or trailing slash.
+    base: mode === 'production' ? '/{{.BaseGuiPath}}/' : './',
+    // For testing, you may set the base path to a less conventional value to resemble a real user environment more closely. Annoyingly, this currently **requires** the trailing slash to be added in the URL. Navigating to http://localhost:8080/dev/gui will **not** work; http://localhost:8080/dev/gui/ will. Issue: https://github.com/vitejs/vite/issues/9236
+    // base: '/dev/gui/',
+    server: {
+      port: 8080,
     },
-  },
+    plugins: [
+      vue(),
+      svgLoader(),
+    ],
+    resolve: {
+      alias: {
+        /**
+         * Used to import files using, for example, '@/api/kumaApi'.
+         */
+        '@': path.resolve('./src'),
+      },
+    },
+  }
 })


### PR DESCRIPTION
Adds the `{{.BaseGuiPath}}` string in the index.html file generated when building for production. This variable is going to be replaced when being served by the Go application. It is expected to be replaced with the GUI base path without a leading or trailing slash (e.g. "", "gui",  "dev/gui", "a/b/c/gui", etc.).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>