### PR TITLE
chore: uses dedicated icons instead of HTML entities

### DIFF
--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -124,6 +124,9 @@ exports[`App.vue fails to renders basic view 1`] = `
           >
             
   
+            <title>
+              Notifications
+            </title>
             
   
             <path

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -124,9 +124,6 @@ exports[`App.vue fails to renders basic view 1`] = `
           >
             
   
-            <title>
-              Notifications
-            </title>
             
   
             <path

--- a/src/app/common/DataOverview.vue
+++ b/src/app/common/DataOverview.vue
@@ -137,29 +137,6 @@
             </span>
           </template>
 
-          <template #selected="{row}">
-            <a
-              class="data-table-action-link"
-              :class="{ 'is-active': selectedRow === row.name }"
-            >
-              <span
-                v-if="selectedRow === row.name"
-                class="action-link__active-state"
-              >
-                ✓
-
-                <span class="sr-only">Selected</span>
-              </span>
-
-              <span
-                v-else
-                class="action-link__normal-state"
-              >
-                View
-              </span>
-            </a>
-          </template>
-
           <!--- dp Version --->
           <template #dpVersion="{ row, rowValue }">
             <div
@@ -211,7 +188,8 @@
                   :icon="row.warnings.length > 0 ? 'warning' : 'info'"
                   :color="row.warnings.length > 0 ? 'var(--black-75)' : 'var(--blue-500)'"
                   :secondary-color="row.warnings.length > 0 ? 'var(--yellow-300)' : undefined"
-                  size="20"
+                  size="16"
+                  hide-title
                 />
               </template>
               Details
