### PR TITLE
fix(notifications): Additionally check for MeshAccessLog/MeshTrace before showing notice

### DIFF
--- a/src/store/modules/notifications/notifications.spec.ts
+++ b/src/store/modules/notifications/notifications.spec.ts
@@ -29,7 +29,12 @@ describe('notifications module', () => {
         },
       }
 
-      const result = notificationsModule.getters.singleMeshNotificationItems(notificationsModule.state(), getters, rootState, undefined)
+      const rootGetters = {
+        getMeshInsight: {
+          policies: {},
+        },
+      }
+      const result = notificationsModule.getters.singleMeshNotificationItems(notificationsModule.state(), getters, rootState, rootGetters)
 
       expect(result).toMatchInlineSnapshot(`
 [

--- a/src/store/modules/notifications/notifications.ts
+++ b/src/store/modules/notifications/notifications.ts
@@ -48,12 +48,18 @@ const getters: GetterTree<NotificationsInterface, State> = {
     )
   },
 
-  singleMeshNotificationItems(_state, getters, rootState): NotificationItem[] {
+  singleMeshNotificationItems(_state, getters, rootState, rootGetters): NotificationItem[] {
     if (rootState.selectedMesh === null) {
       return []
     }
 
     const meshItem: MeshNotificationItem = getters.meshNotificationItemMap[rootState.selectedMesh]
+
+    // if MeshAccessLog or MeshTrace are > 0 then we have logging
+    // totals default to zero via the frontend
+    const hasPolicyBasedLogging = Object.entries(rootGetters.getMeshInsight.policies as {total: number}[])
+      .filter(([key, _item]) => ['MeshAccessLog', 'MeshTrace'].includes(key))
+      .some(([_key, item]) => item.total > 0)
 
     const items: NotificationItem[] = [
       {
@@ -64,7 +70,7 @@ const getters: GetterTree<NotificationsInterface, State> = {
       {
         name: 'Logging',
         component: 'LoggingNotification',
-        isCompleted: meshItem.hasLogging,
+        isCompleted: meshItem.hasLogging || hasPolicyBasedLogging,
       },
       {
         name: 'Zero-trust security',


### PR DESCRIPTION
Previously we only checked the `mesh.logging` property to decide whether to show a notification to remind you to set up logging, this PR also adds checking to see if there are a MeshAccessLog or MeshTrace policies.

Note, I originally just accessed `rootState.meshInsight.policies` instead of using the getter, but I kinda assumed using the getter would be preferable/was more the done thing (even though this lost the type) - if this is the wrong assumption lemme know!

Fixes https://github.com/kumahq/kuma-gui/issues/549

Signed-off-by: John Cowen <john.cowen@konghq.com>

