### PR TITLE
chore: Use node package resolution for some CSS paths

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -1,6 +1,6 @@
-@import '/node_modules/tailwindcss/utilities.css';
-@import '/node_modules/@kong/kongponents/dist/style.css';
-@import '/node_modules/@kong/kongponents/dist/_variables.scss';
+@import 'tailwindcss/utilities.css';
+@import '@kong/kongponents/dist/style.css';
+@import '@kong/kongponents/dist/_variables.scss';
 
 @import 'variables';
 @import 'base';


### PR DESCRIPTION
See title. If `node_modules` isn't where you would think it is (say in a workspace'd setup) this should resolve the packages more reliably.

Signed-off-by: John Cowen <john.cowen@konghq.com>
