### PR TITLE
chore(deps): Bump @kong/kongponents from 8.12.0 to 8.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@amcharts/amcharts4": "^4.10.33",
     "@appscode/json2yaml": "^0.1.2",
     "@datadog/browser-logs": "^4.25.0",
-    "@kong/kongponents": "^8.12.0",
+    "@kong/kongponents": "^8.14.2",
     "prismjs": "^1.29.0",
     "semver": "^7.3.8",
     "tailwindcss": "^3.2.4",

--- a/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
@@ -374,7 +374,7 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                 >
                   
                   <div
-                    class="k-code-block code-block"
+                    class="k-code-block theme-light code-block"
                     data-testid="k-code-block"
                     id="code-block-data-plane"
                     style="--maxLineNumberWidth: 2ch;"
@@ -383,6 +383,13 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                     <div
                       class="k-code-block-actions"
                     >
+                      <p
+                        class="k-code-block-search-results"
+                      >
+                        
+                           
+                        
+                      </p>
                       <div
                         class="k-search-container"
                       >
@@ -392,7 +399,7 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                         >
                           <svg
                             data-testid="k-code-block-search-icon"
-                            fill="currentColor"
+                            fill="var(--steel-500)"
                             height="20"
                             role="img"
                             viewBox="0 0 24 24"
@@ -409,7 +416,7 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                             <path
                               d="M10.88 18.75a7.88 7.88 0 1 0 0-15.75 7.88 7.88 0 0 0 0 15.75ZM16.44 16.44 21 21"
                               fill="none"
-                              stroke="currentColor"
+                              stroke="var(--steel-500)"
                               stroke-width="3"
                             />
                             
@@ -441,7 +448,7 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                         >
                           <svg
                             data-testid="k-code-block-is-processing-icon"
-                            fill="var(--grey-400)"
+                            fill="var(--steel-500)"
                             height="24"
                             role="img"
                             viewBox="0 0 20 20"
@@ -461,7 +468,7 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                               <path
                                 d="M5 10a5 5 0 1 0 5-5"
                                 fill="none"
-                                stroke="var(--grey-400)"
+                                stroke="var(--steel-500)"
                                 stroke-linecap="round"
                                 stroke-linejoin="round"
                                 stroke-width="2"
@@ -477,13 +484,6 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                         </span>
                         <!---->
                       </div>
-                      <p
-                        class="k-code-block-search-results"
-                      >
-                        
-                         No results 
-                        
-                      </p>
                       <div
                         class="k-search-actions"
                       >
@@ -1143,10 +1143,10 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                           class="kong-icon kong-icon-copy"
                         >
                           <svg
-                            height="16"
+                            height="18"
                             role="img"
                             viewBox="0 0 32 32"
-                            width="16"
+                            width="18"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             

--- a/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
@@ -365,7 +365,7 @@ exports[`DataPlaneEntitySummary matches snapshot 1`] = `
           >
             
             <div
-              class="k-code-block code-block"
+              class="k-code-block theme-light code-block"
               data-testid="k-code-block"
               id="code-block-data-plane-summary"
               style="--maxLineNumberWidth: 2ch; --KCodeBlockMaxHeight: 250px;"
@@ -860,10 +860,10 @@ exports[`DataPlaneEntitySummary matches snapshot 1`] = `
                     class="kong-icon kong-icon-copy"
                   >
                     <svg
-                      height="16"
+                      height="18"
                       role="img"
                       viewBox="0 0 32 32"
-                      width="16"
+                      width="18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       

--- a/src/app/data-planes/components/__snapshots__/DataplanePolicies.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataplanePolicies.spec.ts.snap
@@ -227,7 +227,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                       >
                         
                         <div
-                          class="k-code-block code-block"
+                          class="k-code-block theme-light code-block"
                           data-testid="k-code-block"
                           id="policies-0-0-code-block"
                           style="--maxLineNumberWidth: 1ch;"
@@ -430,7 +430,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                       >
                         
                         <div
-                          class="k-code-block code-block"
+                          class="k-code-block theme-light code-block"
                           data-testid="k-code-block"
                           id="policies-0-1-code-block"
                           style="--maxLineNumberWidth: 1ch;"
@@ -633,7 +633,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                       >
                         
                         <div
-                          class="k-code-block code-block"
+                          class="k-code-block theme-light code-block"
                           data-testid="k-code-block"
                           id="policies-0-2-code-block"
                           style="--maxLineNumberWidth: 1ch;"

--- a/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
+++ b/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
@@ -2058,7 +2058,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
               >
                 
                 <div
-                  class="k-code-block code-block"
+                  class="k-code-block theme-light code-block"
                   data-testid="k-code-block"
                   id="code-block-data-plane-summary"
                   style="--maxLineNumberWidth: 2ch; --KCodeBlockMaxHeight: 250px;"
@@ -2547,10 +2547,10 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                         class="kong-icon kong-icon-copy"
                       >
                         <svg
-                          height="16"
+                          height="18"
                           role="img"
                           viewBox="0 0 32 32"
-                          width="16"
+                          width="18"
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           

--- a/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
@@ -38,7 +38,7 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
             Clone the GitHub repository for the demo application:
           </p>
           <div
-            class="k-code-block code-block"
+            class="k-code-block theme-light code-block"
             data-testid="k-code-block"
             id="code-block-clone-command"
             style="--maxLineNumberWidth: 1ch;"
@@ -97,10 +97,10 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
                   class="kong-icon kong-icon-copy"
                 >
                   <svg
