### PR TITLE
fix: policy route using wrong name/param

### DIFF
--- a/src/app/mesh-overview/views/MeshOverviewView.vue
+++ b/src/app/mesh-overview/views/MeshOverviewView.vue
@@ -71,9 +71,9 @@
                     >
                       <router-link
                         :to="{
-                          name: 'policies',
+                          name: 'policy',
                           params: {
-                            policyType: item.path
+                            policyPath: item.path
                           }
                         }"
                       >


### PR DESCRIPTION
Fixes a small issue with links to specific policy views using the route name for the general policies route and a `policyType` param which doesn’t exist.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>