### PR TITLE
fix: accessing dataplaneInsight prematurely

### DIFF
--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -300,7 +300,7 @@ const dataPlaneVersions = computed(() => getVersions(props.dataPlaneOverview.dat
 const rawDataPlane = computed(() => stripTimes(props.dataPlane))
 const mtlsData = computed(() => parseMTLSData(props.dataPlaneOverview))
 const insightSubscriptions = computed(() => {
-  const subscriptions = Array.from(props.dataPlaneOverview.dataplaneInsight.subscriptions)
+  const subscriptions = Array.from(props.dataPlaneOverview.dataplaneInsight?.subscriptions ?? [])
 
   subscriptions.reverse()
 
@@ -316,7 +316,7 @@ const kumaDocsVersion = computed(() => {
 const filteredTabs = computed(() => warnings.value.length === 0 ? tabs.filter((tab) => tab.hash !== '#warnings') : tabs)
 
 function setWarnings() {
-  const subscriptions = props.dataPlaneOverview.dataplaneInsight.subscriptions
+  const subscriptions = props.dataPlaneOverview.dataplaneInsight?.subscriptions ?? []
 
   if (subscriptions.length === 0 || !('version' in subscriptions[0])) {
     return

--- a/src/app/data-planes/components/DataPlaneEntitySummary.vue
+++ b/src/app/data-planes/components/DataPlaneEntitySummary.vue
@@ -171,7 +171,7 @@ const dataPlane = computed(() => {
 const dataPlaneTags = computed(() => dpTags(props.dataPlaneOverview.dataplane))
 
 const subscriptionWrappers = computed(() => {
-  const subscriptions = Array.from(props.dataPlaneOverview.dataplaneInsight.subscriptions)
+  const subscriptions = Array.from(props.dataPlaneOverview.dataplaneInsight?.subscriptions ?? [])
 
   subscriptions.reverse()
 
@@ -218,7 +218,7 @@ const dependencies = computed(() => {
 })
 
 const warnings = computed(() => {
-  const { subscriptions } = props.dataPlaneOverview.dataplaneInsight
+  const subscriptions = props.dataPlaneOverview.dataplaneInsight?.subscriptions ?? []
 
   if (subscriptions.length === 0) {
     return []

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -306,6 +306,7 @@ async function parseData(dataPlaneOverview: DataPlaneOverview) {
   }
 
   const { status } = getStatus(dataPlaneOverview.dataplane, dataPlaneOverview.dataplaneInsight)
+  const subscriptions = dataPlaneOverview.dataplaneInsight?.subscriptions ?? []
 
   const initialData: any = {
     totalUpdates: 0,
@@ -317,7 +318,7 @@ async function parseData(dataPlaneOverview: DataPlaneOverview) {
     version: null,
   }
 
-  const summary = dataPlaneOverview.dataplaneInsight.subscriptions.reduce(
+  const summary = subscriptions.reduce(
     (acc, subscription) => {
       if (subscription.connectTime) {
         const connectDate = Date.parse(subscription.connectTime)

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -218,7 +218,7 @@ export interface DataPlaneOverview extends MeshEntity {
   dataplane: {
     networking: DataPlaneNetworking
   }
-  dataplaneInsight: DataPlaneInsight
+  dataplaneInsight?: DataPlaneInsight
 }
 
 export interface PolicyType extends MeshEntity {


### PR DESCRIPTION
Fixes a premature access to the `dataplaneInsight` property which can be absent.

Fixes #475.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>