### PR TITLE
ci: moves project specific env variables to repository variables

### DIFF
--- a/.github/workflows/create-gui-pr.yml
+++ b/.github/workflows/create-gui-pr.yml
@@ -13,10 +13,6 @@ on:
       # See “Filter pattern cheat sheet” https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
     branches: [ master, 'release-[0-9]+.[0-9]+' ]
 
-env:
-  HOST_REPOSITORY: kumahq/kuma
-  HOST_DIST_DIRECTORY: "app/kuma-ui/pkg/resources/data"
-
 jobs:
   # Creates a pull request in the main application to update its GUI.
   create-gui-pr:
@@ -38,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18.13"
+          node-version: '18.13'
 
       - name: Cache node_modules and dist
         uses: actions/cache@v3
@@ -46,7 +42,7 @@ jobs:
         with:
           path: |
             **/node_modules
-            dist
+            ${{ vars.DIST_DIRECTORY }}
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
@@ -60,7 +56,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ github.token }}
-          repository: ${{ env.HOST_REPOSITORY }}
+          repository: ${{ vars.HOST_REPOSITORY }}
           # Allows merges into release branches (see note 1 above).
           ref: ${{ github.ref }}
           path: main-application
@@ -68,8 +64,8 @@ jobs:
       - name: Copy dist into main application
         run: |
           cd main-application
-          rm -rf ${{ env.HOST_DIST_DIRECTORY }}
-          cp -r ../dist/ ${{ env.HOST_DIST_DIRECTORY }}
+          rm -rf ${{ vars.HOST_DIST_DIRECTORY }}
+          cp -r ../${{ vars.DIST_DIRECTORY }}/ ${{ vars.HOST_DIST_DIRECTORY }}
 
       - name: Create pull request
         # https://github.com/peter-evans/create-pull-request
@@ -89,7 +85,7 @@ jobs:
           signoff: true
           branch: chore/update-gui-in-${{ github.ref_name }}
           delete-branch: true
-          title: "chore(deps): bump ${{ github.repository }} to ${{ github.sha }}"
+          title: 'chore(deps): bump ${{ github.repository }} to ${{ github.sha }}'
           labels: ci/skip-e2e-test,ci/auto-merge
           body: |
             Bumps ${{ github.repository }} to version  [${{ github.ref_name }}@${{ github.sha }}](https://github.com/${{ github.repository }}/tree/${{ github.sha }})

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           path: |
             **/node_modules
-            dist
+            ${{ vars.DIST_DIRECTORY }}
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install


### PR DESCRIPTION
Replaces all project-specific environment variables with repository variables so that their values aren’t part of the workflow file.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>