### PR TITLE
refactor(insight): rename and refactor status related functions

### DIFF
--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -199,7 +199,7 @@ import {
   compatibilityKind,
   COMPATIBLE,
   dpTags,
-  getStatus,
+  getStatusAndReason,
   getVersions,
   INCOMPATIBLE_WRONG_FORMAT,
   INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS,
@@ -283,7 +283,7 @@ const processedDataPlane = computed(() => {
   }
 })
 
-const statusWithReason = computed(() => getStatus(props.dataPlane, props.dataPlaneOverview.dataplaneInsight))
+const statusWithReason = computed(() => getStatusAndReason(props.dataPlane, props.dataPlaneOverview.dataplaneInsight))
 const dataPlaneTags = computed(() => dpTags(props.dataPlane))
 const dataPlaneVersions = computed(() => getVersions(props.dataPlaneOverview.dataplaneInsight))
 const rawDataPlane = computed(() => stripTimes(props.dataPlane))

--- a/src/app/data-planes/components/DataPlaneEntitySummary.vue
+++ b/src/app/data-planes/components/DataPlaneEntitySummary.vue
@@ -141,7 +141,7 @@ import { rawReadableDate } from '@/utilities/helpers'
 import TagList from '@/app/common/TagList.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import YamlView from '@/app/common/YamlView.vue'
-import { dpTags, getStatus, getVersions } from '@/utilities/dataplane'
+import { dpTags, getStatusAndReason, getVersions } from '@/utilities/dataplane'
 
 const props = defineProps({
   dataPlaneOverview: {
@@ -195,7 +195,7 @@ const subscriptionWrappers = computed(() => {
 })
 
 const status = computed(() => {
-  const { status } = getStatus(props.dataPlaneOverview.dataplane, props.dataPlaneOverview.dataplaneInsight)
+  const { status } = getStatusAndReason(props.dataPlaneOverview.dataplane, props.dataPlaneOverview.dataplaneInsight)
 
   return status
 })

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -124,7 +124,7 @@ import { datadogLogEvents } from '@/utilities/datadogLogEvents'
 import {
   compatibilityKind,
   dpTags,
-  getStatus,
+  getStatusAndReason,
   COMPATIBLE,
   INCOMPATIBLE_UNSUPPORTED_ENVOY,
   INCOMPATIBLE_UNSUPPORTED_KUMA_DP,
@@ -355,7 +355,7 @@ async function parseData(dataPlaneOverview: DataPlaneOverview) {
     }
   }
 
-  const { status } = getStatus(dataPlaneOverview.dataplane, dataPlaneOverview.dataplaneInsight)
+  const { status } = getStatusAndReason(dataPlaneOverview.dataplane, dataPlaneOverview.dataplaneInsight)
   const subscriptions = dataPlaneOverview.dataplaneInsight?.subscriptions ?? []
 
   const initialData: any = {

--- a/src/utilities/dataplane.spec.ts
+++ b/src/utilities/dataplane.spec.ts
@@ -27,7 +27,7 @@ describe('utilities/dataplane', () => {
           subscriptions: [
             {
               connectTime: '1',
-            } as DiscoverySubscription,
+            },
           ],
         }],
         expected: 'online',
@@ -39,7 +39,7 @@ describe('utilities/dataplane', () => {
             {
               connectTime: '1',
               disconnectTime: '2',
-            } as DiscoverySubscription,
+            },
           ],
         }],
         expected: 'offline',
@@ -50,11 +50,11 @@ describe('utilities/dataplane', () => {
           subscriptions: [
             {
               connectTime: '1',
-            } as DiscoverySubscription,
+            },
             {
               connectTime: '1',
               disconnectTime: '2',
-            } as DiscoverySubscription,
+            },
           ],
         }],
         expected: 'online',

--- a/src/utilities/dataplane.spec.ts
+++ b/src/utilities/dataplane.spec.ts
@@ -133,7 +133,7 @@ describe('utilities/dataplane', () => {
         }],
         expected: {
           status: 'offline',
-          reason: [''],
+          reason: [`Inbound on port ${1} is not ready (kuma.io/service: ${'service'})`],
         },
       },
       {
@@ -159,13 +159,12 @@ describe('utilities/dataplane', () => {
         }],
         expected: {
           status: 'partially_degraded',
-          reason: [''],
+          reason: [`Inbound on port ${1} is not ready (kuma.io/service: ${'service'})`],
         },
       },
     ] as TestCases))('$message', (item) => {
       const actual = getStatusAndReason(...item.args)
-      expect(actual.status).toBe(item.expected.status)
-      expect(actual.reason.length).toBe(item.expected.reason.length)
+      expect(actual).toStrictEqual(item.expected)
     })
   })
 })