@@ -444,25 +422,6 @@ function getRowAttributes({ name }: any): Record<string, string> {
 
 .with-warnings {
   color: var(--yellow-500);
-}
-
-.data-table-action-link {
-  padding: 0;
-}
-
-.action-link__active-state {
-  --size: 18px;
-
-  display: block;
-  width: var(--size);
-  height: var(--size);
-  line-height: var(--size);
-  border-radius: 50%;
-  background-color: var(--logo-green);
-  margin: 0 0 0 var(--spacing-xxs);
-  color: var(--white);
-  font-size: 13px;
-  text-align: center;
 }
 </style>
 

--- a/src/app/common/DocumentationLink.vue
+++ b/src/app/common/DocumentationLink.vue
@@ -5,9 +5,12 @@
     target="_blank"
     :to="props.href"
   >
-    <template #icon>
-      <KIcon icon="externalLink" />
-    </template>
+    <KIcon
+      icon="externalLink"
+      color="currentColor"
+      size="16"
+      hide-title
+    />
 
     Documentation
   </KButton>

--- a/src/app/common/NotificationIcon.vue
+++ b/src/app/common/NotificationIcon.vue
@@ -5,8 +5,9 @@
     @click="openModal"
   >
     <KIcon
-      color="var(--yellow-300)"
       icon="notificationBell"
+      color="var(--yellow-300)"
+      hide-title
     />
 
     <span

--- a/src/app/common/NotificationIcon.vue
+++ b/src/app/common/NotificationIcon.vue
@@ -7,7 +7,6 @@
     <KIcon
       icon="notificationBell"
       color="var(--yellow-300)"
-      hide-title
     />
 
     <span

--- a/src/app/common/PaginationWidget.vue
+++ b/src/app/common/PaginationWidget.vue
@@ -6,7 +6,14 @@
       data-testid="pagination-previous-button"
       @click="onPreviousButtonClick"
     >
-      &lsaquo; Previous
+      <KIcon
+        icon="chevronLeft"
+        color="currentColor"
+        size="16"
+        hide-title
+      />
+
+      Previous
     </KButton>
 
     <KButton
@@ -15,14 +22,21 @@
       data-testid="pagination-next-button"
       @click="onNextButtonClick"
     >
-      Next &rsaquo;
+      Next
+
+      <KIcon
+        icon="chevronRight"
+        color="currentColor"
+        size="16"
+        hide-title
+      />
     </KButton>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { datadogLogs } from '@datadog/browser-logs'
-import { KButton } from '@kong/kongponents'
+import { KButton, KIcon } from '@kong/kongponents'
 
 import { datadogLogEvents } from '@/utilities/datadogLogEvents'
 

--- a/src/app/common/PaginationWidget.vue
+++ b/src/app/common/PaginationWidget.vue
@@ -11,6 +11,7 @@
         color="currentColor"
         size="16"
         hide-title
+        aria-hidden="true"
       />
 
       Previous
@@ -29,6 +30,7 @@
         color="currentColor"
         size="16"
         hide-title
+        aria-hidden="true"
       />
     </KButton>
   </div>

--- a/src/app/common/__snapshots__/DocumentationLink.spec.ts.snap
+++ b/src/app/common/__snapshots__/DocumentationLink.spec.ts.snap
@@ -8,6 +8,9 @@ exports[`DocumentationLink.vue renders snapshot 1`] = `
   type="button"
 >
   
+  <!---->
+  
+  
   <span
     class="kong-icon-externalLink kong-icon"
   >
@@ -35,8 +38,6 @@ exports[`DocumentationLink.vue renders snapshot 1`] = `
     
 
   </span>
-  
-  
    Documentation 
   
   <!---->

--- a/src/app/common/__snapshots__/PaginationWidget.spec.ts.snap
+++ b/src/app/common/__snapshots__/PaginationWidget.spec.ts.snap
@@ -45,7 +45,36 @@ exports[`PaginationWidget.vue renders pagination 1`] = `
     <!---->
     
     
-     ‹ Previous 
+    <span
+      class="kong-icon-chevronLeft kong-icon"
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 20 20"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        
+  
+        <title>
+          Back
+        </title>
+        
+  
+        <path
+          d="m12.3 14.7-5-5.2 5-5.2"
+          fill="none"
+          stroke="#A3BBCC"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
+        
+
+      </svg>
+      
+
+    </span>
+     Previous 
     
     <!---->
   </button>
@@ -58,7 +87,36 @@ exports[`PaginationWidget.vue renders pagination 1`] = `
     <!---->
     
     
-     Next › 
+     Next 
+    <span
+      class="kong-icon-chevronRight kong-icon"
+    >
+      <svg
+        fill="none"
+        viewBox="0 0 20 20"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        
+  
+        <title>
+          Forward
+        </title>
+        
+  
+        <path
+          d="m7.3 14.7 5-5.2-5-5.2"
+          fill="none"
+          stroke="#A3BBCC"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
+        
+
+      </svg>
+      
+
+    </span>
     
     <!---->
   </button>

--- a/src/app/common/__snapshots__/PaginationWidget.spec.ts.snap
+++ b/src/app/common/__snapshots__/PaginationWidget.spec.ts.snap
@@ -46,6 +46,7 @@ exports[`PaginationWidget.vue renders pagination 1`] = `
     
     
     <span
+      aria-hidden="true"
       class="kong-icon-chevronLeft kong-icon"
     >
       <svg
@@ -89,6 +90,7 @@ exports[`PaginationWidget.vue renders pagination 1`] = `
     
      Next 
     <span
+      aria-hidden="true"
       class="kong-icon-chevronRight kong-icon"
     >
       <svg

--- a/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
+++ b/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
@@ -626,17 +626,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                           class="kong-icon-info kong-icon"
                         >
                           <svg
-                            height="20"
+                            height="16"
                             role="img"
                             viewBox="0 0 16 16"
-                            width="20"
+                            width="16"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             
   
-                            <title>
-                              Information
-                            </title>
                             
   
                             <path
@@ -742,19 +739,16 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                           class="kong-icon-warning kong-icon"
                         >
                           <svg
-                            height="20"
+                            height="16"
                             role="img"
                             version="1.1"
                             viewBox="0 0 48 42"
-                            width="20"
+                            width="16"
                             xmlns="http://www.w3.org/2000/svg"
                             xmlns:xlink="http://www.w3.org/1999/xlink"
                           >
                             
   
-                            <title>
-                              Warning
-                            </title>
                             
   
                             <g
@@ -897,17 +891,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                           class="kong-icon-info kong-icon"
                         >
                           <svg
-                            height="20"
+                            height="16"
                             role="img"
                             viewBox="0 0 16 16"
-                            width="20"
+                            width="16"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             
   
-                            <title>
-                              Information
-                            </title>
                             
   
                             <path
@@ -1013,17 +1004,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                           class="kong-icon-info kong-icon"
                         >
                           <svg
-                            height="20"
+                            height="16"
                             role="img"
                             viewBox="0 0 16 16"
-                            width="20"
+                            width="16"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             
   
-                            <title>
-                              Information
-                            </title>
                             
   
                             <path
@@ -1129,17 +1117,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                           class="kong-icon-info kong-icon"
                         >
                           <svg
-                            height="20"
+                            height="16"
                             role="img"
                             viewBox="0 0 16 16"
-                            width="20"
+                            width="16"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             
   
-                            <title>
-                              Information
-                            </title>
                             
   
                             <path
@@ -1245,17 +1230,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                           class="kong-icon-info kong-icon"
                         >
                           <svg
-                            height="20"
+                            height="16"
                             role="img"
                             viewBox="0 0 16 16"
-                            width="20"
+                            width="16"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             
   
-                            <title>
-                              Information
-                            </title>
                             
   
                             <path
@@ -1361,17 +1343,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                           class="kong-icon-info kong-icon"
                         >
                           <svg
-                            height="20"
+                            height="16"
                             role="img"
                             viewBox="0 0 16 16"
-                            width="20"
+                            width="16"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             
   
-                            <title>
-                              Information
-                            </title>
                             
   
                             <path
@@ -1477,17 +1456,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                           class="kong-icon-info kong-icon"
                         >
                           <svg
-                            height="20"
+                            height="16"
                             role="img"
                             viewBox="0 0 16 16"
-                            width="20"
+                            width="16"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             
   
-                            <title>
-                              Information
-                            </title>
                             
   
                             <path
@@ -1593,17 +1569,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                           class="kong-icon-info kong-icon"
                         >
                           <svg
-                            height="20"
+                            height="16"
                             role="img"
                             viewBox="0 0 16 16"
-                            width="20"
+                            width="16"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             
   
-                            <title>
-                              Information
-                            </title>
                             
   
                             <path
@@ -1646,7 +1619,36 @@ exports[`DataPlaneListView matches snapshot 1`] = `
               <!---->
               
               
-               Next › 
+               Next 
+              <span
+                class="kong-icon-chevronRight kong-icon"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 20 20"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  
+  
+                  
+  
+                  <path
+                    d="m7.3 14.7 5-5.2-5-5.2"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                  
+
+                </svg>
+                
+
+              </span>
               
               <!---->
             </button>

--- a/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
+++ b/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
@@ -1621,9 +1621,11 @@ exports[`DataPlaneListView matches snapshot 1`] = `
               
                Next 
               <span
+                aria-hidden="true"
                 class="kong-icon-chevronRight kong-icon"
               >
                 <svg
+                  aria-hidden="true"
                   fill="currentColor"
                   height="16"
                   role="img"

--- a/src/app/wizard/components/StepSkeleton.vue
+++ b/src/app/wizard/components/StepSkeleton.vue
@@ -232,8 +232,23 @@ export default {
 
 .wizard-steps__content {
   p,
+  h2,
+  h3,
+  h4,
   .code-block {
     margin-bottom: var(--spacing-md);
+  }
+
+  h2 {
+    font-size: var(--type-xxl);
+  }
+
+  h3 {
+    font-size: var(--type-xl);
+  }
+
+  h4 {
+    font-size: var(--type-lg);
   }
 }
 
@@ -244,29 +259,73 @@ export default {
     border-bottom: 1px solid #e6e7e8;
   }
 
-  p:not(:last-of-type) {
-    margin-bottom: var(--spacing-sm);
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: var(--type-lg);
+    margin: 0 0 var(--spacing-sm) 0;
+  }
+
+  p {
+    &:not(:last-of-type) {
+      margin-bottom: var(--spacing-sm);
+    }
   }
 }
 </style>
 
 <style lang="scss" scoped>
+$sidebar-width: 320px; // was 240px
+$bp-min-width: 1220px;
+$bp-lg-min-width: 1760px;
+$bp-max-width: 1219px;
+
 .wizard-steps {
-  @media (max-width: 999.98px) {
-    > :not(:first-child) {
-      margin-top: var(--spacing-md);
+  @media screen and (min-width: $bp-min-width) {
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+    margin-right: calc(320px - 44px);
+
+    .wizard-steps__content-wrapper {
+      width: 800px;
+      padding: 0 16px;
+    }
+
+    .wizard-steps__sidebar {
+      position: absolute;
+      top: 0;
+      right: 0;
+      padding-top: 80px;
+    }
+
+    .wizard-steps__sidebar__content {
+      width: $sidebar-width;
+      height: calc(100vh - 80px);
+      overflow-y: auto;
+      overflow-x: hidden;
     }
   }
 
-  @media (min-width: 1000px) {
-    display: grid;
-    grid-template-columns: 1fr 300px;
-    gap: var(--spacing-lg);
+  @media screen and (min-width: $bp-lg-min-width) {
+    .wizard-steps__content-wrapper {
+      width: 1000px;
+      padding: 0 16px;
+    }
   }
-}
 
-.wizard-steps__sidebar {
-  border-radius: 6px;
+  @media screen and (max-width: $bp-max-width) {
+    > * {
+      margin-bottom: 16px;
+    }
+
+    .wizard-steps__sidebar {
+      border-radius: 6px;
+    }
+  }
 }
 
 .wizard-steps__sidebar {
@@ -284,7 +343,7 @@ export default {
 }
 
 .wizard-steps__indicator__controls {
-  --wizard-tab-bg: var(--blue-700);
+  --wizard-tab-bg: var(--logo-purple);
   --wizard-tab-text-selected-color: var(--white);
 
   border: 1px solid var(--grey-300);

--- a/src/app/wizard/components/StepSkeleton.vue
+++ b/src/app/wizard/components/StepSkeleton.vue
@@ -52,7 +52,14 @@
           data-testid="next-previous-button"
           @click="goToPrevStep"
         >
-          &lsaquo; Previous
+          <KIcon
+            icon="chevronLeft"
+            color="currentColor"
+            size="16"
+            hide-title
+          />
+
+          Previous
         </KButton>
         <KButton
           v-show="!indexCanAdvance"
@@ -61,7 +68,14 @@
           data-testid="next-step-button"
           @click="goToNextStep"
         >
-          Next &rsaquo;
+          Next
+
+          <KIcon
+            icon="chevronRight"
+            color="currentColor"
+            size="16"
+            hide-title
+          />
         </KButton>
       </footer>
     </div>
@@ -81,11 +95,12 @@
 </template>
 
 <script>
-import { KButton } from '@kong/kongponents'
+import { KButton, KIcon } from '@kong/kongponents'
 
 export default {
   components: {
     KButton,
+    KIcon,
   },
 
   props: {
@@ -217,23 +232,8 @@ export default {
 
 .wizard-steps__content {
   p,
-  h2,
-  h3,
-  h4,
   .code-block {
     margin-bottom: var(--spacing-md);
-  }
-
-  h2 {
-    font-size: var(--type-xxl);
-  }
-
-  h3 {
-    font-size: var(--type-xl);
-  }
-
-  h4 {
-    font-size: var(--type-lg);
   }
 }
 
@@ -244,73 +244,29 @@ export default {
     border-bottom: 1px solid #e6e7e8;
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-size: var(--type-lg);
-    margin: 0 0 var(--spacing-sm) 0;
-  }
-
-  p {
-    &:not(:last-of-type) {
-      margin-bottom: var(--spacing-sm);
-    }
+  p:not(:last-of-type) {
+    margin-bottom: var(--spacing-sm);
   }
 }
 </style>
 
 <style lang="scss" scoped>
-$sidebar-width: 320px; // was 240px
-$bp-min-width: 1220px;
-$bp-lg-min-width: 1760px;
-$bp-max-width: 1219px;
-
 .wizard-steps {
-  @media screen and (min-width: $bp-min-width) {
-    display: flex;
-    align-items: stretch;
-    justify-content: center;
-    margin-right: calc(320px - 44px);
-
-    .wizard-steps__content-wrapper {
-      width: 800px;
-      padding: 0 16px;
-    }
-
-    .wizard-steps__sidebar {
-      position: absolute;
-      top: 0;
-      right: 0;
-      padding-top: 80px;
-    }
-
-    .wizard-steps__sidebar__content {
-      width: $sidebar-width;
-      height: calc(100vh - 80px);
-      overflow-y: auto;
-      overflow-x: hidden;
+  @media (max-width: 999.98px) {
+    > :not(:first-child) {
+      margin-top: var(--spacing-md);
     }
   }
 
-  @media screen and (min-width: $bp-lg-min-width) {
-    .wizard-steps__content-wrapper {
-      width: 1000px;
-      padding: 0 16px;
-    }
+  @media (min-width: 1000px) {
+    display: grid;
+    grid-template-columns: 1fr 300px;
+    gap: var(--spacing-lg);
   }
+}
 
-  @media screen and (max-width: $bp-max-width) {
-    > * {
-      margin-bottom: 16px;
-    }
-
-    .wizard-steps__sidebar {
-      border-radius: 6px;
-    }
-  }
+.wizard-steps__sidebar {
+  border-radius: 6px;
 }
 
 .wizard-steps__sidebar {
@@ -328,7 +284,7 @@ $bp-max-width: 1219px;
 }
 
 .wizard-steps__indicator__controls {
-  --wizard-tab-bg: var(--logo-purple);
+  --wizard-tab-bg: var(--blue-700);
   --wizard-tab-text-selected-color: var(--white);
 
   border: 1px solid var(--grey-300);

--- a/src/app/wizard/views/__snapshots__/DataplaneUniversal.spec.ts.snap
+++ b/src/app/wizard/views/__snapshots__/DataplaneUniversal.spec.ts.snap
@@ -692,7 +692,36 @@ networking:
             <!---->
             
             
-             ‹ Previous 
+            <span
+              class="kong-icon-chevronLeft kong-icon"
+            >
+              <svg
+                fill="currentColor"
+                height="16"
+                role="img"
+                viewBox="0 0 20 20"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                
+  
+                
+  
+                <path
+                  d="m12.3 14.7-5-5.2 5-5.2"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                
+
+              </svg>
+              
+
+            </span>
+             Previous 
             
             <!---->
           </button>
@@ -706,7 +735,36 @@ networking:
             <!---->
             
             
-             Next › 
+             Next 
+            <span
+              class="kong-icon-chevronRight kong-icon"
+            >
+              <svg
+                fill="currentColor"
+                height="16"
+                role="img"
+                viewBox="0 0 20 20"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                
+  
+                
+  
+                <path
+                  d="m7.3 14.7 5-5.2-5-5.2"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                
+
+              </svg>
+              
+
+            </span>
             
             <!---->
           </button>

--- a/src/app/wizard/views/__snapshots__/Mesh.spec.ts.snap
+++ b/src/app/wizard/views/__snapshots__/Mesh.spec.ts.snap
@@ -937,7 +937,36 @@ metrics:
             <!---->
             
             
-             ‹ Previous 
+            <span
+              class="kong-icon-chevronLeft kong-icon"
+            >
+              <svg
+                fill="currentColor"
+                height="16"
+                role="img"
+                viewBox="0 0 20 20"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                
+  
+                
+  
+                <path
+                  d="m12.3 14.7-5-5.2 5-5.2"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                
+
+              </svg>
+              
+
+            </span>
+             Previous 
             
             <!---->
           </button>
@@ -951,7 +980,36 @@ metrics:
             <!---->
             
             
-             Next › 
+             Next 
+            <span
+              class="kong-icon-chevronRight kong-icon"
+            >
+              <svg
+                fill="currentColor"
+                height="16"
+                role="img"
+                viewBox="0 0 20 20"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                
+  
+                
+  
+                <path
+                  d="m7.3 14.7 5-5.2-5-5.2"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                
+
+              </svg>
+              
+
+            </span>
             
             <!---->
           </button>


### PR DESCRIPTION
Uses dedicated icon components instead of HTML entities and sets standard button icon sizes.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>