### PR TITLE
refactor: runs post mount operations on custom event

### DIFF
--- a/src/app/App.spec.ts
+++ b/src/app/App.spec.ts
@@ -37,10 +37,13 @@ describe('App.vue', () => {
   test('renders main view when successful', async () => {
     withVersion('10.2.0')
     const wrapper = renderComponent('OK')
-    store.dispatch('bootstrap')
 
+    await store.dispatch('updateGlobalLoading', true)
+    store.dispatch('bootstrap')
     expect(wrapper.find('[data-testid="app-progress-bar"]').exists()).toBe(true)
+
     await flushPromises()
+    await store.dispatch('updateGlobalLoading', false)
     expect(wrapper.find('[data-testid="app-progress-bar"]').exists()).toBe(false)
 
     expect(wrapper.html()).toContain('Create a virtual mesh')
@@ -49,10 +52,13 @@ describe('App.vue', () => {
   test('fails to renders basic view', async () => {
     withVersion('10.2.0')
     const wrapper = renderComponent('ERROR')
-    store.dispatch('bootstrap')
 
+    await store.dispatch('updateGlobalLoading', true)
+    store.dispatch('bootstrap')
     expect(wrapper.find('[data-testid="app-progress-bar"]').exists()).toBe(true)
+
     await flushPromises()
+    await store.dispatch('updateGlobalLoading', false)
     expect(wrapper.find('[data-testid="app-progress-bar"]').exists()).toBe(false)
 
     expect(wrapper.element).toMatchSnapshot()

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,40 +17,55 @@ import type { State } from '@/store/storeConfig'
 export function useApp(
   env: (key: keyof EnvVars) => string,
   routes: RouteRecordRaw[],
-  logger: {setup: (config: ClientConfigInterface) => void},
+  logger: { setup: (config: ClientConfigInterface) => void },
   kumaApi: KumaApi,
   store: Store<State>,
   storeKey: InjectionKey<Store<State>>,
 ) {
   document.title = `${env('KUMA_PRODUCT_NAME')} Manager`
-  // during development setBaseUrl also optionally installs MSW mocking via
-  // MockKumaApi
-  kumaApi.setBaseUrl(env('KUMA_API_URL'))
-
-  if (import.meta.env.PROD) {
-    (async () => {
-      const config = await kumaApi.getConfig()
-      logger.setup(config)
-    })()
-  }
 
   return async (App: Component) => {
     const app = createApp(App)
 
     app.use(store, storeKey)
 
-    await Promise.all([
-      // Fetches basic resources before setting up the router and mounting the
-      // application. This is mainly needed to properly redirect users to the
-      // onboarding flow in the appropriate scenarios.
-      store.dispatch('bootstrap'),
-      // Loads available policy types in order to populate the necessary information used for titling/breadcrumbing and policy lookups in the app.
-      store.dispatch('fetchPolicyTypes'),
-    ])
     const router = await createRouter(routes, store, env('KUMA_BASE_PATH'))
-
     app.use(router)
+
+    // Triggering post mount routines via custom event allows for this event to be delayed and fired from a place that is not the main entry point of the application.
+    document.addEventListener('app:ready', function () {
+      runPostMountRoutines(env, logger, kumaApi, store)
+    })
 
     return app
   }
+}
+
+async function runPostMountRoutines(
+  env: (key: keyof EnvVars) => string,
+  logger: { setup: (config: ClientConfigInterface) => void },
+  kumaApi: KumaApi,
+  store: Store<State>,
+) {
+  await store.dispatch('updateGlobalLoading', true)
+
+  if (import.meta.env.PROD) {
+    kumaApi.getConfig().then((config) => {
+      logger.setup(config)
+    })
+  }
+
+  // During development setBaseUrl also optionally installs MSW mocking via MockKumaApi
+  kumaApi.setBaseUrl(env('KUMA_API_URL'))
+
+  await Promise.all([
+    // Fetches basic resources before setting up the router and mounting the
+    // application. This is mainly needed to properly redirect users to the
+    // onboarding flow in the appropriate scenarios.
+    store.dispatch('bootstrap'),
+    // Loads available policy types in order to populate the necessary information used for titling/breadcrumbing and policy lookups in the app.
+    store.dispatch('fetchPolicyTypes'),
+  ])
+
+  await store.dispatch('updateGlobalLoading', false)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,12 @@
 import { TOKENS, get } from '@/services'
 import App from './app/App.vue'
-(async () => {
+
+async function mountVueApplication() {
   const app = await get(TOKENS.app)(App)
+
   app.mount('#app')
-})()
+
+  document.dispatchEvent(new CustomEvent('app:ready'))
+}
+
+mountVueApplication()

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -256,9 +256,11 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
     },
 
     actions: {
-      async bootstrap({ commit, dispatch, getters, state }) {
-        commit('SET_GLOBAL_LOADING', true)
+      updateGlobalLoading({ commit }, isLoading: boolean) {
+        commit('SET_GLOBAL_LOADING', isLoading)
+      },
 
+      async bootstrap({ dispatch, getters, state }) {
         // check the Kuma status before we do anything else
         await dispatch('config/getStatus')
 
@@ -295,8 +297,6 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
             await dispatch('updateSelectedMesh', null)
           }
         }
-
-        commit('SET_GLOBAL_LOADING', false)
       },
 
       updatePageTitle({ commit }, pageTitle: string) {


### PR DESCRIPTION
Changes the main entry point of the application to only make API calls after the application is ready as indicated by a custom `app:ready` event fired on the `document`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>