### PR TITLE
refactor: migrates onboarding child components to composition api

### DIFF
--- a/src/app/onboarding/components/ItemStatus.vue
+++ b/src/app/onboarding/components/ItemStatus.vue
@@ -1,10 +1,10 @@
 <template>
-  <li class="flex items-center mb-2">
-    <span class="circle">
+  <li class="item-status mb-2">
+    <span class="circle mr-2">
       <KIcon
         v-if="props.status"
         icon="check"
-        size="10"
+        size="14"
         color="var(--kuma-purple-1)"
       />
     </span>
@@ -30,9 +30,18 @@ const props = defineProps({
 </script>
 
 <style lang="scss" scoped>
-.circle {
-  @apply flex items-center justify-center text-sm w-4 h-4 rounded-full mr-2;
+.item-status {
+  display: flex;
+  align-items: center;
+}
 
-  background-color: rgba(var(--kuma-purple-1-rgb), 0.1);
+.circle {
+  height: 1rem;
+  width: 1rem;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--grey-300);
 }
 </style>

--- a/src/app/onboarding/components/OnboardingHeading.spec.ts
+++ b/src/app/onboarding/components/OnboardingHeading.spec.ts
@@ -5,7 +5,7 @@ import OnboardingHeading from './OnboardingHeading.vue'
 
 function renderComponent() {
   return mount(OnboardingHeading, {
-    props: {
+    slots: {
       title: 'title',
       description: 'description',
     },

--- a/src/app/onboarding/components/OnboardingHeading.vue
+++ b/src/app/onboarding/components/OnboardingHeading.vue
@@ -1,40 +1,46 @@
 <template>
-  <div class="relative">
+  <div class="onboarding-heading">
     <h1 class="onboarding-title">
-      {{ title }}
+      <slot name="title" />
     </h1>
-    <p
-      v-if="description"
-      class="text-center text-lg mt-3"
+
+    <div
+      v-if="slots.description"
+      class="onboarding-description"
     >
-      {{ description }}
-    </p>
+      <slot name="description" />
+    </div>
   </div>
 </template>
 
-<script>
-export default {
-  name: 'OnboardingHeading',
-  props: {
-    title: {
-      type: String,
-      required: true,
-    },
-    description: {
-      type: String,
-      default: '',
-    },
-  },
-}
+<script lang="ts" setup>
+import { useSlots } from 'vue'
+
+const slots = useSlots()
 </script>
 
 <style lang="scss" scoped>
-.onboarding-title {
-  @apply text-center text-4xl font-bold;
+.onboarding-heading {
+  position: relative;
+}
 
-  background: linear-gradient(to right, var(--OnboardingTitle));
+.onboarding-title {
+  padding-top: var(--spacing-xxs);
+  padding-bottom: var(--spacing-xxs);
+  text-align: center;
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+  font-weight: bold;
+  color: transparent;
+  background-image: linear-gradient(to right, var(--OnboardingTitle));
   -webkit-background-clip: text;
   background-clip: text;
-  color: transparent;
+}
+
+.onboarding-description {
+  margin-top: var(--spacing-sm);
+  text-align: center;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
 }
 </style>

--- a/src/app/onboarding/components/OnboardingNavigation.vue
+++ b/src/app/onboarding/components/OnboardingNavigation.vue
@@ -1,133 +1,102 @@
 <template>
-  <div :class="classes">
+  <div class="onboarding-actions">
     <KButton
-      v-if="previousStep"
-      appearance="primary"
-      class="navigation-button navigation-button--back"
-      :to="{ name: previousStep }"
+      v-if="props.previousStep"
+      appearance="secondary"
+      :to="{ name: props.previousStep }"
       data-testid="onboarding-previous-button"
-      @click="changeStep(previousStep)"
+      @click="changeStep(props.previousStep)"
     >
       Back
     </KButton>
 
-    <div>
+    <div class="button-list">
       <KButton
-        v-if="showSkip"
-        class="skip-button"
-        appearance="btn-link"
-        size="small"
+        v-if="props.showSkip"
+        appearance="outline"
         data-testid="onboarding-skip-button"
+        :to="{ name: 'home' }"
         @click="skipOnboarding"
       >
-        Skip Setup
+        Skip setup
       </KButton>
 
-      <span :class="['inline-block', {'cursor-not-allowed': !shouldAllowNext} ]">
-        <KButton
-          :disabled="!shouldAllowNext"
-          class="navigation-button navigation-button--next"
-          appearance="primary"
-          :to="{ name: nextStep }"
-          data-testid="onboarding-next-button"
-          @click="lastStep ? skipOnboarding() : changeStep(nextStep)"
-        >
-          {{ nextStepTitle }}
-        </KButton>
-      </span>
+      <KButton
+        :disabled="!props.shouldAllowNext"
+        :appearance="props.lastStep ? 'creation' : 'primary'"
+        :to="{ name: props.lastStep ? 'home' : props.nextStep }"
+        data-testid="onboarding-next-button"
+        @click="props.lastStep ? skipOnboarding() : changeStep(props.nextStep)"
+      >
+        {{ props.nextStepTitle }}
+      </KButton>
     </div>
   </div>
 </template>
 
-<script>
-import { mapActions } from 'vuex'
+<script lang="ts" setup>
 import { KButton } from '@kong/kongponents'
 
-export default {
-  name: 'OnboardingNavigation',
+import { useStore } from '@/store/store'
 
-  components: {
-    KButton,
+const store = useStore()
+
+const props = defineProps({
+  shouldAllowNext: {
+    type: Boolean,
+    required: false,
+    default: true,
   },
 
-  props: {
-    shouldAllowNext: {
-      type: Boolean,
-      default: true,
-    },
-    showSkip: {
-      type: Boolean,
-      default: true,
-    },
-    nextStep: {
-      type: String,
-      required: true,
-    },
-    previousStep: {
-      type: String,
-      default: '',
-    },
-    nextStepTitle: {
-      type: String,
-      default: 'Next',
-    },
-    lastStep: {
-      type: Boolean,
-      default: false,
-    },
+  showSkip: {
+    type: Boolean,
+    required: false,
+    default: true,
   },
-  computed: {
-    classes() {
-      return [
-        'mt-4 flex items-center flex-col sm:flex-row',
-        {
-          'justify-center': this.lastStep,
-          'justify-between': this.previousStep && !this.lastStep,
-          'justify-end': !this.previousStep && !this.lastStep,
-        },
-      ]
-    },
-  },
-  methods: {
-    ...mapActions('onboarding', ['completeOnboarding', 'changeStep']),
 
-    skipOnboarding() {
-      this.completeOnboarding()
-      this.$router.push({ name: 'home' })
-    },
+  nextStep: {
+    type: String,
+    required: true,
   },
+
+  previousStep: {
+    type: String,
+    required: false,
+    default: '',
+  },
+
+  nextStepTitle: {
+    type: String,
+    required: false,
+    default: 'Next',
+  },
+
+  lastStep: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+})
+
+function skipOnboarding(): void {
+  store.dispatch('onboarding/completeOnboarding')
+}
+
+function changeStep(step: string): void {
+  store.dispatch('onboarding/changeStep', step)
 }
 </script>
 
 <style lang="scss" scoped>
-.navigation-button {
-  @apply text-lg font-bold;
-
-  --KButtonPaddingY: 12px;
-  --KButtonPaddingX: 48px;
-  --KButtonRadius: 25px;
-
-  &--back {
-    color: var(--grey-600) !important;
-    --KButtonPrimaryBase: var(--OnboardingBackButton);
-    --KButtonPrimaryHover: var(--OnboardingBackButtonHover);
-    --KButtonPrimaryActive: var(--OnboardingBackButtonHover);
-  }
-
-  &--next {
-    --KButtonPrimaryBase: var(--OnboardingNextButton);
-    --KButtonPrimaryHover: var(--OnboardingNextButtonHover);
-    --KButtonPrimaryActive: var(--OnboardingNextButtonHover);
-  }
-
-  &[disabled] {
-    cursor: not-allowed;
-  }
+.onboarding-actions {
+  display: flex;
+  justify-content: space-between;
 }
 
-.skip-button {
-  @apply font-medium mr-8;
-
-  --KButtonBtnLink: var(--OnboardingSkipSetupButton);
+.button-list {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
 }
 </style>

--- a/src/app/onboarding/components/OnboardingPage.vue
+++ b/src/app/onboarding/components/OnboardingPage.vue
@@ -4,68 +4,79 @@
       <div class="onboarding-container__header">
         <slot name="header" />
       </div>
-      <div :class="classes">
-        <div class="w-full">
+
+      <div
+        class="onboarding-container__content"
+        :class="{ 'onboarding-container__content--with-image': props.withImage }"
+      >
+        <div class="onboarding-container__inner-content">
           <slot name="content" />
         </div>
       </div>
-      <slot name="navigation" />
+
+      <div class="mt-4">
+        <slot name="navigation" />
+      </div>
     </div>
 
     <div class="background-image" />
   </div>
 </template>
 
-<script>
-export default {
-  name: 'OnboardingContainer',
-  props: {
-    withImage: {
-      type: Boolean,
-      default: false,
-    },
+<script lang="ts" setup>
+const props = defineProps({
+  withImage: {
+    type: Boolean,
+    required: false,
+    default: false,
   },
-
-  computed: {
-    classes() {
-      return ['onboarding-container__content', this.withImage ? 'onboarding-container__content--with-image' : '']
-    },
-  },
-}
+})
 </script>
 
 <style lang="scss" scoped>
 .onboarding-container {
-  @apply w-full mx-auto my-0 px-4;
+  width: 100%;
+  margin: 0 auto;
+  padding: var(--spacing-md);
 
-  &__header {
-    @apply my-10;
-  }
-
-  &__content {
-    @apply relative flex items-center justify-center p-10 w-full bg-white text-lg;
-    min-height: 500px;
-    box-shadow: var(--OnboardingShadow);
-
-    --KTableHeaderSize: 18px;
-
-    &--with-image {
-      background: var(--OnboardingPageGraphBackground);
-    }
-  }
-
-  @media screen and (min-width: 768px) {
+  @media (min-width: 768px) {
     max-width: 1075px;
   }
 
-  @media screen and (min-height: 950px) {
+  @media (min-height: 950px) {
     width: 100%;
     position: absolute;
-    top: 40%;
-    transform: translateY(-50%);
+    top: 50%;
     left: 0;
     right: 0;
+    transform: translateY(-50%);
   }
+}
+
+.onboarding-container__header {
+  margin-bottom: var(--spacing-lg);
+}
+
+.onboarding-container__content {
+  width: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 500px;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  background-color: var(--white);
+  box-shadow: var(--OnboardingShadow);
+}
+
+.onboarding-container__content--with-image {
+  background: var(--OnboardingPageGraphBackground);
+}
+
+.onboarding-container__inner-content {
+  width: 100%;
+  padding: var(--spacing-lg);
 }
 
 .background-image {
@@ -78,10 +89,9 @@ export default {
   filter: grayscale(1);
   width: 100vw;
   background: transparent url('@/assets/images/onboarding-background.svg?url') no-repeat scroll 0% 0%;
-
   min-width: 1700px;
 
-  @media screen and (max-width: 1699px) {
+  @media (max-width: 1699px) {
     left: 50%;
     top: 50%;
     transform: translateX(-50%) translateY(-50%);

--- a/src/app/onboarding/components/ServiceBox.vue
+++ b/src/app/onboarding/components/ServiceBox.vue
@@ -1,53 +1,43 @@
 <template>
   <div
+    class="box"
+    :class="{ 'box--active': props.active }"
     data-testid="box"
-    :class="classes"
-    @click="$emit('clicked')"
+    @click="emit('clicked')"
   >
     <slot />
   </div>
 </template>
 
-<script>
-export default {
-  name: 'ServiceBox',
-
-  props: {
-    active: {
-      type: Boolean,
-      default: false,
-    },
+<script lang="ts" setup>
+const props = defineProps({
+  active: {
+    type: Boolean,
+    required: false,
+    default: false,
   },
+})
 
-  emits: ['clicked'],
-
-  computed: {
-    classes() {
-      return [
-        'box',
-        {
-          'box--active': this.active,
-        },
-      ]
-    },
-  },
-}
+const emit = defineEmits<{
+  (event: 'clicked'): void,
+}>()
 </script>
 
 <style lang="scss" scoped>
 .box {
-  @apply w-72 h-72 p-12 flex items-center justify-center;
-
-  border: 3px solid #c2c2c2;
+  cursor: pointer;
+  height: 18rem;
+  width: 18rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-lg);
+  border: 3px solid var(--grey-400);
   border-radius: 5px;
   box-shadow: 4px 4px 14px 4px var(--OnboardingShadow);
+}
 
-  &--active {
-    border-color: var(--OnbordingBoxBorder);
-  }
-
-  &--small {
-    @apply w-32 h-40 p-4 m-2;
-  }
+.box--active {
+  border-color: var(--OnbordingBoxBorder);
 }
 </style>

--- a/src/app/onboarding/components/WelcomeAnimationSvg.vue
+++ b/src/app/onboarding/components/WelcomeAnimationSvg.vue
@@ -1,7 +1,7 @@
 <template>
   <svg
-    class="background"
-    :class="svgClasses"
+    class="background svg"
+    :class="{ active: mounted }"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1920 1080"
   >
@@ -51,74 +51,48 @@
         stroke-width="6"
       >
         <path
-          class="nodepath"
           d="M1444 893h252"
         />
         <path
-          class="nodepath"
           stroke-opacity=".4"
           d="M1529 705h232M1452 603h237"
         />
         <path
-          class="nodepath"
           d="M1754 563l-332 332h-76M1444 935l121 121M263 859l156 156"
         />
         <path
-          class="nodepath"
           stroke-opacity=".4"
           d="M742 781H556"
         />
         <path
-          class="nodepath"
           d="M697 736H513"
         />
         <path
-          class="nodepath"
           stroke-opacity=".4"
           d="M695 783V577"
         />
         <path
-          class="nodepath"
           d="M261 1026V751M509 573V438M1502 415l291 290"
         />
         <path
-          class="nodepath"
           stroke-opacity=".4"
           d="M698 912L26 240M1368 411v540l61 61 95-95M1434 3h267l193 192v354"
         />
         <path
-          class="nodepath"
           d="M517 411h342l138 138M1416 573v242l371 323"
         />
         <path
-          class="nodepath"
           d="M1486 817V612l-146-146M839 243h-97l-83 84v348M1698 1063V817l58-57h122M1069 299L558 810M696 1058H585L468 941V570L322 424"
         />
         <path
-          class="nodepath"
           d="M277 528l160 160 236-236 121 121M632 979h-45l-67-67v-86H0M106 669h275M70 707h331M207 745h210M85 784h356M1417 558h228M1609 634h203M528 946h76M619 604v131M1359 567l125 125M1332 594l156 156M1594 1070V959M381 632L260 753"
         />
         <path
-          class="nodepath"
           stroke-opacity=".4"
           d="M605 817V497M1851 959h-518M944 570H390"
         />
         <path
-          class="nodepath"
           d="M638 912H342M635 1139V912"
-        />
-        <path
-          stroke="url(#a)"
-          d="M1024 573h297v532h-31"
-          class="final"
-          transform="translate(0 3)"
-        />
-        <path
-          fill="url(#b)"
-          fill-rule="nonzero"
-          d="M1024 592a18 18 0 100-36 18 18 0 000 36z"
-          class="final circle"
-          transform="translate(0 3)"
         />
       </g>
       <foreignObject
@@ -158,31 +132,16 @@
   </svg>
 </template>
 
-<script>
-export default {
-  name: 'WelcomeAnimationSvg',
-  data() {
-    return {
-      mounted: false,
-    }
-  },
+<script lang="ts" setup>
+import { onMounted, ref } from 'vue'
 
-  computed: {
-    svgClasses() {
-      return [
-        'svg',
-        {
-          active: this.mounted,
-        },
-      ]
-    },
-  },
-  mounted() {
-    setTimeout(() => {
-      this.mounted = true
-    }, 30)
-  },
-}
+const mounted = ref(false)
+
+onMounted(function () {
+  window.setTimeout(() => {
+    mounted.value = true
+  }, 30)
+})
 </script>
 
 <style lang="scss" scoped>
@@ -336,18 +295,6 @@ export default {
     opacity: 0.3;
     will-change: stroke-dashoffset, filter;
 
-    &.final {
-      stroke-dashoffset: 1000px;
-    }
-    &.circle {
-      opacity: 1;
-      stroke-dasharray: 0 0;
-      stroke-dashoffset: 0;
-      transform: scale(0);
-      transition: #{0.2*$baseSpeed}s ease-in-out;
-      transform-origin: 1022px 570px;
-    }
-
     @for $i from 1 through 5 {
       $length: nth($lengths, $i);
       filter: hue-rotate(40deg) brightness(2) blur(4px);
@@ -394,24 +341,6 @@ export default {
       stroke-dashoffset: 0;
       opacity: 0.3;
       filter: hue-rotate(0deg) brightness(1) blur(0px);
-      @for $i from 1 through 20 {
-        &:nth-of-type(#{$i}) {
-          &.final {
-            opacity: 1;
-            transition: #{0.75*$baseSpeed}s ease-in-out, stroke-dashoffset #{1.5*$baseSpeed}s ease-in-out;
-            transition-delay: #{7*$baseSpeed}s, #{7.15*$baseSpeed}s;
-            &.circle {
-              transition: 400ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
-              transition-delay: #{1*$baseSpeed}s;
-            }
-          }
-        }
-      }
-
-      &.circle {
-        transform: scale(1);
-        opacity: 1;
-      }
     }
     @supports (not (offset-distance: 100%)) {
       foreignObject div {
@@ -421,11 +350,8 @@ export default {
   }
 }
 .background {
-  position: absolute;
+  position: fixed;
   z-index: -1;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  inset: 0;
 }
 </style>

--- a/src/app/onboarding/components/__snapshots__/OnboardingHeading.spec.ts.snap
+++ b/src/app/onboarding/components/__snapshots__/OnboardingHeading.spec.ts.snap
@@ -2,17 +2,21 @@
 
 exports[`OnboardingHeading.vue renders snapshot 1`] = `
 <div
-  class="relative"
+  class="onboarding-heading"
 >
   <h1
     class="onboarding-title"
   >
+    
     title
+    
   </h1>
-  <p
-    class="text-center text-lg mt-3"
+  <div
+    class="onboarding-description"
   >
+    
     description
-  </p>
+    
+  </div>
 </div>
 `;

--- a/src/app/onboarding/components/__snapshots__/OnboardingNavigation.spec.ts.snap
+++ b/src/app/onboarding/components/__snapshots__/OnboardingNavigation.spec.ts.snap
@@ -2,10 +2,10 @@
 
 exports[`OnboardingNavigation.vue renders snapshot 1`] = `
 <div
-  class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+  class="onboarding-actions"
 >
   <a
-    class="k-button medium rounded primary navigation-button navigation-button--back"
+    class="k-button medium rounded secondary"
     data-testid="onboarding-previous-button"
     href="/onboarding/welcome"
     type="button"
@@ -18,38 +18,37 @@ exports[`OnboardingNavigation.vue renders snapshot 1`] = `
     
     <!---->
   </a>
-  <div>
-    <button
-      class="k-button small rounded btn-link skip-button"
+  <div
+    class="button-list"
+  >
+    <a
+      class="k-button medium rounded outline"
       data-testid="onboarding-skip-button"
+      href="/"
       type="button"
     >
       
       <!---->
       
       
-       Skip Setup 
+       Skip setup 
       
       <!---->
-    </button>
-    <span
-      class="inline-block"
+    </a>
+    <a
+      class="k-button medium rounded primary"
+      data-testid="onboarding-next-button"
+      href="/onboarding/configuration-types"
+      type="button"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--next"
-        data-testid="onboarding-next-button"
-        href="/onboarding/configuration-types"
-        type="button"
-      >
-        
-        <!---->
-        
-        
-        Next
-        
-        <!---->
-      </a>
-    </span>
+      
+      <!---->
+      
+      
+      Next
+      
+      <!---->
+    </a>
   </div>
 </div>
 `;

--- a/src/app/onboarding/views/AddNewServices.vue
+++ b/src/app/onboarding/views/AddNewServices.vue
@@ -1,7 +1,11 @@
 <template>
   <OnboardingPage>
     <template #header>
-      <OnboardingHeading title="Add services" />
+      <OnboardingHeading>
+        <template #title>
+          Add services
+        </template>
+      </OnboardingHeading>
     </template>
 
     <template #content>

--- a/src/app/onboarding/views/AddNewServicesCode.vue
+++ b/src/app/onboarding/views/AddNewServicesCode.vue
@@ -1,8 +1,13 @@
 <template>
   <OnboardingPage>
     <template #header>
-      <OnboardingHeading title="Add services" />
+      <OnboardingHeading>
+        <template #title>
+          Add services
+        </template>
+      </OnboardingHeading>
     </template>
+
     <template #content>
       <p class="text-center mb-12">
         The demo application includes two services: a Redis backend to store a counter value,

--- a/src/app/onboarding/views/CompletedView.vue
+++ b/src/app/onboarding/views/CompletedView.vue
@@ -1,7 +1,11 @@
 <template>
   <OnboardingPage>
     <template #header>
-      <OnboardingHeading title="Go to the dashboard" />
+      <OnboardingHeading>
+        <template #title>
+          Go to the dashboard
+        </template>
+      </OnboardingHeading>
     </template>
 
     <template #content>

--- a/src/app/onboarding/views/ConfigurationTypes.vue
+++ b/src/app/onboarding/views/ConfigurationTypes.vue
@@ -1,7 +1,11 @@
 <template>
   <OnboardingPage with-image>
     <template #header>
-      <OnboardingHeading title="Learn about configuration storage" />
+      <OnboardingHeading>
+        <template #title>
+          Learn about configuration storage
+        </template>
+      </OnboardingHeading>
     </template>
 
     <template #content>

--- a/src/app/onboarding/views/CreateMesh.vue
+++ b/src/app/onboarding/views/CreateMesh.vue
@@ -1,7 +1,11 @@
 <template>
   <OnboardingPage>
     <template #header>
-      <OnboardingHeading title="Create the mesh" />
+      <OnboardingHeading>
+        <template #title>
+          Create the mesh
+        </template>
+      </OnboardingHeading>
     </template>
 
     <template #content>

--- a/src/app/onboarding/views/DataplanesOverview.vue
+++ b/src/app/onboarding/views/DataplanesOverview.vue
@@ -1,10 +1,18 @@
 <template>
   <OnboardingPage>
     <template #header>
-      <OnboardingHeading
-        :title="title"
-        :description="description"
-      />
+      <OnboardingHeading>
+        <template #title>
+          <p>{{ title }}</p>
+        </template>
+
+        <template
+          v-if="description !== null"
+          #description
+        >
+          <p>{{ description }}</p>
+        </template>
+      </onboardingheading>
     </template>
 
     <template #content>

--- a/src/app/onboarding/views/DeploymentTypes.vue
+++ b/src/app/onboarding/views/DeploymentTypes.vue
@@ -1,12 +1,15 @@
 <template>
   <OnboardingPage with-image>
     <template #header>
-      <OnboardingHeading
-        title="Learn about deployments"
-        :description="
-          `${productName} can be deployed in standalone or multi-zone mode.`
-        "
-      />
+      <OnboardingHeading>
+        <template #title>
+          Learn about deployments
+        </template>
+
+        <template #description>
+          <p>{{ productName }} can be deployed in standalone or multi-zone mode.</p>
+        </template>
+      </onboardingheading>
     </template>
 
     <template #content>

--- a/src/app/onboarding/views/MultiZoneView.vue
+++ b/src/app/onboarding/views/MultiZoneView.vue
@@ -1,7 +1,11 @@
 <template>
   <OnboardingPage>
     <template #header>
-      <OnboardingHeading title="Add zones" />
+      <OnboardingHeading>
+        <template #title>
+          Add zones
+        </template>
+      </OnboardingHeading>
     </template>
 
     <template #content>

--- a/src/app/onboarding/views/WelcomeView.vue
+++ b/src/app/onboarding/views/WelcomeView.vue
@@ -2,17 +2,21 @@
   <div>
     <div class="welcome-container">
       <div class="content">
-        <h1 class="welcome-title">
-          Welcome to {{ productName }}
-        </h1>
+        <OnboardingHeading>
+          <template #title>
+            Welcome to {{ productName }}
+          </template>
 
-        <p class="welcome-description">
-          Congratulations on downloading {{ productName }}! You are just a <strong>few minutes</strong> away from getting your service mesh fully online.
-        </p>
+          <template #description>
+            <p>
+              Congratulations on downloading {{ productName }}! You are just a <strong>few minutes</strong> away from getting your service mesh fully online.
+            </p>
 
-        <p class="welcome-description">
-          We have automatically detected that you are running on <strong>{{ enviromentFormatted }}</strong>.
-        </p>
+            <p>
+              We have automatically detected that you are running on <strong>{{ enviromentFormatted }}</strong>.
+            </p>
+          </template>
+        </OnboardingHeading>
 
         <h2 class="welcome-detected">
           Let's get started:
@@ -42,6 +46,7 @@ import { mapGetters } from 'vuex'
 
 import { PRODUCT_NAME } from '@/constants'
 import ItemStatus from '../components/ItemStatus.vue'
+import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import { useWelcomeAnimationSvg } from '@/components'
 
@@ -49,8 +54,10 @@ const WelcomeAnimationSvg = useWelcomeAnimationSvg()
 
 export default {
   name: 'WelcomeView',
+
   components: {
     ItemStatus,
+    OnboardingHeading,
     OnboardingNavigation,
     WelcomeAnimationSvg,
   },
@@ -60,6 +67,7 @@ export default {
       productName: PRODUCT_NAME,
     }
   },
+
   computed: {
     ...mapGetters({
       environment: 'config/getEnvironment',
@@ -123,23 +131,6 @@ export default {
   width: 28rem;
   animation: show 0.75s 0s 1 forwards;
   background-color: var(--white);
-}
-
-.welcome-title {
-  @apply text-5xl font-bold mb-3;
-
-  background: linear-gradient(to right, var(--OnboardingTitle));
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-}
-
-.welcome-description {
-  @apply text-base mb-4;
-
-  @media screen and (max-width: 1699px) {
-    @apply mb-2;
-  }
 }
 
 .welcome-detected {

--- a/src/app/onboarding/views/__snapshots__/AddNewServices.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/AddNewServices.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Add services
+          
+           Add services 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,7 +27,7 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <div
@@ -85,43 +87,46 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/create-mesh"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/create-mesh"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            class="k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             href="/onboarding/add-services-code"
             type="button"
@@ -134,10 +139,10 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Add services
+          
+           Add services 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,7 +27,7 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <p
@@ -199,43 +201,47 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/add-services"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/add-services"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            aria-current="page"
+            class="router-link-active router-link-exact-active k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             href="/onboarding/dataplanes-overview"
             type="button"
@@ -248,10 +254,10 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/CompletedView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/CompletedView.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`CompletedView.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Go to the dashboard
+          
+           Go to the dashboard 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,7 +27,7 @@ exports[`CompletedView.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <div
@@ -36,18 +38,20 @@ exports[`CompletedView.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-center"
+      class="mt-4"
     >
-      <!--v-if-->
-      <div>
+      
+      <div
+        class="onboarding-actions"
+      >
         <!--v-if-->
-        <span
-          class="inline-block"
+        <div
+          class="button-list"
         >
+          <!--v-if-->
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            class="k-button medium rounded creation"
             data-testid="onboarding-next-button"
             href="/"
             type="button"
@@ -60,10 +64,10 @@ exports[`CompletedView.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/ConfigurationTypes.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/ConfigurationTypes.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`ConfigurationTypes.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Learn about configuration storage
+          
+           Learn about configuration storage 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,7 +27,7 @@ exports[`ConfigurationTypes.vue renders snapshot 1`] = `
       class="onboarding-container__content onboarding-container__content--with-image"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <div
@@ -947,43 +949,46 @@ exports[`ConfigurationTypes.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/deployment-types"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/deployment-types"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            class="k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             href="/onboarding/create-mesh"
             type="button"
@@ -996,10 +1001,10 @@ exports[`ConfigurationTypes.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/CreateMesh.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/CreateMesh.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`CreateMesh.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Create the mesh
+          
+           Create the mesh 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,7 +27,7 @@ exports[`CreateMesh.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <p
@@ -150,43 +152,47 @@ exports[`CreateMesh.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/configuration-types"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/configuration-types"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            aria-current="page"
+            class="router-link-active router-link-exact-active k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             href="/onboarding/add-services"
             type="button"
@@ -199,10 +205,10 @@ exports[`CreateMesh.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/DataplanesOverview.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/DataplanesOverview.spec.ts.snap
@@ -10,18 +10,26 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Success
+          
+          <p>
+            Success
+          </p>
+          
         </h1>
-        <p
-          class="text-center text-lg mt-3"
+        <div
+          class="onboarding-description"
         >
-          The following data plane proxies (DPPs) are connected to the control plane:
-        </p>
+          
+          <p>
+            The following data plane proxies (DPPs) are connected to the control plane:
+          </p>
+          
+        </div>
       </div>
       
     </div>
@@ -29,7 +37,7 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <div>
@@ -408,43 +416,47 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/add-services-code"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/add-services-code"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            aria-current="page"
+            class="router-link-active router-link-exact-active k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             href="/onboarding/completed"
             type="button"
@@ -457,10 +469,10 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/DeploymentTypes.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/DeploymentTypes.spec.ts.snap
@@ -10,18 +10,24 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Learn about deployments
+          
+           Learn about deployments 
+          
         </h1>
-        <p
-          class="text-center text-lg mt-3"
+        <div
+          class="onboarding-description"
         >
-          Kuma can be deployed in standalone or multi-zone mode.
-        </p>
+          
+          <p>
+            Kuma can be deployed in standalone or multi-zone mode.
+          </p>
+          
+        </div>
       </div>
       
     </div>
@@ -29,7 +35,7 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
       class="onboarding-container__content onboarding-container__content--with-image"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <div
@@ -637,43 +643,46 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/welcome"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/welcome"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            class="k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             href="/onboarding/configuration-types"
             type="button"
@@ -686,10 +695,10 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/MultiZoneView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/MultiZoneView.spec.ts.snap
@@ -10,12 +10,14 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
     >
       
       <div
-        class="relative"
+        class="onboarding-heading"
       >
         <h1
           class="onboarding-title"
         >
-          Add zones
+          
+           Add zones 
+          
         </h1>
         <!--v-if-->
       </div>
@@ -25,7 +27,7 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
       class="onboarding-container__content"
     >
       <div
-        class="w-full"
+        class="onboarding-container__inner-content"
       >
         
         <p
@@ -120,43 +122,46 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
         
       </div>
     </div>
-    
     <div
-      class="mt-4 flex items-center flex-col sm:flex-row justify-between"
+      class="mt-4"
     >
-      <a
-        class="k-button medium rounded primary navigation-button navigation-button--back"
-        data-testid="onboarding-previous-button"
-        href="/onboarding/configuration-types"
-        type="button"
+      
+      <div
+        class="onboarding-actions"
       >
-        
-        <!---->
-        
-        
-         Back 
-        
-        <!---->
-      </a>
-      <div>
-        <button
-          class="k-button small rounded btn-link skip-button"
-          data-testid="onboarding-skip-button"
+        <a
+          class="k-button medium rounded secondary"
+          data-testid="onboarding-previous-button"
+          href="/onboarding/configuration-types"
           type="button"
         >
           
           <!---->
           
           
-           Skip Setup 
+           Back 
           
           <!---->
-        </button>
-        <span
-          class="inline-block cursor-not-allowed"
+        </a>
+        <div
+          class="button-list"
         >
           <a
-            class="k-button medium rounded primary navigation-button navigation-button--next"
+            class="k-button medium rounded outline"
+            data-testid="onboarding-skip-button"
+            href="/"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+             Skip setup 
+            
+            <!---->
+          </a>
+          <a
+            class="k-button medium rounded primary"
             data-testid="onboarding-next-button"
             disabled="true"
             href="/onboarding/create-mesh"
@@ -170,10 +175,10 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
             
             <!---->
           </a>
-        </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div
     class="background-image"

--- a/src/app/onboarding/views/__snapshots__/WelcomeView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/WelcomeView.spec.ts.snap
@@ -8,29 +8,37 @@ exports[`WelcomeView.vue renders snapshot 1`] = `
     <div
       class="content"
     >
-      <h1
-        class="welcome-title"
+      <div
+        class="onboarding-heading"
       >
-         Welcome to Kuma
-      </h1>
-      <p
-        class="welcome-description"
-      >
-         Congratulations on downloading Kuma! You are just a 
-        <strong>
-          few minutes
-        </strong>
-         away from getting your service mesh fully online. 
-      </p>
-      <p
-        class="welcome-description"
-      >
-         We have automatically detected that you are running on 
-        <strong>
-          Universal
-        </strong>
-        . 
-      </p>
+        <h1
+          class="onboarding-title"
+        >
+          
+           Welcome to Kuma
+          
+        </h1>
+        <div
+          class="onboarding-description"
+        >
+          
+          <p>
+             Congratulations on downloading Kuma! You are just a 
+            <strong>
+              few minutes
+            </strong>
+             away from getting your service mesh fully online. 
+          </p>
+          <p>
+             We have automatically detected that you are running on 
+            <strong>
+              Universal
+            </strong>
+            . 
+          </p>
+          
+        </div>
+      </div>
       <h2
         class="welcome-detected"
       >
@@ -39,10 +47,10 @@ exports[`WelcomeView.vue renders snapshot 1`] = `
       <ul>
         
         <li
-          class="flex items-center mb-2"
+          class="item-status mb-2"
         >
           <span
-            class="circle"
+            class="circle mr-2"
           >
             <span
               class="kong-icon kong-icon-check"
@@ -72,50 +80,50 @@ exports[`WelcomeView.vue renders snapshot 1`] = `
            Run Kuma control plane
         </li>
         <li
-          class="flex items-center mb-2"
+          class="item-status mb-2"
         >
           <span
-            class="circle"
+            class="circle mr-2"
           >
             <!--v-if-->
           </span>
            Learn about deployments
         </li>
         <li
-          class="flex items-center mb-2"
+          class="item-status mb-2"
         >
           <span
-            class="circle"
+            class="circle mr-2"
           >
             <!--v-if-->
           </span>
            Learn about configuration storage
         </li>
         <li
-          class="flex items-center mb-2"
+          class="item-status mb-2"
         >
           <span
-            class="circle"
+            class="circle mr-2"
           >
             <!--v-if-->
           </span>
            Create the mesh
         </li>
         <li
-          class="flex items-center mb-2"
+          class="item-status mb-2"
         >
           <span
-            class="circle"
+            class="circle mr-2"
           >
             <!--v-if-->
           </span>
            Add services
         </li>
         <li
-          class="flex items-center mb-2"
+          class="item-status mb-2"
         >
           <span
-            class="circle"
+            class="circle mr-2"
           >
             <!--v-if-->
           </span>
@@ -128,41 +136,40 @@ exports[`WelcomeView.vue renders snapshot 1`] = `
       class="welcome-navigation"
     >
       <div
-        class="mt-4 flex items-center flex-col sm:flex-row justify-end"
+        class="onboarding-actions"
       >
         <!--v-if-->
-        <div>
-          <button
-            class="k-button small rounded btn-link skip-button"
+        <div
+          class="button-list"
+        >
+          <a
+            class="k-button medium rounded outline"
             data-testid="onboarding-skip-button"
+            href="/"
             type="button"
           >
             
             <!---->
             
             
-             Skip Setup 
+             Skip setup 
             
             <!---->
-          </button>
-          <span
-            class="inline-block"
+          </a>
+          <a
+            class="k-button medium rounded primary"
+            data-testid="onboarding-next-button"
+            href="/onboarding/deployment-types"
+            type="button"
           >
-            <a
-              class="k-button medium rounded primary navigation-button navigation-button--next"
-              data-testid="onboarding-next-button"
-              href="/onboarding/deployment-types"
-              type="button"
-            >
-              
-              <!---->
-              
-              
-              Next
-              
-              <!---->
-            </a>
-          </span>
+            
+            <!---->
+            
+            
+            Next
+            
+            <!---->
+          </a>
         </div>
       </div>
     </div>
@@ -219,74 +226,48 @@ exports[`WelcomeView.vue renders snapshot 1`] = `
         stroke-width="6"
       >
         <path
-          class="nodepath"
           d="M1444 893h252"
         />
         <path
-          class="nodepath"
           d="M1529 705h232M1452 603h237"
           stroke-opacity=".4"
         />
         <path
-          class="nodepath"
           d="M1754 563l-332 332h-76M1444 935l121 121M263 859l156 156"
         />
         <path
-          class="nodepath"
           d="M742 781H556"
           stroke-opacity=".4"
         />
         <path
-          class="nodepath"
           d="M697 736H513"
         />
         <path
-          class="nodepath"
           d="M695 783V577"
           stroke-opacity=".4"
         />
         <path
-          class="nodepath"
           d="M261 1026V751M509 573V438M1502 415l291 290"
         />
         <path
-          class="nodepath"
           d="M698 912L26 240M1368 411v540l61 61 95-95M1434 3h267l193 192v354"
           stroke-opacity=".4"
         />
         <path
-          class="nodepath"
           d="M517 411h342l138 138M1416 573v242l371 323"
         />
         <path
-          class="nodepath"
           d="M1486 817V612l-146-146M839 243h-97l-83 84v348M1698 1063V817l58-57h122M1069 299L558 810M696 1058H585L468 941V570L322 424"
         />
         <path
-          class="nodepath"
           d="M277 528l160 160 236-236 121 121M632 979h-45l-67-67v-86H0M106 669h275M70 707h331M207 745h210M85 784h356M1417 558h228M1609 634h203M528 946h76M619 604v131M1359 567l125 125M1332 594l156 156M1594 1070V959M381 632L260 753"
         />
         <path
-          class="nodepath"
           d="M605 817V497M1851 959h-518M944 570H390"
           stroke-opacity=".4"
         />
         <path
-          class="nodepath"
           d="M638 912H342M635 1139V912"
-        />
-        <path
-          class="final"
-          d="M1024 573h297v532h-31"
-          stroke="url(#a)"
-          transform="translate(0 3)"
-        />
-        <path
-          class="final circle"
-          d="M1024 592a18 18 0 100-36 18 18 0 000 36z"
-          fill="url(#b)"
-          fill-rule="nonzero"
-          transform="translate(0 3)"
         />
       </g>
       <foreignobject


### PR DESCRIPTION
Migrates all onboarding-related child components to composition API.

Fixes an issue of the onboarding heading not being visible in Chrome on account of Chrome only supporting a vendor-prefixed CSS property we didn’t use.

Replaces a few Tailwind styles in migrated components.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>