### PR TITLE
fix(service): not loading correct data when switching service

### DIFF
--- a/src/api/setupMockWorker.ts
+++ b/src/api/setupMockWorker.ts
@@ -14,6 +14,7 @@ export function setupMockWorker(url: string): void {
   )
 
   worker.start({
+    quiet: true,
     onUnhandledRequest(req: MockedRequest) {
       // Ignores warnings about unhandled requests.
       if (

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -78,11 +78,16 @@ const isLoading = ref(store.state.globalLoading)
 /**
  * The `router-view`’s `key` attribute value.
  *
- * Is always set to `'NONE'` (i.e. will never trigger an explicit re-render via Vue’s `key` mechanism).
- * However, in some scenarios, we want Vue to re-render a route’s components
- * (e.g. `src/app/policies/views/PolicyView.vue` which is used by some dozen policy routes).
+ * Set to the current `route.path` to trigger an explicit re-render via Vue’s `key` mechanism when navigating between routes that only change in dynamic path segments while matching the same route definition.
+ *
+ * **Example**:
+ *
+ * From: /mesh/default/services/backend
+ * To: /mesh/default/services/ingress
+ *
+ * Both routes resolve to the same route definition and the router’s default behavior is to not re-render the component in such navigations.
  */
-const routeKey = computed(() => route.meta.shouldReRender ? route.path : 'NONE')
+const routeKey = computed(() => route.path)
 const shouldShowAppError = computed(() => store.state.config.status !== 'OK')
 const shouldSuggestOnboarding = computed(() => store.getters['onboarding/showOnboarding'])
 const shouldShowNotificationManager = computed(() => store.getters['notifications/amountOfActions'] > 0)

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -42,7 +42,7 @@ const error = ref<Error | null>(null)
 
 watch(() => route.params.mesh, function () {
   // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== 'service-insights-detail-view') {
+  if (route.name !== 'service-detail-view') {
     return
   }
 
@@ -51,7 +51,7 @@ watch(() => route.params.mesh, function () {
 
 watch(() => route.params.name, function () {
   // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== 'service-insights-detail-view') {
+  if (route.name !== 'service-detail-view') {
     return
   }
 

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -10,7 +10,6 @@ function getPolicyRoutes(policies: PolicyDefinition[]): RouteRecordRaw[] {
     path: policy.path,
     name: policy.path,
     meta: {
-      shouldReRender: true,
       title: policy.pluralDisplayName,
     },
     props: (route) => ({

--- a/src/shims-vue-router.d.ts
+++ b/src/shims-vue-router.d.ts
@@ -26,10 +26,5 @@ declare module 'vue-router' {
      * Whether a route is part of a wizard (e.g. “Create mesh” or “Create data plane proxy”).
      */
     wizardProcess?: boolean
-
-    /**
-     * Indicates that a router-view rendering this route should be re-rendered on a path change via an updated `key` attribute (see `src/app/App.vue` for an implementation example).
-     */
-    shouldReRender?: boolean
   }
 }


### PR DESCRIPTION
Fixes an issue with not loading the service data when switching between different services while on a service detail view. This happened because our router doesn’t trigger a re-render in these cases.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>