### PR TITLE
refactor: extracts app mounting into entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,10 @@ import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { State } from '@/store/storeConfig'
 
 /**
- * Initializes and mounts the Vue application.
- *
  * This is a good place to run operations that should ideally be initiated or completed before the Vue application instance exists.
+ *
+ * @returns a factory creating an initialized Vue application with installed store and router without mounting it.
  */
-
 export function useApp(
   env: (key: keyof EnvVars) => string,
   routes: RouteRecordRaw[],
@@ -34,9 +33,12 @@ export function useApp(
       logger.setup(config)
     })()
   }
+
   return async (App: Component) => {
     const app = createApp(App)
+
     app.use(store, storeKey)
+
     await Promise.all([
       // Fetches basic resources before setting up the router and mounting the
       // application. This is mainly needed to properly redirect users to the
@@ -46,8 +48,9 @@ export function useApp(
       store.dispatch('fetchPolicyTypes'),
     ])
     const router = await createRouter(routes, store, env('KUMA_BASE_PATH'))
+
     app.use(router)
-    app.mount('#app')
+
     return app
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { TOKENS, get } from '@/services'
 import App from './app/App.vue'
 (async () => {
-  await get(TOKENS.app)(App)
+  const app = await get(TOKENS.app)(App)
+  app.mount('#app')
 })()


### PR DESCRIPTION
Moves the call to `app.mount` into the entry point file so that consuming applications can make further `app.use` calls **before** the application is being rendered. This is especially relevant for registering components before trying to render them.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>