### PR TITLE
fix: stripping slash from absolute URL

### DIFF
--- a/src/services/kuma-api/RestClient.spec.ts
+++ b/src/services/kuma-api/RestClient.spec.ts
@@ -163,6 +163,8 @@ describe('RestClient', () => {
     ['http://example.org/', '/path/', 'http://example.org/path'],
     ['http://example.org/', '', 'http://example.org'],
     ['http://example.org/', '/', 'http://example.org'],
+    ['http://example.org/', 'http://konghq.tech/path', 'http://konghq.tech/path'],
+    ['http://example.org/', 'http://konghq.tech/path/', 'http://konghq.tech/path/'],
   ])('sends correct request URL', (baseUrlOrPath, requestPath, expectedRequestUrl) => {
     jest.spyOn(MakeRequestModule, 'makeRequest').mockImplementation(() => Promise.resolve({
       response: new Response(),

--- a/src/services/kuma-api/RestClient.ts
+++ b/src/services/kuma-api/RestClient.ts
@@ -92,9 +92,9 @@ export class RestClient {
       url = [this.baseUrl, urlOrPath]
         .map((pathSegment) => pathSegment.replace(/\/+$/, '').replace(/^\/+/, ''))
         .join('/')
-    }
 
-    url = url === '/' ? url : url.replace(/\/+$/, '')
+      url = url === '/' ? url : url.replace(/\/+$/, '')
+    }
 
     // Merges headers from stored options and override headers.
     const headers = new Headers(this.options.headers)


### PR DESCRIPTION
Fixes stripping trailing slashes from absolute URLs in the RestClient. Generally, our APIs don’t require a trailing slash. But we make one request for getting the latest Kuma version to our docs site and depending on the web server configuration, requesting without a trailing slash can fail because the server responds with a redirect.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>