### PR TITLE
fix(api): Backport: Fixes an issue where KUMA_API_BASE_PATH was not being respected

### DIFF
--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -24,7 +24,7 @@ export default class Env {
     let _env: EnvInternal = envArgs
     const env = (str: keyof EnvInternal, d: string = '') => this.var(str, _env?.[str] ?? d)
 
-    const config = readPathConfigFromDom()
+    const config = this.getConfig()
     const version = semver(env('KUMA_VERSION', config.version))
 
     _env = {
@@ -37,13 +37,34 @@ export default class Env {
       // TODO(jc): not totally sure we need to use a regex here, maybe just split and join if not
       KUMA_DOCS_URL: `${env('KUMA_DOCS_URL')}/${version.patch === '0.0.0' ? 'dev' : version.patch.replace(/\.\d+$/, '.x')}`,
       KUMA_VERSION: version.pre,
-      KUMA_API_URL: env('KUMA_API_URL') ?? config.apiUrl,
-      KUMA_BASE_PATH: env('KUMA_BASE_PATH') ?? config.baseGuiPath,
+      KUMA_API_URL: env('KUMA_API_URL') || config.apiUrl,
+      KUMA_BASE_PATH: env('KUMA_BASE_PATH') || config.baseGuiPath,
     }
   }
 
   var(key: keyof EnvVars, d: string = '') {
     return this.env?.[key] ?? d
+  }
+
+  /**
+   * Reads the path config object from a JSON string found in a special script
+   * tag that’s populated during server-side rendering of the Vue application’s
+   * index.html file.
+   */
+  protected getConfig(): PathConfig {
+    const pathConfigNode = document.querySelector('#kuma-config')
+
+    if (pathConfigNode instanceof HTMLScriptElement) {
+      try {
+        return JSON.parse(pathConfigNode.innerText.trim())
+      } catch {
+        // Handled by falling back to a default value.
+      }
+    }
+
+    // Falls back to a sensible default when encountering a malformed JSON payload
+    // or non-replaced template.
+    return PATH_CONFIG_DEFAULT
   }
 }
 
@@ -56,25 +77,4 @@ export function semver(version: string): { major: string, minor: string, patch: 
     patch: `${major}.${minor}.${patch}`,
     pre: `${major}.${minor}.${patch}${pre !== undefined ? `-${pre}` : ''}`,
   }
-}
-
-/**
- * Reads the path config object from a JSON string found in a special script
- * tag that’s populated during server-side rendering of the Vue application’s
- * index.html file.
- */
-function readPathConfigFromDom(): PathConfig {
-  const pathConfigNode = document.querySelector('#kuma-config')
-
-  if (pathConfigNode instanceof HTMLScriptElement) {
-    try {
-      return JSON.parse(pathConfigNode.innerText.trim())
-    } catch {
-      // Handled by falling back to a default value.
-    }
-  }
-
-  // Falls back to a sensible default when encountering a malformed JSON payload
-  // or non-replaced template.
-  return PATH_CONFIG_DEFAULT
 }

--- a/src/services/env/env.spec.ts
+++ b/src/services/env/env.spec.ts
@@ -1,16 +1,41 @@
 import { describe, expect, test } from '@jest/globals'
-
-import { semver } from './Env'
+import Env, { semver } from './Env'
 
 describe('env', () => {
-  describe('semver', () => {
-    test('it works', () => {
-      expect(semver('1.1.1').patch).toBe('1.1.1')
-      expect(semver('0.0.0-preview.1').patch).toBe('0.0.0')
-      expect(semver('0.0.1-rc.1').patch).toBe('0.0.1')
-      expect(semver('10.10.1').major).toBe('10')
-      expect(semver('0.9.1').minor).toBe('0.9')
-      expect(semver('0.9.1-rc.10').pre).toBe('0.9.1-rc.10')
-    })
+  test('semver', () => {
+    expect(semver('1.1.1').patch).toBe('1.1.1')
+    expect(semver('0.0.0-preview.1').patch).toBe('0.0.0')
+    expect(semver('0.0.1-rc.1').patch).toBe('0.0.1')
+    expect(semver('10.10.1').major).toBe('10')
+    expect(semver('0.9.1').minor).toBe('0.9')
+    expect(semver('0.9.1-rc.10').pre).toBe('0.9.1-rc.10')
+  })
+  test('var', () => {
+    class MockEnv extends Env {
+      protected getConfig() {
+        return {
+          baseGuiPath: '/not/gui',
+          apiUrl: '/somewhere/else/',
+          version: '110.127.30',
+        }
+      }
+    }
+    const env = new MockEnv(
+      {
+        KUMA_PRODUCT_NAME: 'product',
+        KUMA_FEEDBACK_URL: 'http://feedback.fake',
+        KUMA_CHAT_URL: 'http://chat.fake',
+        KUMA_INSTALL_URL: 'http://install.fake',
+        KUMA_VERSION_URL: 'http://version.fake',
+        KUMA_DOCS_URL: 'http://docs.fake',
+      },
+    )
+    expect(env.var('KUMA_DOCS_URL')).toBe('http://docs.fake/110.127.x')
+    expect(env.var('KUMA_INSTALL_URL')).toBe('http://install.fake?utm_source=product&utm_medium=product')
+    expect(env.var('KUMA_VERSION')).toBe('110.127.30')
+    expect(env.var('KUMA_API_URL')).toBe('/somewhere/else/')
+    expect(env.var('KUMA_BASE_PATH')).toBe('/not/gui')
+    expect(env.var('KUMA_PRODUCT_NAME')).toBe('product')
+    expect(env.var('KUMA_FEEDBACK_URL')).toBe('http://feedback.fake')
   })
 })

--- a/src/services/env/env.spec.ts
+++ b/src/services/env/env.spec.ts
@@ -31,7 +31,7 @@ describe('env', () => {
       },
     )
     expect(env.var('KUMA_DOCS_URL')).toBe('http://docs.fake/110.127.x')
-    expect(env.var('KUMA_INSTALL_URL')).toBe('http://install.fake?utm_source=product&utm_medium=product')
+    expect(env.var('KUMA_INSTALL_URL')).toBe('http://install.fake?utm_source=product&utm_medium=product-GUI')
     expect(env.var('KUMA_VERSION')).toBe('110.127.30')
     expect(env.var('KUMA_API_URL')).toBe('/somewhere/else/')
     expect(env.var('KUMA_BASE_PATH')).toBe('/not/gui')


### PR DESCRIPTION
See https://github.com/kumahq/kuma-gui/pull/639

Additionally for the backport, I had to add the `-GUI` string back in for the tests, as on 2.1 we still have that in the UTM codes whereas in `master` we don't

Signed-off-by: John Cowen <john.cowen@konghq.com>