### PR TITLE
ci: creates unique branch name

### DIFF
--- a/.github/workflows/create-gui-pr.yml
+++ b/.github/workflows/create-gui-pr.yml
@@ -87,7 +87,7 @@ jobs:
           committer: GitHub <noreply@github.com>
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           signoff: true
-          branch: chore/update-gui
+          branch: chore/update-gui-in-${{ github.ref_name }}
           delete-branch: true
           title: "chore(deps): bump ${{ github.repository }} to ${{ github.sha }}"
           labels: ci/skip-e2e-test,ci/auto-merge


### PR DESCRIPTION
Uses a branch name that’s unique between the target branches (e.g. when merging into a release branch).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>