### PR TITLE
refactor: moves setting base URL out of bootstrap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,15 +30,13 @@ export function useApp(
 }
 
 export function useBootstrap(
-  env: (key: keyof EnvVars) => string,
   logger: { setup: (config: ClientConfigInterface) => void },
   kumaApi: KumaApi,
   store: Store<State>,
 ) {
   return async () => {
     await store.dispatch('updateGlobalLoading', true)
-    // During development setBaseUrl also optionally installs MSW mocking via MockKumaApi
-    kumaApi.setBaseUrl(env('KUMA_API_URL'))
+
     if (import.meta.env.PROD) {
       kumaApi.getConfig().then((config) => {
         logger.setup(config)

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,14 @@ import App from './app/App.vue'
 import { TOKENS, get } from '@/services'
 
 async function mountVueApplication() {
+  const env = get(TOKENS.env)
+  const kumaApi = get(TOKENS.api)
+  // During development setBaseUrl also optionally installs MSW mocking via MockKumaApi
+  kumaApi.setBaseUrl(env('KUMA_API_URL'))
+
   const app = await get(TOKENS.app)(App)
   app.mount('#app')
+
   get(TOKENS.bootstrap)()
 }
 

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -32,7 +32,6 @@ const $ = {
 }
 
 export const services: ServiceDefinition[] = [
-
   // Env
   [$.EnvVars, {
     constant: {
@@ -112,7 +111,6 @@ export const services: ServiceDefinition[] = [
   [$.bootstrap, {
     service: useBootstrap,
     arguments: [
-      $.env,
       $.logger,
       $.api,
       $.store,


### PR DESCRIPTION
Moves setting the Kuma API base URL out of the bootstrap function so that it doesn’t get overridden when setting it before bootstrap elsewhere.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>