### PR TITLE
fix: reading subscriptions too early

### DIFF
--- a/src/app/zones/views/ZonesView.vue
+++ b/src/app/zones/views/ZonesView.vue
@@ -255,19 +255,19 @@ function parseData(zoneOverview: ZoneOverview): any {
   let storeType = ''
   let cpCompat = true
 
-  if (zoneOverview.zoneInsight.subscriptions && zoneOverview.zoneInsight.subscriptions.length > 0) {
-    zoneOverview.zoneInsight.subscriptions.forEach((item: any) => {
-      if (item.version && item.version.kumaCp) {
-        zoneCpVersion = item.version.kumaCp.version
-        const { kumaCpGlobalCompatible = true } = item.version.kumaCp
+  const subscriptions = zoneOverview.zoneInsight?.subscriptions ?? []
 
-        cpCompat = kumaCpGlobalCompatible
-        if (item.config) {
-          storeType = JSON.parse(item.config).store.type
-        }
+  subscriptions.forEach((item: any) => {
+    if (item.version && item.version.kumaCp) {
+      zoneCpVersion = item.version.kumaCp.version
+      const { kumaCpGlobalCompatible = true } = item.version.kumaCp
+
+      cpCompat = kumaCpGlobalCompatible
+      if (item.config) {
+        storeType = JSON.parse(item.config).store.type
       }
-    })
-  }
+    }
+  })
 
   const status = getItemStatusFromInsight(zoneOverview.zoneInsight)
 
@@ -386,8 +386,8 @@ async function getEntity({ name }: { name: string }): Promise<void> {
         })
       }
 
-      if (subscriptions[subscriptions.length - 1].config) {
-        codeOutput.value = JSON.stringify(JSON.parse(subscriptions[subscriptions.length - 1].config), null, 2)
+      if (lastSubscription.config) {
+        codeOutput.value = JSON.stringify(JSON.parse(lastSubscription.config), null, 2)
       }
     }
   } catch (err) {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -436,7 +436,7 @@ export interface Zone extends Entity {
 export interface ZoneOverview extends MeshEntity {
   type: 'ZoneOverview'
   zone: Zone
-  zoneInsight: ZoneInsight
+  zoneInsight?: ZoneInsight
 }
 
 export interface ZoneIngressOverview extends MeshEntity {

--- a/src/utilities/helpers.ts
+++ b/src/utilities/helpers.ts
@@ -155,12 +155,16 @@ export async function fetchAllResources<T = Object>(endpoint: (params: Object) =
 }
 
 export function getZoneDpServerAuthType(zone: ZoneOverview): string {
-  const subscriptionsLength = zone?.zoneInsight?.subscriptions.length ?? 0
+  const subscriptions = zone.zoneInsight?.subscriptions ?? []
 
-  if (subscriptionsLength && zone.zoneInsight.subscriptions[subscriptionsLength - 1].config) {
-    const parsedConfig = JSON.parse(zone.zoneInsight.subscriptions[subscriptionsLength - 1].config)
+  if (subscriptions.length > 0) {
+    const lastSubscription = subscriptions[subscriptions.length - 1]
 
-    return get(parsedConfig, 'dpServer.auth.type', DISABLED)
+    if (lastSubscription.config) {
+      const parsedConfig = JSON.parse(lastSubscription.config)
+
+      return get(parsedConfig, 'dpServer.auth.type', DISABLED)
+    }
   }
 
   return DISABLED


### PR DESCRIPTION
Fixes an issue of accessing a zone insight’s subscriptions too early when briefly after creating a zone, the zoneInsight object is not available, yet.

Fixes #585.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>