### PR TITLE
chore: Remove old docs link from MultizoneView

### DIFF
--- a/src/app/onboarding/views/MultiZoneView.vue
+++ b/src/app/onboarding/views/MultiZoneView.vue
@@ -75,7 +75,6 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
 import { KCard } from '@kong/kongponents'
 
 import { kumaApi } from '@/api/kumaApi'
@@ -109,12 +108,6 @@ export default {
   computed: {
     servicesOnline() {
       return this.hasZoneIngresses && this.hasZones
-    },
-    ...mapGetters({
-      kumaDocsVersion: 'config/getKumaDocsVersion',
-    }),
-    documentationLink() {
-      return `https://kuma.io/docs/${this.kumaDocsVersion}/deployments/multi-zone/#zone-control-plane`
     },
   },
 


### PR DESCRIPTION
I noticed some dead code in MultizoneView, probably should have been removed as part of https://github.com/kumahq/kuma-gui/pull/466

Signed-off-by: John Cowen <john.cowen@konghq.com>

