### PR TITLE
fix(onboarding): Fixes missing header text during onboarding

### DIFF
--- a/src/app/onboarding/components/OnboardingHeading.vue
+++ b/src/app/onboarding/components/OnboardingHeading.vue
@@ -33,7 +33,8 @@ export default {
   @apply text-center text-4xl font-bold;
 
   background: linear-gradient(to right, var(--OnboardingTitle));
+  -webkit-background-clip: text;
   background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: transparent;
 }
 </style>

--- a/src/app/onboarding/views/WelcomeView.vue
+++ b/src/app/onboarding/views/WelcomeView.vue
@@ -127,8 +127,9 @@ export default {
   @apply text-5xl font-bold mb-3;
 
   background: linear-gradient(to right, var(--OnboardingTitle));
+  -webkit-background-clip: text;
   background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: transparent;
 }
 
 .welcome-description {


### PR DESCRIPTION
This fixes an issue where the headers during onboarding would appear as a colored bar:

## Before

![Screenshot 2023-02-02 at 16 58 18](https://user-images.githubusercontent.com/554604/216391273-bedb7350-1e39-49c4-880f-768e94a612f5.png)

## After

![Screenshot 2023-02-02 at 16 58 03](https://user-images.githubusercontent.com/554604/216391252-c170a735-8b00-425b-b966-1c71cf6d422d.png)

Signed-off-by: John Cowen <john.cowen@konghq.com>

