### PR TITLE
refactor: streamlines LabelList and KCard usage

### DIFF
--- a/src/app/common/AccordionItem.vue
+++ b/src/app/common/AccordionItem.vue
@@ -21,7 +21,7 @@
     >
       <div
         v-if="visible"
-        class="px-4 py-1"
+        class="accordion-item-content"
         data-testid="accordion-item-content"
       >
         <slot name="accordion-content" />
@@ -134,7 +134,8 @@ function end(el: HTMLElement): void {
   display: block;
   width: 100%;
   text-align: left;
-  padding: var(--spacing-xs) var(--spacing-sm);
+  padding-top: var(--spacing-xs);
+  padding-bottom: var(--spacing-xs);
 
   &::after {
     position: absolute;
@@ -147,5 +148,10 @@ function end(el: HTMLElement): void {
     border-left: 0.325em solid transparent;
     transition: 0.25s ease;
   }
+}
+
+.accordion-item-content {
+  padding-top: var(--spacing-xs);
+  padding-bottom: var(--spacing-xs);
 }
 </style>

--- a/src/app/common/EnvoyData.vue
+++ b/src/app/common/EnvoyData.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="envoy-data">
+  <div>
     <div class="envoy-data-actions">
       <KButton
         :disabled="isLoading"
@@ -132,10 +132,6 @@ async function fetchContent() {
 </script>
 
 <style lang="scss" scoped>
-.envoy-data {
-  padding: var(--spacing-md);
-}
-
 .envoy-data-actions {
   display: flex;
   justify-content: flex-end;

--- a/src/app/common/LabelList.vue
+++ b/src/app/common/LabelList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="label-list">
     <LoadingBlock v-if="props.isLoading" />
 
     <ErrorBlock v-else-if="props.hasError" />
@@ -8,22 +8,14 @@
 
     <div
       v-else
-      class="label-list-content"
+      class="label-list__content"
     >
-      <KCard border-variant="noBorder">
-        <template #body>
-          <div class="label-list__col-wrapper multi-col">
-            <slot />
-          </div>
-        </template>
-      </KCard>
+      <slot />
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { KCard } from '@kong/kongponents'
-
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
@@ -47,67 +39,31 @@ const props = defineProps({
 </script>
 
 <style lang="scss">
-.label-list-content .kong-card {
-  margin-bottom: 0 !important;
+.label-list {
+  h2, h3, h4, h5, h6 {
+    margin-bottom: var(--spacing-xs);
+    color: var(--grey-500);
+  }
+
+  h2, h3, h4 {
+    text-transform: uppercase;
+  }
 }
 
-.label-list__col-wrapper {
-  h4 {
-    margin-bottom: var(--spacing-xs);
-    text-transform: uppercase;
-    color: var(--grey-500);
+.label-list__content {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  row-gap: var(--spacing-lg);
+
+  > * {
+    flex-grow: 999;
+    flex-basis: 0;
+    min-inline-size: 500px;
   }
 
   li:not(:first-child) {
     margin-top: var(--spacing-md);
-  }
-
-  @media screen and (min-width: 1024px) {
-    &.multi-col {
-      display: flex;
-
-      > * {
-        flex-grow: 1;
-        flex-basis: 33.333333%;
-
-        &:not(:last-of-type) {
-          margin-right: var(--spacing-md);
-        }
-      }
-    }
-  }
-}
-
-// Tag columns
-
-.tag-cols {
-  display: grid;
-  grid-auto-flow: column dense;
-  grid-template-columns: 1fr 2fr;
-
-  span {
-    display: inline-block;
-    padding: var(--spacing-xs);
-  }
-
-  span:first-of-type {
-    font-weight: 600;
-  }
-}
-
-// Label columns
-
-.label-cols {
-  display: flex;
-  align-items: stretch;
-
-  span:first-of-type {
-    &:after {
-      display: inline-block;
-      content: '/';
-      margin: 0 3px 0 1px;
-      color: var(--grey-500);
-    }
   }
 }
 </style>

--- a/src/app/common/TabsWidget.vue
+++ b/src/app/common/TabsWidget.vue
@@ -25,10 +25,15 @@
           @changed="switchTab"
         >
           <template
-            v-for="tab in tabsSlots"
+            v-for="(tab, index) in tabsSlots"
+            :key="index"
             #[tab]
           >
-            <slot :name="tab" />
+            <KCard border-variant="noBorder">
+              <template #body>
+                <slot :name="tab" />
+              </template>
+            </KCard>
           </template>
 
           <template #warnings-anchor>
@@ -52,7 +57,7 @@
 
 <script lang="ts" setup>
 import { datadogLogs } from '@datadog/browser-logs'
-import { KIcon, KTabs } from '@kong/kongponents'
+import { KCard, KIcon, KTabs } from '@kong/kongponents'
 import { computed, PropType, ref } from 'vue'
 
 import ErrorBlock from '@/app/common/ErrorBlock.vue'

--- a/src/app/common/__snapshots__/EnvoyData.spec.ts.snap
+++ b/src/app/common/__snapshots__/EnvoyData.spec.ts.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EnvoyData.vue renders snapshot 1`] = `
-<div
-  class="envoy-data"
->
+<div>
   <div
     class="envoy-data-actions"
   >

--- a/src/app/common/__snapshots__/TabsWidget.spec.ts.snap
+++ b/src/app/common/__snapshots__/TabsWidget.spec.ts.snap
@@ -61,11 +61,30 @@ exports[`TabsWidget.vue renders basic snapshot 1`] = `
         tabindex="0"
       >
         
-        
-        <div>
-          Universal
-        </div>
-        
+        <section
+          aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+          class="kong-card noBorder"
+        >
+          <!---->
+          <!---->
+          <div
+            class="k-card-content d-flex"
+          >
+            <div
+              class="k-card-body"
+              id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+            >
+              
+              
+              <div>
+                Universal
+              </div>
+              
+              
+            </div>
+            <!---->
+          </div>
+        </section>
         
       </div>
       <div

--- a/src/app/common/warnings/WarningsWidget.vue
+++ b/src/app/common/warnings/WarningsWidget.vue
@@ -1,28 +1,24 @@
 <template>
-  <KCard border-variant="noBorder">
-    <template #body>
-      <ul>
-        <li
-          v-for="(warning, index) in props.warnings"
-          :key="`${warning.kind}/${index}`"
-          class="mb-1"
-        >
-          <KAlert appearance="warning">
-            <template #alertMessage>
-              <component
-                :is="getWarningComponent(warning.kind)"
-                :payload="warning.payload"
-              />
-            </template>
-          </KAlert>
-        </li>
-      </ul>
-    </template>
-  </KCard>
+  <ul>
+    <li
+      v-for="(warning, index) in props.warnings"
+      :key="`${warning.kind}/${index}`"
+      class="mb-1"
+    >
+      <KAlert appearance="warning">
+        <template #alertMessage>
+          <component
+            :is="getWarningComponent(warning.kind)"
+            :payload="warning.payload"
+          />
+        </template>
+      </KAlert>
+    </li>
+  </ul>
 </template>
 
 <script lang="ts" setup>
-import { KAlert, KCard } from '@kong/kongponents'
+import { KAlert } from '@kong/kongponents'
 import { PropType } from 'vue'
 
 import WarningDefault from './WarningDefault.vue'

--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -76,38 +76,33 @@
         </div>
       </LabelList>
 
-      <div class="config-wrapper">
-        <YamlView
-          id="code-block-data-plane"
-          :content="rawDataPlane"
-          is-searchable
-        />
-      </div>
+      <YamlView
+        id="code-block-data-plane"
+        class="mt-4"
+        :content="rawDataPlane"
+        is-searchable
+      />
     </template>
 
     <template #insights>
       <StatusInfo :is-empty="insightSubscriptions.length === 0">
-        <KCard border-variant="noBorder">
-          <template #body>
-            <AccordionList :initially-open="0">
-              <AccordionItem
-                v-for="(insight, key) in insightSubscriptions"
-                :key="key"
-              >
-                <template #accordion-header>
-                  <SubscriptionHeader :details="insight" />
-                </template>
+        <AccordionList :initially-open="0">
+          <AccordionItem
+            v-for="(insight, key) in insightSubscriptions"
+            :key="key"
+          >
+            <template #accordion-header>
+              <SubscriptionHeader :details="insight" />
+            </template>
 
-                <template #accordion-content>
-                  <SubscriptionDetails
-                    :details="insight"
-                    is-discovery-subscription
-                  />
-                </template>
-              </AccordionItem>
-            </AccordionList>
-          </template>
-        </KCard>
+            <template #accordion-content>
+              <SubscriptionDetails
+                :details="insight"
+                is-discovery-subscription
+              />
+            </template>
+          </AccordionItem>
+        </AccordionList>
       </StatusInfo>
     </template>
 
@@ -182,7 +177,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KCard, KAlert } from '@kong/kongponents'
+import { KAlert } from '@kong/kongponents'
 import { computed, ref, PropType } from 'vue'
 
 import DataplanePolicies from './DataplanePolicies.vue'
@@ -344,9 +339,18 @@ setWarnings()
   margin-top: var(--spacing-xxs);
 }
 
-.config-wrapper {
-  padding-right: var(--spacing-md);
-  padding-left: var(--spacing-md);
-  padding-bottom: var(--spacing-md);
+.tag-cols {
+  display: grid;
+  grid-auto-flow: column dense;
+  grid-template-columns: 1fr 2fr;
+
+  span {
+    display: inline-block;
+    padding: var(--spacing-xs);
+  }
+
+  span:first-of-type {
+    font-weight: 600;
+  }
 }
 </style>

--- a/src/app/data-planes/components/DataPlaneEntitySummary.vue
+++ b/src/app/data-planes/components/DataPlaneEntitySummary.vue
@@ -1,139 +1,143 @@
 <template>
-  <div class="entity-summary entity-section-list">
-    <section>
-      <div class="block-list">
-        <div>
-          <h3
-            class="entity-title"
-            data-testid="data-plane-proxy-title"
-          >
-            <span>
-              DPP:
-
-              <router-link
-                :to="{
-                  name: 'data-plane-detail-view',
-                  params: {
-                    mesh: dataPlaneOverview.mesh,
-                    dataPlane: dataPlaneOverview.name,
-                  },
-                }"
+  <KCard border-variant="noBorder">
+    <template #body>
+      <div class="entity-section-list">
+        <section>
+          <div class="block-list">
+            <div>
+              <h3
+                class="entity-title"
+                data-testid="data-plane-proxy-title"
               >
-                {{ dataPlaneOverview.name }}
-              </router-link>
-            </span>
+                <span>
+                  DPP:
 
-            <StatusBadge :status="status" />
-          </h3>
+                  <router-link
+                    :to="{
+                      name: 'data-plane-detail-view',
+                      params: {
+                        mesh: dataPlaneOverview.mesh,
+                        dataPlane: dataPlaneOverview.name,
+                      },
+                    }"
+                  >
+                    {{ dataPlaneOverview.name }}
+                  </router-link>
+                </span>
 
-          <div class="definition">
-            <span>Mesh:</span>
-            <span>{{ dataPlaneOverview.mesh }}</span>
+                <StatusBadge :status="status" />
+              </h3>
+
+              <div class="definition">
+                <span>Mesh:</span>
+                <span>{{ dataPlaneOverview.mesh }}</span>
+              </div>
+            </div>
+
+            <div v-if="dataPlaneTags.length > 0">
+              <h4>Tags</h4>
+
+              <TagList :tags="dataPlaneTags" />
+            </div>
+
+            <div v-if="dependencies.length > 0">
+              <h4>Dependencies</h4>
+
+              <div
+                v-for="(dependency, index) in dependencies"
+                :key="index"
+                class="definition"
+              >
+                <span>{{ dependency.name }}:</span>
+                <span>{{ dependency.version }}</span>
+              </div>
+
+              <template v-if="warnings.length > 0">
+                <h5 class="mt-2 heading-with-icon">
+                  Warnings
+
+                  <KIcon
+                    class="ml-1"
+                    icon="warning"
+                    color="var(--black-75)"
+                    secondary-color="var(--yellow-300)"
+                    size="20"
+                  />
+                </h5>
+
+                <p
+                  v-for="(warning, index) in warnings"
+                  :key="index"
+                >
+                  {{ warning }}
+                </p>
+              </template>
+            </div>
           </div>
-        </div>
+        </section>
 
-        <div v-if="dataPlaneTags.length > 0">
-          <h4>Tags</h4>
+        <section v-if="subscriptionWrappers.length > 0">
+          <h4>Insights</h4>
 
-          <TagList :tags="dataPlaneTags" />
-        </div>
-
-        <div v-if="dependencies.length > 0">
-          <h4>Dependencies</h4>
-
-          <div
-            v-for="(dependency, index) in dependencies"
-            :key="index"
-            class="definition"
-          >
-            <span>{{ dependency.name }}:</span>
-            <span>{{ dependency.version }}</span>
-          </div>
-
-          <template v-if="warnings.length > 0">
-            <h5 class="mt-2 heading-with-icon">
-              Warnings
-
-              <KIcon
-                class="ml-1"
-                icon="warning"
-                color="var(--black-75)"
-                secondary-color="var(--yellow-300)"
-                size="20"
-              />
-            </h5>
-
-            <p
-              v-for="(warning, index) in warnings"
+          <div class="block-list">
+            <div
+              v-for="(subscriptionWrapper, index) in subscriptionWrappers"
               :key="index"
             >
-              {{ warning }}
-            </p>
-          </template>
-        </div>
-      </div>
-    </section>
+              <div
+                class="definition"
+                :data-testid="`data-plane-connect-time-${index}`"
+              >
+                <span>Connect time:</span>
+                <span>{{ subscriptionWrapper.formattedConnectDate }}</span>
+              </div>
 
-    <section v-if="subscriptionWrappers.length > 0">
-      <h4>Insights</h4>
+              <div
+                class="definition"
+                :data-testid="`data-plane-disconnect-time-${index}`"
+              >
+                <span>Disconnect time:</span>
+                <span>{{ subscriptionWrapper.formattedDisconnectDate }}</span>
+              </div>
 
-      <div class="block-list">
-        <div
-          v-for="(subscriptionWrapper, index) in subscriptionWrappers"
-          :key="index"
-        >
-          <div
-            class="definition"
-            :data-testid="`data-plane-connect-time-${index}`"
-          >
-            <span>Connect time:</span>
-            <span>{{ subscriptionWrapper.formattedConnectDate }}</span>
-          </div>
+              <div class="definition">
+                <span>CP instance ID:</span>
+                <span>{{ subscriptionWrapper.subscription.controlPlaneInstanceId }}</span>
+              </div>
 
-          <div
-            class="definition"
-            :data-testid="`data-plane-disconnect-time-${index}`"
-          >
-            <span>Disconnect time:</span>
-            <span>{{ subscriptionWrapper.formattedDisconnectDate }}</span>
-          </div>
+              <details v-if="subscriptionWrapper.statuses.length > 0">
+                <summary>
+                  Responses (acknowledged / sent)
+                </summary>
 
-          <div class="definition">
-            <span>CP instance ID:</span>
-            <span>{{ subscriptionWrapper.subscription.controlPlaneInstanceId }}</span>
-          </div>
-
-          <details v-if="subscriptionWrapper.statuses.length > 0">
-            <summary>
-              Responses (acknowledged / sent)
-            </summary>
-
-            <div
-              v-for="(subscriptionStatus, subscriptionStatusIndex) in subscriptionWrapper.statuses"
-              :key="`${index}-${subscriptionStatusIndex}`"
-              class="definition"
-              :data-testid="`data-plane-subscription-status-${index}-${subscriptionStatusIndex}`"
-            >
-              <span>{{ subscriptionStatus.type }}:</span>
-              <span>{{ subscriptionStatus.ratio }}</span>
+                <div
+                  v-for="(subscriptionStatus, subscriptionStatusIndex) in subscriptionWrapper.statuses"
+                  :key="`${index}-${subscriptionStatusIndex}`"
+                  class="definition"
+                  :data-testid="`data-plane-subscription-status-${index}-${subscriptionStatusIndex}`"
+                >
+                  <span>{{ subscriptionStatus.type }}:</span>
+                  <span>{{ subscriptionStatus.ratio }}</span>
+                </div>
+              </details>
             </div>
-          </details>
-        </div>
-      </div>
-    </section>
+          </div>
+        </section>
 
-    <section class="config-section">
-      <YamlView
-        id="code-block-data-plane-summary"
-        :content="dataPlane"
-        code-max-height="250px"
-      />
-    </section>
-  </div>
+        <section class="config-section">
+          <YamlView
+            id="code-block-data-plane-summary"
+            :content="dataPlane"
+            code-max-height="250px"
+          />
+        </section>
+      </div>
+    </template>
+  </KCard>
 </template>
 
 <script lang="ts" setup>
-import { KIcon } from '@kong/kongponents'
+import { KCard, KIcon } from '@kong/kongponents'
 import { computed, PropType } from 'vue'
 
 import StatusBadge from '@/app/common/StatusBadge.vue'
@@ -251,10 +255,6 @@ h3, h4, h5 {
 .heading-with-icon {
   display: flex;
   align-items: center;
-}
-
-.entity-summary {
-  padding: var(--spacing-md);
 }
 
 .entity-section-list {

--- a/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
@@ -151,1072 +151,1066 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
         tabindex="0"
       >
         
-        
-        <div>
-          <div
-            class="label-list-content"
-          >
-            <section
-              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-              class="kong-card noBorder"
-            >
-              <!---->
-              <!---->
-              <div
-                class="k-card-content d-flex"
-              >
-                <div
-                  class="k-card-body"
-                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-                >
-                  
-                  <div
-                    class="label-list__col-wrapper multi-col"
-                  >
-                    
-                    <div>
-                      <ul>
-                        
-                        <li>
-                          <h4>
-                            type
-                          </h4>
-                          <div>
-                            Dataplane
-                          </div>
-                        </li>
-                        <li>
-                          <h4>
-                            name
-                          </h4>
-                          <div>
-                            backend
-                          </div>
-                        </li>
-                        <li>
-                          <h4>
-                            mesh
-                          </h4>
-                          <div>
-                            test-mesh
-                          </div>
-                        </li>
-                        
-                        <li>
-                          <h4>
-                            Status
-                          </h4>
-                          <div>
-                            <span
-                              class="status status--with-title status--success"
-                              data-testid="status-badge"
-                            >
-                              <span
-                                class=""
-                              >
-                                online
-                              </span>
-                            </span>
-                          </div>
-                        </li>
-                        <!--v-if-->
-                      </ul>
-                    </div>
-                    <div>
-                      <ul>
-                        <li>
-                          <h4>
-                            Tags
-                          </h4>
-                          <span
-                            class="tag-list"
-                          >
-                            
-                            <div
-                              class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
-                              tabindex="0"
-                            >
-                              <div
-                                class="k-badge-text truncate"
-                              >
-                                <div
-                                  class="k-badge-text truncate"
-                                >
-                                  
-                                  <span>
-                                    kuma.io/protocol:
-                                    <b>
-                                      http
-                                    </b>
-                                  </span>
-                                  
-                                </div>
-                              </div>
-                              <!---->
-                            </div>
-                            <div
-                              class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
-                              tabindex="0"
-                            >
-                              <div
-                                class="k-badge-text truncate"
-                              >
-                                <div
-                                  class="k-badge-text truncate"
-                                >
-                                  
-                                  <a
-                                    class=""
-                                    href="/mesh/default/services/backend"
-                                  >
-                                    kuma.io/service:
-                                    <b>
-                                      backend
-                                    </b>
-                                  </a>
-                                  
-                                </div>
-                              </div>
-                              <!---->
-                            </div>
-                            
-                          </span>
-                        </li>
-                        <li>
-                          <h4>
-                            Versions
-                          </h4>
-                          <p>
-                            
-                            <span
-                              class="tag-cols"
-                            >
-                              <span>
-                                envoy: 
-                              </span>
-                              <span>
-                                1.16.2
-                              </span>
-                            </span>
-                            <span
-                              class="tag-cols"
-                            >
-                              <span>
-                                kumaDp: 
-                              </span>
-                              <span>
-                                1.0.7
-                              </span>
-                            </span>
-                            <span
-                              class="tag-cols"
-                            >
-                              <span>
-                                coredns: 
-                              </span>
-                              <span>
-                                1.8.3
-                              </span>
-                            </span>
-                            
-                          </p>
-                        </li>
-                      </ul>
-                    </div>
-                    
-                  </div>
-                  
-                </div>
-                <!---->
-              </div>
-            </section>
-          </div>
-        </div>
-        <div
-          class="config-wrapper"
+        <section
+          aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+          class="kong-card noBorder"
         >
+          <!---->
+          <!---->
           <div
-            class="yaml-view"
+            class="k-card-content d-flex"
           >
             <div
-              class="yaml-view-content"
+              class="k-card-body"
+              id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
             >
+              
+              
               <div
-                class="k-tabs"
+                class="label-list"
               >
-                <ul
-                  aria-label="Tabs"
-                  role="tablist"
-                >
-                  
-                  <li
-                    aria-controls="panel-0"
-                    aria-selected="true"
-                    class="tab-item active"
-                    id="universal-tab"
-                    role="tab"
-                    tabindex="0"
-                  >
-                    <a
-                      class="tab-link"
-                    >
-                      
-                      Universal
-                      
-                    </a>
-                  </li>
-                  <li
-                    aria-controls="panel-1"
-                    aria-selected="false"
-                    class="tab-item"
-                    id="kubernetes-tab"
-                    role="tab"
-                    tabindex="0"
-                  >
-                    <a
-                      class="tab-link"
-                    >
-                      
-                      Kubernetes
-                      
-                    </a>
-                  </li>
-                  
-                </ul>
-                
                 <div
-                  aria-labelledby="universal-tab"
-                  class="tab-container"
-                  id="panel-0"
-                  role="tabpanel"
-                  tabindex="0"
+                  class="label-list__content"
                 >
                   
-                  <div
-                    class="k-code-block theme-light code-block"
-                    data-testid="k-code-block"
-                    id="code-block-data-plane"
-                    style="--maxLineNumberWidth: 2ch;"
-                    tabindex="0"
-                  >
-                    <div
-                      class="k-code-block-actions"
-                    >
-                      <p
-                        class="k-code-block-search-results"
-                      >
-                        
-                           
-                        
-                      </p>
-                      <div
-                        class="k-search-container"
-                      >
-                        <span
-                          class="k-search-icon kong-icon kong-icon-search"
-                          data-testid="k-code-block-search-icon"
-                        >
-                          <svg
-                            data-testid="k-code-block-search-icon"
-                            fill="var(--steel-500)"
-                            height="20"
-                            role="img"
-                            viewBox="0 0 24 24"
-                            width="20"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            
-  
-                            <title>
-                              Search
-                            </title>
-                            
-  
-                            <path
-                              d="M10.88 18.75a7.88 7.88 0 1 0 0-15.75 7.88 7.88 0 0 0 0 15.75ZM16.44 16.44 21 21"
-                              fill="none"
-                              stroke="var(--steel-500)"
-                              stroke-width="3"
-                            />
-                            
-
-                          </svg>
-                          
-
-                        </span>
-                        <label
-                          class="k-code-block-search-label"
-                          for="code-block-data-plane-search-input"
-                        >
-                          <span
-                            class="k-visually-hidden"
-                          >
-                            Search
-                          </span>
-                        </label>
-                        <input
-                          class="k-code-block-search-input"
-                          data-testid="k-code-block-search-input"
-                          id="code-block-data-plane-search-input"
-                          type="text"
-                        />
-                        <!---->
-                        <span
-                          class="k-is-processing-icon kong-icon kong-icon-spinner"
-                          data-testid="k-code-block-is-processing-icon"
-                        >
-                          <svg
-                            data-testid="k-code-block-is-processing-icon"
-                            fill="var(--steel-500)"
-                            height="24"
-                            role="img"
-                            viewBox="0 0 20 20"
-                            width="24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            
-  
-                            <title>
-                              Loading
-                            </title>
-                            
-  
-                            <g>
-                              
-    
-                              <path
-                                d="M5 10a5 5 0 1 0 5-5"
-                                fill="none"
-                                stroke="var(--steel-500)"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                              />
-                              
-  
-                            </g>
-                            
-
-                          </svg>
-                          
-
-                        </span>
-                        <!---->
-                      </div>
-                      <div
-                        class="k-search-actions"
-                      >
-                        <button
-                          aria-pressed="false"
-                          class="k-button small outline k-regexp-mode-button"
-                          data-testid="k-code-block-regexp-mode-button"
-                          title="Use regular expression (Alt+R)"
-                          type="button"
-                        >
-                          
-                          <!---->
-                          
-                          
-                          <span
-                            class="k-visually-hidden"
-                          >
-                            RegExp mode enabled
-                          </span>
-                           .* 
-                          
-                          <!---->
-                        </button>
-                        <button
-                          aria-pressed="false"
-                          class="k-button small outline k-filter-mode-button"
-                          data-testid="k-code-block-filter-mode-button"
-                          title="Filter results (Alt+F)"
-                          type="button"
-                        >
-                          
-                          <span
-                            class="k-button-icon kong-icon kong-icon-filter"
-                          >
-                            <svg
-                              height="16"
-                              role="img"
-                              viewBox="0 0 14 11"
-                              width="16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              
-  
-                              <title>
-                                Filter results (Alt+F)
-                              </title>
-                              
-  
-                              <path
-                                d="M8 9v2H6V9h2zm2-3v2H4V6h6zm2-3v2H2V3h10zm2-3v2H0V0h14z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                              
-
-                            </svg>
-                            
-
-                          </span>
-                          
-                          
-                          <span
-                            class="k-visually-hidden"
-                          >
-                            Filter mode enabled
-                          </span>
-                          
-                          <!---->
-                        </button>
-                        <button
-                          class="k-button small outline k-previous-match-button"
-                          data-testid="k-code-block-previous-match-button"
-                          disabled=""
-                          title="Previous match (Shift+F3)"
-                          type="button"
-                        >
-                          
-                          <span
-                            class="k-button-icon kong-icon kong-icon-chevronUp"
-                          >
-                            <svg
-                              fill="currentColor"
-                              height="16"
-                              role="img"
-                              viewBox="0 0 20 20"
-                              width="16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              
-  
-                              <title>
-                                Previous match (Shift+F3)
-                              </title>
-                              
-  
-                              <path
-                                d="M15 12 9.8 7l-5.2 5"
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                              />
-                              
-
-                            </svg>
-                            
-
-                          </span>
-                          
-                          
-                          <span
-                            class="k-visually-hidden"
-                          >
-                            Previous match
-                          </span>
-                          
-                          <!---->
-                        </button>
-                        <button
-                          class="k-button small outline k-next-match-button"
-                          data-testid="k-code-block-next-match-button"
-                          disabled=""
-                          title="Next match (F3)"
-                          type="button"
-                        >
-                          
-                          <span
-                            class="k-button-icon kong-icon kong-icon-chevronDown"
-                          >
-                            <svg
-                              fill="currentColor"
-                              height="16"
-                              role="img"
-                              viewBox="0 0 20 20"
-                              width="16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              
-  
-                              <title>
-                                Next match (F3)
-                              </title>
-                              
-  
-                              <path
-                                d="m4.6 7 5.2 5L15 7"
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                              />
-                              
-
-                            </svg>
-                            
-
-                          </span>
-                          
-                          
-                          <span
-                            class="k-visually-hidden"
-                          >
-                            Next match
-                          </span>
-                          
-                          <!---->
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      class="k-code-block-content"
-                    >
-                      <pre
-                        class="k-highlighted-code-block show-copy-button language-yaml"
-                        data-testid="k-code-block-highlighted-code-block"
-                        tabindex="0"
-                      >
-                                
-                        <span
-                          class="k-line-number-rows"
-                        >
-                          
-          
-                          
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L1"
-                            >
-                              1
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L2"
-                            >
-                              2
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L3"
-                            >
-                              3
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L4"
-                            >
-                              4
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L5"
-                            >
-                              5
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L6"
-                            >
-                              6
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L7"
-                            >
-                              7
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L8"
-                            >
-                              8
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L9"
-                            >
-                              9
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L10"
-                            >
-                              10
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L11"
-                            >
-                              11
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L12"
-                            >
-                              12
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L13"
-                            >
-                              13
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L14"
-                            >
-                              14
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L15"
-                            >
-                              15
-                            </a>
-                            
-          
-                          </span>
-                          <span
-                            class="k-line"
-                          >
-                            
-            
-                            <a
-                              class="k-line-anchor"
-                              id="code-block-data-plane-L16"
-                            >
-                              16
-                            </a>
-                            
-          
-                          </span>
-                          
-                          
-        
-                        </span>
-                        
-        
-                        <code
-                          class="language-yaml"
-                        >
-                          <span
-                            class="token key atrule"
-                          >
-                            type
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                           Dataplane
-
-                          <span
-                            class="token key atrule"
-                          >
-                            mesh
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                           test
-                          <span
-                            class="token punctuation"
-                          >
-                            -
-                          </span>
+                  <div>
+                    <ul>
+                      
+                      <li>
+                        <h4>
+                          type
+                        </h4>
+                        <div>
+                          Dataplane
+                        </div>
+                      </li>
+                      <li>
+                        <h4>
+                          name
+                        </h4>
+                        <div>
+                          backend
+                        </div>
+                      </li>
+                      <li>
+                        <h4>
                           mesh
-
+                        </h4>
+                        <div>
+                          test-mesh
+                        </div>
+                      </li>
+                      
+                      <li>
+                        <h4>
+                          Status
+                        </h4>
+                        <div>
                           <span
-                            class="token key atrule"
+                            class="status status--with-title status--success"
+                            data-testid="status-badge"
                           >
-                            name
+                            <span
+                              class=""
+                            >
+                              online
+                            </span>
                           </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                           backend
-
-                          <span
-                            class="token key atrule"
-                          >
-                            networking
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                          
-  
-                          <span
-                            class="token key atrule"
-                          >
-                            address
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                           127.0.0.1
-  
-                          <span
-                            class="token key atrule"
-                          >
-                            inbound
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                          
-    
-                          <span
-                            class="token punctuation"
-                          >
-                            -
-                          </span>
-                           
-                          <span
-                            class="token key atrule"
-                          >
-                            port
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                           
-                          <span
-                            class="token number"
-                          >
-                            7776
-                          </span>
-                          
-      
-                          <span
-                            class="token key atrule"
-                          >
-                            servicePort
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                           
-                          <span
-                            class="token number"
-                          >
-                            7777
-                          </span>
-                          
-      
-                          <span
-                            class="token key atrule"
-                          >
-                            serviceAddress
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                           127.0.0.1
-      
-                          <span
-                            class="token key atrule"
-                          >
-                            tags
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                          
-        
-                          <span
-                            class="token key atrule"
-                          >
-                            kuma.io/protocol
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                           http
-        
-                          <span
-                            class="token key atrule"
-                          >
-                            kuma.io/service
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                           backend
-  
-                          <span
-                            class="token key atrule"
-                          >
-                            outbound
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                          
-    
-                          <span
-                            class="token punctuation"
-                          >
-                            -
-                          </span>
-                           
-                          <span
-                            class="token key atrule"
-                          >
-                            port
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                           
-                          <span
-                            class="token number"
-                          >
-                            10001
-                          </span>
-                          
-      
-                          <span
-                            class="token key atrule"
-                          >
-                            tags
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                          
-        
-                          <span
-                            class="token key atrule"
-                          >
-                            kuma.io/service
-                          </span>
-                          <span
-                            class="token punctuation"
-                          >
-                            :
-                          </span>
-                           frontend
-                        </code>
-                        
-      
-                      </pre>
-                      <button
-                        class="k-button small outline k-code-block-copy-button"
-                        data-testid="k-code-block-copy-button"
-                        title="Copy (Alt+C)"
-                        type="button"
-                      >
-                        
-                        <!---->
-                        
-                        
+                        </div>
+                      </li>
+                      <!--v-if-->
+                    </ul>
+                  </div>
+                  <div>
+                    <ul>
+                      <li>
+                        <h4>
+                          Tags
+                        </h4>
                         <span
-                          class="kong-icon kong-icon-copy"
+                          class="tag-list"
                         >
-                          <svg
-                            height="18"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width="18"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            
-  
-                            <title>
-                              Copy (Alt+C)
-                            </title>
-                            
-  
-                            <path
-                              d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
-                              fill="currentColor"
-                            />
-                            
-
-                          </svg>
                           
-
+                          <div
+                            class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
+                            tabindex="0"
+                          >
+                            <div
+                              class="k-badge-text truncate"
+                            >
+                              <div
+                                class="k-badge-text truncate"
+                              >
+                                
+                                <span>
+                                  kuma.io/protocol:
+                                  <b>
+                                    http
+                                  </b>
+                                </span>
+                                
+                              </div>
+                            </div>
+                            <!---->
+                          </div>
+                          <div
+                            class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
+                            tabindex="0"
+                          >
+                            <div
+                              class="k-badge-text truncate"
+                            >
+                              <div
+                                class="k-badge-text truncate"
+                              >
+                                
+                                <a
+                                  class=""
+                                  href="/mesh/default/services/backend"
+                                >
+                                  kuma.io/service:
+                                  <b>
+                                    backend
+                                  </b>
+                                </a>
+                                
+                              </div>
+                            </div>
+                            <!---->
+                          </div>
+                          
                         </span>
-                        <span
-                          class="k-visually-hidden"
-                        >
-                          Copy
-                        </span>
-                        
-                        <!---->
-                      </button>
-                    </div>
+                      </li>
+                      <li>
+                        <h4>
+                          Versions
+                        </h4>
+                        <p>
+                          
+                          <span
+                            class="tag-cols"
+                          >
+                            <span>
+                              envoy: 
+                            </span>
+                            <span>
+                              1.16.2
+                            </span>
+                          </span>
+                          <span
+                            class="tag-cols"
+                          >
+                            <span>
+                              kumaDp: 
+                            </span>
+                            <span>
+                              1.0.7
+                            </span>
+                          </span>
+                          <span
+                            class="tag-cols"
+                          >
+                            <span>
+                              coredns: 
+                            </span>
+                            <span>
+                              1.8.3
+                            </span>
+                          </span>
+                          
+                        </p>
+                      </li>
+                    </ul>
                   </div>
                   
                 </div>
-                <div
-                  aria-labelledby="kubernetes-tab"
-                  class="tab-container"
-                  id="panel-1"
-                  role="tabpanel"
-                  tabindex="0"
-                >
-                  <!---->
-                </div>
-                
               </div>
-            </div>
-          </div>
-        </div>
+              <div
+                class="yaml-view mt-4"
+              >
+                <div
+                  class="yaml-view-content"
+                >
+                  <div
+                    class="k-tabs"
+                  >
+                    <ul
+                      aria-label="Tabs"
+                      role="tablist"
+                    >
+                      
+                      <li
+                        aria-controls="panel-0"
+                        aria-selected="true"
+                        class="tab-item active"
+                        id="universal-tab"
+                        role="tab"
+                        tabindex="0"
+                      >
+                        <a
+                          class="tab-link"
+                        >
+                          
+                          Universal
+                          
+                        </a>
+                      </li>
+                      <li
+                        aria-controls="panel-1"
+                        aria-selected="false"
+                        class="tab-item"
+                        id="kubernetes-tab"
+                        role="tab"
+                        tabindex="0"
+                      >
+                        <a
+                          class="tab-link"
+                        >
+                          
+                          Kubernetes
+                          
+                        </a>
+                      </li>
+                      
+                    </ul>
+                    
+                    <div
+                      aria-labelledby="universal-tab"
+                      class="tab-container"
+                      id="panel-0"
+                      role="tabpanel"
+                      tabindex="0"
+                    >
+                      
+                      <div
+                        class="k-code-block theme-light code-block"
+                        data-testid="k-code-block"
+                        id="code-block-data-plane"
+                        style="--maxLineNumberWidth: 2ch;"
+                        tabindex="0"
+                      >
+                        <div
+                          class="k-code-block-actions"
+                        >
+                          <p
+                            class="k-code-block-search-results"
+                          >
+                            
+                               
+                            
+                          </p>
+                          <div
+                            class="k-search-container"
+                          >
+                            <span
+                              class="k-search-icon kong-icon kong-icon-search"
+                              data-testid="k-code-block-search-icon"
+                            >
+                              <svg
+                                data-testid="k-code-block-search-icon"
+                                fill="var(--steel-500)"
+                                height="20"
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width="20"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                
+  
+                                <title>
+                                  Search
+                                </title>
+                                
+  
+                                <path
+                                  d="M10.88 18.75a7.88 7.88 0 1 0 0-15.75 7.88 7.88 0 0 0 0 15.75ZM16.44 16.44 21 21"
+                                  fill="none"
+                                  stroke="var(--steel-500)"
+                                  stroke-width="3"
+                                />
+                                
+
+                              </svg>
+                              
+
+                            </span>
+                            <label
+                              class="k-code-block-search-label"
+                              for="code-block-data-plane-search-input"
+                            >
+                              <span
+                                class="k-visually-hidden"
+                              >
+                                Search
+                              </span>
+                            </label>
+                            <input
+                              class="k-code-block-search-input"
+                              data-testid="k-code-block-search-input"
+                              id="code-block-data-plane-search-input"
+                              type="text"
+                            />
+                            <!---->
+                            <span
+                              class="k-is-processing-icon kong-icon kong-icon-spinner"
+                              data-testid="k-code-block-is-processing-icon"
+                            >
+                              <svg
+                                data-testid="k-code-block-is-processing-icon"
+                                fill="var(--steel-500)"
+                                height="24"
+                                role="img"
+                                viewBox="0 0 20 20"
+                                width="24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                
+  
+                                <title>
+                                  Loading
+                                </title>
+                                
+  
+                                <g>
+                                  
+    
+                                  <path
+                                    d="M5 10a5 5 0 1 0 5-5"
+                                    fill="none"
+                                    stroke="var(--steel-500)"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                  
+  
+                                </g>
+                                
+
+                              </svg>
+                              
+
+                            </span>
+                            <!---->
+                          </div>
+                          <div
+                            class="k-search-actions"
+                          >
+                            <button
+                              aria-pressed="false"
+                              class="k-button small outline k-regexp-mode-button"
+                              data-testid="k-code-block-regexp-mode-button"
+                              title="Use regular expression (Alt+R)"
+                              type="button"
+                            >
+                              
+                              <!---->
+                              
+                              
+                              <span
+                                class="k-visually-hidden"
+                              >
+                                RegExp mode enabled
+                              </span>
+                               .* 
+                              
+                              <!---->
+                            </button>
+                            <button
+                              aria-pressed="false"
+                              class="k-button small outline k-filter-mode-button"
+                              data-testid="k-code-block-filter-mode-button"
+                              title="Filter results (Alt+F)"
+                              type="button"
+                            >
+                              
+                              <span
+                                class="k-button-icon kong-icon kong-icon-filter"
+                              >
+                                <svg
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 14 11"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  
+  
+                                  <title>
+                                    Filter results (Alt+F)
+                                  </title>
+                                  
+  
+                                  <path
+                                    d="M8 9v2H6V9h2zm2-3v2H4V6h6zm2-3v2H2V3h10zm2-3v2H0V0h14z"
+                                    fill="currentColor"
+                                    fill-rule="evenodd"
+                                  />
+                                  
+
+                                </svg>
+                                
+
+                              </span>
+                              
+                              
+                              <span
+                                class="k-visually-hidden"
+                              >
+                                Filter mode enabled
+                              </span>
+                              
+                              <!---->
+                            </button>
+                            <button
+                              class="k-button small outline k-previous-match-button"
+                              data-testid="k-code-block-previous-match-button"
+                              disabled=""
+                              title="Previous match (Shift+F3)"
+                              type="button"
+                            >
+                              
+                              <span
+                                class="k-button-icon kong-icon kong-icon-chevronUp"
+                              >
+                                <svg
+                                  fill="currentColor"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 20 20"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  
+  
+                                  <title>
+                                    Previous match (Shift+F3)
+                                  </title>
+                                  
+  
+                                  <path
+                                    d="M15 12 9.8 7l-5.2 5"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                  
+
+                                </svg>
+                                
+
+                              </span>
+                              
+                              
+                              <span
+                                class="k-visually-hidden"
+                              >
+                                Previous match
+                              </span>
+                              
+                              <!---->
+                            </button>
+                            <button
+                              class="k-button small outline k-next-match-button"
+                              data-testid="k-code-block-next-match-button"
+                              disabled=""
+                              title="Next match (F3)"
+                              type="button"
+                            >
+                              
+                              <span
+                                class="k-button-icon kong-icon kong-icon-chevronDown"
+                              >
+                                <svg
+                                  fill="currentColor"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 20 20"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  
+  
+                                  <title>
+                                    Next match (F3)
+                                  </title>
+                                  
+  
+                                  <path
+                                    d="m4.6 7 5.2 5L15 7"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                  
+
+                                </svg>
+                                
+
+                              </span>
+                              
+                              
+                              <span
+                                class="k-visually-hidden"
+                              >
+                                Next match
+                              </span>
+                              
+                              <!---->
+                            </button>
+                          </div>
+                        </div>
+                        <div
+                          class="k-code-block-content"
+                        >
+                          <pre
+                            class="k-highlighted-code-block show-copy-button language-yaml"
+                            data-testid="k-code-block-highlighted-code-block"
+                            tabindex="0"
+                          >
+                                    
+                            <span
+                              class="k-line-number-rows"
+                            >
+                              
+          
+                              
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L1"
+                                >
+                                  1
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L2"
+                                >
+                                  2
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L3"
+                                >
+                                  3
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L4"
+                                >
+                                  4
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L5"
+                                >
+                                  5
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L6"
+                                >
+                                  6
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L7"
+                                >
+                                  7
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L8"
+                                >
+                                  8
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L9"
+                                >
+                                  9
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L10"
+                                >
+                                  10
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L11"
+                                >
+                                  11
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L12"
+                                >
+                                  12
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L13"
+                                >
+                                  13
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L14"
+                                >
+                                  14
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L15"
+                                >
+                                  15
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-L16"
+                                >
+                                  16
+                                </a>
+                                
+          
+                              </span>
+                              
+                              
         
+                            </span>
+                            
+        
+                            <code
+                              class="language-yaml"
+                            >
+                              <span
+                                class="token key atrule"
+                              >
+                                type
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               Dataplane
+
+                              <span
+                                class="token key atrule"
+                              >
+                                mesh
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               test
+                              <span
+                                class="token punctuation"
+                              >
+                                -
+                              </span>
+                              mesh
+
+                              <span
+                                class="token key atrule"
+                              >
+                                name
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               backend
+
+                              <span
+                                class="token key atrule"
+                              >
+                                networking
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                              
+  
+                              <span
+                                class="token key atrule"
+                              >
+                                address
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               127.0.0.1
+  
+                              <span
+                                class="token key atrule"
+                              >
+                                inbound
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                              
+    
+                              <span
+                                class="token punctuation"
+                              >
+                                -
+                              </span>
+                               
+                              <span
+                                class="token key atrule"
+                              >
+                                port
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               
+                              <span
+                                class="token number"
+                              >
+                                7776
+                              </span>
+                              
+      
+                              <span
+                                class="token key atrule"
+                              >
+                                servicePort
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               
+                              <span
+                                class="token number"
+                              >
+                                7777
+                              </span>
+                              
+      
+                              <span
+                                class="token key atrule"
+                              >
+                                serviceAddress
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               127.0.0.1
+      
+                              <span
+                                class="token key atrule"
+                              >
+                                tags
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                              
+        
+                              <span
+                                class="token key atrule"
+                              >
+                                kuma.io/protocol
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               http
+        
+                              <span
+                                class="token key atrule"
+                              >
+                                kuma.io/service
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               backend
+  
+                              <span
+                                class="token key atrule"
+                              >
+                                outbound
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                              
+    
+                              <span
+                                class="token punctuation"
+                              >
+                                -
+                              </span>
+                               
+                              <span
+                                class="token key atrule"
+                              >
+                                port
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               
+                              <span
+                                class="token number"
+                              >
+                                10001
+                              </span>
+                              
+      
+                              <span
+                                class="token key atrule"
+                              >
+                                tags
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                              
+        
+                              <span
+                                class="token key atrule"
+                              >
+                                kuma.io/service
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               frontend
+                            </code>
+                            
+      
+                          </pre>
+                          <button
+                            class="k-button small outline k-code-block-copy-button"
+                            data-testid="k-code-block-copy-button"
+                            title="Copy (Alt+C)"
+                            type="button"
+                          >
+                            
+                            <!---->
+                            
+                            
+                            <span
+                              class="kong-icon kong-icon-copy"
+                            >
+                              <svg
+                                height="18"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width="18"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                
+  
+                                <title>
+                                  Copy (Alt+C)
+                                </title>
+                                
+  
+                                <path
+                                  d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
+                                  fill="currentColor"
+                                />
+                                
+
+                              </svg>
+                              
+
+                            </span>
+                            <span
+                              class="k-visually-hidden"
+                            >
+                              Copy
+                            </span>
+                            
+                            <!---->
+                          </button>
+                        </div>
+                      </div>
+                      
+                    </div>
+                    <div
+                      aria-labelledby="kubernetes-tab"
+                      class="tab-container"
+                      id="panel-1"
+                      role="tabpanel"
+                      tabindex="0"
+                    >
+                      <!---->
+                    </div>
+                    
+                  </div>
+                </div>
+              </div>
+              
+              
+            </div>
+            <!---->
+          </div>
+        </section>
         
       </div>
       <div

--- a/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
@@ -1,937 +1,956 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataPlaneEntitySummary matches snapshot 1`] = `
-<div
-  class="entity-summary entity-section-list"
+<section
+  aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+  class="kong-card noBorder"
 >
-  <section>
-    <div
-      class="block-list"
-    >
-      <div>
-        <h3
-          class="entity-title"
-          data-testid="data-plane-proxy-title"
-        >
-          <span>
-             DPP: 
-            <a
-              class=""
-              href="/mesh/test-mesh/data-planes/backend"
-            >
-              backend
-            </a>
-          </span>
-          <span
-            class="status status--with-title status--success"
-            data-testid="status-badge"
-          >
-            <span
-              class=""
-            >
-              online
-            </span>
-          </span>
-        </h3>
-        <div
-          class="definition"
-        >
-          <span>
-            Mesh:
-          </span>
-          <span>
-            test-mesh
-          </span>
-        </div>
-      </div>
-      <div>
-        <h4>
-          Tags
-        </h4>
-        <span
-          class="tag-list"
-        >
-          
-          <div
-            class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
-            tabindex="0"
-          >
-            <div
-              class="k-badge-text truncate"
-            >
-              <div
-                class="k-badge-text truncate"
-              >
-                
-                <span>
-                  kuma.io/protocol:
-                  <b>
-                    http
-                  </b>
-                </span>
-                
-              </div>
-            </div>
-            <!---->
-          </div>
-          <div
-            class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
-            tabindex="0"
-          >
-            <div
-              class="k-badge-text truncate"
-            >
-              <div
-                class="k-badge-text truncate"
-              >
-                
-                <a
-                  class=""
-                  href="/mesh/default/services/backend"
-                >
-                  kuma.io/service:
-                  <b>
-                    backend
-                  </b>
-                </a>
-                
-              </div>
-            </div>
-            <!---->
-          </div>
-          
-        </span>
-      </div>
-      <div>
-        <h4>
-          Dependencies
-        </h4>
-        
-        <div
-          class="definition"
-        >
-          <span>
-            envoy:
-          </span>
-          <span>
-            1.16.2
-          </span>
-        </div>
-        <div
-          class="definition"
-        >
-          <span>
-            kumaDp:
-          </span>
-          <span>
-            1.0.7
-          </span>
-        </div>
-        <div
-          class="definition"
-        >
-          <span>
-            coredns:
-          </span>
-          <span>
-            1.8.3
-          </span>
-        </div>
-        
-        <!--v-if-->
-      </div>
-    </div>
-  </section>
-  <section>
-    <h4>
-      Insights
-    </h4>
-    <div
-      class="block-list"
-    >
-      
-      <div>
-        <div
-          class="definition"
-          data-testid="data-plane-connect-time-0"
-        >
-          <span>
-            Connect time:
-          </span>
-          <span>
-            February 17, 2021 at 7:33:36 AM
-          </span>
-        </div>
-        <div
-          class="definition"
-          data-testid="data-plane-disconnect-time-0"
-        >
-          <span>
-            Disconnect time:
-          </span>
-          <span>
-            —
-          </span>
-        </div>
-        <div
-          class="definition"
-        >
-          <span>
-            CP instance ID:
-          </span>
-          <span>
-            foo
-          </span>
-        </div>
-        <details>
-          <summary>
-             Responses (acknowledged / sent) 
-          </summary>
-          
-          <div
-            class="definition"
-            data-testid="data-plane-subscription-status-0-0"
-          >
-            <span>
-              CDS:
-            </span>
-            <span>
-              1 / 1
-            </span>
-          </div>
-          <div
-            class="definition"
-            data-testid="data-plane-subscription-status-0-1"
-          >
-            <span>
-              EDS:
-            </span>
-            <span>
-              2 / 2
-            </span>
-          </div>
-          <div
-            class="definition"
-            data-testid="data-plane-subscription-status-0-2"
-          >
-            <span>
-              LDS:
-            </span>
-            <span>
-              2 / 2
-            </span>
-          </div>
-          <div
-            class="definition"
-            data-testid="data-plane-subscription-status-0-3"
-          >
-            <span>
-              RDS:
-            </span>
-            <span>
-              0 / 0
-            </span>
-          </div>
-          
-        </details>
-      </div>
-      <div>
-        <div
-          class="definition"
-          data-testid="data-plane-connect-time-1"
-        >
-          <span>
-            Connect time:
-          </span>
-          <span>
-            February 17, 2021 at 7:33:36 AM
-          </span>
-        </div>
-        <div
-          class="definition"
-          data-testid="data-plane-disconnect-time-1"
-        >
-          <span>
-            Disconnect time:
-          </span>
-          <span>
-            February 17, 2021 at 7:33:36 AM
-          </span>
-        </div>
-        <div
-          class="definition"
-        >
-          <span>
-            CP instance ID:
-          </span>
-          <span>
-            foo
-          </span>
-        </div>
-        <details>
-          <summary>
-             Responses (acknowledged / sent) 
-          </summary>
-          
-          <div
-            class="definition"
-            data-testid="data-plane-subscription-status-1-0"
-          >
-            <span>
-              CDS:
-            </span>
-            <span>
-              1 / 1
-            </span>
-          </div>
-          <div
-            class="definition"
-            data-testid="data-plane-subscription-status-1-1"
-          >
-            <span>
-              EDS:
-            </span>
-            <span>
-              2 / 2
-            </span>
-          </div>
-          <div
-            class="definition"
-            data-testid="data-plane-subscription-status-1-2"
-          >
-            <span>
-              LDS:
-            </span>
-            <span>
-              2 / 2
-            </span>
-          </div>
-          <div
-            class="definition"
-            data-testid="data-plane-subscription-status-1-3"
-          >
-            <span>
-              RDS:
-            </span>
-            <span>
-              0 / 0
-            </span>
-          </div>
-          
-        </details>
-      </div>
-      
-    </div>
-  </section>
-  <section
-    class="config-section"
+  <!---->
+  <!---->
+  <div
+    class="k-card-content d-flex"
   >
     <div
-      class="yaml-view"
+      class="k-card-body"
+      id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
     >
+      
       <div
-        class="yaml-view-content"
+        class="entity-section-list"
       >
-        <div
-          class="k-tabs"
-        >
-          <ul
-            aria-label="Tabs"
-            role="tablist"
-          >
-            
-            <li
-              aria-controls="panel-0"
-              aria-selected="true"
-              class="tab-item active"
-              id="universal-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Universal
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-1"
-              aria-selected="false"
-              class="tab-item"
-              id="kubernetes-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Kubernetes
-                
-              </a>
-            </li>
-            
-          </ul>
-          
+        <section>
           <div
-            aria-labelledby="universal-tab"
-            class="tab-container"
-            id="panel-0"
-            role="tabpanel"
-            tabindex="0"
+            class="block-list"
           >
-            
-            <div
-              class="k-code-block theme-light code-block"
-              data-testid="k-code-block"
-              id="code-block-data-plane-summary"
-              style="--maxLineNumberWidth: 2ch; --KCodeBlockMaxHeight: 250px;"
-              tabindex="0"
-            >
-              <!---->
-              <div
-                class="k-code-block-content"
+            <div>
+              <h3
+                class="entity-title"
+                data-testid="data-plane-proxy-title"
               >
-                <pre
-                  class="k-highlighted-code-block show-copy-button language-yaml"
-                  data-testid="k-code-block-highlighted-code-block"
+                <span>
+                   DPP: 
+                  <a
+                    class=""
+                    href="/mesh/test-mesh/data-planes/backend"
+                  >
+                    backend
+                  </a>
+                </span>
+                <span
+                  class="status status--with-title status--success"
+                  data-testid="status-badge"
+                >
+                  <span
+                    class=""
+                  >
+                    online
+                  </span>
+                </span>
+              </h3>
+              <div
+                class="definition"
+              >
+                <span>
+                  Mesh:
+                </span>
+                <span>
+                  test-mesh
+                </span>
+              </div>
+            </div>
+            <div>
+              <h4>
+                Tags
+              </h4>
+              <span
+                class="tag-list"
+              >
+                
+                <div
+                  class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
                   tabindex="0"
                 >
-                          
-                  <span
-                    class="k-line-number-rows"
+                  <div
+                    class="k-badge-text truncate"
                   >
-                    
-          
-                    
-                    <span
-                      class="k-line"
+                    <div
+                      class="k-badge-text truncate"
                     >
                       
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L1"
-                      >
-                        1
-                      </a>
+                      <span>
+                        kuma.io/protocol:
+                        <b>
+                          http
+                        </b>
+                      </span>
                       
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L2"
-                      >
-                        2
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L3"
-                      >
-                        3
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L4"
-                      >
-                        4
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L5"
-                      >
-                        5
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L6"
-                      >
-                        6
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L7"
-                      >
-                        7
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L8"
-                      >
-                        8
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L9"
-                      >
-                        9
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L10"
-                      >
-                        10
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L11"
-                      >
-                        11
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L12"
-                      >
-                        12
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L13"
-                      >
-                        13
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L14"
-                      >
-                        14
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L15"
-                      >
-                        15
-                      </a>
-                      
-          
-                    </span>
-                    <span
-                      class="k-line"
-                    >
-                      
-            
-                      <a
-                        class="k-line-anchor"
-                        id="code-block-data-plane-summary-L16"
-                      >
-                        16
-                      </a>
-                      
-          
-                    </span>
-                    
-                    
-        
-                  </span>
-                  
-        
-                  <code
-                    class="language-yaml"
-                  >
-                    <span
-                      class="token key atrule"
-                    >
-                      type
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                     Dataplane
-
-                    <span
-                      class="token key atrule"
-                    >
-                      name
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                     backend
-
-                    <span
-                      class="token key atrule"
-                    >
-                      mesh
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                     test
-                    <span
-                      class="token punctuation"
-                    >
-                      -
-                    </span>
-                    mesh
-
-                    <span
-                      class="token key atrule"
-                    >
-                      networking
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                    
-  
-                    <span
-                      class="token key atrule"
-                    >
-                      address
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                     127.0.0.1
-  
-                    <span
-                      class="token key atrule"
-                    >
-                      inbound
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                    
-    
-                    <span
-                      class="token punctuation"
-                    >
-                      -
-                    </span>
-                     
-                    <span
-                      class="token key atrule"
-                    >
-                      port
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                     
-                    <span
-                      class="token number"
-                    >
-                      7776
-                    </span>
-                    
-      
-                    <span
-                      class="token key atrule"
-                    >
-                      servicePort
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                     
-                    <span
-                      class="token number"
-                    >
-                      7777
-                    </span>
-                    
-      
-                    <span
-                      class="token key atrule"
-                    >
-                      serviceAddress
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                     127.0.0.1
-      
-                    <span
-                      class="token key atrule"
-                    >
-                      tags
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                    
-        
-                    <span
-                      class="token key atrule"
-                    >
-                      kuma.io/protocol
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                     http
-        
-                    <span
-                      class="token key atrule"
-                    >
-                      kuma.io/service
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                     backend
-  
-                    <span
-                      class="token key atrule"
-                    >
-                      outbound
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                    
-    
-                    <span
-                      class="token punctuation"
-                    >
-                      -
-                    </span>
-                     
-                    <span
-                      class="token key atrule"
-                    >
-                      port
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                     
-                    <span
-                      class="token number"
-                    >
-                      10001
-                    </span>
-                    
-      
-                    <span
-                      class="token key atrule"
-                    >
-                      tags
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                    
-        
-                    <span
-                      class="token key atrule"
-                    >
-                      kuma.io/service
-                    </span>
-                    <span
-                      class="token punctuation"
-                    >
-                      :
-                    </span>
-                     frontend
-                  </code>
-                  
-      
-                </pre>
-                <button
-                  class="k-button small outline k-code-block-copy-button"
-                  data-testid="k-code-block-copy-button"
-                  title="Copy (Alt+C)"
-                  type="button"
+                    </div>
+                  </div>
+                  <!---->
+                </div>
+                <div
+                  class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
+                  tabindex="0"
                 >
-                  
-                  <!---->
-                  
-                  
-                  <span
-                    class="kong-icon kong-icon-copy"
+                  <div
+                    class="k-badge-text truncate"
                   >
-                    <svg
-                      height="18"
-                      role="img"
-                      viewBox="0 0 32 32"
-                      width="18"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <div
+                      class="k-badge-text truncate"
                     >
                       
-  
-                      <title>
-                        Copy (Alt+C)
-                      </title>
+                      <a
+                        class=""
+                        href="/mesh/default/services/backend"
+                      >
+                        kuma.io/service:
+                        <b>
+                          backend
+                        </b>
+                      </a>
                       
-  
-                      <path
-                        d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
-                        fill="currentColor"
-                      />
-                      
-
-                    </svg>
-                    
-
-                  </span>
-                  <span
-                    class="k-visually-hidden"
-                  >
-                    Copy
-                  </span>
-                  
+                    </div>
+                  </div>
                   <!---->
-                </button>
+                </div>
+                
+              </span>
+            </div>
+            <div>
+              <h4>
+                Dependencies
+              </h4>
+              
+              <div
+                class="definition"
+              >
+                <span>
+                  envoy:
+                </span>
+                <span>
+                  1.16.2
+                </span>
               </div>
+              <div
+                class="definition"
+              >
+                <span>
+                  kumaDp:
+                </span>
+                <span>
+                  1.0.7
+                </span>
+              </div>
+              <div
+                class="definition"
+              >
+                <span>
+                  coredns:
+                </span>
+                <span>
+                  1.8.3
+                </span>
+              </div>
+              
+              <!--v-if-->
+            </div>
+          </div>
+        </section>
+        <section>
+          <h4>
+            Insights
+          </h4>
+          <div
+            class="block-list"
+          >
+            
+            <div>
+              <div
+                class="definition"
+                data-testid="data-plane-connect-time-0"
+              >
+                <span>
+                  Connect time:
+                </span>
+                <span>
+                  February 17, 2021 at 7:33:36 AM
+                </span>
+              </div>
+              <div
+                class="definition"
+                data-testid="data-plane-disconnect-time-0"
+              >
+                <span>
+                  Disconnect time:
+                </span>
+                <span>
+                  —
+                </span>
+              </div>
+              <div
+                class="definition"
+              >
+                <span>
+                  CP instance ID:
+                </span>
+                <span>
+                  foo
+                </span>
+              </div>
+              <details>
+                <summary>
+                   Responses (acknowledged / sent) 
+                </summary>
+                
+                <div
+                  class="definition"
+                  data-testid="data-plane-subscription-status-0-0"
+                >
+                  <span>
+                    CDS:
+                  </span>
+                  <span>
+                    1 / 1
+                  </span>
+                </div>
+                <div
+                  class="definition"
+                  data-testid="data-plane-subscription-status-0-1"
+                >
+                  <span>
+                    EDS:
+                  </span>
+                  <span>
+                    2 / 2
+                  </span>
+                </div>
+                <div
+                  class="definition"
+                  data-testid="data-plane-subscription-status-0-2"
+                >
+                  <span>
+                    LDS:
+                  </span>
+                  <span>
+                    2 / 2
+                  </span>
+                </div>
+                <div
+                  class="definition"
+                  data-testid="data-plane-subscription-status-0-3"
+                >
+                  <span>
+                    RDS:
+                  </span>
+                  <span>
+                    0 / 0
+                  </span>
+                </div>
+                
+              </details>
+            </div>
+            <div>
+              <div
+                class="definition"
+                data-testid="data-plane-connect-time-1"
+              >
+                <span>
+                  Connect time:
+                </span>
+                <span>
+                  February 17, 2021 at 7:33:36 AM
+                </span>
+              </div>
+              <div
+                class="definition"
+                data-testid="data-plane-disconnect-time-1"
+              >
+                <span>
+                  Disconnect time:
+                </span>
+                <span>
+                  February 17, 2021 at 7:33:36 AM
+                </span>
+              </div>
+              <div
+                class="definition"
+              >
+                <span>
+                  CP instance ID:
+                </span>
+                <span>
+                  foo
+                </span>
+              </div>
+              <details>
+                <summary>
+                   Responses (acknowledged / sent) 
+                </summary>
+                
+                <div
+                  class="definition"
+                  data-testid="data-plane-subscription-status-1-0"
+                >
+                  <span>
+                    CDS:
+                  </span>
+                  <span>
+                    1 / 1
+                  </span>
+                </div>
+                <div
+                  class="definition"
+                  data-testid="data-plane-subscription-status-1-1"
+                >
+                  <span>
+                    EDS:
+                  </span>
+                  <span>
+                    2 / 2
+                  </span>
+                </div>
+                <div
+                  class="definition"
+                  data-testid="data-plane-subscription-status-1-2"
+                >
+                  <span>
+                    LDS:
+                  </span>
+                  <span>
+                    2 / 2
+                  </span>
+                </div>
+                <div
+                  class="definition"
+                  data-testid="data-plane-subscription-status-1-3"
+                >
+                  <span>
+                    RDS:
+                  </span>
+                  <span>
+                    0 / 0
+                  </span>
+                </div>
+                
+              </details>
             </div>
             
           </div>
+        </section>
+        <section
+          class="config-section"
+        >
           <div
-            aria-labelledby="kubernetes-tab"
-            class="tab-container"
-            id="panel-1"
-            role="tabpanel"
-            tabindex="0"
+            class="yaml-view"
           >
-            <!---->
-          </div>
+            <div
+              class="yaml-view-content"
+            >
+              <div
+                class="k-tabs"
+              >
+                <ul
+                  aria-label="Tabs"
+                  role="tablist"
+                >
+                  
+                  <li
+                    aria-controls="panel-0"
+                    aria-selected="true"
+                    class="tab-item active"
+                    id="universal-tab"
+                    role="tab"
+                    tabindex="0"
+                  >
+                    <a
+                      class="tab-link"
+                    >
+                      
+                      Universal
+                      
+                    </a>
+                  </li>
+                  <li
+                    aria-controls="panel-1"
+                    aria-selected="false"
+                    class="tab-item"
+                    id="kubernetes-tab"
+                    role="tab"
+                    tabindex="0"
+                  >
+                    <a
+                      class="tab-link"
+                    >
+                      
+                      Kubernetes
+                      
+                    </a>
+                  </li>
+                  
+                </ul>
+                
+                <div
+                  aria-labelledby="universal-tab"
+                  class="tab-container"
+                  id="panel-0"
+                  role="tabpanel"
+                  tabindex="0"
+                >
+                  
+                  <div
+                    class="k-code-block theme-light code-block"
+                    data-testid="k-code-block"
+                    id="code-block-data-plane-summary"
+                    style="--maxLineNumberWidth: 2ch; --KCodeBlockMaxHeight: 250px;"
+                    tabindex="0"
+                  >
+                    <!---->
+                    <div
+                      class="k-code-block-content"
+                    >
+                      <pre
+                        class="k-highlighted-code-block show-copy-button language-yaml"
+                        data-testid="k-code-block-highlighted-code-block"
+                        tabindex="0"
+                      >
+                                
+                        <span
+                          class="k-line-number-rows"
+                        >
+                          
           
-        </div>
+                          
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L1"
+                            >
+                              1
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L2"
+                            >
+                              2
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L3"
+                            >
+                              3
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L4"
+                            >
+                              4
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L5"
+                            >
+                              5
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L6"
+                            >
+                              6
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L7"
+                            >
+                              7
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L8"
+                            >
+                              8
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L9"
+                            >
+                              9
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L10"
+                            >
+                              10
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L11"
+                            >
+                              11
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L12"
+                            >
+                              12
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L13"
+                            >
+                              13
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L14"
+                            >
+                              14
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L15"
+                            >
+                              15
+                            </a>
+                            
+          
+                          </span>
+                          <span
+                            class="k-line"
+                          >
+                            
+            
+                            <a
+                              class="k-line-anchor"
+                              id="code-block-data-plane-summary-L16"
+                            >
+                              16
+                            </a>
+                            
+          
+                          </span>
+                          
+                          
+        
+                        </span>
+                        
+        
+                        <code
+                          class="language-yaml"
+                        >
+                          <span
+                            class="token key atrule"
+                          >
+                            type
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                           Dataplane
+
+                          <span
+                            class="token key atrule"
+                          >
+                            name
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                           backend
+
+                          <span
+                            class="token key atrule"
+                          >
+                            mesh
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                           test
+                          <span
+                            class="token punctuation"
+                          >
+                            -
+                          </span>
+                          mesh
+
+                          <span
+                            class="token key atrule"
+                          >
+                            networking
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                          
+  
+                          <span
+                            class="token key atrule"
+                          >
+                            address
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                           127.0.0.1
+  
+                          <span
+                            class="token key atrule"
+                          >
+                            inbound
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                          
+    
+                          <span
+                            class="token punctuation"
+                          >
+                            -
+                          </span>
+                           
+                          <span
+                            class="token key atrule"
+                          >
+                            port
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                           
+                          <span
+                            class="token number"
+                          >
+                            7776
+                          </span>
+                          
+      
+                          <span
+                            class="token key atrule"
+                          >
+                            servicePort
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                           
+                          <span
+                            class="token number"
+                          >
+                            7777
+                          </span>
+                          
+      
+                          <span
+                            class="token key atrule"
+                          >
+                            serviceAddress
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                           127.0.0.1
+      
+                          <span
+                            class="token key atrule"
+                          >
+                            tags
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                          
+        
+                          <span
+                            class="token key atrule"
+                          >
+                            kuma.io/protocol
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                           http
+        
+                          <span
+                            class="token key atrule"
+                          >
+                            kuma.io/service
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                           backend
+  
+                          <span
+                            class="token key atrule"
+                          >
+                            outbound
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                          
+    
+                          <span
+                            class="token punctuation"
+                          >
+                            -
+                          </span>
+                           
+                          <span
+                            class="token key atrule"
+                          >
+                            port
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                           
+                          <span
+                            class="token number"
+                          >
+                            10001
+                          </span>
+                          
+      
+                          <span
+                            class="token key atrule"
+                          >
+                            tags
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                          
+        
+                          <span
+                            class="token key atrule"
+                          >
+                            kuma.io/service
+                          </span>
+                          <span
+                            class="token punctuation"
+                          >
+                            :
+                          </span>
+                           frontend
+                        </code>
+                        
+      
+                      </pre>
+                      <button
+                        class="k-button small outline k-code-block-copy-button"
+                        data-testid="k-code-block-copy-button"
+                        title="Copy (Alt+C)"
+                        type="button"
+                      >
+                        
+                        <!---->
+                        
+                        
+                        <span
+                          class="kong-icon kong-icon-copy"
+                        >
+                          <svg
+                            height="18"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width="18"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            <title>
+                              Copy (Alt+C)
+                            </title>
+                            
+  
+                            <path
+                              d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
+                              fill="currentColor"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        <span
+                          class="k-visually-hidden"
+                        >
+                          Copy
+                        </span>
+                        
+                        <!---->
+                      </button>
+                    </div>
+                  </div>
+                  
+                </div>
+                <div
+                  aria-labelledby="kubernetes-tab"
+                  class="tab-container"
+                  id="panel-1"
+                  role="tabpanel"
+                  tabindex="0"
+                >
+                  <!---->
+                </div>
+                
+              </div>
+            </div>
+          </div>
+        </section>
       </div>
+      
     </div>
-  </section>
-</div>
+    <!---->
+  </div>
+</section>
 `;

--- a/src/app/data-planes/components/__snapshots__/DataplanePolicies.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataplanePolicies.spec.ts.snap
@@ -50,7 +50,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
         persisted="false"
       >
         <div
-          class="px-4 py-1"
+          class="accordion-item-content"
           data-testid="accordion-item-content"
         >
           

--- a/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
+++ b/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
@@ -1756,933 +1756,952 @@ exports[`DataPlaneListView matches snapshot 1`] = `
     class="content-wrapper__sidebar component-frame"
   >
     
-    <div
-      class="entity-summary entity-section-list"
+    <section
+      aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+      class="kong-card noBorder"
     >
-      <section>
-        <div
-          class="block-list"
-        >
-          <div>
-            <h3
-              class="entity-title"
-              data-testid="data-plane-proxy-title"
-            >
-              <span>
-                 DPP: 
-                <a
-                  class=""
-                  href="/mesh/default/data-planes/backend"
-                >
-                  backend
-                </a>
-              </span>
-              <span
-                class="status status--with-title status--success"
-                data-testid="status-badge"
-              >
-                <span
-                  class=""
-                >
-                  online
-                </span>
-              </span>
-            </h3>
-            <div
-              class="definition"
-            >
-              <span>
-                Mesh:
-              </span>
-              <span>
-                default
-              </span>
-            </div>
-          </div>
-          <div>
-            <h4>
-              Tags
-            </h4>
-            <span
-              class="tag-list"
-            >
-              
-              <div
-                class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
-                tabindex="0"
-              >
-                <div
-                  class="k-badge-text truncate"
-                >
-                  <div
-                    class="k-badge-text truncate"
-                  >
-                    
-                    <span>
-                      kuma.io/protocol:
-                      <b>
-                        http
-                      </b>
-                    </span>
-                    
-                  </div>
-                </div>
-                <!---->
-              </div>
-              <div
-                class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
-                tabindex="0"
-              >
-                <div
-                  class="k-badge-text truncate"
-                >
-                  <div
-                    class="k-badge-text truncate"
-                  >
-                    
-                    <a
-                      class=""
-                      href="/mesh/default/services/backend"
-                    >
-                      kuma.io/service:
-                      <b>
-                        backend
-                      </b>
-                    </a>
-                    
-                  </div>
-                </div>
-                <!---->
-              </div>
-              
-            </span>
-          </div>
-          <div>
-            <h4>
-              Dependencies
-            </h4>
-            
-            <div
-              class="definition"
-            >
-              <span>
-                envoy:
-              </span>
-              <span>
-                1.16.2
-              </span>
-            </div>
-            <div
-              class="definition"
-            >
-              <span>
-                kumaDp:
-              </span>
-              <span>
-                1.0.7
-              </span>
-            </div>
-            <div
-              class="definition"
-            >
-              <span>
-                coredns:
-              </span>
-              <span>
-                1.8.3
-              </span>
-            </div>
-            
-            <!--v-if-->
-          </div>
-        </div>
-      </section>
-      <section>
-        <h4>
-          Insights
-        </h4>
-        <div
-          class="block-list"
-        >
-          
-          <div>
-            <div
-              class="definition"
-              data-testid="data-plane-connect-time-0"
-            >
-              <span>
-                Connect time:
-              </span>
-              <span>
-                February 17, 2021 at 7:33:36 AM
-              </span>
-            </div>
-            <div
-              class="definition"
-              data-testid="data-plane-disconnect-time-0"
-            >
-              <span>
-                Disconnect time:
-              </span>
-              <span>
-                —
-              </span>
-            </div>
-            <div
-              class="definition"
-            >
-              <span>
-                CP instance ID:
-              </span>
-              <span>
-                foo
-              </span>
-            </div>
-            <details>
-              <summary>
-                 Responses (acknowledged / sent) 
-              </summary>
-              
-              <div
-                class="definition"
-                data-testid="data-plane-subscription-status-0-0"
-              >
-                <span>
-                  CDS:
-                </span>
-                <span>
-                  1 / 1
-                </span>
-              </div>
-              <div
-                class="definition"
-                data-testid="data-plane-subscription-status-0-1"
-              >
-                <span>
-                  EDS:
-                </span>
-                <span>
-                  2 / 2
-                </span>
-              </div>
-              <div
-                class="definition"
-                data-testid="data-plane-subscription-status-0-2"
-              >
-                <span>
-                  LDS:
-                </span>
-                <span>
-                  2 / 2
-                </span>
-              </div>
-              <div
-                class="definition"
-                data-testid="data-plane-subscription-status-0-3"
-              >
-                <span>
-                  RDS:
-                </span>
-                <span>
-                  0 / 0
-                </span>
-              </div>
-              
-            </details>
-          </div>
-          <div>
-            <div
-              class="definition"
-              data-testid="data-plane-connect-time-1"
-            >
-              <span>
-                Connect time:
-              </span>
-              <span>
-                February 17, 2021 at 7:33:36 AM
-              </span>
-            </div>
-            <div
-              class="definition"
-              data-testid="data-plane-disconnect-time-1"
-            >
-              <span>
-                Disconnect time:
-              </span>
-              <span>
-                February 17, 2021 at 7:33:36 AM
-              </span>
-            </div>
-            <div
-              class="definition"
-            >
-              <span>
-                CP instance ID:
-              </span>
-              <span>
-                foo
-              </span>
-            </div>
-            <details>
-              <summary>
-                 Responses (acknowledged / sent) 
-              </summary>
-              
-              <div
-                class="definition"
-                data-testid="data-plane-subscription-status-1-0"
-              >
-                <span>
-                  CDS:
-                </span>
-                <span>
-                  1 / 1
-                </span>
-              </div>
-              <div
-                class="definition"
-                data-testid="data-plane-subscription-status-1-1"
-              >
-                <span>
-                  EDS:
-                </span>
-                <span>
-                  2 / 2
-                </span>
-              </div>
-              <div
-                class="definition"
-                data-testid="data-plane-subscription-status-1-2"
-              >
-                <span>
-                  LDS:
-                </span>
-                <span>
-                  2 / 2
-                </span>
-              </div>
-              <div
-                class="definition"
-                data-testid="data-plane-subscription-status-1-3"
-              >
-                <span>
-                  RDS:
-                </span>
-                <span>
-                  0 / 0
-                </span>
-              </div>
-              
-            </details>
-          </div>
-          
-        </div>
-      </section>
-      <section
-        class="config-section"
+      <!---->
+      <!---->
+      <div
+        class="k-card-content d-flex"
       >
         <div
-          class="yaml-view"
+          class="k-card-body"
+          id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
         >
+          
           <div
-            class="yaml-view-content"
+            class="entity-section-list"
           >
-            <div
-              class="k-tabs"
-            >
-              <ul
-                aria-label="Tabs"
-                role="tablist"
-              >
-                
-                <li
-                  aria-controls="panel-0"
-                  aria-selected="true"
-                  class="tab-item active"
-                  id="universal-tab"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <a
-                    class="tab-link"
-                  >
-                    
-                    Universal
-                    
-                  </a>
-                </li>
-                <li
-                  aria-controls="panel-1"
-                  aria-selected="false"
-                  class="tab-item"
-                  id="kubernetes-tab"
-                  role="tab"
-                  tabindex="0"
-                >
-                  <a
-                    class="tab-link"
-                  >
-                    
-                    Kubernetes
-                    
-                  </a>
-                </li>
-                
-              </ul>
-              
+            <section>
               <div
-                aria-labelledby="universal-tab"
-                class="tab-container"
-                id="panel-0"
-                role="tabpanel"
-                tabindex="0"
+                class="block-list"
               >
-                
-                <div
-                  class="k-code-block theme-light code-block"
-                  data-testid="k-code-block"
-                  id="code-block-data-plane-summary"
-                  style="--maxLineNumberWidth: 2ch; --KCodeBlockMaxHeight: 250px;"
-                  tabindex="0"
-                >
-                  <!---->
-                  <div
-                    class="k-code-block-content"
+                <div>
+                  <h3
+                    class="entity-title"
+                    data-testid="data-plane-proxy-title"
                   >
-                    <pre
-                      class="k-highlighted-code-block show-copy-button language-yaml"
-                      data-testid="k-code-block-highlighted-code-block"
+                    <span>
+                       DPP: 
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/backend"
+                      >
+                        backend
+                      </a>
+                    </span>
+                    <span
+                      class="status status--with-title status--success"
+                      data-testid="status-badge"
+                    >
+                      <span
+                        class=""
+                      >
+                        online
+                      </span>
+                    </span>
+                  </h3>
+                  <div
+                    class="definition"
+                  >
+                    <span>
+                      Mesh:
+                    </span>
+                    <span>
+                      default
+                    </span>
+                  </div>
+                </div>
+                <div>
+                  <h4>
+                    Tags
+                  </h4>
+                  <span
+                    class="tag-list"
+                  >
+                    
+                    <div
+                      class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
                       tabindex="0"
                     >
-                              
-                      <span
-                        class="k-line-number-rows"
+                      <div
+                        class="k-badge-text truncate"
                       >
-                        
-          
-                        
-                        <span
-                          class="k-line"
+                        <div
+                          class="k-badge-text truncate"
                         >
                           
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L1"
-                          >
-                            1
-                          </a>
+                          <span>
+                            kuma.io/protocol:
+                            <b>
+                              http
+                            </b>
+                          </span>
                           
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L2"
-                          >
-                            2
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L3"
-                          >
-                            3
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L4"
-                          >
-                            4
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L5"
-                          >
-                            5
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L6"
-                          >
-                            6
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L7"
-                          >
-                            7
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L8"
-                          >
-                            8
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L9"
-                          >
-                            9
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L10"
-                          >
-                            10
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L11"
-                          >
-                            11
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L12"
-                          >
-                            12
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L13"
-                          >
-                            13
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L14"
-                          >
-                            14
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L15"
-                          >
-                            15
-                          </a>
-                          
-          
-                        </span>
-                        <span
-                          class="k-line"
-                        >
-                          
-            
-                          <a
-                            class="k-line-anchor"
-                            id="code-block-data-plane-summary-L16"
-                          >
-                            16
-                          </a>
-                          
-          
-                        </span>
-                        
-                        
-        
-                      </span>
-                      
-        
-                      <code
-                        class="language-yaml"
-                      >
-                        <span
-                          class="token key atrule"
-                        >
-                          type
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                         Dataplane
-
-                        <span
-                          class="token key atrule"
-                        >
-                          name
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                         backend
-
-                        <span
-                          class="token key atrule"
-                        >
-                          mesh
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                         default
-
-                        <span
-                          class="token key atrule"
-                        >
-                          networking
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                        
-  
-                        <span
-                          class="token key atrule"
-                        >
-                          address
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                         127.0.0.1
-  
-                        <span
-                          class="token key atrule"
-                        >
-                          inbound
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                        
-    
-                        <span
-                          class="token punctuation"
-                        >
-                          -
-                        </span>
-                         
-                        <span
-                          class="token key atrule"
-                        >
-                          port
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                         
-                        <span
-                          class="token number"
-                        >
-                          7776
-                        </span>
-                        
-      
-                        <span
-                          class="token key atrule"
-                        >
-                          servicePort
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                         
-                        <span
-                          class="token number"
-                        >
-                          7777
-                        </span>
-                        
-      
-                        <span
-                          class="token key atrule"
-                        >
-                          serviceAddress
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                         127.0.0.1
-      
-                        <span
-                          class="token key atrule"
-                        >
-                          tags
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                        
-        
-                        <span
-                          class="token key atrule"
-                        >
-                          kuma.io/protocol
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                         http
-        
-                        <span
-                          class="token key atrule"
-                        >
-                          kuma.io/service
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                         backend
-  
-                        <span
-                          class="token key atrule"
-                        >
-                          outbound
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                        
-    
-                        <span
-                          class="token punctuation"
-                        >
-                          -
-                        </span>
-                         
-                        <span
-                          class="token key atrule"
-                        >
-                          port
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                         
-                        <span
-                          class="token number"
-                        >
-                          10001
-                        </span>
-                        
-      
-                        <span
-                          class="token key atrule"
-                        >
-                          tags
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                        
-        
-                        <span
-                          class="token key atrule"
-                        >
-                          kuma.io/service
-                        </span>
-                        <span
-                          class="token punctuation"
-                        >
-                          :
-                        </span>
-                         frontend
-                      </code>
-                      
-      
-                    </pre>
-                    <button
-                      class="k-button small outline k-code-block-copy-button"
-                      data-testid="k-code-block-copy-button"
-                      title="Copy (Alt+C)"
-                      type="button"
+                        </div>
+                      </div>
+                      <!---->
+                    </div>
+                    <div
+                      class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
+                      tabindex="0"
                     >
-                      
-                      <!---->
-                      
-                      
-                      <span
-                        class="kong-icon kong-icon-copy"
+                      <div
+                        class="k-badge-text truncate"
                       >
-                        <svg
-                          height="18"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width="18"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="k-badge-text truncate"
                         >
                           
-  
-                          <title>
-                            Copy (Alt+C)
-                          </title>
+                          <a
+                            class=""
+                            href="/mesh/default/services/backend"
+                          >
+                            kuma.io/service:
+                            <b>
+                              backend
+                            </b>
+                          </a>
                           
-  
-                          <path
-                            d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
-                            fill="currentColor"
-                          />
-                          
-
-                        </svg>
-                        
-
-                      </span>
-                      <span
-                        class="k-visually-hidden"
-                      >
-                        Copy
-                      </span>
-                      
+                        </div>
+                      </div>
                       <!---->
-                    </button>
+                    </div>
+                    
+                  </span>
+                </div>
+                <div>
+                  <h4>
+                    Dependencies
+                  </h4>
+                  
+                  <div
+                    class="definition"
+                  >
+                    <span>
+                      envoy:
+                    </span>
+                    <span>
+                      1.16.2
+                    </span>
                   </div>
+                  <div
+                    class="definition"
+                  >
+                    <span>
+                      kumaDp:
+                    </span>
+                    <span>
+                      1.0.7
+                    </span>
+                  </div>
+                  <div
+                    class="definition"
+                  >
+                    <span>
+                      coredns:
+                    </span>
+                    <span>
+                      1.8.3
+                    </span>
+                  </div>
+                  
+                  <!--v-if-->
+                </div>
+              </div>
+            </section>
+            <section>
+              <h4>
+                Insights
+              </h4>
+              <div
+                class="block-list"
+              >
+                
+                <div>
+                  <div
+                    class="definition"
+                    data-testid="data-plane-connect-time-0"
+                  >
+                    <span>
+                      Connect time:
+                    </span>
+                    <span>
+                      February 17, 2021 at 7:33:36 AM
+                    </span>
+                  </div>
+                  <div
+                    class="definition"
+                    data-testid="data-plane-disconnect-time-0"
+                  >
+                    <span>
+                      Disconnect time:
+                    </span>
+                    <span>
+                      —
+                    </span>
+                  </div>
+                  <div
+                    class="definition"
+                  >
+                    <span>
+                      CP instance ID:
+                    </span>
+                    <span>
+                      foo
+                    </span>
+                  </div>
+                  <details>
+                    <summary>
+                       Responses (acknowledged / sent) 
+                    </summary>
+                    
+                    <div
+                      class="definition"
+                      data-testid="data-plane-subscription-status-0-0"
+                    >
+                      <span>
+                        CDS:
+                      </span>
+                      <span>
+                        1 / 1
+                      </span>
+                    </div>
+                    <div
+                      class="definition"
+                      data-testid="data-plane-subscription-status-0-1"
+                    >
+                      <span>
+                        EDS:
+                      </span>
+                      <span>
+                        2 / 2
+                      </span>
+                    </div>
+                    <div
+                      class="definition"
+                      data-testid="data-plane-subscription-status-0-2"
+                    >
+                      <span>
+                        LDS:
+                      </span>
+                      <span>
+                        2 / 2
+                      </span>
+                    </div>
+                    <div
+                      class="definition"
+                      data-testid="data-plane-subscription-status-0-3"
+                    >
+                      <span>
+                        RDS:
+                      </span>
+                      <span>
+                        0 / 0
+                      </span>
+                    </div>
+                    
+                  </details>
+                </div>
+                <div>
+                  <div
+                    class="definition"
+                    data-testid="data-plane-connect-time-1"
+                  >
+                    <span>
+                      Connect time:
+                    </span>
+                    <span>
+                      February 17, 2021 at 7:33:36 AM
+                    </span>
+                  </div>
+                  <div
+                    class="definition"
+                    data-testid="data-plane-disconnect-time-1"
+                  >
+                    <span>
+                      Disconnect time:
+                    </span>
+                    <span>
+                      February 17, 2021 at 7:33:36 AM
+                    </span>
+                  </div>
+                  <div
+                    class="definition"
+                  >
+                    <span>
+                      CP instance ID:
+                    </span>
+                    <span>
+                      foo
+                    </span>
+                  </div>
+                  <details>
+                    <summary>
+                       Responses (acknowledged / sent) 
+                    </summary>
+                    
+                    <div
+                      class="definition"
+                      data-testid="data-plane-subscription-status-1-0"
+                    >
+                      <span>
+                        CDS:
+                      </span>
+                      <span>
+                        1 / 1
+                      </span>
+                    </div>
+                    <div
+                      class="definition"
+                      data-testid="data-plane-subscription-status-1-1"
+                    >
+                      <span>
+                        EDS:
+                      </span>
+                      <span>
+                        2 / 2
+                      </span>
+                    </div>
+                    <div
+                      class="definition"
+                      data-testid="data-plane-subscription-status-1-2"
+                    >
+                      <span>
+                        LDS:
+                      </span>
+                      <span>
+                        2 / 2
+                      </span>
+                    </div>
+                    <div
+                      class="definition"
+                      data-testid="data-plane-subscription-status-1-3"
+                    >
+                      <span>
+                        RDS:
+                      </span>
+                      <span>
+                        0 / 0
+                      </span>
+                    </div>
+                    
+                  </details>
                 </div>
                 
               </div>
+            </section>
+            <section
+              class="config-section"
+            >
               <div
-                aria-labelledby="kubernetes-tab"
-                class="tab-container"
-                id="panel-1"
-                role="tabpanel"
-                tabindex="0"
+                class="yaml-view"
               >
-                <!---->
+                <div
+                  class="yaml-view-content"
+                >
+                  <div
+                    class="k-tabs"
+                  >
+                    <ul
+                      aria-label="Tabs"
+                      role="tablist"
+                    >
+                      
+                      <li
+                        aria-controls="panel-0"
+                        aria-selected="true"
+                        class="tab-item active"
+                        id="universal-tab"
+                        role="tab"
+                        tabindex="0"
+                      >
+                        <a
+                          class="tab-link"
+                        >
+                          
+                          Universal
+                          
+                        </a>
+                      </li>
+                      <li
+                        aria-controls="panel-1"
+                        aria-selected="false"
+                        class="tab-item"
+                        id="kubernetes-tab"
+                        role="tab"
+                        tabindex="0"
+                      >
+                        <a
+                          class="tab-link"
+                        >
+                          
+                          Kubernetes
+                          
+                        </a>
+                      </li>
+                      
+                    </ul>
+                    
+                    <div
+                      aria-labelledby="universal-tab"
+                      class="tab-container"
+                      id="panel-0"
+                      role="tabpanel"
+                      tabindex="0"
+                    >
+                      
+                      <div
+                        class="k-code-block theme-light code-block"
+                        data-testid="k-code-block"
+                        id="code-block-data-plane-summary"
+                        style="--maxLineNumberWidth: 2ch; --KCodeBlockMaxHeight: 250px;"
+                        tabindex="0"
+                      >
+                        <!---->
+                        <div
+                          class="k-code-block-content"
+                        >
+                          <pre
+                            class="k-highlighted-code-block show-copy-button language-yaml"
+                            data-testid="k-code-block-highlighted-code-block"
+                            tabindex="0"
+                          >
+                                    
+                            <span
+                              class="k-line-number-rows"
+                            >
+                              
+          
+                              
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L1"
+                                >
+                                  1
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L2"
+                                >
+                                  2
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L3"
+                                >
+                                  3
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L4"
+                                >
+                                  4
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L5"
+                                >
+                                  5
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L6"
+                                >
+                                  6
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L7"
+                                >
+                                  7
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L8"
+                                >
+                                  8
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L9"
+                                >
+                                  9
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L10"
+                                >
+                                  10
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L11"
+                                >
+                                  11
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L12"
+                                >
+                                  12
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L13"
+                                >
+                                  13
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L14"
+                                >
+                                  14
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L15"
+                                >
+                                  15
+                                </a>
+                                
+          
+                              </span>
+                              <span
+                                class="k-line"
+                              >
+                                
+            
+                                <a
+                                  class="k-line-anchor"
+                                  id="code-block-data-plane-summary-L16"
+                                >
+                                  16
+                                </a>
+                                
+          
+                              </span>
+                              
+                              
+        
+                            </span>
+                            
+        
+                            <code
+                              class="language-yaml"
+                            >
+                              <span
+                                class="token key atrule"
+                              >
+                                type
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               Dataplane
+
+                              <span
+                                class="token key atrule"
+                              >
+                                name
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               backend
+
+                              <span
+                                class="token key atrule"
+                              >
+                                mesh
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               default
+
+                              <span
+                                class="token key atrule"
+                              >
+                                networking
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                              
+  
+                              <span
+                                class="token key atrule"
+                              >
+                                address
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               127.0.0.1
+  
+                              <span
+                                class="token key atrule"
+                              >
+                                inbound
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                              
+    
+                              <span
+                                class="token punctuation"
+                              >
+                                -
+                              </span>
+                               
+                              <span
+                                class="token key atrule"
+                              >
+                                port
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               
+                              <span
+                                class="token number"
+                              >
+                                7776
+                              </span>
+                              
+      
+                              <span
+                                class="token key atrule"
+                              >
+                                servicePort
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               
+                              <span
+                                class="token number"
+                              >
+                                7777
+                              </span>
+                              
+      
+                              <span
+                                class="token key atrule"
+                              >
+                                serviceAddress
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               127.0.0.1
+      
+                              <span
+                                class="token key atrule"
+                              >
+                                tags
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                              
+        
+                              <span
+                                class="token key atrule"
+                              >
+                                kuma.io/protocol
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               http
+        
+                              <span
+                                class="token key atrule"
+                              >
+                                kuma.io/service
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               backend
+  
+                              <span
+                                class="token key atrule"
+                              >
+                                outbound
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                              
+    
+                              <span
+                                class="token punctuation"
+                              >
+                                -
+                              </span>
+                               
+                              <span
+                                class="token key atrule"
+                              >
+                                port
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               
+                              <span
+                                class="token number"
+                              >
+                                10001
+                              </span>
+                              
+      
+                              <span
+                                class="token key atrule"
+                              >
+                                tags
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                              
+        
+                              <span
+                                class="token key atrule"
+                              >
+                                kuma.io/service
+                              </span>
+                              <span
+                                class="token punctuation"
+                              >
+                                :
+                              </span>
+                               frontend
+                            </code>
+                            
+      
+                          </pre>
+                          <button
+                            class="k-button small outline k-code-block-copy-button"
+                            data-testid="k-code-block-copy-button"
+                            title="Copy (Alt+C)"
+                            type="button"
+                          >
+                            
+                            <!---->
+                            
+                            
+                            <span
+                              class="kong-icon kong-icon-copy"
+                            >
+                              <svg
+                                height="18"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width="18"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                
+  
+                                <title>
+                                  Copy (Alt+C)
+                                </title>
+                                
+  
+                                <path
+                                  d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
+                                  fill="currentColor"
+                                />
+                                
+
+                              </svg>
+                              
+
+                            </span>
+                            <span
+                              class="k-visually-hidden"
+                            >
+                              Copy
+                            </span>
+                            
+                            <!---->
+                          </button>
+                        </div>
+                      </div>
+                      
+                    </div>
+                    <div
+                      aria-labelledby="kubernetes-tab"
+                      class="tab-container"
+                      id="panel-1"
+                      role="tabpanel"
+                      tabindex="0"
+                    >
+                      <!---->
+                    </div>
+                    
+                  </div>
+                </div>
               </div>
-              
-            </div>
+            </section>
           </div>
+          
         </div>
-      </section>
-    </div>
+        <!---->
+      </div>
+    </section>
     
   </div>
 </div>

--- a/src/app/mesh-overview/views/MeshOverviewView.vue
+++ b/src/app/mesh-overview/views/MeshOverviewView.vue
@@ -3,106 +3,113 @@
 
   <ContentWrapper class="mt-8">
     <template #content>
-      <div
+      <KCard
         v-if="mesh !== null"
+        border-variant="noBorder"
       >
-        <LabelList
-          :has-error="hasError"
-          :is-loading="isLoading"
-          :is-empty="isEmpty"
-        >
-          <div>
-            <ul>
-              <li
-                v-for="(value, key) in basicMesh"
-                :key="key"
-              >
-                <h4>{{ key }}</h4>
-
-                <KBadge
-                  v-if="typeof value === 'boolean'"
-                  :appearance="value ? 'success' : 'danger'"
+        <template #body>
+          <LabelList
+            :has-error="hasError"
+            :is-loading="isLoading"
+            :is-empty="isEmpty"
+          >
+            <div>
+              <ul>
+                <li
+                  v-for="(value, key) in basicMesh"
+                  :key="key"
                 >
-                  {{ value ? 'Enabled' : 'Disabled' }}
-                </KBadge>
+                  <h4>{{ key }}</h4>
 
-                <p v-else>
-                  {{ value }}
-                </p>
-              </li>
-            </ul>
-          </div>
-
-          <div>
-            <ul>
-              <li
-                v-for="(value, key) in extendedMesh"
-                :key="key"
-              >
-                <h4>{{ key }}</h4>
-
-                <KBadge
-                  v-if="typeof value === 'boolean'"
-                  :appearance="value ? 'success' : 'danger'"
-                >
-                  {{ value ? 'Enabled' : 'Disabled' }}
-                </KBadge>
-
-                <p v-else>
-                  {{ value }}
-                </p>
-              </li>
-            </ul>
-          </div>
-          <div>
-            <ul class="policy-counts">
-              <li>
-                <h4>
-                  Policies ({{ totalPolicyCount }})
-                </h4>
-                <ul>
-                  <template
-                    v-for="(item, key) in policyCounts"
-                    :key="key"
+                  <KBadge
+                    v-if="typeof value === 'boolean'"
+                    :appearance="value ? 'success' : 'danger'"
                   >
-                    <li
-                      v-if="item.length !== 0"
+                    {{ value ? 'Enabled' : 'Disabled' }}
+                  </KBadge>
+
+                  <p v-else>
+                    {{ value }}
+                  </p>
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <ul>
+                <li
+                  v-for="(value, key) in extendedMesh"
+                  :key="key"
+                >
+                  <h4>{{ key }}</h4>
+
+                  <KBadge
+                    v-if="typeof value === 'boolean'"
+                    :appearance="value ? 'success' : 'danger'"
+                  >
+                    {{ value ? 'Enabled' : 'Disabled' }}
+                  </KBadge>
+
+                  <p v-else>
+                    {{ value }}
+                  </p>
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <ul class="policy-counts">
+                <li>
+                  <h4>
+                    Policies ({{ totalPolicyCount }})
+                  </h4>
+                  <ul>
+                    <template
+                      v-for="(item, key) in policyCounts"
+                      :key="key"
                     >
-                      <router-link
-                        :to="{
-                          name: 'policy',
-                          params: {
-                            policyPath: item.path
-                          }
-                        }"
+                      <li
+                        v-if="item.length !== 0"
                       >
-                        {{ item.name }}: {{ item.length }}
-                      </router-link>
-                    </li>
-                  </template>
-                </ul>
-              </li>
-            </ul>
-          </div>
-        </LabelList>
-      </div>
+                        <router-link
+                          :to="{
+                            name: 'policy',
+                            params: {
+                              policyPath: item.path
+                            }
+                          }"
+                        >
+                          {{ item.name }}: {{ item.length }}
+                        </router-link>
+                      </li>
+                    </template>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          </LabelList>
+        </template>
+      </KCard>
     </template>
   </ContentWrapper>
 
-  <div
+  <KCard
     v-if="rawMesh !== null"
     class="mt-4"
   >
-    <YamlView
-      id="code-block-mesh"
-      :content="rawMesh"
-    />
-  </div>
+    <template #body>
+      <YamlView
+        id="code-block-mesh"
+        :content="rawMesh"
+      />
+    </template>
+  </KCard>
+
   <MeshResources class="mt-6" />
 </template>
 
 <script lang="ts" setup>
-import { KBadge } from '@kong/kongponents'
+import { KBadge, KCard } from '@kong/kongponents'
 import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 

--- a/src/app/policies/components/PolicyConnections.vue
+++ b/src/app/policies/components/PolicyConnections.vue
@@ -1,45 +1,44 @@
 
 <template>
-  <div>
-    <LabelList
-      :has-error="hasError"
-      :is-loading="isLoading"
-      :is-empty="!hasDataplanes"
-    >
-      <ul>
-        <li>
-          <h4>Dataplanes</h4>
-          <input
-            id="dataplane-search"
-            v-model="searchInput"
-            type="text"
-            class="k-input mb-4"
-            placeholder="Filter by name"
-            required
-            data-testid="dataplane-search-input"
+  <LabelList
+    :has-error="hasError"
+    :is-loading="isLoading"
+    :is-empty="!hasDataplanes"
+  >
+    <ul>
+      <li>
+        <h4>Dataplanes</h4>
+
+        <input
+          id="dataplane-search"
+          v-model="searchInput"
+          type="text"
+          class="k-input mb-4"
+          placeholder="Filter by name"
+          required
+          data-testid="dataplane-search-input"
+        >
+        <p
+          v-for="(dataplane, key) in filteredDataplanes"
+          :key="key"
+          class="my-1"
+          data-testid="dataplane-name"
+        >
+          <router-link
+            :to="{
+              name: 'data-plane-detail-view',
+              params: {
+                mesh: dataplane.dataplane.mesh,
+                dataPlane: dataplane.dataplane.name,
+              },
+            }"
           >
-          <p
-            v-for="(dataplane, key) in filteredDataplanes"
-            :key="key"
-            class="my-1"
-            data-testid="dataplane-name"
-          >
-            <router-link
-              :to="{
-                name: 'data-plane-detail-view',
-                params: {
-                  mesh: dataplane.dataplane.mesh,
-                  dataPlane: dataplane.dataplane.name,
-                },
-              }"
-            >
-              {{ dataplane.dataplane.name }}
-            </router-link>
-          </p>
-        </li>
-      </ul>
-    </LabelList>
-  </div>
+            {{ dataplane.dataplane.name }}
+          </router-link>
+        </p>
+      </li>
+    </ul>
+  </LabelList>
 </template>
 
 <script lang="ts" setup>

--- a/src/app/policies/components/__snapshots__/PolicyConnections.spec.ts.snap
+++ b/src/app/policies/components/__snapshots__/PolicyConnections.spec.ts.snap
@@ -1,87 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PolicyConnections.vue renders snapshot 1`] = `
-<div>
-  <div>
-    <div
-      class="label-list-content"
-    >
-      <section
-        aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-        class="kong-card noBorder"
-      >
-        <!---->
-        <!---->
-        <div
-          class="k-card-content d-flex"
+<div
+  class="label-list"
+>
+  <div
+    class="label-list__content"
+  >
+    
+    <ul>
+      <li>
+        <h4>
+          Dataplanes
+        </h4>
+        <input
+          class="k-input mb-4"
+          data-testid="dataplane-search-input"
+          id="dataplane-search"
+          placeholder="Filter by name"
+          required=""
+          type="text"
+        />
+        
+        <p
+          class="my-1"
+          data-testid="dataplane-name"
         >
-          <div
-            class="k-card-body"
-            id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+          <a
+            class=""
+            href="/mesh/default/data-planes/backend"
           >
-            
-            <div
-              class="label-list__col-wrapper multi-col"
-            >
-              
-              <ul>
-                <li>
-                  <h4>
-                    Dataplanes
-                  </h4>
-                  <input
-                    class="k-input mb-4"
-                    data-testid="dataplane-search-input"
-                    id="dataplane-search"
-                    placeholder="Filter by name"
-                    required=""
-                    type="text"
-                  />
-                  
-                  <p
-                    class="my-1"
-                    data-testid="dataplane-name"
-                  >
-                    <a
-                      class=""
-                      href="/mesh/default/data-planes/backend"
-                    >
-                      backend
-                    </a>
-                  </p>
-                  <p
-                    class="my-1"
-                    data-testid="dataplane-name"
-                  >
-                    <a
-                      class=""
-                      href="/mesh/default/data-planes/db"
-                    >
-                      db
-                    </a>
-                  </p>
-                  <p
-                    class="my-1"
-                    data-testid="dataplane-name"
-                  >
-                    <a
-                      class=""
-                      href="/mesh/default/data-planes/frontend"
-                    >
-                      frontend
-                    </a>
-                  </p>
-                  
-                </li>
-              </ul>
-              
-            </div>
-            
-          </div>
-          <!---->
-        </div>
-      </section>
-    </div>
+            backend
+          </a>
+        </p>
+        <p
+          class="my-1"
+          data-testid="dataplane-name"
+        >
+          <a
+            class=""
+            href="/mesh/default/data-planes/db"
+          >
+            db
+          </a>
+        </p>
+        <p
+          class="my-1"
+          data-testid="dataplane-name"
+        >
+          <a
+            class=""
+            href="/mesh/default/data-planes/frontend"
+          >
+            frontend
+          </a>
+        </p>
+        
+      </li>
+    </ul>
+    
   </div>
 </div>
 `;

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -21,6 +21,7 @@
           {{ policy.name }}
         </h1>
       </template>
+
       <template #overview>
         <LabelList>
           <div data-testid="policy-overview-tab">
@@ -41,13 +42,13 @@
             </ul>
           </div>
         </LabelList>
-        <div class="config-wrapper">
-          <YamlView
-            id="code-block-policy"
-            :content="stripTimes(policy)"
-            is-searchable
-          />
-        </div>
+
+        <YamlView
+          id="code-block-policy"
+          class="mt-4"
+          :content="stripTimes(policy)"
+          is-searchable
+        />
       </template>
 
       <template #affected-dpps>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -114,17 +114,16 @@
             </div>
           </LabelList>
 
-          <div class="config-wrapper">
-            <YamlView
-              v-if="rawEntity !== null"
-              id="code-block-policy"
-              :has-error="entityHasError"
-              :is-loading="entityIsLoading"
-              :is-empty="entityIsEmpty"
-              :content="rawEntity"
-              is-searchable
-            />
-          </div>
+          <YamlView
+            v-if="rawEntity !== null"
+            id="code-block-policy"
+            class="mt-4"
+            :has-error="entityHasError"
+            :is-loading="entityIsLoading"
+            :is-empty="entityIsEmpty"
+            :content="rawEntity"
+            is-searchable
+          />
         </template>
 
         <template #affected-dpps>
@@ -142,9 +141,9 @@
 
 <script lang="ts" setup>
 import {
-  KSelect,
   KAlert,
   KButton,
+  KSelect,
 } from '@kong/kongponents'
 import { computed, ref, watch } from 'vue'
 import { RouteLocationNamedRaw, useRoute, useRouter } from 'vue-router'
@@ -215,7 +214,6 @@ const pageOffset = ref(props.offset)
 
 const tableData = ref<{ headers: TableHeader[], data: any[] }>({
   headers: [
-    { label: 'Actions', key: 'actions', hideLabel: true },
     { label: 'Name', key: 'name' },
     { label: 'Type', key: 'type' },
   ],
@@ -388,11 +386,5 @@ async function getEntity(selectedEntity: { mesh: string, path: string, name: str
 .entity-heading {
   font-size: inherit;
   font-weight: normal;
-}
-
-.config-wrapper {
-  padding-right: var(--spacing-md);
-  padding-left: var(--spacing-md);
-  padding-bottom: var(--spacing-md);
 }
 </style>

--- a/src/app/services/components/ServiceSummary.vue
+++ b/src/app/services/components/ServiceSummary.vue
@@ -1,77 +1,84 @@
 <template>
-  <div class="entity-summary entity-section-list">
-    <section>
-      <div class="block-list">
-        <div>
-          <h1 class="entity-title">
-            <span>
-              Service:
+  <KCard border-variant="noBorder">
+    <template #body>
+      <div class="entity-section-list">
+        <section>
+          <div class="block-list">
+            <div>
+              <h1 class="entity-title">
+                <span>
+                  Service:
 
-              <router-link :to="serviceRoute">
-                {{ props.service.name }}
-              </router-link>
-            </span>
+                  <router-link :to="serviceRoute">
+                    {{ props.service.name }}
+                  </router-link>
+                </span>
 
-            <StatusBadge
-              v-if="status"
-              :status="status"
-            />
-          </h1>
+                <StatusBadge
+                  v-if="status"
+                  :status="status"
+                />
+              </h1>
 
-          <div class="definition">
-            <span>Mesh:</span>
-            <span>{{ props.service.mesh }}</span>
+              <div class="definition">
+                <span>Mesh:</span>
+                <span>{{ props.service.mesh }}</span>
+              </div>
+
+              <div class="definition">
+                <span>Address:</span>
+                <span>
+                  <template v-if="address !== null">
+                    {{ address }}
+                  </template>
+
+                  <template v-else>—</template>
+                </span>
+              </div>
+
+              <div
+                v-if="tls !== null"
+                class="definition"
+              >
+                <span>TLS:</span>
+                <span>{{ tls }}</span>
+              </div>
+
+              <div
+                v-if="numberOfDataPlaneProxies !== null"
+                class="definition"
+              >
+                <span>Data plane proxies:</span>
+                <span>{{ numberOfDataPlaneProxies }}</span>
+              </div>
+            </div>
+
+            <div v-if="tags !== null">
+              <h2>Tags</h2>
+
+              <TagList :tags="tags" />
+            </div>
           </div>
+        </section>
 
-          <div class="definition">
-            <span>Address:</span>
-            <span>
-              <template v-if="address !== null">
-                {{ address }}
-              </template>
-
-              <template v-else>—</template>
-            </span>
-          </div>
-
-          <div
-            v-if="tls !== null"
-            class="definition"
-          >
-            <span>TLS:</span>
-            <span>{{ tls }}</span>
-          </div>
-
-          <div
-            v-if="numberOfDataPlaneProxies !== null"
-            class="definition"
-          >
-            <span>Data plane proxies:</span>
-            <span>{{ numberOfDataPlaneProxies }}</span>
-          </div>
-        </div>
-
-        <div v-if="tags !== null">
-          <h2>Tags</h2>
-
-          <TagList :tags="tags" />
-        </div>
+        <section
+          v-if="props.service.serviceType === 'external'"
+          class="config-section"
+        >
+          <YamlView
+            id="code-block-service"
+            :content="rawService"
+            is-searchable
+            code-max-height="250px"
+          />
+        </section>
       </div>
-    </section>
-
-    <section class="config-section">
-      <YamlView
-        v-if="props.service.serviceType === 'external'"
-        id="code-block-service"
-        :content="rawService"
-        is-searchable
-        code-max-height="250px"
-      />
-    </section>
-  </div>
+    </template>
+  </KCard>
 </template>
 
 <script lang="ts" setup>
+import { KCard } from '@kong/kongponents'
 import { computed, PropType } from 'vue'
 import { RouteLocationNamedRaw } from 'vue-router'
 
@@ -149,10 +156,6 @@ const rawService = computed(() => stripTimes(props.externalService ?? props.serv
 </script>
 
 <style lang="scss" scoped>
-.entity-summary {
-  padding: var(--spacing-md);
-}
-
 .entity-section-list {
   display: flex;
   flex-wrap: wrap;

--- a/src/app/wizard/views/__snapshots__/MeshWizard.spec.ts.snap
+++ b/src/app/wizard/views/__snapshots__/MeshWizard.spec.ts.snap
@@ -198,483 +198,497 @@ exports[`MeshWizard passes whole wizzard and render yaml 1`] = `
                           tabindex="0"
                         >
                           
-                          
-                          <div
-                            class="k-code-block theme-light code-block"
-                            data-testid="universal"
-                            id="code-block-universal-command"
-                            style="--maxLineNumberWidth: 2ch;"
-                            tabindex="0"
+                          <section
+                            aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                            class="kong-card noBorder"
                           >
                             <!---->
+                            <!---->
                             <div
-                              class="k-code-block-content"
+                              class="k-card-content d-flex"
                             >
-                              <pre
-                                class="k-highlighted-code-block show-copy-button language-bash"
-                                data-testid="k-code-block-highlighted-code-block"
-                                tabindex="0"
+                              <div
+                                class="k-card-body"
+                                id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                               >
-                                        
-                                <span
-                                  class="k-line-number-rows"
-                                >
-                                  
-          
-                                  
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L1"
-                                    >
-                                      1
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L2"
-                                    >
-                                      2
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L3"
-                                    >
-                                      3
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L4"
-                                    >
-                                      4
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L5"
-                                    >
-                                      5
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L6"
-                                    >
-                                      6
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L7"
-                                    >
-                                      7
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L8"
-                                    >
-                                      8
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L9"
-                                    >
-                                      9
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L10"
-                                    >
-                                      10
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L11"
-                                    >
-                                      11
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L12"
-                                    >
-                                      12
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L13"
-                                    >
-                                      13
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L14"
-                                    >
-                                      14
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L15"
-                                    >
-                                      15
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L16"
-                                    >
-                                      16
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L17"
-                                    >
-                                      17
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L18"
-                                    >
-                                      18
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L19"
-                                    >
-                                      19
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L20"
-                                    >
-                                      20
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L21"
-                                    >
-                                      21
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L22"
-                                    >
-                                      22
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L23"
-                                    >
-                                      23
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L24"
-                                    >
-                                      24
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L25"
-                                    >
-                                      25
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L26"
-                                    >
-                                      26
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L27"
-                                    >
-                                      27
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L28"
-                                    >
-                                      28
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L29"
-                                    >
-                                      29
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L30"
-                                    >
-                                      30
-                                    </a>
-                                    
-          
-                                  </span>
-                                  <span
-                                    class="k-line"
-                                  >
-                                    
-            
-                                    <a
-                                      class="k-line-anchor"
-                                      id="code-block-universal-command-L31"
-                                    >
-                                      31
-                                    </a>
-                                    
-          
-                                  </span>
-                                  
-                                  
-        
-                                </span>
                                 
-        
-                                <code
-                                  class="language-bash"
+                                
+                                <div
+                                  class="k-code-block theme-light code-block"
+                                  data-testid="universal"
+                                  id="code-block-universal-command"
+                                  style="--maxLineNumberWidth: 2ch;"
+                                  tabindex="0"
                                 >
-                                  <span
-                                    class="token builtin class-name"
+                                  <!---->
+                                  <div
+                                    class="k-code-block-content"
                                   >
-                                    echo
-                                  </span>
-                                   
-                                  <span
-                                    class="token string"
-                                  >
-                                    "type: Mesh
+                                    <pre
+                                      class="k-highlighted-code-block show-copy-button language-bash"
+                                      data-testid="k-code-block-highlighted-code-block"
+                                      tabindex="0"
+                                    >
+                                              
+                                      <span
+                                        class="k-line-number-rows"
+                                      >
+                                        
+          
+                                        
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L1"
+                                          >
+                                            1
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L2"
+                                          >
+                                            2
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L3"
+                                          >
+                                            3
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L4"
+                                          >
+                                            4
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L5"
+                                          >
+                                            5
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L6"
+                                          >
+                                            6
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L7"
+                                          >
+                                            7
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L8"
+                                          >
+                                            8
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L9"
+                                          >
+                                            9
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L10"
+                                          >
+                                            10
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L11"
+                                          >
+                                            11
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L12"
+                                          >
+                                            12
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L13"
+                                          >
+                                            13
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L14"
+                                          >
+                                            14
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L15"
+                                          >
+                                            15
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L16"
+                                          >
+                                            16
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L17"
+                                          >
+                                            17
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L18"
+                                          >
+                                            18
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L19"
+                                          >
+                                            19
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L20"
+                                          >
+                                            20
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L21"
+                                          >
+                                            21
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L22"
+                                          >
+                                            22
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L23"
+                                          >
+                                            23
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L24"
+                                          >
+                                            24
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L25"
+                                          >
+                                            25
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L26"
+                                          >
+                                            26
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L27"
+                                          >
+                                            27
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L28"
+                                          >
+                                            28
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L29"
+                                          >
+                                            29
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L30"
+                                          >
+                                            30
+                                          </a>
+                                          
+          
+                                        </span>
+                                        <span
+                                          class="k-line"
+                                        >
+                                          
+            
+                                          <a
+                                            class="k-line-anchor"
+                                            id="code-block-universal-command-L31"
+                                          >
+                                            31
+                                          </a>
+                                          
+          
+                                        </span>
+                                        
+                                        
+        
+                                      </span>
+                                      
+        
+                                      <code
+                                        class="language-bash"
+                                      >
+                                        <span
+                                          class="token builtin class-name"
+                                        >
+                                          echo
+                                        </span>
+                                         
+                                        <span
+                                          class="token string"
+                                        >
+                                          "type: Mesh
 name: default
 mtls:
   enabledBackend: fake-name
@@ -694,54 +708,54 @@ logging:
   backends:
     - name: fake-name
       format: '{ start_time: "
-                                  </span>
-                                  %START_TIME%
-                                  <span
-                                    class="token string"
-                                  >
-                                    ", source: "
-                                  </span>
-                                  %KUMA_SOURCE_SERVICE%
-                                  <span
-                                    class="token string"
-                                  >
-                                    ", destination: "
-                                  </span>
-                                  %KUMA_DESTINATION_SERVICE%
-                                  <span
-                                    class="token string"
-                                  >
-                                    ", source_address: "
-                                  </span>
-                                  %KUMA_SOURCE_ADDRESS_WITHOUT_PORT%
-                                  <span
-                                    class="token string"
-                                  >
-                                    ", destination_address: "
-                                  </span>
-                                  %UPSTREAM_HOST%
-                                  <span
-                                    class="token string"
-                                  >
-                                    ", duration_millis: "
-                                  </span>
-                                  %DURATION%
-                                  <span
-                                    class="token string"
-                                  >
-                                    ", bytes_received: "
-                                  </span>
-                                  %BYTES_RECEIVED%
-                                  <span
-                                    class="token string"
-                                  >
-                                    ", bytes_sent: "
-                                  </span>
-                                  %BYTES_SENT%
-                                  <span
-                                    class="token string"
-                                  >
-                                    " }'
+                                        </span>
+                                        %START_TIME%
+                                        <span
+                                          class="token string"
+                                        >
+                                          ", source: "
+                                        </span>
+                                        %KUMA_SOURCE_SERVICE%
+                                        <span
+                                          class="token string"
+                                        >
+                                          ", destination: "
+                                        </span>
+                                        %KUMA_DESTINATION_SERVICE%
+                                        <span
+                                          class="token string"
+                                        >
+                                          ", source_address: "
+                                        </span>
+                                        %KUMA_SOURCE_ADDRESS_WITHOUT_PORT%
+                                        <span
+                                          class="token string"
+                                        >
+                                          ", destination_address: "
+                                        </span>
+                                        %UPSTREAM_HOST%
+                                        <span
+                                          class="token string"
+                                        >
+                                          ", duration_millis: "
+                                        </span>
+                                        %DURATION%
+                                        <span
+                                          class="token string"
+                                        >
+                                          ", bytes_received: "
+                                        </span>
+                                        %BYTES_RECEIVED%
+                                        <span
+                                          class="token string"
+                                        >
+                                          ", bytes_sent: "
+                                        </span>
+                                        %BYTES_SENT%
+                                        <span
+                                          class="token string"
+                                        >
+                                          " }'
       type: tcp
       conf:
         address: 127.0.0.1:5000
@@ -753,72 +767,77 @@ metrics:
       conf:
         port: 5670
         path: /metrics"
-                                  </span>
-                                   
-                                  <span
-                                    class="token operator"
-                                  >
-                                    |
-                                  </span>
-                                   kumactl apply 
-                                  <span
-                                    class="token parameter variable"
-                                  >
-                                    -f
-                                  </span>
-                                   -
-                                </code>
-                                
+                                        </span>
+                                         
+                                        <span
+                                          class="token operator"
+                                        >
+                                          |
+                                        </span>
+                                         kumactl apply 
+                                        <span
+                                          class="token parameter variable"
+                                        >
+                                          -f
+                                        </span>
+                                         -
+                                      </code>
+                                      
       
-                              </pre>
-                              <button
-                                class="k-button small outline k-code-block-copy-button"
-                                data-testid="k-code-block-copy-button"
-                                title="Copy (Alt+C)"
-                                type="button"
-                              >
-                                
-                                <!---->
-                                
-                                
-                                <span
-                                  class="kong-icon kong-icon-copy"
-                                >
-                                  <svg
-                                    height="18"
-                                    role="img"
-                                    viewBox="0 0 32 32"
-                                    width="18"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    
+                                    </pre>
+                                    <button
+                                      class="k-button small outline k-code-block-copy-button"
+                                      data-testid="k-code-block-copy-button"
+                                      title="Copy (Alt+C)"
+                                      type="button"
+                                    >
+                                      
+                                      <!---->
+                                      
+                                      
+                                      <span
+                                        class="kong-icon kong-icon-copy"
+                                      >
+                                        <svg
+                                          height="18"
+                                          role="img"
+                                          viewBox="0 0 32 32"
+                                          width="18"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          
   
-                                    <title>
-                                      Copy (Alt+C)
-                                    </title>
-                                    
+                                          <title>
+                                            Copy (Alt+C)
+                                          </title>
+                                          
   
-                                    <path
-                                      d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
-                                      fill="currentColor"
-                                    />
-                                    
+                                          <path
+                                            d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
+                                            fill="currentColor"
+                                          />
+                                          
 
-                                  </svg>
-                                  
+                                        </svg>
+                                        
 
-                                </span>
-                                <span
-                                  class="k-visually-hidden"
-                                >
-                                  Copy
-                                </span>
+                                      </span>
+                                      <span
+                                        class="k-visually-hidden"
+                                      >
+                                        Copy
+                                      </span>
+                                      
+                                      <!---->
+                                    </button>
+                                  </div>
+                                </div>
                                 
-                                <!---->
-                              </button>
+                                
+                              </div>
+                              <!---->
                             </div>
-                          </div>
-                          
+                          </section>
                           
                         </div>
                         

--- a/src/app/zones/views/ZoneEgresses.vue
+++ b/src/app/zones/views/ZoneEgresses.vue
@@ -60,27 +60,23 @@
         </template>
 
         <template #insights>
-          <KCard border-variant="noBorder">
-            <template #body>
-              <AccordionList :initially-open="0">
-                <AccordionItem
-                  v-for="(value, key) in subscriptionsReversed"
-                  :key="key"
-                >
-                  <template #accordion-header>
-                    <SubscriptionHeader :details="value" />
-                  </template>
+          <AccordionList :initially-open="0">
+            <AccordionItem
+              v-for="(value, key) in subscriptionsReversed"
+              :key="key"
+            >
+              <template #accordion-header>
+                <SubscriptionHeader :details="value" />
+              </template>
 
-                  <template #accordion-content>
-                    <SubscriptionDetails
-                      :details="value"
-                      is-discovery-subscription
-                    />
-                  </template>
-                </AccordionItem>
-              </AccordionList>
-            </template>
-          </KCard>
+              <template #accordion-content>
+                <SubscriptionDetails
+                  :details="value"
+                  is-discovery-subscription
+                />
+              </template>
+            </AccordionItem>
+          </AccordionList>
         </template>
 
         <template #xds-configuration>
@@ -112,7 +108,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KButton, KCard } from '@kong/kongponents'
+import { KButton } from '@kong/kongponents'
 import { onBeforeMount, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
@@ -183,7 +179,6 @@ const isEmpty = ref(false)
 const error = ref<Error | null>(null)
 const tableData = ref<{ headers: TableHeader[], data: any[] }>({
   headers: [
-    { label: 'Actions', key: 'actions', hideLabel: true },
     { label: 'Status', key: 'status' },
     { label: 'Name', key: 'name' },
   ],

--- a/src/app/zones/views/ZoneIngresses.vue
+++ b/src/app/zones/views/ZoneIngresses.vue
@@ -29,6 +29,7 @@
           </KButton>
         </template>
       </DataOverview>
+
       <TabsWidget
         v-if="isEmpty === false && entity !== null"
         :has-error="error !== null"
@@ -40,6 +41,7 @@
             Zone Ingress: {{ entity.name }}
           </h1>
         </template>
+
         <template #overview>
           <LabelList>
             <div>
@@ -59,28 +61,25 @@
             </div>
           </LabelList>
         </template>
-        <template #insights>
-          <KCard border-variant="noBorder">
-            <template #body>
-              <AccordionList :initially-open="0">
-                <AccordionItem
-                  v-for="(value, key) in subscriptionsReversed"
-                  :key="key"
-                >
-                  <template #accordion-header>
-                    <SubscriptionHeader :details="value" />
-                  </template>
 
-                  <template #accordion-content>
-                    <SubscriptionDetails
-                      :details="value"
-                      is-discovery-subscription
-                    />
-                  </template>
-                </AccordionItem>
-              </AccordionList>
-            </template>
-          </KCard>
+        <template #insights>
+          <AccordionList :initially-open="0">
+            <AccordionItem
+              v-for="(value, key) in subscriptionsReversed"
+              :key="key"
+            >
+              <template #accordion-header>
+                <SubscriptionHeader :details="value" />
+              </template>
+
+              <template #accordion-content>
+                <SubscriptionDetails
+                  :details="value"
+                  is-discovery-subscription
+                />
+              </template>
+            </AccordionItem>
+          </AccordionList>
         </template>
 
         <template #xds-configuration>
@@ -112,7 +111,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KButton, KCard } from '@kong/kongponents'
+import { KButton } from '@kong/kongponents'
 import { onBeforeMount, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
@@ -186,7 +185,6 @@ const isEmpty = ref(false)
 const error = ref<Error | null>(null)
 const tableData = ref<{ headers: TableHeader[], data: any[] }>({
   headers: [
-    { label: 'Actions', key: 'actions', hideLabel: true },
     { label: 'Status', key: 'status' },
     { label: 'Name', key: 'name' },
   ],

--- a/src/app/zones/views/ZonesView.vue
+++ b/src/app/zones/views/ZonesView.vue
@@ -75,41 +75,31 @@
         </template>
 
         <template #insights>
-          <KCard border-variant="noBorder">
-            <template #body>
-              <AccordionList :initially-open="0">
-                <AccordionItem
-                  v-for="(value, key) in subscriptionsReversed"
-                  :key="key"
-                >
-                  <template #accordion-header>
-                    <SubscriptionHeader :details="value" />
-                  </template>
+          <AccordionList :initially-open="0">
+            <AccordionItem
+              v-for="(value, key) in subscriptionsReversed"
+              :key="key"
+            >
+              <template #accordion-header>
+                <SubscriptionHeader :details="value" />
+              </template>
 
-                  <template #accordion-content>
-                    <SubscriptionDetails :details="value" />
-                  </template>
-                </AccordionItem>
-              </AccordionList>
-            </template>
-          </KCard>
+              <template #accordion-content>
+                <SubscriptionDetails :details="value" />
+              </template>
+            </AccordionItem>
+          </AccordionList>
         </template>
 
         <template #config>
-          <KCard
+          <CodeBlock
             v-if="codeOutput"
-            border-variant="noBorder"
-          >
-            <template #body>
-              <CodeBlock
-                id="code-block-zone-config"
-                language="json"
-                :code="codeOutput"
-                is-searchable
-                query-key="zone-config"
-              />
-            </template>
-          </KCard>
+            id="code-block-zone-config"
+            language="json"
+            :code="codeOutput"
+            is-searchable
+            query-key="zone-config"
+          />
         </template>
 
         <template #warnings>
@@ -121,7 +111,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KBadge, KButton, KCard } from '@kong/kongponents'
+import { KBadge, KButton } from '@kong/kongponents'
 import { onBeforeMount, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
@@ -196,7 +186,6 @@ const entityHasError = ref(false)
 const tableDataIsEmpty = ref(false)
 const tableData = ref<{ headers: TableHeader[], data: any[] }>({
   headers: [
-    { label: 'Actions', key: 'actions', hideLabel: true },
     { label: 'Status', key: 'status' },
     { label: 'Name', key: 'name' },
     { label: 'Zone CP Version', key: 'zoneCpVersion' },

--- a/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
@@ -95,22 +95,6 @@ exports[`ZoneEgresses.vue renders snapshot when multizone 1`] = `
                       >
                         
                         <span
-                          class="sr-only"
-                        >
-                          Actions
-                        </span>
-                        
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        
-                        <span
                           class=""
                         >
                           Status
@@ -146,13 +130,6 @@ exports[`ZoneEgresses.vue renders snapshot when multizone 1`] = `
                     tabindex="0"
                   >
                     
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      
-                    </td>
                     <td
                       class=""
                     >
@@ -315,61 +292,59 @@ exports[`ZoneEgresses.vue renders snapshot when multizone 1`] = `
             tabindex="0"
           >
             
-            
-            <div>
+            <section
+              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              class="kong-card noBorder"
+            >
+              <!---->
+              <!---->
               <div
-                class="label-list-content"
+                class="k-card-content d-flex"
               >
-                <section
-                  aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-                  class="kong-card noBorder"
+                <div
+                  class="k-card-body"
+                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                 >
-                  <!---->
-                  <!---->
+                  
+                  
                   <div
-                    class="k-card-content d-flex"
+                    class="label-list"
                   >
                     <div
-                      class="k-card-body"
-                      id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                      class="label-list__content"
                     >
                       
-                      <div
-                        class="label-list__col-wrapper multi-col"
-                      >
-                        
-                        <div>
-                          <ul>
-                            
-                            <li>
-                              <h4>
-                                type
-                              </h4>
-                              <p>
-                                ZoneEgressOverview
-                              </p>
-                            </li>
-                            <li>
-                              <h4>
-                                name
-                              </h4>
-                              <p>
-                                zoneegress-1
-                              </p>
-                            </li>
-                            
-                          </ul>
-                        </div>
-                        
+                      <div>
+                        <ul>
+                          
+                          <li>
+                            <h4>
+                              type
+                            </h4>
+                            <p>
+                              ZoneEgressOverview
+                            </p>
+                          </li>
+                          <li>
+                            <h4>
+                              name
+                            </h4>
+                            <p>
+                              zoneegress-1
+                            </p>
+                          </li>
+                          
+                        </ul>
                       </div>
                       
                     </div>
-                    <!---->
                   </div>
-                </section>
+                  
+                  
+                </div>
+                <!---->
               </div>
-            </div>
-            
+            </section>
             
           </div>
           <div
@@ -513,22 +488,6 @@ exports[`ZoneEgresses.vue renders snapshot when no multizone 1`] = `
                       >
                         
                         <span
-                          class="sr-only"
-                        >
-                          Actions
-                        </span>
-                        
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        
-                        <span
                           class=""
                         >
                           Status
@@ -564,13 +523,6 @@ exports[`ZoneEgresses.vue renders snapshot when no multizone 1`] = `
                     tabindex="0"
                   >
                     
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      
-                    </td>
                     <td
                       class=""
                     >
@@ -733,61 +685,59 @@ exports[`ZoneEgresses.vue renders snapshot when no multizone 1`] = `
             tabindex="0"
           >
             
-            
-            <div>
+            <section
+              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              class="kong-card noBorder"
+            >
+              <!---->
+              <!---->
               <div
-                class="label-list-content"
+                class="k-card-content d-flex"
               >
-                <section
-                  aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-                  class="kong-card noBorder"
+                <div
+                  class="k-card-body"
+                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                 >
-                  <!---->
-                  <!---->
+                  
+                  
                   <div
-                    class="k-card-content d-flex"
+                    class="label-list"
                   >
                     <div
-                      class="k-card-body"
-                      id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                      class="label-list__content"
                     >
                       
-                      <div
-                        class="label-list__col-wrapper multi-col"
-                      >
-                        
-                        <div>
-                          <ul>
-                            
-                            <li>
-                              <h4>
-                                type
-                              </h4>
-                              <p>
-                                ZoneEgressOverview
-                              </p>
-                            </li>
-                            <li>
-                              <h4>
-                                name
-                              </h4>
-                              <p>
-                                zoneegress-1
-                              </p>
-                            </li>
-                            
-                          </ul>
-                        </div>
-                        
+                      <div>
+                        <ul>
+                          
+                          <li>
+                            <h4>
+                              type
+                            </h4>
+                            <p>
+                              ZoneEgressOverview
+                            </p>
+                          </li>
+                          <li>
+                            <h4>
+                              name
+                            </h4>
+                            <p>
+                              zoneegress-1
+                            </p>
+                          </li>
+                          
+                        </ul>
                       </div>
                       
                     </div>
-                    <!---->
                   </div>
-                </section>
+                  
+                  
+                </div>
+                <!---->
               </div>
-            </div>
-            
+            </section>
             
           </div>
           <div
@@ -964,7 +914,6 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
         tabindex="0"
       >
         
-        
         <section
           aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
           class="kong-card noBorder"
@@ -978,6 +927,7 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
               class="k-card-body"
               id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
             >
+              
               
               <ul
                 class="accordion-list"
@@ -1013,7 +963,7 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                     persisted="false"
                   >
                     <div
-                      class="px-4 py-1"
+                      class="accordion-item-content"
                       data-testid="accordion-item-content"
                     >
                       
@@ -1152,11 +1102,11 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                 
               </ul>
               
+              
             </div>
             <!---->
           </div>
         </section>
-        
         
       </div>
       <div

--- a/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
@@ -97,22 +97,6 @@ exports[`ZoneIngresses.vue renders snapshot when multizone 1`] = `
                       >
                         
                         <span
-                          class="sr-only"
-                        >
-                          Actions
-                        </span>
-                        
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        
-                        <span
                           class=""
                         >
                           Status
@@ -148,13 +132,6 @@ exports[`ZoneIngresses.vue renders snapshot when multizone 1`] = `
                     tabindex="0"
                   >
                     
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      
-                    </td>
                     <td
                       class=""
                     >
@@ -317,61 +294,59 @@ exports[`ZoneIngresses.vue renders snapshot when multizone 1`] = `
             tabindex="0"
           >
             
-            
-            <div>
+            <section
+              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              class="kong-card noBorder"
+            >
+              <!---->
+              <!---->
               <div
-                class="label-list-content"
+                class="k-card-content d-flex"
               >
-                <section
-                  aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-                  class="kong-card noBorder"
+                <div
+                  class="k-card-body"
+                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                 >
-                  <!---->
-                  <!---->
+                  
+                  
                   <div
-                    class="k-card-content d-flex"
+                    class="label-list"
                   >
                     <div
-                      class="k-card-body"
-                      id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                      class="label-list__content"
                     >
                       
-                      <div
-                        class="label-list__col-wrapper multi-col"
-                      >
-                        
-                        <div>
-                          <ul>
-                            
-                            <li>
-                              <h4>
-                                type
-                              </h4>
-                              <p>
-                                ZoneIngressOverview
-                              </p>
-                            </li>
-                            <li>
-                              <h4>
-                                name
-                              </h4>
-                              <p>
-                                zone-ingress-1
-                              </p>
-                            </li>
-                            
-                          </ul>
-                        </div>
-                        
+                      <div>
+                        <ul>
+                          
+                          <li>
+                            <h4>
+                              type
+                            </h4>
+                            <p>
+                              ZoneIngressOverview
+                            </p>
+                          </li>
+                          <li>
+                            <h4>
+                              name
+                            </h4>
+                            <p>
+                              zone-ingress-1
+                            </p>
+                          </li>
+                          
+                        </ul>
                       </div>
                       
                     </div>
-                    <!---->
                   </div>
-                </section>
+                  
+                  
+                </div>
+                <!---->
               </div>
-            </div>
-            
+            </section>
             
           </div>
           <div
@@ -641,7 +616,6 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
         tabindex="0"
       >
         
-        
         <section
           aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
           class="kong-card noBorder"
@@ -655,6 +629,7 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
               class="k-card-body"
               id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
             >
+              
               
               <ul
                 class="accordion-list"
@@ -690,7 +665,7 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                     persisted="false"
                   >
                     <div
-                      class="px-4 py-1"
+                      class="accordion-item-content"
                       data-testid="accordion-item-content"
                     >
                       
@@ -829,11 +804,11 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                 
               </ul>
               
+              
             </div>
             <!---->
           </div>
         </section>
-        
         
       </div>
       <div

--- a/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
@@ -97,22 +97,6 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
                       >
                         
                         <span
-                          class="sr-only"
-                        >
-                          Actions
-                        </span>
-                        
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        
-                        <span
                           class=""
                         >
                           Status
@@ -228,13 +212,6 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
                     tabindex="0"
                   >
                     
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      
-                    </td>
                     <td
                       class=""
                     >
@@ -373,13 +350,6 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
                       class=""
                     >
                       
-                      
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
                       <span
                         class="status status--with-title status--success"
                         data-testid="status-badge"
@@ -444,13 +414,6 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
                     tabindex="0"
                   >
                     
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      
-                    </td>
                     <td
                       class=""
                     >
@@ -585,13 +548,6 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
                     tabindex="0"
                   >
                     
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      
-                    </td>
                     <td
                       class=""
                     >
@@ -846,93 +802,91 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
             tabindex="0"
           >
             
-            
-            <div>
+            <section
+              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              class="kong-card noBorder"
+            >
+              <!---->
+              <!---->
               <div
-                class="label-list-content"
+                class="k-card-content d-flex"
               >
-                <section
-                  aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-                  class="kong-card noBorder"
+                <div
+                  class="k-card-body"
+                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                 >
-                  <!---->
-                  <!---->
+                  
+                  
                   <div
-                    class="k-card-content d-flex"
+                    class="label-list"
                   >
                     <div
-                      class="k-card-body"
-                      id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                      class="label-list__content"
                     >
                       
-                      <div
-                        class="label-list__col-wrapper multi-col"
-                      >
-                        
-                        <div>
-                          <ul>
-                            
-                            <li>
-                              <h4>
-                                type
-                              </h4>
-                              <p>
-                                ZoneOverview
-                              </p>
-                            </li>
-                            <li>
-                              <h4>
-                                name
-                              </h4>
-                              <p>
-                                cluster-1
-                              </p>
-                            </li>
-                            <li>
-                              <h4>
-                                status
-                              </h4>
-                              <p>
+                      <div>
+                        <ul>
+                          
+                          <li>
+                            <h4>
+                              type
+                            </h4>
+                            <p>
+                              ZoneOverview
+                            </p>
+                          </li>
+                          <li>
+                            <h4>
+                              name
+                            </h4>
+                            <p>
+                              cluster-1
+                            </p>
+                          </li>
+                          <li>
+                            <h4>
+                              status
+                            </h4>
+                            <p>
+                              <div
+                                class="k-badge d-inline-flex k-badge-success k-badge-rounded"
+                                tabindex="0"
+                              >
                                 <div
-                                  class="k-badge d-inline-flex k-badge-success k-badge-rounded"
-                                  tabindex="0"
+                                  class="k-badge-text truncate"
                                 >
                                   <div
                                     class="k-badge-text truncate"
                                   >
-                                    <div
-                                      class="k-badge-text truncate"
-                                    >
-                                      
-                                      online
-                                      
-                                    </div>
+                                    
+                                    online
+                                    
                                   </div>
-                                  <!---->
                                 </div>
-                              </p>
-                            </li>
-                            <li>
-                              <h4>
-                                Authentication Type
-                              </h4>
-                              <p>
-                                dpToken
-                              </p>
-                            </li>
-                            
-                          </ul>
-                        </div>
-                        
+                                <!---->
+                              </div>
+                            </p>
+                          </li>
+                          <li>
+                            <h4>
+                              Authentication Type
+                            </h4>
+                            <p>
+                              dpToken
+                            </p>
+                          </li>
+                          
+                        </ul>
                       </div>
                       
                     </div>
-                    <!---->
                   </div>
-                </section>
+                  
+                  
+                </div>
+                <!---->
               </div>
-            </div>
-            
+            </section>
             
           </div>
           <div
@@ -1250,7 +1204,6 @@ exports[`ZonesView.vue renders zone insights 1`] = `
         tabindex="0"
       >
         
-        
         <section
           aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
           class="kong-card noBorder"
@@ -1264,6 +1217,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
               class="k-card-body"
               id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
             >
+              
               
               <ul
                 class="accordion-list"
@@ -1299,7 +1253,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                     persisted="false"
                   >
                     <div
-                      class="px-4 py-1"
+                      class="accordion-item-content"
                       data-testid="accordion-item-content"
                     >
                       
@@ -1759,11 +1713,11 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                 
               </ul>
               
+              
             </div>
             <!---->
           </div>
         </section>
-        
         
       </div>
       <div

--- a/src/assets/styles/_components.scss
+++ b/src/assets/styles/_components.scss
@@ -1,4 +1,5 @@
 .component-frame {
-  border: 1px solid var(--grey-300);
+  border: var(--KCardBorder);
   border-radius: 3px;
+  background-color: var(--white);
 }

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -29,4 +29,6 @@
   --KBadgeFontSize: 1rem;
   // Removes the default max width of 200 pixels because badges should never be cut-off.
   --KBadgeMaxWidth: auto;
+  // Sets a default border style for commonly used component frames/panels.
+  --KCardBorder: 1px solid var(--grey-300);
 }


### PR DESCRIPTION
Removes the built-in KCard from LabelList so that it can be (1) nested and (2) used where no card styles are necessary (e.g. in a context where this already a wrapping KCard).

Integrates a default KCard into the `TabsWidget` tabs and removes all instances where one was explicitly added. This cuts down on quite a bit of redundant code.

Uses KCard in some place where we were previously achieving a similar look with class-based padding. Overall, these changes achieve a much more consistent padding of panel-like boxes in the UI.

Removes some unused actions columns from some tables.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>