### PR TITLE
feat: allows hiding alerts

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -19,7 +19,7 @@
 
         <NotificationManager v-if="shouldShowNotificationManager" />
 
-        <AppOnboardingNotification v-if="shouldSuggestOnboarding" />
+        <AppOnboardingNotification v-if="shouldShowOnboardingNotification" />
 
         <AppBreadcrumbs v-if="shouldShowBreadcrumbs" />
 
@@ -84,10 +84,10 @@ const isLoading = ref(store.state.globalLoading)
  * Both routes resolve to the same route definition and the router’s default behavior is to not re-render the component in such navigations.
  */
 const routeKey = computed(() => route.path)
-const shouldShowAppError = computed(() => store.state.config.status !== 'OK')
-const shouldSuggestOnboarding = computed(() => store.getters.shouldSuggestOnboarding)
-const shouldShowNotificationManager = computed(() => store.getters['notifications/amountOfActions'] > 0)
-const shouldShowBreadcrumbs = computed(() => route.meta.shouldShowBreadcrumbs !== false)
+const shouldShowAppError = computed(() => store.getters.shouldShowAppError)
+const shouldShowNotificationManager = computed(() => store.getters.shouldShowNotificationManager)
+const shouldShowOnboardingNotification = computed(() => store.getters.shouldShowOnboardingNotification)
+const shouldShowBreadcrumbs = computed(() => store.getters.getShouldShowBreadcrumbs(route.meta))
 
 watch(() => store.state.globalLoading, function (globalLoading) {
   isLoading.value = globalLoading

--- a/src/app/AppHeader.vue
+++ b/src/app/AppHeader.vue
@@ -19,7 +19,7 @@
     </div>
 
     <div
-      v-if="store.state.config.status === 'OK'"
+      v-if="!shouldShowAppError"
       class="horizontal-list"
     >
       <div class="app-status app-status--mobile">
@@ -119,7 +119,8 @@ const [
 const store = useStore()
 const env = useEnv()
 
-const shouldShowNotificationManager = computed(() => store.getters['notifications/amountOfActions'] > 0)
+const shouldShowAppError = computed(() => store.getters.shouldShowAppError)
+const shouldShowNotificationManager = computed(() => store.getters.shouldShowNotificationManager)
 const environmentName = computed(() => {
   const environment = store.getters['config/getEnvironment']
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export function useBootstrap(
         store.dispatch('fetchPolicyTypes'),
       ])
     } else {
-      store.state.config.status = 'OK'
+      store.state.defaultVisibility.appError = false
     }
 
     await store.dispatch('updateGlobalLoading', false)

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -53,7 +53,7 @@ const updateSelectedMeshGuard = (store: Store<State>): NavigationGuard => (to, _
 const onboardingRouteGuard = (store: Store<State>): NavigationGuard => (to, _from, next) => {
   const isOnboardingCompleted = store.state.onboarding.isCompleted
   const isOnboardingRoute = to.meta.onboardingProcess
-  const shouldSuggestOnboarding = store.getters.shouldSuggestOnboarding
+  const shouldSuggestOnboarding = store.getters.shouldShowOnboardingNotification
 
   if (isOnboardingCompleted && isOnboardingRoute && !shouldSuggestOnboarding) {
     next({ name: 'home' })


### PR DESCRIPTION
Streamlines how general pieces of the UI may show up. Only if their respective entry in `state.defaultVisibility` is `true` become any of their other specific checks relevant.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>