### PR TITLE
refactor: allows bypassing initial API calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,22 +34,26 @@ export function useBootstrap(
   kumaApi: KumaApi,
   store: Store<State>,
 ) {
-  return async () => {
+  return async (isAllowedToMakeApiCalls: boolean = true) => {
     await store.dispatch('updateGlobalLoading', true)
 
-    if (import.meta.env.PROD) {
-      kumaApi.getConfig().then((config) => {
-        logger.setup(config)
-      })
+    if (isAllowedToMakeApiCalls) {
+      if (import.meta.env.PROD) {
+        kumaApi.getConfig().then((config) => {
+          logger.setup(config)
+        })
+      }
+      await Promise.all([
+        // Fetches basic resources before setting up the router and mounting the
+        // application. This is mainly needed to properly redirect users to the
+        // onboarding flow in the appropriate scenarios.
+        store.dispatch('bootstrap'),
+        // Loads available policy types in order to populate the necessary information used for titling/breadcrumbing and policy lookups in the app.
+        store.dispatch('fetchPolicyTypes'),
+      ])
+    } else {
+      store.state.config.status = 'OK'
     }
-    await Promise.all([
-      // Fetches basic resources before setting up the router and mounting the
-      // application. This is mainly needed to properly redirect users to the
-      // onboarding flow in the appropriate scenarios.
-      store.dispatch('bootstrap'),
-      // Loads available policy types in order to populate the necessary information used for titling/breadcrumbing and policy lookups in the app.
-      store.dispatch('fetchPolicyTypes'),
-    ])
 
     await store.dispatch('updateGlobalLoading', false)
   }


### PR DESCRIPTION
Adds an optional `isAllowedToMakeApiCalls` to the bootstrap function that, if set to `false`, will cause the function to not make any API calls. In that case, it explicitly sets the `config.status` state to `'OK'` to not falsely indicate a not working API.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>