### PR TITLE
chore: adds eslint-import-resolver-alias

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,11 @@ const INLINE_NON_VOID_ELEMENTS = [
   settings: {
     'import/resolver': {
       typescript: true,
+      alias: {
+        map: [
+          ['@', './src'],
+        ],
+      },
     },
   },
   rules: {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "^8.35.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-friendly-formatter": "^4.0.1",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-typescript": "^3.5.3",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^15.6.1",

--- a/src/app/common/TagList.vue
+++ b/src/app/common/TagList.vue
@@ -16,9 +16,9 @@
 </template>
 
 <script lang="ts" setup>
+import { KBadge } from '@kong/kongponents'
 import { computed, PropType } from 'vue'
 import { RouteLocation, useRouter } from 'vue-router'
-import { KBadge } from '@kong/kongponents'
 
 import { LabelValue } from '@/types/index.d'
 import { getLabels } from '@/utilities/getLabels'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3253,6 +3253,11 @@ eslint-friendly-formatter@^4.0.1:
     strip-ansi "^4.0.0"
     text-table "^0.2.0"
 
+eslint-import-resolver-alias@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz#297062890e31e4d6651eb5eba9534e1f6e68fc97"
+  integrity sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==
+
 eslint-import-resolver-node@^0.3.7:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz#83b375187d412324a1963d84fa664377a23eb4d7"


### PR DESCRIPTION
* **chore: adds eslint-import-resolver-alias**

  Allows ESLint to know which aliases for paths belong to the same group.

* **chore: runs linter script**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>