### PR TITLE
chore: fix type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@datadog/browser-logs": "^4.34.2",
-    "@kong/kongponents": "^8.29.2",
+    "@kong/kongponents": "^8.30.0",
     "brandi": "^5.0.0",
     "js-yaml": "^4.1.0",
     "chart.js": "^4.2.1",

--- a/src/app/policies/views/PolicyView.vue
+++ b/src/app/policies/views/PolicyView.vue
@@ -43,7 +43,7 @@
         <template #additionalControls>
           <KSelect
             label="Policies"
-            :items="policies"
+            :items="policySelectItems"
             :label-attributes="{ class: 'visually-hidden' }"
             appearance="select"
             :enable-filtering="true"
@@ -52,7 +52,7 @@
             <template #item-template="{ item }">
               <span
                 :class="{
-                  'policy-type-empty': item.length === 0
+                  'policy-type-empty': policyTypeNamesWithNoPolicies.includes(item.label)
                 }"
               >
                 {{ item.label }}
@@ -148,6 +148,7 @@ import {
   KAlert,
   KButton,
 } from '@kong/kongponents'
+import type { SelectItem } from '@kong/kongponents/dist/types/components/KSelect/KSelect.vue.d'
 
 import { getSome, stripTimes } from '@/utilities/helpers'
 import { PAGE_SIZE_DEFAULT } from '@/constants'
@@ -223,15 +224,17 @@ const tableData = ref<{ headers: TableHeader[], data: any[] }>({
 })
 
 const policyType = computed(() => store.state.policyTypesByPath[props.policyPath])
-const policies = computed(() => {
-  return store.state.policyTypes.map((policyType) => {
-    return {
-      length: store.state.sidebar.insights.mesh.policies[policyType.name] ?? 0,
-      label: policyType.name,
-      value: policyType.path,
-      selected: policyType.path === props.policyPath,
-    }
-  })
+const policySelectItems = computed<SelectItem[]>(() => {
+  return store.state.policyTypes.map((policyType) => ({
+    label: policyType.name,
+    value: policyType.path,
+    selected: policyType.path === props.policyPath,
+  }))
+})
+const policyTypeNamesWithNoPolicies = computed(() => {
+  return store.state.policyTypes
+    .filter((policyType) => (store.state.sidebar.insights.mesh.policies[policyType.name] ?? 0) === 0)
+    .map((policyType) => policyType.name)
 })
 
 watch(() => route.params.mesh, function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,10 +1402,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@kong/kongponents@^8.29.2":
-  version "8.29.2"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.29.2.tgz#b0ac3cb1acc9f28764a129103b49210f1e727703"
-  integrity sha512-NZ1i0kNZ2pZT0ma5XAS68cyfOG6XjAAA7gj94dzbeC6D7qDIJu+5Jcw4/oU3kbwjYKEAMwtsLVBiz5fbcd9twQ==
+"@kong/kongponents@^8.30.0":
+  version "8.30.0"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.30.0.tgz#562cfc2d6f8ab012567f101f9a2d05db2e0773b8"
+  integrity sha512-mD6xjKbaOWmRvYoJprRj8J08e9DsneKOn0Mxram/kvuTbmXhhxQLBlnRe2wgWjOfxMIDxjyOnAlMEAvqEHb2gQ==
   dependencies:
     axios "^0.27.2"
     date-fns "^2.29.3"


### PR DESCRIPTION
Fixes a type error in the policy view component caused by KSelect now having a more specific type that doesn’t allow additional properties to be used on its items.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>