### PR TITLE
chore: Remove 'bare' store access

### DIFF
--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -27,11 +27,6 @@ const router = createRouter(get(TOKENS.routes), get(TOKENS.store))
 config.global.plugins.push(router)
 
 /**
- * Adds the application’s Vuex store to vue test utils. This way tests don’t have to set-up a new store instance on their own.
- */
-config.global.plugins.push([get(TOKENS.store), get(TOKENS.storeKey)])
-
-/**
  * Kongponents uses generated UUIDs for several attribute values.
  * This breaks the project’s snapshot tests since they’re based on fully-mounted components
  * which also includes those from external sources like Kongponents.

--- a/src/app/App.spec.ts
+++ b/src/app/App.spec.ts
@@ -3,13 +3,16 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { withVersion } from '@/../jest/jest-setup-after-env'
 
 import App from './App.vue'
-import { store } from '@/store/store'
 import { TOKENS } from '@/components'
 import { set } from '@/services'
+import { useStore, useEnv } from '@/utilities'
+
+const store = useStore()
 
 function renderComponent(status: string) {
+  const env = useEnv()
   store.state.globalLoading = true
-  store.state.config.tagline = import.meta.env.VITE_NAMESPACE
+  store.state.config.tagline = env('KUMA_PRODUCT_NAME')
   store.state.config.status = status
 
   // keeps the github-button as a <github-button> instead of a span in

--- a/src/app/AppNavItem.spec.ts
+++ b/src/app/AppNavItem.spec.ts
@@ -2,8 +2,9 @@ import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import AppNavItem from './AppNavItem.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 
+const store = useStore()
 function renderComponent() {
   return mount(AppNavItem, {
     props: {

--- a/src/app/AppSidebar.spec.ts
+++ b/src/app/AppSidebar.spec.ts
@@ -2,8 +2,9 @@ import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import AppSidebar from './AppSidebar.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 
+const store = useStore()
 async function renderComponent() {
   await store.dispatch('fetchPolicyTypes')
 

--- a/src/app/data-planes/components/DataPlaneDetails.spec.ts
+++ b/src/app/data-planes/components/DataPlaneDetails.spec.ts
@@ -2,13 +2,14 @@ import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneDetails from './DataPlaneDetails.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 import { createDataPlane } from '@/test-data/createDataPlane'
 import { createDataPlaneOverview } from '@/test-data/createDataPlaneOverview'
 
 const dataPlane = createDataPlane()
 const dataPlaneOverview = createDataPlaneOverview()
 
+const store = useStore()
 async function renderComponent(props = {}) {
   await store.dispatch('fetchPolicyTypes')
 

--- a/src/app/data-planes/components/DataplanePolicies.spec.ts
+++ b/src/app/data-planes/components/DataplanePolicies.spec.ts
@@ -3,12 +3,13 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { rest } from 'msw'
 
 import DataplanePolicies from './DataplanePolicies.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 import { server } from '@/../jest/jest-setup-after-env'
 import {
   DataPlane,
 } from '@/types/index.d'
 
+const store = useStore()
 async function renderComponent(props = {}) {
   await store.dispatch('fetchPolicyTypes')
   const dataPlane: DataPlane = {

--- a/src/app/data-planes/components/PolicyTypeEntryList.spec.ts
+++ b/src/app/data-planes/components/PolicyTypeEntryList.spec.ts
@@ -2,9 +2,10 @@ import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import PolicyTypeEntryList from './PolicyTypeEntryList.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 import { createPolicyTypeEntries } from '@/test-data/createPolicyTypeEntries'
 
+const store = useStore()
 const policyTypeEntries = createPolicyTypeEntries()
 
 async function renderComponent(props = {}) {

--- a/src/app/notification-manager/components/NotificationManager.spec.ts
+++ b/src/app/notification-manager/components/NotificationManager.spec.ts
@@ -2,8 +2,9 @@ import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import NotificationManager from './NotificationManager.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 
+const store = useStore()
 function renderComponent({ meshes, selectedMesh }: { meshes: any, selectedMesh: string }) {
   store.state.meshes = meshes
   store.state.selectedMesh = selectedMesh

--- a/src/app/onboarding/components/OnboardingNavigation.spec.ts
+++ b/src/app/onboarding/components/OnboardingNavigation.spec.ts
@@ -2,8 +2,9 @@ import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import OnboardingNavigation from './OnboardingNavigation.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 
+const store = useStore()
 function renderComponent(props = {}) {
   return mount(OnboardingNavigation, {
     props: {

--- a/src/app/onboarding/views/ConfigurationTypes.spec.ts
+++ b/src/app/onboarding/views/ConfigurationTypes.spec.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import ConfigurationTypes from './ConfigurationTypes.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
+const store = useStore()
 function renderComponent(mode = 'standalone') {
   const clientConfig: ClientConfigInterface = { ...config, mode }
   store.state.config.clientConfig = clientConfig

--- a/src/app/onboarding/views/CreateMesh.spec.ts
+++ b/src/app/onboarding/views/CreateMesh.spec.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import CreateMesh from './CreateMesh.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
+const store = useStore()
 function renderComponent(mode = 'standalone') {
   const clientConfig: ClientConfigInterface = { ...config, mode }
   store.state.config.clientConfig = clientConfig

--- a/src/app/onboarding/views/WelcomeView.spec.ts
+++ b/src/app/onboarding/views/WelcomeView.spec.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from '@jest/globals'
 import { mount } from '@vue/test-utils'
 
 import WelcomeView from './WelcomeView.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
+const store = useStore()
 function renderComponent(environment: string) {
   const clientConfig: ClientConfigInterface = { ...config, environment }
   store.state.config.clientConfig = clientConfig

--- a/src/app/policies/views/PolicyView.spec.ts
+++ b/src/app/policies/views/PolicyView.spec.ts
@@ -2,9 +2,10 @@ import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import PolicyView from './PolicyView.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 import { router } from '@/../jest/jest-setup-after-env'
 
+const store = useStore()
 async function createWrapper(props = {}) {
   router.push({ name: 'mesh-detail-view', params: { mesh: 'default' } })
   await store.dispatch('fetchPolicyTypes')

--- a/src/app/wizard/views/DataplaneUniversal.spec.ts
+++ b/src/app/wizard/views/DataplaneUniversal.spec.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, jest, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataplaneUniversal from './DataplaneUniversal.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 
+const store = useStore()
 function renderComponent() {
   return mount(DataplaneUniversal)
 }

--- a/src/app/wizard/views/MeshWizard.spec.ts
+++ b/src/app/wizard/views/MeshWizard.spec.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from '@jest/globals'
 import { DOMWrapper, flushPromises, mount, VueWrapper } from '@vue/test-utils'
 
 import MeshWizard from './MeshWizard.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
+const store = useStore()
 function renderComponent(mode = 'standalone') {
   store.state.config.tagline = import.meta.env.VITE_NAMESPACE
   store.state.config.kumaDocsVersion = '1.2.0'

--- a/src/app/zones/views/ZoneEgresses.spec.ts
+++ b/src/app/zones/views/ZoneEgresses.spec.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import ZoneEgresses from './ZoneEgresses.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
+const store = useStore()
 function renderComponent(mode = 'standalone') {
   const clientConfig: ClientConfigInterface = { ...config, mode }
   store.state.config.clientConfig = clientConfig

--- a/src/app/zones/views/ZoneIngresses.spec.ts
+++ b/src/app/zones/views/ZoneIngresses.spec.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import ZoneIngresses from './ZoneIngresses.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
+const store = useStore()
 function renderComponent(mode = 'standalone') {
   const clientConfig: ClientConfigInterface = { ...config, mode }
   store.state.config.clientConfig = clientConfig

--- a/src/app/zones/views/ZonesView.spec.ts
+++ b/src/app/zones/views/ZonesView.spec.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import ZonesView from './ZonesView.vue'
-import { store } from '@/store/store'
+import { useStore } from '@/utilities'
 import { ClientConfigInterface } from '@/store/modules/config/config.types'
 import * as config from '@/api/mock-data/config.json'
 
+const store = useStore()
 function renderComponent(mode = 'standalone') {
   const clientConfig: ClientConfigInterface = { ...config, mode }
   store.state.config.clientConfig = clientConfig

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,10 +1,8 @@
 import { get, TOKENS } from '@/services'
-import { useStore as useVuexStore, Store } from 'vuex'
+import type { Store } from 'vuex'
 
 import type { State } from './storeConfig'
 
-export const store: Store<State> = get(TOKENS.store)
-
 export function useStore(): Store<State> {
-  return useVuexStore(get(TOKENS.storeKey))
+  return get(TOKENS.store)
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -4,4 +4,5 @@ export const [
   useEnv,
   useNav,
   useKumaApi,
-] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api)
+  useStore,
+] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api, TOKENS.store)


### PR DESCRIPTION
Throughout our application all store access goes via `useStore` whereas in our tests we needed an extra `store` export to access the store.

This PR adds a `useStore` that's accessible for tests also. Resulting in the code in the application and in the tests setup being almost the same.

This addresses the second half of https://github.com/kumahq/kuma-gui/issues/660 i.e. accessing the same stuff in the same way everywhere and removing as many references to `get` and `TOKENS` from the application code as possible, therefore hiding the service container completely. (first half is https://github.com/kumahq/kuma-gui/pull/663)

Note: There'll be a follow up PR at some point after this removing the last instance of `store` related `getting` in `store/store.ts`, I figured it would be better to separate that task off to a separate PR.

Oh, I also replaced an instance of `VITE_NAMESPACE` with our `env` helper while I was here

P.S. Forgot to note, whilst I was doing this I was tempted to stop having a 'file global' `store` object in all the tests. There's probably a way we can automatically prevent any leaking mocks/tests when we edit values in the store during testing. I figured doing that would be best for a potential different task though.

Signed-off-by: John Cowen <john.cowen@konghq.com>