### PR TITLE
fix: file-relative font asset references

### DIFF
--- a/src/assets/styles/_fonts.scss
+++ b/src/assets/styles/_fonts.scss
@@ -4,7 +4,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('../fonts/Inter/Inter-Regular-latin-ext.woff2') format('woff2');
+  src: url('@/assets/fonts/Inter/Inter-Regular-latin-ext.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -14,7 +14,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('../fonts/Inter/Inter-Regular-latin.woff2') format('woff2');
+  src: url('@/assets/fonts/Inter/Inter-Regular-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -24,7 +24,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('../fonts/Inter/Inter-Medium-latin-ext.woff2') format('woff2');
+  src: url('@/assets/fonts/Inter/Inter-Medium-latin-ext.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -34,7 +34,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('../fonts/Inter/Inter-Medium-latin.woff2') format('woff2');
+  src: url('@/assets/fonts/Inter/Inter-Medium-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -44,7 +44,7 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url('../fonts/Inter/Inter-SemiBold-latin-ext.woff2') format('woff2');
+  src: url('@/assets/fonts/Inter/Inter-SemiBold-latin-ext.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -54,7 +54,7 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url('../fonts/Inter/Inter-SemiBold-latin.woff2') format('woff2');
+  src: url('@/assets/fonts/Inter/Inter-SemiBold-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -64,7 +64,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('../fonts/Inter/Inter-Bold-latin-ext.woff2') format('woff2');
+  src: url('@/assets/fonts/Inter/Inter-Bold-latin-ext.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -74,7 +74,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('../fonts/Inter/Inter-Bold-latin.woff2') format('woff2');
+  src: url('@/assets/fonts/Inter/Inter-Bold-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -84,7 +84,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('../fonts/Fira_Mono/FiraMono-Regular-latin-ext.woff2') format('woff2');
+  src: url('@/assets/fonts/Fira_Mono/FiraMono-Regular-latin-ext.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -94,6 +94,6 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('../fonts/Fira_Mono/FiraMono-Regular-latin.woff2') format('woff2');
+  src: url('@/assets/fonts/Fira_Mono/FiraMono-Regular-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
Fixes an issue with file-relative asset references not being resolved correctly in some dev server contexts.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>