### PR TITLE
refactor: uses Kongponents colors

### DIFF
--- a/src/app/AppLoadingBar.vue
+++ b/src/app/AppLoadingBar.vue
@@ -64,7 +64,7 @@ onUnmounted(function () {
 
     .progress-bar {
       height: 5px;
-      background-color: var(--logo-purple-light);
+      background-color: var(--blue-400);
     }
   }
 }

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -708,12 +708,54 @@ exports[`App.vue fails to renders basic view 1`] = `
                     class="resource-list-actions mt-4"
                   >
                     <a
-                      class="medium rounded primary k-button"
+                      class="medium rounded creation k-button"
                       href="/wizard/mesh"
                       type="button"
                     >
                       
-                      <!---->
+                      <span
+                        class="k-button-icon kong-icon-plus kong-icon"
+                      >
+                        <svg
+                          fill="white"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 20 20"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          
+  
+                          <title>
+                            Add
+                          </title>
+                          
+  
+                          <rect
+                            fill="white"
+                            height="12"
+                            rx="1"
+                            width="2.77"
+                            x="8.62"
+                            y="4"
+                          />
+                          
+  
+                          <rect
+                            fill="white"
+                            height="12"
+                            rx="1"
+                            transform="rotate(90 16 8.62)"
+                            width="2.77"
+                            x="16"
+                            y="8.62"
+                          />
+                          
+
+                        </svg>
+                        
+
+                      </span>
                       
                       
                        Create mesh 

--- a/src/app/common/EntityStatus.vue
+++ b/src/app/common/EntityStatus.vue
@@ -46,7 +46,7 @@ const entityStatusClassNames = computed(() => {
 }
 
 .entity-status.is-online {
-  color: var(--green-400);
+  color: var(--green-500);
 }
 
 .entity-status.is-offline {
@@ -54,7 +54,7 @@ const entityStatusClassNames = computed(() => {
 }
 
 .entity-status.is-degraded {
-  color: var(--custom-orange);
+  color: #ff8040;
 }
 
 .entity-status.is-not-available {

--- a/src/app/common/IconSuccess.vue
+++ b/src/app/common/IconSuccess.vue
@@ -16,7 +16,7 @@ $size: 30px;
   height: #{$size};
   line-height: #{$size};
   border-radius: 50%;
-  background-color: var(--logo-green);
+  background-color: var(--green-500);
   margin: 0 auto;
   color: var(--white);
   font-size: 13px;

--- a/src/app/common/MeshResources.vue
+++ b/src/app/common/MeshResources.vue
@@ -8,8 +8,9 @@
 
         <div class="resource-list-actions mt-4">
           <KButton
+            icon="plus"
+            appearance="creation"
             :to="{ name: 'create-mesh' }"
-            appearance="primary"
           >
             Create mesh
           </KButton>

--- a/src/app/common/PolicyTypeTag.vue
+++ b/src/app/common/PolicyTypeTag.vue
@@ -107,7 +107,7 @@ const policy = computed(() => POLICIES[props.policyType])
 
 <style lang="scss" scoped>
 .policy-type-tag {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: var(--spacing-xs);
 }

--- a/src/app/common/TagList.vue
+++ b/src/app/common/TagList.vue
@@ -115,7 +115,7 @@ $border-radius: 5px;
 }
 
 .tag__label--is-kuma-io-label {
-  background-color: var(--logo-purple);
+  background-color: var(--blue-700);
 }
 
 .tag__value {

--- a/src/app/data-planes/components/DataPlaneEntitySummary.vue
+++ b/src/app/data-planes/components/DataPlaneEntitySummary.vue
@@ -309,7 +309,7 @@ h5 {
 }
 
 .status--success {
-  color: var(--green-400);
+  color: var(--green-500);
 }
 
 .status--warning {

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -72,7 +72,6 @@
           </KDropdownMenu>
 
           <KButton
-            class="add-dp-button"
             appearance="creation"
             :to="dataplaneWizardRoute"
             icon="plus"
@@ -485,10 +484,6 @@ function selectDataPlaneOverview(name: string | null): void {
 </script>
 
 <style lang="scss" scoped>
-.add-dp-button.add-dp-button {
-  background-color: var(--logo-green);
-}
-
 .table-header-selector-item-checkbox {
   padding: var(--spacing-md) var(--spacing-lg);
   display: flex;

--- a/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
+++ b/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
@@ -300,7 +300,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
           
         </div>
         <a
-          class="medium rounded creation k-button add-dp-button"
+          class="medium rounded creation k-button"
           data-testid="data-plane-create-data-plane-button"
           href="/wizard/kubernetes-dataplane"
           type="button"

--- a/src/app/main-overview/views/__snapshots__/MainOverviewView.spec.ts.snap
+++ b/src/app/main-overview/views/__snapshots__/MainOverviewView.spec.ts.snap
@@ -1711,12 +1711,53 @@ exports[`MainOverviewView.vue renders basic snapshot 1`] = `
             class="resource-list-actions mt-4"
           >
             <a
