### PR TITLE
feat: adds refresh button to xDS/stats/clusters tabs

### DIFF
--- a/src/app/common/EnvoyData.vue
+++ b/src/app/common/EnvoyData.vue
@@ -1,22 +1,36 @@
 <template>
-  <StatusInfo
-    class="envoy-data"
-    :has-error="error !== undefined"
-    :is-loading="isLoading"
-    :error="error"
-  >
-    <CodeBlock
-      :id="`code-block-${dataPath}`"
-      language="json"
-      :code="code"
-      is-searchable
-      :query-key="queryKey ?? `code-block-${dataPath}`"
-    />
-  </StatusInfo>
+  <div class="envoy-data">
+    <div class="envoy-data-actions">
+      <KButton
+        :disabled="isLoading"
+        appearance="primary"
+        icon="redo"
+        data-testid="envoy-data-refresh-button"
+        @click="fetchContent"
+      >
+        Refresh
+      </KButton>
+    </div>
+
+    <StatusInfo
+      :has-error="error !== null"
+      :is-loading="isLoading"
+      :error="error"
+    >
+      <CodeBlock
+        :id="`code-block-${props.dataPath}`"
+        language="json"
+        :code="code"
+        is-searchable
+        :query-key="props.queryKey ?? `code-block-${props.dataPath}`"
+      />
+    </StatusInfo>
+  </div>
 </template>
 
 <script lang="ts" setup>
 import { onMounted, PropType, ref, watch } from 'vue'
+import { KButton } from '@kong/kongponents'
 
 import { kumaApi } from '@/api/kumaApi'
 import CodeBlock from './CodeBlock.vue'
@@ -60,7 +74,7 @@ const props = defineProps({
 })
 
 const isLoading = ref(true)
