### PR TITLE
chore: Makes AppHeader and AppSidebar injectable

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -51,12 +51,21 @@ import { useRoute } from 'vue-router'
 import { useStore } from '@/store/store'
 import AppBreadcrumbs from './AppBreadcrumbs.vue'
 import AppErrorMessage from './AppErrorMessage.vue'
-import AppHeader from './AppHeader.vue'
 import AppLoadingBar from './AppLoadingBar.vue'
 import AppOnboardingNotification from './AppOnboardingNotification.vue'
-import AppSidebar from './AppSidebar.vue'
 import NotificationManager from '@/app/notification-manager/components/NotificationManager.vue'
+import {
+  useAppSidebar,
+  useAppHeader,
+} from '@/components'
 
+const [
+  AppSidebar,
+  AppHeader,
+] = [
+  useAppSidebar(),
+  useAppHeader(),
+]
 const store = useStore()
 const route = useRoute()
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,8 @@ import PostgresGraph from '@/app/onboarding/components/graphs/PostgresGraph.vue'
 import MemoryGraph from '@/app/onboarding/components/graphs/MemoryGraph.vue'
 import MultizoneGraph from '@/app/onboarding/components/graphs/MultizoneGraph.vue'
 import StandaloneGraph from '@/app/onboarding/components/graphs/StandaloneGraph.vue'
+import AppSidebar from '@/app/AppSidebar.vue'
+import AppHeader from '@/app/AppHeader.vue'
 
 export const TOKENS = {
   KumaLogo: service(() => KumaLogo, { description: 'KumaLogo' }),
@@ -17,6 +19,8 @@ export const TOKENS = {
   MemoryGraph: service(() => MemoryGraph, { description: 'MemoryGraph' }),
   MultizoneGraph: service(() => MultizoneGraph, { description: 'MultizoneGraph' }),
   StandaloneGraph: service(() => StandaloneGraph, { description: 'StandaloneGraph' }),
+  AppSidebar: service(() => AppSidebar, { description: 'AppSidebar' }),
+  AppHeader: service(() => AppHeader, { description: 'AppHeader' }),
 }
 export const [
   useKumaLogo,
@@ -27,6 +31,8 @@ export const [
   useMemoryGraph,
   useMultizoneGraph,
   useStandaloneGraph,
+  useAppSidebar,
+  useAppHeader,
 ] = createInjections(
   TOKENS.KumaLogo,
   TOKENS.GithubButton,
@@ -36,4 +42,6 @@ export const [
   TOKENS.MemoryGraph,
   TOKENS.MultizoneGraph,
   TOKENS.StandaloneGraph,
+  TOKENS.AppSidebar,
+  TOKENS.AppHeader,
 )

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import type { State } from '@/store/storeConfig'
 
 export function useApp(
   env: (key: keyof EnvVars) => string,
-  routes: readonly RouteRecordRaw[],
+  routes: RouteRecordRaw[],
   logger: {setup: (config: ClientConfigInterface) => void},
   kumaApi: KumaApi,
   store: Store<State>,

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -10,7 +10,7 @@ import type { Store } from 'vuex'
 
 import { ClientStorage } from '@/utilities/ClientStorage'
 
-export function createRouter(routes: readonly RouteRecordRaw[], store: Store<State>, baseGuiPath: string = '/'): Router {
+export function createRouter(routes: RouteRecordRaw[], store: Store<State>, baseGuiPath: string = '/'): Router {
   const router = createVueRouter({
     history: createWebHistory(baseGuiPath),
     routes,

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -8,7 +8,7 @@ import {
 } from 'vue-router'
 import { getLastNumberParameter } from '@/router/getLastParameter'
 
-export default (store: Store<State>): readonly RouteRecordRaw[] => {
+export default (store: Store<State>): RouteRecordRaw[] => {
   return [
     {
       path: '/404',


### PR DESCRIPTION
Moves AppHeader and AppSidebar to our component container.

I also removed the `readonly` routes here as that seems to be unnecessary.

Signed-off-by: John Cowen <john.cowen@konghq.com>

