### PR TITLE
chore: add useBootstrap for bootstrapping the application separately

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-import { Component, createApp, InjectionKey } from 'vue'
+import { Component, createApp } from 'vue'
 import { RouteRecordRaw } from 'vue-router'
 
 import { createRouter } from './router/router'
 
 import type { EnvVars } from '@/services/env/Env'
 import type { ClientConfigInterface } from '@/store/modules/config/config.types'
-import type { Store } from 'vuex'
+import { Store, storeKey } from 'vuex'
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { State } from '@/store/storeConfig'
 
@@ -17,55 +17,43 @@ import type { State } from '@/store/storeConfig'
 export function useApp(
   env: (key: keyof EnvVars) => string,
   routes: RouteRecordRaw[],
-  logger: { setup: (config: ClientConfigInterface) => void },
-  kumaApi: KumaApi,
   store: Store<State>,
-  storeKey: InjectionKey<Store<State>>,
 ) {
   document.title = `${env('KUMA_PRODUCT_NAME')} Manager`
 
   return async (App: Component) => {
     const app = createApp(App)
-
-    app.use(store, storeKey)
-
     const router = await createRouter(routes, store, env('KUMA_BASE_PATH'))
+    app.use(store, storeKey)
     app.use(router)
-
-    // Triggering post mount routines via custom event allows for this event to be delayed and fired from a place that is not the main entry point of the application.
-    document.addEventListener('app:ready', function () {
-      runPostMountRoutines(env, logger, kumaApi, store)
-    })
-
     return app
   }
 }
 
