### PR TITLE
fix: incorrectly turning camel case into words

### DIFF
--- a/src/app/common/subscriptions/SubscriptionDetails.vue
+++ b/src/app/common/subscriptions/SubscriptionDetails.vue
@@ -35,7 +35,7 @@
           :key="label"
         >
           <h6 class="overview-tertiary-title">
-            {{ camelCaseToWords(label) }}:
+            {{ label }}:
           </h6>
 
           <ul>
@@ -43,7 +43,7 @@
               v-for="(k, v) in item"
               :key="v"
             >
-              <strong>{{ camelCaseToWords(v) }}:</strong>&nbsp;
+              <strong>{{ v }}:</strong>&nbsp;
               <span class="mono">{{ formatError(formatValue(k)) }}</span>
             </li>
           </ul>
@@ -71,7 +71,7 @@
 import { computed } from 'vue'
 import { KAlert, KIcon } from '@kong/kongponents'
 
-import { humanReadableDate, camelCaseToWords } from '@/utilities/helpers'
+import { humanReadableDate } from '@/utilities/helpers'
 
 const props = defineProps({
   details: {
@@ -112,7 +112,6 @@ function formatError(value: string): string {
 .overview-tertiary-title {
   font-size: var(--type-sm);
   font-weight: bold;
-  text-transform: uppercase;
   color: var(--grey-500);
   margin: var(--spacing-xs) 0;
 }

--- a/src/app/common/subscriptions/SubscriptionDetails.vue
+++ b/src/app/common/subscriptions/SubscriptionDetails.vue
@@ -7,22 +7,22 @@
 
       <ul>
         <li v-if="details.globalInstanceId">
-          <strong>Global Instance ID:</strong>&nbsp;
-          <span class="mono">{{ details.globalInstanceId }}</span>
+          <strong>Global Instance ID:</strong>
+          <span>{{ details.globalInstanceId }}</span>
         </li>
 
         <li v-if="details.controlPlaneInstanceId">
-          <strong>Control Plane Instance ID:</strong>&nbsp;
-          <span class="mono">{{ details.controlPlaneInstanceId }}</span>
+          <strong>Control Plane Instance ID:</strong>
+          <span>{{ details.controlPlaneInstanceId }}</span>
         </li>
 
         <li v-if="details.connectTime">
-          <strong>Last Connected:</strong>&nbsp;
+          <strong>Last Connected:</strong>
           {{ humanReadableDate(details.connectTime) }}
         </li>
 
         <li v-if="details.disconnectTime">
-          <strong>Last Disconnected:</strong>&nbsp;
+          <strong>Last Disconnected:</strong>
           {{ humanReadableDate(details.disconnectTime) }}
         </li>
       </ul>
@@ -43,8 +43,8 @@
               v-for="(k, v) in item"
               :key="v"
             >
-              <strong>{{ v }}:</strong>&nbsp;
-              <span class="mono">{{ formatError(formatValue(k)) }}</span>
+              <strong>{{ v }}:</strong>
+              <span>{{ formatError(formatValue(k)) }}</span>
             </li>
           </ul>
         </li>
@@ -73,6 +73,12 @@ import { KAlert, KIcon } from '@kong/kongponents'
 
 import { humanReadableDate } from '@/utilities/helpers'
 
+const map: Record<string, string> = {
+  responsesSent: 'Responses Sent',
+  responsesAcknowledged: 'Responses Acknowledged',
+  responsesRejected: 'Responses Rejected',
+}
+
 const props = defineProps({
   details: {
     type: Object,
@@ -86,13 +92,29 @@ const props = defineProps({
 })
 
 const detailsIterator = computed<Record<string, Record<string, any>>>(() => {
+  let details
   if (props.isDiscoverySubscription) {
     const { lastUpdateTime, total, ...restDetails } = props.details.status
 
-    return restDetails
+    details = restDetails
   }
 
-  return props.details.status?.stat
+  if (props.details.status?.stat) {
+    details = props.details.status?.stat
+  }
+
+  for (const detailProperty in details) {
+    const detail: any = details[detailProperty]
+
+    for (const prop in detail) {
+      if (prop in map) {
+        detail[map[prop]] = detail[prop]
+        delete detail[prop]
+      }
+    }
+  }
+
+  return details
 })
 
 function formatValue(value: string): string {

--- a/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
@@ -1030,10 +1030,7 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                               <strong>
                                 Control Plane Instance ID:
                               </strong>
-                                
-                              <span
-                                class="mono"
-                              >
+                              <span>
                                 kuma-control-plane-84f5589874-nmspq-0867
                               </span>
                             </li>
@@ -1041,7 +1038,7 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                               <strong>
                                 Last Connected:
                               </strong>
-                                July 13, 2021
+                               July 13, 2021
                             </li>
                             <!--v-if-->
                           </ul>
@@ -1061,23 +1058,17 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     3
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     3
                                   </span>
                                 </li>
@@ -1094,23 +1085,17 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     2
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     3
                                   </span>
                                 </li>
@@ -1127,23 +1112,17 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     3
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     3
                                   </span>
                                 </li>

--- a/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
@@ -1055,13 +1055,13 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Cds: 
+                                cds: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1072,7 +1072,7 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1088,13 +1088,13 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Eds: 
+                                eds: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1105,7 +1105,7 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1121,13 +1121,13 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Lds: 
+                                lds: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1138,7 +1138,7 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1154,7 +1154,7 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Rds: 
+                                rds: 
                               </h6>
                               <ul>
                                 

--- a/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
@@ -732,13 +732,13 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Cds: 
+                                cds: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -749,7 +749,7 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -765,13 +765,13 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Eds: 
+                                eds: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -782,7 +782,7 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -798,13 +798,13 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Lds: 
+                                lds: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -815,7 +815,7 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -831,7 +831,7 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Rds: 
+                                rds: 
                               </h6>
                               <ul>
                                 

--- a/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
@@ -707,10 +707,7 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                               <strong>
                                 Control Plane Instance ID:
                               </strong>
-                                
-                              <span
-                                class="mono"
-                              >
+                              <span>
                                 kuma-control-plane-84f5589874-nmspq-0867
                               </span>
                             </li>
@@ -718,7 +715,7 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                               <strong>
                                 Last Connected:
                               </strong>
-                                July 13, 2021
+                               July 13, 2021
                             </li>
                             <!--v-if-->
                           </ul>
@@ -738,23 +735,17 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     3
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     3
                                   </span>
                                 </li>
@@ -771,23 +762,17 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     2
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     3
                                   </span>
                                 </li>
@@ -804,23 +789,17 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     3
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     3
                                   </span>
                                 </li>

--- a/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
@@ -1315,10 +1315,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                               <strong>
                                 Global Instance ID:
                               </strong>
-                                
-                              <span
-                                class="mono"
-                              >
+                              <span>
                                 MacBook-Pro-Bartlomiej.local-9e52
                               </span>
                             </li>
@@ -1327,7 +1324,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                               <strong>
                                 Last Connected:
                               </strong>
-                                February 19, 2021
+                               February 19, 2021
                             </li>
                             <!--v-if-->
                           </ul>
@@ -1347,23 +1344,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1380,23 +1371,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1413,23 +1398,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1446,23 +1425,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1479,23 +1452,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1512,23 +1479,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1545,23 +1506,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1578,23 +1533,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1611,23 +1560,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1644,23 +1587,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1677,23 +1614,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1710,23 +1641,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1743,23 +1668,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
@@ -1776,23 +1695,17 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    responsesSent:
+                                    Responses Sent:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>
                                 <li>
                                   <strong>
-                                    responsesAcknowledged:
+                                    Responses Acknowledged:
                                   </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
+                                  <span>
                                     1
                                   </span>
                                 </li>

--- a/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
@@ -1341,13 +1341,13 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Circuit Breaker: 
+                                CircuitBreaker: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1358,7 +1358,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1380,7 +1380,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1391,7 +1391,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1413,7 +1413,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1424,40 +1424,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
-                                  </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
-                                    1
-                                  </span>
-                                </li>
-                                
-                              </ul>
-                            </li>
-                            <li>
-                              <h6
-                                class="overview-tertiary-title"
-                              >
-                                External Service: 
-                              </h6>
-                              <ul>
-                                
-                                <li>
-                                  <strong>
-                                    Responses Sent:
-                                  </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
-                                    1
-                                  </span>
-                                </li>
-                                <li>
-                                  <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1473,13 +1440,13 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Fault Injection: 
+                                ExternalService: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1490,7 +1457,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1506,13 +1473,13 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Health Check: 
+                                FaultInjection: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1523,7 +1490,40 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
+                                  </strong>
+                                    
+                                  <span
+                                    class="mono"
+                                  >
+                                    1
+                                  </span>
+                                </li>
+                                
+                              </ul>
+                            </li>
+                            <li>
+                              <h6
+                                class="overview-tertiary-title"
+                              >
+                                HealthCheck: 
+                              </h6>
+                              <ul>
+                                
+                                <li>
+                                  <strong>
+                                    responsesSent:
+                                  </strong>
+                                    
+                                  <span
+                                    class="mono"
+                                  >
+                                    1
+                                  </span>
+                                </li>
+                                <li>
+                                  <strong>
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1545,7 +1545,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1556,7 +1556,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1572,13 +1572,13 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Proxy Template: 
+                                ProxyTemplate: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1589,7 +1589,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1611,7 +1611,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1622,7 +1622,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1644,7 +1644,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1655,40 +1655,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
-                                  </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
-                                    1
-                                  </span>
-                                </li>
-                                
-                              </ul>
-                            </li>
-                            <li>
-                              <h6
-                                class="overview-tertiary-title"
-                              >
-                                Traffic Log: 
-                              </h6>
-                              <ul>
-                                
-                                <li>
-                                  <strong>
-                                    Responses Sent:
-                                  </strong>
-                                    
-                                  <span
-                                    class="mono"
-                                  >
-                                    1
-                                  </span>
-                                </li>
-                                <li>
-                                  <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1704,13 +1671,13 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Traffic Permission: 
+                                TrafficLog: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1721,7 +1688,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1737,13 +1704,13 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Traffic Route: 
+                                TrafficPermission: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1754,7 +1721,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span
@@ -1770,13 +1737,13 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                               <h6
                                 class="overview-tertiary-title"
                               >
-                                Traffic Trace: 
+                                TrafficRoute: 
                               </h6>
                               <ul>
                                 
                                 <li>
                                   <strong>
-                                    Responses Sent:
+                                    responsesSent:
                                   </strong>
                                     
                                   <span
@@ -1787,7 +1754,40 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 </li>
                                 <li>
                                   <strong>
-                                    Responses Acknowledged:
+                                    responsesAcknowledged:
+                                  </strong>
+                                    
+                                  <span
+                                    class="mono"
+                                  >
+                                    1
+                                  </span>
+                                </li>
+                                
+                              </ul>
+                            </li>
+                            <li>
+                              <h6
+                                class="overview-tertiary-title"
+                              >
+                                TrafficTrace: 
+                              </h6>
+                              <ul>
+                                
+                                <li>
+                                  <strong>
+                                    responsesSent:
+                                  </strong>
+                                    
+                                  <span
+                                    class="mono"
+                                  >
+                                    1
+                                  </span>
+                                </li>
+                                <li>
+                                  <strong>
+                                    responsesAcknowledged:
                                   </strong>
                                     
                                   <span

--- a/src/utilities/helpers.spec.ts
+++ b/src/utilities/helpers.spec.ts
@@ -92,12 +92,12 @@ describe('helpers', () => {
 
   describe('camelCaseToWords', () => {
     test.each([
-      ['test', 'test'],
+      ['test', 'Test'],
       ['MeshOPAPolicy', 'Mesh OPA Policy'],
       ['MeshOPA', 'Mesh OPA'],
       ['MeshCircuitBreaker', 'Mesh Circuit Breaker'],
       ['Mesh Circuit Breaker', 'Mesh Circuit Breaker'],
-      ['meshCircuitBreaker', 'mesh Circuit Breaker'],
+      ['meshCircuitBreaker', 'Mesh Circuit Breaker'],
     ])('works for “%s”', (str, expectedString) => {
       expect(camelCaseToWords(str)).toBe(expectedString)
     })

--- a/src/utilities/helpers.spec.ts
+++ b/src/utilities/helpers.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, jest, test } from '@jest/globals'
 
 import { DISABLED } from '@/constants'
-import { getZoneDpServerAuthType, fetchAllResources } from './helpers'
+import { getZoneDpServerAuthType, fetchAllResources, camelCaseToWords } from './helpers'
 import { ZoneOverview } from '@/types/index.d'
 
 describe('helpers', () => {
@@ -87,6 +87,19 @@ describe('helpers', () => {
       expect(request).toHaveBeenCalledTimes(2)
       expect(request).toHaveBeenNthCalledWith(1, { offset: 0, size: 500 })
       expect(request).toHaveBeenNthCalledWith(2, { offset: 500, size: 500 })
+    })
+  })
+
+  describe('camelCaseToWords', () => {
+    test.each([
+      ['test', 'test'],
+      ['MeshOPAPolicy', 'Mesh OPA Policy'],
+      ['MeshOPA', 'Mesh OPA'],
+      ['MeshCircuitBreaker', 'Mesh Circuit Breaker'],
+      ['Mesh Circuit Breaker', 'Mesh Circuit Breaker'],
+      ['meshCircuitBreaker', 'mesh Circuit Breaker'],
+    ])('works for “%s”', (str, expectedString) => {
+      expect(camelCaseToWords(str)).toBe(expectedString)
     })
   })
 })

--- a/src/utilities/helpers.spec.ts
+++ b/src/utilities/helpers.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, jest, test } from '@jest/globals'
 
 import { DISABLED } from '@/constants'
-import { getZoneDpServerAuthType, fetchAllResources, camelCaseToWords } from './helpers'
+import { getZoneDpServerAuthType, fetchAllResources } from './helpers'
 import { ZoneOverview } from '@/types/index.d'
 
 describe('helpers', () => {
@@ -87,19 +87,6 @@ describe('helpers', () => {
       expect(request).toHaveBeenCalledTimes(2)
       expect(request).toHaveBeenNthCalledWith(1, { offset: 0, size: 500 })
       expect(request).toHaveBeenNthCalledWith(2, { offset: 500, size: 500 })
-    })
-  })
-
-  describe('camelCaseToWords', () => {
-    test.each([
-      ['test', 'Test'],
-      ['MeshOPAPolicy', 'Mesh OPA Policy'],
-      ['MeshOPA', 'Mesh OPA'],
-      ['MeshCircuitBreaker', 'Mesh Circuit Breaker'],
-      ['Mesh Circuit Breaker', 'Mesh Circuit Breaker'],
-      ['meshCircuitBreaker', 'Mesh Circuit Breaker'],
-    ])('works for “%s”', (str, expectedString) => {
-      expect(camelCaseToWords(str)).toBe(expectedString)
     })
   })
 })

--- a/src/utilities/helpers.ts
+++ b/src/utilities/helpers.ts
@@ -101,42 +101,6 @@ export function stripTimes<T extends { creationTime?: any, modificationTime?: an
 }
 
 /**
- * camelCaseToWords
- *
- * Converts camelcase to human-readable words in titlecase format
- *
- * @param {String} str
- */
-export function camelCaseToWords(str: string): string {
-  const result: string[] = []
-  let isPreviousCharUppercase = false
-  let isPreviousCharLowercase = false
-
-  for (const char of Array.from(str)) {
-    const isUppercase = /[A-Z]/.test(char)
-    const isLowercase = /[a-z]/.test(char)
-
-    if (isUppercase) {
-      if (isPreviousCharLowercase && result.length > 0) {
-        result.push(' ')
-      }
-    } else if (isLowercase) {
-      if (isPreviousCharUppercase && result.length > 1) {
-        const previousChar = result.pop() as string
-        const previousPreviousChar = result[result.length - 1]
-        result.push((/[A-Z]/.test(previousPreviousChar) ? ' ' : '') + previousChar)
-      }
-    }
-
-    result.push(result.length === 0 ? char.toUpperCase() : char)
-    isPreviousCharUppercase = isUppercase
-    isPreviousCharLowercase = isLowercase
-  }
-
-  return result.join('')
-}
-
-/**
  * kebabCase
  *
  * @param {*} value

--- a/src/utilities/helpers.ts
+++ b/src/utilities/helpers.ts
@@ -107,13 +107,33 @@ export function stripTimes<T extends { creationTime?: any, modificationTime?: an
  *
  * @param {String} str
  */
-export function camelCaseToWords(str: string) {
-  const search = /^[a-z]+|[A-Z][a-z]*/g
+export function camelCaseToWords(str: string): string {
+  const result: string[] = []
+  let isPreviousCharUppercase = false
+  let isPreviousCharLowercase = false
 
-  return str
-    .match(search)
-    ?.map((x: string) => x[0].toUpperCase() + x.substr(1).toLowerCase())
-    .join(' ')
+  for (const char of Array.from(str)) {
+    const isUppercase = /[A-Z]/.test(char)
+    const isLowercase = /[a-z]/.test(char)
+
+    if (isUppercase) {
+      if (isPreviousCharLowercase && result.length > 0) {
+        result.push(' ')
+      }
+    } else if (isLowercase) {
+      if (isPreviousCharUppercase && result.length > 1) {
+        const previousChar = result.pop() as string
+        const previousPreviousChar = result[result.length - 1]
+        result.push((/[A-Z]/.test(previousPreviousChar) ? ' ' : '') + previousChar)
+      }
+    }
+
+    result.push(char)
+    isPreviousCharUppercase = isUppercase
+    isPreviousCharLowercase = isLowercase
+  }
+
+  return result.join('')
 }
 
 /**

--- a/src/utilities/helpers.ts
+++ b/src/utilities/helpers.ts
@@ -128,7 +128,7 @@ export function camelCaseToWords(str: string): string {
       }
     }
 
-    result.push(char)
+    result.push(result.length === 0 ? char.toUpperCase() : char)
     isPreviousCharUppercase = isUppercase
     isPreviousCharLowercase = isLowercase
   }


### PR DESCRIPTION
Fixes a small issue with the `camelCaseToWords` utility not handling words with subsequent uppercase letter correctly (e.g. MeshOPAPolicy).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>