### PR TITLE
chore(deps): setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"    
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Provides dependabot configuration to keep npm and github-actions up-to-date.
This is based on [kuma configuration](https://github.com/kumahq/kuma/blob/master/.github/dependabot.yml) 

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>