### PR TITLE
fix: dpp filters no working correctly for service detail view

### DIFF
--- a/src/app/services/components/ServiceDetails.vue
+++ b/src/app/services/components/ServiceDetails.vue
@@ -61,6 +61,12 @@ const emit = defineEmits<{
 }>()
 
 function loadData(offset: number, params: DataPlaneOverviewParameters): void {
+  const isGatewayService = props.service.serviceType?.startsWith('gateway') ?? false
+  if (!isGatewayService) {
+    // Never propagate a gateway filter when listing DPPs for services because we use the same table for them.
+    delete params.gateway
+  }
+
   emit('load-dataplane-overviews', offset, params)
 }
 </script>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -385,7 +385,7 @@ export type MeshGatewayListenerEntry = {
  */
 export interface ServiceInsight extends MeshEntity {
   type: 'ServiceInsight'
-  serviceType?: 'internal' | 'external'
+  serviceType?: 'internal' | 'external' | 'gateway_builtin' | 'gateway_delegated'
   addressPort?: string
   status?: StatusKeyword
   dataplanes?: {


### PR DESCRIPTION
Fixes an issue with the DPP filters when used as part of the service detail view on account of them accidentally propagating a `gateway=true` parameter.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>