### PR TITLE
feat: Accept "string only" versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "js-yaml": "^4.1.0",
     "chart.js": "^4.2.1",
     "prismjs": "^1.29.0",
-    "semver": "^7.3.8",
     "tailwindcss": "^3.2.7",
     "vue": "^3.2.47",
     "vue-chartjs": "^5.2.0",

--- a/src/app/AppHeader.vue
+++ b/src/app/AppHeader.vue
@@ -30,14 +30,14 @@
 
           <template #content>
             <p>
-              {{ store.state.config.tagline }} <b>{{ store.state.config.version }}</b> on <b>{{ environmentName }}</b> ({{ mode }})
+              {{ env('KUMA_PRODUCT_NAME') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ environmentName }}</b> ({{ mode }})
             </p>
           </template>
         </KPop>
       </div>
 
       <p class="app-status app-status--desktop">
-        {{ store.state.config.tagline }} <b>{{ store.state.config.version }}</b> on <b>{{ environmentName }}</b> ({{ mode }})
+        {{ env('KUMA_PRODUCT_NAME') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ environmentName }}</b> ({{ mode }})
       </p>
 
       <NotificationIcon v-if="shouldShowNotificationManager" />

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -78,7 +78,7 @@ exports[`App.vue fails to renders basic view 1`] = `
                 <p>
                   Kuma 
                   <b>
-                    1.7.1
+                    10.2.0
                   </b>
                    on 
                   <b>
@@ -98,7 +98,7 @@ exports[`App.vue fails to renders basic view 1`] = `
       >
         Kuma 
         <b>
-          1.7.1
+          10.2.0
         </b>
          on 
         <b>

--- a/src/app/common/UpgradeCheck.vue
+++ b/src/app/common/UpgradeCheck.vue
@@ -40,7 +40,8 @@ const env = useEnv()
 const latestVersion = ref('')
 const showNotice = ref(false)
 
-checkVersion()
+checkVersion(env('KUMA_VERSION'))
+
 // mostly taken from semver-compare
 const compare = (a: string, b: string) => {
   const pa = a.split('.')
@@ -48,44 +49,36 @@ const compare = (a: string, b: string) => {
   for (let i = 0; i < 3; i++) {
     const na = Number(pa[i])
     const nb = Number(pb[i])
-    if (i === 0) {
-      // if 'major' isn't a number then prefer the alternate
-      if (isNaN(na)) {
-        return 1
-      } else if (isNaN(nb)) {
-        return 0
-      }
-    }
     if (na > nb) return 1
     if (nb > na) return -1
-    if (!isNaN(na) && isNaN(nb)) return 1
-    if (isNaN(na) && !isNaN(nb)) return -1
   }
   return 0
 }
 
-async function checkVersion(): Promise<void> {
+async function checkVersion(currentVersion: string): Promise<void> {
+  if (!currentVersion.match('^[0-9]+.[0-9]+.[0-9]+$')) {
+    return
+  }
+
   try {
     latestVersion.value = await kumaApi.getLatestVersion()
   } catch (error) {
-    showNotice.value = false
-
     console.error(error)
-  } finally {
-    if (latestVersion.value !== '') {
-      // compare the latest version to the currently running version
-      // but only if we were able to set the latest version in the first place.
-      const comparison = compare(latestVersion.value, env('KUMA_VERSION'))
-      showNotice.value = comparison === 1
-    } else {
-      const timespan = 3 // months
-      const today = new Date()
-      const refDate = new Date('2020-06-03 12:00:00')
-      const later = new Date(refDate.getFullYear(), refDate.getMonth() + timespan, refDate.getDate())
+    return
+  }
+  if (latestVersion.value !== '') {
+    // compare the latest version to the currently running version
+    // but only if we were able to set the latest version in the first place.
+    const comparison = compare(latestVersion.value, currentVersion)
+    showNotice.value = comparison === 1
+  } else {
+    const timespan = 3 // months
+    const today = new Date()
+    const refDate = new Date('2020-06-03 12:00:00')
+    const later = new Date(refDate.getFullYear(), refDate.getMonth() + timespan, refDate.getDate())
 
-      // compare dates and handle the notice accordingly
-      showNotice.value = today.getTime() >= later.getTime()
-    }
+    // compare dates and handle the notice accordingly
+    showNotice.value = today.getTime() >= later.getTime()
   }
 }
 </script>

--- a/src/app/common/UpgradeCheck.vue
+++ b/src/app/common/UpgradeCheck.vue
@@ -30,7 +30,6 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-import compare from 'semver/functions/compare'
 import { KAlert, KButton } from '@kong/kongponents'
 
 import { useEnv, useKumaApi } from '@/utilities'
@@ -42,6 +41,28 @@ const latestVersion = ref('')
 const showNotice = ref(false)
 
 checkVersion()
+// mostly taken from semver-compare
+const compare = (a: string, b: string) => {
+  const pa = a.split('.')
+  const pb = b.split('.')
+  for (let i = 0; i < 3; i++) {
+    const na = Number(pa[i])
+    const nb = Number(pb[i])
+    if (i === 0) {
+      // if 'major' isn't a number then prefer the alternate
+      if (isNaN(na)) {
+        return 1
+      } else if (isNaN(nb)) {
+        return 0
+      }
+    }
+    if (na > nb) return 1
+    if (nb > na) return -1
+    if (!isNaN(na) && isNaN(nb)) return 1
+    if (isNaN(na) && !isNaN(nb)) return -1
+  }
+  return 0
+}
 
 async function checkVersion(): Promise<void> {
   try {

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -84,9 +84,9 @@ export function semver(version: string): { major: string, minor: string, patch: 
   const [major, minor, ...patchPre] = version.split('.')
   if (isNaN(parseInt(major))) {
     return {
-      major: '0',
-      minor: '0',
-      patch: '0',
+      major,
+      minor: major,
+      patch: major,
       pre: major,
     }
   }

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -82,6 +82,14 @@ export default class Env {
 
 export function semver(version: string): { major: string, minor: string, patch: string, pre: string } {
   const [major, minor, ...patchPre] = version.split('.')
+  if (isNaN(parseInt(major))) {
+    return {
+      major: '0',
+      minor: '0',
+      patch: '0',
+      pre: major,
+    }
+  }
   const [patch, pre] = patchPre.join('.').split('-')
   return {
     major,


### PR DESCRIPTION
Loosens up our version related things so we can use string based versions if we need to. The rule it uses is "if major doesn't parse as a number, then its a 'string version'". String versions will never ask for updates as they are more likely to be dev versions and suchlike.

I switched a couple of old store-type things to use env vars whilst I was here.

The entire thing assumes that we never deal with actual full semvers, only 3 numbers i.e. we never need to be aware of carets and tildes, only 3 numbers joined by dots `~3.0.0` vs `3.0.0`.

This PR makes it so we only need to be aware of "3 numbers joined by dots" and "full strings" - we still don't need to be aware of `~` or `^` prefixed semvers.

Signed-off-by: John Cowen <john.cowen@konghq.com>