-async function runPostMountRoutines(
+export function useBootstrap(
   env: (key: keyof EnvVars) => string,
   logger: { setup: (config: ClientConfigInterface) => void },
   kumaApi: KumaApi,
   store: Store<State>,
 ) {
-  await store.dispatch('updateGlobalLoading', true)
+  return async () => {
+    await store.dispatch('updateGlobalLoading', true)
+    // During development setBaseUrl also optionally installs MSW mocking via MockKumaApi
+    kumaApi.setBaseUrl(env('KUMA_API_URL'))
+    if (import.meta.env.PROD) {
+      kumaApi.getConfig().then((config) => {
+        logger.setup(config)
+      })
+    }
+    await Promise.all([
+      // Fetches basic resources before setting up the router and mounting the
+      // application. This is mainly needed to properly redirect users to the
+      // onboarding flow in the appropriate scenarios.
+      store.dispatch('bootstrap'),
+      // Loads available policy types in order to populate the necessary information used for titling/breadcrumbing and policy lookups in the app.
+      store.dispatch('fetchPolicyTypes'),
+    ])
 
-  if (import.meta.env.PROD) {
-    kumaApi.getConfig().then((config) => {
-      logger.setup(config)
-    })
+    await store.dispatch('updateGlobalLoading', false)
   }
-
-  // During development setBaseUrl also optionally installs MSW mocking via MockKumaApi
-  kumaApi.setBaseUrl(env('KUMA_API_URL'))
-
-  await Promise.all([
-    // Fetches basic resources before setting up the router and mounting the
-    // application. This is mainly needed to properly redirect users to the
-    // onboarding flow in the appropriate scenarios.
-    store.dispatch('bootstrap'),
-    // Loads available policy types in order to populate the necessary information used for titling/breadcrumbing and policy lookups in the app.
-    store.dispatch('fetchPolicyTypes'),
-  ])
-
-  await store.dispatch('updateGlobalLoading', false)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,10 +3,8 @@ import App from './app/App.vue'
 
 async function mountVueApplication() {
   const app = await get(TOKENS.app)(App)
-
   app.mount('#app')
-
-  document.dispatchEvent(new CustomEvent('app:ready'))
+  get(TOKENS.bootstrap)()
 }
 
 mountVueApplication()

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -9,6 +9,7 @@ export type EnvArgs = {
   KUMA_VERSION_URL: string
   KUMA_DOCS_URL: string
   KUMA_API_URL: string
+  KUMA_MOCK_API_ENABLED: string
 }
 type EnvProps = {
   KUMA_VERSION: string

--- a/src/services/env/env.spec.ts
+++ b/src/services/env/env.spec.ts
@@ -33,6 +33,7 @@ describe('env', () => {
         KUMA_INSTALL_URL: 'http://install.fake',
         KUMA_VERSION_URL: 'http://version.fake',
         KUMA_DOCS_URL: 'http://docs.fake',
+        KUMA_MOCK_API_ENABLED: 'false',
         KUMA_API_URL: '/somewhere/else/',
       },
     )
@@ -67,6 +68,7 @@ describe('env', () => {
       KUMA_INSTALL_URL: 'http://install.fake',
       KUMA_VERSION_URL: 'http://version.fake',
       KUMA_DOCS_URL: 'http://docs.fake',
+      KUMA_MOCK_API_ENABLED: 'false',
       KUMA_API_URL: '',
     })
 

--- a/src/services/kuma-api/MockKumaApi.ts
+++ b/src/services/kuma-api/MockKumaApi.ts
@@ -12,8 +12,8 @@ export default class MockKumaApi extends KumaApi {
 
   setBaseUrl(baseUrl: string): void {
     super.setBaseUrl(baseUrl)
-    if (import.meta.env.VITE_MOCK_API_ENABLED === 'true') {
-      setupMockWorker(setupHandlers(this.baseUrl, this.mocks))
+    if (this.env.var('KUMA_MOCK_API_ENABLED') === 'true') {
+      setupMockWorker(setupHandlers(this.env.var('KUMA_API_URL'), this.mocks))
     }
   }
 }

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -5,10 +5,9 @@ import KumaApi from '@/services/kuma-api/KumaApi'
 import routes from '@/router/routes'
 import { getNavItems } from '@/app/getNavItems'
 import { storeConfig, State } from '@/store/storeConfig'
-import { useApp } from '../index'
+import { useApp, useBootstrap } from '../index'
 
-import { InjectionKey } from 'vue'
-import { createStore, Store } from 'vuex'
+import { createStore } from 'vuex'
 
 export const TOKENS = {
   EnvVars: constant({
@@ -18,13 +17,13 @@ export const TOKENS = {
     KUMA_INSTALL_URL: import.meta.env.VITE_INSTALL_URL,
     KUMA_VERSION_URL: import.meta.env.VITE_VERSION_URL,
     KUMA_DOCS_URL: import.meta.env.VITE_DOCS_BASE_URL,
+    KUMA_MOCK_API_ENABLED: import.meta.env.VITE_MOCK_API_ENABLED,
   } as EnvArgs, { description: 'EnvVars' }),
   Env: service(Env, { description: 'Env' }),
   env: service(() => (key: keyof EnvVars) => get(TOKENS.Env).var(key), { description: 'env' }),
 
   api: service(KumaApi, { description: 'api' }),
 
-  storeKey: constant(Symbol('store') as InjectionKey<Store<State>>, { description: 'storeKey' }),
   storeConfig: service(storeConfig, { description: 'storeConfig' }),
   store: service(createStore<State>, { description: 'store' }),
 
@@ -32,6 +31,7 @@ export const TOKENS = {
   routes: service(routes, { description: 'routes' }),
   logger: service(Logger, { description: 'logger' }),
   app: service(useApp, { description: 'app' }),
+  bootstrap: service(useBootstrap, { description: 'bootstrap' }),
 }
 
 injected(Env, TOKENS.EnvVars)
@@ -40,4 +40,5 @@ injected(storeConfig, TOKENS.api)
 injected(createStore<State>, TOKENS.storeConfig)
 injected(routes, TOKENS.store)
 injected(Logger, TOKENS.Env)
-injected(useApp, TOKENS.env, TOKENS.routes, TOKENS.logger, TOKENS.api, TOKENS.store, TOKENS.storeKey)
+injected(useApp, TOKENS.env, TOKENS.routes, TOKENS.store)
+injected(useBootstrap, TOKENS.env, TOKENS.logger, TOKENS.api, TOKENS.store)


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/684 we added a custom event to separate application 'creation' from 'bootstrapping'.

Events are usually used for "one-to-many" operations, i.e. you fire an event and any number of things can be listening to that, or you fire multiple times. I don't think we need either of those characteristics right now at least. More importantly, we were passing dependencies used for 'bootstrapping' through to the creation 'service' only to then pass them through to the bootstrapping function when the custom event was fired.

This change adds a 'useBootstrap' function, so we can just call this function after project creation as you usually would, removing the indirection, it's dependencies being provided via our service container.

```javascript
const app = await get(TOKENS.app)(App)
app.mount('#app')
get(TOKENS.bootstrap)()
```

or

```javascript
const app = await get(TOKENS.app)(App)
app.mount('#app')
```

```javascript
// in another file later on
get(TOKENS.bootstrap)()
```

Consequently, this means `useApp` has less dependencies (the ones it doesn't actually use) as these have been moved to be required by `useBootstrap` directly.

Bit of background: I actually did a lot more work of trying to unravel the kumaAPI from store/routes so that it would only be instantiated during 'bootstrap', but it was far more work than I was expecting so I pulled it back to what is left here. Why do I want to do this? Right now we call setBaseURL during bootstrap even though we set the baseURL in the kumaAPI constructor already, setBaseURL is currently acting more like an initializer after construction (or a 'resetter'). Constructor kumaAPI during bootstrap rather than app creation would be nicer. So, this is likely to change, or maybe be renamed, in future. There were a few other things I saw whilst I was doing this, so there might be upcoming PRs related to this if I come back to revisit, I'll try to remember to mention this PR if I get to those.

I also added KUMA_MOCK_API_ENABLED to our env vars. Related: there's an issue somewhere to convert all the VITE_ ones to KUMA_ ones. I also removed the storeKey from the service container (I'm hoping to remove `app.use(store, storeKey)` at some point soon, as we can access the store from our container)

I also noticed that there has always been a call to kumaAPI before `setBaseUrl` was called:

https://github.com/kumahq/kuma-gui/blob/38e9690311d34d9602273d8fa8015bf6caf0a959/src/main.ts#L14-L16

https://github.com/kumahq/kuma-gui/blob/38e9690311d34d9602273d8fa8015bf6caf0a959/src/utilities/setupDatadog.ts#L6

https://github.com/kumahq/kuma-gui/blob/38e9690311d34d9602273d8fa8015bf6caf0a959/src/main.ts#L28

That is a few months back ^, and has been refactored out slightly, but even the refactor kept the previous "make a call to API before setting the base path for the API", so at some point API calls could be made to one API base URL and then suddenly change to use a new one. So this fixes that up also.

Signed-off-by: John Cowen <john.cowen@konghq.com>