### PR TITLE
chore: Use regexes for vite aliasing

### DIFF
--- a/vite.config.development.ts
+++ b/vite.config.development.ts
@@ -1,15 +1,15 @@
 import { defineConfig, mergeConfig, UserConfigFn, UserConfig } from 'vite'
+import { fileURLToPath, URL } from 'url'
 import { config as prodConfig } from './vite.config'
-
 // https://vitejs.dev/config/
 export const config: UserConfigFn = (env) => {
   return mergeConfig(
     prodConfig(env),
     ({
       resolve: {
-        alias: {
-          '/src/services/index.ts': '/src/services/development.ts',
-        },
+        alias: [
+          { find: /^@\/services$/, replacement: fileURLToPath(new URL('./src/services/development.ts', import.meta.url)) },
+        ],
       },
     } as UserConfig),
   )


### PR DESCRIPTION
I noticed our preview site weren't working due to a change in https://github.com/kumahq/kuma-gui/pull/625, we figured elsewhere that this was due to a difference to how vite deals with aliasing during dev and build, so I changed things to use regex here also.

Signed-off-by: John Cowen <john.cowen@konghq.com>

