### PR TITLE
fix: env not using base URL

### DIFF
--- a/src/pathConfigDefault.ts
+++ b/src/pathConfigDefault.ts
@@ -1,9 +1,11 @@
 import { PathConfig } from './types/index'
 
-export const PATH_CONFIG_DEFAULT: PathConfig = {
-  baseGuiPath: '',
-  // **TIP**: Change this value to test various GUI base path scenarios.
-  // baseGuiPath: '/dev/gui',
-  apiUrl: '/',
-  version: '1.7.0',
+export function getPathConfigDefault(apiUrlDefault: string): PathConfig {
+  return {
+    baseGuiPath: '',
+    // **TIP**: Change this value to test various GUI base path scenarios.
+    // baseGuiPath: '/dev/gui',
+    apiUrl: apiUrlDefault,
+    version: '1.7.0',
+  }
 }

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -1,4 +1,4 @@
-import { PATH_CONFIG_DEFAULT } from '@/pathConfigDefault'
+import { getPathConfigDefault } from '@/pathConfigDefault'
 import { PathConfig } from '@/types/index'
 
 export type EnvArgs = {
@@ -8,6 +8,7 @@ export type EnvArgs = {
   KUMA_INSTALL_URL: string
   KUMA_VERSION_URL: string
   KUMA_DOCS_URL: string
+  KUMA_API_URL: string
 }
 type EnvProps = {
   KUMA_VERSION: string
@@ -65,7 +66,7 @@ export default class Env {
 
     // Falls back to a sensible default when encountering a malformed JSON payload
     // or non-replaced template.
-    return PATH_CONFIG_DEFAULT
+    return getPathConfigDefault(import.meta.env.PROD ? window.location.origin : import.meta.env.VITE_KUMA_API_SERVER_URL)
   }
 }
 

--- a/src/services/env/env.spec.ts
+++ b/src/services/env/env.spec.ts
@@ -28,6 +28,7 @@ describe('env', () => {
         KUMA_INSTALL_URL: 'http://install.fake',
         KUMA_VERSION_URL: 'http://version.fake',
         KUMA_DOCS_URL: 'http://docs.fake',
+        KUMA_API_URL: '/somewhere/else/',
       },
     )
     expect(env.var('KUMA_DOCS_URL')).toBe('http://docs.fake/110.127.x')

--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -31,8 +31,9 @@ import Env from '@/services/env/Env'
 export default class KumaApi {
   client: RestClient
   env: Env
+
   constructor(env: Env) {
-    this.client = new RestClient()
+    this.client = new RestClient(env.var('KUMA_API_URL'))
     this.env = env
   }
 

--- a/src/services/kuma-api/RestClient.spec.ts
+++ b/src/services/kuma-api/RestClient.spec.ts
@@ -5,7 +5,7 @@ import * as MakeRequestModule from './makeRequest'
 
 describe('RestClient', () => {
   test('has expected initial base URL', () => {
-    const restClient = new RestClient()
+    const restClient = new RestClient('http://localhost:5681')
 
     expect(restClient.baseUrl).toBe('http://localhost:5681')
   })
@@ -20,7 +20,7 @@ describe('RestClient', () => {
     ['http://localhost:1234/api', 'http://localhost:1234/api'],
     ['http://localhost:1234/api/', 'http://localhost:1234/api'],
   ])('sets expected base URL for “%s”', (newBaseUrl, expectedBaseUrl) => {
-    const restClient = new RestClient()
+    const restClient = new RestClient('http://localhost:5681')
 
     restClient.baseUrl = newBaseUrl
 
@@ -84,7 +84,7 @@ describe('RestClient', () => {
       data: null,
     }))
 
-    const restClient = new RestClient()
+    const restClient = new RestClient('http://localhost:5681')
     restClient.raw('path', { params })
 
     expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith('http://localhost:5681/path', expectedOptions)

--- a/src/services/kuma-api/RestClient.ts
+++ b/src/services/kuma-api/RestClient.ts
@@ -1,12 +1,16 @@
 import { makeRequest } from './makeRequest'
 
-const DEFAULT_BASE_URL = import.meta.env.PROD ? window.location.origin : import.meta.env.VITE_KUMA_API_SERVER_URL
-
 export class RestClient {
   /**
    * The API base URL. **Will always be stored without a trailing slash**.
    */
-  _baseUrl: string = DEFAULT_BASE_URL
+  _baseUrl: string
+  _defaultBaseUrl: string
+
+  constructor(defaultBaseUrl: string) {
+    this._baseUrl = defaultBaseUrl
+    this._defaultBaseUrl = defaultBaseUrl
+  }
 
   /**
    * The absolute API base URL used in all requests. Includes its base path segment if one is set.
@@ -23,7 +27,7 @@ export class RestClient {
       this._baseUrl = trimTrailingSlashes(baseUrlOrPath)
     } else {
       const basePath = trimSlashes(baseUrlOrPath)
-      this._baseUrl = [DEFAULT_BASE_URL, basePath].filter((segment) => segment !== '').join('/')
+      this._baseUrl = [this._defaultBaseUrl, basePath].filter((segment) => segment !== '').join('/')
     }
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,12 +6,14 @@ import pluginRewriteAll from 'vite-plugin-rewrite-all'
 import svgLoader from 'vite-svg-loader'
 import vue from '@vitejs/plugin-vue'
 
-import { PATH_CONFIG_DEFAULT } from './src/pathConfigDefault'
+import { getPathConfigDefault } from './src/pathConfigDefault'
 
 dotenv.config()
 
 // https://vitejs.dev/config/
 export const config: UserConfigFn = ({ mode }) => {
+  const pathConfigDefault = getPathConfigDefault(process.env.VITE_KUMA_API_SERVER_URL as string)
+
   return {
     base: './',
     server: {
@@ -38,8 +40,8 @@ export const config: UserConfigFn = ({ mode }) => {
             /**
              * Adds the appropriate GUI base path placeholder to the index.html file. It is going to be replaced using server-side templating when serving the GUI application in production.
              */
-            baseGuiPath: mode === 'production' ? '{{.BaseGuiPath}}' : PATH_CONFIG_DEFAULT.baseGuiPath,
-            config: mode === 'production' ? '{{.}}' : JSON.stringify(PATH_CONFIG_DEFAULT),
+            baseGuiPath: mode === 'production' ? '{{.BaseGuiPath}}' : pathConfigDefault.baseGuiPath,
+            config: mode === 'production' ? '{{.}}' : JSON.stringify(pathConfigDefault),
           },
         },
       }),


### PR DESCRIPTION
Fixes RestClient not using `env` for its base URL.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>