-const error = ref<Error | undefined>(undefined)
+const error = ref<Error | null>(null)
 const code = ref('')
 
 watch(() => props.dppName, function () {
@@ -78,7 +92,7 @@ onMounted(function () {
 })
 
 async function fetchContent() {
-  error.value = undefined
+  error.value = null
   isLoading.value = true
 
   try {
@@ -120,10 +134,10 @@ async function fetchContent() {
   padding: var(--spacing-md);
 }
 
-.copy-button {
-  position: absolute;
-  top: var(--spacing-md);
-  right: var(--spacing-md);
-  display: block;
+.envoy-data-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin-bottom: var(--spacing-md);
 }
 </style>

--- a/src/app/common/ErrorBlock.vue
+++ b/src/app/common/ErrorBlock.vue
@@ -14,13 +14,13 @@
       </template>
 
       <template
-        v-if="isErrorObject || causes.length > 0"
+        v-if="error !== null || causes.length > 0"
         #message
       >
         <details class="error-block-details">
           <summary>Details</summary>
 
-          <p v-if="isErrorObject">
+          <p v-if="error !== null">
             {{ error.message }}
           </p>
 
@@ -55,20 +55,19 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, PropType } from 'vue'
 import { KBadge, KEmptyState, KIcon } from '@kong/kongponents'
 
 import { ApiError } from '@/services/kuma-api/ApiError'
 
 const props = defineProps({
   error: {
-    type: [Error, ApiError],
+    type: [Error, null] as PropType<Error | null>,
     required: false,
     default: null,
   },
 })
 
-const isErrorObject = computed(() => props.error instanceof Error)
 const causes = computed(() => props.error instanceof ApiError ? props.error.causes : [])
 </script>
 

--- a/src/app/common/StatusInfo.vue
+++ b/src/app/common/StatusInfo.vue
@@ -16,10 +16,11 @@
 </template>
 
 <script lang="ts" setup>
+import { PropType } from 'vue'
+
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { ApiError } from '@/services/kuma-api/ApiError'
 
 defineProps({
   isLoading: {
@@ -38,7 +39,7 @@ defineProps({
   },
 
   error: {
-    type: [Error, ApiError],
+    type: [Error, null] as PropType<Error | null>,
     required: false,
     default: null,
   },

--- a/src/app/common/__snapshots__/EnvoyData.spec.ts.snap
+++ b/src/app/common/__snapshots__/EnvoyData.spec.ts.snap
@@ -4,78 +4,126 @@ exports[`EnvoyData.vue renders snapshot 1`] = `
 <div
   class="envoy-data"
 >
-  <section
-    class="empty-state-wrapper"
-    data-testid="loading-block"
+  <div
+    class="envoy-data-actions"
   >
-    <div
-      class="empty-state-title"
+    <button
+      class="k-button medium rounded primary"
+      data-testid="envoy-data-refresh-button"
+      disabled=""
+      type="button"
     >
-      <!---->
-      <div
-        class="k-empty-state-title-header mt-4 mb-4"
+      
+      <span
+        class="k-button-icon kong-icon kong-icon-redo"
       >
-        
-        <span
-          class="mb-3 kong-icon kong-icon-spinner"
+        <svg
+          fill="none"
+          height="14"
+          viewBox="0 0 17 14"
+          width="17"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            fill="none"
-            viewBox="0 0 20 20"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            
+          
   
-            <title>
-              Loading
-            </title>
-            
+          <title>
+            Redo
+          </title>
+          
   
-            <g>
-              
-    
-              <path
-                d="M5 10a5 5 0 1 0 5-5"
-                fill="none"
-                stroke="#A3BBCC"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              
-  
-            </g>
-            
-
-          </svg>
+          <path
+            clip-rule="evenodd"
+            d="M12.466 12.06a6.868 6.868 0 112.196-5.676l.85-.85a.847.847 0 011.201-.017c.327.327.315.869-.017 1.2L14.233 9.18c-.342.342-.88.35-1.208.023L10.654 6.83c-.324-.324-.314-.859.028-1.2.34-.34.881-.348 1.2-.029l.847.846a4.938 4.938 0 10-1.63 4.245l1.367 1.367z"
+            fill="#A3BBCC"
+            fill-rule="evenodd"
+          />
           
 
-        </span>
+        </svg>
         
-        <p>
-          Loading data …
-        </p>
-        
-        
-      </div>
-    </div>
-    <div
-      class="empty-state-content"
+
+      </span>
+      
+      
+       Refresh 
+      
+      <!---->
+    </button>
+  </div>
+  <div>
+    <section
+      class="empty-state-wrapper"
+      data-testid="loading-block"
     >
       <div
-        class="k-empty-state-message mb-6"
+        class="empty-state-title"
       >
-        
-        
+        <!---->
+        <div
+          class="k-empty-state-title-header mt-4 mb-4"
+        >
+          
+          <span
+            class="mb-3 kong-icon kong-icon-spinner"
+          >
+            <svg
+              fill="none"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              
+  
+              <title>
+                Loading
+              </title>
+              
+  
+              <g>
+                
+    
+                <path
+                  d="M5 10a5 5 0 1 0 5-5"
+                  fill="none"
+                  stroke="#A3BBCC"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                
+  
+              </g>
+              
+
+            </svg>
+            
+
+          </span>
+          
+          <p>
+            Loading data …
+          </p>
+          
+          
+        </div>
       </div>
       <div
-        class="k-empty-state-cta"
+        class="empty-state-content"
       >
-        
-        <!---->
-        
+        <div
+          class="k-empty-state-message mb-6"
+        >
+          
+          
+        </div>
+        <div
+          class="k-empty-state-cta"
+        >
+          
+          <!---->
+          
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
+  </div>
 </div>
 `;

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -175,7 +175,7 @@ const props = defineProps({
   },
 
   error: {
-    type: Error as PropType<Error | null>,
+    type: [Error, null] as PropType<Error | null>,
     required: false,
     default: null,
   },


### PR DESCRIPTION
Adds a refresh button to the envoy data tabs for xDS, stats, and clusters. On activation, the loading routine for this data is run again.

Streamlines handling of error objects in a few components.

Resolves #419.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>