### PR TITLE
ci: Lint Vue Typescript

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,12 +40,15 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Lint lock file
-        run: npm run lint:lockfile
+        run: yarn run lint:lockfile
 
       - name: Lint
         run: yarn run lint
         env:
           LINTER_MODE: strict
+
+      - name: Lint TS
+        run: yarn run lint:ts
 
       - name: Test
         run: yarn run test

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:ci": "cross-env VITE_MOCK_API_ENABLED=true VITE_FAKE_MULTIZONE=true yarn run build --mode preview",
     "lint": "eslint --ext .js,.ts,.vue --fix .",
     "lint:lockfile": "lockfile-lint --path yarn.lock --allowed-hosts yarn --validate-https",
+    "lint:ts": "vue-tsc --noEmit",
     "test": "cross-env TZ=UTC jest",
     "test:watch": "yarn run test --watch"
   },
@@ -74,7 +75,8 @@
     "vite": "^3.2.5",
     "vite-plugin-html": "^3.2.0",
     "vite-plugin-rewrite-all": "^1.0.0",
-    "vite-svg-loader": "^3.6.0"
+    "vite-svg-loader": "^3.6.0",
+    "vue-tsc": "^1.0.11"
   },
   "browserslist": [
     "> 1%",

--- a/src/app/common/charts/DonutChart.vue
+++ b/src/app/common/charts/DonutChart.vue
@@ -242,6 +242,8 @@ function createChart(): any {
   chart = createFromConfig(createDefaultConfig(), chartNode.value, PieChart)
 
   if (props.saveChart) {
+    // We declare these properties on globalThis in index.d.ts
+    // once these are gone we can also remove those declarations
     window.chart = chart
     window.series = series
   }

--- a/src/app/data-planes/components/DataplanePolicies.spec.ts
+++ b/src/app/data-planes/components/DataplanePolicies.spec.ts
@@ -5,12 +5,27 @@ import { rest } from 'msw'
 import DataplanePolicies from './DataplanePolicies.vue'
 import { store } from '@/store/store'
 import { server } from '@/../jest/jest-setup-after-env'
+import {
+  DataPlane,
+} from '@/types/index.d'
 
 async function renderComponent(props = {}) {
   await store.dispatch('fetchPolicies')
-
+  const dataPlane:DataPlane = {
+    type: 'Dataplane',
+    mesh: 'foo',
+    name: 'dataplane-test-456',
+    creationTime: '',
+    modificationTime: '',
+    networking: {
+      address: '',
+    },
+  }
   return mount(DataplanePolicies, {
-    props,
+    props: {
+      dataPlane,
+      ...props,
+    },
     global: {
       stubs: {
         'router-link': RouterLinkStub,
@@ -21,13 +36,7 @@ async function renderComponent(props = {}) {
 
 describe('DataplanePolicies.vue', () => {
   test('renders snapshot', async () => {
-    const wrapper = await renderComponent({
-      dataPlane: {
-        mesh: 'foo',
-        name: 'dataplane-test-456',
-        networking: {},
-      },
-    })
+    const wrapper = await renderComponent()
 
     await flushPromises()
 
@@ -37,31 +46,19 @@ describe('DataplanePolicies.vue', () => {
   })
 
   test('renders loading', async () => {
-    const wrapper = await renderComponent({
-      dataPlane: {
-        mesh: 'foo',
-        name: 'dataplane-test-456',
-        networking: {},
-      },
-    })
+    const wrapper = await renderComponent()
 
     expect(wrapper.find('[data-testid="loading-block"]').exists()).toBe(true)
   })
 
   test('renders error', async () => {
     server.use(
-      rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/dataplanes/:dataplaneName/policies', (req, res, ctx) =>
+      rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/dataplanes/:dataplaneName/policies', (_req, res, ctx) =>
         res(ctx.status(500), ctx.json({})),
       ),
     )
 
-    const wrapper = await renderComponent({
-      dataPlane: {
-        mesh: 'foo',
-        name: 'dataplane-test-456',
-        networking: {},
-      },
-    })
+    const wrapper = await renderComponent()
 
     await flushPromises()
 
@@ -75,13 +72,7 @@ describe('DataplanePolicies.vue', () => {
       ),
     )
 
-    const wrapper = await renderComponent({
-      dataPlane: {
-        mesh: 'foo',
-        name: 'dataplane-test-456',
-        networking: {},
-      },
-    })
+    const wrapper = await renderComponent()
 
     await flushPromises()
 

--- a/src/app/onboarding/components/OnboardingNavigation.spec.ts
+++ b/src/app/onboarding/components/OnboardingNavigation.spec.ts
@@ -6,7 +6,10 @@ import { store } from '@/store/store'
 
 function renderComponent(props = {}) {
   return mount(OnboardingNavigation, {
-    props,
+    props: {
+      nextStep: 'bar',
+      ...props,
+    },
     global: {
       stubs: {
         'router-link': RouterLinkStub,
@@ -19,7 +22,6 @@ describe('OnboardingNavigation.vue', () => {
   test('renders snapshot', () => {
     const wrapper = renderComponent({
       previousStep: 'foo',
-      nextStep: 'bar',
     })
 
     expect(wrapper.element).toMatchSnapshot()
@@ -28,7 +30,6 @@ describe('OnboardingNavigation.vue', () => {
   test('displays different next step title', () => {
     const wrapper = renderComponent({
       previousStep: 'foo',
-      nextStep: 'bar',
       nextStepTitle: 'nextStepTitle',
     })
 
@@ -38,7 +39,6 @@ describe('OnboardingNavigation.vue', () => {
   test('display disabled next button', () => {
     const wrapper = renderComponent({
       previousStep: 'foo',
-      nextStep: 'bar',
       shouldAllowNext: false,
     })
 
@@ -46,9 +46,7 @@ describe('OnboardingNavigation.vue', () => {
   })
 
   test('doesn\'t display previous step', () => {
-    const wrapper = renderComponent({
-      nextStep: 'bar',
-    })
+    const wrapper = renderComponent()
 
     expect(wrapper.html()).not.toContain('Back')
   })
@@ -56,7 +54,6 @@ describe('OnboardingNavigation.vue', () => {
   test('changes step to previous', async () => {
     const wrapper = renderComponent({
       previousStep: 'foo',
-      nextStep: 'bar',
     })
 
     expect(store.state.onboarding.step).toBe('onboarding-welcome')
@@ -69,7 +66,6 @@ describe('OnboardingNavigation.vue', () => {
   test('calls skip onboarding', async () => {
     const wrapper = renderComponent({
       previousStep: 'foo',
-      nextStep: 'bar',
     })
 
     expect(store.state.onboarding.isCompleted).toBe(false)

--- a/src/app/policies/components/PolicyConnections.spec.ts
+++ b/src/app/policies/components/PolicyConnections.spec.ts
@@ -6,16 +6,19 @@ import PolicyConnections from './PolicyConnections.vue'
 import { server } from '@/../jest/jest-setup-after-env'
 
 function renderComponent(props = {}) {
-  return mount(PolicyConnections, { props })
+  return mount(PolicyConnections, {
+    props: {
+      mesh: 'foo',
+      policyType: 'foo',
+      policyName: 'foo',
+      ...props,
+    },
+  })
 }
 
 describe('PolicyConnections.vue', () => {
   test('renders snapshot', async () => {
-    const wrapper = renderComponent({
-      mesh: 'foo',
-      policyType: 'foo',
-      policyName: 'foo',
-    })
+    const wrapper = renderComponent()
 
     await flushPromises()
 
@@ -25,11 +28,7 @@ describe('PolicyConnections.vue', () => {
   })
 
   test('filters result', async () => {
-    const wrapper = renderComponent({
-      mesh: 'foo',
-      policyType: 'foo',
-      policyName: 'foo',
-    })
+    const wrapper = renderComponent()
 
     await flushPromises()
 
@@ -44,11 +43,7 @@ describe('PolicyConnections.vue', () => {
   })
 
   test('renders loading', () => {
-    const wrapper = renderComponent({
-      mesh: 'foo',
-      policyType: 'foo',
-      policyName: 'foo',
-    })
+    const wrapper = renderComponent()
 
     expect(wrapper.find('[data-testid="loading-block"]').exists()).toBe(true)
   })
@@ -60,11 +55,7 @@ describe('PolicyConnections.vue', () => {
       ),
     )
 
-    const wrapper = renderComponent({
-      mesh: 'foo',
-      policyType: 'foo',
-      policyName: 'foo',
-    })
+    const wrapper = renderComponent()
 
     await flushPromises()
 
@@ -78,11 +69,7 @@ describe('PolicyConnections.vue', () => {
       ),
     )
 
-    const wrapper = renderComponent({
-      mesh: 'foo',
-      policyType: 'foo',
-      policyName: 'foo',
-    })
+    const wrapper = renderComponent()
 
     await flushPromises()
 

--- a/src/app/policies/components/PolicyConnections.vue
+++ b/src/app/policies/components/PolicyConnections.vue
@@ -78,14 +78,14 @@ const filteredDataplanes = computed(() => {
 })
 
 watch(() => props.policyName, function () {
-  fetchPolicyConntections()
+  fetchPolicyConnections()
 })
 
 onMounted(function () {
-  fetchPolicyConntections()
+  fetchPolicyConnections()
 })
 
-async function fetchPolicyConntections(): Promise<void> {
+async function fetchPolicyConnections(): Promise<void> {
   hasError.value = false
   isLoading.value = true
 

--- a/src/app/policies/views/PolicyView.spec.ts
+++ b/src/app/policies/views/PolicyView.spec.ts
@@ -10,13 +10,16 @@ async function createWrapper(props = {}) {
   await store.dispatch('fetchPolicies')
 
   return mount(PolicyView, {
-    props,
+    props: {
+      policyPath: 'circuit-breakers',
+      ...props,
+    },
   })
 }
 
 describe('PolicyView', () => {
   test('renders default view correctly', async () => {
-    const wrapper = await createWrapper({ policyPath: 'circuit-breakers' })
+    const wrapper = await createWrapper()
 
     await flushPromises()
 

--- a/src/app/services/components/ServiceDetails.spec.ts
+++ b/src/app/services/components/ServiceDetails.spec.ts
@@ -11,7 +11,11 @@ const serviceInsight = createServiceInsight()
 
 function renderComponent(props = {}) {
   return shallowMount(ServiceDetails, {
-    props,
+    props: {
+      name: 'wrong-name',
+      mesh: 'wrong-mesh',
+      ...props,
+    },
   })
 }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,5 +1,13 @@
 import { RouteLocationNamedRaw } from 'vue-router'
 
+// These are set in DonutChart, but its not super clear what for
+// If they go from Donut Chart they can go here also
+export declare global {
+  interface Window {
+    chart: any;
+    series: any;
+  }
+}
 export type PathConfig = {
   /**
    * The base API URL. Won’t include a trailing slash.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1695,6 +1695,51 @@
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-3.2.0.tgz#a1484089dd85d6528f435743f84cdd0d215bbb54"
   integrity sha512-E0tnaL4fr+qkdCNxJ+Xd0yM31UwMkQje76fsDVBBUCoGOUPexu2VDUYHL8P4CwV+zMvWw6nlRw19OnRKmYAJpw==
 
+"@volar/language-core@1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@volar/language-core/-/language-core-1.0.11.tgz#14c17add91483f0a39a5ee3207a615bdc71c9db4"
+  integrity sha512-YwUYKxIyDc+Fq3kQ6BGGfkrKCG5JzE2Yr6vMxrxEXW2rg/gsq3JgMk/4sI8ybRsaTirhCB4V8+AIVYsvcRxgig==
+  dependencies:
+    "@volar/source-map" "1.0.11"
+    "@vue/reactivity" "^3.2.45"
+    muggle-string "^0.1.0"
+
+"@volar/source-map@1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-1.0.11.tgz#8db897b382ce13afde012ced2d9ca2acb85efe3a"
+  integrity sha512-tkuV9MD+OuiZfHA0qZXrPdW6F7TvnpnuTan6Qe7UGUs9+sflezlMJdjaYdGgQObfP+06pcT1E3xdkOoi08ZyyQ==
+  dependencies:
+    muggle-string "^0.1.0"
+
+"@volar/typescript@1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@volar/typescript/-/typescript-1.0.11.tgz#e127e5598f9bc7e39cf69c8dd6e2f43070a3fd72"
+  integrity sha512-mq7wDDAs0Eb43jev2FxbowuiwWqvL3kb+tar1we8VQbdabpyQ5dmbWPwo/IglevMmW3SKo1Et+6rqAeZpXNnPQ==
+  dependencies:
+    "@volar/language-core" "1.0.11"
+
+"@volar/vue-language-core@1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@volar/vue-language-core/-/vue-language-core-1.0.11.tgz#e185b0d4e6bd1de8e350dfc396639034c5c02bff"
+  integrity sha512-A3ODs0/ua7BcpSSnE7KtO8bzWsYsbOJRyW2Q/2uktxlfHj8srln3JdgK/mNlIgfnWtACbE5K+EfMJOgJKv864A==
+  dependencies:
+    "@volar/language-core" "1.0.11"
+    "@volar/source-map" "1.0.11"
+    "@vue/compiler-dom" "^3.2.45"
+    "@vue/compiler-sfc" "^3.2.45"
+    "@vue/reactivity" "^3.2.45"
+    "@vue/shared" "^3.2.45"
+    minimatch "^5.1.0"
+    vue-template-compiler "^2.7.14"
+
+"@volar/vue-typescript@1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@volar/vue-typescript/-/vue-typescript-1.0.11.tgz#5cbc021854186f1c3cdfc6305d4c3870df28c5a2"
+  integrity sha512-jlnFPvBcTyPiAbGlgjhKK7fp3Q+Z7Z5eU1NTbTSS0lQC8Gog3sh2UxLAFG5Voe1gHIxasoOEPXzMR0CWF4bKbA==
+  dependencies:
+    "@volar/typescript" "1.0.11"
+    "@volar/vue-language-core" "1.0.11"
+
 "@vue/compiler-core@3.2.45":
   version "3.2.45"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.45.tgz#d9311207d96f6ebd5f4660be129fb99f01ddb41b"
@@ -1705,7 +1750,7 @@
     estree-walker "^2.0.2"
     source-map "^0.6.1"
 
-"@vue/compiler-dom@3.2.45":
+"@vue/compiler-dom@3.2.45", "@vue/compiler-dom@^3.2.45":
   version "3.2.45"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz#c43cc15e50da62ecc16a42f2622d25dc5fd97dce"
   integrity sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==
@@ -1713,7 +1758,7 @@
     "@vue/compiler-core" "3.2.45"
     "@vue/shared" "3.2.45"
 
-"@vue/compiler-sfc@3.2.45", "@vue/compiler-sfc@^3.2.20":
+"@vue/compiler-sfc@3.2.45", "@vue/compiler-sfc@^3.2.20", "@vue/compiler-sfc@^3.2.45":
   version "3.2.45"
   resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz#7f7989cc04ec9e7c55acd406827a2c4e96872c70"
   integrity sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==
@@ -1762,7 +1807,7 @@
     estree-walker "^2.0.2"
     magic-string "^0.25.7"
 
-"@vue/reactivity@3.2.45":
+"@vue/reactivity@3.2.45", "@vue/reactivity@^3.2.45":
   version "3.2.45"
   resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.45.tgz#412a45b574de601be5a4a5d9a8cbd4dee4662ff0"
   integrity sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==
@@ -1794,7 +1839,7 @@
     "@vue/compiler-ssr" "3.2.45"
     "@vue/shared" "3.2.45"
 
-"@vue/shared@3.2.45":
+"@vue/shared@3.2.45", "@vue/shared@^3.2.45":
   version "3.2.45"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.45.tgz#a3fffa7489eafff38d984e23d0236e230c818bc2"
   integrity sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==
@@ -2828,6 +2873,11 @@ date-fns@^2.16.1, date-fns@^2.29.3:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
+de-indent@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
+  integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
 
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
@@ -5251,6 +5301,13 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.1.tgz#6c9dffcf9927ff2a31e74b5af11adf8b9604b022"
+  integrity sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
@@ -5295,6 +5352,11 @@ msw@~0.49.1:
     strict-event-emitter "^0.2.6"
     type-fest "^2.19.0"
     yargs "^17.3.1"
+
+muggle-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/muggle-string/-/muggle-string-0.1.0.tgz#1fda8a281c8b27bb8b70466dbc9f27586a8baa6c"
+  integrity sha512-Tr1knR3d2mKvvWthlk7202rywKbiOm4rVFLsfAaSIhJ6dt9o47W4S+JMtWhd/PW9Wrdew2/S2fSvhz3E2gkfEg==
 
 mute-stream@0.0.8:
   version "0.0.8"
@@ -6967,6 +7029,22 @@ vue-router@^4.1.6:
   integrity sha512-DYWYwsG6xNPmLq/FmZn8Ip+qrhFEzA14EI12MsMgVxvHFDYvlr4NXpVF5hrRH1wVcDP8fGi5F4rxuJSl8/r+EQ==
   dependencies:
     "@vue/devtools-api" "^6.4.5"
+
+vue-template-compiler@^2.7.14:
+  version "2.7.14"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz#4545b7dfb88090744c1577ae5ac3f964e61634b1"
+  integrity sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==
+  dependencies:
+    de-indent "^1.0.2"
+    he "^1.2.0"
+
+vue-tsc@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-1.0.11.tgz#b4d1a74dbdef79c0458839abf27c717f969a2e67"
+  integrity sha512-lj+6dEroPsE4wmQOPtjCzAf8x363Km5/tuEvMEoQaoRnzs9myBM46FNvCGIIPStYUGuaqF1W1bORmP2KDQEORA==
+  dependencies:
+    "@volar/vue-language-core" "1.0.11"
+    "@volar/vue-typescript" "1.0.11"
 
 vue@^3.2.45:
   version "3.2.45"


### PR DESCRIPTION
Adds `vue-tsc` and adds a run of that to CI so tests break/merging is blocked if the types are incorrect.

When I brought this in there were a few little problems unrelated to what I'm working on, so I just fixed those up real quick so we are passing from the start. Going forwards this will catch any Vue related TS errors in CI and consequently any related JS errors that we don't have tests around as yet.

---

Unrelated: I noticed we were using mostly `yarn` in the GH action, with one reference to `npm` so I changed that up while I was there, ah plus I fixed a little typo I noticed while I was there.


Signed-off-by: John Cowen <john.cowen@konghq.com>