### PR TITLE
fix: base API URL being set incorrectly

### DIFF
--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -67,7 +67,7 @@ export default class Env {
         const config = JSON.parse(pathConfigNode.textContent.trim()) as PathConfig
 
         // Ensures the config always has an absolute URL.
-        config.apiUrl = getAbsoluteUrl(window.location.origin, config.apiUrl)
+        config.apiUrl = getNormalizedApiUrl(config.apiUrl)
 
         return config
       } catch {
@@ -76,7 +76,7 @@ export default class Env {
     }
     // console.error('Unable to parse kuma config. Falling back to defaults')
 
-    return getPathConfigDefault(import.meta.env.PROD ? window.location.origin : import.meta.env.VITE_KUMA_API_SERVER_URL)
+    return getPathConfigDefault(import.meta.env.PROD ? '/' : import.meta.env.VITE_KUMA_API_SERVER_URL)
   }
 }
 
@@ -92,17 +92,13 @@ export function semver(version: string): { major: string, minor: string, patch: 
 }
 
 /**
- * @returns an absolute URL given the current origin and a base URL or base path string. When a path is provided, it is concatenated to the current origin; when a URL is provided, no concatenation takes place. In both cases, the URL is returned without any trailing slashes.
+ * @returns a normalized API URL or URL path without trailing slashes. URL paths will always have a leading slash.
  */