-                    height="16"
+                    height="18"
                     role="img"
                     viewBox="0 0 32 32"
-                    width="16"
+                    width="18"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     

--- a/src/app/wizard/views/__snapshots__/DataplaneUniversal.spec.ts.snap
+++ b/src/app/wizard/views/__snapshots__/DataplaneUniversal.spec.ts.snap
@@ -115,7 +115,7 @@ exports[`DataplaneUniversal.vue passes whole wizzard and render yaml 1`] = `
                     Generate Dataplane Token
                   </h4>
                   <div
-                    class="k-code-block code-block"
+                    class="k-code-block theme-light code-block"
                     data-testid="k-code-block"
                     id="code-block-generate-token-command"
                     style="--maxLineNumberWidth: 1ch;"
@@ -191,10 +191,10 @@ exports[`DataplaneUniversal.vue passes whole wizzard and render yaml 1`] = `
                           class="kong-icon kong-icon-copy"
                         >
                           <svg
-                            height="16"
+                            height="18"
                             role="img"
                             viewBox="0 0 32 32"
-                            width="16"
+                            width="18"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             
@@ -228,7 +228,7 @@ exports[`DataplaneUniversal.vue passes whole wizzard and render yaml 1`] = `
                     Start Dataplane Process
                   </h4>
                   <div
-                    class="k-code-block code-block"
+                    class="k-code-block theme-light code-block"
                     data-testid="k-code-block"
                     id="code-block-stard-dp-command"
                     style="--maxLineNumberWidth: 2ch;"
@@ -543,10 +543,10 @@ networking:
                           class="kong-icon kong-icon-copy"
                         >
                           <svg
-                            height="16"
+                            height="18"
                             role="img"
                             viewBox="0 0 32 32"
-                            width="16"
+                            width="18"
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             
@@ -800,7 +800,7 @@ networking:
                Below is an example of a Dataplane resource output: 
             </p>
             <div
-              class="k-code-block code-block mt-3"
+              class="k-code-block theme-light code-block mt-3"
               data-testid="k-code-block"
               id="onboarding-dpp-universal-example"
               style="--maxLineNumberWidth: 2ch;"
@@ -1138,10 +1138,10 @@ networking:
                     class="kong-icon kong-icon-copy"
                   >
                     <svg
-                      height="16"
+                      height="18"
                       role="img"
                       viewBox="0 0 32 32"
-                      width="16"
+                      width="18"
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       

--- a/src/app/wizard/views/__snapshots__/Mesh.spec.ts.snap
+++ b/src/app/wizard/views/__snapshots__/Mesh.spec.ts.snap
@@ -200,7 +200,7 @@ exports[`Mesh.vue passes whole wizzard and render yaml 1`] = `
                           
                           
                           <div
-                            class="k-code-block code-block"
+                            class="k-code-block theme-light code-block"
                             data-testid="universal"
                             id="code-block-universal-command"
                             style="--maxLineNumberWidth: 2ch;"
@@ -780,10 +780,10 @@ metrics:
                                   class="kong-icon kong-icon-copy"
                                 >
                                   <svg
-                                    height="16"
+                                    height="18"
                                     role="img"
                                     viewBox="0 0 32 32"
-                                    width="16"
+                                    width="18"
                                     xmlns="http://www.w3.org/2000/svg"
                                   >
                                     

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,16 +1331,16 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@kong/kongponents@^8.12.0":
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.12.0.tgz#2f0db798c95a3acdfc4e683add4683cfa37ca4c1"
-  integrity sha512-AQ6C4805yUWY+QWwHU7PC8l8XA9rh2GJ69/CeGkGTX2jEKb2zOq8LtZoy446OgO823m7gvkGK1yEMuMEoiwzVA==
+"@kong/kongponents@^8.14.2":
+  version "8.15.1"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.15.1.tgz#09e5a6c463b954f06000ab4b7b66cf5fde1aa479"
+  integrity sha512-AIXf+WDuZNBLx/zFfrFBqYQK28RZCgrx3AX6mdUKDnw8UhJ8xhnsrPF/Lffc0iHAu+3fQBFUypLzX4sEQSI99Q==
   dependencies:
     axios "^0.27.2"
     date-fns "^2.29.3"
     date-fns-tz "^1.3.7"
     focus-trap "^7.1.0"
-    focus-trap-vue "^3.3.1"
+    focus-trap-vue "^3.4.0"
     popper.js "^1.15.0"
     sortablejs "^1.15.0"
     swrv "^1.0.0"
@@ -3887,10 +3887,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-focus-trap-vue@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/focus-trap-vue/-/focus-trap-vue-3.3.1.tgz#d7934f6569e7e09d7230f62f614cf3499e121b06"
-  integrity sha512-bsZXt0//ZpdvVbcR4KYq/n73XF57a31mHmiKT6FBdv9osqSAYmjbwmdxlytWO786nv8wbCxKZw+t87nYVstB4g==
+focus-trap-vue@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/focus-trap-vue/-/focus-trap-vue-3.4.0.tgz#ea63ef2dce04e929bc09e2b3df0e36a058574b82"
+  integrity sha512-VAI4gJgsjC8KcjDH+h4j2SxFY2XrXmm47a1EXti8gx311abybzqVhkS32Um7i+00J8RQD7hqL1Kfc26WpsMx0w==
 
 focus-trap@^7.1.0:
   version "7.2.0"


### PR DESCRIPTION
See https://github.com/kumahq/kuma-gui/pull/529. Tests were failing there due to snapshots changing

Signed-off-by: John Cowen <john.cowen@konghq.com>