### PR TITLE
chore: Adds type-annotation-spacing spacing lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,15 +84,6 @@ const INLINE_NON_VOID_ELEMENTS = [
         'no-undef': 'off',
         // Turns off some non-TypeScript rules in favor of their specific TypeScript rules to avoid false negatives:
         indent: 'off',
-        '@typescript-eslint/type-annotation-spacing': ['error', {
-          before: false,
-          after: true,
-          overrides: {
-            arrow: {
-              before: true,
-            },
-          },
-        }],
         '@typescript-eslint/indent': ['error', 2],
 
         'func-call-spacing': 'off',
@@ -102,6 +93,15 @@ const INLINE_NON_VOID_ELEMENTS = [
         '@typescript-eslint/no-unused-vars': [process.env.LINTER_MODE === 'strict' ? 'error' : 'warn', {
           argsIgnorePattern: '^_',
           ignoreRestSiblings: true,
+        }],
+        '@typescript-eslint/type-annotation-spacing': ['error', {
+          before: false,
+          after: true,
+          overrides: {
+            arrow: {
+              before: true,
+            },
+          },
         }],
       },
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,6 +84,15 @@ const INLINE_NON_VOID_ELEMENTS = [
         'no-undef': 'off',
         // Turns off some non-TypeScript rules in favor of their specific TypeScript rules to avoid false negatives:
         indent: 'off',
+        '@typescript-eslint/type-annotation-spacing': ['error', {
+          before: false,
+          after: true,
+          overrides: {
+            arrow: {
+              before: true,
+            },
+          },
+        }],
         '@typescript-eslint/indent': ['error', 2],
 
         'func-call-spacing': 'off',

--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -72,7 +72,7 @@ afterEach(() => container.restore?.())
 // add a utility to easily setup/mock out API endpoints
 const re = /\+/g
 
-const useMock = (url: string, response: Record<string, unknown>):MockFunction => {
+const useMock = (url: string, response: Record<string, unknown>): MockFunction => {
   return (_opts, cb) => {
     server.use(
       rest.get(`${import.meta.env.VITE_KUMA_API_SERVER_URL.slice(0, -1)}${url.replace(re, '\\+')}`, (req, res, ctx) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ import { PATH_CONFIG_DEFAULT } from './src/pathConfigDefault'
 dotenv.config()
 
 // https://vitejs.dev/config/
-export const config:UserConfigFn = ({ mode }) => {
+export const config: UserConfigFn = ({ mode }) => {
   return {
     base: './',
     server: {


### PR DESCRIPTION
I noticed that I occasionally miss a space between `:` and type (i.e. `var:Type`). I much prefer the `var: Type` style (with a space after the colon), and it also seems by far to be the style already existing informally in the application.

This PR adds this style to our CI/package scripts so its applied for for any/all contributors.

Couple of corrections included.

Signed-off-by: John Cowen <john.cowen@konghq.com>
