### PR TITLE
refactor(zones): migrate components to composition API

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,3 @@
-VITE_DATA_TIMEOUT=500
 VITE_INSTALL_URL=https://kuma.io/install/latest/
 VITE_VERSION_URL=https://kuma.io/latest_version/
 VITE_NAMESPACE=Kuma

--- a/src/api/kumaApi.ts
+++ b/src/api/kumaApi.ts
@@ -21,6 +21,8 @@ import {
   ServiceInsight,
   SidecarDataplane,
   Zone,
+  ZoneEgressOverview,
+  ZoneIngressOverview,
   ZoneOverview,
 } from '@/types/index.d'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
@@ -101,11 +103,11 @@ class KumaApi {
     return this.client.get(`zoneingresses/${zoneIngressName}/${dataPath}`, { params })
   }
 
-  getAllZoneIngressOverviews(params?: PaginationParameters): Promise<any> {
+  getAllZoneIngressOverviews(params?: PaginationParameters): Promise<PaginatedApiListResponse<ZoneIngressOverview>> {
     return this.client.get('zoneingresses+insights', { params })
   }
 
-  getZoneIngressOverview({ name }: { name: string }, params?: PaginationParameters): Promise<any> {
+  getZoneIngressOverview({ name }: { name: string }, params?: PaginationParameters): Promise<ZoneIngressOverview> {
     return this.client.get(`zoneingresses+insights/${name}`, { params })
   }
 
@@ -116,11 +118,11 @@ class KumaApi {
     return this.client.get(`zoneegresses/${zoneEgressName}/${dataPath}`, { params })
   }
 
-  getAllZoneEgressOverviews(params?: PaginationParameters): Promise<any> {
+  getAllZoneEgressOverviews(params?: PaginationParameters): Promise<PaginatedApiListResponse<ZoneEgressOverview>> {
     return this.client.get('zoneegressoverviews', { params })
   }
 
-  getZoneEgressOverview({ name }: { name: string }, params?: PaginationParameters): Promise<any> {
+  getZoneEgressOverview({ name }: { name: string }, params?: PaginationParameters): Promise<ZoneEgressOverview> {
     return this.client.get(`zoneegressoverviews/${name}`, { params })
   }
 

--- a/src/app/common/subscriptions/SubscriptionDetails.vue
+++ b/src/app/common/subscriptions/SubscriptionDetails.vue
@@ -4,22 +4,26 @@
       <h5 class="overview-tertiary-title">
         General Information:
       </h5>
+
       <ul>
         <li v-if="details.globalInstanceId">
           <strong>Global Instance ID:</strong>&nbsp;
           <span class="mono">{{ details.globalInstanceId }}</span>
         </li>
+
         <li v-if="details.controlPlaneInstanceId">
           <strong>Control Plane Instance ID:</strong>&nbsp;
           <span class="mono">{{ details.controlPlaneInstanceId }}</span>
         </li>
+
         <li v-if="details.connectTime">
           <strong>Last Connected:</strong>&nbsp;
-          {{ readableDate(details.connectTime) }}
+          {{ humanReadableDate(details.connectTime) }}
         </li>
+
         <li v-if="details.disconnectTime">
           <strong>Last Disconnected:</strong>&nbsp;
-          {{ readableDate(details.disconnectTime) }}
+          {{ humanReadableDate(details.disconnectTime) }}
         </li>
       </ul>
     </div>
@@ -31,20 +35,22 @@
           :key="label"
         >
           <h6 class="overview-tertiary-title">
-            {{ humanReadable(label) }}:
+            {{ camelCaseToWords(label) }}:
           </h6>
+
           <ul>
             <li
               v-for="(k, v) in item"
               :key="v"
             >
-              <strong>{{ humanReadable(v) }}:</strong>&nbsp;
+              <strong>{{ camelCaseToWords(v) }}:</strong>&nbsp;
               <span class="mono">{{ formatError(formatValue(k)) }}</span>
             </li>
           </ul>
         </li>
       </ul>
     </div>
+
     <KAlert
       v-else
       appearance="info"
@@ -53,6 +59,7 @@
       <template #alertIcon>
         <KIcon icon="portal" />
       </template>
+
       <template #alertMessage>
         There are no subscription statistics for <strong>{{ details.id }}</strong>
       </template>
@@ -60,62 +67,44 @@
   </div>
 </template>
 
-<script>
-import { humanReadableDate, camelCaseToWords } from '@/utilities/helpers'
+<script lang="ts" setup>
+import { computed } from 'vue'
 import { KAlert, KIcon } from '@kong/kongponents'
 
-export default {
-  name: 'SubscriptionDetails',
+import { humanReadableDate, camelCaseToWords } from '@/utilities/helpers'
 
-  components: {
-    KAlert,
-    KIcon,
+const props = defineProps({
+  details: {
+    type: Object,
+    required: true,
   },
 
-  props: {
-    details: {
-      type: Object,
-      required: true,
-    },
-    isDiscoverySubscription: {
-      type: Boolean,
-      default: false,
-    },
+  isDiscoverySubscription: {
+    type: Boolean,
+    default: false,
   },
+})
 
-  computed: {
-    detailsIterator() {
-      if (this.isDiscoverySubscription) {
-        const { lastUpdateTime, total, ...restDetails } = this.details.status
+const detailsIterator = computed<Record<string, Record<string, any>>>(() => {
+  if (props.isDiscoverySubscription) {
+    const { lastUpdateTime, total, ...restDetails } = props.details.status
 
-        return restDetails
-      }
+    return restDetails
+  }
 
-      return this.details.status?.stat
-    },
-  },
+  return props.details.status?.stat
+})
 
-  methods: {
-    formatValue(value) {
-      return value ? parseInt(value, 10).toLocaleString('en').toString() : 0
-    },
+function formatValue(value: string): string {
+  return value ? parseInt(value, 10).toLocaleString('en').toString() : '0'
+}
 
-    readableDate(value) {
-      return humanReadableDate(value)
-    },
+function formatError(value: string): string {
+  if (value === '--') {
+    return 'error calculating'
+  }
 
-    humanReadable(value) {
-      return camelCaseToWords(value)
-    },
-
-    formatError(value) {
-      if (value === '--') {
-        return 'error calculating'
-      }
-
-      return value
-    },
-  },
+  return value
 }
 </script>
 

--- a/src/app/common/subscriptions/SubscriptionHeader.vue
+++ b/src/app/common/subscriptions/SubscriptionHeader.vue
@@ -1,35 +1,25 @@
 <template>
   <h4 class="text-lg font-medium">
     <span class="color-green-500">
-      Connect time: {{ rawReadableDateFilter(details.connectTime) }}
+      Connect time: {{ rawReadableDate(props.details.connectTime) }}
     </span>
 
     <span
-      v-if="details.disconnectTime"
+      v-if="props.details.disconnectTime"
       class="ml-4 color-red-600"
     >
-      Disconnect time: {{ rawReadableDateFilter(details.disconnectTime) }}
+      Disconnect time: {{ rawReadableDate(props.details.disconnectTime) }}
     </span>
   </h4>
 </template>
 
-<script>
+<script lang="ts" setup>
 import { rawReadableDate } from '@/utilities/helpers'
 
-export default {
-  name: 'SubscriptionHeader',
-
-  props: {
-    details: {
-      type: Object,
-      required: true,
-    },
+const props = defineProps({
+  details: {
+    type: Object,
+    required: true,
   },
-
-  methods: {
-    rawReadableDateFilter(value) {
-      return rawReadableDate(value)
-    },
-  },
-}
+})
 </script>

--- a/src/app/common/warnings/WarningsWidget.vue
+++ b/src/app/common/warnings/WarningsWidget.vue
@@ -3,15 +3,15 @@
     <template #body>
       <ul>
         <li
-          v-for="{ kind, payload, index } in warnings"
-          :key="`${kind}/${index}`"
+          v-for="(warning, index) in props.warnings"
+          :key="`${warning.kind}/${index}`"
           class="mb-1"
         >
           <KAlert appearance="warning">
             <template #alertMessage>
               <component
-                :is="getWarningComponent(kind)"
-                :payload="payload"
+                :is="getWarningComponent(warning.kind)"
+                :payload="warning.payload"
               />
             </template>
           </KAlert>
@@ -21,7 +21,8 @@
   </KCard>
 </template>
 
-<script>
+<script lang="ts" setup>
+import { PropType } from 'vue'
 import { KAlert, KCard } from '@kong/kongponents'
 
 import WarningDefault from './WarningDefault.vue'
@@ -29,43 +30,33 @@ import WarningEnvoyIncompatible from './WarningEnvoyIncompatible.vue'
 import WarningZoneAndKumaDPVersionsIncompatible from './WarningZoneAndKumaDPVersionsIncompatible.vue'
 import WarningUnsupportedKumaDPVersion from './WarningUnsupportedKumaDPVersion.vue'
 import WarningZoneAndGlobalCPSVersionsIncompatible from './WarningZoneAndGlobalCPSVersionsIncompatible.vue'
-
 import {
   INCOMPATIBLE_UNSUPPORTED_ENVOY,
   INCOMPATIBLE_UNSUPPORTED_KUMA_DP,
   INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS,
   INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS,
 } from '@/utilities/dataplane'
+import { Compatibility, ZoneCompatibility } from '@/types/index.d'
 
-export default {
-  name: 'WarningsWidget',
+const props = defineProps({
+  warnings: {
+    type: Array as PropType<Array<Compatibility | ZoneCompatibility>>,
+    required: true,
+  },
+})
 
-  components: {
-    KAlert,
-    KCard,
-  },
-
-  props: {
-    warnings: {
-      type: Array,
-      required: true,
-    },
-  },
-  methods: {
-    getWarningComponent(kind = '') {
-      switch (kind) {
-        case INCOMPATIBLE_UNSUPPORTED_ENVOY:
-          return WarningEnvoyIncompatible
-        case INCOMPATIBLE_UNSUPPORTED_KUMA_DP:
-          return WarningUnsupportedKumaDPVersion
-        case INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS:
-          return WarningZoneAndKumaDPVersionsIncompatible
-        case INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS:
-          return WarningZoneAndGlobalCPSVersionsIncompatible
-        default:
-          return WarningDefault
-      }
-    },
-  },
+function getWarningComponent(kind: string = ''): any {
+  switch (kind) {
+    case INCOMPATIBLE_UNSUPPORTED_ENVOY:
+      return WarningEnvoyIncompatible
+    case INCOMPATIBLE_UNSUPPORTED_KUMA_DP:
+      return WarningUnsupportedKumaDPVersion
+    case INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS:
+      return WarningZoneAndKumaDPVersionsIncompatible
+    case INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS:
+      return WarningZoneAndGlobalCPSVersionsIncompatible
+    default:
+      return WarningDefault
+  }
 }
 </script>

--- a/src/app/onboarding/components/ItemStatus.vue
+++ b/src/app/onboarding/components/ItemStatus.vue
@@ -2,37 +2,31 @@
   <li class="flex items-center mb-2">
     <span class="circle">
       <KIcon
-        v-if="status"
+        v-if="props.status"
         icon="check"
         size="10"
         color="var(--kuma-purple-1)"
       />
     </span>
-    {{ name }}
+
+    {{ props.name }}
   </li>
 </template>
 
-<script>
+<script lang="ts" setup>
 import { KIcon } from '@kong/kongponents'
 
-export default {
-  name: 'ItemStatus',
-
-  components: {
-    KIcon,
+const props = defineProps({
+  name: {
+    type: String,
+    required: true,
   },
 
-  props: {
-    name: {
-      type: String,
-      required: true,
-    },
-    status: {
-      type: Boolean,
-      default: false,
-    },
+  status: {
+    type: Boolean,
+    default: false,
   },
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/onboarding/components/graphs/KubernetesGraph.vue
+++ b/src/app/onboarding/components/graphs/KubernetesGraph.vue
@@ -145,14 +145,14 @@
         />
       </g>
       <template #content>
-        Configuration for all {{ productName }} resources is specified in YAML config files. The config files can be stored in an external datastore.
+        Configuration for all {{ PRODUCT_NAME }} resources is specified in YAML config files. The config files can be stored in an external datastore.
 
       </template>
     </KPop>
 
     <KPop
       trigger="hover"
-      :title="productName"
+      :title="PRODUCT_NAME"
       :is-svg="true"
       tag="g"
       placement="rightEnd"
@@ -180,7 +180,7 @@
         />
       </g>
       <template #content>
-        In Kubernetes mode, the {{ productName }} control plane listens to the Kubernetes API to fetch the right resources and configure the service mesh.
+        In Kubernetes mode, the {{ PRODUCT_NAME }} control plane listens to the Kubernetes API to fetch the right resources and configure the service mesh.
 
       </template>
     </KPop>
@@ -215,7 +215,7 @@
         />
       </g>
       <template #content>
-        You can store the YAML config files for {{ productName }} in etcd, the native datastore for Kubernetes.
+        You can store the YAML config files for {{ PRODUCT_NAME }} in etcd, the native datastore for Kubernetes.
       </template>
     </KPop>
 
@@ -726,22 +726,8 @@
   </svg>
 </template>
 
-<script>
+<script lang="ts" setup>
 import { KPop } from '@kong/kongponents'
 
 import { PRODUCT_NAME } from '@/constants'
-
-export default {
-  name: 'KubernetesGraph',
-
-  components: {
-    KPop,
-  },
-
-  data() {
-    return {
-      productName: PRODUCT_NAME,
-    }
-  },
-}
 </script>

--- a/src/app/onboarding/components/graphs/MemoryGraph.vue
+++ b/src/app/onboarding/components/graphs/MemoryGraph.vue
@@ -89,13 +89,13 @@
 
       </g>
       <template #content>
-        You can store the YAML config files for {{ productName }} in memory to skip the complexity of setting up a reliable datastore. For testing only. Not for production.
+        You can store the YAML config files for {{ PRODUCT_NAME }} in memory to skip the complexity of setting up a reliable datastore. For testing only. Not for production.
       </template>
     </KPop>
 
     <KPop
       trigger="hover"
-      :title="productName"
+      :title="PRODUCT_NAME"
       :is-svg="true"
       tag="g"
       placement="rightEnd"
@@ -124,7 +124,7 @@
 
       </g>
       <template #content>
-        Since everything is stored in-memory, if {{ productName }} restarts the configuration will be lost. This mode is only recommended in development/testing mode.
+        Since everything is stored in-memory, if {{ PRODUCT_NAME }} restarts the configuration will be lost. This mode is only recommended in development/testing mode.
       </template>
     </KPop>
 
@@ -391,22 +391,8 @@
   </svg>
 </template>
 
-<script>
+<script lang="ts" setup>
 import { KPop } from '@kong/kongponents'
 
 import { PRODUCT_NAME } from '@/constants'
-
-export default {
-  name: 'MemoryGraph',
-
-  components: {
-    KPop,
-  },
-
-  data() {
-    return {
-      productName: PRODUCT_NAME,
-    }
-  },
-}
 </script>

--- a/src/app/onboarding/components/graphs/MultizoneGraph.vue
+++ b/src/app/onboarding/components/graphs/MultizoneGraph.vue
@@ -200,7 +200,7 @@
     />
     <KPop
       trigger="hover"
-      :title="productName"
+      :title="PRODUCT_NAME"
       :is-svg="true"
       tag="g"
       placement="rightEnd"
@@ -299,7 +299,7 @@
         />
       </g>
       <template #content>
-        {{ productName }} attaches a data plane proxy sidecar to each service in your mesh.
+        {{ PRODUCT_NAME }} attaches a data plane proxy sidecar to each service in your mesh.
         This sidecar handles the mesh configuration for the service.
       </template>
     </KPop>
@@ -933,22 +933,8 @@
   </svg>
 </template>
 
-<script>
+<script lang="ts" setup>
 import { KPop } from '@kong/kongponents'
 
 import { PRODUCT_NAME } from '@/constants'
-
-export default {
-  name: 'MultizoneGraph',
-
-  components: {
-    KPop,
-  },
-
-  data() {
-    return {
-      productName: PRODUCT_NAME,
-    }
-  },
-}
 </script>

--- a/src/app/onboarding/components/graphs/PostgresGraph.vue
+++ b/src/app/onboarding/components/graphs/PostgresGraph.vue
@@ -143,13 +143,13 @@
         />
       </g>
       <template #content>
-        Configuration for all {{ productName }} resources is specified in YAML config files. The config files can be stored in an external datastore.
+        Configuration for all {{ PRODUCT_NAME }} resources is specified in YAML config files. The config files can be stored in an external datastore.
       </template>
     </KPop>
 
     <KPop
       trigger="hover"
-      :title="productName"
+      :title="PRODUCT_NAME"
       :is-svg="true"
       tag="g"
       placement="rightEnd"
@@ -178,7 +178,7 @@
 
       </g>
       <template #content>
-        In Postgres mode, the {{ productName }} control plane connects to Postgres to fetch the right resources and configure the service mesh.
+        In Postgres mode, the {{ PRODUCT_NAME }} control plane connects to Postgres to fetch the right resources and configure the service mesh.
       </template>
     </KPop>
 
@@ -212,7 +212,7 @@
         />
       </g>
       <template #content>
-        You can store the YAML config files for {{ productName }} in a Postgres database. You can work with a managed Postgres offering or manage your own.
+        You can store the YAML config files for {{ PRODUCT_NAME }} in a Postgres database. You can work with a managed Postgres offering or manage your own.
       </template>
     </KPop>
 
@@ -723,22 +723,8 @@
   </svg>
 </template>
 
-<script>
+<script lang="ts" setup>
 import { KPop } from '@kong/kongponents'
 
 import { PRODUCT_NAME } from '@/constants'
-
-export default {
-  name: 'PostgresGraph',
-
-  components: {
-    KPop,
-  },
-
-  data() {
-    return {
-      productName: PRODUCT_NAME,
-    }
-  },
-}
 </script>

--- a/src/app/onboarding/components/graphs/StandaloneGraph.vue
+++ b/src/app/onboarding/components/graphs/StandaloneGraph.vue
@@ -96,7 +96,7 @@
       trigger="hover"
       :is-svg="true"
       tag="g"
-      :title="productName"
+      :title="PRODUCT_NAME"
       placement="rightEnd"
       :popover-timeout="5"
     >
@@ -156,7 +156,7 @@
         />
       </g>
       <template #content>
-        {{ productName }} attaches a data plane proxy sidecar to each service in your mesh.
+        {{ PRODUCT_NAME }} attaches a data plane proxy sidecar to each service in your mesh.
         This sidecar handles the mesh configuration for the service.
       </template>
     </KPop>
@@ -467,22 +467,8 @@
   </svg>
 </template>
 
-<script>
+<script lang="ts" setup>
 import { KPop } from '@kong/kongponents'
 
 import { PRODUCT_NAME } from '@/constants'
-
-export default {
-  name: 'StandaloneGraph',
-
-  components: {
-    KPop,
-  },
-
-  data() {
-    return {
-      productName: PRODUCT_NAME,
-    }
-  },
-}
 </script>

--- a/src/app/onboarding/views/MultiZoneView.spec.ts
+++ b/src/app/onboarding/views/MultiZoneView.spec.ts
@@ -32,9 +32,13 @@ describe('MultiZoneView.vue', () => {
       .spyOn(kumaApi, 'getAllZoneIngressOverviews')
       .mockResolvedValueOnce({
         total: 0,
+        items: [],
+        next: null,
       })
       .mockResolvedValueOnce({
         total: 1,
+        items: [],
+        next: '',
       })
 
     const wrapper = renderComponent()

--- a/src/app/onboarding/views/ShellEmpty.vue
+++ b/src/app/onboarding/views/ShellEmpty.vue
@@ -12,12 +12,6 @@
   </router-view>
 </template>
 
-<script>
-export default {
-  name: 'ShellEmpty',
-}
-</script>
-
 <style lang="scss" scoped>
 .onboarding-view {
   --kuma-purple-1: #260d50;

--- a/src/app/zones/components/MultizoneInfo.vue
+++ b/src/app/zones/components/MultizoneInfo.vue
@@ -7,7 +7,7 @@
         size="42"
       />
 
-      <p>{{ $options.productName }} is running in Standalone mode.</p>
+      <p>{{ PRODUCT_NAME }} is running in Standalone mode.</p>
     </template>
 
     <template #message>
@@ -18,7 +18,7 @@
 
     <template #cta>
       <KButton
-        :to="`${$options.env('KUMA_DOCS_URL')}/documentation/deployments/?${$options.env('KUMA_UTM_QUERY_PARAMS')}`"
+        :to="`${env('KUMA_DOCS_URL')}/documentation/deployments/?${env('KUMA_UTM_QUERY_PARAMS')}`"
         target="_blank"
         appearance="primary"
       >
@@ -28,23 +28,11 @@
   </KEmptyState>
 </template>
 
-<script>
+<script lang="ts" setup>
 import { KButton, KEmptyState, KIcon } from '@kong/kongponents'
 
 import { PRODUCT_NAME } from '@/constants'
 import { useEnv } from '@/utilities'
+
 const env = useEnv()
-
-export default {
-  name: 'MultizoneInfo',
-  env,
-  productName: PRODUCT_NAME,
-
-  components: {
-    KButton,
-    KEmptyState,
-    KIcon,
-  },
-
-}
 </script>

--- a/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
@@ -97,7 +97,7 @@ exports[`ZoneEgresses.vue renders snapshot when multizone 1`] = `
                         <span
                           class="sr-only"
                         >
-                          actions
+                          Actions
                         </span>
                         
                         <!---->
@@ -515,7 +515,7 @@ exports[`ZoneEgresses.vue renders snapshot when no multizone 1`] = `
                         <span
                           class="sr-only"
                         >
-                          actions
+                          Actions
                         </span>
                         
                         <!---->

--- a/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
@@ -99,7 +99,7 @@ exports[`ZoneIngresses.vue renders snapshot when multizone 1`] = `
                         <span
                           class="sr-only"
                         >
-                          actions
+                          Actions
                         </span>
                         
                         <!---->

--- a/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
@@ -99,7 +99,7 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
                         <span
                           class="sr-only"
                         >
-                          actions
+                          Actions
                         </span>
                         
                         <!---->
@@ -211,7 +211,7 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
                         <span
                           class="sr-only"
                         >
-                          warnings
+                          Warnings
                         </span>
                         
                         <!---->
@@ -886,6 +886,30 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
                               </h4>
                               <p>
                                 cluster-1
+                              </p>
+                            </li>
+                            <li>
+                              <h4>
+                                status
+                              </h4>
+                              <p>
+                                <div
+                                  class="k-badge d-inline-flex k-badge-success k-badge-rounded"
+                                  tabindex="0"
+                                >
+                                  <div
+                                    class="k-badge-text truncate"
+                                  >
+                                    <div
+                                      class="k-badge-text truncate"
+                                    >
+                                      
+                                      online
+                                      
+                                    </div>
+                                  </div>
+                                  <!---->
+                                </div>
                               </p>
                             </li>
                             <li>

--- a/src/shims-env.d.ts
+++ b/src/shims-env.d.ts
@@ -1,5 +1,4 @@
 interface ImportMetaEnv {
-  readonly VITE_DATA_TIMEOUT: number
   readonly VITE_INSTALL_URL: string
   readonly VITE_VERSION_URL: string
   readonly VITE_NAMESPACE: string

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -213,6 +213,14 @@ export type Compatibility = {
   }
 }
 
+export type ZoneCompatibility = {
+  kind: INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS
+  payload?: {
+    zoneCpVersion: string
+    globalCpVersion: string
+  }
+}
+
 export interface LabelValue {
   label: string
   value: string
@@ -429,6 +437,18 @@ export interface ZoneOverview extends MeshEntity {
   type: 'ZoneOverview'
   zone: Zone
   zoneInsight: ZoneInsight
+}
+
+export interface ZoneIngressOverview extends MeshEntity {
+  type: 'ZoneIngressOverview'
+  zoneIngress: any
+  zoneIngressInsight: any
+}
+
+export interface ZoneEgressOverview extends MeshEntity {
+  type: 'ZoneEgressOverview'
+  zoneEgress: any
+  zoneEgressInsight: any
 }
 
 /**

--- a/src/utilities/dataplane.ts
+++ b/src/utilities/dataplane.ts
@@ -6,6 +6,7 @@ import {
   DataPlaneNetworking,
   DataPlaneOverview,
   DiscoverySubscription,
+  KDSSubscription,
   LabelValue,
   StatusKeyword,
   Version,
@@ -70,7 +71,7 @@ export function dpTags(dataplane: { networking: DataPlaneNetworking }): LabelVal
 
 // getItemStatusFromInsight takes object with subscriptions and returns a
 // status 'online' | 'offline'
-export function getItemStatusFromInsight(insight: { subscriptions?: DiscoverySubscription[] } | undefined = { subscriptions: [] }): StatusKeyword {
+export function getItemStatusFromInsight(insight: { subscriptions?: DiscoverySubscription[] | KDSSubscription[] } | undefined = { subscriptions: [] }): StatusKeyword {
   const proxyOnline = (insight.subscriptions ?? []).some((subscription) => subscription.connectTime?.length && !subscription.disconnectTime)
   return proxyOnline ? 'online' : 'offline'
 }


### PR DESCRIPTION
Migrates all zone-related (and a few simple ones) to composition API.

This aids in providing better type system support for component code which is lackluster for components written in Options API style.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>