### PR TITLE
fix: data plane table not always recomputing

### DIFF
--- a/src/api/mock-data/meshes/default/dataplanes+insights__gateways-all.json
+++ b/src/api/mock-data/meshes/default/dataplanes+insights__gateways-all.json
@@ -1,0 +1,255 @@
+{
+  "total": 2,
+  "items": [
+    {
+      "type": "DataplaneOverview",
+      "mesh": "default",
+      "name": "alarm-gateway-0",
+      "creationTime": "2021-02-17T08:33:36.442044+01:00",
+      "modificationTime": "2021-02-17T08:33:36.442044+01:00",
+      "dataplane": {
+        "networking": {
+          "address": "229.220.224.147",
+          "gateway": {
+            "tags": {
+              "kuma.io/service": "alarm-gateway-0"
+            },
+            "type": "DELEGATED"
+          },
+          "inbound": [
+            {
+              "port": 11178,
+              "servicePort": 20537,
+              "serviceAddress": "120.233.146.171",
+              "tags": {
+                "kuma.io/protocol": "tcp",
+                "kuma.io/service": "alarm-service-0"
+              }
+            }
+          ],
+          "outbound": [
+            {
+              "port": 31080,
+              "tags": {
+                "kuma.io/service": "bus-0"
+              }
+            }
+          ]
+        }
+      },
+      "dataplaneInsight": {
+        "subscriptions": [
+          {
+            "id": "118b4d6f-7a98-4172-96d9-85ffb8b20b16",
+            "controlPlaneInstanceId": "foo",
+            "connectTime": "2021-02-17T07:33:36.412683Z",
+            "disconnectTime": "2021-02-17T07:33:36.412683Z",
+            "status": {
+              "lastUpdateTime": "2021-02-17T10:48:03.638434Z",
+              "total": {
+                "responsesSent": "5",
+                "responsesAcknowledged": "5"
+              },
+              "cds": {
+                "responsesSent": "1",
+                "responsesAcknowledged": "1"
+              },
+              "eds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "lds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "rds": {}
+            },
+            "version": {
+              "kumaDp": {
+                "version": "1.0.7",
+                "gitTag": "unknown",
+                "gitCommit": "unknown",
+                "buildDate": "unknown"
+              },
+              "envoy": {
+                "version": "1.16.2",
+                "build": "e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL"
+              },
+              "dependencies": {
+                "coredns": "1.8.3"
+              }
+            }
+          },
+          {
+            "id": "118b4d6f-7a98-4172-96d9-85ffb8b20b16",
+            "controlPlaneInstanceId": "foo",
+            "connectTime": "2021-02-17T07:33:36.412683Z",
+            "status": {
+              "lastUpdateTime": "2021-02-17T10:48:03.638434Z",
+              "total": {
+                "responsesSent": "5",
+                "responsesAcknowledged": "5"
+              },
+              "cds": {
+                "responsesSent": "1",
+                "responsesAcknowledged": "1"
+              },
+              "eds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "lds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "rds": {}
+            },
+            "version": {
+              "kumaDp": {
+                "version": "1.0.7",
+                "gitTag": "unknown",
+                "gitCommit": "unknown",
+                "buildDate": "unknown",
+                "kumaCpCompatible": true
+              },
+              "envoy": {
+                "version": "1.16.2",
+                "build": "e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL",
+                "kumaDpCompatible": true
+              },
+              "dependencies": {
+                "coredns": "1.8.3"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "DataplaneOverview",
+      "mesh": "default",
+      "name": "transmitter-gateway-0",
+      "creationTime": "2021-02-17T08:33:36.442044+01:00",
+      "modificationTime": "2021-02-17T08:33:36.442044+01:00",
+      "dataplane": {
+        "networking": {
+          "address": "179.174.104.209",
+          "gateway": {
+            "tags": {
+              "kuma.io/service": "transmitter-gateway-0",
+              "kuma.io/zone": "interface-0"
+            },
+            "type": "BUILTIN"
+          },
+          "inbound": [
+            {
+              "port": 12547,
+              "servicePort": 34987,
+              "serviceAddress": "143.112.216.10",
+              "tags": {
+                "kuma.io/protocol": "kafka",
+                "kuma.io/service": "transmitter-service-0"
+              }
+            }
+          ],
+          "outbound": [
+            {
+              "port": 14587,
+              "tags": {
+                "kuma.io/service": "circuit-0"
+              }
+            }
+          ]
+        }
+      },
+      "dataplaneInsight": {
+        "subscriptions": [
+          {
+            "id": "118b4d6f-7a98-4172-96d9-85ffb8b20b16",
+            "controlPlaneInstanceId": "foo",
+            "connectTime": "2021-02-17T07:33:36.412683Z",
+            "disconnectTime": "2021-02-17T07:33:36.412683Z",
+            "status": {
+              "lastUpdateTime": "2021-02-17T10:48:03.638434Z",
+              "total": {
+                "responsesSent": "5",
+                "responsesAcknowledged": "5"
+              },
+              "cds": {
+                "responsesSent": "1",
+                "responsesAcknowledged": "1"
+              },
+              "eds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "lds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "rds": {}
+            },
+            "version": {
+              "kumaDp": {
+                "version": "1.0.7",
+                "gitTag": "unknown",
+                "gitCommit": "unknown",
+                "buildDate": "unknown"
+              },
+              "envoy": {
+                "version": "1.16.2",
+                "build": "e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL"
+              },
+              "dependencies": {
+                "coredns": "1.8.3"
+              }
+            }
+          },
+          {
+            "id": "118b4d6f-7a98-4172-96d9-85ffb8b20b16",
+            "controlPlaneInstanceId": "foo",
+            "connectTime": "2021-02-17T07:33:36.412683Z",
+            "status": {
+              "lastUpdateTime": "2021-02-17T10:48:03.638434Z",
+              "total": {
+                "responsesSent": "5",
+                "responsesAcknowledged": "5"
+              },
+              "cds": {
+                "responsesSent": "1",
+                "responsesAcknowledged": "1"
+              },
+              "eds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "lds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "rds": {}
+            },
+            "version": {
+              "kumaDp": {
+                "version": "1.0.7",
+                "gitTag": "unknown",
+                "gitCommit": "unknown",
+                "buildDate": "unknown",
+                "kumaCpCompatible": true
+              },
+              "envoy": {
+                "version": "1.16.2",
+                "build": "e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL",
+                "kumaDpCompatible": true
+              },
+              "dependencies": {
+                "coredns": "1.8.3"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "next": "http://localhost:5681/meshes/default/dataplanes+insights?offset=24&size=24"
+}

--- a/src/api/mock-data/meshes/default/dataplanes+insights__gateways-builtin.json
+++ b/src/api/mock-data/meshes/default/dataplanes+insights__gateways-builtin.json
@@ -1,0 +1,131 @@
+{
+  "total": 1,
+  "items": [
+    {
+      "type": "DataplaneOverview",
+      "mesh": "default",
+      "name": "transmitter-gateway-0",
+      "creationTime": "2021-02-17T08:33:36.442044+01:00",
+      "modificationTime": "2021-02-17T08:33:36.442044+01:00",
+      "dataplane": {
+        "networking": {
+          "address": "179.174.104.209",
+          "gateway": {
+            "tags": {
+              "kuma.io/service": "transmitter-gateway-0",
+              "kuma.io/zone": "interface-0"
+            },
+            "type": "BUILTIN"
+          },
+          "inbound": [
+            {
+              "port": 12547,
+              "servicePort": 34987,
+              "serviceAddress": "143.112.216.10",
+              "tags": {
+                "kuma.io/protocol": "kafka",
+                "kuma.io/service": "transmitter-service-0"
+              }
+            }
+          ],
+          "outbound": [
+            {
+              "port": 14587,
+              "tags": {
+                "kuma.io/service": "circuit-0"
+              }
+            }
+          ]
+        }
+      },
+      "dataplaneInsight": {
+        "subscriptions": [
+          {
+            "id": "118b4d6f-7a98-4172-96d9-85ffb8b20b16",
+            "controlPlaneInstanceId": "foo",
+            "connectTime": "2021-02-17T07:33:36.412683Z",
+            "disconnectTime": "2021-02-17T07:33:36.412683Z",
+            "status": {
+              "lastUpdateTime": "2021-02-17T10:48:03.638434Z",
+              "total": {
+                "responsesSent": "5",
+                "responsesAcknowledged": "5"
+              },
+              "cds": {
+                "responsesSent": "1",
+                "responsesAcknowledged": "1"
+              },
+              "eds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "lds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "rds": {}
+            },
+            "version": {
+              "kumaDp": {
+                "version": "1.0.7",
+                "gitTag": "unknown",
+                "gitCommit": "unknown",
+                "buildDate": "unknown"
+              },
+              "envoy": {
+                "version": "1.16.2",
+                "build": "e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL"
+              },
+              "dependencies": {
+                "coredns": "1.8.3"
+              }
+            }
+          },
+          {
+            "id": "118b4d6f-7a98-4172-96d9-85ffb8b20b16",
+            "controlPlaneInstanceId": "foo",
+            "connectTime": "2021-02-17T07:33:36.412683Z",
+            "status": {
+              "lastUpdateTime": "2021-02-17T10:48:03.638434Z",
+              "total": {
+                "responsesSent": "5",
+                "responsesAcknowledged": "5"
+              },
+              "cds": {
+                "responsesSent": "1",
+                "responsesAcknowledged": "1"
+              },
+              "eds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "lds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "rds": {}
+            },
+            "version": {
+              "kumaDp": {
+                "version": "1.0.7",
+                "gitTag": "unknown",
+                "gitCommit": "unknown",
+                "buildDate": "unknown",
+                "kumaCpCompatible": true
+              },
+              "envoy": {
+                "version": "1.16.2",
+                "build": "e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL",
+                "kumaDpCompatible": true
+              },
+              "dependencies": {
+                "coredns": "1.8.3"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "next": "http://localhost:5681/meshes/default/dataplanes+insights?offset=24&size=24"
+}

--- a/src/api/mock-data/meshes/default/dataplanes+insights__gateways-delegated.json
+++ b/src/api/mock-data/meshes/default/dataplanes+insights__gateways-delegated.json
@@ -1,0 +1,130 @@
+{
+  "total": 1,
+  "items": [
+    {
+      "type": "DataplaneOverview",
+      "mesh": "default",
+      "name": "alarm-gateway-0",
+      "creationTime": "2021-02-17T08:33:36.442044+01:00",
+      "modificationTime": "2021-02-17T08:33:36.442044+01:00",
+      "dataplane": {
+        "networking": {
+          "address": "229.220.224.147",
+          "gateway": {
+            "tags": {
+              "kuma.io/service": "alarm-gateway-0"
+            },
+            "type": "DELEGATED"
+          },
+          "inbound": [
+            {
+              "port": 11178,
+              "servicePort": 20537,
+              "serviceAddress": "120.233.146.171",
+              "tags": {
+                "kuma.io/protocol": "tcp",
+                "kuma.io/service": "alarm-service-0"
+              }
+            }
+          ],
+          "outbound": [
+            {
+              "port": 31080,
+              "tags": {
+                "kuma.io/service": "bus-0"
+              }
+            }
+          ]
+        }
+      },
+      "dataplaneInsight": {
+        "subscriptions": [
+          {
+            "id": "118b4d6f-7a98-4172-96d9-85ffb8b20b16",
+            "controlPlaneInstanceId": "foo",
+            "connectTime": "2021-02-17T07:33:36.412683Z",
+            "disconnectTime": "2021-02-17T07:33:36.412683Z",
+            "status": {
+              "lastUpdateTime": "2021-02-17T10:48:03.638434Z",
+              "total": {
+                "responsesSent": "5",
+                "responsesAcknowledged": "5"
+              },
+              "cds": {
+                "responsesSent": "1",
+                "responsesAcknowledged": "1"
+              },
+              "eds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "lds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "rds": {}
+            },
+            "version": {
+              "kumaDp": {
+                "version": "1.0.7",
+                "gitTag": "unknown",
+                "gitCommit": "unknown",
+                "buildDate": "unknown"
+              },
+              "envoy": {
+                "version": "1.16.2",
+                "build": "e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL"
+              },
+              "dependencies": {
+                "coredns": "1.8.3"
+              }
+            }
+          },
+          {
+            "id": "118b4d6f-7a98-4172-96d9-85ffb8b20b16",
+            "controlPlaneInstanceId": "foo",
+            "connectTime": "2021-02-17T07:33:36.412683Z",
+            "status": {
+              "lastUpdateTime": "2021-02-17T10:48:03.638434Z",
+              "total": {
+                "responsesSent": "5",
+                "responsesAcknowledged": "5"
+              },
+              "cds": {
+                "responsesSent": "1",
+                "responsesAcknowledged": "1"
+              },
+              "eds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "lds": {
+                "responsesSent": "2",
+                "responsesAcknowledged": "2"
+              },
+              "rds": {}
+            },
+            "version": {
+              "kumaDp": {
+                "version": "1.0.7",
+                "gitTag": "unknown",
+                "gitCommit": "unknown",
+                "buildDate": "unknown",
+                "kumaCpCompatible": true
+              },
+              "envoy": {
+                "version": "1.16.2",
+                "build": "e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL",
+                "kumaDpCompatible": true
+              },
+              "dependencies": {
+                "coredns": "1.8.3"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "next": "http://localhost:5681/meshes/default/dataplanes+insights?offset=24&size=24"
+}

--- a/src/api/mocks.ts
+++ b/src/api/mocks.ts
@@ -200,18 +200,24 @@ export function setupHandlers(url: string = ''): RestHandler[] {
   handlers.push(
     rest.get(getApiPath('meshes/default/dataplanes\\+insights'), async (req, res, ctx) => {
       const gateway = req.url.searchParams.get('gateway')
-      const data = JSON.parse(JSON.stringify(await loadMockFile(() => import('./mock-data/meshes/default/dataplanes+insights.json'))))
-      if (gateway !== null && gateway !== 'false') {
-        data.total = '1'
-        data.items = [data.items.find((item: any) => item.name === 'cluster-1.gateway-01')]
-        if (gateway === 'delegated') {
-          data.items[0].dataplane.networking.gateway.type = 'DELEGATED'
-        }
+      let response
+
+      if (gateway === 'true') {
+        response = JSON.parse(JSON.stringify(await loadMockFile(() => import('./mock-data/meshes/default/dataplanes+insights__gateways-all.json'))))
+      } else if (gateway === 'builtin') {
+        response = JSON.parse(JSON.stringify(await loadMockFile(() => import('./mock-data/meshes/default/dataplanes+insights__gateways-builtin.json'))))
+      } else if (gateway === 'delegated') {
+        response = JSON.parse(JSON.stringify(await loadMockFile(() => import('./mock-data/meshes/default/dataplanes+insights__gateways-delegated.json'))))
+      } else if (gateway === 'false') {
+        response = JSON.parse(JSON.stringify(await loadMockFile(() => import('./mock-data/meshes/default/dataplanes+insights.json'))))
+
+        response.items = response.items.filter((item: any) => item.dataplane.networking.gateway === undefined)
+        response.total = response.items.length
       } else {
-        data.items = data.items.filter((item: any) => item.dataplane.networking.gateway === undefined)
-        data.total = `${data.items.length}`
+        response = JSON.parse(JSON.stringify(await loadMockFile(() => import('./mock-data/meshes/default/dataplanes+insights.json'))))
       }
-      return res(ctx.json(data))
+
+      return res(ctx.json(response))
     }),
   )
 

--- a/src/app/common/DataOverview.vue
+++ b/src/app/common/DataOverview.vue
@@ -342,15 +342,19 @@ const tableHeaders = computed(() => {
   }
 })
 const customSlots = computed(() => props.tableData.headers.map((header) => header.key).filter((key) => slots[key]))
-/**
- * Just changing the table data/headers doesn’t cause the table component to re-render, so by updating its `key` prop when this happens, we force a re-render. This is necessary to get the column visibility toggles and similar operations to work in the data planes list view.
- */
-const tableRecompuationKey = computed(() => `${props.tableData.data.length}-${tableHeaders.value.length}`)
+const tableRecompuationKey = ref(0)
 
 watch(() => props.isLoading, function () {
   if (!props.isLoading && props.tableData.data.length > 0) {
     selectedRow.value = props.selectedEntityName || props.tableData.data[0].name
   }
+})
+
+/**
+ * Just changing the table data/headers doesn’t cause the table component to re-render, so by updating its `key` prop when this happens, we force a re-render. This is necessary to get the column visibility toggles and similar operations to work in the data planes list view.
+ */
+watch(() => props.tableData, function () {
+  tableRecompuationKey.value++
 })
 
 function tableDataFetcher(): { data: object[], total: number } {


### PR DESCRIPTION
Fixes an issue with data plane tables not always recomputing when loading new data.

Also updates mock data so that issues like this can be spotted with mock data.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>