### PR TITLE
chore: Adds latest version retrieval to the mocks

### DIFF
--- a/src/api/kumaApi.ts
+++ b/src/api/kumaApi.ts
@@ -26,6 +26,8 @@ import {
   ZoneOverview,
 } from '@/types/index.d'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
+import { TOKENS, get } from '@/services'
+const env = get(TOKENS.Env)
 
 class KumaApi {
   client: RestClient
@@ -62,7 +64,7 @@ class KumaApi {
   }
 
   async getLatestVersion(): Promise<string> {
-    return this.client.get(import.meta.env.VITE_VERSION_URL)
+    return this.client.get(env.var('KUMA_VERSION_URL'))
   }
 
   getConfig(): Promise<ClientConfigInterface> {

--- a/src/api/mocks.ts
+++ b/src/api/mocks.ts
@@ -236,7 +236,3 @@ export function setupHandlers(url: string = ''): RestHandler[] {
 
   return handlers
 }
-
-export const additionalTestHandlers: RestHandler[] = [
-  rest.get('https://kuma.io/latest_version/', (_req, res, ctx) => res(ctx.status(200), ctx.text('1.2.2'))),
-]

--- a/src/api/mocks.ts
+++ b/src/api/mocks.ts
@@ -1,7 +1,9 @@
 import { rest, RestHandler } from 'msw'
+import { TOKENS, get } from '@/services'
 
 import { Info } from '@/types/index.d'
 
+const env = get(TOKENS.Env)
 async function loadMockFile(importFn: () => Promise<any>): Promise<any> {
   const fileModule = await importFn()
 
@@ -11,7 +13,7 @@ async function loadMockFile(importFn: () => Promise<any>): Promise<any> {
 function getBaseInfo(): Info {
   return {
     hostname: 'control-plane-5d94cb99c6-rzr96',
-    tagline: import.meta.env.VITE_NAMESPACE,
+    tagline: env.var('KUMA_PRODUCT_NAME'),
     version: '1.7.1',
     basedOnKuma: '1.7.1',
     instanceId: 'control-plane-5d94cb99c6-rzr96-ca19',
@@ -171,6 +173,7 @@ export function setupHandlers(url: string = ''): RestHandler[] {
     return rest.get(getApiPath(path), async (_req, res, ctx) => res(ctx.json(await loadMockFile(importFn))))
   })
 
+  handlers.push(rest.get(env.var('KUMA_VERSION_URL'), (_req, res, ctx) => res(ctx.text('2.0.2'))))
   handlers.push(rest.get(getApiPath(), (_req, res, ctx) => res(ctx.json(getBaseInfo()))))
 
   handlers.push(

--- a/src/api/mocks.ts
+++ b/src/api/mocks.ts
@@ -173,7 +173,7 @@ export function setupHandlers(url: string = ''): RestHandler[] {
     return rest.get(getApiPath(path), async (_req, res, ctx) => res(ctx.json(await loadMockFile(importFn))))
   })
 
-  handlers.push(rest.get(env.var('KUMA_VERSION_URL'), (_req, res, ctx) => res(ctx.text('2.0.2'))))
+  handlers.push(rest.get(env.var('KUMA_VERSION_URL'), (_req, res, ctx) => res(ctx.text('5.0.2'))))
   handlers.push(rest.get(getApiPath(), (_req, res, ctx) => res(ctx.json(getBaseInfo()))))
 
   handlers.push(

--- a/src/api/setupMockServer.ts
+++ b/src/api/setupMockServer.ts
@@ -1,6 +1,6 @@
 import { setupServer, SetupServerApi } from 'msw/node'
 
-import { setupHandlers, additionalTestHandlers } from './mocks'
+import { setupHandlers } from './mocks'
 
 /**
  * Sets up a mock server for the use in tests.
@@ -8,5 +8,5 @@ import { setupHandlers, additionalTestHandlers } from './mocks'
  * **IMPORTANT**: Do not import this file in the regular application. Since it imports `msw/node`, this will cause the application to break because it will try to import (require, actually) Node built-ins which aren’t available in browser environments.
  */
 export function setupMockServer(url: string = ''): SetupServerApi {
-  return setupServer(...setupHandlers(url), ...additionalTestHandlers)
+  return setupServer(...setupHandlers(url))
 }

--- a/src/app/App.spec.ts
+++ b/src/app/App.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { withVersion } from '@/../jest/jest-setup-after-env'
 
 import App from './App.vue'
 import { store } from '@/store/store'
@@ -26,9 +27,9 @@ function renderComponent(status: string) {
     },
   })
 }
-
 describe('App.vue', () => {
   test('renders main view when successful', async () => {
+    withVersion('10.2.0')
     const wrapper = renderComponent('OK')
     store.dispatch('bootstrap')
 
@@ -40,6 +41,7 @@ describe('App.vue', () => {
   })
 
   test('fails to renders basic view', async () => {
+    withVersion('10.2.0')
     const wrapper = renderComponent('ERROR')
     store.dispatch('bootstrap')
 

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -236,7 +236,7 @@ exports[`App.vue fails to renders basic view 1`] = `
                     >
                       
                       <a
-                        href="https://kuma.io/docs/1.7.x/?utm_source=Kuma&utm_medium=Kuma-GUI"
+                        href="https://kuma.io/docs/10.2.x/?utm_source=Kuma&utm_medium=Kuma-GUI"
                         rel="noopener noreferrer"
                         target="_blank"
                       >
@@ -861,7 +861,7 @@ exports[`App.vue fails to renders basic view 1`] = `
                   >
                     <a
                       class="k-button medium rounded primary"
-                      href="https://kuma.io/docs/1.7.x/policies/?utm_source=Kuma&utm_medium=Kuma-GUI"
+                      href="https://kuma.io/docs/10.2.x/policies/?utm_source=Kuma&utm_medium=Kuma-GUI"
                       target="_blank"
                       type="button"
                     >
@@ -919,7 +919,7 @@ exports[`App.vue fails to renders basic view 1`] = `
                   <ul>
                     <li>
                       <a
-                        href="https://kuma.io/docs/1.7.x/?utm_source=Kuma&utm_medium=Kuma-GUI"
+                        href="https://kuma.io/docs/10.2.x/?utm_source=Kuma&utm_medium=Kuma-GUI"
                         target="_blank"
                       >
                         Kuma Documentation 

--- a/src/app/common/UpgradeCheck.spec.ts
+++ b/src/app/common/UpgradeCheck.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
-import { container, TOKENS, service, injected } from '@/services'
-import Env from '@/services/env/Env'
+import { withVersion } from '@/../jest/jest-setup-after-env'
 
 import UpgradeCheck from './UpgradeCheck.vue'
 
@@ -11,19 +10,7 @@ function renderComponent() {
 
 describe('UpgradeCheck.vue', () => {
   test('renders snapshot', async () => {
-    container.capture?.()
-
-    class TestEnv extends Env {
-      var(...rest: Parameters<Env['var']>) {
-        const key = rest[0]
-        if (key === 'KUMA_VERSION') {
-          return '1.2.0'
-        }
-        return super.var(...rest)
-      }
-    }
-    TOKENS.Env = service(TestEnv, { description: 'Env' })
-    injected(TestEnv, TOKENS.EnvVars)
+    withVersion('1.2.0')
 
     const wrapper = renderComponent()
 
@@ -31,6 +18,5 @@ describe('UpgradeCheck.vue', () => {
     expect(wrapper.html()).toContain('Update')
 
     expect(wrapper.element).toMatchSnapshot()
-    container.restore?.()
   })
 })

--- a/src/services/development.ts
+++ b/src/services/development.ts
@@ -2,7 +2,7 @@ import { TOKENS } from './production'
 import { service, injected } from './utils'
 import CookiedEnv from '@/services/env/CookiedEnv'
 
-export { service, constant, get, container, injected, createInjections } from './utils'
+export { service, constant, get, set, container, injected, createInjections } from './utils'
 export { TOKENS } from './production'
 
 TOKENS.Env = service(CookiedEnv, { description: 'Env' })

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -6,6 +6,7 @@ export type EnvArgs = {
   KUMA_FEEDBACK_URL: string
   KUMA_CHAT_URL: string
   KUMA_INSTALL_URL: string
+  KUMA_VERSION_URL: string
   KUMA_DOCS_URL: string
 }
 type EnvProps = {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,2 +1,2 @@
-export { service, constant, get, container, injected, createInjections } from './utils'
+export { service, constant, get, set, container, injected, createInjections } from './utils'
 export { TOKENS } from './production'

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -9,6 +9,7 @@ export const TOKENS = {
     KUMA_FEEDBACK_URL: import.meta.env.VITE_FEEDBACK_URL,
     KUMA_CHAT_URL: import.meta.env.VITE_CHAT_URL,
     KUMA_INSTALL_URL: import.meta.env.VITE_INSTALL_URL,
+    KUMA_VERSION_URL: import.meta.env.VITE_VERSION_URL,
     KUMA_DOCS_URL: import.meta.env.VITE_DOCS_BASE_URL,
   } as EnvArgs, { description: 'EnvVars' }),
   Env: service(Env, { description: 'Env' }),

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -50,6 +50,12 @@ export const service = <T>(func: UnknownCreator<T>, config: DependencyDefinition
     .inSingletonScope()
   return t as Token<T>
 }
+export const set = <T>(t: Token, func: UnknownCreator<T>) => {
+  const bound = container.bind(t)
+  bound.toInstance(func as Parameters<typeof bound.toInstance>[0])
+    .inSingletonScope()
+  return func
+}
 export const constant = <T>(func: T, config: DependencyDefinition): Token<T> => {
   const t = token<T>(config.description)
   const bound = container.bind(t)


### PR DESCRIPTION
This PR adds a new `KUMA_VERSION_URL` (replacing/using `VITE_VERSION_URL`) and then mocks that out using `msw`. 

This prevents us actually called out to the `VERSION_URL` during development. During tests it looks like this was originally mocked out using a similar approach (but did not read `VITE_VERSION_URL`)

I noticed that App.spec tested for no upgrade available, and we already have a test for when an upgrade is available (in `UpgradeCheck.spec`) and wanted to keep both these types of test, so I injected a super big version in `App.spec` that is higher than the currently hardcoded mocked version. I probably could have gone the other way around and mocked out the response from the endpoint also, and I'll possibly do something similar to this at a later date, this PR is already going a bit out of scope for what I want to do this for.

P.S. Probably worth noting, I'm half cheating and using `get(TOKEN......)` again here and not using native constructor/argument injection. The reason I'm doing this is to avoid all the churn which would happen if we had to reorganise all dependencies to be passed in via arguments/constructors. We should still do a re-org at a later date to completely hide the service container from the rest of the application.

Signed-off-by: John Cowen <john.cowen@konghq.com>