### PR TITLE
chore: Move to a 2 step "define then build" process

### DIFF
--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -8,7 +8,7 @@ import { replaceAttributesSnapshotSerializer } from './jest-replace-attribute-sn
 import { setupMockServer } from '../src/api/setupMockServer'
 import { TOKENS as COMPONENT_TOKENS } from '../src/components'
 import { createRouter } from '../src/router/router'
-import { TOKENS, get, container, set, injected } from '../src/services'
+import { TOKENS, get, container, build } from '../src/services'
 import { setupHandlers, mocks } from '@/api/mocks'
 import Env from '@/services/env/Env'
 
@@ -85,7 +85,13 @@ export const withVersion = (v: string) => {
       return super.var(...rest)
     }
   }
-  set(TOKENS.Env, TestEnv)
-  injected(TestEnv, TOKENS.EnvVars)
+  build(
+    [
+      [TOKENS.Env, {
+        service: TestEnv,
+        arguments: [TOKENS.EnvVars],
+      }],
+    ],
+  )
 }
 export { router, server, useMock }

--- a/src/app/App.spec.ts
+++ b/src/app/App.spec.ts
@@ -4,7 +4,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import App from './App.vue'
 import { withVersion } from '@/../jest/jest-setup-after-env'
 import { TOKENS } from '@/components'
-import { set } from '@/services'
+import { build } from '@/services'
 import { useStore, useEnv } from '@/utilities'
 
 const store = useStore()
