### PR TITLE
fix(policy): Fix up old policy link in MeshOverview

### DIFF
--- a/src/app/mesh-overview/views/MeshOverviewView.vue
+++ b/src/app/mesh-overview/views/MeshOverviewView.vue
@@ -71,7 +71,10 @@
                     >
                       <router-link
                         :to="{
-                          name: item.path
+                          name: 'policies',
+                          params: {
+                            policyType: item.path
+                          }
                         }"
                       >
                         {{ item.name }}: {{ item.length }}


### PR DESCRIPTION
I missed this one as part of https://github.com/kumahq/kuma-gui/pull/543

Signed-off-by: John Cowen <john.cowen@konghq.com>
