### PR TITLE
feat(policy): Add dynamic policy route instead of generating static ones

### DIFF
--- a/src/app/data-planes/components/DataplanePolicies.vue
+++ b/src/app/data-planes/components/DataplanePolicies.vue
@@ -179,8 +179,11 @@ function getPolicyRoutes(policies: Record<string, PolicyType> | undefined): Mesh
       type: policy.type,
       name: policy.name,
       route: {
-        name: policyDefinition.path,
-        params: { mesh: policy.mesh },
+        name: 'policy',
+        params: {
+          mesh: policy.mesh,
+          policyPath: policyDefinition.path,
+        },
         query: { ns: policy.name },
       },
     })
@@ -234,9 +237,12 @@ function getPolicyEntryConnections(policy: PolicyType, policyDefinition: PolicyD
   const origin: PolicyTypeEntryOrigin = {
     name: policy.name,
     route: {
-      name: policyDefinition.path,
+      name: 'policy',
       query: { ns: policy.name },
-      params: { mesh: policy.mesh },
+      params: {
+        mesh: policy.mesh,
+        policyPath: policyDefinition.path,
+      },
     },
   }
   const origins: PolicyTypeEntryOrigin[] = [origin]
@@ -327,9 +333,12 @@ function getPolicyEntryConnectionsFromRules(rule: DataplaneRule, policyDefinitio
     origins.push({
       name: ruleOrigin.name,
       route: {
-        name: policyDefinition.path,
+        name: 'policy',
         query: { ns: ruleOrigin.name },
-        params: { mesh: ruleOrigin.mesh },
+        params: {
+          mesh: ruleOrigin.mesh,
+          policyPath: policyDefinition.path,
+        },
       },
     })
   }

--- a/src/app/policies/views/PolicyView.vue
+++ b/src/app/policies/views/PolicyView.vue
@@ -70,7 +70,7 @@
             class="back-button"
             appearance="primary"
             icon="arrowLeft"
-            :to="{ name: policy.path }"
+            :to="{ name: 'policy', params: { policyPath: policyPath } }"
           >
             View all
           </KButton>
@@ -243,6 +243,17 @@ watch(() => route.params.mesh, function () {
   }
 
   // Ensures basic state is reset when switching meshes using the mesh selector.
+  isLoading.value = true
+  isEmpty.value = false
+  entityIsLoading.value = true
+  entityIsEmpty.value = false
+  entityHasError.value = false
+  tableDataIsEmpty.value = false
+  error.value = null
+
+  loadData(0)
+})
+watch(() => route.query.ns, function () {
   isLoading.value = true
   isEmpty.value = false
   entityIsLoading.value = true

--- a/src/app/policies/views/PolicyView.vue
+++ b/src/app/policies/views/PolicyView.vue
@@ -226,7 +226,7 @@ const policies = computed(() => {
       length: store.state.sidebar.insights.mesh.policies[item.name] ?? 0,
       label: item.pluralDisplayName,
       value: item.path,
-      selected: item.path === route.name,
+      selected: item.path === props.policyPath,
     }
   })
 })
@@ -316,7 +316,11 @@ async function loadData(offset: number): Promise<void> {
 
 function changePolicyType(item: {value: string}) {
   router.push({
-    name: item.value,
+    name: 'policy',
+    params: {
+      ...route.params,
+      policyPath: item.value,
+    },
   })
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,11 +42,12 @@ async function initializeVue() {
   await Promise.all([
     // Fetches basic resources before setting up the router and mounting the application. This is mainly needed to properly redirect users to the onboarding flow in the appropriate scenarios.
     store.dispatch('bootstrap'),
-    // Loads available policies in order to populate the necessary routes.
+    // Loads available policies in order to populate the necessary route information.
+    // i.e. pluralDisplayName and amounts of policyTypes
     store.dispatch('fetchPolicies'),
   ])
 
-  const router = await createRouter(pathConfig.baseGuiPath, store.state.policies)
+  const router = await createRouter(pathConfig.baseGuiPath)
 
   app.use(router)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,10 +40,12 @@ async function initializeVue() {
   app.use(store, storeKey)
 
   await Promise.all([
-    // Fetches basic resources before setting up the router and mounting the application. This is mainly needed to properly redirect users to the onboarding flow in the appropriate scenarios.
+    // Fetches basic resources before setting up the router and mounting the
+    // application. This is mainly needed to properly redirect users to the
+    // onboarding flow in the appropriate scenarios.
     store.dispatch('bootstrap'),
-    // Loads available policies in order to populate the necessary route information.
-    // i.e. pluralDisplayName and amounts of policyTypes
+    // Loads available policies in order to populate the necessary information
+    // used for titling/breadcrumbing and policy lookups in the app.
     store.dispatch('fetchPolicies'),
   ])
 


### PR DESCRIPTION
Previously we were looping through all possible policyTypes and generating static routes for each of them.

This PR changes that to use a dynamic route for all of them instead `/policies/:policyType` instead. All policies now live under `/policies/*` instead of just `/*` meaning clashes are less likely.

Setting the title is a little hacky here, and setting the page title does seems to be possible via a `store.dispatch` to the data layer. But when I looked at setting the breadcrumb, it didn't seem possible with the current code without setting the route.meta.title within the route, ideally breadcrumbs I'd vote for breadcrumbs (and titles) being set within the *View.vue, but I didn't want to go about changing too much just for this - either via that alternative or a different one.

I think I removed all the code we no longer need, but please shout if there is something I've missed as I'm not totally sure.

Fixes https://github.com/kumahq/kuma-gui/issues/526

Signed-off-by: John Cowen <john.cowen@konghq.com>
