### PR TITLE
chore: Makes App injectable, moves injections to composition root/main

### DIFF
--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -23,7 +23,7 @@ jest.mock('vue-github-button', () => ({ template: '<span />' }))
 /**
  * Adds the application’s router to vue test utils. This way tests don’t have to set-up a new router instance on their own.
  */
-const router = createRouter(get(TOKENS.routes))
+const router = createRouter(get(TOKENS.routes), get(TOKENS.store))
 config.global.plugins.push(router)
 
 /**

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Kuma Manager",
   "author": "Kong",
+  "main": "src/index.ts",
   "scripts": {
     "dev": "yarn run dev:mock-api",
     "dev:mock-api": "cross-env VITE_MOCK_API_ENABLED=true vite -c ./vite.config.development.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,53 @@
+import { Component, createApp, InjectionKey } from 'vue'
+import { RouteRecordRaw } from 'vue-router'
+
+import { createRouter } from './router/router'
+
+import type { EnvVars } from '@/services/env/Env'
+import type { ClientConfigInterface } from '@/store/modules/config/config.types'
+import type { Store } from 'vuex'
+import type KumaApi from '@/services/kuma-api/KumaApi'
+import type { State } from '@/store/storeConfig'
+
+/**
+ * Initializes and mounts the Vue application.
+ *
+ * This is a good place to run operations that should ideally be initiated or completed before the Vue application instance exists.
+ */
+
+export function useApp(
+  env: (key: keyof EnvVars) => string,
+  routes: readonly RouteRecordRaw[],
+  logger: {setup: (config: ClientConfigInterface) => void},
+  kumaApi: KumaApi,
+  store: Store<State>,
+  storeKey: InjectionKey<Store<State>>,
+) {
+  document.title = `${env('KUMA_PRODUCT_NAME')} Manager`
+  // during development setBaseUrl also optionally installs MSW mocking via
+  // MockKumaApi
+  kumaApi.setBaseUrl(env('KUMA_API_URL'))
+
+  if (import.meta.env.PROD) {
+    (async () => {
+      const config = await kumaApi.getConfig()
+      logger.setup(config)
+    })()
+  }
+  return async (App: Component) => {
+    const app = createApp(App)
+    app.use(store, storeKey)
+    await Promise.all([
+      // Fetches basic resources before setting up the router and mounting the
+      // application. This is mainly needed to properly redirect users to the
+      // onboarding flow in the appropriate scenarios.
+      store.dispatch('bootstrap'),
+      // Loads available policy types in order to populate the necessary information used for titling/breadcrumbing and policy lookups in the app.
+      store.dispatch('fetchPolicyTypes'),
+    ])
+    const router = await createRouter(routes, store, env('KUMA_BASE_PATH'))
+    app.use(router)
+    app.mount('#app')
+    return app
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,56 +1,5 @@
-import { createApp } from 'vue'
-import { RouteRecordRaw } from 'vue-router'
-
-import { createRouter } from './router/router'
-import { EnvVars } from '@/services/env/Env'
 import { TOKENS, get } from '@/services'
 import App from './app/App.vue'
-import type { ClientConfigInterface } from '@/store/modules/config/config.types'
-
-/**
- * Initializes and mounts the Vue application.
- *
- * This is a good place to run operations that should ideally be initiated or completed before the Vue application instance exists.
- */
-
-async function initializeVue(
-  env: (key: keyof EnvVars) => string,
-  routes: readonly RouteRecordRaw[],
-  logger: {setup: (config: ClientConfigInterface) => void},
-) {
-  const store = get(TOKENS.store)
-  const kumaApi = get(TOKENS.api)
-
-  document.title = `${env('KUMA_PRODUCT_NAME')} Manager`
-  // during development setBaseUrl also optionally installs MSW mocking via
-  // MockKumaApi
-  kumaApi.setBaseUrl(env('KUMA_API_URL'))
-
-  if (import.meta.env.PROD) {
-    (async () => {
-      const config = await kumaApi.getConfig()
-      logger.setup(config)
-    })()
-  }
-
-  const app = createApp(App)
-
-  app.use(store, get(TOKENS.storeKey))
-
-  await Promise.all([
-    // Fetches basic resources before setting up the router and mounting the
-    // application. This is mainly needed to properly redirect users to the
-    // onboarding flow in the appropriate scenarios.
-    store.dispatch('bootstrap'),
-    // Loads available policy types in order to populate the necessary information used for titling/breadcrumbing and policy lookups in the app.
-    store.dispatch('fetchPolicyTypes'),
-  ])
-
-  const router = await createRouter(routes, env('KUMA_BASE_PATH'))
-
-  app.use(router)
-
-  app.mount('#app')
-}
-
-initializeVue(get(TOKENS.env), get(TOKENS.routes), get(TOKENS.logger))
+(async () => {
+  await get(TOKENS.app)(App)
+})()

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -5,19 +5,20 @@ import {
   Router,
   RouteRecordRaw,
 } from 'vue-router'
+import type { State } from '@/store/storeConfig'
+import type { Store } from 'vuex'
 
-import { store } from '@/store/store'
 import { ClientStorage } from '@/utilities/ClientStorage'
 
-export function createRouter(routes: readonly RouteRecordRaw[], baseGuiPath: string = '/'): Router {
+export function createRouter(routes: readonly RouteRecordRaw[], store: Store<State>, baseGuiPath: string = '/'): Router {
   const router = createVueRouter({
     history: createWebHistory(baseGuiPath),
     routes,
   })
 
-  router.beforeEach(redirectOldHashHistoryUrlPaths)
-  router.beforeEach(updateSelectedMeshGuard)
-  router.beforeEach(onboardingRouteGuard)
+  router.beforeEach(redirectOldHashHistoryUrlPaths())
+  router.beforeEach(updateSelectedMeshGuard(store))
+  router.beforeEach(onboardingRouteGuard(store))
 
   return router
 }
@@ -25,7 +26,7 @@ export function createRouter(routes: readonly RouteRecordRaw[], baseGuiPath: str
 /**
  * Redirects navigations to old hash history-style URL paths.
  */
-const redirectOldHashHistoryUrlPaths: NavigationGuard = function (to, _from, next) {
+const redirectOldHashHistoryUrlPaths = (): NavigationGuard => (to, _from, next) => {
   if (to.fullPath.startsWith('/#/')) {
     next(to.fullPath.substring(2))
   } else {
@@ -36,7 +37,7 @@ const redirectOldHashHistoryUrlPaths: NavigationGuard = function (to, _from, nex
 /**
  * Updates `state.selectedMesh` when navigating to a page associated to a different mesh.
  */
-const updateSelectedMeshGuard: NavigationGuard = function (to, _from, next) {
+const updateSelectedMeshGuard = (store: Store<State>): NavigationGuard => (to, _from, next) => {
   if (to.params.mesh && to.params.mesh !== store.state.selectedMesh) {
     store.dispatch('updateSelectedMesh', to.params.mesh)
   }
@@ -49,7 +50,7 @@ const updateSelectedMeshGuard: NavigationGuard = function (to, _from, next) {
  *
  * Redirects the user to the home view if they’re navigating to an onboarding route while having already completed onboarding. An exception is made when we suggest onboarding for users who don’t have data plane proxies, yet (we show an alert suggesting it and allow going to the onboarding again).
  */
-const onboardingRouteGuard: NavigationGuard = function (to, _from, next) {
+const onboardingRouteGuard = (store: Store<State>): NavigationGuard => (to, _from, next) => {
   const isOnboardingCompleted = store.state.onboarding.isCompleted
   const isOnboardingRoute = to.meta.onboardingProcess
   const shouldSuggestOnboarding = store.getters.shouldSuggestOnboarding

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -5,6 +5,7 @@ import KumaApi from '@/services/kuma-api/KumaApi'
 import routes from '@/router/routes'
 import { getNavItems } from '@/app/getNavItems'
 import { storeConfig, State } from '@/store/storeConfig'
+import { useApp } from '../index'
 
 import { InjectionKey } from 'vue'
 import { createStore, Store } from 'vuex'
@@ -30,6 +31,7 @@ export const TOKENS = {
   nav: service(() => (multizone: boolean, hasMeshes: boolean) => getNavItems(multizone, hasMeshes), { description: 'nav' }),
   routes: service(routes, { description: 'routes' }),
   logger: service(Logger, { description: 'logger' }),
+  app: service(useApp, { description: 'app' }),
 }
 
 injected(Env, TOKENS.EnvVars)
@@ -38,3 +40,4 @@ injected(storeConfig, TOKENS.api)
 injected(createStore<State>, TOKENS.storeConfig)
 injected(routes, TOKENS.store)
 injected(Logger, TOKENS.Env)
+injected(useApp, TOKENS.env, TOKENS.routes, TOKENS.logger, TOKENS.api, TOKENS.store, TOKENS.storeKey)


### PR DESCRIPTION
This PR re-arranges `initializeVue` slightly to no longer use `get(TOKENS.*)` and use parameter/constructor injection instead. This is partly to further hide our service container from the actual application code, partly to move the injections to the very root of the application (`main.ts`) and partly to allow us to inject `App` if we ever need to make use of that. We continue to do the majority of our application wiring in `@/services` and import that into `main` so we can `get` the 'application' and call it.

I also added `"main": "index.ts"` to the `package.json` meaning `kuma-gui` can now be used as a real dependency/sub-package.

Signed-off-by: John Cowen <john.cowen@konghq.com>

