### PR TITLE
feat: adds support for more request methods

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 VITE_INSTALL_URL=https://kuma.io/install/latest/
-VITE_VERSION_URL=https://kuma.io/latest_version/
+VITE_VERSION_URL=https://kuma.io/latest_version
 VITE_NAMESPACE=Kuma
 VITE_KUMA_API_SERVER_URL=http://localhost:5681
 VITE_KUMA_DP_SERVER_URL=https://localhost:5678

--- a/src/services/kuma-api/RestClient.spec.ts
+++ b/src/services/kuma-api/RestClient.spec.ts
@@ -28,13 +28,18 @@ describe('RestClient', () => {
   test.each([
     [
       undefined,
-      {},
+      {
+        method: 'GET',
+        credentials: 'include',
+      },
     ],
     [
       {
         tag: 'kuma.io/service:backend',
       },
       {
+        method: 'GET',
+        credentials: 'include',
         params: [['tag', 'kuma.io/service:backend']],
       },
     ],
@@ -43,6 +48,8 @@ describe('RestClient', () => {
         tag: ['kuma.io/service:backend', 'version:v1'],
       },
       {
+        method: 'GET',
+        credentials: 'include',
         params: [
           ['tag', 'kuma.io/service:backend'],
           ['tag', 'version:v1'],
@@ -55,6 +62,8 @@ describe('RestClient', () => {
         tag: ['kuma.io/service:backend', 'version:v1'],
       },
       {
+        method: 'GET',
+        credentials: 'include',
         params: [
           ['gateway', true],
           ['tag', 'kuma.io/service:backend'],
@@ -69,6 +78,8 @@ describe('RestClient', () => {
         ['tag', 'version:v1'],
       ],
       {
+        method: 'GET',
+        credentials: 'include',
         params: [
           ['gateway', true],
           ['tag', 'kuma.io/service:backend'],
@@ -83,9 +94,9 @@ describe('RestClient', () => {
     }))
 
     const restClient = new RestClient('http://localhost:5681')
-    restClient.raw('path', { params })
+    restClient.raw('path', undefined, { params })
 
-    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith('http://localhost:5681/path', expectedOptions)
+    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith('http://localhost:5681/path', expectedOptions, undefined)
   })
 
   test.each([
@@ -116,6 +127,7 @@ describe('RestClient', () => {
       } as RequestInit,
       {
         method: 'GET',
+        credentials: 'include',
         headers: {
           'Content-Type': 'text/html',
         },
@@ -131,7 +143,7 @@ describe('RestClient', () => {
     restClient.options = options
     restClient.get('path')
 
-    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith('http://localhost:5681/path', expectedOptions)
+    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith('http://localhost:5681/path', expectedOptions, undefined)
   })
 
   test.each([
@@ -141,12 +153,16 @@ describe('RestClient', () => {
     ['/', '/path', '/path'],
     ['/', 'path/', '/path'],
     ['/', '/path/', '/path'],
+    ['/', '', '/'],
+    ['/', '/', '/'],
     ['http://example.org', 'path', 'http://example.org/path'],
     ['http://example.org', '/path', 'http://example.org/path'],
     ['http://example.org/', 'path', 'http://example.org/path'],
     ['http://example.org/', '/path', 'http://example.org/path'],
     ['http://example.org/', 'path/', 'http://example.org/path'],
     ['http://example.org/', '/path/', 'http://example.org/path'],
+    ['http://example.org/', '', 'http://example.org'],
+    ['http://example.org/', '/', 'http://example.org'],
   ])('sends correct request URL', (baseUrlOrPath, requestPath, expectedRequestUrl) => {
     jest.spyOn(MakeRequestModule, 'makeRequest').mockImplementation(() => Promise.resolve({
       response: new Response(),
@@ -156,6 +172,6 @@ describe('RestClient', () => {
     const restClient = new RestClient(baseUrlOrPath)
     restClient.raw(requestPath)
 
-    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith(expectedRequestUrl, {})
+    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith(expectedRequestUrl, { method: 'GET', credentials: 'include' }, undefined)
   })
 })

--- a/src/services/kuma-api/makeRequest.ts
+++ b/src/services/kuma-api/makeRequest.ts
@@ -1,6 +1,6 @@
 import { ApiError } from './ApiError'
 
-export async function makeRequest(url: string, options: RequestInit & { params?: any } = {}) {
+export async function makeRequest(url: string, options: RequestInit & { params?: any } = {}, payload?: any) {
   const init = options
   const method = init.method ?? 'GET'
 
@@ -14,13 +14,17 @@ export async function makeRequest(url: string, options: RequestInit & { params?:
 
   let completeUrl = url
 
-  if ('params' in options) {
-    if (method === 'GET') {
-      // Turns `params` into query parameters for GET requests.
-      completeUrl += `?${new URLSearchParams(options.params).toString()}`
-    } else if (init.headers.get('content-type')?.startsWith('application/json')) {
-      // Sets the request body to the JSON representation of `params`.
-      init.body = JSON.stringify(options.params)
+  if ('params' in options && method === 'GET') {
+    // Turns `params` into query parameters for GET requests.
+    completeUrl += `?${new URLSearchParams(options.params).toString()}`
+  }
+
+  if (payload !== undefined) {
+    if (init.headers.get('content-type')?.startsWith('application/json')) {
+      // Sets the request body to the JSON representation of `payload`.
+      init.body = JSON.stringify(payload)
+    } else {
+      init.body = payload
     }
   }
 

--- a/src/services/kuma-api/makeRequest.ts
+++ b/src/services/kuma-api/makeRequest.ts
@@ -37,7 +37,7 @@ export async function makeRequest(url: string, options: RequestInit & { params?:
   }
 
   const contentType = response.headers.get('content-type')
-  const isJson = contentType !== null ? contentType.startsWith('application/json') : false
+  const isJson = contentType !== null ? contentType.startsWith('application/json') || contentType.startsWith('application/problem+json') : false
   const data = isJson ? await response.json() : await response.text()
 
   if (response.ok) {


### PR DESCRIPTION
Adds support for `delete`, `post`, `put`, and `patch` methods on `RestClient` as our APIs are involving.

Sets the `credentials` option to default to `'include'` for all instances of `RestClient`. Environments in which no session state is transferred via cookies aren’t affected as there wouldn’t be any cookie stored to send with requests. Environments which do need to transfer such session state in turn will benefit from not needing to set `credentials: 'include'` on all the individual API instances.

Ensures URLs are consistently constructed without a trailing slash and adds test cases for that edge case.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>