### PR TITLE
fix(policies): Ensure empty policies are greyed out in the policy selector

### DIFF
--- a/src/app/policies/views/PolicyView.vue
+++ b/src/app/policies/views/PolicyView.vue
@@ -216,7 +216,7 @@ const policy = computed(() => store.state.policiesByPath[props.policyPath])
 const policies = computed(() => {
   return store.state.policies.map((item) => {
     return {
-      length: store.state.sidebar.insights.mesh.policies[item.name],
+      length: store.state.sidebar.insights.mesh.policies[item.name] ?? 0,
       label: item.pluralDisplayName,
       value: item.path,
       selected: item.path === route.name,


### PR DESCRIPTION
Previously we assumed the policy count was always `0` or greater, but it could be `undefined`.

With fix:

![policy-selection](https://user-images.githubusercontent.com/554604/210595465-999f0384-d1e6-402d-a7b0-1a4896ead1c8.gif)

Fixes https://github.com/kumahq/kuma-gui/issues/524

Signed-off-by: John Cowen <john.cowen@konghq.com>