### PR TITLE
fix: using non-existing mesh from local storage

### DIFF
--- a/src/store/storeConfig.spec.ts
+++ b/src/store/storeConfig.spec.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+import { ActionHandler, ActionTree } from 'vuex'
+
+import { State, storeConfig } from '@/store/storeConfig'
+import { ClientStorage } from '@/utilities/ClientStorage'
+
+describe('storeConfig', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test.each([
+    [[], null, null],
+    [[{ name: 'test' }], null, 'test'],
+    [[{ name: 'test' }], 'all', 'test'],
+    [[{ name: 'test' }], 'outdated', 'test'],
+  ])('bootstrap sets reasonable selected mesh as fallback', async (meshes, storedSelectedMesh, expectedSelectedMesh) => {
+    const actions = storeConfig.actions as ActionTree<State, State>
+    const bootstrap = actions.bootstrap as ActionHandler<State, State>
+
+    const commit = jest.fn()
+    const dispatch = jest.fn()
+    const getters = {
+      'config/getStatus': 'OK',
+    }
+    const state = {
+      meshes: {
+        items: meshes,
+      },
+    }
+
+    jest.spyOn(ClientStorage, 'get').mockImplementation(() => storedSelectedMesh)
+
+    // @ts-ignore go away
+    await bootstrap({ commit, dispatch, getters, state })
+
+    expect(dispatch).toHaveBeenLastCalledWith('updateSelectedMesh', expectedSelectedMesh)
+  })
+})

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -243,6 +243,8 @@ export const storeConfig: StoreOptions<State> = {
         const newStoredMesh = ClientStorage.get('selectedMesh')
         if ((newStoredMesh === null || newStoredMesh === 'all') && state.meshes.items.length > 0) {
           dispatch('updateSelectedMesh', state.meshes.items[0].name)
+        } else if (newStoredMesh !== null && !state.meshes.items.some((mesh) => mesh.name === newStoredMesh)) {
+          dispatch('updateSelectedMesh', null)
         }
       }
 
@@ -284,8 +286,13 @@ export const storeConfig: StoreOptions<State> = {
     },
 
     // update the selected mesh
-    updateSelectedMesh({ commit }, mesh) {
-      ClientStorage.set('selectedMesh', mesh)
+    updateSelectedMesh({ commit }, mesh: string | null) {
+      if (mesh !== null) {
+        ClientStorage.set('selectedMesh', mesh)
+      } else {
+        ClientStorage.remove('selectedMesh')
+      }
+
       commit('SET_SELECTED_MESH', mesh)
     },
 

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -225,10 +225,9 @@ export const storeConfig: StoreOptions<State> = {
 
       // only dispatch these actions if the Kuma is online
       if (getters['config/getStatus'] === 'OK') {
+        // Sets selected mesh from client storage.
         const storedMesh = ClientStorage.get('selectedMesh')
-
-        // Sets selected mesh from client storage. Ignores “all” mesh because it’s being deprecated.
-        if (storedMesh && storedMesh !== 'all') {
+        if (storedMesh) {
           dispatch('updateSelectedMesh', storedMesh)
         }
 
@@ -239,12 +238,10 @@ export const storeConfig: StoreOptions<State> = {
           dispatch('sidebar/getInsights'),
         ])
 
-        // Updates the selected mesh if one wasn’t read earlier.
+        // Updates the selected mesh if one wasn’t read earlier or if it’s not an existing mesh.
         const newStoredMesh = ClientStorage.get('selectedMesh')
-        if ((newStoredMesh === null || newStoredMesh === 'all') && state.meshes.items.length > 0) {
+        if (newStoredMesh === null || !state.meshes.items.some((mesh) => mesh.name === newStoredMesh)) {
           dispatch('updateSelectedMesh', state.meshes.items[0].name)
-        } else if (newStoredMesh !== null && !state.meshes.items.some((mesh) => mesh.name === newStoredMesh)) {
-          dispatch('updateSelectedMesh', null)
         }
       }
 

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -238,10 +238,14 @@ export const storeConfig: StoreOptions<State> = {
           dispatch('sidebar/getInsights'),
         ])
 
-        // Updates the selected mesh if one wasn’t read earlier or if it’s not an existing mesh.
-        const newStoredMesh = ClientStorage.get('selectedMesh')
-        if (newStoredMesh === null || !state.meshes.items.some((mesh) => mesh.name === newStoredMesh)) {
-          dispatch('updateSelectedMesh', state.meshes.items[0].name)
+        if (state.meshes.items.length === 0) {
+          dispatch('updateSelectedMesh', null)
+        } else {
+          // Updates the selected mesh if one wasn’t read earlier or if it’s not an existing mesh.
+          const newStoredMesh = ClientStorage.get('selectedMesh')
+          if (newStoredMesh === null || !state.meshes.items.some((mesh) => mesh.name === newStoredMesh)) {
+            dispatch('updateSelectedMesh', state.meshes.items[0].name)
+          }
         }
       }
 


### PR DESCRIPTION
Fixes an issue with using a stored value for the `selectedMesh` state when that value doesn’t represent an existing mesh. Then, we’d still let users navigate to routes associated to this resource. This happens more commonly for developers frequently switching around their data during development.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>