### PR TITLE
fix(services): don't filter a services proxies by non-gateways

### DIFF
--- a/src/app/services/components/ServiceDetails.vue
+++ b/src/app/services/components/ServiceDetails.vue
@@ -12,6 +12,7 @@
     :data-plane-overviews="props.dataPlaneOverviews"
     :dpp-filter-fields="props.dppFilterFields"
     :selected-dpp-name="props.selectedDppName"
+    :is-gateway-view="props.dataPlaneOverviews[0]?.dataplane.networking.gateway !== undefined ?? false"
     @load-data="loadData"
   />
 </template>

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -134,13 +134,11 @@ async function loadDataplaneOverviews(offset: number, dppParams: DataPlaneOvervi
 function getDataPlaneOverviewParameters(name: string, offset: number, dppParams: DataPlaneOverviewParameters): DataPlaneOverviewParameters {
   const size = 50
   const serviceTag = `kuma.io/service:${name}`
-  const gateway = 'false'
 
   const params: DataPlaneOverviewParameters = {
     ...dppParams,
     offset,
     size,
-    gateway,
   }
 
   // Prunes any service tags from the received parameters because this view always looks-up DPPs by its own service tag


### PR DESCRIPTION
Services can have gateways, but we currently ask for non-gateways when requesting the dataplane proxies for a service.

This PR removes that filter and makes sure that the table displays the correct columns depending on what the first item in the list is. Whilst it's theoretically possible that this list can be a mix of the 2 types its highly unlikely, and could potentially be validated to be impossible in the future.

There has been some discussion on whether we do want to cope properly for mixed lists, but if we did want to do that we would need to decide whether to:

- Show everything in the same table/list (seems strange seeing as we recently changed things elsewhere not to do this)
- Show a tabbed interface with a tab for each type
- Other ideas...

In the meantime this PR makes it so you can see a services gateways as well as its standard proxies.

Fixes https://github.com/kumahq/kuma-gui/issues/502

Signed-off-by: John Cowen <john.cowen@konghq.com>