### PR TITLE
chore: turns off module preload option

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,6 +52,11 @@ export const config:UserConfigFn = ({ mode }) => {
         '@': path.resolve('./src'),
       },
     },
+    build: {
+      modulePreload: {
+        resolveDependencies: () => [],
+      },
+    },
   }
 }
 export default defineConfig(config)


### PR DESCRIPTION
Turns off the `build.modulePreload` option in the Vite configuration because it interferes with our tests and isn’t strictly necessary.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>