### PR TITLE
refactor: streamlines selected table row persisting

### DIFF
--- a/src/app/common/StatusBadge.vue
+++ b/src/app/common/StatusBadge.vue
@@ -54,6 +54,10 @@ const statusObject = computed(() => STATUS[props.status])
 </script>
 
 <style lang="scss" scoped>
+.status {
+  white-space: nowrap;
+}
+
 .status::before {
   content: '';
   display: inline-block;

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -179,7 +179,7 @@ const props = defineProps({
     default: 0,
   },
 
-  name: {
+  selectedDppName: {
     type: String,
     required: false,
     default: null,
@@ -284,7 +284,7 @@ function onCreateClick() {
 async function initializeData(): Promise<void> {
   try {
     if (Array.isArray(props.dataPlaneOverviews) && props.dataPlaneOverviews.length > 0) {
-      selectDataPlaneOverview(props.name ?? props.dataPlaneOverviews[0].name)
+      selectDataPlaneOverview(props.selectedDppName ?? props.dataPlaneOverviews[0].name)
       tableData.value.data = await Promise.all(props.dataPlaneOverviews.map((item) => parseData(item)))
     } else {
       selectDataPlaneOverview(null)
@@ -298,10 +298,10 @@ async function initializeData(): Promise<void> {
 function selectDataPlaneOverview(name: string | null): void {
   if (name && props.dataPlaneOverviews.length > 0) {
     dataPlaneOverview.value = props.dataPlaneOverviews.find((data) => data.name === name) ?? props.dataPlaneOverviews[0]
-    patchQueryParam('name', dataPlaneOverview.value.name)
+    patchQueryParam('dpp', dataPlaneOverview.value.name)
   } else {
     dataPlaneOverview.value = null
-    patchQueryParam('name', null)
+    patchQueryParam('dpp', null)
   }
 }
 

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -298,10 +298,10 @@ async function initializeData(): Promise<void> {
 function selectDataPlaneOverview(name: string | null): void {
   if (name && props.dataPlaneOverviews.length > 0) {
     dataPlaneOverview.value = props.dataPlaneOverviews.find((data) => data.name === name) ?? props.dataPlaneOverviews[0]
-    patchQueryParam('dpp', dataPlaneOverview.value.name)
+    patchQueryParam(props.isGatewayView ? 'gateway' : 'dpp', dataPlaneOverview.value.name)
   } else {
     dataPlaneOverview.value = null
-    patchQueryParam('dpp', null)
+    patchQueryParam(props.isGatewayView ? 'gateway' : 'dpp', null)
   }
 }
 

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -5,6 +5,7 @@
     :error="error"
     :next-url="nextUrl"
     :page-offset="pageOffset"
+    :selected-dpp-name="props.selectedDppName"
     :is-gateway-view="props.isGatewayView"
     @gateway-type-change="($event) => loadData(0, $event)"
     @load-data="loadData"
@@ -30,7 +31,7 @@ const GATEWAY_TYPES = {
 
 const route = useRoute()
 const props = defineProps({
-  name: {
+  selectedDppName: {
     type: String,
     required: false,
     default: null,

--- a/src/app/policies/views/PolicyView.vue
+++ b/src/app/policies/views/PolicyView.vue
@@ -180,6 +180,12 @@ const route = useRoute()
 const store = useStore()
 
 const props = defineProps({
+  selectedPolicyName: {
+    type: String,
+    required: false,
+    default: null,
+  },
+
   policyPath: {
     type: String,
     required: true,
@@ -285,11 +291,9 @@ async function loadData(offset: number): Promise<void> {
       tableDataIsEmpty.value = false
       isEmpty.value = false
 
-      await getEntity({
-        mesh: items[0].mesh,
-        name: items[0].name,
-        path,
-      })
+      const selectedPolicyName = props.selectedPolicyName ?? items[0].name
+
+      await getEntity({ name: selectedPolicyName, mesh, path })
     } else {
       tableData.value.data = []
       tableDataIsEmpty.value = true
@@ -346,6 +350,7 @@ async function getEntity(selectedEntity: { mesh: string, path: string, name: str
       const selected = ['type', 'name', 'mesh']
 
       entity.value = getSome(item, selected)
+      patchQueryParam('policy', entity.value.name)
       rawEntity.value = stripTimes(item)
     } else {
       entity.value = {}

--- a/src/app/services/components/ServiceDetails.vue
+++ b/src/app/services/components/ServiceDetails.vue
@@ -10,6 +10,7 @@
     v-if="props.dataPlaneOverviews !== null"
     class="mt-4"
     :data-plane-overviews="props.dataPlaneOverviews"
+    :selected-dpp-name="props.selectedDppName"
     @load-data="loadData"
   />
 </template>
@@ -37,6 +38,12 @@ const props = defineProps({
 
   dataPlaneOverviews: {
     type: Array as PropType<DataPlaneOverview[] | null>,
+    required: false,
+    default: null,
+  },
+
+  selectedDppName: {
+    type: String,
     required: false,
     default: null,
   },

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -14,6 +14,7 @@
       :service="service"
       :data-plane-overviews="dataPlaneOverviews"
       :external-service="externalService"
+      :selected-dpp-name="props.selectedDppName"
       @load-data="loadData"
     />
   </div>
@@ -33,6 +34,14 @@ import ServiceDetails from '../components/ServiceDetails.vue'
 
 const route = useRoute()
 const store = useStore()
+
+const props = defineProps({
+  selectedDppName: {
+    type: String,
+    required: false,
+    default: null,
+  },
+})
 
 const service = ref<ServiceInsight | null>(null)
 const externalService = ref<ExternalService | null>(null)

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -54,7 +54,7 @@ const EMPTY_STATE = {
 const route = useRoute()
 
 const props = defineProps({
-  name: {
+  selectedServiceName: {
     type: String,
     required: false,
     default: null,
@@ -116,7 +116,7 @@ async function loadData(offset: number): Promise<void> {
 
       tableData.value.data = items.map((item) => processItem(item))
 
-      const activeServiceName = props.name ?? items[0].name
+      const activeServiceName = props.selectedServiceName ?? items[0].name
       await loadService({ name: activeServiceName, mesh })
     } else {
       tableData.value.data = []
@@ -179,6 +179,6 @@ async function loadService({ mesh, name }: { mesh: string, name: string }): Prom
     externalService.value = await kumaApi.getExternalService({ mesh, name })
   }
 
-  patchQueryParam('name', name)
+  patchQueryParam('service', name)
 }
 </script>

--- a/src/app/zones/views/ZoneEgresses.vue
+++ b/src/app/zones/views/ZoneEgresses.vue
@@ -145,6 +145,12 @@ export default {
   },
 
   props: {
+    selectedZoneEgressName: {
+      type: String,
+      required: false,
+      default: null,
+    },
+
     offset: {
       type: Number,
       required: false,
@@ -245,7 +251,7 @@ export default {
         if (data.length) {
           this.isEmpty = false
           this.rawData = data
-          this.getEntity({ name: data[0].name })
+          this.getEntity({ name: this.selectedZoneEgressName ?? data[0].name })
 
           this.tableData.data = data.map((item) => {
             const { zoneEgressInsight = {} } = item
@@ -279,6 +285,7 @@ export default {
       this.subscriptionsReversed = Array.from(subscriptions).reverse()
 
       this.entity = getSome(item, selected)
+      patchQueryParam('zoneEgress', this.entity.name)
     },
 
     /**

--- a/src/app/zones/views/ZoneIngresses.vue
+++ b/src/app/zones/views/ZoneIngresses.vue
@@ -151,6 +151,12 @@ export default {
   },
 
   props: {
+    selectedZoneIngressName: {
+      type: String,
+      required: false,
+      default: null,
+    },
+
     offset: {
       type: Number,
       required: false,
@@ -262,7 +268,7 @@ export default {
         if (data.length) {
           this.isEmpty = false
           this.rawData = data
-          this.getEntity({ name: data[0].name })
+          this.getEntity({ name: this.selectedZoneIngressName ?? data[0].name })
 
           this.tableData.data = data.map((item) => {
             const { zoneIngressInsight = {} } = item
@@ -296,6 +302,7 @@ export default {
       this.subscriptionsReversed = Array.from(subscriptions).reverse()
 
       this.entity = getSome(item, selected)
+      patchQueryParam('zoneIngress', this.entity.name)
     },
 
     /**

--- a/src/app/zones/views/ZonesView.vue
+++ b/src/app/zones/views/ZonesView.vue
@@ -121,6 +121,7 @@ import { KBadge, KButton, KCard } from '@kong/kongponents'
 
 import { fetchAllResources, getSome, getZoneDpServerAuthType } from '@/utilities/helpers'
 import { getItemStatusFromInsight, INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS } from '@/utilities/dataplane'
+import { patchQueryParam } from '@/utilities/patchQueryParam'
 import { PAGE_SIZE_DEFAULT } from '@/constants'
 import { kumaApi } from '@/api/kumaApi'
 import AccordionItem from '@/app/common/AccordionItem.vue'
@@ -134,7 +135,6 @@ import SubscriptionDetails from '@/app/common/subscriptions/SubscriptionDetails.
 import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
 import WarningsWidget from '@/app/common/warnings/WarningsWidget.vue'
-import { patchQueryParam } from '@/utilities/patchQueryParam'
 
 export default {
   name: 'ZonesView',
@@ -157,6 +157,12 @@ export default {
   },
 
   props: {
+    selectedZoneName: {
+      type: String,
+      required: false,
+      default: null,
+    },
+
     offset: {
       type: Number,
       required: false,
@@ -345,7 +351,7 @@ export default {
           this.tableDataIsEmpty = false
           this.isEmpty = false
 
-          this.getEntity({ name: data[0].name })
+          this.getEntity({ name: this.selectedZoneName ?? data[0].name })
         } else {
           this.tableData.data = []
           this.tableDataIsEmpty = true
@@ -386,6 +392,7 @@ export default {
           const subscriptions = response.zoneInsight?.subscriptions ?? []
 
           this.entity = { ...getSome(response, selected), 'Authentication Type': getZoneDpServerAuthType(response) }
+          patchQueryParam('zone', this.entity.name)
           this.subscriptionsReversed = Array.from(subscriptions).reverse()
 
           if (subscriptions.length) {

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -24,6 +24,7 @@ function getPolicyRoutes(policies: PolicyDefinition[]): RouteRecordRaw[] {
       },
       props: (route) => ({
         policyPath: policy.path,
+        selectedPolicyName: route.query.policy,
         offset: getLastNumberParameter(route.query.offset),
       }),
       component: () => import('@/app/policies/views/PolicyView.vue'),
@@ -67,6 +68,7 @@ export function createRouter(baseGuiPath: string = '/', policyDefinitions: Polic
         title: 'Zones',
       },
       props: (route) => ({
+        selectedZoneName: route.query.zone,
         offset: getLastNumberParameter(route.query.offset),
       }),
       component: () => import('@/app/zones/views/ZonesView.vue'),
@@ -78,6 +80,7 @@ export function createRouter(baseGuiPath: string = '/', policyDefinitions: Polic
         title: 'Zone ingresses',
       },
       props: (route) => ({
+        selectedZoneIngressName: route.query.zoneIngress,
         offset: getLastNumberParameter(route.query.offset),
       }),
       component: () => import('@/app/zones/views/ZoneIngresses.vue'),
@@ -89,6 +92,7 @@ export function createRouter(baseGuiPath: string = '/', policyDefinitions: Polic
         title: 'Zone egresses',
       },
       props: (route) => ({
+        selectedZoneEgressName: route.query.zoneEgress,
         offset: getLastNumberParameter(route.query.offset),
       }),
       component: () => import('@/app/zones/views/ZoneEgresses.vue'),

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -118,7 +118,7 @@ export function createRouter(baseGuiPath: string = '/', policyDefinitions: Polic
                 title: 'Gateways',
               },
               props: (route) => ({
-                selectedDppName: route.query.dpp,
+                selectedDppName: route.query.gateway,
                 offset: getLastNumberParameter(route.query.offset),
                 isGatewayView: true,
               }),

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -114,7 +114,7 @@ export function createRouter(baseGuiPath: string = '/', policyDefinitions: Polic
                 title: 'Gateways',
               },
               props: (route) => ({
-                name: route.query.name,
+                selectedDppName: route.query.dpp,
                 offset: getLastNumberParameter(route.query.offset),
                 isGatewayView: true,
               }),
@@ -142,7 +142,7 @@ export function createRouter(baseGuiPath: string = '/', policyDefinitions: Polic
                 title: 'Data plane proxies',
               },
               props: (route) => ({
-                name: route.query.name,
+                selectedDppName: route.query.dpp,
                 offset: getLastNumberParameter(route.query.offset),
               }),
               component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
@@ -169,7 +169,7 @@ export function createRouter(baseGuiPath: string = '/', policyDefinitions: Polic
                 title: 'Services',
               },
               props: (route) => ({
-                name: route.query.name,
+                selectedServiceName: route.query.service,
                 offset: getLastNumberParameter(route.query.offset),
               }),
               component: () => import('@/app/services/views/ServiceListView.vue'),
@@ -182,6 +182,9 @@ export function createRouter(baseGuiPath: string = '/', policyDefinitions: Polic
                 parent: 'service-list-view',
                 breadcrumbTitleParam: 'service',
               },
+              props: (route) => ({
+                selectedDppName: route.query.dpp,
+              }),
               component: () => import('@/app/services/views/ServiceDetailView.vue'),
             },
           ],


### PR DESCRIPTION
Reworks slightly how selected rows are persisted in DPP and service tables. The associated props and query parameters were given more accurate names to avoid conflicts and give a clearer indication of what they’re representing.

Also fixes one or two instances of persisting selected rows not actually working.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>