### PR TITLE
chore: Removes `@api/kumaApi` in favour of `useKumaApi`

### DIFF
--- a/src/api/kumaApi.ts
+++ b/src/api/kumaApi.ts
@@ -1,2 +1,0 @@
-import { get, TOKENS } from '@/services'
-export const kumaApi = get(TOKENS.api)

--- a/src/app/AppErrorMessage.vue
+++ b/src/app/AppErrorMessage.vue
@@ -26,5 +26,7 @@
 <script lang="ts" setup>
 import { KEmptyState, KIcon } from '@kong/kongponents'
 
-import { kumaApi } from '@/api/kumaApi'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 </script>

--- a/src/app/common/EnvoyData.vue
+++ b/src/app/common/EnvoyData.vue
@@ -32,9 +32,11 @@
 import { onMounted, PropType, ref, watch } from 'vue'
 import { KButton } from '@kong/kongponents'
 
-import { kumaApi } from '@/api/kumaApi'
 import CodeBlock from './CodeBlock.vue'
 import StatusInfo from './StatusInfo.vue'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const props = defineProps({
   dataPath: {

--- a/src/app/common/UpgradeCheck.vue
+++ b/src/app/common/UpgradeCheck.vue
@@ -33,8 +33,9 @@ import { ref } from 'vue'
 import compare from 'semver/functions/compare'
 import { KAlert, KButton } from '@kong/kongponents'
 
-import { kumaApi } from '@/api/kumaApi'
-import { useEnv } from '@/utilities'
+import { useEnv, useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 const env = useEnv()
 
 const latestVersion = ref('')

--- a/src/app/data-planes/components/DataplanePolicies.vue
+++ b/src/app/data-planes/components/DataplanePolicies.vue
@@ -35,7 +35,6 @@
 import { PropType, ref, watch } from 'vue'
 
 import { useStore } from '@/store/store'
-import { kumaApi } from '@/api/kumaApi'
 import { toYaml } from '@/utilities/toYaml'
 import SidecarDataplanePolicyList from './SidecarDataplanePolicyList.vue'
 import MeshGatewayDataplanePolicyList from './MeshGatewayDataplanePolicyList.vue'
@@ -59,7 +58,9 @@ import {
   RuleEntryConnection,
   SidecarDataplane,
 } from '@/types/index.d'
+import { useKumaApi } from '@/utilities'
 
+const kumaApi = useKumaApi()
 const store = useStore()
 
 const props = defineProps({

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -23,12 +23,13 @@ import { useRoute } from 'vue-router'
 
 import { DataPlane, DataPlaneOverview } from '@/types/index.d'
 import { useStore } from '@/store/store'
-import { kumaApi } from '@/api/kumaApi'
 import DataPlaneDetails from '../components/DataPlaneDetails.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
+import { useKumaApi } from '@/utilities'
 
+const kumaApi = useKumaApi()
 const route = useRoute()
 const store = useStore()
 

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -20,9 +20,11 @@ import { useRoute } from 'vue-router'
 import { DataPlaneOverview } from '@/types/index.d'
 import { DataPlaneOverviewParameters } from '@/types/api'
 import { FilterFields } from '@/app/common/KFilterBar.vue'
-import { kumaApi } from '@/api/kumaApi'
 import { QueryParameter } from '@/utilities/QueryParameter'
 import DataPlaneList from '../components/DataPlaneList.vue'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const PAGE_SIZE = 50
 

--- a/src/app/mesh-overview/views/MeshOverviewView.vue
+++ b/src/app/mesh-overview/views/MeshOverviewView.vue
@@ -111,11 +111,12 @@ import MeshCharts from '../components/MeshCharts.vue'
 import MeshResources from '@/app/common/MeshResources.vue'
 import LabelList from '@/app/common/LabelList.vue'
 import YamlView from '@/app/common/YamlView.vue'
-import { kumaApi } from '@/api/kumaApi'
 import { Mesh, MeshInsight } from '@/types/index.d'
 import { humanReadableDate, stripTimes } from '@/utilities/helpers'
 import { useStore } from '@/store/store'
+import { useKumaApi } from '@/utilities'
 
+const kumaApi = useKumaApi()
 const route = useRoute()
 const store = useStore()
 

--- a/src/app/onboarding/views/AddNewServicesCode.spec.ts
+++ b/src/app/onboarding/views/AddNewServicesCode.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import AddNewServicesCode from './AddNewServicesCode.vue'
-import { kumaApi } from '@/api/kumaApi'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 function renderComponent() {
   return mount(AddNewServicesCode)

--- a/src/app/onboarding/views/AddNewServicesCode.vue
+++ b/src/app/onboarding/views/AddNewServicesCode.vue
@@ -84,14 +84,15 @@
 <script lang="ts" setup>
 import { computed, onUnmounted, ref } from 'vue'
 
-import { kumaApi } from '@/api/kumaApi'
 import { useStore } from '@/store/store'
 import CodeBlock from '@/app/common/CodeBlock.vue'
 import LoadingBox from '../components/LoadingBox.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
+import { useKumaApi } from '@/utilities'
 
+const kumaApi = useKumaApi()
 const store = useStore()
 
 const LONG_POOLING_INTERVAL = 1000

--- a/src/app/onboarding/views/DataplanesOverview.vue
+++ b/src/app/onboarding/views/DataplanesOverview.vue
@@ -63,12 +63,14 @@ import { computed, onBeforeUnmount, ref } from 'vue'
 import { KTable } from '@kong/kongponents'
 
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
-import { kumaApi } from '@/api/kumaApi'
 import LoadingBox from '../components/LoadingBox.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const TABLE_HEADERS = [
   { label: 'Mesh', key: 'mesh' },

--- a/src/app/onboarding/views/MultiZoneView.spec.ts
+++ b/src/app/onboarding/views/MultiZoneView.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import MultiZoneView from './MultiZoneView.vue'
-import { kumaApi } from '@/api/kumaApi'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 function renderComponent() {
   return mount(MultiZoneView)

--- a/src/app/onboarding/views/MultiZoneView.vue
+++ b/src/app/onboarding/views/MultiZoneView.vue
@@ -75,13 +75,13 @@
 <script lang="ts" setup>
 import { onUnmounted, ref } from 'vue'
 
-import { kumaApi } from '@/api/kumaApi'
-import { useEnv } from '@/utilities'
 import LoadingBox from '../components/LoadingBox.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
+import { useEnv, useKumaApi } from '@/utilities'
 
+const kumaApi = useKumaApi()
 const env = useEnv()
 
 const LONG_POOLING_INTERVAL = 1000

--- a/src/app/policies/components/PolicyConnections.vue
+++ b/src/app/policies/components/PolicyConnections.vue
@@ -45,8 +45,10 @@
 <script lang="ts" setup>
 import { computed, onMounted, ref, watch } from 'vue'
 
-import { kumaApi } from '@/api/kumaApi'
 import LabelList from '@/app/common/LabelList.vue'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const props = defineProps({
   mesh: {

--- a/src/app/policies/views/PolicyView.vue
+++ b/src/app/policies/views/PolicyView.vue
@@ -150,7 +150,6 @@ import {
 } from '@kong/kongponents'
 
 import { getSome, stripTimes } from '@/utilities/helpers'
-import { kumaApi } from '@/api/kumaApi'
 import { PAGE_SIZE_DEFAULT } from '@/constants'
 import { PolicyEntity, TableHeader } from '@/types/index.d'
 import { QueryParameter } from '@/utilities/QueryParameter'
@@ -163,7 +162,9 @@ import PolicyConnections from '../components/PolicyConnections.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
 import YamlView from '@/app/common/YamlView.vue'
 
-import { useEnv } from '@/utilities'
+import { useEnv, useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 const env = useEnv()
 
 const tabs = [

--- a/src/app/services/views/ServiceDetailView.spec.ts
+++ b/src/app/services/views/ServiceDetailView.spec.ts
@@ -2,9 +2,11 @@ import { beforeAll, describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, shallowMount } from '@vue/test-utils'
 
 import ServiceDetailView from './ServiceDetailView.vue'
-import { kumaApi } from '@/api/kumaApi'
 import { createExternalService } from '@/test-data/createExternalService'
 import { createServiceInsight } from '@/test-data/createServiceInsight'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const externalService = createExternalService()
 const serviceInsight = createServiceInsight()

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -28,13 +28,15 @@ import { useRoute } from 'vue-router'
 import { DataPlaneOverview, ExternalService, ServiceInsight } from '@/types/index.d'
 import { DataPlaneOverviewParameters } from '@/types/api.d'
 import { FilterFields } from '@/app/common/KFilterBar.vue'
-import { kumaApi } from '@/api/kumaApi'
 import { QueryParameter } from '@/utilities/QueryParameter'
 import { useStore } from '@/store/store'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import ServiceDetails from '../components/ServiceDetails.vue'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const DPP_FILTER_FIELDS: FilterFields = {
   name: { description: 'filter by name or parts of a name' },

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -29,13 +29,14 @@
 <script lang="ts" setup>
 import { ref, watch } from 'vue'
 import { useRoute, RouteLocationRaw, RouteLocationNamedRaw } from 'vue-router'
-
 import { ExternalService, ServiceInsight, TableHeader } from '@/types/index.d'
-import { kumaApi } from '@/api/kumaApi'
 import { QueryParameter } from '@/utilities/QueryParameter'
 import ContentWrapper from '@/app/common/ContentWrapper.vue'
 import DataOverview from '@/app/common/DataOverview.vue'
 import ServiceSummary from '../components/ServiceSummary.vue'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const headers: TableHeader[] = [
   { label: 'Service', key: 'name' },

--- a/src/app/wizard/views/DataplaneKubernetes.vue
+++ b/src/app/wizard/views/DataplaneKubernetes.vue
@@ -441,7 +441,6 @@ import { KAlert, KButton, KCard } from '@kong/kongponents'
 
 import { formatForCLI } from '../formatForCLI'
 import { kebabCase } from '@/utilities/helpers'
-import { kumaApi } from '@/api/kumaApi'
 import { PRODUCT_NAME } from '@/constants'
 import { QueryParameter } from '@/utilities/QueryParameter'
 import { useStore } from '@/store/store'
@@ -451,6 +450,9 @@ import EntityScanner from '../components/EntityScanner.vue'
 import EnvironmentSwitcher from '../components/EnvironmentSwitcher.vue'
 import FormFragment from '../components/FormFragment.vue'
 import StepSkeleton from '../components/StepSkeleton.vue'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const EXAMPLE_CODE = `apiVersion: 'kuma.io/v1alpha1'
 kind: Dataplane

--- a/src/app/wizard/views/DataplaneUniversal.vue
+++ b/src/app/wizard/views/DataplaneUniversal.vue
@@ -443,7 +443,6 @@ import { useRouter } from 'vue-router'
 import { KAlert, KButton, KCard } from '@kong/kongponents'
 
 import { kebabCase } from '@/utilities/helpers'
-import { kumaApi } from '@/api/kumaApi'
 import { kumaDpServerUrl } from '@/utilities/kumaDpServerUrl'
 import { PRODUCT_NAME } from '@/constants'
 import { QueryParameter } from '@/utilities/QueryParameter'
@@ -456,6 +455,9 @@ import EnvironmentSwitcher from '../components/EnvironmentSwitcher.vue'
 import FormFragment from '../components/FormFragment.vue'
 import HelperTooltip from '../components/HelperTooltip.vue'
 import StepSkeleton from '../components/StepSkeleton.vue'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const EXAMPLE_CODE = `type: Dataplane
 mesh: default

--- a/src/app/wizard/views/MeshWizard.vue
+++ b/src/app/wizard/views/MeshWizard.vue
@@ -641,10 +641,8 @@ import { ClientStorage } from '@/utilities/ClientStorage'
 import { computed, ref, watch } from 'vue'
 import { formatForCLI } from '../formatForCLI'
 import { kebabCase } from '@/utilities/helpers'
-import { kumaApi } from '@/api/kumaApi'
 import { PRODUCT_NAME } from '@/constants'
 import { QueryParameter } from '@/utilities/QueryParameter'
-import { useEnv } from '@/utilities'
 import { useStore } from '@/store/store'
 import CodeBlock from '@/app/common/CodeBlock.vue'
 import EntityScanner from '../components/EntityScanner.vue'
@@ -652,6 +650,9 @@ import FormFragment from '../components/FormFragment.vue'
 import meshSchema from './MeshSchema'
 import StepSkeleton from '../components/StepSkeleton.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
+import { useEnv, useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const STEPS = [
   {

--- a/src/app/zones/views/ZoneEgresses.vue
+++ b/src/app/zones/views/ZoneEgresses.vue
@@ -119,7 +119,6 @@ import { KButton, KCard } from '@kong/kongponents'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
 import { getSome } from '@/utilities/helpers'
 import { TableHeader, ZoneEgressOverview } from '@/types/index.d'
-import { kumaApi } from '@/api/kumaApi'
 import { PAGE_SIZE_DEFAULT } from '@/constants'
 import { QueryParameter } from '@/utilities/QueryParameter'
 import AccordionItem from '@/app/common/AccordionItem.vue'
@@ -131,6 +130,9 @@ import LabelList from '@/app/common/LabelList.vue'
 import SubscriptionDetails from '@/app/common/subscriptions/SubscriptionDetails.vue'
 import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const EMPTY_STATE = {
   title: 'No Data',

--- a/src/app/zones/views/ZoneIngresses.vue
+++ b/src/app/zones/views/ZoneIngresses.vue
@@ -118,7 +118,6 @@ import { KButton, KCard } from '@kong/kongponents'
 
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
 import { getSome } from '@/utilities/helpers'
-import { kumaApi } from '@/api/kumaApi'
 import { PAGE_SIZE_DEFAULT } from '@/constants'
 import { QueryParameter } from '@/utilities/QueryParameter'
 import { TableHeader, ZoneIngressOverview } from '@/types/index.d'
@@ -133,6 +132,9 @@ import MultizoneInfo from '../components/MultizoneInfo.vue'
 import SubscriptionDetails from '@/app/common/subscriptions/SubscriptionDetails.vue'
 import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const EMPTY_STATE = {
   title: 'No Data',

--- a/src/app/zones/views/ZonesView.vue
+++ b/src/app/zones/views/ZonesView.vue
@@ -127,7 +127,6 @@ import { KBadge, KButton, KCard } from '@kong/kongponents'
 
 import { fetchAllResources, getSome, getZoneDpServerAuthType } from '@/utilities/helpers'
 import { getItemStatusFromInsight, INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS } from '@/utilities/dataplane'
-import { kumaApi } from '@/api/kumaApi'
 import { PAGE_SIZE_DEFAULT } from '@/constants'
 import { QueryParameter } from '@/utilities/QueryParameter'
 import { KDSSubscription, TableHeader, ZoneCompatibility, ZoneOverview } from '@/types/index.d'
@@ -143,6 +142,9 @@ import SubscriptionDetails from '@/app/common/subscriptions/SubscriptionDetails.
 import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
 import WarningsWidget from '@/app/common/warnings/WarningsWidget.vue'
+import { useKumaApi } from '@/utilities'
+
+const kumaApi = useKumaApi()
 
 const EMPTY_STATE = {
   title: 'No Data',

--- a/src/services/kuma-api/README.md
+++ b/src/services/kuma-api/README.md
@@ -7,5 +7,11 @@ this service.
 This service is currently available via:
 
 ```javascript
-import { kumaApi } from '@/api/kumaApi'
+import { useKumaApi } from '@/utilities'
+const kumaApi = useKumaApi()
+kumaApi.getConfig()
 ```
+
+During development `useKumaApi` returns an instance of `MockKumaApi` which
+additionally/optionally installs a mock service worker to proxy/mock all HTTP
+requests to avoid requiring a real Kuma running in the background.

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -3,4 +3,5 @@ import { TOKENS, createInjections } from '@/services'
 export const [
   useEnv,
   useNav,
-] = createInjections(TOKENS.env, TOKENS.nav)
+  useKumaApi,
+] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api)


### PR DESCRIPTION
Addresses part of https://github.com/kumahq/kuma-gui/issues/660

This PR removes  `@api/kumaApi` in favour of a `useKumaApi`, `@api/kumaApi` was a simple shim over our service container to avoid a bunch of churn whilst this was shaking out. This goes back (now everything has shaken out a bit) to keep the codebase consistent.

As a sidenote I also noticed that the only things left in `@/api` now are the mock api related files which are soon to be improved as part of https://github.com/kumahq/kuma-gui/issues/522

Signed-off-by: John Cowen <john.cowen@konghq.com>

