### PR TITLE
refactor: streamlines naming of policy type

### DIFF
--- a/src/api/kumaApi.ts
+++ b/src/api/kumaApi.ts
@@ -16,8 +16,8 @@ import {
   Mesh,
   MeshGatewayDataplane,
   MeshInsight,
-  PolicyDefinition,
   PolicyEntity,
+  PolicyType,
   ServiceInsight,
   SidecarDataplane,
   Zone,
@@ -70,7 +70,7 @@ class KumaApi {
   /**
    * Retrieves a list of known policy definitions.
    */
-  getPolicyDefinitions(): Promise<{ policies: PolicyDefinition[] }> {
+  getPolicyTypes(): Promise<{ policies: PolicyType[] }> {
     return this.client.get('policies')
   }
 

--- a/src/app/AppSidebar.spec.ts
+++ b/src/app/AppSidebar.spec.ts
@@ -5,7 +5,7 @@ import AppSidebar from './AppSidebar.vue'
 import { store } from '@/store/store'
 
 async function renderComponent() {
-  await store.dispatch('fetchPolicies')
+  await store.dispatch('fetchPolicyTypes')
 
   return mount(AppSidebar, {
     global: {

--- a/src/app/common/PolicyTypeTag.vue
+++ b/src/app/common/PolicyTypeTag.vue
@@ -108,10 +108,10 @@ const props = defineProps({
 })
 
 const policyTagDefinitions = computed<Record<string, PolicyTagDefinition>>(() => {
-  const policyTagDefinitionEntries: [string, PolicyTagDefinition][] = store.state.policies.map((policyDefinition) => {
-    const policyTagDefinition = POLICIES[policyDefinition.name] ?? { iconUrl: null }
+  const policyTagDefinitionEntries: [string, PolicyTagDefinition][] = store.state.policyTypes.map((policyType) => {
+    const policyTagDefinition = POLICIES[policyType.name] ?? { iconUrl: null }
 
-    return [policyDefinition.name, policyTagDefinition]
+    return [policyType.name, policyTagDefinition]
   })
 
   return Object.fromEntries(policyTagDefinitionEntries)

--- a/src/app/data-planes/components/DataPlaneDetails.spec.ts
+++ b/src/app/data-planes/components/DataPlaneDetails.spec.ts
@@ -10,7 +10,7 @@ const dataPlane = createDataPlane()
 const dataPlaneOverview = createDataPlaneOverview()
 
 async function renderComponent(props = {}) {
-  await store.dispatch('fetchPolicies')
+  await store.dispatch('fetchPolicyTypes')
 
   return mount(DataPlaneDetails, {
     props: {

--- a/src/app/data-planes/components/DataplanePolicies.spec.ts
+++ b/src/app/data-planes/components/DataplanePolicies.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '@/types/index.d'
 
 async function renderComponent(props = {}) {
-  await store.dispatch('fetchPolicies')
+  await store.dispatch('fetchPolicyTypes')
   const dataPlane:DataPlane = {
     type: 'Dataplane',
     mesh: 'foo',

--- a/src/app/data-planes/components/PolicyTypeEntryList.spec.ts
+++ b/src/app/data-planes/components/PolicyTypeEntryList.spec.ts
@@ -8,7 +8,7 @@ import { createPolicyTypeEntries } from '@/test-data/createPolicyTypeEntries'
 const policyTypeEntries = createPolicyTypeEntries()
 
 async function renderComponent(props = {}) {
-  await store.dispatch('fetchPolicies')
+  await store.dispatch('fetchPolicyTypes')
   return mount(PolicyTypeEntryList, {
     props: {
       policyTypeEntries,

--- a/src/app/mesh-overview/views/MeshOverviewView.vue
+++ b/src/app/mesh-overview/views/MeshOverviewView.vue
@@ -74,7 +74,7 @@
                           name: item.path
                         }"
                       >
-                        {{ item.pluralDisplayName }}: {{ item.length }}
+                        {{ item.name }}: {{ item.length }}
                       </router-link>
                     </li>
                   </template>
@@ -160,9 +160,9 @@ const extendedMesh = computed(() => {
 })
 
 const policyCounts = computed(() => {
-  return store.state.policies.map((policy) => ({
-    ...policy,
-    length: store.state.meshInsight.policies[policy.name]?.total ?? 0,
+  return store.state.policyTypes.map((policyType) => ({
+    ...policyType,
+    length: store.state.meshInsight.policies[policyType.name]?.total ?? 0,
   }))
 })
 

--- a/src/app/policies/views/PolicyView.spec.ts
+++ b/src/app/policies/views/PolicyView.spec.ts
@@ -7,7 +7,7 @@ import { router } from '@/../jest/jest-setup-after-env'
 
 async function createWrapper(props = {}) {
   router.push({ name: 'mesh-detail-view', params: { mesh: 'default' } })
-  await store.dispatch('fetchPolicies')
+  await store.dispatch('fetchPolicyTypes')
 
   return mount(PolicyView, {
     props: {
@@ -27,7 +27,7 @@ describe('PolicyView', () => {
     expect(documentationLink.exists()).toBe(true)
 
     const singleEntity = wrapper.find('[data-testid="policy-single-entity"]')
-    expect(singleEntity.html()).toContain('Circuit Breaker: cb1')
+    expect(singleEntity.html()).toContain('CircuitBreaker: cb1')
 
     const policyOverview = wrapper.find('[data-testid="policy-overview-tab"]')
     expect(policyOverview.html()).toContain('CircuitBreaker')

--- a/src/app/policies/views/PolicyView.vue
+++ b/src/app/policies/views/PolicyView.vue
@@ -1,11 +1,11 @@
 <template>
   <div
-    v-if="policy"
+    v-if="policyType"
     class="relative"
-    :class="policy.path"
+    :class="policyType.path"
   >
     <div
-      v-if="policy.isExperimental"
+      v-if="policyType.isExperimental"
       class="mb-4"
     >
       <KAlert appearance="warning">
@@ -30,7 +30,7 @@
         :is-loading="isLoading"
         :empty-state="{
           title: 'No Data',
-          message: `There are no ${policy.pluralDisplayName} present.`,
+          message: `There are no ${policyType.name} policies present.`,
         }"
         :table-data="tableData"
         :table-data-is-empty="tableDataIsEmpty"
@@ -61,7 +61,7 @@
           </KSelect>
 
           <DocumentationLink
-            :href="`${env('KUMA_DOCS_URL')}/policies/${policy.path}/?${env('KUMA_UTM_QUERY_PARAMS')}`"
+            :href="`${env('KUMA_DOCS_URL')}/policies/${policyType.path}/?${env('KUMA_UTM_QUERY_PARAMS')}`"
             data-testid="policy-documentation-link"
           />
 
@@ -70,7 +70,7 @@
             class="back-button"
             appearance="primary"
             icon="arrowLeft"
-            :to="{ name: 'policy', params: { policyPath: policyPath } }"
+            :to="{ name: 'policy', params: { policyPath: props.policyPath } }"
           >
             View all
           </KButton>
@@ -90,7 +90,7 @@
             class="entity-heading"
             data-testid="policy-single-entity"
           >
-            {{ policy.singularDisplayName }}: {{ entity.name }}
+            {{ policyType.name }}: {{ entity.name }}
           </h1>
         </template>
 
@@ -133,7 +133,7 @@
             v-if="rawEntity !== null"
             :mesh="rawEntity.mesh"
             :policy-name="rawEntity.name"
-            :policy-type="policy.path"
+            :policy-type="policyType.path"
           />
         </template>
       </TabsWidget>
@@ -222,14 +222,14 @@ const tableData = ref<{ headers: TableHeader[], data: any[] }>({
   data: [],
 })
 
-const policy = computed(() => store.state.policiesByPath[props.policyPath])
+const policyType = computed(() => store.state.policyTypesByPath[props.policyPath])
 const policies = computed(() => {
-  return store.state.policies.map((item) => {
+  return store.state.policyTypes.map((policyType) => {
     return {
-      length: store.state.sidebar.insights.mesh.policies[item.name] ?? 0,
-      label: item.pluralDisplayName,
-      value: item.path,
-      selected: item.path === props.policyPath,
+      length: store.state.sidebar.insights.mesh.policies[policyType.name] ?? 0,
+      label: policyType.name,
+      value: policyType.path,
+      selected: policyType.path === props.policyPath,
     }
   })
 })
@@ -275,7 +275,7 @@ async function loadData(offset: number): Promise<void> {
 
   const name = route.query.ns as string || null
   const mesh = route.params.mesh as string
-  const path = policy.value.path
+  const path = policyType.value.path
 
   try {
     let items: PolicyEntity[]
@@ -357,7 +357,7 @@ async function getEntity(selectedEntity: { mesh: string, path: string, name: str
   entityIsEmpty.value = false
 
   try {
-    const item = await kumaApi.getSinglePolicyEntity({ mesh: selectedEntity.mesh, path: policy.value.path, name: selectedEntity.name })
+    const item = await kumaApi.getSinglePolicyEntity({ mesh: selectedEntity.mesh, path: policyType.value.path, name: selectedEntity.name })
 
     if (item) {
       const selected = ['type', 'name', 'mesh']

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,9 +43,8 @@ async function initializeVue() {
     // application. This is mainly needed to properly redirect users to the
     // onboarding flow in the appropriate scenarios.
     store.dispatch('bootstrap'),
-    // Loads available policies in order to populate the necessary information
-    // used for titling/breadcrumbing and policy lookups in the app.
-    store.dispatch('fetchPolicies'),
+    // Loads available policy types in order to populate the necessary information used for titling/breadcrumbing and policy lookups in the app.
+    store.dispatch('fetchPolicyTypes'),
   ])
 
   const router = await createRouter(env('KUMA_BASE_PATH'))

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -178,10 +178,10 @@ export function createRouter(baseGuiPath: string = '/'): Router {
             title: 'Policies',
           },
           redirect: (to: RouteLocation): RouteLocationRaw => {
-            let item = store.state.policies
+            let item = store.state.policyTypes
               .find((item) => store.state.sidebar.insights.mesh.policies[item.name] !== 0)
             if (item === undefined) {
-              item = store.state.policies[0]
+              item = store.state.policyTypes[0]
             }
             return {
               ...to,
@@ -201,8 +201,10 @@ export function createRouter(baseGuiPath: string = '/'): Router {
           },
           component: () => import('@/app/policies/views/PolicyView.vue'),
           props: (route) => {
-            const policy = store.state.policiesByPath[route.params.policyPath as string]
-            route.meta.title = policy.pluralDisplayName
+            const policy = store.state.policyTypesByPath[route.params.policyPath as string]
+
+            route.meta.title = policy.name
+
             return {
               policyPath: route.params.policyPath,
               selectedPolicyName: route.query.policy,

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -15,7 +15,7 @@ import { fetchAllResources } from '@/utilities/helpers'
 import { getEmptyInsight, mergeInsightsReducer, parseInsightReducer } from '@/store/reducers/mesh-insights'
 import { kumaApi } from '@/api/kumaApi'
 import { ClientStorage } from '@/utilities/ClientStorage'
-import { Mesh, PolicyDefinition } from '@/types/index.d'
+import { Mesh, PolicyType } from '@/types/index.d'
 
 const ONLINE = 'Online'
 const OFFLINE = 'Offline'
@@ -70,9 +70,9 @@ interface BareRootState {
   serviceInsightsFetching: boolean
   externalServicesFetching: boolean
   zonesInsightsFetching: boolean
-  policies: PolicyDefinition[]
-  policiesByPath: Record<string, PolicyDefinition>
-  policiesByType: Record<string, PolicyDefinition>
+  policyTypes: PolicyType[]
+  policyTypesByPath: Record<string, PolicyType>
+  policyTypesByName: Record<string, PolicyType>
 }
 
 const initialState: BareRootState = {
@@ -132,9 +132,9 @@ const initialState: BareRootState = {
   serviceInsightsFetching: false,
   externalServicesFetching: false,
   zonesInsightsFetching: false,
-  policies: [],
-  policiesByPath: {},
-  policiesByType: {},
+  policyTypes: [],
+  policyTypesByPath: {},
+  policyTypesByName: {},
 }
 
 /**
@@ -219,13 +219,13 @@ export const storeConfig: StoreOptions<State> = {
 
       state.overviewCharts[chartName].data = data
     },
-    SET_POLICIES: (state, policies: PolicyDefinition[]) => {
-      policies.sort((policyDefinitionA, policyDefinitionB) => policyDefinitionA.name.localeCompare(policyDefinitionB.name))
+    SET_POLICY_TYPES: (state, policyTypes: PolicyType[]) => {
+      policyTypes.sort((policyTypeA, policyTypeB) => policyTypeA.name.localeCompare(policyTypeB.name))
 
-      state.policies = policies
+      state.policyTypes = policyTypes
     },
-    SET_POLICIES_BY_PATH: (state, policiesByPath) => (state.policiesByPath = policiesByPath),
-    SET_POLICIES_BY_TYPE: (state, policiesByType) => (state.policiesByType = policiesByType),
+    SET_POLICY_TYPES_BY_PATH: (state, policyTypesByPath) => (state.policyTypesByPath = policyTypesByPath),
+    SET_POLICY_TYPES_BY_NAME: (state, policyTypesByName) => (state.policyTypesByName = policyTypesByName),
   },
   actions: {
     async bootstrap({ commit, dispatch, getters, state }) {
@@ -448,14 +448,14 @@ export const storeConfig: StoreOptions<State> = {
       commit('SET_ZONES_INSIGHTS_FETCHING', false)
     },
 
-    async fetchPolicies({ commit }) {
-      const { policies } = await kumaApi.getPolicyDefinitions()
-      const policiesByPath = policies.reduce((obj, policy) => Object.assign(obj, { [policy.path]: policy }), {})
-      const policiesByType = policies.reduce((obj, policy) => Object.assign(obj, { [policy.name]: policy }), {})
+    async fetchPolicyTypes({ commit }) {
+      const { policies: policyTypes } = await kumaApi.getPolicyTypes()
+      const policyTypesByPath = policyTypes.reduce((obj, policyType) => Object.assign(obj, { [policyType.path]: policyType }), {})
+      const policyTypesByName = policyTypes.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})
 
-      commit('SET_POLICIES', policies)
-      commit('SET_POLICIES_BY_PATH', policiesByPath)
-      commit('SET_POLICIES_BY_TYPE', policiesByType)
+      commit('SET_POLICY_TYPES', policyTypes)
+      commit('SET_POLICY_TYPES_BY_PATH', policyTypesByPath)
+      commit('SET_POLICY_TYPES_BY_NAME', policyTypesByName)
     },
 
     setChartsFromMeshInsights({ dispatch }) {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -169,17 +169,11 @@ export type DataPlaneNetworking = {
 /**
  * A policy definition as returned via the `/policies` endpoint.
  */
-export type PolicyDefinition = {
+export type PolicyType = {
   /**
-   * The policies internal name (e.g. “CircuitBreaker”).
+   * The policy type’s name (e.g. “CircuitBreaker”).
    */
   name: string
-
-  /**
-   * The policies display name. In plural form (e.g. “Circuit Breakers”); a singular form is also provided.
-   */
-  pluralDisplayName: string
-  singularDisplayName: string
 
   /**
    * The associated API path for the policy. Used to look up all set-up policies and policies for specific meshes.
@@ -271,7 +265,7 @@ export type PolicyMatch = {
   }
 }
 
-export interface PolicyType extends MeshEntity {
+export interface MatchedPolicyType extends MeshEntity {
   sources?: PolicyMatch[]
   destinations?: PolicyMatch[]
   selectors?: Array<{ match: Record<string, string> }>
@@ -282,14 +276,14 @@ export interface SidecarDataplane {
   type: 'inbound' | 'outbound' | 'service' | 'dataplane'
   service: string
   name: string
-  matchedPolicies: Record<string, PolicyType[]>
+  matchedPolicies: Record<string, MatchedPolicyType[]>
 }
 
 export type MeshGatewayDataplaneDestination = {
   tags: {
     'kuma.io/service': string
   }
-  policies: Record<string, PolicyType>
+  policies: Record<string, MatchedPolicyType>
 }
 
 export type MeshGatewayDataplaneRoute = {
@@ -315,7 +309,7 @@ export interface MeshGatewayDataplane {
     name: string
   }
   listeners: MeshGatewayDataplaneListener[]
-  policies?: Record<string, PolicyType>
+  policies?: Record<string, MatchedPolicyType>
 }
 
 export type PolicyTypeEntryOrigin = {


### PR DESCRIPTION
Renames state and other variables related to policy types to distinguish the concepts of policy types (e.g. CircuitBreaker) from policies (e.g. one specific instance of a policy type).

Removes all uses of the policy type fields `singularDisplayName` and `pluralDisplayName` to be consistent with how we refer to these entities in the docs.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>