-              class="medium rounded primary k-button"
+              class="medium rounded creation k-button"
               href="/wizard/mesh"
               type="button"
             >
               
-              <!---->
+              <span
+                class="k-button-icon kong-icon-plus kong-icon"
+              >
+                <svg
+                  fill="none"
+                  height="16"
+                  viewBox="0 0 20 20"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  
+  
+                  <title>
+                    Add
+                  </title>
+                  
+  
+                  <rect
+                    fill="#A3BBCC"
+                    height="12"
+                    rx="1"
+                    width="2.77"
+                    x="8.62"
+                    y="4"
+                  />
+                  
+  
+                  <rect
+                    fill="#A3BBCC"
+                    height="12"
+                    rx="1"
+                    transform="rotate(90 16 8.62)"
+                    width="2.77"
+                    x="16"
+                    y="8.62"
+                  />
+                  
+
+                </svg>
+                
+
+              </span>
               
               
                Create mesh 

--- a/src/app/notification-manager/components/SingleMeshNotifications.vue
+++ b/src/app/notification-manager/components/SingleMeshNotifications.vue
@@ -8,7 +8,7 @@
         <div class="flex items-center">
           <KIcon
             v-if="item.isCompleted"
-            color="var(--green-400)"
+            color="var(--green-500)"
             icon="check"
             size="20"
             class="mr-4"

--- a/src/app/services/components/ExternalServiceDetails.vue
+++ b/src/app/services/components/ExternalServiceDetails.vue
@@ -105,7 +105,7 @@ h4 {
 }
 
 .status--success {
-  color: var(--green-400);
+  color: var(--green-500);
 }
 
 .status--warning {

--- a/src/app/services/components/ServiceInsightDetails.vue
+++ b/src/app/services/components/ServiceInsightDetails.vue
@@ -110,7 +110,7 @@ h3 {
 }
 
 .status--success {
-  color: var(--green-400);
+  color: var(--green-500);
 }
 
 .status--warning {

--- a/src/app/wizard/components/StepSkeleton.vue
+++ b/src/app/wizard/components/StepSkeleton.vue
@@ -343,7 +343,7 @@ $bp-max-width: 1219px;
 }
 
 .wizard-steps__indicator__controls {
-  --wizard-tab-bg: var(--logo-purple);
+  --wizard-tab-bg: var(--blue-700);
   --wizard-tab-text-selected-color: var(--white);
 
   border: 1px solid var(--grey-300);

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -9,13 +9,13 @@ a {
 
 a:link,
 a:visited {
-  color: var(--logo-purple);
+  color: var(--blue-700);
 }
 
 a:hover,
 a:active,
 a:focus {
-  color: var(--logo-purple-light);
+  color: var(--blue-500);
 }
 
 img {
@@ -25,10 +25,9 @@ img {
 
 select {
   appearance: none;
-  border: 1px solid var(--grey-400);
+  border: 1px solid var(--grey-300);
   border-radius: 3px;
   font-size: 16px;
-  color: var(--logo-purple);
   line-height: 20px;
   padding: 10px 30px 10px 13px;
   background-color: var(--white);

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -1,20 +1,8 @@
-$logo-purple: #290b53;
-
 :root {
   --font-family-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
   --font-family-mono: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 
-  --logo-purple: #{$logo-purple};
-  --logo-purple-light: #{rgba($logo-purple, 0.75)};
-  --logo-purple-lighter: #{rgba($logo-purple, 0.08)};
-  --logo-green: #3db664;
-  --custom-orange: #ff8040;
-
   // COMPONENTS
   --AppHeaderHeight: 60px;
   --AppSidebarWidth: 280px;
-
-  // KONGPONENTS OVERRIDES
-  --KButtonPrimaryBase: var(--logo-purple);
-  --KButtonPrimaryHover: var(--logo-purple-light);
 }


### PR DESCRIPTION
Removes the last two Kongponents variable overrides. These changed the theme of buttons which affects us as follows: (1) primary buttons now have the Kongponent default blue background and (2) buttons that navigate to a wizard (e.g. "Create mesh") now use the "creation" appearance giving them a green background.

Removes all custom colors in favor of Kongponents standard colors.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>