### PR TITLE
ci: uses .nvmrc file for node

### DIFF
--- a/.github/workflows/create-gui-pr.yml
+++ b/.github/workflows/create-gui-pr.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.13'
+          node-version-file: '.nvmrc'
 
       - name: Cache node_modules and dist
         uses: actions/cache@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         # https://github.com/actions/setup-node
         uses: actions/setup-node@v3
         with:
-          node-version: '18.13'
+          node-version-file: '.nvmrc'
 
       - name: Cache node_modules and dist
         # https://github.com/actions/cache


### PR DESCRIPTION
Looks like this is supported but not listed on https://github.com/actions/setup-node.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>