### PR TITLE
fix(zones): Add a guard for insight.subscriptions

### DIFF
--- a/src/utilities/dataplane.ts
+++ b/src/utilities/dataplane.ts
@@ -140,7 +140,7 @@ export function getVersions(dataPlaneInsight: DataPlaneInsight | undefined): Rec
 getItemStatusFromInsight takes object with subscriptions and returns the status 'Online' or 'Offline'
  */
 export function getItemStatusFromInsight(dataPlaneInsight: DataPlaneInsight | undefined): StatusKeyword {
-  if (dataPlaneInsight === undefined) {
+  if (dataPlaneInsight === undefined || dataPlaneInsight.subscriptions === undefined) {
     return 'offline'
   }
 


### PR DESCRIPTION
If `zoneInsight.subscriptions` is undefined then this means we are we are `offline`

Related https://github.com/kumahq/kuma-gui/pull/476

Fixes https://github.com/kumahq/kuma-gui/issues/517

Signed-off-by: John Cowen <john.cowen@konghq.com>

