### PR TITLE
feat: persist selected tab in URL

### DIFF
--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -1,8 +1,5 @@
 <template>
-  <TabsWidget
-    :tabs="filteredTabs"
-    initial-tab-override="overview"
-  >
+  <TabsWidget :tabs="filteredTabs">
     <template #tabHeader>
       <h1 class="entity-heading">
         DPP: {{ dataPlane.name }}

--- a/src/app/data-planes/components/DataplanePolicies.vue
+++ b/src/app/data-planes/components/DataplanePolicies.vue
@@ -141,8 +141,11 @@ function getMeshGatewayListenerEntries(meshGatewayDataplane: MeshGatewayDataplan
           const routeEntry: MeshGatewayRouteEntry = {
             routeName: route.route,
             route: {
-              name: 'meshgatewayroutes',
-              params: { mesh: meshGatewayDataplane.gateway.mesh },
+              name: 'policy',
+              params: {
+                mesh: meshGatewayDataplane.gateway.mesh,
+                policyPath: 'meshgatewayroutes',
+              },
               query: { ns: route.route },
             },
             service: destination.tags['kuma.io/service'],

--- a/src/app/policies/views/PolicyView.vue
+++ b/src/app/policies/views/PolicyView.vue
@@ -83,7 +83,6 @@
         :error="error"
         :is-loading="isLoading"
         :tabs="tabs"
-        initial-tab-override="overview"
       >
         <template #tabHeader>
           <h1

--- a/src/app/zones/views/ZoneEgresses.vue
+++ b/src/app/zones/views/ZoneEgresses.vue
@@ -31,7 +31,6 @@
         :has-error="error !== null"
         :is-loading="isLoading"
         :tabs="tabs"
-        initial-tab-override="overview"
       >
         <template #tabHeader>
           <h1 class="entity-heading">

--- a/src/app/zones/views/ZoneIngresses.vue
+++ b/src/app/zones/views/ZoneIngresses.vue
@@ -34,7 +34,6 @@
         :has-error="error !== null"
         :is-loading="isLoading"
         :tabs="tabs"
-        initial-tab-override="overview"
       >
         <template #tabHeader>
           <h1 class="entity-heading">

--- a/src/app/zones/views/ZonesView.vue
+++ b/src/app/zones/views/ZonesView.vue
@@ -35,7 +35,6 @@
         :has-error="error"
         :is-loading="isLoading"
         :tabs="filterTabs()"
-        initial-tab-override="overview"
       >
         <template #tabHeader>
           <h1 class="entity-heading">


### PR DESCRIPTION
Persists a selected tab of the `TabsWidget` component in the URL.

Resolves #544.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>