--- a/src/utilities/dataplane.spec.ts
+++ b/src/utilities/dataplane.spec.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from '@jest/globals'
+
+import { getStatusAndReason, getItemStatusFromInsight } from './dataplane'
+
+import {
+  DiscoverySubscription,
+  DataPlaneNetworking,
+} from '@/types/index.d'
+
+describe('utilities/dataplane', () => {
+  describe('getItemStatusFromInsight', () => {
+    type TestCases = {message: string, args: [{ subscriptions?: DiscoverySubscription[] }], expected: string}[]
+    test.each(([
+      {
+        message: 'undefined insight is offline',
+        args: [undefined],
+        expected: 'offline',
+      },
+      {
+        message: 'undefined subscriptions is offline',
+        args: [{}],
+        expected: 'offline',
+      },
+      {
+        message: 'single connected subscription is online',
+        args: [{
+          subscriptions: [
+            {
+              connectTime: '1',
+            } as DiscoverySubscription,
+          ],
+        }],
+        expected: 'online',
+      },
+      {
+        message: 'single disconnected subscription is offline',
+        args: [{
+          subscriptions: [
+            {
+              connectTime: '1',
+              disconnectTime: '2',
+            } as DiscoverySubscription,
+          ],
+        }],
+        expected: 'offline',
+      },
+      {
+        message: 'multiple subscriptions with a single connected is online',
+        args: [{
+          subscriptions: [
+            {
+              connectTime: '1',
+            } as DiscoverySubscription,
+            {
+              connectTime: '1',
+              disconnectTime: '2',
+            } as DiscoverySubscription,
+          ],
+        }],
+        expected: 'online',
+      },
+    ] as TestCases))('$message', (item) => {
+      expect(getItemStatusFromInsight(...item.args)).toBe(item.expected)
+    })
+  })
+
+  describe('getStatusAndReason', () => {
+    type TestCases = {message: string, args: [{ networking: DataPlaneNetworking }, { subscriptions?: DiscoverySubscription[] }], expected: any}[]
+    test.each(([
+      {
+        message: 'nothing defined is online',
+        args: [{
+          networking: {
+            address: '',
+          },
+        }],
+        expected: {
+          status: 'online',
+          reason: [],
+        },
+      },
+      {
+        message: 'empty inbounds is online',
+        args: [{
+          networking: {
+            address: '',
+            inbound: [],
+          },
+        }],
+        expected: {
+          status: 'online',
+          reason: [],
+        },
+      },
+      {
+        message: 'single healthy inbound defers to getItemStatusFromInsight (online)',
+        args: [{
+          networking: {
+            address: '',
+            inbound: [{
+              health: {
+                ready: true,
+              },
+            }],
+          },
+        }, {
+          subscriptions: [
+            {
+              connectTime: '1',
+            },
+          ],
+        }],
+        expected: {
+          status: 'online',
+          reason: [],
+        },
+      },
+      {
+        message: 'single unhealthy inbound is offline with a single reason',
+        args: [{
+          networking: {
+            address: '',
+            inbound: [{
+              health: {
+                ready: false,
+              },
+              port: 1,
+              tags: {
+                'kuma.io/service': 'service',
+              },
+            }],
+          },
+        }],
+        expected: {
+          status: 'offline',
+          reason: [''],
+        },
+      },
+      {
+        message: 'single unhealthy inbound out of multiple is partially_degraded',
+        args: [{
+          networking: {
+            address: '',
+            inbound: [{
+              health: {
+                ready: false,
+              },
+              port: 1,
+              tags: {
+                'kuma.io/service': 'service',
+              },
+            },
+            {
+              health: {
+                ready: true,
+              },
+            }],
+          },
+        }],
+        expected: {
+          status: 'partially_degraded',
+          reason: [''],
+        },
+      },
+    ] as TestCases))('$message', (item) => {
+      const actual = getStatusAndReason(...item.args)
+      expect(actual.status).toBe(item.expected.status)
+      expect(actual.reason.length).toBe(item.expected.reason.length)
+    })
+  })
+})

