### PR TITLE
feat: adds options setter for rest client

### DIFF
--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -50,8 +50,13 @@ export default class KumaApi {
     this.client.baseUrl = baseUrl
   }
 
-  setHeader(name: string, value: string): void {
-    this.client.setHeader(name, value)
+  /**
+   * Sets the default options to be used for [the fetch API’s `options` parameter][1].
+   *
+   * [1]: https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters
+   */
+  setOptions(options: RequestInit): void {
+    this.client.options = options
   }
 
   getInfo(): Promise<Info> {


### PR DESCRIPTION
Adds a way to set default options for `RestClient` and removes the ability to set headers specifically as they can be set using options. This is useful for changing the credentials option for example.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>