### PR TITLE
refactor: cleans up onboarding store

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -76,7 +76,7 @@ const isLoading = ref(store.state.globalLoading)
  */
 const routeKey = computed(() => route.path)
 const shouldShowAppError = computed(() => store.state.config.status !== 'OK')
-const shouldSuggestOnboarding = computed(() => store.getters['onboarding/showOnboarding'])
+const shouldSuggestOnboarding = computed(() => store.getters.shouldSuggestOnboarding)
 const shouldShowNotificationManager = computed(() => store.getters['notifications/amountOfActions'] > 0)
 
 watch(() => store.state.globalLoading, function (globalLoading) {

--- a/src/app/onboarding/views/AddNewServices.vue
+++ b/src/app/onboarding/views/AddNewServices.vue
@@ -9,7 +9,7 @@
         <ServiceBox
           :active="mode === 'demo'"
           class="cursor-pointer"
-          @clicked="update('demo')"
+          @clicked="setMode('demo')"
         >
           <div>
             <img src="@/assets/images/new-service-demo.svg?url">
@@ -27,7 +27,7 @@
         <ServiceBox
           :active="mode === 'manually'"
           class="cursor-pointer"
-          @clicked="update('manually')"
+          @clicked="setMode('manually')"
         >
           <div class="cursor-pointer">
             <img src="@/assets/images/new-service-manually.svg?url">
@@ -54,7 +54,8 @@
 </template>
 
 <script>
-import { mapGetters, mapMutations } from 'vuex'
+import { mapState } from 'vuex'
+
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
@@ -62,37 +63,28 @@ import ServiceBox from '../components/ServiceBox.vue'
 
 export default {
   name: 'AddNewServices',
+
   components: {
     OnboardingNavigation,
     OnboardingHeading,
     OnboardingPage,
     ServiceBox,
   },
+
   computed: {
-    ...mapGetters({
-      onboardingMode: 'onboarding/getMode',
+    ...mapState({
+      mode: (state) => state.onboarding.mode,
     }),
 
     nextStep() {
-      if (this.mode === 'manually') {
-        return 'onboarding-completed'
-      }
-
-      return 'onboarding-add-services-code'
-    },
-    mode: {
-      get() {
-        return this.onboardingMode
-      },
-      set(value) {
-        this.update(value)
-      },
+      return this.mode === 'manually' ? 'onboarding-completed' : 'onboarding-add-services-code'
     },
   },
+
   methods: {
-    ...mapMutations({
-      update: 'onboarding/UPDATE_MODE',
-    }),
+    setMode(newMode) {
+      this.$store.dispatch('onboarding/changeMode', newMode)
+    },
   },
 }
 </script>

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -52,7 +52,7 @@ const updateSelectedMeshGuard: NavigationGuard = function (to, _from, next) {
 const onboardingRouteGuard: NavigationGuard = function (to, _from, next) {
   const isOnboardingCompleted = store.state.onboarding.isCompleted
   const isOnboardingRoute = to.meta.onboardingProcess
-  const shouldSuggestOnboarding = store.getters['onboarding/showOnboarding']
+  const shouldSuggestOnboarding = store.getters.shouldSuggestOnboarding
 
   if (isOnboardingCompleted && isOnboardingRoute && !shouldSuggestOnboarding) {
     next({ name: 'home' })

--- a/src/store/modules/onboarding/onboarding.ts
+++ b/src/store/modules/onboarding/onboarding.ts
@@ -1,4 +1,5 @@
-import { ActionTree, GetterTree, MutationTree } from 'vuex'
+import { ActionTree, MutationTree } from 'vuex'
+
 import { State } from '../../storeConfig'
 import { OnboardingInterface } from './onboarding.types'
 import { ClientStorage } from '@/utilities/ClientStorage'
@@ -10,27 +11,14 @@ const initialOnboardingState: OnboardingInterface = {
 }
 
 const mutations: MutationTree<OnboardingInterface> = {
-  SET_STEP: (state, step) => (state.step = step),
-  SET_IS_COMPLETED: (state, isCompleted) => (state.isCompleted = isCompleted),
-  UPDATE_MODE: (state, message) => (state.mode = message),
-}
-
-const getters: GetterTree<OnboardingInterface, State> = {
-  getMode: state => state.mode,
-  showOnboarding: (_state, _getters, rootState) => {
-    const hasOnlyDefaultMesh = rootState.meshes.items.length === 1 && rootState.meshes.items[0].name === 'default'
-
-    return rootState.totalDataplaneCount === 0 && hasOnlyDefaultMesh
-  },
+  SET_STEP: (state, step: typeof state.step) => (state.step = step),
+  SET_IS_COMPLETED: (state, isCompleted: typeof state.isCompleted) => (state.isCompleted = isCompleted),
+  UPDATE_MODE: (state, mode: typeof state.mode) => (state.mode = mode),
 }
 
 const actions: ActionTree<OnboardingInterface, State> = {
-  // complete/skip onboarding
   completeOnboarding({ commit, dispatch }) {
-    // fetch the dataplanes
     dispatch('fetchDataplaneTotalCount', null, { root: true })
-
-    // fetch sidebar insights
     dispatch('sidebar/getInsights', null, { root: true })
 
     commit('SET_IS_COMPLETED', true)
@@ -38,17 +26,19 @@ const actions: ActionTree<OnboardingInterface, State> = {
     ClientStorage.remove('onboardingStep')
   },
 
-  // change step in onboarding
   changeStep({ commit }, step) {
     commit('SET_STEP', step)
     ClientStorage.set('onboardingStep', step)
+  },
+
+  changeMode({ commit }, mode) {
+    commit('UPDATE_MODE', mode)
   },
 }
 
 const onboardingModule = {
   namespaced: true,
   state: () => initialOnboardingState,
-  getters,
   mutations,
   actions,
 }

--- a/src/store/modules/onboarding/onboarding.types.ts
+++ b/src/store/modules/onboarding/onboarding.types.ts
@@ -1,5 +1,5 @@
 export interface OnboardingInterface {
   isCompleted: boolean;
   step: string;
-  mode: string
+  mode: 'demo' | 'manually'
 }

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -194,6 +194,11 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
           }
         }
       },
+      shouldSuggestOnboarding: (state) => {
+        const hasOnlyDefaultMesh = state.meshes.items.length === 1 && state.meshes.items[0].name === 'default'
+
+        return state.totalDataplaneCount === 0 && hasOnlyDefaultMesh
+      },
     },
 
     mutations: {


### PR DESCRIPTION
Moves `shouldSuggestOnboarding` getter into global state as it only accesses global state.

Stops using store setter in component.

Stops setting computed property in component (they should be read-only).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>