### PR TITLE
chore: Add a component composition root with KumaLogo and GHButton

### DIFF
--- a/src/app/AppHeader.vue
+++ b/src/app/AppHeader.vue
@@ -2,11 +2,7 @@
   <header class="app-header">
     <div class="horizontal-list">
       <router-link :to="{ name: 'home' }">
-        <img
-          class="logo-image"
-          src="@/assets/images/product-logo.png"
-          :alt="`${store.state.config.tagline} Logo`"
-        >
+        <KumaLogo />
       </router-link>
 
       <GithubButton
@@ -102,12 +98,24 @@ import {
   KIcon,
   KPop,
 } from '@kong/kongponents'
-import GithubButton from 'vue-github-button'
+
+import {
+  useKumaLogo,
+  useGithubButton,
+} from '@/components'
 
 import { useStore } from '@/store/store'
 import { useEnv } from '@/utilities'
 import NotificationIcon from './common/NotificationIcon.vue'
 import UpgradeCheck from './common/UpgradeCheck.vue'
+
+const [
+  KumaLogo,
+  GithubButton,
+] = [
+  useKumaLogo(),
+  useGithubButton(),
+]
 
 const store = useStore()
 const env = useEnv()
@@ -144,9 +152,6 @@ const mode = computed(() => store.getters['config/getMulticlusterStatus'] ? 'Mul
   background-color: var(--white);
 }
 
-.logo-image {
-  max-height: 36px;
-}
 .gh-star {
   height: 20px;
 }

--- a/src/app/common/KumaLogo.vue
+++ b/src/app/common/KumaLogo.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import { useEnv } from '@/utilities'
+const env = useEnv()
+</script>
+<template>
+  <img
+    src="@/assets/images/product-logo.png"
+    :alt="`${env('KUMA_PRODUCT_NAME')} Logo`"
+  >
+</template>
+<style lang="scss" scoped>
+img {
+  max-height: 36px;
+}
+</style>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,10 @@
+import KumaLogo from '@/app/common/KumaLogo.vue'
+import GithubButton from 'vue-github-button'
+
+export const [
+  useKumaLogo,
+  useGithubButton,
+] = [
+  () => KumaLogo,
+  () => GithubButton,
+]


### PR DESCRIPTION
This PR slightly changes the way we consume components, in that we consume them from a single composition root in `@/components`. I wanted to try it out with multiple components so used the KumaLogo and the recently added GHButton so see/show how the application level code looks when using multiple components like this.

Notes:

1. Whilst exporting functions that return the component seems a little redundant (as opposed to just exporting the component), this matches up with the `use*()` that we use for services and other things, therefore everything works the same.
2. We have a separate composition root specifically for components, ideally we want a single composition root (we already have `@/services`, now we have `@/components` and `@/services`). This avoids problems with circular imports which is caused by not being able to use constructor injection for components. There are probably other ways around this, but this is the simplest, and having 2 composition roots that work exactly the same is fine by me.
3. I haven't used our service container for components as yet (maybe never). The fact that we can't use constructor injection and take advantage of automatic dependency resolution and injection means using that would be kinda redundant. Although I did notice that using the service container here _may_ help with exporting these functions when/if the amount of these grows. We can try that a later date though, we can change the composition root however we like in the future as long as the exports stay the same, which in turn would mean we don't have to change any application code.

Signed-off-by: John Cowen <john.cowen@konghq.com>