### PR TITLE
chore(policies): Remove hardcoded policy listing

### DIFF
--- a/src/store/reducers/__snapshots__/mesh-insights.spec.ts.snap
+++ b/src/store/reducers/__snapshots__/mesh-insights.spec.ts.snap
@@ -12,59 +12,7 @@ exports[`mesh-insights calls mergeInsightsReducer with an empty array 1`] = `
     "kumaDp": {},
   },
   "meshesTotal": 0,
-  "policies": {
-    "CircuitBreaker": {
-      "total": 0,
-    },
-    "FaultInjection": {
-      "total": 0,
-    },
-    "HealthCheck": {
-      "total": 0,
-    },
-    "MeshAccessLog": {
-      "total": 0,
-    },
-    "MeshGateway": {
-      "total": 0,
-    },
-    "MeshGatewayRoute": {
-      "total": 0,
-    },
-    "MeshTrace": {
-      "total": 0,
-    },
-    "MeshTrafficPermission": {
-      "total": 0,
-    },
-    "ProxyTemplate": {
-      "total": 0,
-    },
-    "RateLimit": {
-      "total": 0,
-    },
-    "Retry": {
-      "total": 0,
-    },
-    "Timeout": {
-      "total": 0,
-    },
-    "TrafficLog": {
-      "total": 0,
-    },
-    "TrafficPermission": {
-      "total": 0,
-    },
-    "TrafficRoute": {
-      "total": 0,
-    },
-    "TrafficTrace": {
-      "total": 0,
-    },
-    "VirtualOutbound": {
-      "total": 0,
-    },
-  },
+  "policies": {},
 }
 `;
 
@@ -103,62 +51,17 @@ exports[`mesh-insights calls mergeInsightsReducer with mesh insights array 1`] =
   },
   "meshesTotal": 5,
   "policies": {
-    "CircuitBreaker": {
-      "total": 0,
-    },
-    "FaultInjection": {
-      "total": 0,
-    },
-    "HealthCheck": {
-      "total": 0,
-    },
-    "MeshAccessLog": {
-      "total": 0,
-    },
-    "MeshGateway": {
-      "total": 0,
-    },
-    "MeshGatewayRoute": {
-      "total": 0,
-    },
-    "MeshTrace": {
-      "total": 0,
-    },
-    "MeshTrafficPermission": {
-      "total": 0,
-    },
-    "ProxyTemplate": {
-      "total": 0,
-    },
-    "RateLimit": {
-      "total": 0,
-    },
-    "Retry": {
-      "total": 0,
-    },
     "Secret": {
       "total": 12,
     },
     "ServiceInsight": {
       "total": 22,
     },
-    "Timeout": {
-      "total": 0,
-    },
-    "TrafficLog": {
-      "total": 0,
-    },
     "TrafficPermission": {
       "total": 6,
     },
     "TrafficRoute": {
       "total": 10,
-    },
-    "TrafficTrace": {
-      "total": 0,
-    },
-    "VirtualOutbound": {
-      "total": 0,
     },
   },
 }
@@ -199,62 +102,17 @@ exports[`mesh-insights calls parseInsightReducer with mesh insights 1`] = `
   },
   "meshesTotal": 1,
   "policies": {
-    "CircuitBreaker": {
-      "total": 0,
-    },
-    "FaultInjection": {
-      "total": 0,
-    },
-    "HealthCheck": {
-      "total": 0,
-    },
-    "MeshAccessLog": {
-      "total": 0,
-    },
-    "MeshGateway": {
-      "total": 0,
-    },
-    "MeshGatewayRoute": {
-      "total": 0,
-    },
-    "MeshTrace": {
-      "total": 0,
-    },
-    "MeshTrafficPermission": {
-      "total": 0,
-    },
-    "ProxyTemplate": {
-      "total": 0,
-    },
-    "RateLimit": {
-      "total": 0,
-    },
-    "Retry": {
-      "total": 0,
-    },
     "Secret": {
       "total": 6,
     },
     "ServiceInsight": {
       "total": 11,
     },
-    "Timeout": {
-      "total": 0,
-    },
-    "TrafficLog": {
-      "total": 0,
-    },
     "TrafficPermission": {
       "total": 3,
     },
     "TrafficRoute": {
       "total": 5,
-    },
-    "TrafficTrace": {
-      "total": 0,
-    },
-    "VirtualOutbound": {
-      "total": 0,
     },
   },
 }
@@ -272,58 +130,6 @@ exports[`mesh-insights calls parseInsightReducer without any data 1`] = `
     "kumaDp": {},
   },
   "meshesTotal": 1,
