### PR TITLE
ci: runs create GUI PR workflow only on successful CI

### DIFF
--- a/.github/workflows/create-gui-pr.yml
+++ b/.github/workflows/create-gui-pr.yml
@@ -1,21 +1,25 @@
 name: 'Create GUI update PR'
 
+# **Note 1**: You can merge a pull request into a release branch of the below form (e.g. “release-2.1”) in order to create the GUI update PR in the matching release branch of the host repository. For this to work, the name of this repository’s release branch must match that of the host repository exactly.
+
 # Ensures that we only run one workflow per branch at a time.
 # Already running workflows will be cancelled.
 concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
 
-
-# **Note 1**: You can merge a pull request into a release branch of the below form (e.g. “release-2.1”) in order to create the GUI update PR in the matching release branch of the host repository. For this to work, the name of this repository’s release branch must match that of the host repository exactly.
 on:
-  push:
+  workflow_run:
+    workflows: ['Tests & build']
+    types: [completed]
       # See “Filter pattern cheat sheet” https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
     branches: [master, 'release-[0-9]+.[0-9]+']
 
 jobs:
   # Creates a pull request in the main application to update its GUI.
   create-gui-pr:
+    # Only runs this job when the triggering workflow run was a success (i.e. the “Tests & build” workflow passes).
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Create GUI update PR
     runs-on: ubuntu-latest
     steps:
@@ -57,7 +61,7 @@ jobs:
         with:
           token: ${{ github.token }}
           repository: ${{ vars.HOST_REPOSITORY }}
-          # Allows merges into release branches (see note 1 above).
+          # Allows merges into release branches (see Note 1 above).
           ref: ${{ github.ref }}
           path: main-application
 


### PR DESCRIPTION
Changes the workflow trigger for the "Create GUI update PR" workflow to only run on successful workflow runs of the "Tests & build" workflow (provided that workflow run happened on the default or a release branch).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>