### PR TITLE
refactor: migrates onboarding components to composition api

### DIFF
--- a/src/app/App.spec.ts
+++ b/src/app/App.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, jest, test } from '@jest/globals'
-import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { withVersion } from '@/../jest/jest-setup-after-env'
 
 import App from './App.vue'
@@ -29,11 +29,11 @@ function renderComponent(status: string) {
       stubs: {
         // Let’s not unnecessarily render all that chart markup.
         DonutChart: true,
-        'router-link': RouterLinkStub,
       },
     },
   })
 }
+
 describe('App.vue', () => {
   test('renders main view when successful', async () => {
     withVersion('10.2.0')

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -76,7 +76,7 @@ const isLoading = ref(store.state.globalLoading)
  */
 const routeKey = computed(() => route.path)
 const shouldShowAppError = computed(() => store.state.config.status !== 'OK')
-const shouldSuggestOnboarding = computed(() => store.getters['onboarding/showOnboarding'])
+const shouldSuggestOnboarding = computed(() => store.getters.shouldSuggestOnboarding)
 const shouldShowNotificationManager = computed(() => store.getters['notifications/amountOfActions'] > 0)
 
 watch(() => store.state.globalLoading, function (globalLoading) {

--- a/src/app/AppSidebar.spec.ts
+++ b/src/app/AppSidebar.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals'
-import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 
 import AppSidebar from './AppSidebar.vue'
 import { store } from '@/store/store'
@@ -7,13 +7,7 @@ import { store } from '@/store/store'
 async function renderComponent() {
   await store.dispatch('fetchPolicyTypes')
 
-  return mount(AppSidebar, {
-    global: {
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
-    },
-  })
+  return mount(AppSidebar)
 }
 
 describe('AppSidebar.vue', () => {

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -9,7 +9,11 @@ exports[`App.vue fails to renders basic view 1`] = `
     <div
       class="horizontal-list"
     >
-      <a>
+      <a
+        aria-current="page"
+        class="router-link-active router-link-exact-active"
+        href="/"
+      >
         <img
           alt="Kuma Logo"
         />
@@ -276,6 +280,7 @@ exports[`App.vue fails to renders basic view 1`] = `
       <a
         button-appearance="btn-link"
         class="k-button medium rounded outline"
+        href="/diagnostics"
         type="button"
       >
         
@@ -332,7 +337,9 @@ exports[`App.vue fails to renders basic view 1`] = `
           data-testid="home"
         >
           <a
-            class="nav-link nav-link--is-active"
+            aria-current="page"
+            class="router-link-active router-link-exact-active nav-link nav-link--is-active"
+            href="/"
           >
             Home 
             <!--v-if-->
@@ -404,6 +411,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         >
           <a
             class="nav-link"
+            href="/mesh/default"
           >
             Overview 
             <!--v-if-->
@@ -417,6 +425,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         >
           <a
             class="nav-link"
+            href="/mesh/default/services"
           >
             Services 
             <span
@@ -434,6 +443,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         >
           <a
             class="nav-link"
+            href="/mesh/default/gateways"
           >
             Gateways 
             <span
@@ -451,6 +461,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         >
           <a
             class="nav-link"
+            href="/mesh/default/data-planes"
           >
             Data Plane Proxies 
             <span
@@ -468,6 +479,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         >
           <a
             class="nav-link"
+            href="/mesh/default/policies"
           >
             Policies 
             <span
@@ -897,6 +909,7 @@ exports[`App.vue fails to renders basic view 1`] = `
                   >
                     <a
                       class="k-button medium rounded creation"
+                      href="/wizard/mesh"
                       type="button"
                     >
                       
@@ -997,6 +1010,7 @@ exports[`App.vue fails to renders basic view 1`] = `
                   >
                     <a
                       class="k-button medium rounded primary"
+                      href="/wizard/universal-dataplane"
                       type="button"
                     >
                       

--- a/src/app/__snapshots__/AppSidebar.spec.ts.snap
+++ b/src/app/__snapshots__/AppSidebar.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`AppSidebar.vue renders snapshot 1`] = `
     >
       <a
         class="nav-link"
+        href="/"
       >
         Home 
         <!--v-if-->

--- a/src/app/common/KumaLogo.vue
+++ b/src/app/common/KumaLogo.vue
@@ -1,14 +1,14 @@
-<script lang="ts" setup>
-import { useEnv } from '@/utilities'
-const env = useEnv()
-</script>
-
 <template>
   <img
     src="@/assets/images/product-logo.png"
     :alt="`${env('KUMA_PRODUCT_NAME')} Logo`"
   >
 </template>
+
+<script lang="ts" setup>
+import { useEnv } from '@/utilities'
+const env = useEnv()
+</script>
 
 <style lang="scss" scoped>
 img {

--- a/src/app/data-planes/components/DataPlaneDetails.spec.ts
+++ b/src/app/data-planes/components/DataPlaneDetails.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals'
-import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneDetails from './DataPlaneDetails.vue'
 import { store } from '@/store/store'
@@ -17,11 +17,6 @@ async function renderComponent(props = {}) {
       dataPlane,
       dataPlaneOverview,
       ...props,
-    },
-    global: {
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
     },
   })
 }

--- a/src/app/data-planes/components/PolicyTypeEntryList.spec.ts
+++ b/src/app/data-planes/components/PolicyTypeEntryList.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals'
-import { mount, RouterLinkStub } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 
 import PolicyTypeEntryList from './PolicyTypeEntryList.vue'
 import { store } from '@/store/store'
@@ -13,11 +13,6 @@ async function renderComponent(props = {}) {
     props: {
       policyTypeEntries,
       ...props,
-    },
-    global: {
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
     },
   })
 }

--- a/src/app/onboarding/components/ItemStatus.vue
+++ b/src/app/onboarding/components/ItemStatus.vue
@@ -1,10 +1,10 @@
 <template>
-  <li class="flex items-center mb-2">
-    <span class="circle">
+  <li class="item-status mb-2">
+    <span class="circle mr-2">
       <KIcon
         v-if="props.status"
         icon="check"
-        size="10"
+        size="14"
         color="var(--kuma-purple-1)"
       />
     </span>
@@ -30,9 +30,18 @@ const props = defineProps({
 </script>
 
 <style lang="scss" scoped>
-.circle {
-  @apply flex items-center justify-center text-sm w-4 h-4 rounded-full mr-2;
+.item-status {
+  display: flex;
+  align-items: center;
+}
 
-  background-color: rgba(var(--kuma-purple-1-rgb), 0.1);
+.circle {
+  height: 1rem;
+  width: 1rem;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--grey-300);
 }
 </style>

--- a/src/app/onboarding/components/OnboardingHeading.spec.ts
+++ b/src/app/onboarding/components/OnboardingHeading.spec.ts
@@ -5,7 +5,7 @@ import OnboardingHeading from './OnboardingHeading.vue'
 
 function renderComponent() {
   return mount(OnboardingHeading, {
-    props: {
+    slots: {
       title: 'title',
       description: 'description',
     },

--- a/src/app/onboarding/components/OnboardingHeading.vue
+++ b/src/app/onboarding/components/OnboardingHeading.vue
@@ -1,39 +1,43 @@
 <template>
-  <div class="relative">
+  <div class="onboarding-heading">
     <h1 class="onboarding-title">
-      {{ title }}
+      <slot name="title" />
     </h1>
-    <p
-      v-if="description"
-      class="text-center text-lg mt-3"
+
+    <div
+      v-if="slots.description"
+      class="onboarding-description"
     >
-      {{ description }}
-    </p>
+      <slot name="description" />
+    </div>
   </div>
 </template>
 
-<script>
-export default {
-  name: 'OnboardingHeading',
-  props: {
-    title: {
-      type: String,
-      required: true,
-    },
-    description: {
-      type: String,
-      default: '',
-    },
-  },
-}
+<script lang="ts" setup>
+import { useSlots } from 'vue'
+
+const slots = useSlots()
 </script>
 
 <style lang="scss" scoped>
-.onboarding-title {
-  @apply text-center text-4xl font-bold;
+.onboarding-heading {
+  position: relative;
+}
 
-  background: linear-gradient(to right, var(--OnboardingTitle));
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
+.onboarding-title {
+  padding-top: var(--spacing-xxs);
+  padding-bottom: var(--spacing-xxs);
+  text-align: center;
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+  font-weight: bold;
+  color: var(--kuma-purple-1);
+}
+
+.onboarding-description {
+  margin-top: var(--spacing-sm);
+  text-align: center;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
 }
 </style>

--- a/src/app/onboarding/components/OnboardingNavigation.spec.ts
+++ b/src/app/onboarding/components/OnboardingNavigation.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals'
-import { mount, RouterLinkStub } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 
 import OnboardingNavigation from './OnboardingNavigation.vue'
 import { store } from '@/store/store'
@@ -7,13 +7,8 @@ import { store } from '@/store/store'
 function renderComponent(props = {}) {
   return mount(OnboardingNavigation, {
     props: {
-      nextStep: 'bar',
+      nextStep: 'onboarding-configuration-types',
       ...props,
-    },
-    global: {
-      stubs: {
-        'router-link': RouterLinkStub,
-      },
     },
   })
 }
@@ -21,7 +16,7 @@ function renderComponent(props = {}) {
 describe('OnboardingNavigation.vue', () => {
   test('renders snapshot', () => {
     const wrapper = renderComponent({
-      previousStep: 'foo',
+      previousStep: 'onboarding-welcome',
     })
 
     expect(wrapper.element).toMatchSnapshot()
@@ -29,7 +24,7 @@ describe('OnboardingNavigation.vue', () => {
 
   test('displays different next step title', () => {
     const wrapper = renderComponent({
-      previousStep: 'foo',
+      previousStep: 'onboarding-welcome',
       nextStepTitle: 'nextStepTitle',
     })
 
@@ -38,7 +33,7 @@ describe('OnboardingNavigation.vue', () => {
 
   test('display disabled next button', () => {
     const wrapper = renderComponent({
-      previousStep: 'foo',
+      previousStep: 'onboarding-welcome',
       shouldAllowNext: false,
     })
 
@@ -52,20 +47,21 @@ describe('OnboardingNavigation.vue', () => {
   })
 
   test('changes step to previous', async () => {
+    store.state.onboarding.step = 'onboarding-deployment-types'
     const wrapper = renderComponent({
-      previousStep: 'foo',
+      previousStep: 'onboarding-welcome',
     })
 
-    expect(store.state.onboarding.step).toBe('onboarding-welcome')
+    expect(store.state.onboarding.step).toBe('onboarding-deployment-types')
 
     await wrapper.find('[data-testid="onboarding-previous-button"]').trigger('click')
 
-    expect(store.state.onboarding.step).toBe('foo')
+    expect(store.state.onboarding.step).toBe('onboarding-welcome')
   })
 
   test('calls skip onboarding', async () => {
     const wrapper = renderComponent({
-      previousStep: 'foo',
+      previousStep: 'onboarding-welcome',
     })
 
     expect(store.state.onboarding.isCompleted).toBe(false)

--- a/src/app/onboarding/components/OnboardingNavigation.vue
+++ b/src/app/onboarding/components/OnboardingNavigation.vue
@@ -1,133 +1,102 @@
 <template>
-  <div :class="classes">
+  <div class="onboarding-actions">
     <KButton
-      v-if="previousStep"
-      appearance="primary"
-      class="navigation-button navigation-button--back"
-      :to="{ name: previousStep }"
+      v-if="props.previousStep"
+      appearance="secondary"
+      :to="{ name: props.previousStep }"
       data-testid="onboarding-previous-button"
-      @click="changeStep(previousStep)"
+      @click="changeStep(props.previousStep)"
     >
       Back
     </KButton>
 
-    <div>
+    <div class="button-list">
       <KButton
-        v-if="showSkip"
-        class="skip-button"
-        appearance="btn-link"
-        size="small"
+        v-if="props.showSkip"
+        appearance="outline"
         data-testid="onboarding-skip-button"
+        :to="{ name: 'home' }"
         @click="skipOnboarding"
       >
-        Skip Setup
+        Skip setup
       </KButton>
 
-      <span :class="['inline-block', {'cursor-not-allowed': !shouldAllowNext} ]">
-        <KButton
-          :disabled="!shouldAllowNext"
-          class="navigation-button navigation-button--next"
-          appearance="primary"
-          :to="{ name: nextStep }"
-          data-testid="onboarding-next-button"
-          @click="lastStep ? skipOnboarding() : changeStep(nextStep)"
-        >
-          {{ nextStepTitle }}
-        </KButton>
-      </span>
+      <KButton
+        :disabled="!props.shouldAllowNext"
+        :appearance="props.lastStep ? 'creation' : 'primary'"
+        :to="{ name: props.lastStep ? 'home' : props.nextStep }"
+        data-testid="onboarding-next-button"
+        @click="props.lastStep ? skipOnboarding() : changeStep(props.nextStep)"
+      >
+        {{ props.nextStepTitle }}
+      </KButton>
     </div>
   </div>
 </template>
 
-<script>
-import { mapActions } from 'vuex'
+<script lang="ts" setup>
 import { KButton } from '@kong/kongponents'
 
-export default {
-  name: 'OnboardingNavigation',
+import { useStore } from '@/store/store'
 
-  components: {
-    KButton,
+const store = useStore()
+
+const props = defineProps({
+  shouldAllowNext: {
+    type: Boolean,
+    required: false,
+    default: true,
   },
 
-  props: {
-    shouldAllowNext: {
-      type: Boolean,
-      default: true,
-    },
-    showSkip: {
-      type: Boolean,
-      default: true,
-    },
-    nextStep: {
-      type: String,
-      required: true,
-    },
-    previousStep: {
-      type: String,
-      default: '',
-    },
-    nextStepTitle: {
-      type: String,
-      default: 'Next',
-    },
-    lastStep: {
-      type: Boolean,
-      default: false,
-    },
+  showSkip: {
+    type: Boolean,
+    required: false,
+    default: true,
   },
-  computed: {
-    classes() {
-      return [
-        'mt-4 flex items-center flex-col sm:flex-row',
-        {
-          'justify-center': this.lastStep,
-          'justify-between': this.previousStep && !this.lastStep,
-          'justify-end': !this.previousStep && !this.lastStep,
-        },
-      ]
-    },
-  },
-  methods: {
-    ...mapActions('onboarding', ['completeOnboarding', 'changeStep']),
 
-    skipOnboarding() {
-      this.completeOnboarding()
-      this.$router.push({ name: 'home' })
-    },
+  nextStep: {
+    type: String,
+    required: true,
   },
+
+  previousStep: {
+    type: String,
+    required: false,
+    default: '',
+  },
+
+  nextStepTitle: {
+    type: String,
+    required: false,
+    default: 'Next',
+  },
+
+  lastStep: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+})
+
+function skipOnboarding(): void {
+  store.dispatch('onboarding/completeOnboarding')
+}
+
+function changeStep(step: string): void {
+  store.dispatch('onboarding/changeStep', step)
 }
 </script>
 
 <style lang="scss" scoped>
-.navigation-button {
-  @apply text-lg font-bold;
-
-  --KButtonPaddingY: 12px;
-  --KButtonPaddingX: 48px;
-  --KButtonRadius: 25px;
-
-  &--back {
-    color: var(--grey-600) !important;
-    --KButtonPrimaryBase: var(--OnboardingBackButton);
-    --KButtonPrimaryHover: var(--OnboardingBackButtonHover);
-    --KButtonPrimaryActive: var(--OnboardingBackButtonHover);
-  }
-
-  &--next {
-    --KButtonPrimaryBase: var(--OnboardingNextButton);
-    --KButtonPrimaryHover: var(--OnboardingNextButtonHover);
-    --KButtonPrimaryActive: var(--OnboardingNextButtonHover);
-  }
-
-  &[disabled] {
-    cursor: not-allowed;
-  }
+.onboarding-actions {
+  display: flex;
+  justify-content: space-between;
 }
 
-.skip-button {
-  @apply font-medium mr-8;
-
-  --KButtonBtnLink: var(--OnboardingSkipSetupButton);
+.button-list {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
 }
 </style>

--- a/src/app/onboarding/components/OnboardingPage.vue
+++ b/src/app/onboarding/components/OnboardingPage.vue
@@ -4,68 +4,78 @@
       <div class="onboarding-container__header">
         <slot name="header" />
       </div>
-      <div :class="classes">
-        <div class="w-full">
+
+      <div
+        class="onboarding-container__content"
+        :class="{ 'onboarding-container__content--with-image': props.withImage }"
+      >
+        <div class="onboarding-container__inner-content">
           <slot name="content" />
         </div>
       </div>
-      <slot name="navigation" />
+
+      <div class="mt-4">
+        <slot name="navigation" />
+      </div>
     </div>
 
     <div class="background-image" />
   </div>
 </template>
 
-<script>
-export default {
-  name: 'OnboardingContainer',
-  props: {
-    withImage: {
-      type: Boolean,
-      default: false,
-    },
+<script lang="ts" setup>
+const props = defineProps({
+  withImage: {
+    type: Boolean,
+    required: false,
+    default: false,
   },
-
-  computed: {
-    classes() {
-      return ['onboarding-container__content', this.withImage ? 'onboarding-container__content--with-image' : '']
-    },
-  },
-}
+})
 </script>
 
 <style lang="scss" scoped>
 .onboarding-container {
-  @apply w-full mx-auto my-0 px-4;
+  width: 100%;
+  margin: 0 auto;
+  padding: var(--spacing-md);
+  background-color: var(--white);
+  box-shadow: var(--OnboardingShadow);
 
-  &__header {
-    @apply my-10;
-  }
-
-  &__content {
-    @apply relative flex items-center justify-center p-10 w-full bg-white text-lg;
-    min-height: 500px;
-    box-shadow: var(--OnboardingShadow);
-
-    --KTableHeaderSize: 18px;
-
-    &--with-image {
-      background: var(--OnboardingPageGraphBackground);
-    }
-  }
-
-  @media screen and (min-width: 768px) {
+  @media (min-width: 768px) {
     max-width: 1075px;
   }
 
-  @media screen and (min-height: 950px) {
+  @media (min-height: 950px) {
     width: 100%;
     position: absolute;
-    top: 40%;
-    transform: translateY(-50%);
+    top: 50%;
     left: 0;
     right: 0;
+    transform: translateY(-50%);
   }
+}
+
+.onboarding-container__header {
+  margin-bottom: var(--spacing-lg);
+}
+
+.onboarding-container__content {
+  width: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 500px;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
+.onboarding-container__inner-content {
+  width: 100%;
+}
+
+.onboarding-container__content--with-image {
+  background: var(--OnboardingPageGraphBackground);
 }
 
 .background-image {
@@ -78,10 +88,9 @@ export default {
   filter: grayscale(1);
   width: 100vw;
   background: transparent url('@/assets/images/onboarding-background.svg?url') no-repeat scroll 0% 0%;
-
   min-width: 1700px;
 
-  @media screen and (max-width: 1699px) {
+  @media (max-width: 1699px) {
     left: 50%;
     top: 50%;
     transform: translateX(-50%) translateY(-50%);

--- a/src/app/onboarding/components/ServiceBox.vue
+++ b/src/app/onboarding/components/ServiceBox.vue
@@ -1,53 +1,43 @@
 <template>
   <div
+    class="box"
+    :class="{ 'box--active': props.active }"
     data-testid="box"
-    :class="classes"
-    @click="$emit('clicked')"
+    @click="emit('clicked')"
   >
     <slot />
   </div>
 </template>
 
-<script>
-export default {
-  name: 'ServiceBox',
-
-  props: {
-    active: {
-      type: Boolean,
-      default: false,
-    },
+<script lang="ts" setup>
+const props = defineProps({
+  active: {
+    type: Boolean,
+    required: false,
+    default: false,
   },
+})
 
-  emits: ['clicked'],
-
-  computed: {
-    classes() {
-      return [
-        'box',
-        {
-          'box--active': this.active,
-        },
-      ]
-    },
-  },
-}
+const emit = defineEmits<{
+  (event: 'clicked'): void,
+}>()
 </script>
 
 <style lang="scss" scoped>
 .box {
-  @apply w-72 h-72 p-12 flex items-center justify-center;
-
-  border: 3px solid #c2c2c2;
+  cursor: pointer;
+  height: 18rem;
+  width: 18rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-lg);
+  border: 3px solid var(--grey-400);
   border-radius: 5px;
   box-shadow: 4px 4px 14px 4px var(--OnboardingShadow);
+}
 
-  &--active {
-    border-color: var(--OnbordingBoxBorder);
-  }
-
-  &--small {
-    @apply w-32 h-40 p-4 m-2;
-  }
+.box--active {
+  border-color: var(--OnbordingBoxBorder);
 }
 </style>

--- a/src/app/onboarding/components/WelcomeAnimationSvg.vue
+++ b/src/app/onboarding/components/WelcomeAnimationSvg.vue
@@ -1,7 +1,7 @@
 <template>
   <svg
-    class="background"
-    :class="svgClasses"
+    class="background svg"
+    :class="{ active: mounted }"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1920 1080"
   >
@@ -51,74 +51,48 @@
         stroke-width="6"
       >
         <path
-          class="nodepath"
           d="M1444 893h252"
         />
         <path
-          class="nodepath"
           stroke-opacity=".4"
           d="M1529 705h232M1452 603h237"
         />
         <path
-          class="nodepath"
           d="M1754 563l-332 332h-76M1444 935l121 121M263 859l156 156"
         />
         <path
-          class="nodepath"
           stroke-opacity=".4"
           d="M742 781H556"
         />
         <path
-          class="nodepath"
           d="M697 736H513"
         />
         <path
-          class="nodepath"
           stroke-opacity=".4"
           d="M695 783V577"
         />
         <path
-          class="nodepath"
           d="M261 1026V751M509 573V438M1502 415l291 290"
         />
         <path
-          class="nodepath"
           stroke-opacity=".4"
           d="M698 912L26 240M1368 411v540l61 61 95-95M1434 3h267l193 192v354"
         />
         <path
-          class="nodepath"
           d="M517 411h342l138 138M1416 573v242l371 323"
         />
         <path
-          class="nodepath"
           d="M1486 817V612l-146-146M839 243h-97l-83 84v348M1698 1063V817l58-57h122M1069 299L558 810M696 1058H585L468 941V570L322 424"
         />
         <path
-          class="nodepath"
           d="M277 528l160 160 236-236 121 121M632 979h-45l-67-67v-86H0M106 669h275M70 707h331M207 745h210M85 784h356M1417 558h228M1609 634h203M528 946h76M619 604v131M1359 567l125 125M1332 594l156 156M1594 1070V959M381 632L260 753"
         />
         <path
-          class="nodepath"
           stroke-opacity=".4"
           d="M605 817V497M1851 959h-518M944 570H390"
         />
         <path
-          class="nodepath"
           d="M638 912H342M635 1139V912"
-        />
-        <path
-          stroke="url(#a)"
-          d="M1024 573h297v532h-31"
-          class="final"
-          transform="translate(0 3)"
-        />
-        <path
-          fill="url(#b)"
-          fill-rule="nonzero"
-          d="M1024 592a18 18 0 100-36 18 18 0 000 36z"
-          class="final circle"
-          transform="translate(0 3)"
         />
       </g>
       <foreignObject
@@ -158,31 +132,16 @@
   </svg>
 </template>
 
-<script>
-export default {
-  name: 'WelcomeAnimationSvg',
-  data() {
-    return {
-      mounted: false,
-    }
-  },
+<script lang="ts" setup>
+import { onMounted, ref } from 'vue'
 
-  computed: {
-    svgClasses() {
-      return [
-        'svg',
-        {
-          active: this.mounted,
-        },
-      ]
-    },
-  },
-  mounted() {
-    setTimeout(() => {
-      this.mounted = true
-    }, 30)
-  },
-}
+const mounted = ref(false)
+
+onMounted(function () {
+  window.setTimeout(() => {
+    mounted.value = true
+  }, 30)
+})
 </script>
 
 <style lang="scss" scoped>
@@ -336,18 +295,6 @@ export default {
     opacity: 0.3;
     will-change: stroke-dashoffset, filter;
 
-    &.final {
-      stroke-dashoffset: 1000px;
-    }
-    &.circle {
-      opacity: 1;
-      stroke-dasharray: 0 0;
-      stroke-dashoffset: 0;
-      transform: scale(0);
-      transition: #{0.2*$baseSpeed}s ease-in-out;
-      transform-origin: 1022px 570px;
-    }
-
     @for $i from 1 through 5 {
       $length: nth($lengths, $i);
       filter: hue-rotate(40deg) brightness(2) blur(4px);
@@ -394,24 +341,6 @@ export default {
       stroke-dashoffset: 0;
       opacity: 0.3;
       filter: hue-rotate(0deg) brightness(1) blur(0px);
-      @for $i from 1 through 20 {
-        &:nth-of-type(#{$i}) {
-          &.final {
-            opacity: 1;
-            transition: #{0.75*$baseSpeed}s ease-in-out, stroke-dashoffset #{1.5*$baseSpeed}s ease-in-out;
-            transition-delay: #{7*$baseSpeed}s, #{7.15*$baseSpeed}s;
-            &.circle {
-              transition: 400ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
-              transition-delay: #{1*$baseSpeed}s;
-            }
-          }
-        }
-      }
-
-      &.circle {
-        transform: scale(1);
-        opacity: 1;
-      }
     }
     @supports (not (offset-distance: 100%)) {
       foreignObject div {
@@ -421,11 +350,8 @@ export default {
   }
 }
 .background {
-  position: absolute;
+  position: fixed;
   z-index: -1;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  inset: 0;
 }
 </style>

--- a/src/app/onboarding/components/__snapshots__/OnboardingHeading.spec.ts.snap
+++ b/src/app/onboarding/components/__snapshots__/OnboardingHeading.spec.ts.snap
@@ -2,17 +2,21 @@
 
 exports[`OnboardingHeading.vue renders snapshot 1`] = `
 <div
-  class="relative"
+  class="onboarding-heading"
 >
   <h1
     class="onboarding-title"
   >
+    
     title
+    
   </h1>
-  <p
-    class="text-center text-lg mt-3"
+  <div
+    class="onboarding-description"
   >
+    
     description
-  </p>
+    
+  </div>
 </div>
 `;

--- a/src/app/onboarding/components/__snapshots__/OnboardingNavigation.spec.ts.snap
+++ b/src/app/onboarding/components/__snapshots__/OnboardingNavigation.spec.ts.snap
@@ -2,11 +2,12 @@
 
 exports[`OnboardingNavigation.vue renders snapshot 1`] = `
 <div
-  class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+  class="onboarding-actions"
 >
   <a
-    class="k-button medium rounded primary navigation-button navigation-button--back"
+    class="k-button medium rounded secondary"
     data-testid="onboarding-previous-button"
+    href="/onboarding/welcome"
     type="button"
   >
     
@@ -17,37 +18,37 @@ exports[`OnboardingNavigation.vue renders snapshot 1`] = `
     
     <!---->
   </a>
-  <div>
-    <button
-      class="k-button small rounded btn-link skip-button"
+  <div
+    class="button-list"
+  >
+    <a
+      class="k-button medium rounded outline"
       data-testid="onboarding-skip-button"
+      href="/"
       type="button"
     >
       
       <!---->
       
       
-       Skip Setup 
+       Skip setup 
       
       <!---->
-    </button>
-    <span
-      class="inline-block"
+    </a>
+    <a
+      class="k-button medium rounded primary"
+      data-testid="onboarding-next-button"
+      href="/onboarding/configuration-types"
+      type="button"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--next"
-        data-testid="onboarding-next-button"
-        type="button"
-      >
-        
-        <!---->
-        
-        
-        Next
-        
-        <!---->
-      </a>
-    </span>
+      
+      <!---->
+      
+      
+      Next
+      
+      <!---->
+    </a>
   </div>
 </div>
 `;

--- a/src/app/onboarding/views/AddNewServices.vue
+++ b/src/app/onboarding/views/AddNewServices.vue
@@ -1,44 +1,42 @@
 <template>
   <OnboardingPage>
     <template #header>
-      <OnboardingHeading title="Add services" />
+      <OnboardingHeading>
+        <template #title>
+          Add services
+        </template>
+      </OnboardingHeading>
     </template>
 
     <template #content>
-      <div class="h-full w-full flex justify-evenly items-center">
+      <div class="service-mode-list">
         <ServiceBox
           :active="mode === 'demo'"
-          class="cursor-pointer"
-          @clicked="update('demo')"
+          @clicked="setMode('demo')"
         >
-          <div>
+          <div class="service-box-content">
             <img src="@/assets/images/new-service-demo.svg?url">
 
-            <div class="ml-3">
-              <p class="uppercase font-bold tracking-wider">
-                Demo app
-              </p>
+            <p class="service-mode-title">
+              Demo app
+            </p>
 
-              <p>Counter application</p>
-            </div>
+            <p>Counter application</p>
           </div>
         </ServiceBox>
 
         <ServiceBox
           :active="mode === 'manually'"
-          class="cursor-pointer"
-          @clicked="update('manually')"
+          @clicked="setMode('manually')"
         >
-          <div class="cursor-pointer">
+          <div class="service-box-content">
             <img src="@/assets/images/new-service-manually.svg?url">
 
-            <div class="ml-3">
-              <p class="uppercase font-bold tracking-wider">
-                Manually
-              </p>
+            <p class="service-mode-title">
+              Manually
+            </p>
 
-              <p>After this wizard</p>
-            </div>
+            <p>After this wizard</p>
           </div>
         </ServiceBox>
       </div>
@@ -53,46 +51,46 @@
   </OnboardingPage>
 </template>
 
-<script>
-import { mapGetters, mapMutations } from 'vuex'
+<script lang="ts" setup>
+import { computed, ref, watch } from 'vue'
+
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
 import ServiceBox from '../components/ServiceBox.vue'
+import { useStore } from '@/store/store'
 
-export default {
-  name: 'AddNewServices',
-  components: {
-    OnboardingNavigation,
-    OnboardingHeading,
-    OnboardingPage,
-    ServiceBox,
-  },
-  computed: {
-    ...mapGetters({
-      onboardingMode: 'onboarding/getMode',
-    }),
+const store = useStore()
 
-    nextStep() {
-      if (this.mode === 'manually') {
-        return 'onboarding-completed'
-      }
+const mode = ref<'demo' | 'manually'>(store.state.onboarding.mode)
+const nextStep = computed(() => mode.value === 'manually' ? 'onboarding-completed' : 'onboarding-add-services-code')
 
-      return 'onboarding-add-services-code'
-    },
-    mode: {
-      get() {
-        return this.onboardingMode
-      },
-      set(value) {
-        this.update(value)
-      },
-    },
-  },
-  methods: {
-    ...mapMutations({
-      update: 'onboarding/UPDATE_MODE',
-    }),
-  },
+watch(() => mode.value, function () {
+  store.dispatch('onboarding/changeMode', mode.value)
+})
+
+function setMode(newMode: typeof mode.value): void {
+  mode.value = newMode
 }
 </script>
+
+<style lang="scss" scoped>
+.service-mode-list {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.service-box-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.service-mode-title {
+  text-transform: uppercase;
+  font-weight: bold;
+}
+</style>

--- a/src/app/onboarding/views/AddNewServicesCode.vue
+++ b/src/app/onboarding/views/AddNewServicesCode.vue
@@ -1,12 +1,16 @@
 <template>
   <OnboardingPage>
     <template #header>
-      <OnboardingHeading title="Add services" />
+      <OnboardingHeading>
+        <template #title>
+          Add services
+        </template>
+      </OnboardingHeading>
     </template>
+
     <template #content>
-      <p class="text-center mb-12">
-        The demo application includes two services: a Redis backend to store a counter value,
-        and a frontend web UI to show and increment the counter.
+      <p class="mb-4 text-center">
+        The demo application includes two services: a Redis backend to store a counter value, and a frontend web UI to show and increment the counter.
       </p>
 
       <template v-if="isKubernetes">
@@ -20,51 +24,53 @@
       </template>
 
       <div v-else>
-        <p>Clone the GitHub repository for the demo application:</p>
+        <p class="mb-4 text-center">
+          Clone <a
+            :href="githubLink"
+            target="_blank"
+          >the GitHub repository</a> for the demo application:
+        </p>
 
         <CodeBlock
           id="code-block-clone-command"
           language="bash"
-          :code="githubLink"
+          :code="`git clone ${githubLink}`"
         />
 
-        <KCard
-          title="And follow the instructions in the README"
-          border-variant="noBorder"
-        >
-          <template #body>
-            <a
-              target="_blank"
-              class="external-link-code-block"
-              :href="githubLinkReadme"
-            >
-              {{ githubLinkReadme }}
-            </a>
-          </template>
-        </KCard>
+        <p class="mt-4 text-center">
+          And follow the instructions in <a
+            :href="githubLinkReadme"
+            target="_blank"
+          >the README</a>.
+        </p>
       </div>
+
       <div>
-        <p class="text-center my-4">
+        <p class="status-box mt-4">
           DPPs status:
+
           <span
             v-if="hasDPPs"
-            class="text-green-500"
+            class="status--is-connected"
             data-testid="dpps-connected"
           >Connected</span>
+
           <span
             v-else
-            class="text-red-500"
+            class="status--is-disconnected"
             data-testid="dpps-disconnected"
-          >Disconeccted</span>
+          >Disconnected</span>
         </p>
+
         <div
           v-if="!hasDPPs"
-          class="flex justify-center"
+          class="status-loading-box mt-4"
         >
           <LoadingBox />
         </div>
       </div>
     </template>
+
     <template #navigation>
       <OnboardingNavigation
         next-step="onboarding-dataplanes-overview"
@@ -75,96 +81,73 @@
   </OnboardingPage>
 </template>
 
-<script>
-import { mapGetters } from 'vuex'
-import { KCard } from '@kong/kongponents'
+<script lang="ts" setup>
+import { computed, onUnmounted, ref } from 'vue'
 
 import { kumaApi } from '@/api/kumaApi'
-import { PRODUCT_NAME } from '@/constants'
-import { kumaDpServerUrl } from '@/utilities/kumaDpServerUrl'
-import { toYaml } from '@/utilities/toYaml'
+import { useStore } from '@/store/store'
 import CodeBlock from '@/app/common/CodeBlock.vue'
 import LoadingBox from '@/app/common/LoadingBox.vue'
-import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
+import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
+
+const store = useStore()
 
 const LONG_POOLING_INTERVAL = 1000
 
-const START_DP_CODE_DATAPLANE = {
-  type: 'Dataplane',
-  mesh: 'default',
-  name: 'example',
-  networking: {
-    address: 'localhost',
-    inbound: [
-      {
-        port: 7777,
-        servicePort: 7777,
-        serviceAddress: '127.0.0.1',
-        tags: {
-          'kuma.io/service': 'example',
-          'kuma.io/protocol': 'tcp',
-        },
-      },
-    ],
-  },
+const githubLink = 'https://github.com/kumahq/kuma-counter-demo/'
+const githubLinkReadme = 'https://github.com/kumahq/kuma-counter-demo/blob/master/README.md'
+const k8sRunCommand = 'kubectl apply -f https://bit.ly/3Kh2Try'
+
+const hasDPPs = ref(false)
+const dppsTimeout = ref<number | null>(null)
+
+const isKubernetes = computed(() => store.getters['config/getEnvironment'] === 'kubernetes')
+
+getDPPs()
+
+onUnmounted(function () {
+  clearTimeout()
+})
+
+async function getDPPs() {
+  try {
+    const { total } = await kumaApi.getAllDataplanes()
+
+    hasDPPs.value = total > 0
+  } catch (err) {
+    console.error(err)
+  } finally {
+    if (!hasDPPs.value) {
+      clearTimeout()
+      dppsTimeout.value = window.setTimeout(() => getDPPs(), LONG_POOLING_INTERVAL)
+    }
+  }
 }
 
-export default {
-  name: 'AddNewServicesCode',
-  components: {
-    CodeBlock,
-    OnboardingNavigation,
-    OnboardingHeading,
-    OnboardingPage,
-    LoadingBox,
-    KCard,
-  },
-  data() {
-    return {
-      productName: PRODUCT_NAME,
-      githubLink: 'https://github.com/kumahq/kuma-counter-demo/',
-      githubLinkReadme: 'https://github.com/kumahq/kuma-counter-demo/blob/master/README.md',
-      k8sRunCommand: 'kubectl apply -f https://bit.ly/3Kh2Try',
-      generateDpTokenCode: 'kumactl generate dataplane-token --name=redis > kuma-token-redis',
-      startDpCode: `kuma-dp run \\
-  --cp-address=${kumaDpServerUrl()} \\
-  --dataplane=${`"${toYaml(START_DP_CODE_DATAPLANE)}"`} \\
-  --dataplane-token-file=kuma-token-example`,
-      hasDPPs: false,
-      DPPsTimeout: null,
-    }
-  },
-  computed: {
-    ...mapGetters({
-      environment: 'config/getEnvironment',
-    }),
-    isKubernetes() {
-      return this.environment === 'kubernetes'
-    },
-  },
-  created() {
-    this.getDPPs()
-  },
-  unmounted() {
-    clearTimeout(this.DPPsTimeout)
-  },
-
-  methods: {
-    async getDPPs() {
-      try {
-        const { total } = await kumaApi.getAllDataplanes()
-
-        this.hasDPPs = total > 0
-      } catch (e) {
-        console.error(e)
-      }
-
-      if (!this.hasDPPs) {
-        this.DPPsTimeout = setTimeout(() => this.getDPPs(), LONG_POOLING_INTERVAL)
-      }
-    },
-  },
+function clearTimeout(): void {
+  if (dppsTimeout.value !== null) {
+    window.clearTimeout(dppsTimeout.value)
+  }
 }
 </script>
+
+<style lang="scss" scoped>
+.status-box {
+  text-align: center;
+}
+
+.status--is-connected {
+  color: var(--green-500);
+}
+
+.status--is-disconnected {
+  color: var(--red-500);
+}
+
+.status-loading-box {
+  display: flex;
+  justify-content: center;
+}
+</style>

--- a/src/app/onboarding/views/CompletedView.vue
+++ b/src/app/onboarding/views/CompletedView.vue
@@ -1,11 +1,15 @@
 <template>
   <OnboardingPage>
     <template #header>
-      <OnboardingHeading title="Go to the dashboard" />
+      <OnboardingHeading>
+        <template #title>
+          Go to the dashboard
+        </template>
+      </OnboardingHeading>
     </template>
 
     <template #content>
-      <div class="flex justify-center">
+      <div class="gui-preview-image">
         <img src="@/assets/images/kuma_gui.png">
       </div>
     </template>
@@ -13,7 +17,7 @@
     <template #navigation>
       <OnboardingNavigation
         next-step="home"
-        next-step-title="Completed"
+        next-step-title="Complete"
         last-step
         :show-skip="false"
       />
@@ -26,3 +30,10 @@ import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
 </script>
+
+<style lang="scss" scoped>
+.gui-preview-image {
+  display: flex;
+  justify-content: center;
+}
+</style>

--- a/src/app/onboarding/views/ConfigurationTypes.spec.ts
+++ b/src/app/onboarding/views/ConfigurationTypes.spec.ts
@@ -10,16 +10,7 @@ function renderComponent(mode = 'standalone') {
   const clientConfig: ClientConfigInterface = { ...config, mode }
   store.state.config.clientConfig = clientConfig
 
-  return mount(ConfigurationTypes, {
-    global: {
-      stubs: {
-        'router-link': {
-          props: ['to'],
-          template: '<a>{{ to.name }}</a>',
-        },
-      },
-    },
-  })
+  return mount(ConfigurationTypes)
 }
 
 describe('ConfigurationTypes.vue', () => {
@@ -32,6 +23,6 @@ describe('ConfigurationTypes.vue', () => {
   test('renders multizone previous step', () => {
     const wrapper = renderComponent('global')
 
-    expect(wrapper.html()).toContain('onboarding-multi-zone')
+    expect(wrapper.html()).toContain('/onboarding/multi-zone')
   })
 })

--- a/src/app/onboarding/views/ConfigurationTypes.vue
+++ b/src/app/onboarding/views/ConfigurationTypes.vue
@@ -1,15 +1,19 @@
 <template>
   <OnboardingPage with-image>
     <template #header>
-      <OnboardingHeading title="Learn about configuration storage" />
+      <OnboardingHeading>
+        <template #title>
+          Learn about configuration storage
+        </template>
+      </OnboardingHeading>
     </template>
 
     <template #content>
-      <div class="h-full w-full flex items-center justify-center mb-10">
-        <component :is="currentGraph" />
+      <div class="graph-list mb-6">
+        <component :is="currentGraphComponent" />
       </div>
 
-      <div class="radio flex text-base justify-between w-full sm:w-3/4 md:w-3/5 lg:w-1/2 absolute bottom-0 right-0 left-0 mb-10 mx-auto configuration-type-radio-buttons">
+      <div class="radio-button-group">
         <KRadio
           v-model="mode"
           name="deployment"
@@ -45,66 +49,57 @@
   </OnboardingPage>
 </template>
 
-<script>
-import { mapGetters } from 'vuex'
+<script lang="ts" setup>
+import { computed, onMounted, ref } from 'vue'
 import { KRadio } from '@kong/kongponents'
 
-import { PRODUCT_NAME } from '@/constants'
+import { useStore } from '@/store/store'
 import KubernetesGraph from '../components/graphs/KubernetesGraph.vue'
-import PostgresGraph from '../components/graphs/PostgresGraph.vue'
 import MemoryGraph from '../components/graphs/MemoryGraph.vue'
-import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
+import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
+import PostgresGraph from '../components/graphs/PostgresGraph.vue'
 
-export default {
-  name: 'ConfigurationTypes',
-  components: {
-    KubernetesGraph,
-    PostgresGraph,
-    MemoryGraph,
-    OnboardingNavigation,
-    OnboardingHeading,
-    OnboardingPage,
-    KRadio,
-  },
-  data() {
-    return { mode: 'kubernetes', productName: PRODUCT_NAME }
-  },
-  computed: {
-    ...mapGetters({
-      multicluster: 'config/getMulticlusterStatus',
-      configurationType: 'config/getConfigurationType',
-    }),
-    nextStep() {
-      return this.multicluster ? 'onboarding-multi-zone' : 'onboarding-create-mesh'
-    },
-    currentGraph() {
-      switch (this.mode) {
-        case 'kubernetes':
-          return 'KubernetesGraph'
-        case 'postgres':
-          return 'PostgresGraph'
-        case 'memory':
-          return 'MemoryGraph'
-        default:
-          return 'KubernetesGraph'
-      }
-    },
-  },
-  mounted() {
-    this.mode = this.configurationType
-  },
+const componentMap: Record<string, any> = {
+  postgres: PostgresGraph,
+  memory: MemoryGraph,
+  kubernetes: KubernetesGraph,
 }
+
+const store = useStore()
+
+const mode = ref<'kubernetes' | 'postgres' | 'memory'>('kubernetes')
+
+onMounted(function () {
+  mode.value = store.getters['config/getConfigurationType']
+})
+
+const nextStep = computed(() => store.getters['config/getMulticlusterStatus'] ? 'onboarding-multi-zone' : 'onboarding-create-mesh')
+
+const currentGraphComponent = computed(() => componentMap[mode.value])
 </script>
 
 <style lang="scss" scoped>
-.configuration-type-radio-buttons {
+.graph-list {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.radio-button-group {
   --KRadioPrimary: var(--OnboardingRadio);
+
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-md);
   color: var(--OnboardingRadio);
 }
 
-.configuration-type-radio-buttons .k-radio {
+.radio-button-group .k-radio {
   cursor: pointer;
 }
 </style>

--- a/src/app/onboarding/views/CreateMesh.spec.ts
+++ b/src/app/onboarding/views/CreateMesh.spec.ts
@@ -10,16 +10,7 @@ function renderComponent(mode = 'standalone') {
   const clientConfig: ClientConfigInterface = { ...config, mode }
   store.state.config.clientConfig = clientConfig
 
-  return mount(CreateMesh, {
-    global: {
-      stubs: {
-        routerLink: {
-          props: ['to'],
-          template: '<a>{{ to.name }}</a>',
-        },
-      },
-    },
-  })
+  return mount(CreateMesh)
 }
 
 describe('CreateMesh.vue', () => {
@@ -34,6 +25,6 @@ describe('CreateMesh.vue', () => {
   test('renders multizone next step', () => {
     const wrapper = renderComponent('global')
 
-    expect(wrapper.html()).toContain('onboarding-multi-zone')
+    expect(wrapper.html()).toContain('/onboarding/multi-zone')
   })
 })

--- a/src/app/onboarding/views/CreateMesh.vue
+++ b/src/app/onboarding/views/CreateMesh.vue
@@ -1,26 +1,26 @@
 <template>
   <OnboardingPage>
     <template #header>
-      <OnboardingHeading title="Create the mesh" />
+      <OnboardingHeading>
+        <template #title>
+          Create the mesh
+        </template>
+      </OnboardingHeading>
     </template>
 
     <template #content>
-      <p class="text-center mb-4">
-        When you install, {{ productName }} creates a <i>default</i> mesh, but you can add as many meshes as you need.
+      <p class="mb-4 text-center">
+        When you install, {{ PRODUCT_NAME }} creates a <i>default</i> mesh, but you can add as many meshes as you need.
       </p>
 
-      <div class="flex justify-center mt-10 mb-12 pb-12">
-        <div class="w-full sm:w-3/5 lg:w-2/5 p-4">
-          <KTable
-            :fetcher="() => tableData"
-            :headers="tableHeaders"
-            disable-pagination
-            is-small
-          />
-        </div>
-      </div>
+      <KTable
+        class="table"
+        :fetcher="() => tableData"
+        :headers="TABLE_HEADERS"
+        disable-pagination
+      />
 
-      <p class="text-center">
+      <p class="mt-4 text-center">
         This mesh is empty. Next, you add services and their data plane proxies.
       </p>
     </template>
@@ -34,52 +34,41 @@
   </OnboardingPage>
 </template>
 
-<script>
-import { mapGetters } from 'vuex'
+<script lang="ts" setup>
+import { computed, ref } from 'vue'
 import { KTable } from '@kong/kongponents'
 
 import { PRODUCT_NAME } from '@/constants'
+import { useStore } from '@/store/store'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
 
-export default {
-  name: 'CreateMesh',
+const TABLE_HEADERS = [
+  { label: 'Name', key: 'name' },
+  { label: 'Services', key: 'servicesAmount' },
+  { label: 'DPPs', key: 'dppsAmount' },
+]
 
-  components: {
-    OnboardingNavigation,
-    OnboardingHeading,
-    OnboardingPage,
-    KTable,
-  },
+const store = useStore()
 
-  data() {
-    return {
-      productName: PRODUCT_NAME,
-      tableHeaders: [
-        { label: 'Name', key: 'name' },
-        { label: 'Services', key: 'servicesAmount' },
-        { label: 'DPPs', key: 'dppsAmount' },
-      ],
-      tableData: {
-        total: 1,
-        data: [
-          {
-            name: 'default',
-            servicesAmount: 0,
-            dppsAmount: 0,
-          },
-        ],
-      },
-    }
-  },
-  computed: {
-    ...mapGetters({
-      multicluster: 'config/getMulticlusterStatus',
-    }),
-    previousStep() {
-      return this.multicluster ? 'onboarding-multi-zone' : 'onboarding-configuration-types'
+const tableData = ref<{ total: number, data: any [] }>({
+  total: 1,
+  data: [
+    {
+      name: 'default',
+      servicesAmount: 0,
+      dppsAmount: 0,
     },
-  },
-}
+  ],
+})
+
+const previousStep = computed(() => store.getters['config/getMulticlusterStatus'] ? 'onboarding-multi-zone' : 'onboarding-configuration-types')
 </script>
+
+<style lang="scss" scoped>
+.table {
+  width: 50%;
+  margin: 0 auto;
+}
+</style>

--- a/src/app/onboarding/views/DeploymentTypes.vue
+++ b/src/app/onboarding/views/DeploymentTypes.vue
@@ -1,20 +1,23 @@
 <template>
   <OnboardingPage with-image>
     <template #header>
-      <OnboardingHeading
-        title="Learn about deployments"
-        :description="
-          `${productName} can be deployed in standalone or multi-zone mode.`
-        "
-      />
+      <OnboardingHeading>
+        <template #title>
+          Learn about deployments
+        </template>
+
+        <template #description>
+          <p>{{ PRODUCT_NAME }} can be deployed in standalone or multi-zone mode.</p>
+        </template>
+      </onboardingheading>
     </template>
 
     <template #content>
-      <div class="h-full w-full flex items-center justify-center mb-10">
-        <component :is="currentGraph" />
+      <div class="graph-list mb-6">
+        <component :is="currentGraphComponent" />
       </div>
 
-      <div class="radio flex text-base justify-between w-full sm:w-3/4 md:w-3/5 lg:w-1/2 absolute bottom-0 right-0 left-0 mb-10 mx-auto deployment-type-radio-buttons">
+      <div class="radio-button-group">
         <KRadio
           v-model="mode"
           name="mode"
@@ -44,52 +47,55 @@
   </OnboardingPage>
 </template>
 
-<script>
-import { mapGetters } from 'vuex'
+<script lang="ts" setup>
+import { computed, onMounted, ref } from 'vue'
 import { KRadio } from '@kong/kongponents'
 
 import { PRODUCT_NAME } from '@/constants'
+import { useStore } from '@/store/store'
 import MultizoneGraph from '../components/graphs/MultizoneGraph.vue'
 import StandaloneGraph from '../components/graphs/StandaloneGraph.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
 
-export default {
-  name: 'DeploymentTypes',
-  components: {
-    MultizoneGraph,
-    StandaloneGraph,
-    OnboardingNavigation,
-    OnboardingHeading,
-    OnboardingPage,
-    KRadio,
-  },
-  data() {
-    return { mode: 'standalone', productName: PRODUCT_NAME }
-  },
-
-  computed: {
-    ...mapGetters({
-      multicluster: 'config/getMulticlusterStatus',
-    }),
-    currentGraph() {
-      return this.mode === 'standalone' ? 'StandaloneGraph' : 'MultizoneGraph'
-    },
-  },
-  mounted() {
-    this.mode = this.multicluster ? 'multi-zone' : 'standalone'
-  },
+const componentMap: Record<string, any> = {
+  standalone: StandaloneGraph,
+  'multi-zone': MultizoneGraph,
 }
+
+const store = useStore()
+
+const mode = ref<'standalone' | 'multi-zone'>('standalone')
+
+const currentGraphComponent = computed(() => componentMap[mode.value])
+
+onMounted(function () {
+  mode.value = store.getters['config/getMulticlusterStatus'] ? 'multi-zone' : 'standalone'
+})
 </script>
 
 <style lang="scss" scoped>
-.deployment-type-radio-buttons {
+.graph-list {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.radio-button-group {
   --KRadioPrimary: var(--OnboardingRadio);
+  color: var(--OnboardingRadio);
+
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-md);
   color: var(--OnboardingRadio);
 }
 
-.deployment-type-radio-buttons .k-radio {
+.radio-button-group .k-radio {
   cursor: pointer;
 }
 </style>

--- a/src/app/onboarding/views/ShellEmpty.vue
+++ b/src/app/onboarding/views/ShellEmpty.vue
@@ -15,20 +15,16 @@
 <style lang="scss" scoped>
 .onboarding-view {
   --kuma-purple-1: #260d50;
-  --kuma-purple-1-rgb: 38, 13, 80;
   --kuma-purple-2: #822dc5;
-  --kuma-purple-2-rgb: 130, 45, 197;
-  --kuma-gradient: var(--kuma-purple-1), var(--kuma-purple-2);
-  --OnboardingTitle: var(--kuma-gradient);
   --OnboardingRadio: #5da46f;
   --OnboardingPageGraphBackground: #f6f8fd;
   --OnboardingNextButton: #5da46f;
   --OnboardingNextButtonHover: #539464;
   --OnboardingBackButton: #f6f8fd;
   --OnboardingBackButtonHover: #e1e8f8;
-  --OnboardingSkipSetupButton: rgba(var(--kuma-purple-1-rgb), 0.3);
+  --OnboardingSkipSetupButton: rgba(38, 13, 80, 0.3);
   --OnbordingBoxBorder: #7b2bbc;
-  --OnboardingLoading: var(--kuma-purple-2-rgb);
+  --OnboardingLoading: 130, 45, 197;
   --OnboardingShadow: 4px 4px 14px 4px rgba(103, 71, 128, 0.11);
 }
 </style>

--- a/src/app/onboarding/views/WelcomeView.vue
+++ b/src/app/onboarding/views/WelcomeView.vue
@@ -1,24 +1,30 @@
 <template>
   <div>
-    <div class="welcome-container">
-      <div class="content">
-        <h1 class="welcome-title">
-          Welcome to {{ productName }}
-        </h1>
+    <OnboardingPage>
+      <template #header>
+        <OnboardingHeading>
+          <template #title>
+            Welcome to {{ PRODUCT_NAME }}
+          </template>
 
-        <p class="welcome-description">
-          Congratulations on downloading {{ productName }}! You are just a <strong>few minutes</strong> away from getting your service mesh fully online.
-        </p>
+          <template #description>
+            <p>
+              Congratulations on downloading {{ PRODUCT_NAME }}! You are just a <strong>few minutes</strong> away from getting your service mesh fully online.
+            </p>
 
-        <p class="welcome-description">
-          We have automatically detected that you are running on <strong>{{ enviromentFormatted }}</strong>.
-        </p>
+            <p>
+              We have automatically detected that you are running on <strong>{{ enviromentFormatted }}</strong>.
+            </p>
+          </template>
+        </OnboardingHeading>
+      </template>
 
-        <h2 class="welcome-detected">
-          Let's get started:
+      <template #content>
+        <h2>
+          Let’s get started:
         </h2>
 
-        <ul>
+        <ul class="mt-4">
           <ItemStatus
             v-for="item in statuses"
             :key="item.name"
@@ -26,134 +32,61 @@
             :status="item.status"
           />
         </ul>
-      </div>
+      </template>
 
-      <div class="welcome-navigation">
+      <template #navigation>
         <OnboardingNavigation next-step="onboarding-deployment-types" />
-      </div>
-    </div>
+      </template>
+    </OnboardingPage>
 
-    <WelcomeAnimationSvg :longer="multicluster" />
+    <WelcomeAnimationSvg :longer="isMulticluster" />
   </div>
 </template>
 
-<script>
-import { mapGetters } from 'vuex'
+<script lang="ts" setup>
+import { computed } from 'vue'
 
 import { PRODUCT_NAME } from '@/constants'
+import { useStore } from '@/store/store'
 import ItemStatus from '../components/ItemStatus.vue'
 import WelcomeAnimationSvg from '../components/WelcomeAnimationSvg.vue'
+import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
+import OnboardingPage from '../components/OnboardingPage.vue'
 
-export default {
-  name: 'WelcomeView',
-  components: {
-    ItemStatus,
-    OnboardingNavigation,
-    WelcomeAnimationSvg,
+const store = useStore()
+
+const enviromentFormatted = computed(() => {
+  const environment = store.getters['config/getEnvironment']
+  return environment.charAt(0).toUpperCase() + environment.slice(1)
+})
+
+const isMulticluster = computed(() => store.getters['config/getMulticlusterStatus'])
+const statuses = computed(() => [
+  {
+    name: `Run ${PRODUCT_NAME} control plane`,
+    status: true,
   },
-
-  data() {
-    return {
-      productName: PRODUCT_NAME,
-    }
+  {
+    name: 'Learn about deployments',
+    status: false,
   },
-  computed: {
-    ...mapGetters({
-      environment: 'config/getEnvironment',
-      multicluster: 'config/getMulticlusterStatus',
-    }),
-    enviromentFormatted() {
-      return this.environment.charAt(0).toUpperCase() + this.environment.slice(1)
-    },
-    multizoneItems() {
-      const multizoneItems = []
-
-      if (this.multicluster) {
-        multizoneItems.push({
-          name: 'Add zones',
-          status: false,
-        })
-      }
-
-      return multizoneItems
-    },
-    statuses() {
-      return [
-        {
-          name: `Run ${this.productName} control plane`,
-          status: true,
-        },
-        {
-          name: 'Learn about deployments',
-          status: false,
-        },
-        {
-          name: 'Learn about configuration storage',
-          status: false,
-        },
-        ...this.multizoneItems,
-        {
-          name: 'Create the mesh',
-          status: false,
-        },
-        {
-          name: 'Add services',
-          status: false,
-        },
-        {
-          name: 'Go to the dashboard',
-          status: false,
-        },
-      ]
-    },
+  {
+    name: 'Learn about configuration storage',
+    status: false,
   },
-}
+  ...isMulticluster.value ? [{ name: 'Add zones', status: false }] : [],
+  {
+    name: 'Create the mesh',
+    status: false,
+  },
+  {
+    name: 'Add services',
+    status: false,
+  },
+  {
+    name: 'Go to the dashboard',
+    status: false,
+  },
+])
 </script>
-
-<style lang="scss" scoped>
-.welcome-container {
-  position: absolute;
-  z-index: 0;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 28rem;
-  animation: show 0.75s 0s 1 forwards;
-  background-color: var(--white);
-}
-
-.welcome-title {
-  @apply text-5xl font-bold mb-3;
-
-  background: linear-gradient(to right, var(--OnboardingTitle));
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
-
-.welcome-description {
-  @apply text-base mb-4;
-
-  @media screen and (max-width: 1699px) {
-    @apply mb-2;
-  }
-}
-
-.welcome-detected {
-  @apply text-2xl mb-4 font-bold;
-
-  @media screen and (max-width: 1699px) {
-    @apply text-xl mb-3;
-  }
-}
-
-@keyframes show {
-  0% {
-    opacity: 0;
-  }
-
-  100% {
-    opacity: 1;
-  }
-}
-</style>

--- a/src/app/onboarding/views/__snapshots__/AddNewServices.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/AddNewServices.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Add services
+          
+           Add services 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,59 +27,49 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <div
-          class="h-full w-full flex justify-evenly items-center"
+          class="service-mode-list"
         >
           <div
-            class="box box--active cursor-pointer"
-            data-testid="box"
-          >
-            
-            <div>
-              <img
-                src="[object Object]"
-              />
-              <div
-                class="ml-3"
-              >
-                <p
-                  class="uppercase font-bold tracking-wider"
-                >
-                   Demo app 
-                </p>
-                <p>
-                  Counter application
-                </p>
-              </div>
-            </div>
-            
-          </div>
-          <div
-            class="box cursor-pointer"
+            class="box box--active"
             data-testid="box"
           >
             
             <div
-              class="cursor-pointer"
+              class="service-box-content"
             >
-              <img
-                src="[object Object]"
-              />
-              <div
-                class="ml-3"
+              <img />
+              <p
+                class="service-mode-title"
               >
-                <p
-                  class="uppercase font-bold tracking-wider"
-                >
-                   Manually 
-                </p>
-                <p>
-                  After this wizard
-                </p>
-              </div>
+                 Demo app 
+              </p>
+              <p>
+                Counter application
+              </p>
+            </div>
+            
+          </div>
+          <div
+            class="box"
+            data-testid="box"
+          >
+            
+            <div
+              class="service-box-content"
+            >
+              <img />
+              <p
+                class="service-mode-title"
+              >
+                 Manually 
+              </p>
+              <p>
+                After this wizard
+              </p>
             </div>
             
           </div>
@@ -85,43 +77,46 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/create-mesh"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/create-mesh"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            class="k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             href="/onboarding/add-services-code"
             type="button"
@@ -134,10 +129,10 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Add services
+          
+           Add services 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,17 +27,26 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <p
-          class="text-center mb-12"
+          class="mb-4 text-center"
         >
            The demo application includes two services: a Redis backend to store a counter value, and a frontend web UI to show and increment the counter. 
         </p>
         <div>
-          <p>
-            Clone the GitHub repository for the demo application:
+          <p
+            class="mb-4 text-center"
+          >
+             Clone 
+            <a
+              href="https://github.com/kumahq/kuma-counter-demo/"
+              target="_blank"
+            >
+              the GitHub repository
+            </a>
+             for the demo application: 
           </p>
           <div
             class="k-code-block theme-light code-block"
@@ -83,7 +94,12 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
                 <code
                   class="language-bash"
                 >
-                  https://github.com/kumahq/kuma-counter-demo/
+                  <span
+                    class="token function"
+                  >
+                    git
+                  </span>
+                   clone https://github.com/kumahq/kuma-counter-demo/
                 </code>
                 
       
@@ -135,60 +151,26 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
               </button>
             </div>
           </div>
-          <section
-            aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-            aria-label="And follow the instructions in the README"
-            class="kong-card noBorder"
+          <p
+            class="mt-4 text-center"
           >
-            <div
-              class="k-card-header d-flex mb-3"
+             And follow the instructions in 
+            <a
+              href="https://github.com/kumahq/kuma-counter-demo/blob/master/README.md"
+              target="_blank"
             >
-              <!---->
-              <div
-                class="k-card-title mb-3"
-              >
-                <h4>
-                  
-                  And follow the instructions in the README
-                  
-                </h4>
-              </div>
-              <div
-                class="k-card-actions"
-              >
-                
-                
-              </div>
-            </div>
-            <!---->
-            <div
-              class="k-card-content d-flex"
-            >
-              <div
-                class="k-card-body"
-                id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-              >
-                
-                <a
-                  class="external-link-code-block"
-                  href="https://github.com/kumahq/kuma-counter-demo/blob/master/README.md"
-                  target="_blank"
-                >
-                  https://github.com/kumahq/kuma-counter-demo/blob/master/README.md
-                </a>
-                
-              </div>
-              <!---->
-            </div>
-          </section>
+              the README
+            </a>
+            . 
+          </p>
         </div>
         <div>
           <p
-            class="text-center my-4"
+            class="status-box mt-4"
           >
              DPPs status: 
             <span
-              class="text-green-500"
+              class="status--is-connected"
               data-testid="dpps-connected"
             >
               Connected
@@ -199,43 +181,47 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/add-services"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/add-services"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            aria-current="page"
+            class="router-link-active router-link-exact-active k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             href="/onboarding/dataplanes-overview"
             type="button"
@@ -248,10 +234,10 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/CompletedView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/CompletedView.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`CompletedView.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Go to the dashboard
+          
+           Go to the dashboard 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,29 +27,31 @@ exports[`CompletedView.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <div
-          class="flex justify-center"
+          class="gui-preview-image"
         >
           <img />
         </div>
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-center"
+      class="mt-4"
     >
-      <!--v-if-->
-      <div>
+      
+      <div
+        class="onboarding-actions"
+      >
         <!--v-if-->
-        <span
-          class="inline-block"
+        <div
+          class="button-list"
         >
+          <!--v-if-->
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            class="k-button medium rounded creation"
             data-testid="onboarding-next-button"
             href="/"
             type="button"
@@ -56,14 +60,14 @@ exports[`CompletedView.vue renders snapshot 1`] = `
             <!---->
             
             
-            Completed
+            Complete
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/ConfigurationTypes.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/ConfigurationTypes.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`ConfigurationTypes.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Learn about configuration storage
+          
+           Learn about configuration storage 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,11 +27,11 @@ exports[`ConfigurationTypes.vue renders snapshot 1`] = `
       class="onboarding-container__content onboarding-container__content--with-image"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <div
-          class="h-full w-full flex items-center justify-center mb-10"
+          class="graph-list mb-6"
         >
           <svg
             fill="none"
@@ -884,7 +886,7 @@ exports[`ConfigurationTypes.vue renders snapshot 1`] = `
           </svg>
         </div>
         <div
-          class="radio flex text-base justify-between w-full sm:w-3/4 md:w-3/5 lg:w-1/2 absolute bottom-0 right-0 left-0 mb-10 mx-auto configuration-type-radio-buttons"
+          class="radio-button-group"
         >
           <label
             checked="true"
@@ -947,45 +949,62 @@ exports[`ConfigurationTypes.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        onboarding-deployment-types
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/deployment-types"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
-            data-testid="onboarding-next-button"
+            class="k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
             type="button"
           >
-            onboarding-create-mesh
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
           </a>
-        </span>
+          <a
+            class="k-button medium rounded primary"
+            data-testid="onboarding-next-button"
+            href="/onboarding/create-mesh"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+            Next
+            
+            <!---->
+          </a>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/CreateMesh.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/CreateMesh.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`CreateMesh.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Create the mesh
+          
+           Create the mesh 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,11 +27,11 @@ exports[`CreateMesh.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <p
-          class="text-center mb-4"
+          class="mb-4 text-center"
         >
            When you install, Kuma creates a 
           <i>
@@ -38,157 +40,166 @@ exports[`CreateMesh.vue renders snapshot 1`] = `
            mesh, but you can add as many meshes as you need. 
         </p>
         <div
-          class="flex justify-center mt-10 mb-12 pb-12"
+          class="k-table-container table"
         >
-          <div
-            class="w-full sm:w-3/5 lg:w-2/5 p-4"
+          <!---->
+          <section
+            class="k-table-wrapper"
           >
-            <div
-              class="k-table-container"
-              is-small=""
+            <table
+              class="k-table has-hover"
+              data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
             >
-              <!---->
-              <section
-                class="k-table-wrapper"
+              <thead
+                class=""
               >
-                <table
-                  class="k-table has-hover"
-                  data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                <tr
+                  class=""
                 >
-                  <thead
+                  
+                  <th
                     class=""
                   >
-                    <tr
-                      class=""
+                    <span
+                      class="d-flex align-items-center"
                     >
                       
-                      <th
+                      <span
                         class=""
                       >
-                        <span
-                          class="d-flex align-items-center"
-                        >
-                          
-                          <span
-                            class=""
-                          >
-                            Name
-                          </span>
-                          
-                          <!---->
-                        </span>
-                      </th>
-                      <th
-                        class=""
-                      >
-                        <span
-                          class="d-flex align-items-center"
-                        >
-                          
-                          <span
-                            class=""
-                          >
-                            Services
-                          </span>
-                          
-                          <!---->
-                        </span>
-                      </th>
-                      <th
-                        class=""
-                      >
-                        <span
-                          class="d-flex align-items-center"
-                        >
-                          
-                          <span
-                            class=""
-                          >
-                            DPPs
-                          </span>
-                          
-                          <!---->
-                        </span>
-                      </th>
+                        Name
+                      </span>
                       
-                    </tr>
-                  </thead>
-                  <tbody>
+                      <!---->
+                    </span>
+                  </th>
+                  <th
+                    class=""
+                  >
+                    <span
+                      class="d-flex align-items-center"
+                    >
+                      
+                      <span
+                        class=""
+                      >
+                        Services
+                      </span>
+                      
+                      <!---->
+                    </span>
+                  </th>
+                  <th
+                    class=""
+                  >
+                    <span
+                      class="d-flex align-items-center"
+                    >
+                      
+                      <span
+                        class=""
+                      >
+                        DPPs
+                      </span>
+                      
+                      <!---->
+                    </span>
+                  </th>
+                  
+                </tr>
+              </thead>
+              <tbody>
+                
+                <tr>
+                  
+                  <td>
                     
-                    <tr>
-                      
-                      <td>
-                        
-                        default
-                        
-                      </td>
-                      <td>
-                        
-                        0
-                        
-                      </td>
-                      <td>
-                        
-                        0
-                        
-                      </td>
-                      
-                    </tr>
+                    default
                     
-                  </tbody>
-                </table>
-                <!---->
-              </section>
-            </div>
-          </div>
+                  </td>
+                  <td>
+                    
+                    0
+                    
+                  </td>
+                  <td>
+                    
+                    0
+                    
+                  </td>
+                  
+                </tr>
+                
+              </tbody>
+            </table>
+            <!---->
+          </section>
         </div>
         <p
-          class="text-center"
+          class="mt-4 text-center"
         >
            This mesh is empty. Next, you add services and their data plane proxies. 
         </p>
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        onboarding-configuration-types
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/configuration-types"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
-            data-testid="onboarding-next-button"
+            aria-current="page"
+            class="router-link-active router-link-exact-active k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
             type="button"
           >
-            onboarding-add-services
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
           </a>
-        </span>
+          <a
+            class="k-button medium rounded primary"
+            data-testid="onboarding-next-button"
+            href="/onboarding/add-services"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+            Next
+            
+            <!---->
+          </a>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/DataplanesOverview.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/DataplanesOverview.spec.ts.snap
@@ -10,18 +10,26 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Success
+          
+          <p>
+            Success
+          </p>
+          
         </h1>
-        <p
-          class="text-center text-lg mt-3"
+        <div
+          class="onboarding-description"
         >
-          The following data plane proxies (DPPs) are connected to the control plane:
-        </p>
+          
+          <p>
+            The following data plane proxies (DPPs) are connected to the control plane:
+          </p>
+          
+        </div>
       </div>
       
     </div>
@@ -29,422 +37,419 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <div>
-          <div
-            class="flex justify-center mt-10 mb-16 pb-16"
+          <p
+            class="mb-4"
           >
-            <div
-              class="w-full sm:w-3/5 p-4"
+            <b>
+              Found 10 DPPs:
+            </b>
+          </p>
+          <div
+            class="k-table-container mb-4"
+          >
+            <!---->
+            <section
+              class="k-table-wrapper"
             >
-              <p
-                class="font-bold mb-4"
+              <table
+                class="k-table has-hover"
+                data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
               >
-                 Found 10 DPPs: 
-              </p>
-              <div
-                class="k-table-container onboarding-dataplane-table"
-                is-small=""
-              >
-                <!---->
-                <section
-                  class="k-table-wrapper"
+                <thead
+                  class=""
                 >
-                  <table
-                    class="k-table has-hover"
-                    data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                  <tr
+                    class=""
                   >
-                    <thead
+                    
+                    <th
                       class=""
                     >
-                      <tr
-                        class=""
+                      <span
+                        class="d-flex align-items-center"
                       >
                         
-                        <th
+                        <span
                           class=""
                         >
-                          <span
-                            class="d-flex align-items-center"
-                          >
-                            
-                            <span
-                              class=""
-                            >
-                              Mesh
-                            </span>
-                            
-                            <!---->
-                          </span>
-                        </th>
-                        <th
-                          class=""
-                        >
-                          <span
-                            class="d-flex align-items-center"
-                          >
-                            
-                            <span
-                              class=""
-                            >
-                              Name
-                            </span>
-                            
-                            <!---->
-                          </span>
-                        </th>
-                        <th
-                          class=""
-                        >
-                          <span
-                            class="d-flex align-items-center"
-                          >
-                            
-                            <span
-                              class=""
-                            >
-                              Status
-                            </span>
-                            
-                            <!---->
-                          </span>
-                        </th>
+                          Mesh
+                        </span>
                         
-                      </tr>
-                    </thead>
-                    <tbody>
+                        <!---->
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        class="d-flex align-items-center"
+                      >
+                        
+                        <span
+                          class=""
+                        >
+                          Name
+                        </span>
+                        
+                        <!---->
+                      </span>
+                    </th>
+                    <th
+                      class=""
+                    >
+                      <span
+                        class="d-flex align-items-center"
+                      >
+                        
+                        <span
+                          class=""
+                        >
+                          Status
+                        </span>
+                        
+                        <!---->
+                      </span>
+                    </th>
+                    
+                  </tr>
+                </thead>
+                <tbody>
+                  
+                  <tr>
+                    
+                    <td>
                       
-                      <tr>
-                        
-                        <td>
-                          
-                          default
-                          
-                        </td>
-                        <td>
-                          
-                          backend
-                          
-                        </td>
-                        <td>
-                          
-                          <span
-                            class="status status--with-title status--success"
-                            data-testid="status-badge"
-                          >
-                            <span
-                              class=""
-                            >
-                              online
-                            </span>
-                          </span>
-                          
-                        </td>
-                        
-                      </tr>
-                      <tr>
-                        
-                        <td>
-                          
-                          default
-                          
-                        </td>
-                        <td>
-                          
-                          frontend
-                          
-                        </td>
-                        <td>
-                          
-                          <span
-                            class="status status--with-title status--success"
-                            data-testid="status-badge"
-                          >
-                            <span
-                              class=""
-                            >
-                              online
-                            </span>
-                          </span>
-                          
-                        </td>
-                        
-                      </tr>
-                      <tr>
-                        
-                        <td>
-                          
-                          default
-                          
-                        </td>
-                        <td>
-                          
-                          db
-                          
-                        </td>
-                        <td>
-                          
-                          <span
-                            class="status status--with-title status--success"
-                            data-testid="status-badge"
-                          >
-                            <span
-                              class=""
-                            >
-                              online
-                            </span>
-                          </span>
-                          
-                        </td>
-                        
-                      </tr>
-                      <tr>
-                        
-                        <td>
-                          
-                          default
-                          
-                        </td>
-                        <td>
-                          
-                          no-subscriptions
-                          
-                        </td>
-                        <td>
-                          
-                          <span
-                            class="status status--with-title status--danger"
-                            data-testid="status-badge"
-                          >
-                            <span
-                              class=""
-                            >
-                              offline
-                            </span>
-                          </span>
-                          
-                        </td>
-                        
-                      </tr>
-                      <tr>
-                        
-                        <td>
-                          
-                          default
-                          
-                        </td>
-                        <td>
-                          
-                          cluster-1.backend-02
-                          
-                        </td>
-                        <td>
-                          
-                          <span
-                            class="status status--with-title status--success"
-                            data-testid="status-badge"
-                          >
-                            <span
-                              class=""
-                            >
-                              online
-                            </span>
-                          </span>
-                          
-                        </td>
-                        
-                      </tr>
-                      <tr>
-                        
-                        <td>
-                          
-                          default
-                          
-                        </td>
-                        <td>
-                          
-                          cluster-1.backend-03
-                          
-                        </td>
-                        <td>
-                          
-                          <span
-                            class="status status--with-title status--success"
-                            data-testid="status-badge"
-                          >
-                            <span
-                              class=""
-                            >
-                              online
-                            </span>
-                          </span>
-                          
-                        </td>
-                        
-                      </tr>
-                      <tr>
-                        
-                        <td>
-                          
-                          default
-                          
-                        </td>
-                        <td>
-                          
-                          cluster-1.gateway-01
-                          
-                        </td>
-                        <td>
-                          
-                          <span
-                            class="status status--with-title status--success"
-                            data-testid="status-badge"
-                          >
-                            <span
-                              class=""
-                            >
-                              online
-                            </span>
-                          </span>
-                          
-                        </td>
-                        
-                      </tr>
-                      <tr>
-                        
-                        <td>
-                          
-                          default
-                          
-                        </td>
-                        <td>
-                          
-                          cluster-1.ingress-02
-                          
-                        </td>
-                        <td>
-                          
-                          <span
-                            class="status status--with-title status--success"
-                            data-testid="status-badge"
-                          >
-                            <span
-                              class=""
-                            >
-                              online
-                            </span>
-                          </span>
-                          
-                        </td>
-                        
-                      </tr>
-                      <tr>
-                        
-                        <td>
-                          
-                          default
-                          
-                        </td>
-                        <td>
-                          
-                          dataplane-test-456
-                          
-                        </td>
-                        <td>
-                          
-                          <span
-                            class="status status--with-title status--success"
-                            data-testid="status-badge"
-                          >
-                            <span
-                              class=""
-                            >
-                              online
-                            </span>
-                          </span>
-                          
-                        </td>
-                        
-                      </tr>
-                      <tr>
-                        
-                        <td>
-                          
-                          default
-                          
-                        </td>
-                        <td>
-                          
-                          ingress-dp-test-123
-                          
-                        </td>
-                        <td>
-                          
-                          <span
-                            class="status status--with-title status--success"
-                            data-testid="status-badge"
-                          >
-                            <span
-                              class=""
-                            >
-                              online
-                            </span>
-                          </span>
-                          
-                        </td>
-                        
-                      </tr>
+                      default
                       
-                    </tbody>
-                  </table>
-                  <!---->
-                </section>
-              </div>
-            </div>
+                    </td>
+                    <td>
+                      
+                      backend
+                      
+                    </td>
+                    <td>
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr>
+                    
+                    <td>
+                      
+                      default
+                      
+                    </td>
+                    <td>
+                      
+                      frontend
+                      
+                    </td>
+                    <td>
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr>
+                    
+                    <td>
+                      
+                      default
+                      
+                    </td>
+                    <td>
+                      
+                      db
+                      
+                    </td>
+                    <td>
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr>
+                    
+                    <td>
+                      
+                      default
+                      
+                    </td>
+                    <td>
+                      
+                      no-subscriptions
+                      
+                    </td>
+                    <td>
+                      
+                      <span
+                        class="status status--with-title status--danger"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          offline
+                        </span>
+                      </span>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr>
+                    
+                    <td>
+                      
+                      default
+                      
+                    </td>
+                    <td>
+                      
+                      cluster-1.backend-02
+                      
+                    </td>
+                    <td>
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr>
+                    
+                    <td>
+                      
+                      default
+                      
+                    </td>
+                    <td>
+                      
+                      cluster-1.backend-03
+                      
+                    </td>
+                    <td>
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr>
+                    
+                    <td>
+                      
+                      default
+                      
+                    </td>
+                    <td>
+                      
+                      cluster-1.gateway-01
+                      
+                    </td>
+                    <td>
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr>
+                    
+                    <td>
+                      
+                      default
+                      
+                    </td>
+                    <td>
+                      
+                      cluster-1.ingress-02
+                      
+                    </td>
+                    <td>
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr>
+                    
+                    <td>
+                      
+                      default
+                      
+                    </td>
+                    <td>
+                      
+                      dataplane-test-456
+                      
+                    </td>
+                    <td>
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr>
+                    
+                    <td>
+                      
+                      default
+                      
+                    </td>
+                    <td>
+                      
+                      ingress-dp-test-123
+                      
+                    </td>
+                    <td>
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    
+                  </tr>
+                  
+                </tbody>
+              </table>
+              <!---->
+            </section>
           </div>
         </div>
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/add-services-code"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/add-services-code"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            aria-current="page"
+            class="router-link-active router-link-exact-active k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             href="/onboarding/completed"
             type="button"
@@ -457,10 +462,10 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/DeploymentTypes.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/DeploymentTypes.spec.ts.snap
@@ -10,18 +10,24 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Learn about deployments
+          
+           Learn about deployments 
+          
         </h1>
-        <p
-          class="text-center text-lg mt-3"
+        <div
+          class="onboarding-description"
         >
-          Kuma can be deployed in standalone or multi-zone mode.
-        </p>
+          
+          <p>
+            Kuma can be deployed in standalone or multi-zone mode.
+          </p>
+          
+        </div>
       </div>
       
     </div>
@@ -29,11 +35,11 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
       class="onboarding-container__content onboarding-container__content--with-image"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <div
-          class="h-full w-full flex items-center justify-center mb-10"
+          class="graph-list mb-6"
         >
           <svg
             data-testid="standalone-graph"
@@ -591,7 +597,7 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
           </svg>
         </div>
         <div
-          class="radio flex text-base justify-between w-full sm:w-3/4 md:w-3/5 lg:w-1/2 absolute bottom-0 right-0 left-0 mb-10 mx-auto deployment-type-radio-buttons"
+          class="radio-button-group"
         >
           <label
             checked="true"
@@ -637,43 +643,46 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/welcome"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/welcome"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            class="k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             href="/onboarding/configuration-types"
             type="button"
@@ -686,10 +695,10 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/MultiZoneView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/MultiZoneView.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Add zones
+          
+           Add zones 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,85 +27,53 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <p
-          class="text-center mb-4"
+          class="mb-4 text-center"
         >
            A zone requires both the zone control plane and zone ingress. On Kubernetes, you run a single command to create both resources. On Universal, you must create them separately. 
         </p>
-        <section
-          aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-          aria-label="See the documentation for options to install:"
-          class="kong-card noBorder"
+        <p
+          class="mb-4 text-center"
         >
-          <div
-            class="k-card-header d-flex mb-3"
-          >
-            <!---->
-            <div
-              class="k-card-title mb-3"
+          <b>
+            See 
+            <a
+              href="https://kuma.io/docs/1.7.x/deployments/multi-zone/?utm_source=Kuma&utm_medium=Kuma-GUI#zone-control-plane"
+              target="_blank"
             >
-              <h4>
-                
-                See the documentation for options to install:
-                
-              </h4>
-            </div>
-            <div
-              class="k-card-actions"
-            >
-              
-              
-            </div>
-          </div>
-          <!---->
-          <div
-            class="k-card-content d-flex"
-          >
-            <div
-              class="k-card-body"
-              id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-            >
-              
-              <a
-                class="external-link-code-block"
-                href="https://kuma.io/docs/1.7.x/deployments/multi-zone/?utm_source=Kuma&utm_medium=Kuma-GUI#zone-control-plane"
-                target="_blank"
-              >
-                https://kuma.io/docs/1.7.x/deployments/multi-zone/#zone-control-plane 
-              </a>
-              
-            </div>
-            <!---->
-          </div>
-        </section>
+              the documentation for options to install
+            </a>
+            .
+          </b>
+        </p>
         <div>
           <p
-            class="text-center my-4"
+            class="status-box mt-4"
           >
              Zone status: 
             <span
-              class="text-red-500"
+              class="status--is-disconnected"
               data-testid="zone-disconnected"
             >
               Disconnected
             </span>
           </p>
           <p
-            class="text-center mt-4 mb-10"
+            class="status-box mt-4"
           >
              Zone ingress status: 
             <span
-              class="text-red-500"
+              class="status--is-disconnected"
               data-testid="zone-ingress-disconnected"
             >
               Disconnected
             </span>
           </p>
           <div
-            class="flex justify-center"
+            class="status-loading-box mt-4"
           >
             <div
               class="loading"
@@ -120,43 +90,46 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/configuration-types"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/configuration-types"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block cursor-not-allowed"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            class="k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             disabled="true"
             href="/onboarding/create-mesh"
@@ -170,10 +143,10 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/WelcomeView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/WelcomeView.spec.ts.snap
@@ -2,154 +2,176 @@
 
 exports[`WelcomeView.vue renders snapshot 1`] = `
 <div>
-  <div
-    class="welcome-container"
-  >
+  <div>
     <div
-      class="content"
-    >
-      <h1
-        class="welcome-title"
-      >
-         Welcome to Kuma
-      </h1>
-      <p
-        class="welcome-description"
-      >
-         Congratulations on downloading Kuma! You are just a 
-        <strong>
-          few minutes
-        </strong>
-         away from getting your service mesh fully online. 
-      </p>
-      <p
-        class="welcome-description"
-      >
-         We have automatically detected that you are running on 
-        <strong>
-          Universal
-        </strong>
-        . 
-      </p>
-      <h2
-        class="welcome-detected"
-      >
-         Let's get started: 
-      </h2>
-      <ul>
-        
-        <li
-          class="flex items-center mb-2"
-        >
-          <span
-            class="circle"
-          >
-            <span
-              class="kong-icon kong-icon-check"
-            >
-              <svg
-                fill="none"
-                viewBox="0 0 20 20"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                
-  
-                <path
-                  d="m14 7-6 6-3-3"
-                  fill="none"
-                  stroke="#A3BBCC"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2.25"
-                />
-                
-
-              </svg>
-              
-
-            </span>
-          </span>
-           Run Kuma control plane
-        </li>
-        <li
-          class="flex items-center mb-2"
-        >
-          <span
-            class="circle"
-          >
-            <!--v-if-->
-          </span>
-           Learn about deployments
-        </li>
-        <li
-          class="flex items-center mb-2"
-        >
-          <span
-            class="circle"
-          >
-            <!--v-if-->
-          </span>
-           Learn about configuration storage
-        </li>
-        <li
-          class="flex items-center mb-2"
-        >
-          <span
-            class="circle"
-          >
-            <!--v-if-->
-          </span>
-           Create the mesh
-        </li>
-        <li
-          class="flex items-center mb-2"
-        >
-          <span
-            class="circle"
-          >
-            <!--v-if-->
-          </span>
-           Add services
-        </li>
-        <li
-          class="flex items-center mb-2"
-        >
-          <span
-            class="circle"
-          >
-            <!--v-if-->
-          </span>
-           Go to the dashboard
-        </li>
-        
-      </ul>
-    </div>
-    <div
-      class="welcome-navigation"
+      class="onboarding-container"
     >
       <div
-        class="mt-4 flex items-center flex-col sm:flex-row justify-end"
+        class="onboarding-container__header"
       >
-        <!--v-if-->
-        <div>
-          <button
-            class="k-button small rounded btn-link skip-button"
-            data-testid="onboarding-skip-button"
-            type="button"
+        
+        <div
+          class="onboarding-heading"
+        >
+          <h1
+            class="onboarding-title"
           >
             
-            <!---->
+             Welcome to Kuma
             
+          </h1>
+          <div
+            class="onboarding-description"
+          >
             
-             Skip Setup 
+            <p>
+               Congratulations on downloading Kuma! You are just a 
+              <strong>
+                few minutes
+              </strong>
+               away from getting your service mesh fully online. 
+            </p>
+            <p>
+               We have automatically detected that you are running on 
+              <strong>
+                Universal
+              </strong>
+              . 
+            </p>
             
-            <!---->
-          </button>
-          <span
-            class="inline-block"
+          </div>
+        </div>
+        
+      </div>
+      <div
+        class="onboarding-container__content"
+      >
+        <div
+          class="onboarding-container__inner-content"
+        >
+          
+          <h2>
+             Let’s get started: 
+          </h2>
+          <ul
+            class="mt-4"
+          >
+            
+            <li
+              class="item-status mb-2"
+            >
+              <span
+                class="circle mr-2"
+              >
+                <span
+                  class="kong-icon kong-icon-check"
+                >
+                  <svg
+                    fill="none"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    
+  
+                    <path
+                      d="m14 7-6 6-3-3"
+                      fill="none"
+                      stroke="#A3BBCC"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2.25"
+                    />
+                    
+
+                  </svg>
+                  
+
+                </span>
+              </span>
+               Run Kuma control plane
+            </li>
+            <li
+              class="item-status mb-2"
+            >
+              <span
+                class="circle mr-2"
+              >
+                <!--v-if-->
+              </span>
+               Learn about deployments
+            </li>
+            <li
+              class="item-status mb-2"
+            >
+              <span
+                class="circle mr-2"
+              >
+                <!--v-if-->
+              </span>
+               Learn about configuration storage
+            </li>
+            <li
+              class="item-status mb-2"
+            >
+              <span
+                class="circle mr-2"
+              >
+                <!--v-if-->
+              </span>
+               Create the mesh
+            </li>
+            <li
+              class="item-status mb-2"
+            >
+              <span
+                class="circle mr-2"
+              >
+                <!--v-if-->
+              </span>
+               Add services
+            </li>
+            <li
+              class="item-status mb-2"
+            >
+              <span
+                class="circle mr-2"
+              >
+                <!--v-if-->
+              </span>
+               Go to the dashboard
+            </li>
+            
+          </ul>
+          
+        </div>
+      </div>
+      <div
+        class="mt-4"
+      >
+        
+        <div
+          class="onboarding-actions"
+        >
+          <!--v-if-->
+          <div
+            class="button-list"
           >
             <a
-              class="k-button medium rounded primary navigation-button navigation-button--next"
+              class="k-button medium rounded outline"
+              data-testid="onboarding-skip-button"
+              href="/"
+              type="button"
+            >
+              
+              <!---->
+              
+              
+               Skip setup 
+              
+              <!---->
+            </a>
+            <a
+              class="k-button medium rounded primary"
               data-testid="onboarding-next-button"
               href="/onboarding/deployment-types"
               type="button"
@@ -162,10 +184,14 @@ exports[`WelcomeView.vue renders snapshot 1`] = `
               
               <!---->
             </a>
-          </span>
+          </div>
         </div>
+        
       </div>
     </div>
+    <div
+      class="background-image"
+    />
   </div>
   <svg
     class="background svg"
@@ -219,74 +245,48 @@ exports[`WelcomeView.vue renders snapshot 1`] = `
         stroke-width="6"
       >
         <path
-          class="nodepath"
           d="M1444 893h252"
         />
         <path
-          class="nodepath"
           d="M1529 705h232M1452 603h237"
           stroke-opacity=".4"
         />
         <path
-          class="nodepath"
           d="M1754 563l-332 332h-76M1444 935l121 121M263 859l156 156"
         />
         <path
-          class="nodepath"
           d="M742 781H556"
           stroke-opacity=".4"
         />
         <path
-          class="nodepath"
           d="M697 736H513"
         />
         <path
-          class="nodepath"
           d="M695 783V577"
           stroke-opacity=".4"
         />
         <path
-          class="nodepath"
           d="M261 1026V751M509 573V438M1502 415l291 290"
         />
         <path
-          class="nodepath"
           d="M698 912L26 240M1368 411v540l61 61 95-95M1434 3h267l193 192v354"
           stroke-opacity=".4"
         />
         <path
-          class="nodepath"
           d="M517 411h342l138 138M1416 573v242l371 323"
         />
         <path
-          class="nodepath"
           d="M1486 817V612l-146-146M839 243h-97l-83 84v348M1698 1063V817l58-57h122M1069 299L558 810M696 1058H585L468 941V570L322 424"
         />
         <path
-          class="nodepath"
           d="M277 528l160 160 236-236 121 121M632 979h-45l-67-67v-86H0M106 669h275M70 707h331M207 745h210M85 784h356M1417 558h228M1609 634h203M528 946h76M619 604v131M1359 567l125 125M1332 594l156 156M1594 1070V959M381 632L260 753"
         />
         <path
-          class="nodepath"
           d="M605 817V497M1851 959h-518M944 570H390"
           stroke-opacity=".4"
         />
         <path
-          class="nodepath"
           d="M638 912H342M635 1139V912"
-        />
-        <path
-          class="final"
-          d="M1024 573h297v532h-31"
-          stroke="url(#a)"
-          transform="translate(0 3)"
-        />
-        <path
-          class="final circle"
-          d="M1024 592a18 18 0 100-36 18 18 0 000 36z"
-          fill="url(#b)"
-          fill-rule="nonzero"
-          transform="translate(0 3)"
         />
       </g>
       <foreignobject

--- a/src/assets/styles/_utilities.scss
+++ b/src/assets/styles/_utilities.scss
@@ -1,3 +1,17 @@
+.cursor-help {
+  cursor: help;
+}
+
+.animate-pulse {
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@keyframes pulse {
+  50% {
+    opacity: .5
+  }
+}
+
 .visually-hidden {
   position: absolute !important;
   width: 1px !important;

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -52,7 +52,7 @@ const updateSelectedMeshGuard: NavigationGuard = function (to, _from, next) {
 const onboardingRouteGuard: NavigationGuard = function (to, _from, next) {
   const isOnboardingCompleted = store.state.onboarding.isCompleted
   const isOnboardingRoute = to.meta.onboardingProcess
-  const shouldSuggestOnboarding = store.getters['onboarding/showOnboarding']
+  const shouldSuggestOnboarding = store.getters.shouldSuggestOnboarding
 
   if (isOnboardingCompleted && isOnboardingRoute && !shouldSuggestOnboarding) {
     next({ name: 'home' })

--- a/src/store/modules/onboarding/onboarding.ts
+++ b/src/store/modules/onboarding/onboarding.ts
@@ -1,4 +1,5 @@
-import { ActionTree, GetterTree, MutationTree } from 'vuex'
+import { ActionTree, MutationTree } from 'vuex'
+
 import { State } from '../../storeConfig'
 import { OnboardingInterface } from './onboarding.types'
 import { ClientStorage } from '@/utilities/ClientStorage'
@@ -10,27 +11,14 @@ const initialOnboardingState: OnboardingInterface = {
 }
 
 const mutations: MutationTree<OnboardingInterface> = {
-  SET_STEP: (state, step) => (state.step = step),
-  SET_IS_COMPLETED: (state, isCompleted) => (state.isCompleted = isCompleted),
-  UPDATE_MODE: (state, message) => (state.mode = message),
-}
-
-const getters: GetterTree<OnboardingInterface, State> = {
-  getMode: state => state.mode,
-  showOnboarding: (_state, _getters, rootState) => {
-    const hasOnlyDefaultMesh = rootState.meshes.items.length === 1 && rootState.meshes.items[0].name === 'default'
-
-    return rootState.totalDataplaneCount === 0 && hasOnlyDefaultMesh
-  },
+  SET_STEP: (state, step: typeof state.step) => (state.step = step),
+  SET_IS_COMPLETED: (state, isCompleted: typeof state.isCompleted) => (state.isCompleted = isCompleted),
+  UPDATE_MODE: (state, mode: typeof state.mode) => (state.mode = mode),
 }
 
 const actions: ActionTree<OnboardingInterface, State> = {
-  // complete/skip onboarding
   completeOnboarding({ commit, dispatch }) {
-    // fetch the dataplanes
     dispatch('fetchDataplaneTotalCount', null, { root: true })
-
-    // fetch sidebar insights
     dispatch('sidebar/getInsights', null, { root: true })
 
     commit('SET_IS_COMPLETED', true)
@@ -38,17 +26,19 @@ const actions: ActionTree<OnboardingInterface, State> = {
     ClientStorage.remove('onboardingStep')
   },
 
-  // change step in onboarding
   changeStep({ commit }, step) {
     commit('SET_STEP', step)
     ClientStorage.set('onboardingStep', step)
+  },
+
+  changeMode({ commit }, mode) {
+    commit('UPDATE_MODE', mode)
   },
 }
 
 const onboardingModule = {
   namespaced: true,
   state: () => initialOnboardingState,
-  getters,
   mutations,
   actions,
 }

--- a/src/store/modules/onboarding/onboarding.types.ts
+++ b/src/store/modules/onboarding/onboarding.types.ts
@@ -1,5 +1,5 @@
 export interface OnboardingInterface {
   isCompleted: boolean;
   step: string;
-  mode: string
+  mode: 'demo' | 'manually'
 }

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -191,6 +191,11 @@ export const storeConfig: StoreOptions<State> = {
         }
       }
     },
+    shouldSuggestOnboarding: (state) => {
+      const hasOnlyDefaultMesh = state.meshes.items.length === 1 && state.meshes.items[0].name === 'default'
+
+      return state.totalDataplaneCount === 0 && hasOnlyDefaultMesh
+    },
   },
 
   mutations: {

--- a/src/test-data/createPolicyTypeEntries.ts
+++ b/src/test-data/createPolicyTypeEntries.ts
@@ -19,12 +19,13 @@ export function createPolicyTypeEntries(): PolicyTypeEntry[] {
             {
               name: 'mal-1',
               route: {
-                name: 'meshaccesslogs',
+                name: 'policy',
                 query: {
                   ns: 'mal-1',
                 },
                 params: {
                   mesh: 'default',
+                  policyPath: 'meshaccesslogs',
                 },
               },
             },
@@ -44,12 +45,13 @@ export function createPolicyTypeEntries(): PolicyTypeEntry[] {
             {
               name: 'mal-1',
               route: {
-                name: 'meshtraces',
+                name: 'policy',
                 query: {
                   ns: 'mal-1',
                 },
                 params: {
                   mesh: 'default',
+                  policyPath: 'meshtraces',
                 },
               },
             },
@@ -83,12 +85,13 @@ export function createPolicyTypeEntries(): PolicyTypeEntry[] {
             {
               name: 'mtp-1',
               route: {
-                name: 'meshtrafficpermissions',
+                name: 'policy',
                 query: {
                   ns: 'mtp-1',
                 },
                 params: {
                   mesh: 'default',
+                  policyPath: 'meshtrafficpermissions',
                 },
               },
             },
@@ -113,12 +116,13 @@ export function createPolicyTypeEntries(): PolicyTypeEntry[] {
             {
               name: 'default',
               route: {
-                name: 'meshtrafficpermissions',
+                name: 'policy',
                 query: {
                   ns: 'default',
                 },
                 params: {
                   mesh: 'default',
+                  policyPath: 'meshtrafficpermissions',
                 },
               },
             },
@@ -147,24 +151,26 @@ export function createPolicyTypeEntries(): PolicyTypeEntry[] {
             {
               name: 'mtp-1',
               route: {
-                name: 'meshtrafficpermissions',
+                name: 'policy',
                 query: {
                   ns: 'mtp-1',
                 },
                 params: {
                   mesh: 'default',
+                  policyPath: 'meshtrafficpermissions',
                 },
               },
             },
             {
               name: 'mtp-2',
               route: {
-                name: 'meshtrafficpermissions',
+                name: 'policy',
                 query: {
                   ns: 'mtp-2',
                 },
                 params: {
                   mesh: 'default',
+                  policyPath: 'meshtrafficpermissions',
                 },
               },
             },


### PR DESCRIPTION
Migrates all onboarding-related components to composition API.

Moves `shouldSuggestOnboarding` getter into global state as it only accesses global state.

Replaces all Tailwind utility classes in the onboarding module with either custom CSS or utility classes that are also present via Kongponents (which already override the Tailwind ones).

Removes some unnecessary router link stubs from some component tests (no more tests now use RouterLinkStub which allows their actual URLs to be visible).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>