-function getAbsoluteUrl(origin: string, baseUrlOrPath: string): string {
-  let baseUrl
-
+function getNormalizedApiUrl(baseUrlOrPath: string): string {
   if (baseUrlOrPath.startsWith('http')) {
-    baseUrl = baseUrlOrPath
+    return baseUrlOrPath.replace(/\/+$/, '')
   } else {
-    const basePath = baseUrlOrPath.replace(/^\/+/, '')
-    baseUrl = [origin, basePath].filter((segment) => segment !== '').join('/')
+    const basePath = (baseUrlOrPath.startsWith('/') ? '' : '/') + baseUrlOrPath
+    return basePath === '/' ? '/' : basePath.replace(/\/+$/, '')
   }
-
-  return baseUrl.replace(/\/+$/, '')
 }

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -62,9 +62,9 @@ export default class Env {
 
     // TODO: Uncomment noisy console errors (we don't want them during testing
     // but we do want them for our users)
-    if (pathConfigNode instanceof HTMLScriptElement) {
+    if (pathConfigNode instanceof HTMLScriptElement && pathConfigNode.textContent) {
       try {
-        const config = JSON.parse(pathConfigNode.innerText.trim()) as PathConfig
+        const config = JSON.parse(pathConfigNode.textContent.trim()) as PathConfig
 
         // Ensures the config always has an absolute URL.
         config.apiUrl = getAbsoluteUrl(window.location.origin, config.apiUrl)

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -64,9 +64,14 @@ export default class Env {
     // but we do want them for our users)
     if (pathConfigNode instanceof HTMLScriptElement) {
       try {
-        return JSON.parse(pathConfigNode.innerText.trim())
-      } catch (e) {
-        // console.error(e)
+        const config = JSON.parse(pathConfigNode.innerText.trim()) as PathConfig
+
+        // Ensures the config always has an absolute URL.
+        config.apiUrl = getAbsoluteUrl(window.location.origin, config.apiUrl)
+
+        return config
+      } catch {
+        // Handled by falling back to a default value.
       }
     }
     // console.error('Unable to parse kuma config. Falling back to defaults')
@@ -84,4 +89,20 @@ export function semver(version: string): { major: string, minor: string, patch: 
     patch: `${major}.${minor}.${patch}`,
     pre: `${major}.${minor}.${patch}${pre !== undefined ? `-${pre}` : ''}`,
   }
+}
+
+/**
+ * @returns an absolute URL given the current origin and a base URL or base path string. When a path is provided, it is concatenated to the current origin; when a URL is provided, no concatenation takes place. In both cases, the URL is returned without any trailing slashes.
+ */
+function getAbsoluteUrl(origin: string, baseUrlOrPath: string): string {
+  let baseUrl
+
+  if (baseUrlOrPath.startsWith('http')) {
+    baseUrl = baseUrlOrPath
+  } else {
+    const basePath = baseUrlOrPath.replace(/^\/+/, '')
+    baseUrl = [origin, basePath].filter((segment) => segment !== '').join('/')
+  }
+
+  return baseUrl.replace(/\/+$/, '')
 }

--- a/src/services/env/env.spec.ts
+++ b/src/services/env/env.spec.ts
@@ -1,7 +1,11 @@
-import { describe, expect, test } from '@jest/globals'
+import { afterEach, describe, expect, test } from '@jest/globals'
 import Env, { semver } from './Env'
 
 describe('env', () => {
+  afterEach(() => {
+    document.head.innerHTML = ''
+  })
+
   test('semver', () => {
     expect(semver('1.1.1').patch).toBe('1.1.1')
     expect(semver('0.0.0-preview.1').patch).toBe('0.0.0')
@@ -10,6 +14,7 @@ describe('env', () => {
     expect(semver('0.9.1').minor).toBe('0.9')
     expect(semver('0.9.1-rc.10').pre).toBe('0.9.1-rc.10')
   })
+
   test('var', () => {
     class MockEnv extends Env {
       protected getConfig() {
@@ -38,5 +43,31 @@ describe('env', () => {
     expect(env.var('KUMA_BASE_PATH')).toBe('/not/gui')
     expect(env.var('KUMA_PRODUCT_NAME')).toBe('product')
     expect(env.var('KUMA_FEEDBACK_URL')).toBe('http://feedback.fake')
+  })
+
+  test.each([
+    ['/', 'http://localhost'],
+    ['/api', 'http://localhost/api'],
+    ['/api/', 'http://localhost/api'],
+    ['http://example.org', 'http://example.org'],
+    ['http://example.org/', 'http://example.org'],
+    ['http://example.org/api', 'http://example.org/api'],
+    ['http://example.org/api/', 'http://example.org/api'],
+  ])('reading apiUrl constructs correct absolute URLs', (apiUrl, expectedApiUrl) => {
+    const config = { apiUrl }
+
+    document.head.insertAdjacentHTML('beforeend', `<script type="application/json" id="kuma-config">${JSON.stringify(config)}</script>`)
+
+    const env = new Env({
+      KUMA_PRODUCT_NAME: 'product',
+      KUMA_FEEDBACK_URL: 'http://feedback.fake',
+      KUMA_CHAT_URL: 'http://chat.fake',
+      KUMA_INSTALL_URL: 'http://install.fake',
+      KUMA_VERSION_URL: 'http://version.fake',
+      KUMA_DOCS_URL: 'http://docs.fake',
+      KUMA_API_URL: '',
+    })
+
+    expect(env.var('KUMA_API_URL')).toBe(expectedApiUrl)
   })
 })

--- a/src/services/env/env.spec.ts
+++ b/src/services/env/env.spec.ts
@@ -46,9 +46,11 @@ describe('env', () => {
   })
 
   test.each([
-    ['/', 'http://localhost'],
-    ['/api', 'http://localhost/api'],
-    ['/api/', 'http://localhost/api'],
+    ['', '/'],
+    ['api', '/api'],
+    ['/', '/'],
+    ['/api', '/api'],
+    ['/api/', '/api'],
     ['http://example.org', 'http://example.org'],
     ['http://example.org/', 'http://example.org'],
     ['http://example.org/api', 'http://example.org/api'],

--- a/src/services/kuma-api/RestClient.spec.ts
+++ b/src/services/kuma-api/RestClient.spec.ts
@@ -133,4 +133,29 @@ describe('RestClient', () => {
 
     expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith('http://localhost:5681/path', expectedOptions)
   })
+
+  test.each([
+    ['', 'path', '/path'],
+    ['', '/path', '/path'],
+    ['/', 'path', '/path'],
+    ['/', '/path', '/path'],
+    ['/', 'path/', '/path'],
+    ['/', '/path/', '/path'],
+    ['http://example.org', 'path', 'http://example.org/path'],
+    ['http://example.org', '/path', 'http://example.org/path'],
+    ['http://example.org/', 'path', 'http://example.org/path'],
+    ['http://example.org/', '/path', 'http://example.org/path'],
+    ['http://example.org/', 'path/', 'http://example.org/path'],
+    ['http://example.org/', '/path/', 'http://example.org/path'],
+  ])('sends correct request URL', (baseUrlOrPath, requestPath, expectedRequestUrl) => {
+    jest.spyOn(MakeRequestModule, 'makeRequest').mockImplementation(() => Promise.resolve({
+      response: new Response(),
+      data: null,
+    }))
+
+    const restClient = new RestClient(baseUrlOrPath)
+    restClient.raw(requestPath)
+
+    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith(expectedRequestUrl, {})
+  })
 })

--- a/src/services/kuma-api/RestClient.spec.ts
+++ b/src/services/kuma-api/RestClient.spec.ts
@@ -15,14 +15,8 @@ describe('RestClient', () => {
   })
 
   test.each([
-    ['api', 'http://localhost:5681/api'],
-    ['/api', 'http://localhost:5681/api'],
-    ['/api/', 'http://localhost:5681/api'],
-    ['test/api', 'http://localhost:5681/test/api'],
-    ['/test/api', 'http://localhost:5681/test/api'],
-    ['/test/api/', 'http://localhost:5681/test/api'],
     ['http://localhost:1234/api', 'http://localhost:1234/api'],
-    ['http://localhost:1234/api/', 'http://localhost:1234/api'],
+    ['http://localhost:1234/test/api', 'http://localhost:1234/test/api'],
   ])('sets expected base URL for “%s”', (newBaseUrl, expectedBaseUrl) => {
     const restClient = new RestClient('http://localhost:5681')
 

--- a/src/services/kuma-api/RestClient.ts
+++ b/src/services/kuma-api/RestClient.ts
@@ -56,7 +56,15 @@ export class RestClient {
    * @returns the response’s de-serialized data (when applicable) and the raw `Response` object.
    */
   async raw(urlOrPath: string, options?: RequestInit & { params?: any }): Promise<{ response: Response, data: any }> {
-    const url = urlOrPath.startsWith('http') ? urlOrPath : [this.baseUrl, urlOrPath].join('/')
+    let url
+
+    if (urlOrPath.startsWith('http')) {
+      url = urlOrPath
+    } else {
+      url = [this.baseUrl, urlOrPath]
+        .map((pathSegment) => pathSegment.replace(/\/+$/, '').replace(/^\/+/, ''))
+        .join('/')
+    }
 
     const headers = new Headers(this.options.headers)
 

--- a/src/services/kuma-api/RestClient.ts
+++ b/src/services/kuma-api/RestClient.ts
@@ -2,15 +2,16 @@ import { makeRequest } from './makeRequest'
 
 export class RestClient {
   /**
-   * The API base URL. **Will always be stored without a trailing slash**.
+   * The API base URL.
    */
   _baseUrl: string
-  _defaultBaseUrl: string
   _options: RequestInit = {}
 
-  constructor(defaultBaseUrl: string) {
-    this._baseUrl = defaultBaseUrl
-    this._defaultBaseUrl = defaultBaseUrl
+  /**
+   * @param baseUrl an absolute API base URL. **Must not have trailing slashes**.
+   */
+  constructor(baseUrl: string) {
+    this._baseUrl = baseUrl
   }
 
   /**
@@ -21,15 +22,10 @@ export class RestClient {
   }
 
   /**
-   * @param baseUrlOrPath the API base URL or the API base path
+   * @param baseUrl the absolute API base URL. **Must not have trailing slashes**.
    */
-  set baseUrl(baseUrlOrPath: string) {
-    if (baseUrlOrPath.startsWith('http')) {
-      this._baseUrl = trimTrailingSlashes(baseUrlOrPath)
-    } else {
-      const basePath = trimSlashes(baseUrlOrPath)
-      this._baseUrl = [this._defaultBaseUrl, basePath].filter((segment) => segment !== '').join('/')
-    }
+  set baseUrl(baseUrl: string) {
+    this._baseUrl = baseUrl
   }
 
   get options() {
@@ -85,18 +81,6 @@ export class RestClient {
 
     return makeRequest(url, normalizedOptions)
   }
-}
-
-function trimTrailingSlashes(str: string): string {
-  return str.replace(/\/+$/, '')
-}
-
-function trimLeadingSlashes(str: string): string {
-  return str.replace(/^\/+/, '')
-}
-
-function trimSlashes(str: string): string {
-  return trimTrailingSlashes(trimLeadingSlashes(str))
 }
 
 function normalizeParameters(options?: RequestInit & { params?: any }): RequestInit & { params?: any } {


### PR DESCRIPTION
Fixes an issue with the base API URL being set incorrectly. To fix this issue, the logic for ensuring the API base URL is indeed an absolute URL and not just a path segment relative to the origin was moved into the Env.ts file where the Kuma config object is being fetched. `RestClient` now always expects an absolute URL without any trailing slashes.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>