### PR TITLE
fix: not always determining tag links correctly

### DIFF
--- a/src/app/common/TagList.vue
+++ b/src/app/common/TagList.vue
@@ -20,10 +20,12 @@ import { KBadge } from '@kong/kongponents'
 import { computed, PropType } from 'vue'
 import { RouteLocation, useRouter } from 'vue-router'
 
+import { useStore } from '@/store/store'
 import { LabelValue } from '@/types/index.d'
 import { getLabels } from '@/utilities/getLabels'
 
 const router = useRouter()
+const store = useStore()
 
 interface LabelValueWithRoute extends LabelValue {
   route: RouteLocation | undefined
@@ -65,6 +67,7 @@ function getRoute(tag: LabelValue): RouteLocation | undefined {
         return router.resolve({
           name: 'service-detail-view',
           params: {
+            mesh: store.state.selectedMesh,
             service: tag.value,
           },
         })

--- a/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
@@ -265,12 +265,15 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                                   class="k-badge-text truncate"
                                 >
                                   
-                                  <span>
+                                  <a
+                                    class=""
+                                    href="/mesh/default/services/backend"
+                                  >
                                     kuma.io/service:
                                     <b>
                                       backend
                                     </b>
-                                  </span>
+                                  </a>
                                   
                                 </div>
                               </div>

--- a/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
@@ -85,12 +85,15 @@ exports[`DataPlaneEntitySummary matches snapshot 1`] = `
                 class="k-badge-text truncate"
               >
                 
-                <span>
+                <a
+                  class=""
+                  href="/mesh/default/services/backend"
+                >
                   kuma.io/service:
                   <b>
                     backend
                   </b>
-                </span>
+                </a>
                 
               </div>
             </div>

--- a/src/app/data-planes/components/__snapshots__/DataplanePolicies.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataplanePolicies.spec.ts.snap
@@ -182,12 +182,15 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                                 class="k-badge-text truncate"
                               >
                                 
-                                <span>
+                                <a
+                                  class=""
+                                  href="/mesh/default/services/service-a"
+                                >
                                   kuma.io/service:
                                   <b>
                                     service-a
                                   </b>
-                                </span>
+                                </a>
                                 
                               </div>
                             </div>
@@ -216,12 +219,15 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                                 class="k-badge-text truncate"
                               >
                                 
-                                <span>
+                                <a
+                                  class=""
+                                  href="/mesh/default/services/web"
+                                >
                                   kuma.io/service:
                                   <b>
                                     web
                                   </b>
-                                </span>
+                                </a>
                                 
                               </div>
                             </div>
@@ -411,12 +417,15 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                                 class="k-badge-text truncate"
                               >
                                 
-                                <span>
+                                <a
+                                  class=""
+                                  href="/mesh/default/services/service-b"
+                                >
                                   kuma.io/service:
                                   <b>
                                     service-b
                                   </b>
-                                </span>
+                                </a>
                                 
                               </div>
                             </div>
@@ -445,12 +454,15 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                                 class="k-badge-text truncate"
                               >
                                 
-                                <span>
+                                <a
+                                  class=""
+                                  href="/mesh/default/services/web"
+                                >
                                   kuma.io/service:
                                   <b>
                                     web
                                   </b>
-                                </span>
+                                </a>
                                 
                               </div>
                             </div>
@@ -674,12 +686,15 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                                 class="k-badge-text truncate"
                               >
                                 
-                                <span>
+                                <a
+                                  class=""
+                                  href="/mesh/default/services/web"
+                                >
                                   kuma.io/service:
                                   <b>
                                     web
                                   </b>
-                                </span>
+                                </a>
                                 
                               </div>
                             </div>


### PR DESCRIPTION
Fixes `TagList` not always being able to correctly determine tag routes. Specifically, when used on a page where no mesh parameter is in a route, it can’t know which one to use for routes that need it. Adding it explicitly fixes this.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>