### PR TITLE
chore(gateways): Adds gateway type selection to queryParams

### DIFF
--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -35,15 +35,15 @@
 
             <select
               id="data-planes-type-filter"
-              v-model="filteredDataPlaneType"
+              v-model="filteredGatewayType"
               data-testid="data-planes-type-filter"
             >
               <option
-                v-for="(dataPlaneType, key) in dataPlaneTypes"
+                v-for="(value, key) in GATEWAY_TYPES"
                 :key="key"
-                :value="dataPlaneType"
+                :value="key"
               >
-                {{ dataPlaneType }}
+                {{ value }}
               </option>
             </select>
           </div>
@@ -148,23 +148,17 @@ import KFilterBar, { FilterBarEventData, FilterFields } from '@/app/common/KFilt
 const PAGE_SIZE = 50
 
 const GATEWAY_TYPES = {
-  All: 'true',
-  Builtin: 'builtin',
-  Delegated: 'delegated',
+  true: 'All',
+  builtin: 'Builtin',
+  delegated: 'Delegated',
 } as const
 
-const dataPlaneTypes = [
-  'All',
-  'Builtin',
-  'Delegated',
-] as const
+type GatewayType = keyof typeof GATEWAY_TYPES
 
 const EMPTY_STATE = {
   title: 'No Data',
   message: 'There are no data plane proxies present.',
 }
-
-type DataPlaneType = typeof dataPlaneTypes[number]
 
 const route = useRoute()
 const store = useStore()
@@ -210,6 +204,12 @@ const props = defineProps({
     default: false,
   },
 
+  gatewayType: {
+    type: String as PropType<String | undefined>,
+    required: false,
+    default: 'true',
+  },
+
   dppFilterFields: {
     type: Object as PropType<FilterFields>,
     required: true,
@@ -226,7 +226,7 @@ const tableData = ref<{ headers: TableHeader[], data: any }>({
   data: [],
 })
 const filterQuery = ref(QueryParameter.get('filterQuery') ?? '')
-const filteredDataPlaneType = ref<DataPlaneType>('All')
+const filteredGatewayType = ref<GatewayType>(props.gatewayType as GatewayType)
 const dppParams = ref<DataPlaneOverviewParameters>({})
 const dataPlaneOverview = ref<DataPlaneOverview | null>(null)
 const isMultiZoneMode = computed(() => store.getters['config/getMulticlusterStatus'])
@@ -276,7 +276,7 @@ const filteredColumnsDropdownItems = computed<ColumnDropdownItem[]>(() => {
     })
 })
 
-watch(filteredDataPlaneType, function () {
+watch(filteredGatewayType, function () {
   emitLoadDataEvent(0)
 })
 
@@ -310,7 +310,7 @@ function emitLoadDataEvent(offset: number): void {
   }
 
   if (!('gateway' in params)) {
-    params.gateway = GATEWAY_TYPES[filteredDataPlaneType.value]
+    params.gateway = filteredGatewayType.value
   }
 
   emit('load-data', offset, params)

--- a/src/app/data-planes/views/DataPlaneListView.spec.ts
+++ b/src/app/data-planes/views/DataPlaneListView.spec.ts
@@ -81,7 +81,7 @@ describe('DataPlaneListView', () => {
     })
 
     const dataPlaneTypeFilter = wrapper.find('[data-testid="data-planes-type-filter"]')
-    await dataPlaneTypeFilter.setValue('Builtin')
+    await dataPlaneTypeFilter.setValue('builtin')
     await flushPromises()
 
     const tableRows = wrapper.findAll('[data-testid="data-overview-table"] tbody tr')
@@ -93,7 +93,7 @@ describe('DataPlaneListView', () => {
       expect(firstTableRowHtml).toContain(string)
     }
 
-    await dataPlaneTypeFilter.setValue('Delegated')
+    await dataPlaneTypeFilter.setValue('delegated')
     await flushPromises()
 
     const tableRows2 = wrapper.findAll('[data-testid="data-overview-table"] tbody tr')

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -7,6 +7,7 @@
     :page-offset="pageOffset"
     :selected-dpp-name="props.selectedDppName"
     :is-gateway-view="props.isGatewayView"
+    :gateway-type="props.gatewayType"
     :dpp-filter-fields="dppFilterFields"
     @load-data="loadData"
   />
@@ -44,6 +45,12 @@ const props = defineProps({
     type: String,
     required: false,
     default: null,
+  },
+
+  gatewayType: {
+    type: String,
+    required: false,
+    default: 'true',
   },
 
   offset: {
@@ -85,7 +92,10 @@ function start() {
   const filterFields = QueryParameter.get('filterFields')
   const dppParams = filterFields !== null ? JSON.parse(filterFields) as DataPlaneOverviewParameters : {}
 
-  loadData(props.offset, dppParams)
+  loadData(props.offset, {
+    ...dppParams,
+    gateway: props.gatewayType,
+  } as DataPlaneOverviewParameters)
 }
 
 start()
@@ -94,7 +104,7 @@ async function loadData(offset: number, dppParams: DataPlaneOverviewParameters =
   pageOffset.value = offset
   // Puts the offset parameter in the URL so it can be retrieved when the user reloads the page.
   QueryParameter.set('offset', offset > 0 ? offset : null)
-
+  QueryParameter.set('gatewayType', dppParams.gateway === 'true' ? 'all' : dppParams.gateway)
   isLoading.value = true
 
   const mesh = route.params.mesh as string

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -93,6 +93,7 @@ export default (store: Store<State>): readonly RouteRecordRaw[] => {
               },
               props: (route) => ({
                 selectedDppName: route.query.gateway,
+                gatewayType: route.query.gatewayType === 'all' ? 'true' : route.query.gatewayType,
                 offset: getLastNumberParameter(route.query.offset),
                 isGatewayView: true,
               }),


### PR DESCRIPTION
This PR adds the selection of gatewayType to the query params in the Gateway Listing view.

Additionally:

- I removed the doubled up data structure (`GATEWAY_TYPES`, `dataPlaneTypes`)
- I moved the select element to use label/values (values being lowercased 'machine' values, the labels being capitalized human words), the machine value is then what is used in the code and in the query parameters.

Signed-off-by: John Cowen <john.cowen@konghq.com>