@@ -17,12 +17,18 @@ function renderComponent(status: string) {
 
   // keeps the github-button as a <github-button> instead of a span in
   // the snapshot so its as close to actual usage as possible
-  set(TOKENS.GithubButton, () => ({
-    template: '<github-button />',
-    compilerOptions: {
-      isCustomElement: () => true,
-    },
-  }))
+  build(
+    [
+      [TOKENS.GithubButton, {
+        service: () => ({
+          template: '<github-button />',
+          compilerOptions: {
+            isCustomElement: () => true,
+          },
+        }),
+      }],
+    ],
+  )
   return mount(App, {
     global: {
       stubs: {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,19 +9,19 @@ import MemoryGraph from '@/app/onboarding/components/graphs/MemoryGraph.vue'
 import MultizoneGraph from '@/app/onboarding/components/graphs/MultizoneGraph.vue'
 import PostgresGraph from '@/app/onboarding/components/graphs/PostgresGraph.vue'
 import StandaloneGraph from '@/app/onboarding/components/graphs/StandaloneGraph.vue'
-import { service, createInjections } from '@/services/utils'
+import { constant, createInjections } from '@/services/utils'
 
 export const TOKENS = {
-  KumaLogo: service(() => KumaLogo, { description: 'KumaLogo' }),
-  GithubButton: service(() => GithubButton, { description: 'GithubButton' }),
-  OverviewCharts: service(() => OverviewCharts, { description: 'OverviewCharts' }),
-  KubernetesGraph: service(() => KubernetesGraph, { description: 'KubernetesGraph' }),
-  PostgresGraph: service(() => PostgresGraph, { description: 'PostgresGraph' }),
-  MemoryGraph: service(() => MemoryGraph, { description: 'MemoryGraph' }),
-  MultizoneGraph: service(() => MultizoneGraph, { description: 'MultizoneGraph' }),
-  StandaloneGraph: service(() => StandaloneGraph, { description: 'StandaloneGraph' }),
-  AppSidebar: service(() => AppSidebar, { description: 'AppSidebar' }),
-  AppHeader: service(() => AppHeader, { description: 'AppHeader' }),
+  KumaLogo: constant(KumaLogo, { description: 'KumaLogo' }),
+  GithubButton: constant(GithubButton, { description: 'GithubButton' }),
+  OverviewCharts: constant(OverviewCharts, { description: 'OverviewCharts' }),
+  KubernetesGraph: constant(KubernetesGraph, { description: 'KubernetesGraph' }),
+  PostgresGraph: constant(PostgresGraph, { description: 'PostgresGraph' }),
+  MemoryGraph: constant(MemoryGraph, { description: 'MemoryGraph' }),
+  MultizoneGraph: constant(MultizoneGraph, { description: 'MultizoneGraph' }),
+  StandaloneGraph: constant(StandaloneGraph, { description: 'StandaloneGraph' }),
+  AppSidebar: constant(AppSidebar, { description: 'AppSidebar' }),
+  AppHeader: constant(AppHeader, { description: 'AppHeader' }),
 }
 export const [
   useKumaLogo,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,2 +1,2 @@
-export { service, constant, get, set, container, injected, createInjections } from './utils'
+export { constant, get, container, createInjections, build, merge } from './utils'
 export { TOKENS } from './production'

--- a/src/services/kuma-api/MockKumaApi.ts
+++ b/src/services/kuma-api/MockKumaApi.ts
@@ -4,22 +4,18 @@ import { setupMockWorker } from '@/api/setupMockWorker'
 import Env from '@/services/env/Env'
 
 export const mockApi = function (parent: typeof KumaApi) {
-  const name = `Mock${parent.name}`
-  const mocked = {
-    [name]: class extends parent {
-      mocks: Mocks
-      constructor(env: Env, mocks: Mocks) {
-        super(env)
-        this.mocks = mocks
-      }
+  return class MockApi extends parent {
+    mocks: Mocks
+    constructor(env: Env, mocks: Mocks) {
+      super(env)
+      this.mocks = mocks
+    }
 
-      setBaseUrl(baseUrl: string): void {
-        super.setBaseUrl(baseUrl)
-        if (this.env.var('KUMA_MOCK_API_ENABLED') === 'true') {
-          setupMockWorker(setupHandlers(this.env.var('KUMA_API_URL'), this.mocks))
-        }
+    setBaseUrl(baseUrl: string): void {
+      super.setBaseUrl(baseUrl)
+      if (this.env.var('KUMA_MOCK_API_ENABLED') === 'true') {
+        setupMockWorker(setupHandlers(this.env.var('KUMA_API_URL'), this.mocks))
       }
-    },
+    }
   }
-  return mocked[name]
 }

--- a/src/services/kuma-api/MockKumaApi.ts
+++ b/src/services/kuma-api/MockKumaApi.ts
@@ -3,20 +3,6 @@ import { setupHandlers, Mocks } from '@/api/mocks'
 import { setupMockWorker } from '@/api/setupMockWorker'
 import Env from '@/services/env/Env'
 
-export default class MockKumaApi extends KumaApi {
-  mocks: Mocks
-  constructor(env: Env, mocks: Mocks) {
-    super(env)
-    this.mocks = mocks
-  }
-
-  setBaseUrl(baseUrl: string): void {
-    super.setBaseUrl(baseUrl)
-    if (this.env.var('KUMA_MOCK_API_ENABLED') === 'true') {
-      setupMockWorker(setupHandlers(this.env.var('KUMA_API_URL'), this.mocks))
-    }
-  }
-}
 export const mockApi = function (parent: typeof KumaApi) {
   const name = `Mock${parent.name}`
   const mocked = {

--- a/src/services/kuma-api/MockKumaApi.ts
+++ b/src/services/kuma-api/MockKumaApi.ts
@@ -1,7 +1,7 @@
+import KumaApi from './KumaApi'
 import { setupHandlers, Mocks } from '@/api/mocks'
 import { setupMockWorker } from '@/api/setupMockWorker'
 import Env from '@/services/env/Env'
-import KumaApi from '@/services/kuma-api/KumaApi'
 
 export default class MockKumaApi extends KumaApi {
   mocks: Mocks
@@ -16,4 +16,24 @@ export default class MockKumaApi extends KumaApi {
       setupMockWorker(setupHandlers(this.env.var('KUMA_API_URL'), this.mocks))
     }
   }
+}
+export const mockApi = function (parent: typeof KumaApi) {
+  const name = `Mock${parent.name}`
+  const mocked = {
+    [name]: class extends parent {
+      mocks: Mocks
+      constructor(env: Env, mocks: Mocks) {
+        super(env)
+        this.mocks = mocks
+      }
+
+      setBaseUrl(baseUrl: string): void {
+        super.setBaseUrl(baseUrl)
+        if (this.env.var('KUMA_MOCK_API_ENABLED') === 'true') {
+          setupMockWorker(setupHandlers(this.env.var('KUMA_API_URL'), this.mocks))
+        }
+      }
+    },
+  }
+  return mocked[name]
 }

--- a/src/services/logger/DisabledLogger.ts
+++ b/src/services/logger/DisabledLogger.ts
@@ -5,13 +5,9 @@ const c = class {
   }
 }
 export const disabledLogger = function (parent: typeof c) {
-  const name = `Disabled${parent.name}`
-  const disabled = {
-    [name]: class extends parent {
-      setup(_config: ClientConfigInterface) {
-        console.log('Logging disabled')
-      }
-    },
+  return class DisabledLogger extends parent {
+    setup(_config: ClientConfigInterface) {
+      console.log('Logging disabled')
+    }
   }
-  return disabled[name]
 }

--- a/src/services/logger/DisabledLogger.ts
+++ b/src/services/logger/DisabledLogger.ts
@@ -1,8 +1,17 @@
-import Logger from './DatadogLogger'
 import type { ClientConfigInterface } from '@/store/modules/config/config.types'
-
-export default class DisabledLogger extends Logger {
-  setup(_config: ClientConfigInterface) {
-    console.log('Logging disabled')
+const c = class {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(..._args: any[]) {
   }
+}
+export const disabledLogger = function (parent: typeof c) {
+  const name = `Disabled${parent.name}`
+  const disabled = {
+    [name]: class extends parent {
+      setup(_config: ClientConfigInterface) {
+        console.log('Logging disabled')
+      }
+    },
+  }
+  return disabled[name]
 }

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -1,7 +1,9 @@
+import {
+  RouteRecordRaw,
+} from 'vue-router'
+import { createStore, StoreOptions, Store } from 'vuex'
 
-import { createStore } from 'vuex'
-
-import { service, constant, get, injected } from './utils'
+import { ServiceDefinition, token, build } from './utils'
 import { useApp, useBootstrap } from '../index'
 import { getNavItems } from '@/app/getNavItems'
 import routes from '@/router/routes'
@@ -10,36 +12,114 @@ import KumaApi from '@/services/kuma-api/KumaApi'
 import Logger from '@/services/logger/DatadogLogger'
 import { storeConfig, State } from '@/store/storeConfig'
 
-export const TOKENS = {
-  EnvVars: constant({
-    KUMA_PRODUCT_NAME: import.meta.env.VITE_NAMESPACE,
-    KUMA_FEEDBACK_URL: import.meta.env.VITE_FEEDBACK_URL,
-    KUMA_CHAT_URL: import.meta.env.VITE_CHAT_URL,
-    KUMA_INSTALL_URL: import.meta.env.VITE_INSTALL_URL,
-    KUMA_VERSION_URL: import.meta.env.VITE_VERSION_URL,
-    KUMA_DOCS_URL: import.meta.env.VITE_DOCS_BASE_URL,
-    KUMA_MOCK_API_ENABLED: import.meta.env.VITE_MOCK_API_ENABLED,
-  } as EnvArgs, { description: 'EnvVars' }),
-  Env: service(Env, { description: 'Env' }),
-  env: service(() => (key: keyof EnvVars) => get(TOKENS.Env).var(key), { description: 'env' }),
+const $ = {
+  EnvVars: token<EnvVars>('EnvVars'),
+  Env: token<Env>('Env'),
+  env: token<(key: keyof EnvVars) => string>('env'),
 
-  api: service(KumaApi, { description: 'api' }),
+  api: token<KumaApi>('KumaApi'),
 
-  storeConfig: service(storeConfig, { description: 'storeConfig' }),
-  store: service(createStore<State>, { description: 'store' }),
+  storeConfig: token<StoreOptions<State>>('storeOptions'),
+  store: token<Store<State>>('store'),
 
-  nav: service(() => (multizone: boolean, hasMeshes: boolean) => getNavItems(multizone, hasMeshes), { description: 'nav' }),
-  routes: service(routes, { description: 'routes' }),
-  logger: service(Logger, { description: 'logger' }),
-  app: service(useApp, { description: 'app' }),
-  bootstrap: service(useBootstrap, { description: 'bootstrap' }),
+  routes: token<RouteRecordRaw[]>('routes'),
+  nav: token<typeof getNavItems>('nav'),
+
+  logger: token<Logger>('logger'),
+
+  app: token<ReturnType<typeof useApp>>('app'),
+  bootstrap: token<ReturnType<typeof useBootstrap>>('bootstrap'),
 }
 
-injected(Env, TOKENS.EnvVars)
-injected(KumaApi, TOKENS.Env)
-injected(storeConfig, TOKENS.api)
-injected(createStore<State>, TOKENS.storeConfig)
-injected(routes, TOKENS.store)
-injected(Logger, TOKENS.Env)
-injected(useApp, TOKENS.env, TOKENS.routes, TOKENS.store)
-injected(useBootstrap, TOKENS.env, TOKENS.logger, TOKENS.api, TOKENS.store)
+export const services: ServiceDefinition[] = [
+
+  // Env
+  [$.EnvVars, {
+    constant: {
+      KUMA_PRODUCT_NAME: import.meta.env.VITE_NAMESPACE,
+      KUMA_FEEDBACK_URL: import.meta.env.VITE_FEEDBACK_URL,
+      KUMA_CHAT_URL: import.meta.env.VITE_CHAT_URL,
+      KUMA_INSTALL_URL: import.meta.env.VITE_INSTALL_URL,
+      KUMA_VERSION_URL: import.meta.env.VITE_VERSION_URL,
+      KUMA_DOCS_URL: import.meta.env.VITE_DOCS_BASE_URL,
+      KUMA_MOCK_API_ENABLED: import.meta.env.VITE_MOCK_API_ENABLED,
+    } as EnvArgs,
+  }],
+  [$.Env, {
+    service: Env,
+    arguments: [
+      $.EnvVars,
+    ],
+  }],
+  [$.env, {
+    service: (env: Env) => (key: keyof EnvVars) => env.var(key),
+    arguments: [
+      $.Env,
+    ],
+  }],
+
+  // KumaAPI
+  [$.api, {
+    service: KumaApi,
+    arguments: [
+      $.Env,
+    ],
+  }],
+
+  // Logger
+  [$.logger, {
+    service: Logger,
+    arguments: [
+      $.Env,
+    ],
+  }],
+
+  // Store
+  [$.storeConfig, {
+    service: storeConfig,
+    arguments: [
+      $.api,
+    ],
+  }],
+  [$.store, {
+    service: createStore,
+    arguments: [
+      $.storeConfig,
+    ],
+  }],
+
+  // Routes
+  [$.routes, {
+    service: routes,
+    arguments: [
+      $.store,
+    ],
+  }],
+  // Nav
+  [$.nav, {
+    service: () => (multizone: boolean, hasMeshes: boolean) => getNavItems(multizone, hasMeshes),
+  }],
+
+  // App
+  [$.app, {
+    service: useApp,
+    arguments: [
+      $.env,
+      $.routes,
+      $.store,
+    ],
+  }],
+  [$.bootstrap, {
+    service: useBootstrap,
+    arguments: [
+      $.env,
+      $.logger,
+      $.api,
+      $.store,
+    ],
+  }],
+]
+
+build(services)
+
+export const TOKENS = $

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -4,19 +4,19 @@ import {
   Token,
   TokenType,
   TokenValue,
+  RequiredToken,
+  OptionalToken,
+  injected,
 } from 'brandi'
 
 export {
-  injected,
+  token,
 } from 'brandi'
 
 type InjectionHooks<T extends TokenValue[]> = {
   [K in keyof T]: T[K] extends TokenValue ? () => TokenType<T[K]> : never;
 };
 
-type DependencyDefinition = {
-  description: string
-}
 type UnknownConstructor<T> = new (
   ...args: never[]
 ) => T;
@@ -27,9 +27,26 @@ type UnknownCreator<T = unknown> =
   | UnknownConstructor<T>
   | UnknownFunction<T>;
 
+type DependencyDefinition = {
+  constant?: unknown
+  service?: UnknownCreator<unknown>
+  arguments?: Array<RequiredToken | OptionalToken>
+  shared?: boolean
+  labels?: Array<RequiredToken | OptionalToken>
+}
+export type ServiceDefinition = [Token, DependencyDefinition]
+
 export const container = createContainer()
 
 //
+export const merge = (...definitions: Array<ServiceDefinition[]>): ServiceDefinition[] => {
+  return [...new Map([...definitions.flat()]).entries()]
+}
+export const build = (...entries: Array<ServiceDefinition[]>): ServiceDefinition[] => {
+  const merged = merge(...entries)
+  merged.forEach(item => service(...item))
+  return merged
+}
 
 export const get = <T extends TokenValue>(token: T): TokenType<T> => container.get(token)
 export const createInjections = <T extends TokenValue[]>(
@@ -37,21 +54,25 @@ export const createInjections = <T extends TokenValue[]>(
 ): InjectionHooks<T> =>
   tokens.map((token) => () => get(token)) as InjectionHooks<T>
 //
-
-export const service = <T>(func: UnknownCreator<T>, config: DependencyDefinition): Token<T> => {
-  const t = token<T>(config.description)
+export const service = (t: Token, config: DependencyDefinition): void => {
   const bound = container.bind(t)
-  bound.toInstance(func as Parameters<typeof bound.toInstance>[0])
-    .inSingletonScope()
-  return t as Token<T>
+  switch (true) {
+    case 'constant' in config:
+      bound.toConstant(config.constant as Parameters<typeof bound.toConstant>[0])
+      return
+    case 'service' in config: {
+      const s = bound.toInstance(config.service as Parameters<typeof bound.toInstance>[0])
+      if (typeof config.shared === 'undefined' || config.shared === true) {
+        s.inSingletonScope()
+      }
+      break
+    }
+  }
+  if (typeof config.arguments !== 'undefined' && typeof config.service !== 'undefined') {
+    injected(...([config.service, ...config.arguments] as Parameters<typeof injected>))
+  }
 }
-export const set = <T>(t: Token, func: UnknownCreator<T>) => {
-  const bound = container.bind(t)
-  bound.toInstance(func as Parameters<typeof bound.toInstance>[0])
-    .inSingletonScope()
-  return func
-}
-export const constant = <T>(func: T, config: DependencyDefinition): Token<T> => {
+export const constant = <T>(func: T, config: { description: string }): Token<T> => {
   const t = token<T>(config.description)
   const bound = container.bind(t)
   bound.toConstant(func as Parameters<typeof bound.toConstant>[0])

--- a/src/utilities/useEnv.spec.ts
+++ b/src/utilities/useEnv.spec.ts
@@ -1,27 +1,13 @@
 import { describe, expect, test } from '@jest/globals'
 
 import { useEnv } from './index'
-import { container, TOKENS, service, injected } from '@/services'
-import Env from '@/services/env/Env'
+import { withVersion } from '@/../jest/jest-setup-after-env'
 
 describe('useEnv', () => {
   test('it works', () => {
-    container.capture?.()
-
-    class TestEnv extends Env {
-      var(...rest: Parameters<Env['var']>) {
-        const key = rest[0]
-        if (key === 'KUMA_VERSION') {
-          return '100.1.1'
-        }
-        return super.var(...rest)
-      }
-    }
-    TOKENS.Env = service(TestEnv, { description: 'Env' })
-    injected(TestEnv, TOKENS.EnvVars)
+    withVersion('100.1.1')
 
     const env = useEnv()
     expect(env('KUMA_VERSION')).toBe('100.1.1')
-    container.restore?.()
   })
 })


### PR DESCRIPTION
This PR is an evolution/iteration of our service container configuration and favours a 2 step "define and then build" approach rather than "build as you go". Consequently we remove `set` and `injected` and set/inject it all in one place, whilst making things more self explanatory ("this is the service, these are its arguments")

---

This PR is "I think" as close as I can get to what I actually want whilst maintaining the types.

Just declarative configuration:


```yaml
env:
  service: Env
  arguments:
    - EnvVars
kumaApi:
  service: KumaApi
  arguments:
    - Env
  labels:
    - api
```

We can then merge/compose configurations as we want, and `build` as a final step.

Notes:
- We are currently building both in prod and dev (so twice in dev). This isn't an issue right now as it's just resetting everything again and isn't intensive in any way. A little longer down the line building will happen in the application itself, not the configuration file, so building will happen once.
- I made some 'decorator' functions for some of the things we duplicated due to inheritance reasons.

Left for later:

- Tagging/labelling
- Remove everything apart from the configuration from the configuration files (e.g. move `build` into the application code)
- Either detect `constant`s behind the scenes during building, or decide on whether to use a function or a property of `ServiceDefinition`. I use a mix of both here as in some places it feels one way is better in other places the other. We should hide `constant` (i.e. detect its a constant behind the scenes) or just use one approach.

More on tagging/labelling:

I'd like to be able to do things like:

```yaml
policyRoutes:
  service: policyRoutes
  arguments:
    - store
   labels:
    - routes
dataplaneRoutes:
  service: dataplaneRoutes
  arguments:
    - store
  labels:
    - routes
```

```javascript
get(TOKENS.routes) // a concatenation of all the services tagged/labelled as routes
```

This makes it easier to compose things together without the app having to know about what exactly things are composed of, it should also make it easier in the future to decorate services, again without knowing what the service is we are decorating is exactly, only that it is of say a `logger` type for example.

None of the "left for later" is super necessary now, but I think what is here is a good iteration on what we have.

Signed-off-by: John Cowen <john.cowen@konghq.com>