### PR TITLE
feat: enables mock worker to handle multiple api instances

### DIFF
--- a/src/services/development.ts
+++ b/src/services/development.ts
@@ -1,5 +1,5 @@
 import { TOKENS as $, services as prodServices } from './production'
-import { constant, merge, build, ServiceDefinition } from './utils'
+import { merge, build, ServiceDefinition } from './utils'
 import { mocks } from '@/api/mocks'
 import CookiedEnv from '@/services/env/CookiedEnv'
 import KumaApi from '@/services/kuma-api/KumaApi'
@@ -10,7 +10,6 @@ import { disabledLogger } from '@/services/logger/DisabledLogger'
 export { constant, get, container, createInjections, build, merge } from './utils'
 export { TOKENS } from './production'
 
-const MOCKS = constant(mocks, { description: 'mocks' })
 export const services: ServiceDefinition[] = merge(prodServices, [
   [$.Env, {
     service: CookiedEnv,
@@ -18,11 +17,13 @@ export const services: ServiceDefinition[] = merge(prodServices, [
       $.EnvVars,
     ],
   }],
+  [$.mocks, {
+    constant: mocks,
+  }],
   [$.api, {
     service: mockApi(KumaApi),
     arguments: [
       $.Env,
-      MOCKS,
     ],
   }],
   [$.logger, {

--- a/src/services/kuma-api/MockKumaApi.ts
+++ b/src/services/kuma-api/MockKumaApi.ts
@@ -1,20 +1,16 @@
 import KumaApi from './KumaApi'
-import { setupHandlers, Mocks } from '@/api/mocks'
+import { setupHandlers } from '@/api/mocks'
 import { setupMockWorker } from '@/api/setupMockWorker'
-import Env from '@/services/env/Env'
+import { get, TOKENS } from '@/services/index'
 
 export const mockApi = function (parent: typeof KumaApi) {
   return class MockApi extends parent {
-    mocks: Mocks
-    constructor(env: Env, mocks: Mocks) {
-      super(env)
-      this.mocks = mocks
-    }
-
     setBaseUrl(baseUrl: string): void {
       super.setBaseUrl(baseUrl)
+
       if (this.env.var('KUMA_MOCK_API_ENABLED') === 'true') {
-        setupMockWorker(setupHandlers(this.env.var('KUMA_API_URL'), this.mocks))
+        const handlers = setupHandlers(baseUrl, get(TOKENS.mocks))
+        setupMockWorker('KumaApi', handlers)
       }
     }
   }

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -1,10 +1,9 @@
-import {
-  RouteRecordRaw,
-} from 'vue-router'
+import { RouteRecordRaw } from 'vue-router'
 import { createStore, StoreOptions, Store } from 'vuex'
 
 import { ServiceDefinition, token, build } from './utils'
 import { useApp, useBootstrap } from '../index'
+import type { Mocks } from '@/api/mocks'
 import { getNavItems } from '@/app/getNavItems'
 import routes from '@/router/routes'
 import Env, { EnvArgs, EnvVars } from '@/services/env/Env'
@@ -17,6 +16,7 @@ const $ = {
   Env: token<Env>('Env'),
   env: token<(key: keyof EnvVars) => string>('env'),
 
+  mocks: token<Mocks>('mocks'),
   api: token<KumaApi>('KumaApi'),
 
   storeConfig: token<StoreOptions<State>>('storeOptions'),
@@ -58,6 +58,9 @@ export const services: ServiceDefinition[] = [
   }],
 
   // KumaAPI
+  [$.mocks, {
+    constant: [],
+  }],
   [$.api, {
     service: KumaApi,
     arguments: [


### PR DESCRIPTION
Changes `setupMockWorker` to take `apiName` and `handlers` parameters. The function now keeps a record of which handlers belong to which API (as identified by `apiName`). This way, we can store independent handlers per API which might need to be constructed in different ways.

Makes sure to stop the mock worker before starting it again which seems to be necessary despite a logged warning indicating the opposite. Without it, newly added handlers have no effect.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>