-  "policies": {
-    "CircuitBreaker": {
-      "total": 0,
-    },
-    "FaultInjection": {
-      "total": 0,
-    },
-    "HealthCheck": {
-      "total": 0,
-    },
-    "MeshAccessLog": {
-      "total": 0,
-    },
-    "MeshGateway": {
-      "total": 0,
-    },
-    "MeshGatewayRoute": {
-      "total": 0,
-    },
-    "MeshTrace": {
-      "total": 0,
-    },
-    "MeshTrafficPermission": {
-      "total": 0,
-    },
-    "ProxyTemplate": {
-      "total": 0,
-    },
-    "RateLimit": {
-      "total": 0,
-    },
-    "Retry": {
-      "total": 0,
-    },
-    "Timeout": {
-      "total": 0,
-    },
-    "TrafficLog": {
-      "total": 0,
-    },
-    "TrafficPermission": {
-      "total": 0,
-    },
-    "TrafficRoute": {
-      "total": 0,
-    },
-    "TrafficTrace": {
-      "total": 0,
-    },
-    "VirtualOutbound": {
-      "total": 0,
-    },
-  },
+  "policies": {},
 }
 `;

--- a/src/store/reducers/mesh-insights.ts
+++ b/src/store/reducers/mesh-insights.ts
@@ -20,27 +20,7 @@ const sumDataplanes = (curr: DataPlaneStats = {}, next: DataPlaneStats = {}) => 
   }
 }
 
-export const getInitialPolicies = () => ({
-  CircuitBreaker: { total: 0 },
-  FaultInjection: { total: 0 },
-  HealthCheck: { total: 0 },
-  MeshAccessLog: { total: 0 },
-  MeshGateway: { total: 0 },
-  MeshGatewayRoute: { total: 0 },
-  MeshTrace: { total: 0 },
-  MeshTrafficPermission: { total: 0 },
-  ProxyTemplate: { total: 0 },
-  RateLimit: { total: 0 },
-  Retry: { total: 0 },
-  Timeout: { total: 0 },
-  TrafficLog: { total: 0 },
-  TrafficPermission: { total: 0 },
-  TrafficRoute: { total: 0 },
-  TrafficTrace: { total: 0 },
-  VirtualOutbound: { total: 0 },
-})
-
-const sumPolicies = (curr: any = getInitialPolicies(), next: any = {}) =>
+const sumPolicies = (curr: Record<string, {total: string}>, next: any = {}) =>
   Object.entries(next).reduce((acc, [name, stat]) => {
     const currTotal = acc[name] ? acc[name].total : 0
 
@@ -70,7 +50,7 @@ export function getEmptyInsight() {
   return {
     meshesTotal: 0,
     dataplanes: { online: 0, partiallyDegraded: 0, total: 0 },
-    policies: getInitialPolicies(),
+    policies: {},
     dpVersions: { kumaDp: {}, envoy: {} },
   }
 }
@@ -94,7 +74,7 @@ export function mergeInsightsReducer(insights: TODO = []) {
         partiallyDegraded: 0,
         total: 0,
       },
-      policies: getInitialPolicies(),
+      policies: {},
       dpVersions: {
         kumaDp: {},
         envoy: {},


### PR DESCRIPTION
Policies are pluggable so we can't refer to them statically in the code.

If you could give this one an extra look that'd be great, whilst I'm gaining more context on the application, I probably still don't have enough to be totally sure there isn't somewhere where we are trying to do `undefined + 0`. Pretty sure what is here is fine after following the code paths I could find through, but would be good for a second opinion on that.

Signed-off-by: John Cowen <john.cowen@konghq.com>

