### PR TITLE
feat: determines breadcrumb title dynamically

### DIFF
--- a/src/app/AppBreadcrumbs.vue
+++ b/src/app/AppBreadcrumbs.vue
@@ -10,8 +10,11 @@ import { KBreadcrumbs } from '@kong/kongponents'
 import { computed } from 'vue'
 import { useRoute, useRouter, RouteLocation, RouteRecordName } from 'vue-router'
 
+import { useStore } from '@/store/store'
+
 const route = useRoute()
 const router = useRouter()
+const store = useStore()
 
 type BreadcrumbItem = {
   to: RouteLocation | string
@@ -50,7 +53,9 @@ const breadcrumbItems = computed(() => {
     if (isCurrentRoute && matchedRoute.meta.breadcrumbExclude !== true && route.name) {
       let title = route.meta.title as string
 
-      if (route.meta.breadcrumbTitleParam && route.params[route.meta.breadcrumbTitleParam]) {
+      if (typeof route.meta.getBreadcrumbTitle === 'function') {
+        title = route.meta.getBreadcrumbTitle(route, store)
+      } else if (route.meta.breadcrumbTitleParam && route.params[route.meta.breadcrumbTitleParam]) {
         title = route.params[route.meta.breadcrumbTitleParam] as string
       }
 

--- a/src/shims-vue-router.d.ts
+++ b/src/shims-vue-router.d.ts
@@ -18,6 +18,13 @@ declare module 'vue-router' {
     breadcrumbTitleParam?: string
 
     /**
+     * Allows routes to define their breadcrumb title programmatically based on current route and store data.
+     *
+     * Takes precedence over the `breadcrumbTitleParam` mechanism.
+     */
+    getBreadcrumbTitle?: (route: RouteLocationNormalizedLoaded, store: Store<State>) => string
+
+    /**
      * Whether a route is part of the onboarding pages.
      */
     onboardingProcess?: boolean


### PR DESCRIPTION
Adds a feature to the breadcrumbs component for programmatically determining an entry’s title. This can be used to resolve a resource’s name from, for example, a given ID.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>