### PR TITLE
chore: Move navItems into the container

### DIFF
--- a/src/app/AppSidebar.vue
+++ b/src/app/AppSidebar.vue
@@ -25,14 +25,15 @@
 import { computed, onMounted, onUnmounted, watch } from 'vue'
 
 import { useStore } from '@/store/store'
+import { useNav } from '@/utilities'
 import { poll } from '@/utilities/poll'
 import AppMeshSelector from './AppMeshSelector.vue'
 import AppNavItem from './AppNavItem.vue'
-import { getNavItems } from './getNavItems'
 
 const POLLING_INTERVAL_IN_SECONDS = 10
 
 const store = useStore()
+const getNavItems = useNav()
 
 const navItems = computed(() => getNavItems(store.getters['config/getMulticlusterStatus'], store.state.meshes.items.length > 0))
 const meshes = computed(() => store.state.meshes.items)

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -2,6 +2,7 @@ import { service, constant, get, injected } from './utils'
 import Env, { EnvArgs, EnvVars } from '@/services/env/Env'
 import routes from '@/router/routes'
 import { store } from '@/store/store'
+import { getNavItems } from '@/app/getNavItems'
 
 export const TOKENS = {
   EnvVars: constant({
@@ -16,5 +17,6 @@ export const TOKENS = {
 
   env: service(() => (key: keyof EnvVars) => get(TOKENS.Env).var(key), { description: 'env' }),
   routes: service(() => routes(store), { description: 'routes' }),
+  nav: service(() => (multizone: boolean, hasMeshes: boolean) => getNavItems(multizone, hasMeshes), { description: 'nav' }),
 }
 injected(Env, TOKENS.EnvVars)

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -2,4 +2,5 @@ import { TOKENS, createInjections } from '@/services'
 
 export const [
   useEnv,
-] = createInjections(TOKENS.env)
+  useNav,
+] = createInjections(TOKENS.env, TOKENS.nav)


### PR DESCRIPTION
This PR moves `getNavItems` into our service container.

Signed-off-by: John Cowen <john.cowen@konghq.com>