--- a/src/utilities/dataplane.ts
+++ b/src/utilities/dataplane.ts
@@ -82,8 +82,8 @@ export function getItemStatusFromInsight(insight: { subscriptions: DiscoverySubs
 export function getStatusAndReason(dataplane: { networking: DataPlaneNetworking }, insight: { subscriptions: DiscoverySubscription[] } | undefined = { subscriptions: [] }): { status: StatusKeyword, reason: string[] } {
   const inbound = dataplane.networking.inbound ?? []
   const errors = inbound
-    .filter((item: TODO) => item.health && !item.health.ready)
-    .map((item: TODO) => `Inbound on port ${item.port} is not ready (kuma.io/service: ${item.tags['kuma.io/service']})`)
+    .filter(item => item.health && !item.health.ready)
+    .map(item => `Inbound on port ${item.port} is not ready (kuma.io/service: ${item.tags['kuma.io/service']})`)
 
   let status: StatusKeyword
   switch (true) {

--- a/src/utilities/dataplane.ts
+++ b/src/utilities/dataplane.ts
@@ -11,8 +11,6 @@ import {
   Version,
 } from '@/types/index.d'
 
-type TODO = any
-
 /**
  * Takes a data plane and constructs the list of tags. It removes duplicate tags so we don't display them twice. Note that tags are only considered a duplicate if both their key and their value are the same.
  *

--- a/src/utilities/dataplane.ts
+++ b/src/utilities/dataplane.ts
@@ -70,14 +70,14 @@ export function dpTags(dataplane: { networking: DataPlaneNetworking }): LabelVal
 
 // getItemStatusFromInsight takes object with subscriptions and returns a
 // status 'online' | 'offline'
-export function getItemStatusFromInsight(insight: { subscriptions: DiscoverySubscription[] } | undefined = { subscriptions: [] }): StatusKeyword {
+export function getItemStatusFromInsight(insight: { subscriptions?: DiscoverySubscription[] } | undefined = { subscriptions: [] }): StatusKeyword {
   const proxyOnline = (insight.subscriptions ?? []).some((subscription) => subscription.connectTime?.length && !subscription.disconnectTime)
   return proxyOnline ? 'online' : 'offline'
 }
 
 // getStatusAndReason takes Dataplane and DataplaneInsight and returns a
 // {status: 'online' | 'offline' | 'partially_degraded', reason: errors[]}
-export function getStatusAndReason(dataplane: { networking: DataPlaneNetworking }, insight: { subscriptions: DiscoverySubscription[] } | undefined = { subscriptions: [] }): { status: StatusKeyword, reason: string[] } {
+export function getStatusAndReason(dataplane: { networking: DataPlaneNetworking }, insight: { subscriptions?: DiscoverySubscription[] } | undefined = { subscriptions: [] }): { status: StatusKeyword, reason: string[] } {
   const inbound = dataplane.networking.inbound ?? []
   const errors = inbound
     .filter(item => item.health && !item.health.ready)
@@ -85,6 +85,9 @@ export function getStatusAndReason(dataplane: { networking: DataPlaneNetworking 
 
   let status: StatusKeyword
   switch (true) {
+    case inbound.length === 0:
+      status = 'online'
+      break
     // if errors and inbounds are equal, even if they are both 0
     // then we are offline
     case errors.length === inbound.length:


### PR DESCRIPTION
Whilst fixing https://github.com/kumahq/kuma-gui/issues/517 with https://github.com/kumahq/kuma-gui/pull/523 we realized that the type naming didn't quite make sense:

https://github.com/kumahq/kuma-gui/issues/517#issuecomment-1371985785

So we tweaked the types slightly so that things didn't look as weird.

Whilst I was there we noticed a couple of other things we could do regarding `getItemStatusFromInsight` and `getStatus` which led to being able to compose those two functions to DRY things out a little, simplifying the innards of them slightly and a rename of `getStatus`

@lahabana could you double check the changes in the second to last commit (https://github.com/kumahq/kuma-gui/commit/50fb7d99ef5d98f8eb94300e4502d6e0a14dd882), a tweaked it a little more following our catch up and it would be good for someone with more context than me to make sure its doing the right thing. To me it reads a lot better now

Signed-off-by: John Cowen <john.cowen@konghq.com>
