### PR TITLE
refactor: uses cards consistently

### DIFF
--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -599,314 +599,14 @@ exports[`App.vue fails to renders basic view 1`] = `
         <div
           class="transition-root"
         >
-          
-          <section
-            aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-            class="kong-card border"
-          >
-            <!---->
-            <!---->
-            <div
-              class="k-card-content d-flex"
-            >
-              <div
-                class="k-card-body"
-                id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-              >
-                
-                <div
-                  class="chart-box-list"
-                >
-                  <!--v-if-->
-                  <!--v-if-->
-                  <div
-                    class="chart chart chart-1/3"
-                  >
-                    <div
-                      class="chart-canvas-container"
-                    >
-                      <div
-                        class="chart-title-box"
-                      >
-                        <div
-                          class="chart-title"
-                        >
-                          <span
-                            class="chart-title__total"
-                          >
-                            3
-                          </span>
-                           Meshes 
-                          <!--v-if-->
-                        </div>
-                      </div>
-                      <canvas
-                        height="0"
-                        style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-                        width="0"
-                      />
-                    </div>
-                    <div
-                      class="chart-legend"
-                    >
-                      
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #67b7dc;"
-                      >
-                        Mesh (3) 
-                      </div>
-                      
-                    </div>
-                  </div>
-                  <div
-                    class="chart chart chart-1/3"
-                  >
-                    <div
-                      class="chart-canvas-container"
-                    >
-                      <div
-                        class="chart-title-box"
-                      >
-                        <div
-                          class="chart-title"
-                        >
-                          <span
-                            class="chart-title__total"
-                          >
-                            8
-                          </span>
-                           Services 
-                          <!--v-if-->
-                        </div>
-                      </div>
-                      <canvas
-                        height="0"
-                        style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-                        width="0"
-                      />
-                    </div>
-                    <div
-                      class="chart-legend"
-                    >
-                      
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #67b7dc;"
-                      >
-                        Internal (6) 
-                      </div>
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #6771dc;"
-                      >
-                        External (2) 
-                      </div>
-                      
-                    </div>
-                  </div>
-                  <div
-                    class="chart chart chart-1/3"
-                  >
-                    <div
-                      class="chart-canvas-container"
-                    >
-                      <div
-                        class="chart-title-box"
-                      >
-                        <div
-                          class="chart-title"
-                        >
-                          <span
-                            class="chart-title__total"
-                          >
-                            10
-                          </span>
-                           DP Proxies 
-                          <!--v-if-->
-                        </div>
-                      </div>
-                      <canvas
-                        height="0"
-                        style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-                        width="0"
-                      />
-                    </div>
-                    <div
-                      class="chart-legend"
-                    >
-                      
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #19a654;"
-                      >
-                        Online (9) 
-                      </div>
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #f2a230;"
-                      >
-                        Partially degraded (1) 
-                      </div>
-                      
-                    </div>
-                  </div>
-                  <div
-                    class="chart chart chart-1/2 chart-offset-left-1/6"
-                  >
-                    <div
-                      class="chart-canvas-container"
-                    >
-                      <div
-                        class="chart-title-box"
-                      >
-                        <div
-                          class="chart-title"
-                        >
-                          <!--v-if-->
-                           Kuma DP 
-                          <span
-                            class="chart-title__subtitle"
-                          >
-                            versions
-                          </span>
-                        </div>
-                      </div>
-                      <canvas
-                        height="0"
-                        style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-                        width="0"
-                      />
-                    </div>
-                    <div
-                      class="chart-legend"
-                    >
-                      
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #67b7dc;"
-                      >
-                        1.0.0-rc2 (3) 
-                      </div>
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #6771dc;"
-                      >
-                        1.0.4 (5) 
-                      </div>
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #a367dc;"
-                      >
-                        1.0.6 (2) 
-                      </div>
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #dc67ce;"
-                      >
-                        unknown (2) 
-                      </div>
-                      
-                    </div>
-                  </div>
-                  <div
-                    class="chart chart chart-1/2 chart-offset-right-1/6"
-                  >
-                    <div
-                      class="chart-canvas-container"
-                    >
-                      <div
-                        class="chart-title-box"
-                      >
-                        <div
-                          class="chart-title"
-                        >
-                          <!--v-if-->
-                           Envoy 
-                          <span
-                            class="chart-title__subtitle"
-                          >
-                            versions
-                          </span>
-                        </div>
-                      </div>
-                      <canvas
-                        height="0"
-                        style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-                        width="0"
-                      />
-                    </div>
-                    <div
-                      class="chart-legend"
-                    >
-                      
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #67b7dc;"
-                      >
-                        1.14.0 (7) 
-                      </div>
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #6771dc;"
-                      >
-                        1.15.0 (4) 
-                      </div>
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #a367dc;"
-                      >
-                        1.16.1 (8) 
-                      </div>
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #dc67ce;"
-                      >
-                        1.16.2 (4) 
-                      </div>
-                      <div
-                        class="legend-entry"
-                        style="--data-background-color: #dc6788;"
-                      >
-                        unknown (2) 
-                      </div>
-                      
-                    </div>
-                  </div>
-                </div>
-                
-              </div>
-              <!---->
-            </div>
-          </section>
           <div
-            class="resource-list mt-4"
+            class="kcard-stack"
           >
             <section
               aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-              aria-label="Create a virtual mesh"
               class="kong-card border"
             >
-              <div
-                class="k-card-header d-flex mb-3"
-              >
-                <!---->
-                <div
-                  class="k-card-title mb-3"
-                >
-                  <h4>
-                    
-                    Create a virtual mesh
-                    
-                  </h4>
-                </div>
-                <div
-                  class="k-card-actions"
-                >
-                  
-                  
-                </div>
-              </div>
+              <!---->
               <!---->
               <div
                 class="k-card-content d-flex"
@@ -916,266 +616,568 @@ exports[`App.vue fails to renders basic view 1`] = `
                   id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                 >
                   
-                  <p>
-                     We can create multiple isolated Mesh resources (i.e. per application/
-                    <wbr />
-                    team/
-                    <wbr />
-                    business unit). 
-                  </p>
                   <div
-                    class="resource-list-actions mt-4"
+                    class="chart-box-list"
                   >
-                    <a
-                      class="k-button medium rounded creation"
-                      href="/wizard/mesh"
-                      type="button"
+                    <!--v-if-->
+                    <!--v-if-->
+                    <div
+                      class="chart chart chart-1/3"
                     >
-                      
-                      <span
-                        class="k-button-icon kong-icon kong-icon-plus"
+                      <div
+                        class="chart-canvas-container"
                       >
-                        <svg
-                          fill="white"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 20 20"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          class="chart-title-box"
                         >
-                          
-  
-                          <title>
-                            Add
-                          </title>
-                          
-  
-                          <rect
-                            fill="white"
-                            height="12"
-                            rx="1"
-                            width="2.77"
-                            x="8.62"
-                            y="4"
-                          />
-                          
-  
-                          <rect
-                            fill="white"
-                            height="12"
-                            rx="1"
-                            transform="rotate(90 16 8.62)"
-                            width="2.77"
-                            x="16"
-                            y="8.62"
-                          />
-                          
-
-                        </svg>
+                          <div
+                            class="chart-title"
+                          >
+                            <span
+                              class="chart-title__total"
+                            >
+                              3
+                            </span>
+                             Meshes 
+                            <!--v-if-->
+                          </div>
+                        </div>
+                        <canvas
+                          height="0"
+                          style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                          width="0"
+                        />
+                      </div>
+                      <div
+                        class="chart-legend"
+                      >
                         
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #67b7dc;"
+                        >
+                          Mesh (3) 
+                        </div>
+                        
+                      </div>
+                    </div>
+                    <div
+                      class="chart chart chart-1/3"
+                    >
+                      <div
+                        class="chart-canvas-container"
+                      >
+                        <div
+                          class="chart-title-box"
+                        >
+                          <div
+                            class="chart-title"
+                          >
+                            <span
+                              class="chart-title__total"
+                            >
+                              8
+                            </span>
+                             Services 
+                            <!--v-if-->
+                          </div>
+                        </div>
+                        <canvas
+                          height="0"
+                          style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                          width="0"
+                        />
+                      </div>
+                      <div
+                        class="chart-legend"
+                      >
+                        
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #67b7dc;"
+                        >
+                          Internal (6) 
+                        </div>
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #6771dc;"
+                        >
+                          External (2) 
+                        </div>
+                        
+                      </div>
+                    </div>
+                    <div
+                      class="chart chart chart-1/3"
+                    >
+                      <div
+                        class="chart-canvas-container"
+                      >
+                        <div
+                          class="chart-title-box"
+                        >
+                          <div
+                            class="chart-title"
+                          >
+                            <span
+                              class="chart-title__total"
+                            >
+                              10
+                            </span>
+                             DP Proxies 
+                            <!--v-if-->
+                          </div>
+                        </div>
+                        <canvas
+                          height="0"
+                          style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                          width="0"
+                        />
+                      </div>
+                      <div
+                        class="chart-legend"
+                      >
+                        
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #19a654;"
+                        >
+                          Online (9) 
+                        </div>
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #f2a230;"
+                        >
+                          Partially degraded (1) 
+                        </div>
+                        
+                      </div>
+                    </div>
+                    <div
+                      class="chart chart chart-1/2 chart-offset-left-1/6"
+                    >
+                      <div
+                        class="chart-canvas-container"
+                      >
+                        <div
+                          class="chart-title-box"
+                        >
+                          <div
+                            class="chart-title"
+                          >
+                            <!--v-if-->
+                             Kuma DP 
+                            <span
+                              class="chart-title__subtitle"
+                            >
+                              versions
+                            </span>
+                          </div>
+                        </div>
+                        <canvas
+                          height="0"
+                          style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                          width="0"
+                        />
+                      </div>
+                      <div
+                        class="chart-legend"
+                      >
+                        
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #67b7dc;"
+                        >
+                          1.0.0-rc2 (3) 
+                        </div>
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #6771dc;"
+                        >
+                          1.0.4 (5) 
+                        </div>
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #a367dc;"
+                        >
+                          1.0.6 (2) 
+                        </div>
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #dc67ce;"
+                        >
+                          unknown (2) 
+                        </div>
+                        
+                      </div>
+                    </div>
+                    <div
+                      class="chart chart chart-1/2 chart-offset-right-1/6"
+                    >
+                      <div
+                        class="chart-canvas-container"
+                      >
+                        <div
+                          class="chart-title-box"
+                        >
+                          <div
+                            class="chart-title"
+                          >
+                            <!--v-if-->
+                             Envoy 
+                            <span
+                              class="chart-title__subtitle"
+                            >
+                              versions
+                            </span>
+                          </div>
+                        </div>
+                        <canvas
+                          height="0"
+                          style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                          width="0"
+                        />
+                      </div>
+                      <div
+                        class="chart-legend"
+                      >
+                        
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #67b7dc;"
+                        >
+                          1.14.0 (7) 
+                        </div>
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #6771dc;"
+                        >
+                          1.15.0 (4) 
+                        </div>
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #a367dc;"
+                        >
+                          1.16.1 (8) 
+                        </div>
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #dc67ce;"
+                        >
+                          1.16.2 (4) 
+                        </div>
+                        <div
+                          class="legend-entry"
+                          style="--data-background-color: #dc6788;"
+                        >
+                          unknown (2) 
+                        </div>
+                        
+                      </div>
+                    </div>
+                  </div>
+                  
+                </div>
+                <!---->
+              </div>
+            </section>
+            <div
+              class="kcard-list"
+            >
+              <section
+                aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                aria-label="Create a virtual mesh"
+                class="kong-card border"
+              >
+                <div
+                  class="k-card-header d-flex mb-3"
+                >
+                  <!---->
+                  <div
+                    class="k-card-title mb-3"
+                  >
+                    <h4>
+                      
+                      Create a virtual mesh
+                      
+                    </h4>
+                  </div>
+                  <div
+                    class="k-card-actions"
+                  >
+                    
+                    
+                  </div>
+                </div>
+                <!---->
+                <div
+                  class="k-card-content d-flex"
+                >
+                  <div
+                    class="k-card-body"
+                    id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                  >
+                    
+                    <p>
+                       We can create multiple isolated Mesh resources (i.e. per application/
+                      <wbr />
+                      team/
+                      <wbr />
+                      business unit). 
+                    </p>
+                    <div
+                      class="resource-list-actions mt-4"
+                    >
+                      <a
+                        class="k-button medium rounded creation"
+                        href="/wizard/mesh"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="k-button-icon kong-icon kong-icon-plus"
+                        >
+                          <svg
+                            fill="white"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 20 20"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            <title>
+                              Add
+                            </title>
+                            
+  
+                            <rect
+                              fill="white"
+                              height="12"
+                              rx="1"
+                              width="2.77"
+                              x="8.62"
+                              y="4"
+                            />
+                            
+  
+                            <rect
+                              fill="white"
+                              height="12"
+                              rx="1"
+                              transform="rotate(90 16 8.62)"
+                              width="2.77"
+                              x="16"
+                              y="8.62"
+                            />
+                            
 
-                      </span>
-                      
-                      
-                       Create mesh 
-                      
-                      <!---->
-                    </a>
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Create mesh 
+                        
+                        <!---->
+                      </a>
+                    </div>
+                    
                   </div>
-                  
+                  <!---->
                 </div>
-                <!---->
-              </div>
-            </section>
-            <section
-              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-              aria-label="Connect data plane proxies"
-              class="kong-card border"
-            >
-              <div
-                class="k-card-header d-flex mb-3"
-              >
-                <!---->
-                <div
-                  class="k-card-title mb-3"
-                >
-                  <h4>
-                    
-                    Connect data plane proxies
-                    
-                  </h4>
-                </div>
-                <div
-                  class="k-card-actions"
-                >
-                  
-                  
-                </div>
-              </div>
-              <!---->
-              <div
-                class="k-card-content d-flex"
+              </section>
+              <section
+                aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                aria-label="Connect data plane proxies"
+                class="kong-card border"
               >
                 <div
-                  class="k-card-body"
-                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                  class="k-card-header d-flex mb-3"
                 >
-                  
-                  <p>
-                     We need a data plane proxy for each replica of our services within a Mesh resource. 
-                  </p>
+                  <!---->
                   <div
-                    class="resource-list-actions mt-4"
+                    class="k-card-title mb-3"
                   >
-                    <a
-                      class="k-button medium rounded primary"
-                      href="/wizard/universal-dataplane"
-                      type="button"
-                    >
+                    <h4>
                       
-                      <!---->
+                      Connect data plane proxies
                       
-                      
-                       Get started 
-                      
-                      <!---->
-                    </a>
+                    </h4>
                   </div>
-                  
-                </div>
-                <!---->
-              </div>
-            </section>
-            <section
-              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-              aria-label="Apply Kuma policies"
-              class="kong-card border"
-            >
-              <div
-                class="k-card-header d-flex mb-3"
-              >
-                <!---->
-                <div
-                  class="k-card-title mb-3"
-                >
-                  <h4>
-                    
-                    Apply Kuma policies
-                    
-                  </h4>
-                </div>
-                <div
-                  class="k-card-actions"
-                >
-                  
-                  
-                </div>
-              </div>
-              <!---->
-              <div
-                class="k-card-content d-flex"
-              >
-                <div
-                  class="k-card-body"
-                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-                >
-                  
-                  <p>
-                     We can apply Kuma policies to secure, observe, route and manage the Mesh and its data plane proxies. 
-                  </p>
                   <div
-                    class="resource-list-actions mt-4"
+                    class="k-card-actions"
                   >
-                    <a
-                      class="k-button medium rounded primary"
-                      href="https://kuma.io/docs/10.2.x/policies/?utm_source=Kuma&utm_medium=Kuma"
-                      target="_blank"
-                      type="button"
-                    >
-                      
-                      <!---->
-                      
-                      
-                       Explore policies 
-                      
-                      <!---->
-                    </a>
+                    
+                    
                   </div>
-                  
                 </div>
                 <!---->
-              </div>
-            </section>
-            <section
-              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-              aria-label="Resources"
-              class="kong-card border"
-            >
-              <div
-                class="k-card-header d-flex mb-3"
-              >
-                <!---->
                 <div
-                  class="k-card-title mb-3"
+                  class="k-card-content d-flex"
                 >
-                  <h4>
+                  <div
+                    class="k-card-body"
+                    id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                  >
                     
-                    Resources
+                    <p>
+                       We need a data plane proxy for each replica of our services within a Mesh resource. 
+                    </p>
+                    <div
+                      class="resource-list-actions mt-4"
+                    >
+                      <a
+                        class="k-button medium rounded primary"
+                        href="/wizard/universal-dataplane"
+                        type="button"
+                      >
+                        
+                        <!---->
+                        
+                        
+                         Get started 
+                        
+                        <!---->
+                      </a>
+                    </div>
                     
-                  </h4>
+                  </div>
+                  <!---->
                 </div>
-                <div
-                  class="k-card-actions"
-                >
-                  
-                  
-                </div>
-              </div>
-              <!---->
-              <div
-                class="k-card-content d-flex"
+              </section>
+              <section
+                aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                aria-label="Apply Kuma policies"
+                class="kong-card border"
               >
                 <div
-                  class="k-card-body"
-                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                  class="k-card-header d-flex mb-3"
                 >
-                  
-                  <p>
-                     Join the Kuma community and ask questions: 
-                  </p>
-                  <ul>
-                    <li>
-                      <a
-                        href="https://kuma.io/docs/10.2.x/?utm_source=Kuma&utm_medium=Kuma"
-                        target="_blank"
-                      >
-                        Kuma Documentation 
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        href="https://kuma-mesh.slack.com/?utm_source=Kuma&utm_medium=Kuma"
-                        target="_blank"
-                      >
-                        Kuma Community Chat 
-                      </a>
-                    </li>
-                    <li>
-                      <a
-                        href="https://github.com/kumahq/kuma?utm_source=Kuma&utm_medium=Kuma"
-                        target="_blank"
-                      >
-                        Kuma GitHub Repository 
-                      </a>
-                    </li>
-                  </ul>
-                  
+                  <!---->
+                  <div
+                    class="k-card-title mb-3"
+                  >
+                    <h4>
+                      
+                      Apply Kuma policies
+                      
+                    </h4>
+                  </div>
+                  <div
+                    class="k-card-actions"
+                  >
+                    
+                    
+                  </div>
                 </div>
                 <!---->
-              </div>
-            </section>
+                <div
+                  class="k-card-content d-flex"
+                >
+                  <div
+                    class="k-card-body"
+                    id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                  >
+                    
+                    <p>
+                       We can apply Kuma policies to secure, observe, route and manage the Mesh and its data plane proxies. 
+                    </p>
+                    <div
+                      class="resource-list-actions mt-4"
+                    >
+                      <a
+                        class="k-button medium rounded primary"
+                        href="https://kuma.io/docs/10.2.x/policies/?utm_source=Kuma&utm_medium=Kuma"
+                        target="_blank"
+                        type="button"
+                      >
+                        
+                        <!---->
+                        
+                        
+                         Explore policies 
+                        
+                        <!---->
+                      </a>
+                    </div>
+                    
+                  </div>
+                  <!---->
+                </div>
+              </section>
+              <section
+                aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                aria-label="Resources"
+                class="kong-card border"
+              >
+                <div
+                  class="k-card-header d-flex mb-3"
+                >
+                  <!---->
+                  <div
+                    class="k-card-title mb-3"
+                  >
+                    <h4>
+                      
+                      Resources
+                      
+                    </h4>
+                  </div>
+                  <div
+                    class="k-card-actions"
+                  >
+                    
+                    
+                  </div>
+                </div>
+                <!---->
+                <div
+                  class="k-card-content d-flex"
+                >
+                  <div
+                    class="k-card-body"
+                    id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                  >
+                    
+                    <p>
+                       Join the Kuma community and ask questions: 
+                    </p>
+                    <ul>
+                      <li>
+                        <a
+                          href="https://kuma.io/docs/10.2.x/?utm_source=Kuma&utm_medium=Kuma"
+                          target="_blank"
+                        >
+                          Kuma Documentation 
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="https://kuma-mesh.slack.com/?utm_source=Kuma&utm_medium=Kuma"
+                          target="_blank"
+                        >
+                          Kuma Community Chat 
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          href="https://github.com/kumahq/kuma?utm_source=Kuma&utm_medium=Kuma"
+                          target="_blank"
+                        >
+                          Kuma GitHub Repository 
+                        </a>
+                      </li>
+                    </ul>
+                    
+                  </div>
+                  <!---->
+                </div>
+              </section>
+            </div>
           </div>
-          
         </div>
       </transition-stub>
     </main>

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -600,268 +600,287 @@ exports[`App.vue fails to renders basic view 1`] = `
           class="transition-root"
         >
           
-          <div
-            class="chart-box-list mt-16"
+          <section
+            aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+            class="kong-card border"
           >
-            <!--v-if-->
-            <!--v-if-->
+            <!---->
+            <!---->
             <div
-              class="chart chart chart-1/3"
+              class="k-card-content d-flex"
             >
               <div
-                class="chart-canvas-container"
+                class="k-card-body"
+                id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
               >
+                
                 <div
-                  class="chart-title-box"
+                  class="chart-box-list"
                 >
+                  <!--v-if-->
+                  <!--v-if-->
                   <div
-                    class="chart-title"
+                    class="chart chart chart-1/3"
                   >
-                    <span
-                      class="chart-title__total"
+                    <div
+                      class="chart-canvas-container"
                     >
-                      3
-                    </span>
-                     Meshes 
-                    <!--v-if-->
+                      <div
+                        class="chart-title-box"
+                      >
+                        <div
+                          class="chart-title"
+                        >
+                          <span
+                            class="chart-title__total"
+                          >
+                            3
+                          </span>
+                           Meshes 
+                          <!--v-if-->
+                        </div>
+                      </div>
+                      <canvas
+                        height="0"
+                        style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                        width="0"
+                      />
+                    </div>
+                    <div
+                      class="chart-legend"
+                    >
+                      
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #67b7dc;"
+                      >
+                        Mesh (3) 
+                      </div>
+                      
+                    </div>
+                  </div>
+                  <div
+                    class="chart chart chart-1/3"
+                  >
+                    <div
+                      class="chart-canvas-container"
+                    >
+                      <div
+                        class="chart-title-box"
+                      >
+                        <div
+                          class="chart-title"
+                        >
+                          <span
+                            class="chart-title__total"
+                          >
+                            8
+                          </span>
+                           Services 
+                          <!--v-if-->
+                        </div>
+                      </div>
+                      <canvas
+                        height="0"
+                        style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                        width="0"
+                      />
+                    </div>
+                    <div
+                      class="chart-legend"
+                    >
+                      
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #67b7dc;"
+                      >
+                        Internal (6) 
+                      </div>
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #6771dc;"
+                      >
+                        External (2) 
+                      </div>
+                      
+                    </div>
+                  </div>
+                  <div
+                    class="chart chart chart-1/3"
+                  >
+                    <div
+                      class="chart-canvas-container"
+                    >
+                      <div
+                        class="chart-title-box"
+                      >
+                        <div
+                          class="chart-title"
+                        >
+                          <span
+                            class="chart-title__total"
+                          >
+                            10
+                          </span>
+                           DP Proxies 
+                          <!--v-if-->
+                        </div>
+                      </div>
+                      <canvas
+                        height="0"
+                        style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                        width="0"
+                      />
+                    </div>
+                    <div
+                      class="chart-legend"
+                    >
+                      
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #19a654;"
+                      >
+                        Online (9) 
+                      </div>
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #f2a230;"
+                      >
+                        Partially degraded (1) 
+                      </div>
+                      
+                    </div>
+                  </div>
+                  <div
+                    class="chart chart chart-1/2 chart-offset-left-1/6"
+                  >
+                    <div
+                      class="chart-canvas-container"
+                    >
+                      <div
+                        class="chart-title-box"
+                      >
+                        <div
+                          class="chart-title"
+                        >
+                          <!--v-if-->
+                           Kuma DP 
+                          <span
+                            class="chart-title__subtitle"
+                          >
+                            versions
+                          </span>
+                        </div>
+                      </div>
+                      <canvas
+                        height="0"
+                        style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                        width="0"
+                      />
+                    </div>
+                    <div
+                      class="chart-legend"
+                    >
+                      
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #67b7dc;"
+                      >
+                        1.0.0-rc2 (3) 
+                      </div>
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #6771dc;"
+                      >
+                        1.0.4 (5) 
+                      </div>
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #a367dc;"
+                      >
+                        1.0.6 (2) 
+                      </div>
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #dc67ce;"
+                      >
+                        unknown (2) 
+                      </div>
+                      
+                    </div>
+                  </div>
+                  <div
+                    class="chart chart chart-1/2 chart-offset-right-1/6"
+                  >
+                    <div
+                      class="chart-canvas-container"
+                    >
+                      <div
+                        class="chart-title-box"
+                      >
+                        <div
+                          class="chart-title"
+                        >
+                          <!--v-if-->
+                           Envoy 
+                          <span
+                            class="chart-title__subtitle"
+                          >
+                            versions
+                          </span>
+                        </div>
+                      </div>
+                      <canvas
+                        height="0"
+                        style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                        width="0"
+                      />
+                    </div>
+                    <div
+                      class="chart-legend"
+                    >
+                      
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #67b7dc;"
+                      >
+                        1.14.0 (7) 
+                      </div>
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #6771dc;"
+                      >
+                        1.15.0 (4) 
+                      </div>
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #a367dc;"
+                      >
+                        1.16.1 (8) 
+                      </div>
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #dc67ce;"
+                      >
+                        1.16.2 (4) 
+                      </div>
+                      <div
+                        class="legend-entry"
+                        style="--data-background-color: #dc6788;"
+                      >
+                        unknown (2) 
+                      </div>
+                      
+                    </div>
                   </div>
                 </div>
-                <canvas
-                  height="0"
-                  style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-                  width="0"
-                />
-              </div>
-              <div
-                class="chart-legend"
-              >
-                
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #67b7dc;"
-                >
-                  Mesh (3) 
-                </div>
                 
               </div>
+              <!---->
             </div>
-            <div
-              class="chart chart chart-1/3"
-            >
-              <div
-                class="chart-canvas-container"
-              >
-                <div
-                  class="chart-title-box"
-                >
-                  <div
-                    class="chart-title"
-                  >
-                    <span
-                      class="chart-title__total"
-                    >
-                      8
-                    </span>
-                     Services 
-                    <!--v-if-->
-                  </div>
-                </div>
-                <canvas
-                  height="0"
-                  style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-                  width="0"
-                />
-              </div>
-              <div
-                class="chart-legend"
-              >
-                
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #67b7dc;"
-                >
-                  Internal (6) 
-                </div>
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #6771dc;"
-                >
-                  External (2) 
-                </div>
-                
-              </div>
-            </div>
-            <div
-              class="chart chart chart-1/3"
-            >
-              <div
-                class="chart-canvas-container"
-              >
-                <div
-                  class="chart-title-box"
-                >
-                  <div
-                    class="chart-title"
-                  >
-                    <span
-                      class="chart-title__total"
-                    >
-                      10
-                    </span>
-                     DP Proxies 
-                    <!--v-if-->
-                  </div>
-                </div>
-                <canvas
-                  height="0"
-                  style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-                  width="0"
-                />
-              </div>
-              <div
-                class="chart-legend"
-              >
-                
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #19a654;"
-                >
-                  Online (9) 
-                </div>
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #f2a230;"
-                >
-                  Partially degraded (1) 
-                </div>
-                
-              </div>
-            </div>
-            <div
-              class="chart chart chart-1/2 chart-offset-left-1/6"
-            >
-              <div
-                class="chart-canvas-container"
-              >
-                <div
-                  class="chart-title-box"
-                >
-                  <div
-                    class="chart-title"
-                  >
-                    <!--v-if-->
-                     Kuma DP 
-                    <span
-                      class="chart-title__subtitle"
-                    >
-                      versions
-                    </span>
-                  </div>
-                </div>
-                <canvas
-                  height="0"
-                  style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-                  width="0"
-                />
-              </div>
-              <div
-                class="chart-legend"
-              >
-                
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #67b7dc;"
-                >
-                  1.0.0-rc2 (3) 
-                </div>
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #6771dc;"
-                >
-                  1.0.4 (5) 
-                </div>
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #a367dc;"
-                >
-                  1.0.6 (2) 
-                </div>
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #dc67ce;"
-                >
-                  unknown (2) 
-                </div>
-                
-              </div>
-            </div>
-            <div
-              class="chart chart chart-1/2 chart-offset-right-1/6"
-            >
-              <div
-                class="chart-canvas-container"
-              >
-                <div
-                  class="chart-title-box"
-                >
-                  <div
-                    class="chart-title"
-                  >
-                    <!--v-if-->
-                     Envoy 
-                    <span
-                      class="chart-title__subtitle"
-                    >
-                      versions
-                    </span>
-                  </div>
-                </div>
-                <canvas
-                  height="0"
-                  style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-                  width="0"
-                />
-              </div>
-              <div
-                class="chart-legend"
-              >
-                
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #67b7dc;"
-                >
-                  1.14.0 (7) 
-                </div>
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #6771dc;"
-                >
-                  1.15.0 (4) 
-                </div>
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #a367dc;"
-                >
-                  1.16.1 (8) 
-                </div>
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #dc67ce;"
-                >
-                  1.16.2 (4) 
-                </div>
-                <div
-                  class="legend-entry"
-                  style="--data-background-color: #dc6788;"
-                >
-                  unknown (2) 
-                </div>
-                
-              </div>
-            </div>
-          </div>
+          </section>
           <div
-            class="resource-list mt-8"
+            class="resource-list mt-4"
           >
             <section
               aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"

--- a/src/app/common/ContentWrapper.vue
+++ b/src/app/common/ContentWrapper.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="content-wrapper">
-    <div class="content-wrapper__content component-frame">
+    <div class="content-wrapper__content kcard-border">
       <slot name="content" />
     </div>
 
     <div
       v-if="slots.sidebar"
-      class="content-wrapper__sidebar component-frame"
+      class="content-wrapper__sidebar"
     >
       <slot name="sidebar" />
     </div>
@@ -25,7 +25,7 @@ const slots = useSlots()
   // Allows the contained flex items to wrap when their sizing requirements can’t be satisfied any longer.
   flex-wrap: wrap;
   align-items: flex-start;
-  gap: var(--spacing-lg);
+  gap: var(--spacing-md);
 }
 
 .content-wrapper__content {

--- a/src/app/common/FrameSkeleton.vue
+++ b/src/app/common/FrameSkeleton.vue
@@ -1,5 +1,0 @@
-<template>
-  <div class="component-frame">
-    <slot />
-  </div>
-</template>

--- a/src/app/common/MeshResources.vue
+++ b/src/app/common/MeshResources.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="resource-list">
+  <div class="kcard-list">
     <KCard title="Create a virtual mesh">
       <template #body>
         <p>
@@ -111,16 +111,6 @@ const dataplaneWizardRoute = computed(() => {
 ul {
   padding-left: var(--spacing-lg);
   list-style: disc;
-}
-
-.resource-list {
-  display: flex;
-  align-items: stretch;
-  gap: var(--spacing-md);
-}
-
-.resource-list > * {
-  flex-basis: 25%;
 }
 
 .resource-list-actions {

--- a/src/app/common/MeshResources.vue
+++ b/src/app/common/MeshResources.vue
@@ -53,9 +53,7 @@
       </template>
     </KCard>
 
-    <KCard
-      title="Resources"
-    >
+    <KCard title="Resources">
       <template #body>
         <p>
           Join the {{ env('KUMA_PRODUCT_NAME') }} community and ask questions:
@@ -118,7 +116,7 @@ ul {
 .resource-list {
   display: flex;
   align-items: stretch;
-  gap: var(--spacing-xs);
+  gap: var(--spacing-md);
 }
 
 .resource-list > * {

--- a/src/app/common/charts/DoughnutChart.vue
+++ b/src/app/common/charts/DoughnutChart.vue
@@ -181,7 +181,6 @@ const chartOptions = computed<ChartOptions<'doughnut'>>(function () {
 .chart-title-box {
   pointer-events: none;
   position: absolute;
-  z-index: -1; // Ensures the tooltips are above this element.
   inset: 0;
   display: flex;
   justify-content: center;

--- a/src/app/data-planes/components/DataPlaneEntitySummary.vue
+++ b/src/app/data-planes/components/DataPlaneEntitySummary.vue
@@ -1,5 +1,5 @@
 <template>
-  <KCard border-variant="noBorder">
+  <KCard>
     <template #body>
       <div class="entity-section-list">
         <section>

--- a/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`DataPlaneEntitySummary matches snapshot 1`] = `
 <section
   aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-  class="kong-card noBorder"
+  class="kong-card border"
 >
   <!---->
   <!---->

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="component-frame">
+  <div class="kcard-border">
     <LoadingBlock v-if="isLoading" />
 
     <ErrorBlock

--- a/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
+++ b/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
   class="content-wrapper"
 >
   <div
-    class="content-wrapper__content component-frame"
+    class="content-wrapper__content kcard-border"
   >
     
     <div
@@ -1753,12 +1753,12 @@ exports[`DataPlaneListView matches snapshot 1`] = `
     
   </div>
   <div
-    class="content-wrapper__sidebar component-frame"
+    class="content-wrapper__sidebar"
   >
     
     <section
       aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-      class="kong-card noBorder"
+      class="kong-card border"
     >
       <!---->
       <!---->

--- a/src/app/diagnostics/views/DiagnosticsView.vue
+++ b/src/app/diagnostics/views/DiagnosticsView.vue
@@ -1,22 +1,18 @@
 <template>
-  <div class="component-frame">
-    <LoadingBlock v-if="code === null" />
+  <KCard>
+    <template #body>
+      <LoadingBlock v-if="code === null" />
 
-    <KCard
-      v-else
-      border-variant="noBorder"
-    >
-      <template #body>
-        <CodeBlock
-          id="code-block-diagnostics"
-          language="json"
-          :code="code"
-          is-searchable
-          query-key="diagnostics"
-        />
-      </template>
-    </KCard>
-  </div>
+      <CodeBlock
+        v-else
+        id="code-block-diagnostics"
+        language="json"
+        :code="code"
+        is-searchable
+        query-key="diagnostics"
+      />
+    </template>
+  </KCard>
 </template>
 
 <script lang="ts" setup>

--- a/src/app/main-overview/components/OverviewCharts.vue
+++ b/src/app/main-overview/components/OverviewCharts.vue
@@ -1,45 +1,50 @@
 <template>
-  <div class="chart-box-list">
-    <DoughnutChart
-      v-if="isMultizoneMode"
-      class="chart chart-1/2 chart-offset-left-1/6"
-      :data="zonesChartData"
-    />
+  <KCard>
+    <template #body>
+      <div class="chart-box-list">
+        <DoughnutChart
+          v-if="isMultizoneMode"
+          class="chart chart-1/2 chart-offset-left-1/6"
+          :data="zonesChartData"
+        />
 
-    <DoughnutChart
-      v-if="isMultizoneMode"
-      class="chart chart-1/2 chart-offset-right-1/6"
-      :data="zonesCPVersionsChartData"
-    />
+        <DoughnutChart
+          v-if="isMultizoneMode"
+          class="chart chart-1/2 chart-offset-right-1/6"
+          :data="zonesCPVersionsChartData"
+        />
 
-    <DoughnutChart
-      class="chart chart-1/3"
-      :data="meshesChartData"
-    />
+        <DoughnutChart
+          class="chart chart-1/3"
+          :data="meshesChartData"
+        />
 
-    <DoughnutChart
-      class="chart chart-1/3"
-      :data="servicesChartData"
-    />
+        <DoughnutChart
+          class="chart chart-1/3"
+          :data="servicesChartData"
+        />
 
-    <DoughnutChart
-      class="chart chart-1/3"
-      :data="dataplanesChartData"
-    />
+        <DoughnutChart
+          class="chart chart-1/3"
+          :data="dataplanesChartData"
+        />
 
-    <DoughnutChart
-      class="chart chart-1/2 chart-offset-left-1/6"
-      :data="kumaDPVersionsChartData"
-    />
+        <DoughnutChart
+          class="chart chart-1/2 chart-offset-left-1/6"
+          :data="kumaDPVersionsChartData"
+        />
 
-    <DoughnutChart
-      class="chart chart-1/2 chart-offset-right-1/6"
-      :data="envoyVersionsChartData"
-    />
-  </div>
+        <DoughnutChart
+          class="chart chart-1/2 chart-offset-right-1/6"
+          :data="envoyVersionsChartData"
+        />
+      </div>
+    </template>
+  </KCard>
 </template>
 
 <script lang="ts" setup>
+import { KCard } from '@kong/kongponents'
 import { computed, watch } from 'vue'
 
 import DoughnutChart from '@/app/common/charts/DoughnutChart.vue'
@@ -101,9 +106,7 @@ function loadData() {
 .chart-box-list {
   display: flex;
   flex-wrap: wrap;
-}
-.chart {
-  margin-top: var(--spacing-lg);
+  row-gap: var(--spacing-lg);
 }
 
 .chart-1\/2 {

--- a/src/app/main-overview/views/MainOverviewView.vue
+++ b/src/app/main-overview/views/MainOverviewView.vue
@@ -1,7 +1,9 @@
 <template>
-  <OverviewCharts />
+  <div class="kcard-stack">
+    <OverviewCharts />
 
-  <MeshResources class="mt-4" />
+    <MeshResources />
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/src/app/main-overview/views/MainOverviewView.vue
+++ b/src/app/main-overview/views/MainOverviewView.vue
@@ -1,6 +1,7 @@
 <template>
-  <OverviewCharts class="mt-16" />
-  <MeshResources class="mt-8" />
+  <OverviewCharts />
+
+  <MeshResources class="mt-4" />
 </template>
 
 <script lang="ts" setup>

--- a/src/app/main-overview/views/__snapshots__/MainOverviewView.spec.ts.snap
+++ b/src/app/main-overview/views/__snapshots__/MainOverviewView.spec.ts.snap
@@ -3,184 +3,203 @@
 exports[`MainOverviewView.vue renders basic snapshot 1`] = `
 <div>
   
-  <div
-    class="chart-box-list mt-16"
+  <section
+    aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+    class="kong-card border"
   >
-    <!--v-if-->
-    <!--v-if-->
+    <!---->
+    <!---->
     <div
-      class="chart chart chart-1/3"
+      class="k-card-content d-flex"
     >
       <div
-        class="chart-canvas-container"
+        class="k-card-body"
+        id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
       >
+        
         <div
-          class="chart-title-box"
+          class="chart-box-list"
         >
+          <!--v-if-->
+          <!--v-if-->
           <div
-            class="chart-title"
+            class="chart chart chart-1/3"
           >
-            <span
-              class="chart-title__total"
+            <div
+              class="chart-canvas-container"
             >
-              0
-            </span>
-             Meshes 
-            <!--v-if-->
+              <div
+                class="chart-title-box"
+              >
+                <div
+                  class="chart-title"
+                >
+                  <span
+                    class="chart-title__total"
+                  >
+                    0
+                  </span>
+                   Meshes 
+                  <!--v-if-->
+                </div>
+              </div>
+              <canvas
+                height="0"
+                style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                width="0"
+              />
+            </div>
+            <div
+              class="chart-legend"
+            >
+              
+              
+            </div>
+          </div>
+          <div
+            class="chart chart chart-1/3"
+          >
+            <div
+              class="chart-canvas-container"
+            >
+              <div
+                class="chart-title-box"
+              >
+                <div
+                  class="chart-title"
+                >
+                  <span
+                    class="chart-title__total"
+                  >
+                    0
+                  </span>
+                   Services 
+                  <!--v-if-->
+                </div>
+              </div>
+              <canvas
+                height="0"
+                style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                width="0"
+              />
+            </div>
+            <div
+              class="chart-legend"
+            >
+              
+              
+            </div>
+          </div>
+          <div
+            class="chart chart chart-1/3"
+          >
+            <div
+              class="chart-canvas-container"
+            >
+              <div
+                class="chart-title-box"
+              >
+                <div
+                  class="chart-title"
+                >
+                  <span
+                    class="chart-title__total"
+                  >
+                    0
+                  </span>
+                   DP Proxies 
+                  <!--v-if-->
+                </div>
+              </div>
+              <canvas
+                height="0"
+                style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                width="0"
+              />
+            </div>
+            <div
+              class="chart-legend"
+            >
+              
+              
+            </div>
+          </div>
+          <div
+            class="chart chart chart-1/2 chart-offset-left-1/6"
+          >
+            <div
+              class="chart-canvas-container"
+            >
+              <div
+                class="chart-title-box"
+              >
+                <div
+                  class="chart-title"
+                >
+                  <!--v-if-->
+                   Kuma DP 
+                  <span
+                    class="chart-title__subtitle"
+                  >
+                    versions
+                  </span>
+                </div>
+              </div>
+              <canvas
+                height="0"
+                style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                width="0"
+              />
+            </div>
+            <div
+              class="chart-legend"
+            >
+              
+              
+            </div>
+          </div>
+          <div
+            class="chart chart chart-1/2 chart-offset-right-1/6"
+          >
+            <div
+              class="chart-canvas-container"
+            >
+              <div
+                class="chart-title-box"
+              >
+                <div
+                  class="chart-title"
+                >
+                  <!--v-if-->
+                   Envoy 
+                  <span
+                    class="chart-title__subtitle"
+                  >
+                    versions
+                  </span>
+                </div>
+              </div>
+              <canvas
+                height="0"
+                style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
+                width="0"
+              />
+            </div>
+            <div
+              class="chart-legend"
+            >
+              
+              
+            </div>
           </div>
         </div>
-        <canvas
-          height="0"
-          style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-          width="0"
-        />
-      </div>
-      <div
-        class="chart-legend"
-      >
-        
         
       </div>
+      <!---->
     </div>
-    <div
-      class="chart chart chart-1/3"
-    >
-      <div
-        class="chart-canvas-container"
-      >
-        <div
-          class="chart-title-box"
-        >
-          <div
-            class="chart-title"
-          >
-            <span
-              class="chart-title__total"
-            >
-              0
-            </span>
-             Services 
-            <!--v-if-->
-          </div>
-        </div>
-        <canvas
-          height="0"
-          style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-          width="0"
-        />
-      </div>
-      <div
-        class="chart-legend"
-      >
-        
-        
-      </div>
-    </div>
-    <div
-      class="chart chart chart-1/3"
-    >
-      <div
-        class="chart-canvas-container"
-      >
-        <div
-          class="chart-title-box"
-        >
-          <div
-            class="chart-title"
-          >
-            <span
-              class="chart-title__total"
-            >
-              0
-            </span>
-             DP Proxies 
-            <!--v-if-->
-          </div>
-        </div>
-        <canvas
-          height="0"
-          style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-          width="0"
-        />
-      </div>
-      <div
-        class="chart-legend"
-      >
-        
-        
-      </div>
-    </div>
-    <div
-      class="chart chart chart-1/2 chart-offset-left-1/6"
-    >
-      <div
-        class="chart-canvas-container"
-      >
-        <div
-          class="chart-title-box"
-        >
-          <div
-            class="chart-title"
-          >
-            <!--v-if-->
-             Kuma DP 
-            <span
-              class="chart-title__subtitle"
-            >
-              versions
-            </span>
-          </div>
-        </div>
-        <canvas
-          height="0"
-          style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-          width="0"
-        />
-      </div>
-      <div
-        class="chart-legend"
-      >
-        
-        
-      </div>
-    </div>
-    <div
-      class="chart chart chart-1/2 chart-offset-right-1/6"
-    >
-      <div
-        class="chart-canvas-container"
-      >
-        <div
-          class="chart-title-box"
-        >
-          <div
-            class="chart-title"
-          >
-            <!--v-if-->
-             Envoy 
-            <span
-              class="chart-title__subtitle"
-            >
-              versions
-            </span>
-          </div>
-        </div>
-        <canvas
-          height="0"
-          style="display: block; box-sizing: border-box; height: 0px; width: 0px;"
-          width="0"
-        />
-      </div>
-      <div
-        class="chart-legend"
-      >
-        
-        
-      </div>
-    </div>
-  </div>
+  </section>
   <div
-    class="resource-list mt-8"
+    class="resource-list mt-4"
   >
     <section
       aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"

--- a/src/app/main-overview/views/__snapshots__/MainOverviewView.spec.ts.snap
+++ b/src/app/main-overview/views/__snapshots__/MainOverviewView.spec.ts.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MainOverviewView.vue renders basic snapshot 1`] = `
-<div>
-  
+<div
+  class="kcard-stack"
+>
   <section
     aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
     class="kong-card border"
@@ -199,7 +200,7 @@ exports[`MainOverviewView.vue renders basic snapshot 1`] = `
     </div>
   </section>
   <div
-    class="resource-list mt-4"
+    class="kcard-list"
   >
     <section
       aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
@@ -493,6 +494,5 @@ exports[`MainOverviewView.vue renders basic snapshot 1`] = `
       </div>
     </section>
   </div>
-  
 </div>
 `;

--- a/src/app/mesh-overview/components/MeshCharts.vue
+++ b/src/app/mesh-overview/components/MeshCharts.vue
@@ -51,6 +51,8 @@ function loadData() {
 <style lang="scss" scoped>
 .chart-box-list {
   display: flex;
+  flex-wrap: wrap;
+  row-gap: var(--spacing-lg);
 }
 
 .chart-box-list > * {

--- a/src/app/mesh-overview/views/MeshOverviewView.vue
+++ b/src/app/mesh-overview/views/MeshOverviewView.vue
@@ -1,97 +1,97 @@
 <template>
-  <MeshCharts class="mt-24" />
-
-  <ContentWrapper class="mt-8">
-    <template #content>
-      <KCard
-        v-if="mesh !== null"
-        border-variant="noBorder"
-      >
-        <template #body>
-          <LabelList
-            :has-error="hasError"
-            :is-loading="isLoading"
-            :is-empty="isEmpty"
-          >
-            <div>
-              <ul>
-                <li
-                  v-for="(value, key) in basicMesh"
-                  :key="key"
-                >
-                  <h4>{{ key }}</h4>
-
-                  <KBadge
-                    v-if="typeof value === 'boolean'"
-                    :appearance="value ? 'success' : 'danger'"
-                  >
-                    {{ value ? 'Enabled' : 'Disabled' }}
-                  </KBadge>
-
-                  <p v-else>
-                    {{ value }}
-                  </p>
-                </li>
-              </ul>
-            </div>
-
-            <div>
-              <ul>
-                <li
-                  v-for="(value, key) in extendedMesh"
-                  :key="key"
-                >
-                  <h4>{{ key }}</h4>
-
-                  <KBadge
-                    v-if="typeof value === 'boolean'"
-                    :appearance="value ? 'success' : 'danger'"
-                  >
-                    {{ value ? 'Enabled' : 'Disabled' }}
-                  </KBadge>
-
-                  <p v-else>
-                    {{ value }}
-                  </p>
-                </li>
-              </ul>
-            </div>
-
-            <div>
-              <ul class="policy-counts">
-                <li>
-                  <h4>
-                    Policies ({{ totalPolicyCount }})
-                  </h4>
-                  <ul>
-                    <template
-                      v-for="(item, key) in policyCounts"
-                      :key="key"
-                    >
-                      <li
-                        v-if="item.length !== 0"
-                      >
-                        <router-link
-                          :to="{
-                            name: 'policy',
-                            params: {
-                              policyPath: item.path
-                            }
-                          }"
-                        >
-                          {{ item.name }}: {{ item.length }}
-                        </router-link>
-                      </li>
-                    </template>
-                  </ul>
-                </li>
-              </ul>
-            </div>
-          </LabelList>
-        </template>
-      </KCard>
+  <KCard>
+    <template #body>
+      <MeshCharts />
     </template>
-  </ContentWrapper>
+  </KCard>
+
+  <KCard
+    v-if="mesh !== null"
+    class="mt-4"
+  >
+    <template #body>
+      <LabelList
+        :has-error="hasError"
+        :is-loading="isLoading"
+        :is-empty="isEmpty"
+      >
+        <div>
+          <ul>
+            <li
+              v-for="(value, key) in basicMesh"
+              :key="key"
+            >
+              <h4>{{ key }}</h4>
+
+              <KBadge
+                v-if="typeof value === 'boolean'"
+                :appearance="value ? 'success' : 'danger'"
+              >
+                {{ value ? 'Enabled' : 'Disabled' }}
+              </KBadge>
+
+              <p v-else>
+                {{ value }}
+              </p>
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <ul>
+            <li
+              v-for="(value, key) in extendedMesh"
+              :key="key"
+            >
+              <h4>{{ key }}</h4>
+
+              <KBadge
+                v-if="typeof value === 'boolean'"
+                :appearance="value ? 'success' : 'danger'"
+              >
+                {{ value ? 'Enabled' : 'Disabled' }}
+              </KBadge>
+
+              <p v-else>
+                {{ value }}
+              </p>
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <ul class="policy-counts">
+            <li>
+              <h4>
+                Policies ({{ totalPolicyCount }})
+              </h4>
+              <ul>
+                <template
+                  v-for="(item, key) in policyCounts"
+                  :key="key"
+                >
+                  <li
+                    v-if="item.length !== 0"
+                  >
+                    <router-link
+                      :to="{
+                        name: 'policy',
+                        params: {
+                          policyPath: item.path
+                        }
+                      }"
+                    >
+                      {{ item.name }}: {{ item.length }}
+                    </router-link>
+                  </li>
+                </template>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </LabelList>
+    </template>
+  </KCard>
 
   <KCard
     v-if="rawMesh !== null"
@@ -114,7 +114,6 @@ import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
 import MeshCharts from '../components/MeshCharts.vue'
-import ContentWrapper from '@/app/common/ContentWrapper.vue'
 import LabelList from '@/app/common/LabelList.vue'
 import MeshResources from '@/app/common/MeshResources.vue'
 import YamlView from '@/app/common/YamlView.vue'

--- a/src/app/mesh-overview/views/MeshOverviewView.vue
+++ b/src/app/mesh-overview/views/MeshOverviewView.vue
@@ -1,111 +1,107 @@
 <template>
-  <KCard>
-    <template #body>
-      <MeshCharts />
-    </template>
-  </KCard>
+  <div class="kcard-stack">
+    <KCard>
+      <template #body>
+        <MeshCharts />
+      </template>
+    </KCard>
 
-  <KCard
-    v-if="mesh !== null"
-    class="mt-4"
-  >
-    <template #body>
-      <LabelList
-        :has-error="hasError"
-        :is-loading="isLoading"
-        :is-empty="isEmpty"
-      >
-        <div>
-          <ul>
-            <li
-              v-for="(value, key) in basicMesh"
-              :key="key"
-            >
-              <h4>{{ key }}</h4>
-
-              <KBadge
-                v-if="typeof value === 'boolean'"
-                :appearance="value ? 'success' : 'danger'"
+    <KCard v-if="mesh !== null">
+      <template #body>
+        <LabelList
+          :has-error="hasError"
+          :is-loading="isLoading"
+          :is-empty="isEmpty"
+        >
+          <div>
+            <ul>
+              <li
+                v-for="(value, key) in basicMesh"
+                :key="key"
               >
-                {{ value ? 'Enabled' : 'Disabled' }}
-              </KBadge>
+                <h4>{{ key }}</h4>
 
-              <p v-else>
-                {{ value }}
-              </p>
-            </li>
-          </ul>
-        </div>
-
-        <div>
-          <ul>
-            <li
-              v-for="(value, key) in extendedMesh"
-              :key="key"
-            >
-              <h4>{{ key }}</h4>
-
-              <KBadge
-                v-if="typeof value === 'boolean'"
-                :appearance="value ? 'success' : 'danger'"
-              >
-                {{ value ? 'Enabled' : 'Disabled' }}
-              </KBadge>
-
-              <p v-else>
-                {{ value }}
-              </p>
-            </li>
-          </ul>
-        </div>
-
-        <div>
-          <ul class="policy-counts">
-            <li>
-              <h4>
-                Policies ({{ totalPolicyCount }})
-              </h4>
-              <ul>
-                <template
-                  v-for="(item, key) in policyCounts"
-                  :key="key"
+                <KBadge
+                  v-if="typeof value === 'boolean'"
+                  :appearance="value ? 'success' : 'danger'"
                 >
-                  <li
-                    v-if="item.length !== 0"
+                  {{ value ? 'Enabled' : 'Disabled' }}
+                </KBadge>
+
+                <p v-else>
+                  {{ value }}
+                </p>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <ul>
+              <li
+                v-for="(value, key) in extendedMesh"
+                :key="key"
+              >
+                <h4>{{ key }}</h4>
+
+                <KBadge
+                  v-if="typeof value === 'boolean'"
+                  :appearance="value ? 'success' : 'danger'"
+                >
+                  {{ value ? 'Enabled' : 'Disabled' }}
+                </KBadge>
+
+                <p v-else>
+                  {{ value }}
+                </p>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <ul class="policy-counts">
+              <li>
+                <h4>
+                  Policies ({{ totalPolicyCount }})
+                </h4>
+                <ul>
+                  <template
+                    v-for="(item, key) in policyCounts"
+                    :key="key"
                   >
-                    <router-link
-                      :to="{
-                        name: 'policy',
-                        params: {
-                          policyPath: item.path
-                        }
-                      }"
+                    <li
+                      v-if="item.length !== 0"
                     >
-                      {{ item.name }}: {{ item.length }}
-                    </router-link>
-                  </li>
-                </template>
-              </ul>
-            </li>
-          </ul>
-        </div>
-      </LabelList>
-    </template>
-  </KCard>
+                      <router-link
+                        :to="{
+                          name: 'policy',
+                          params: {
+                            policyPath: item.path
+                          }
+                        }"
+                      >
+                        {{ item.name }}: {{ item.length }}
+                      </router-link>
+                    </li>
+                  </template>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </LabelList>
+      </template>
+    </KCard>
 
-  <KCard
-    v-if="rawMesh !== null"
-    class="mt-4"
-  >
-    <template #body>
-      <YamlView
-        id="code-block-mesh"
-        :content="rawMesh"
-      />
-    </template>
-  </KCard>
+    <KCard v-if="rawMesh !== null">
+      <template #body>
+        <YamlView
+          id="code-block-mesh"
+          :content="rawMesh"
+        />
+      </template>
+    </KCard>
 
-  <MeshResources class="mt-6" />
+    <MeshResources />
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="policy-details component-frame">
+  <div class="policy-details kcard-border">
     <LoadingBlock v-if="isLoading" />
 
     <ErrorBlock

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -22,7 +22,7 @@
       </KAlert>
     </div>
 
-    <FrameSkeleton>
+    <div class="kcard-border">
       <DataOverview
         :selected-entity-name="entity.name"
         :page-size="PAGE_SIZE_DEFAULT"
@@ -76,7 +76,9 @@
           </KButton>
         </template>
       </DataOverview>
+    </div>
 
+    <div class="kcard-border mt-4">
       <TabsWidget
         v-if="isEmpty === false"
         :has-error="error !== null"
@@ -135,7 +137,7 @@
           />
         </template>
       </TabsWidget>
-    </FrameSkeleton>
+    </div>
   </div>
 </template>
 
@@ -151,7 +153,6 @@ import { RouteLocationNamedRaw, useRoute, useRouter } from 'vue-router'
 import PolicyConnections from '../components/PolicyConnections.vue'
 import DataOverview from '@/app/common/DataOverview.vue'
 import DocumentationLink from '@/app/common/DocumentationLink.vue'
-import FrameSkeleton from '@/app/common/FrameSkeleton.vue'
 import LabelList from '@/app/common/LabelList.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
 import YamlView from '@/app/common/YamlView.vue'

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -4,139 +4,144 @@
     class="relative"
     :class="policyType.path"
   >
-    <div
-      v-if="policyType.isExperimental"
-      class="mb-4"
-    >
-      <KAlert appearance="warning">
-        <template #alertMessage>
-          <p>
-            <strong>Warning</strong> This policy is experimental. If you encountered any problem please open an
-            <a
-              href="https://github.com/kumahq/kuma/issues/new/choose"
-              target="_blank"
-              rel="noopener noreferrer"
-            >issue</a>
-          </p>
-        </template>
-      </KAlert>
-    </div>
-
-    <div class="kcard-border">
-      <DataOverview
-        :selected-entity-name="entity.name"
-        :page-size="PAGE_SIZE_DEFAULT"
-        :error="error"
-        :is-loading="isLoading"
-        :empty-state="{
-          title: 'No Data',
-          message: `There are no ${policyType.name} policies present.`,
-        }"
-        :table-data="tableData"
-        :table-data-is-empty="tableDataIsEmpty"
-        :next="nextUrl"
-        :page-offset="pageOffset"
-        @table-action="getEntity"
-        @load-data="loadData"
-      >
+    <div class="kcard-stack">
+      <div class="kcard-border">
+        <KCard
+          v-if="policyType.isExperimental"
+          border-variant="noBorder"
+          class="mb-4"
         >
-        <template #additionalControls>
-          <KSelect
-            label="Policies"
-            :items="policySelectItems"
-            :label-attributes="{ class: 'visually-hidden' }"
-            appearance="select"
-            :enable-filtering="true"
-            @selected="changePolicyType"
-          >
-            <template #item-template="{ item }">
-              <span
-                :class="{
-                  'policy-type-empty': policyTypeNamesWithNoPolicies.includes(item.label)
-                }"
-              >
-                {{ item.label }}
-              </span>
-            </template>
-          </KSelect>
+          <template #body>
+            <KAlert appearance="warning">
+              <template #alertMessage>
+                <p>
+                  <strong>Warning</strong> This policy is experimental. If you encountered any problem please open an
+                  <a
+                    href="https://github.com/kumahq/kuma/issues/new/choose"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >issue</a>
+                </p>
+              </template>
+            </KAlert>
+          </template>
+        </KCard>
 
-          <DocumentationLink
-            :href="`${env('KUMA_DOCS_URL')}/policies/${policyType.path}/?${env('KUMA_UTM_QUERY_PARAMS')}`"
-            data-testid="policy-documentation-link"
-          />
-
-          <KButton
-            v-if="$route.query.ns"
-            class="back-button"
-            appearance="primary"
-            icon="arrowLeft"
-            :to="{ name: 'policy', params: { policyPath: props.policyPath } }"
+        <DataOverview
+          :selected-entity-name="entity.name"
+          :page-size="PAGE_SIZE_DEFAULT"
+          :error="error"
+          :is-loading="isLoading"
+          :empty-state="{
+            title: 'No Data',
+            message: `There are no ${policyType.name} policies present.`,
+          }"
+          :table-data="tableData"
+          :table-data-is-empty="tableDataIsEmpty"
+          :next="nextUrl"
+          :page-offset="pageOffset"
+          @table-action="getEntity"
+          @load-data="loadData"
+        >
           >
-            View all
-          </KButton>
-        </template>
-      </DataOverview>
-    </div>
-
-    <div class="kcard-border mt-4">
-      <TabsWidget
-        v-if="isEmpty === false"
-        :has-error="error !== null"
-        :error="error"
-        :is-loading="isLoading"
-        :tabs="tabs"
-      >
-        <template #tabHeader>
-          <h1
-            class="entity-heading"
-            data-testid="policy-single-entity"
-          >
-            {{ policyType.name }}: {{ entity.name }}
-          </h1>
-        </template>
-
-        <template #overview>
-          <LabelList
-            :has-error="entityHasError"
-            :is-loading="entityIsLoading"
-            :is-empty="entityIsEmpty"
-          >
-            <div data-testid="policy-overview-tab">
-              <ul>
-                <li
-                  v-for="(val, key) in entity"
-                  :key="key"
+          <template #additionalControls>
+            <KSelect
+              label="Policies"
+              :items="policySelectItems"
+              :label-attributes="{ class: 'visually-hidden' }"
+              appearance="select"
+              :enable-filtering="true"
+              @selected="changePolicyType"
+            >
+              <template #item-template="{ item }">
+                <span
+                  :class="{
+                    'policy-type-empty': policyTypeNamesWithNoPolicies.includes(item.label)
+                  }"
                 >
-                  <h4>{{ key }}</h4>
-                  <p>
-                    {{ val }}
-                  </p>
-                </li>
-              </ul>
-            </div>
-          </LabelList>
+                  {{ item.label }}
+                </span>
+              </template>
+            </KSelect>
 
-          <YamlView
-            v-if="rawEntity !== null"
-            id="code-block-policy"
-            class="mt-4"
-            :has-error="entityHasError"
-            :is-loading="entityIsLoading"
-            :is-empty="entityIsEmpty"
-            :content="rawEntity"
-            is-searchable
-          />
-        </template>
+            <DocumentationLink
+              :href="`${env('KUMA_DOCS_URL')}/policies/${policyType.path}/?${env('KUMA_UTM_QUERY_PARAMS')}`"
+              data-testid="policy-documentation-link"
+            />
 
-        <template #affected-dpps>
-          <PolicyConnections
-            v-if="rawEntity !== null"
-            :mesh="rawEntity.mesh"
-            :policy-name="rawEntity.name"
-            :policy-type="policyType.path"
-          />
-        </template>
-      </TabsWidget>
+            <KButton
+              v-if="$route.query.ns"
+              class="back-button"
+              appearance="primary"
+              icon="arrowLeft"
+              :to="{ name: 'policy', params: { policyPath: props.policyPath } }"
+            >
+              View all
+            </KButton>
+          </template>
+        </DataOverview>
+      </div>
+
+      <div class="kcard-border">
+        <TabsWidget
+          v-if="isEmpty === false"
+          :has-error="error !== null"
+          :error="error"
+          :is-loading="isLoading"
+          :tabs="tabs"
+        >
+          <template #tabHeader>
+            <h1
+              class="entity-heading"
+              data-testid="policy-single-entity"
+            >
+              {{ policyType.name }}: {{ entity.name }}
+            </h1>
+          </template>
+
+          <template #overview>
+            <LabelList
+              :has-error="entityHasError"
+              :is-loading="entityIsLoading"
+              :is-empty="entityIsEmpty"
+            >
+              <div data-testid="policy-overview-tab">
+                <ul>
+                  <li
+                    v-for="(val, key) in entity"
+                    :key="key"
+                  >
+                    <h4>{{ key }}</h4>
+                    <p>
+                      {{ val }}
+                    </p>
+                  </li>
+                </ul>
+              </div>
+            </LabelList>
+
+            <YamlView
+              v-if="rawEntity !== null"
+              id="code-block-policy"
+              class="mt-4"
+              :has-error="entityHasError"
+              :is-loading="entityIsLoading"
+              :is-empty="entityIsEmpty"
+              :content="rawEntity"
+              is-searchable
+            />
+          </template>
+
+          <template #affected-dpps>
+            <PolicyConnections
+              v-if="rawEntity !== null"
+              :mesh="rawEntity.mesh"
+              :policy-name="rawEntity.name"
+              :policy-type="policyType.path"
+            />
+          </template>
+        </TabsWidget>
+      </div>
     </div>
   </div>
 </template>
@@ -144,6 +149,7 @@
 <script lang="ts" setup>
 import {
   KAlert,
+  KCard,
   KButton,
   KSelect,
 } from '@kong/kongponents'

--- a/src/app/services/components/ServiceDetails.vue
+++ b/src/app/services/components/ServiceDetails.vue
@@ -1,10 +1,8 @@
 <template>
-  <div class="component-frame">
-    <ServiceSummary
-      :service="props.service"
-      :external-service="externalService"
-    />
-  </div>
+  <ServiceSummary
+    :service="props.service"
+    :external-service="externalService"
+  />
 
   <DataPlaneList
     v-if="props.dataPlaneOverviews !== null"

--- a/src/app/services/components/ServiceSummary.vue
+++ b/src/app/services/components/ServiceSummary.vue
@@ -1,5 +1,5 @@
 <template>
-  <KCard border-variant="noBorder">
+  <KCard>
     <template #body>
       <div class="entity-section-list">
         <section>

--- a/src/app/zones/views/ZoneEgresses.vue
+++ b/src/app/zones/views/ZoneEgresses.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="zoneegresses">
-    <FrameSkeleton>
+    <div class="kcard-border">
       <DataOverview
         :selected-entity-name="entity?.name"
         :page-size="PAGE_SIZE_DEFAULT"
@@ -26,7 +26,9 @@
           </KButton>
         </template>
       </DataOverview>
+    </div>
 
+    <div class="kcard-border mt-4">
       <TabsWidget
         v-if="isEmpty === false && entity !== null"
         :has-error="error !== null"
@@ -103,7 +105,7 @@
           />
         </template>
       </TabsWidget>
-    </FrameSkeleton>
+    </div>
   </div>
 </template>
 
@@ -116,7 +118,6 @@ import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
 import DataOverview from '@/app/common/DataOverview.vue'
 import EnvoyData from '@/app/common/EnvoyData.vue'
-import FrameSkeleton from '@/app/common/FrameSkeleton.vue'
 import LabelList from '@/app/common/LabelList.vue'
 import SubscriptionDetails from '@/app/common/subscriptions/SubscriptionDetails.vue'
 import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vue'

--- a/src/app/zones/views/ZoneEgresses.vue
+++ b/src/app/zones/views/ZoneEgresses.vue
@@ -1,110 +1,112 @@
 <template>
   <div class="zoneegresses">
-    <div class="kcard-border">
-      <DataOverview
-        :selected-entity-name="entity?.name"
-        :page-size="PAGE_SIZE_DEFAULT"
-        :is-loading="isLoading"
-        :error="error"
-        :empty-state="EMPTY_STATE"
-        :table-data="tableData"
-        :table-data-is-empty="isEmpty"
-        :next="nextUrl"
-        :page-offset="pageOffset"
-        @table-action="getEntity"
-        @load-data="loadData"
-      >
-        <template #additionalControls>
-          <KButton
-            v-if="$route.query.ns"
-            class="back-button"
-            appearance="primary"
-            icon="arrowLeft"
-            :to="{ name: 'zoneegresses' }"
-          >
-            View all
-          </KButton>
-        </template>
-      </DataOverview>
-    </div>
-
-    <div class="kcard-border mt-4">
-      <TabsWidget
-        v-if="isEmpty === false && entity !== null"
-        :has-error="error !== null"
-        :is-loading="isLoading"
-        :tabs="TABS"
-      >
-        <template #tabHeader>
-          <h1 class="entity-heading">
-            Zone Egress: {{ entity.name }}
-          </h1>
-        </template>
-
-        <template #overview>
-          <LabelList>
-            <div>
-              <ul>
-                <li
-                  v-for="(value, key) in entity"
-                  :key="key"
-                >
-                  <h4 v-if="value">
-                    {{ key }}
-                  </h4>
-                  <p>
-                    {{ value }}
-                  </p>
-                </li>
-              </ul>
-            </div>
-          </LabelList>
-        </template>
-
-        <template #insights>
-          <AccordionList :initially-open="0">
-            <AccordionItem
-              v-for="(value, key) in subscriptionsReversed"
-              :key="key"
+    <div class="kcard-stack">
+      <div class="kcard-border">
+        <DataOverview
+          :selected-entity-name="entity?.name"
+          :page-size="PAGE_SIZE_DEFAULT"
+          :is-loading="isLoading"
+          :error="error"
+          :empty-state="EMPTY_STATE"
+          :table-data="tableData"
+          :table-data-is-empty="isEmpty"
+          :next="nextUrl"
+          :page-offset="pageOffset"
+          @table-action="getEntity"
+          @load-data="loadData"
+        >
+          <template #additionalControls>
+            <KButton
+              v-if="$route.query.ns"
+              class="back-button"
+              appearance="primary"
+              icon="arrowLeft"
+              :to="{ name: 'zoneegresses' }"
             >
-              <template #accordion-header>
-                <SubscriptionHeader :details="value" />
-              </template>
+              View all
+            </KButton>
+          </template>
+        </DataOverview>
+      </div>
 
-              <template #accordion-content>
-                <SubscriptionDetails
-                  :details="value"
-                  is-discovery-subscription
-                />
-              </template>
-            </AccordionItem>
-          </AccordionList>
-        </template>
+      <div class="kcard-border">
+        <TabsWidget
+          v-if="isEmpty === false && entity !== null"
+          :has-error="error !== null"
+          :is-loading="isLoading"
+          :tabs="TABS"
+        >
+          <template #tabHeader>
+            <h1 class="entity-heading">
+              Zone Egress: {{ entity.name }}
+            </h1>
+          </template>
 
-        <template #xds-configuration>
-          <EnvoyData
-            data-path="xds"
-            :zone-egress-name="entity.name"
-            query-key="envoy-data-zone-egress"
-          />
-        </template>
+          <template #overview>
+            <LabelList>
+              <div>
+                <ul>
+                  <li
+                    v-for="(value, key) in entity"
+                    :key="key"
+                  >
+                    <h4 v-if="value">
+                      {{ key }}
+                    </h4>
+                    <p>
+                      {{ value }}
+                    </p>
+                  </li>
+                </ul>
+              </div>
+            </LabelList>
+          </template>
 
-        <template #envoy-stats>
-          <EnvoyData
-            data-path="stats"
-            :zone-egress-name="entity.name"
-            query-key="envoy-data-zone-egress"
-          />
-        </template>
+          <template #insights>
+            <AccordionList :initially-open="0">
+              <AccordionItem
+                v-for="(value, key) in subscriptionsReversed"
+                :key="key"
+              >
+                <template #accordion-header>
+                  <SubscriptionHeader :details="value" />
+                </template>
 
-        <template #envoy-clusters>
-          <EnvoyData
-            data-path="clusters"
-            :zone-egress-name="entity.name"
-            query-key="envoy-data-zone-egress"
-          />
-        </template>
-      </TabsWidget>
+                <template #accordion-content>
+                  <SubscriptionDetails
+                    :details="value"
+                    is-discovery-subscription
+                  />
+                </template>
+              </AccordionItem>
+            </AccordionList>
+          </template>
+
+          <template #xds-configuration>
+            <EnvoyData
+              data-path="xds"
+              :zone-egress-name="entity.name"
+              query-key="envoy-data-zone-egress"
+            />
+          </template>
+
+          <template #envoy-stats>
+            <EnvoyData
+              data-path="stats"
+              :zone-egress-name="entity.name"
+              query-key="envoy-data-zone-egress"
+            />
+          </template>
+
+          <template #envoy-clusters>
+            <EnvoyData
+              data-path="clusters"
+              :zone-egress-name="entity.name"
+              query-key="envoy-data-zone-egress"
+            />
+          </template>
+        </TabsWidget>
+      </div>
     </div>
   </div>
 </template>

--- a/src/app/zones/views/ZoneIngresses.vue
+++ b/src/app/zones/views/ZoneIngresses.vue
@@ -3,7 +3,10 @@
     <MultizoneInfo v-if="store.getters['config/getMulticlusterStatus'] === false" />
 
     <!-- Zone CPs information for when Multicluster is enabled -->
-    <template v-else>
+    <div
+      v-else
+      class="kcard-stack"
+    >
       <div class="kcard-border">
         <DataOverview
           :selected-entity-name="entity?.name"
@@ -32,7 +35,7 @@
         </DataOverview>
       </div>
 
-      <div class="kcard-border mt-4">
+      <div class="kcard-border">
         <TabsWidget
           v-if="isEmpty === false && entity !== null"
           :has-error="error !== null"
@@ -110,7 +113,7 @@
           </template>
         </TabsWidget>
       </div>
-    </template>
+    </div>
   </div>
 </template>
 

--- a/src/app/zones/views/ZoneIngresses.vue
+++ b/src/app/zones/views/ZoneIngresses.vue
@@ -3,110 +3,114 @@
     <MultizoneInfo v-if="store.getters['config/getMulticlusterStatus'] === false" />
 
     <!-- Zone CPs information for when Multicluster is enabled -->
-    <FrameSkeleton v-else>
-      <DataOverview
-        :selected-entity-name="entity?.name"
-        :page-size="PAGE_SIZE_DEFAULT"
-        :is-loading="isLoading"
-        :error="error"
-        :empty-state="EMPTY_STATE"
-        :table-data="tableData"
-        :table-data-is-empty="isEmpty"
-        :next="nextUrl"
-        :page-offset="pageOffset"
-        @table-action="getEntity"
-        @load-data="loadData"
-      >
-        <template #additionalControls>
-          <KButton
-            v-if="$route.query.ns"
-            class="back-button"
-            appearance="primary"
-            icon="arrowLeft"
-            :to="{ name: 'zoneingresses' }"
-          >
-            View all
-          </KButton>
-        </template>
-      </DataOverview>
-
-      <TabsWidget
-        v-if="isEmpty === false && entity !== null"
-        :has-error="error !== null"
-        :is-loading="isLoading"
-        :tabs="TABS"
-      >
-        <template #tabHeader>
-          <h1 class="entity-heading">
-            Zone Ingress: {{ entity.name }}
-          </h1>
-        </template>
-
-        <template #overview>
-          <LabelList>
-            <div>
-              <ul>
-                <li
-                  v-for="(value, key) in entity"
-                  :key="key"
-                >
-                  <h4>
-                    {{ key }}
-                  </h4>
-                  <p>
-                    {{ value }}
-                  </p>
-                </li>
-              </ul>
-            </div>
-          </LabelList>
-        </template>
-
-        <template #insights>
-          <AccordionList :initially-open="0">
-            <AccordionItem
-              v-for="(value, key) in subscriptionsReversed"
-              :key="key"
+    <template v-else>
+      <div class="kcard-border">
+        <DataOverview
+          :selected-entity-name="entity?.name"
+          :page-size="PAGE_SIZE_DEFAULT"
+          :is-loading="isLoading"
+          :error="error"
+          :empty-state="EMPTY_STATE"
+          :table-data="tableData"
+          :table-data-is-empty="isEmpty"
+          :next="nextUrl"
+          :page-offset="pageOffset"
+          @table-action="getEntity"
+          @load-data="loadData"
+        >
+          <template #additionalControls>
+            <KButton
+              v-if="$route.query.ns"
+              class="back-button"
+              appearance="primary"
+              icon="arrowLeft"
+              :to="{ name: 'zoneingresses' }"
             >
-              <template #accordion-header>
-                <SubscriptionHeader :details="value" />
-              </template>
+              View all
+            </KButton>
+          </template>
+        </DataOverview>
+      </div>
 
-              <template #accordion-content>
-                <SubscriptionDetails
-                  :details="value"
-                  is-discovery-subscription
-                />
-              </template>
-            </AccordionItem>
-          </AccordionList>
-        </template>
+      <div class="kcard-border mt-4">
+        <TabsWidget
+          v-if="isEmpty === false && entity !== null"
+          :has-error="error !== null"
+          :is-loading="isLoading"
+          :tabs="TABS"
+        >
+          <template #tabHeader>
+            <h1 class="entity-heading">
+              Zone Ingress: {{ entity.name }}
+            </h1>
+          </template>
 
-        <template #xds-configuration>
-          <EnvoyData
-            data-path="xds"
-            :zone-ingress-name="entity.name"
-            query-key="envoy-data-zone-ingress"
-          />
-        </template>
+          <template #overview>
+            <LabelList>
+              <div>
+                <ul>
+                  <li
+                    v-for="(value, key) in entity"
+                    :key="key"
+                  >
+                    <h4>
+                      {{ key }}
+                    </h4>
+                    <p>
+                      {{ value }}
+                    </p>
+                  </li>
+                </ul>
+              </div>
+            </LabelList>
+          </template>
 
-        <template #envoy-stats>
-          <EnvoyData
-            data-path="stats"
-            :zone-ingress-name="entity.name"
-            query-key="envoy-data-zone-ingress"
-          />
-        </template>
+          <template #insights>
+            <AccordionList :initially-open="0">
+              <AccordionItem
+                v-for="(value, key) in subscriptionsReversed"
+                :key="key"
+              >
+                <template #accordion-header>
+                  <SubscriptionHeader :details="value" />
+                </template>
 
-        <template #envoy-clusters>
-          <EnvoyData
-            data-path="clusters"
-            :zone-ingress-name="entity.name"
-            query-key="envoy-data-zone-ingress"
-          />
-        </template>
-      </TabsWidget>
-    </FrameSkeleton>
+                <template #accordion-content>
+                  <SubscriptionDetails
+                    :details="value"
+                    is-discovery-subscription
+                  />
+                </template>
+              </AccordionItem>
+            </AccordionList>
+          </template>
+
+          <template #xds-configuration>
+            <EnvoyData
+              data-path="xds"
+              :zone-ingress-name="entity.name"
+              query-key="envoy-data-zone-ingress"
+            />
+          </template>
+
+          <template #envoy-stats>
+            <EnvoyData
+              data-path="stats"
+              :zone-ingress-name="entity.name"
+              query-key="envoy-data-zone-ingress"
+            />
+          </template>
+
+          <template #envoy-clusters>
+            <EnvoyData
+              data-path="clusters"
+              :zone-ingress-name="entity.name"
+              query-key="envoy-data-zone-ingress"
+            />
+          </template>
+        </TabsWidget>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -120,7 +124,6 @@ import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
 import DataOverview from '@/app/common/DataOverview.vue'
 import EnvoyData from '@/app/common/EnvoyData.vue'
-import FrameSkeleton from '@/app/common/FrameSkeleton.vue'
 import LabelList from '@/app/common/LabelList.vue'
 import SubscriptionDetails from '@/app/common/subscriptions/SubscriptionDetails.vue'
 import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vue'

--- a/src/app/zones/views/ZonesView.vue
+++ b/src/app/zones/views/ZonesView.vue
@@ -2,111 +2,114 @@
   <div class="zones">
     <MultizoneInfo v-if="store.getters['config/getMulticlusterStatus'] === false" />
 
-    <!-- Zone CPs information for when Multicluster is enabled -->
-    <FrameSkeleton v-else>
-      <DataOverview
-        :selected-entity-name="entity?.name"
-        :page-size="PAGE_SIZE_DEFAULT"
-        :is-loading="isLoading"
-        :error="error"
-        :empty-state="EMPTY_STATE"
-        :table-data="tableData"
-        :table-data-is-empty="tableDataIsEmpty"
-        :show-warnings="tableData.data.some((item) => item.withWarnings)"
-        :next="nextUrl"
-        :page-offset="pageOffset"
-        @table-action="getEntity"
-        @load-data="loadData"
-      >
-        <template #additionalControls>
-          <KButton
-            v-if="$route.query.ns"
-            class="back-button"
-            appearance="primary"
-            icon="arrowLeft"
-            :to="{ name: 'zones' }"
-          >
-            View all
-          </KButton>
-        </template>
-      </DataOverview>
-
-      <TabsWidget
-        v-if="isEmpty === false && entity !== null"
-        :has-error="error !== null"
-        :is-loading="isLoading"
-        :tabs="filterTabs()"
-      >
-        <template #tabHeader>
-          <h1 class="entity-heading">
-            Zone: {{ entity.name }}
-          </h1>
-        </template>
-
-        <template #overview>
-          <LabelList
-            :has-error="entityHasError"
-            :is-loading="entityIsLoading"
-            :is-empty="entityIsEmpty"
-          >
-            <div>
-              <ul>
-                <li
-                  v-for="(value, key) in entity"
-                  :key="key"
-                >
-                  <h4 v-if="value">
-                    {{ key }}
-                  </h4>
-
-                  <p v-if="key === 'status'">
-                    <KBadge :appearance="value === 'Offline' ? 'danger' : 'success'">
-                      {{ value }}
-                    </KBadge>
-                  </p>
-
-                  <p v-else>
-                    {{ value }}
-                  </p>
-                </li>
-              </ul>
-            </div>
-          </LabelList>
-        </template>
-
-        <template #insights>
-          <AccordionList :initially-open="0">
-            <AccordionItem
-              v-for="(value, key) in subscriptionsReversed"
-              :key="key"
+    <template v-else>
+      <div class="kcard-border">
+        <DataOverview
+          :selected-entity-name="entity?.name"
+          :page-size="PAGE_SIZE_DEFAULT"
+          :is-loading="isLoading"
+          :error="error"
+          :empty-state="EMPTY_STATE"
+          :table-data="tableData"
+          :table-data-is-empty="tableDataIsEmpty"
+          :show-warnings="tableData.data.some((item) => item.withWarnings)"
+          :next="nextUrl"
+          :page-offset="pageOffset"
+          @table-action="getEntity"
+          @load-data="loadData"
+        >
+          <template #additionalControls>
+            <KButton
+              v-if="$route.query.ns"
+              class="back-button"
+              appearance="primary"
+              icon="arrowLeft"
+              :to="{ name: 'zones' }"
             >
-              <template #accordion-header>
-                <SubscriptionHeader :details="value" />
-              </template>
+              View all
+            </KButton>
+          </template>
+        </DataOverview>
+      </div>
 
-              <template #accordion-content>
-                <SubscriptionDetails :details="value" />
-              </template>
-            </AccordionItem>
-          </AccordionList>
-        </template>
+      <div class="kcard-border mt-4">
+        <TabsWidget
+          v-if="isEmpty === false && entity !== null"
+          :has-error="error !== null"
+          :is-loading="isLoading"
+          :tabs="filterTabs()"
+        >
+          <template #tabHeader>
+            <h1 class="entity-heading">
+              Zone: {{ entity.name }}
+            </h1>
+          </template>
 
-        <template #config>
-          <CodeBlock
-            v-if="codeOutput"
-            id="code-block-zone-config"
-            language="json"
-            :code="codeOutput"
-            is-searchable
-            query-key="zone-config"
-          />
-        </template>
+          <template #overview>
+            <LabelList
+              :has-error="entityHasError"
+              :is-loading="entityIsLoading"
+              :is-empty="entityIsEmpty"
+            >
+              <div>
+                <ul>
+                  <li
+                    v-for="(value, key) in entity"
+                    :key="key"
+                  >
+                    <h4 v-if="value">
+                      {{ key }}
+                    </h4>
 
-        <template #warnings>
-          <WarningsWidget :warnings="warnings" />
-        </template>
-      </TabsWidget>
-    </FrameSkeleton>
+                    <p v-if="key === 'status'">
+                      <KBadge :appearance="value === 'Offline' ? 'danger' : 'success'">
+                        {{ value }}
+                      </KBadge>
+                    </p>
+
+                    <p v-else>
+                      {{ value }}
+                    </p>
+                  </li>
+                </ul>
+              </div>
+            </LabelList>
+          </template>
+
+          <template #insights>
+            <AccordionList :initially-open="0">
+              <AccordionItem
+                v-for="(value, key) in subscriptionsReversed"
+                :key="key"
+              >
+                <template #accordion-header>
+                  <SubscriptionHeader :details="value" />
+                </template>
+
+                <template #accordion-content>
+                  <SubscriptionDetails :details="value" />
+                </template>
+              </AccordionItem>
+            </AccordionList>
+          </template>
+
+          <template #config>
+            <CodeBlock
+              v-if="codeOutput"
+              id="code-block-zone-config"
+              language="json"
+              :code="codeOutput"
+              is-searchable
+              query-key="zone-config"
+            />
+          </template>
+
+          <template #warnings>
+            <WarningsWidget :warnings="warnings" />
+          </template>
+        </TabsWidget>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -120,7 +123,6 @@ import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
 import CodeBlock from '@/app/common/CodeBlock.vue'
 import DataOverview from '@/app/common/DataOverview.vue'
-import FrameSkeleton from '@/app/common/FrameSkeleton.vue'
 import LabelList from '@/app/common/LabelList.vue'
 import SubscriptionDetails from '@/app/common/subscriptions/SubscriptionDetails.vue'
 import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vue'

--- a/src/app/zones/views/ZonesView.vue
+++ b/src/app/zones/views/ZonesView.vue
@@ -2,7 +2,10 @@
   <div class="zones">
     <MultizoneInfo v-if="store.getters['config/getMulticlusterStatus'] === false" />
 
-    <template v-else>
+    <div
+      v-else
+      class="kcard-stack"
+    >
       <div class="kcard-border">
         <DataOverview
           :selected-entity-name="entity?.name"
@@ -32,7 +35,7 @@
         </DataOverview>
       </div>
 
-      <div class="kcard-border mt-4">
+      <div class="kcard-border">
         <TabsWidget
           v-if="isEmpty === false && entity !== null"
           :has-error="error !== null"
@@ -109,7 +112,7 @@
           </template>
         </TabsWidget>
       </div>
-    </template>
+    </div>
   </div>
 </template>
 

--- a/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
@@ -5,9 +5,8 @@ exports[`ZoneEgresses.vue renders snapshot when multizone 1`] = `
   class="zoneegresses"
 >
   <div
-    class="component-frame"
+    class="kcard-border"
   >
-    
     <div
       class="data-overview"
       data-testid="data-overview"
@@ -174,6 +173,10 @@ exports[`ZoneEgresses.vue renders snapshot when multizone 1`] = `
         <!--v-if-->
       </div>
     </div>
+  </div>
+  <div
+    class="kcard-border mt-4"
+  >
     <div
       class="tab-container"
       data-testid="tab-container"
@@ -388,7 +391,6 @@ exports[`ZoneEgresses.vue renders snapshot when multizone 1`] = `
       </div>
       
     </div>
-    
   </div>
 </div>
 `;
@@ -398,9 +400,8 @@ exports[`ZoneEgresses.vue renders snapshot when no multizone 1`] = `
   class="zoneegresses"
 >
   <div
-    class="component-frame"
+    class="kcard-border"
   >
-    
     <div
       class="data-overview"
       data-testid="data-overview"
@@ -567,6 +568,10 @@ exports[`ZoneEgresses.vue renders snapshot when no multizone 1`] = `
         <!--v-if-->
       </div>
     </div>
+  </div>
+  <div
+    class="kcard-border mt-4"
+  >
     <div
       class="tab-container"
       data-testid="tab-container"
@@ -781,7 +786,6 @@ exports[`ZoneEgresses.vue renders snapshot when no multizone 1`] = `
       </div>
       
     </div>
-    
   </div>
 </div>
 `;

--- a/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
@@ -5,391 +5,395 @@ exports[`ZoneEgresses.vue renders snapshot when multizone 1`] = `
   class="zoneegresses"
 >
   <div
-    class="kcard-border"
+    class="kcard-stack"
   >
     <div
-      class="data-overview"
-      data-testid="data-overview"
+      class="kcard-border"
     >
       <div
-        class="data-table-controls mb-2"
+        class="data-overview"
+        data-testid="data-overview"
       >
-        
-        
-        <button
-          class="k-button medium rounded primary refresh-button"
-          data-testid="data-overview-refresh-button"
-          type="button"
-        >
-          
-          <span
-            class="k-button-icon kong-icon kong-icon-redo"
-          >
-            <svg
-              fill="white"
-              height="16"
-              role="img"
-              viewBox="0 0 17 14"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              
-  
-              <title>
-                Redo
-              </title>
-              
-  
-              <path
-                clip-rule="evenodd"
-                d="M12.466 12.06a6.868 6.868 0 112.196-5.676l.85-.85a.847.847 0 011.201-.017c.327.327.315.869-.017 1.2L14.233 9.18c-.342.342-.88.35-1.208.023L10.654 6.83c-.324-.324-.314-.859.028-1.2.34-.34.881-.348 1.2-.029l.847.846a4.938 4.938 0 10-1.63 4.245l1.367 1.367z"
-                fill="white"
-                fill-rule="evenodd"
-              />
-              
-
-            </svg>
-            
-
-          </span>
-          
-          
-           Refresh 
-          
-          <!---->
-        </button>
-      </div>
-      <div
-        class="data-overview-content"
-      >
-        <!-- data -->
         <div
-          class="data-overview-table"
+          class="data-table-controls mb-2"
         >
-          <div
-            class="k-table-container data-overview-table"
-            data-testid="data-overview-table"
-            is-clickable=""
+          
+          
+          <button
+            class="k-button medium rounded primary refresh-button"
+            data-testid="data-overview-refresh-button"
+            type="button"
           >
-            <!---->
-            <section
-              class="k-table-wrapper"
+            
+            <span
+              class="k-button-icon kong-icon kong-icon-redo"
             >
-              <table
-                class="k-table has-hover is-clickable"
-                data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              <svg
+                fill="white"
+                height="16"
+                role="img"
+                viewBox="0 0 17 14"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <thead
-                  class=""
+                
+  
+                <title>
+                  Redo
+                </title>
+                
+  
+                <path
+                  clip-rule="evenodd"
+                  d="M12.466 12.06a6.868 6.868 0 112.196-5.676l.85-.85a.847.847 0 011.201-.017c.327.327.315.869-.017 1.2L14.233 9.18c-.342.342-.88.35-1.208.023L10.654 6.83c-.324-.324-.314-.859.028-1.2.34-.34.881-.348 1.2-.029l.847.846a4.938 4.938 0 10-1.63 4.245l1.367 1.367z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+                
+
+              </svg>
+              
+
+            </span>
+            
+            
+             Refresh 
+            
+            <!---->
+          </button>
+        </div>
+        <div
+          class="data-overview-content"
+        >
+          <!-- data -->
+          <div
+            class="data-overview-table"
+          >
+            <div
+              class="k-table-container data-overview-table"
+              data-testid="data-overview-table"
+              is-clickable=""
+            >
+              <!---->
+              <section
+                class="k-table-wrapper"
+              >
+                <table
+                  class="k-table has-hover is-clickable"
+                  data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                 >
-                  <tr
+                  <thead
                     class=""
                   >
-                    
-                    <th
+                    <tr
                       class=""
                     >
-                      <span
-                        class="d-flex align-items-center"
+                      
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Status
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Name
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      
+                    </tr>
+                  </thead>
+                  <tbody>
+                    
+                    <tr
+                      class="is-selected"
+                      role="link"
+                      tabindex="0"
+                    >
+                      
+                      <td
+                        class=""
                       >
                         
                         <span
-                          class=""
+                          class="status status--with-title status--success"
+                          data-testid="status-badge"
                         >
-                          Status
+                          <span
+                            class=""
+                          >
+                            online
+                          </span>
                         </span>
                         
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
+                      </td>
+                      <td
+                        class=""
                       >
                         
-                        <span
-                          class=""
-                        >
-                          Name
-                        </span>
                         
-                        <!---->
-                      </span>
-                    </th>
+                        zoneegress-1
+                        
+                        
+                      </td>
+                      
+                    </tr>
                     
-                  </tr>
-                </thead>
-                <tbody>
-                  
-                  <tr
-                    class="is-selected"
-                    role="link"
-                    tabindex="0"
-                  >
-                    
-                    <td
-                      class=""
-                    >
-                      
-                      <span
-                        class="status status--with-title status--success"
-                        data-testid="status-badge"
-                      >
-                        <span
-                          class=""
-                        >
-                          online
-                        </span>
-                      </span>
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      zoneegress-1
-                      
-                      
-                    </td>
-                    
-                  </tr>
-                  
-                </tbody>
-              </table>
-              <!---->
-            </section>
+                  </tbody>
+                </table>
+                <!---->
+              </section>
+            </div>
+            <div
+              class="pagination"
+            >
+              <!--v-if-->
+              <!--v-if-->
+            </div>
           </div>
-          <div
-            class="pagination"
-          >
-            <!--v-if-->
-            <!--v-if-->
-          </div>
+          <!--v-if-->
+          <!--v-if-->
         </div>
-        <!--v-if-->
-        <!--v-if-->
       </div>
     </div>
-  </div>
-  <div
-    class="kcard-border mt-4"
-  >
     <div
-      class="tab-container"
-      data-testid="tab-container"
+      class="kcard-border"
     >
-      
-      <header
-        class="tab__header"
-      >
-        
-        <h1
-          class="entity-heading"
-        >
-           Zone Egress: zoneegress-1
-        </h1>
-        
-      </header>
       <div
-        class="tab__content-container"
+        class="tab-container"
+        data-testid="tab-container"
       >
-        <div
-          class="k-tabs"
+        
+        <header
+          class="tab__header"
         >
-          <ul
-            aria-label="Tabs"
-            role="tablist"
-          >
-            
-            <li
-              aria-controls="panel-0"
-              aria-selected="true"
-              class="tab-item active"
-              id="overview-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Overview
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-1"
-              aria-selected="false"
-              class="tab-item"
-              id="insights-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Zone Egress Insights
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-2"
-              aria-selected="false"
-              class="tab-item"
-              id="xds-configuration-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                XDS Configuration
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-3"
-              aria-selected="false"
-              class="tab-item"
-              id="envoy-stats-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Stats
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-4"
-              aria-selected="false"
-              class="tab-item"
-              id="envoy-clusters-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Clusters
-                
-              </a>
-            </li>
-            
-          </ul>
           
-          <div
-            aria-labelledby="overview-tab"
-            class="tab-container"
-            id="panel-0"
-            role="tabpanel"
-            tabindex="0"
+          <h1
+            class="entity-heading"
           >
-            
-            <section
-              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-              class="kong-card noBorder"
+             Zone Egress: zoneegress-1
+          </h1>
+          
+        </header>
+        <div
+          class="tab__content-container"
+        >
+          <div
+            class="k-tabs"
+          >
+            <ul
+              aria-label="Tabs"
+              role="tablist"
             >
-              <!---->
-              <!---->
-              <div
-                class="k-card-content d-flex"
+              
+              <li
+                aria-controls="panel-0"
+                aria-selected="true"
+                class="tab-item active"
+                id="overview-tab"
+                role="tab"
+                tabindex="0"
               >
-                <div
-                  class="k-card-body"
-                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                <a
+                  class="tab-link"
                 >
                   
+                  Overview
                   
-                  <div
-                    class="label-list"
-                  >
-                    <div
-                      class="label-list__content"
-                    >
-                      
-                      <div>
-                        <ul>
-                          
-                          <li>
-                            <h4>
-                              type
-                            </h4>
-                            <p>
-                              ZoneEgressOverview
-                            </p>
-                          </li>
-                          <li>
-                            <h4>
-                              name
-                            </h4>
-                            <p>
-                              zoneegress-1
-                            </p>
-                          </li>
-                          
-                        </ul>
-                      </div>
-                      
-                    </div>
-                  </div>
+                </a>
+              </li>
+              <li
+                aria-controls="panel-1"
+                aria-selected="false"
+                class="tab-item"
+                id="insights-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
                   
+                  Zone Egress Insights
                   
-                </div>
+                </a>
+              </li>
+              <li
+                aria-controls="panel-2"
+                aria-selected="false"
+                class="tab-item"
+                id="xds-configuration-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
+                  XDS Configuration
+                  
+                </a>
+              </li>
+              <li
+                aria-controls="panel-3"
+                aria-selected="false"
+                class="tab-item"
+                id="envoy-stats-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
+                  Stats
+                  
+                </a>
+              </li>
+              <li
+                aria-controls="panel-4"
+                aria-selected="false"
+                class="tab-item"
+                id="envoy-clusters-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
+                  Clusters
+                  
+                </a>
+              </li>
+              
+            </ul>
+            
+            <div
+              aria-labelledby="overview-tab"
+              class="tab-container"
+              id="panel-0"
+              role="tabpanel"
+              tabindex="0"
+            >
+              
+              <section
+                aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                class="kong-card noBorder"
+              >
                 <!---->
-              </div>
-            </section>
+                <!---->
+                <div
+                  class="k-card-content d-flex"
+                >
+                  <div
+                    class="k-card-body"
+                    id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                  >
+                    
+                    
+                    <div
+                      class="label-list"
+                    >
+                      <div
+                        class="label-list__content"
+                      >
+                        
+                        <div>
+                          <ul>
+                            
+                            <li>
+                              <h4>
+                                type
+                              </h4>
+                              <p>
+                                ZoneEgressOverview
+                              </p>
+                            </li>
+                            <li>
+                              <h4>
+                                name
+                              </h4>
+                              <p>
+                                zoneegress-1
+                              </p>
+                            </li>
+                            
+                          </ul>
+                        </div>
+                        
+                      </div>
+                    </div>
+                    
+                    
+                  </div>
+                  <!---->
+                </div>
+              </section>
+              
+            </div>
+            <div
+              aria-labelledby="insights-tab"
+              class="tab-container"
+              id="panel-1"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
+            <div
+              aria-labelledby="xds-configuration-tab"
+              class="tab-container"
+              id="panel-2"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
+            <div
+              aria-labelledby="envoy-stats-tab"
+              class="tab-container"
+              id="panel-3"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
+            <div
+              aria-labelledby="envoy-clusters-tab"
+              class="tab-container"
+              id="panel-4"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
             
           </div>
-          <div
-            aria-labelledby="insights-tab"
-            class="tab-container"
-            id="panel-1"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          <div
-            aria-labelledby="xds-configuration-tab"
-            class="tab-container"
-            id="panel-2"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          <div
-            aria-labelledby="envoy-stats-tab"
-            class="tab-container"
-            id="panel-3"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          <div
-            aria-labelledby="envoy-clusters-tab"
-            class="tab-container"
-            id="panel-4"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          
         </div>
+        
       </div>
-      
     </div>
   </div>
 </div>
@@ -400,391 +404,395 @@ exports[`ZoneEgresses.vue renders snapshot when no multizone 1`] = `
   class="zoneegresses"
 >
   <div
-    class="kcard-border"
+    class="kcard-stack"
   >
     <div
-      class="data-overview"
-      data-testid="data-overview"
+      class="kcard-border"
     >
       <div
-        class="data-table-controls mb-2"
+        class="data-overview"
+        data-testid="data-overview"
       >
-        
-        
-        <button
-          class="k-button medium rounded primary refresh-button"
-          data-testid="data-overview-refresh-button"
-          type="button"
-        >
-          
-          <span
-            class="k-button-icon kong-icon kong-icon-redo"
-          >
-            <svg
-              fill="white"
-              height="16"
-              role="img"
-              viewBox="0 0 17 14"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              
-  
-              <title>
-                Redo
-              </title>
-              
-  
-              <path
-                clip-rule="evenodd"
-                d="M12.466 12.06a6.868 6.868 0 112.196-5.676l.85-.85a.847.847 0 011.201-.017c.327.327.315.869-.017 1.2L14.233 9.18c-.342.342-.88.35-1.208.023L10.654 6.83c-.324-.324-.314-.859.028-1.2.34-.34.881-.348 1.2-.029l.847.846a4.938 4.938 0 10-1.63 4.245l1.367 1.367z"
-                fill="white"
-                fill-rule="evenodd"
-              />
-              
-
-            </svg>
-            
-
-          </span>
-          
-          
-           Refresh 
-          
-          <!---->
-        </button>
-      </div>
-      <div
-        class="data-overview-content"
-      >
-        <!-- data -->
         <div
-          class="data-overview-table"
+          class="data-table-controls mb-2"
         >
-          <div
-            class="k-table-container data-overview-table"
-            data-testid="data-overview-table"
-            is-clickable=""
+          
+          
+          <button
+            class="k-button medium rounded primary refresh-button"
+            data-testid="data-overview-refresh-button"
+            type="button"
           >
-            <!---->
-            <section
-              class="k-table-wrapper"
+            
+            <span
+              class="k-button-icon kong-icon kong-icon-redo"
             >
-              <table
-                class="k-table has-hover is-clickable"
-                data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              <svg
+                fill="white"
+                height="16"
+                role="img"
+                viewBox="0 0 17 14"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <thead
-                  class=""
+                
+  
+                <title>
+                  Redo
+                </title>
+                
+  
+                <path
+                  clip-rule="evenodd"
+                  d="M12.466 12.06a6.868 6.868 0 112.196-5.676l.85-.85a.847.847 0 011.201-.017c.327.327.315.869-.017 1.2L14.233 9.18c-.342.342-.88.35-1.208.023L10.654 6.83c-.324-.324-.314-.859.028-1.2.34-.34.881-.348 1.2-.029l.847.846a4.938 4.938 0 10-1.63 4.245l1.367 1.367z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+                
+
+              </svg>
+              
+
+            </span>
+            
+            
+             Refresh 
+            
+            <!---->
+          </button>
+        </div>
+        <div
+          class="data-overview-content"
+        >
+          <!-- data -->
+          <div
+            class="data-overview-table"
+          >
+            <div
+              class="k-table-container data-overview-table"
+              data-testid="data-overview-table"
+              is-clickable=""
+            >
+              <!---->
+              <section
+                class="k-table-wrapper"
+              >
+                <table
+                  class="k-table has-hover is-clickable"
+                  data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                 >
-                  <tr
+                  <thead
                     class=""
                   >
-                    
-                    <th
+                    <tr
                       class=""
                     >
-                      <span
-                        class="d-flex align-items-center"
+                      
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Status
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Name
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      
+                    </tr>
+                  </thead>
+                  <tbody>
+                    
+                    <tr
+                      class="is-selected"
+                      role="link"
+                      tabindex="0"
+                    >
+                      
+                      <td
+                        class=""
                       >
                         
                         <span
-                          class=""
+                          class="status status--with-title status--success"
+                          data-testid="status-badge"
                         >
-                          Status
+                          <span
+                            class=""
+                          >
+                            online
+                          </span>
                         </span>
                         
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
+                      </td>
+                      <td
+                        class=""
                       >
                         
-                        <span
-                          class=""
-                        >
-                          Name
-                        </span>
                         
-                        <!---->
-                      </span>
-                    </th>
+                        zoneegress-1
+                        
+                        
+                      </td>
+                      
+                    </tr>
                     
-                  </tr>
-                </thead>
-                <tbody>
-                  
-                  <tr
-                    class="is-selected"
-                    role="link"
-                    tabindex="0"
-                  >
-                    
-                    <td
-                      class=""
-                    >
-                      
-                      <span
-                        class="status status--with-title status--success"
-                        data-testid="status-badge"
-                      >
-                        <span
-                          class=""
-                        >
-                          online
-                        </span>
-                      </span>
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      zoneegress-1
-                      
-                      
-                    </td>
-                    
-                  </tr>
-                  
-                </tbody>
-              </table>
-              <!---->
-            </section>
+                  </tbody>
+                </table>
+                <!---->
+              </section>
+            </div>
+            <div
+              class="pagination"
+            >
+              <!--v-if-->
+              <!--v-if-->
+            </div>
           </div>
-          <div
-            class="pagination"
-          >
-            <!--v-if-->
-            <!--v-if-->
-          </div>
+          <!--v-if-->
+          <!--v-if-->
         </div>
-        <!--v-if-->
-        <!--v-if-->
       </div>
     </div>
-  </div>
-  <div
-    class="kcard-border mt-4"
-  >
     <div
-      class="tab-container"
-      data-testid="tab-container"
+      class="kcard-border"
     >
-      
-      <header
-        class="tab__header"
-      >
-        
-        <h1
-          class="entity-heading"
-        >
-           Zone Egress: zoneegress-1
-        </h1>
-        
-      </header>
       <div
-        class="tab__content-container"
+        class="tab-container"
+        data-testid="tab-container"
       >
-        <div
-          class="k-tabs"
+        
+        <header
+          class="tab__header"
         >
-          <ul
-            aria-label="Tabs"
-            role="tablist"
-          >
-            
-            <li
-              aria-controls="panel-0"
-              aria-selected="true"
-              class="tab-item active"
-              id="overview-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Overview
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-1"
-              aria-selected="false"
-              class="tab-item"
-              id="insights-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Zone Egress Insights
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-2"
-              aria-selected="false"
-              class="tab-item"
-              id="xds-configuration-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                XDS Configuration
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-3"
-              aria-selected="false"
-              class="tab-item"
-              id="envoy-stats-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Stats
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-4"
-              aria-selected="false"
-              class="tab-item"
-              id="envoy-clusters-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Clusters
-                
-              </a>
-            </li>
-            
-          </ul>
           
-          <div
-            aria-labelledby="overview-tab"
-            class="tab-container"
-            id="panel-0"
-            role="tabpanel"
-            tabindex="0"
+          <h1
+            class="entity-heading"
           >
-            
-            <section
-              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-              class="kong-card noBorder"
+             Zone Egress: zoneegress-1
+          </h1>
+          
+        </header>
+        <div
+          class="tab__content-container"
+        >
+          <div
+            class="k-tabs"
+          >
+            <ul
+              aria-label="Tabs"
+              role="tablist"
             >
-              <!---->
-              <!---->
-              <div
-                class="k-card-content d-flex"
+              
+              <li
+                aria-controls="panel-0"
+                aria-selected="true"
+                class="tab-item active"
+                id="overview-tab"
+                role="tab"
+                tabindex="0"
               >
-                <div
-                  class="k-card-body"
-                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                <a
+                  class="tab-link"
                 >
                   
+                  Overview
                   
-                  <div
-                    class="label-list"
-                  >
-                    <div
-                      class="label-list__content"
-                    >
-                      
-                      <div>
-                        <ul>
-                          
-                          <li>
-                            <h4>
-                              type
-                            </h4>
-                            <p>
-                              ZoneEgressOverview
-                            </p>
-                          </li>
-                          <li>
-                            <h4>
-                              name
-                            </h4>
-                            <p>
-                              zoneegress-1
-                            </p>
-                          </li>
-                          
-                        </ul>
-                      </div>
-                      
-                    </div>
-                  </div>
+                </a>
+              </li>
+              <li
+                aria-controls="panel-1"
+                aria-selected="false"
+                class="tab-item"
+                id="insights-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
                   
+                  Zone Egress Insights
                   
-                </div>
+                </a>
+              </li>
+              <li
+                aria-controls="panel-2"
+                aria-selected="false"
+                class="tab-item"
+                id="xds-configuration-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
+                  XDS Configuration
+                  
+                </a>
+              </li>
+              <li
+                aria-controls="panel-3"
+                aria-selected="false"
+                class="tab-item"
+                id="envoy-stats-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
+                  Stats
+                  
+                </a>
+              </li>
+              <li
+                aria-controls="panel-4"
+                aria-selected="false"
+                class="tab-item"
+                id="envoy-clusters-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
+                  Clusters
+                  
+                </a>
+              </li>
+              
+            </ul>
+            
+            <div
+              aria-labelledby="overview-tab"
+              class="tab-container"
+              id="panel-0"
+              role="tabpanel"
+              tabindex="0"
+            >
+              
+              <section
+                aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                class="kong-card noBorder"
+              >
                 <!---->
-              </div>
-            </section>
+                <!---->
+                <div
+                  class="k-card-content d-flex"
+                >
+                  <div
+                    class="k-card-body"
+                    id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                  >
+                    
+                    
+                    <div
+                      class="label-list"
+                    >
+                      <div
+                        class="label-list__content"
+                      >
+                        
+                        <div>
+                          <ul>
+                            
+                            <li>
+                              <h4>
+                                type
+                              </h4>
+                              <p>
+                                ZoneEgressOverview
+                              </p>
+                            </li>
+                            <li>
+                              <h4>
+                                name
+                              </h4>
+                              <p>
+                                zoneegress-1
+                              </p>
+                            </li>
+                            
+                          </ul>
+                        </div>
+                        
+                      </div>
+                    </div>
+                    
+                    
+                  </div>
+                  <!---->
+                </div>
+              </section>
+              
+            </div>
+            <div
+              aria-labelledby="insights-tab"
+              class="tab-container"
+              id="panel-1"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
+            <div
+              aria-labelledby="xds-configuration-tab"
+              class="tab-container"
+              id="panel-2"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
+            <div
+              aria-labelledby="envoy-stats-tab"
+              class="tab-container"
+              id="panel-3"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
+            <div
+              aria-labelledby="envoy-clusters-tab"
+              class="tab-container"
+              id="panel-4"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
             
           </div>
-          <div
-            aria-labelledby="insights-tab"
-            class="tab-container"
-            id="panel-1"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          <div
-            aria-labelledby="xds-configuration-tab"
-            class="tab-container"
-            id="panel-2"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          <div
-            aria-labelledby="envoy-stats-tab"
-            class="tab-container"
-            id="panel-3"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          <div
-            aria-labelledby="envoy-clusters-tab"
-            class="tab-container"
-            id="panel-4"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          
         </div>
+        
       </div>
-      
     </div>
   </div>
 </div>

--- a/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
@@ -7,391 +7,395 @@ exports[`ZoneIngresses.vue renders snapshot when multizone 1`] = `
   
   <!-- Zone CPs information for when Multicluster is enabled -->
   <div
-    class="kcard-border"
+    class="kcard-stack"
   >
     <div
-      class="data-overview"
-      data-testid="data-overview"
+      class="kcard-border"
     >
       <div
-        class="data-table-controls mb-2"
+        class="data-overview"
+        data-testid="data-overview"
       >
-        
-        
-        <button
-          class="k-button medium rounded primary refresh-button"
-          data-testid="data-overview-refresh-button"
-          type="button"
-        >
-          
-          <span
-            class="k-button-icon kong-icon kong-icon-redo"
-          >
-            <svg
-              fill="white"
-              height="16"
-              role="img"
-              viewBox="0 0 17 14"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              
-  
-              <title>
-                Redo
-              </title>
-              
-  
-              <path
-                clip-rule="evenodd"
-                d="M12.466 12.06a6.868 6.868 0 112.196-5.676l.85-.85a.847.847 0 011.201-.017c.327.327.315.869-.017 1.2L14.233 9.18c-.342.342-.88.35-1.208.023L10.654 6.83c-.324-.324-.314-.859.028-1.2.34-.34.881-.348 1.2-.029l.847.846a4.938 4.938 0 10-1.63 4.245l1.367 1.367z"
-                fill="white"
-                fill-rule="evenodd"
-              />
-              
-
-            </svg>
-            
-
-          </span>
-          
-          
-           Refresh 
-          
-          <!---->
-        </button>
-      </div>
-      <div
-        class="data-overview-content"
-      >
-        <!-- data -->
         <div
-          class="data-overview-table"
+          class="data-table-controls mb-2"
         >
-          <div
-            class="k-table-container data-overview-table"
-            data-testid="data-overview-table"
-            is-clickable=""
+          
+          
+          <button
+            class="k-button medium rounded primary refresh-button"
+            data-testid="data-overview-refresh-button"
+            type="button"
           >
-            <!---->
-            <section
-              class="k-table-wrapper"
+            
+            <span
+              class="k-button-icon kong-icon kong-icon-redo"
             >
-              <table
-                class="k-table has-hover is-clickable"
-                data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              <svg
+                fill="white"
+                height="16"
+                role="img"
+                viewBox="0 0 17 14"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <thead
-                  class=""
+                
+  
+                <title>
+                  Redo
+                </title>
+                
+  
+                <path
+                  clip-rule="evenodd"
+                  d="M12.466 12.06a6.868 6.868 0 112.196-5.676l.85-.85a.847.847 0 011.201-.017c.327.327.315.869-.017 1.2L14.233 9.18c-.342.342-.88.35-1.208.023L10.654 6.83c-.324-.324-.314-.859.028-1.2.34-.34.881-.348 1.2-.029l.847.846a4.938 4.938 0 10-1.63 4.245l1.367 1.367z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+                
+
+              </svg>
+              
+
+            </span>
+            
+            
+             Refresh 
+            
+            <!---->
+          </button>
+        </div>
+        <div
+          class="data-overview-content"
+        >
+          <!-- data -->
+          <div
+            class="data-overview-table"
+          >
+            <div
+              class="k-table-container data-overview-table"
+              data-testid="data-overview-table"
+              is-clickable=""
+            >
+              <!---->
+              <section
+                class="k-table-wrapper"
+              >
+                <table
+                  class="k-table has-hover is-clickable"
+                  data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
                 >
-                  <tr
+                  <thead
                     class=""
                   >
-                    
-                    <th
+                    <tr
                       class=""
                     >
-                      <span
-                        class="d-flex align-items-center"
+                      
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Status
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Name
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      
+                    </tr>
+                  </thead>
+                  <tbody>
+                    
+                    <tr
+                      class="is-selected"
+                      role="link"
+                      tabindex="0"
+                    >
+                      
+                      <td
+                        class=""
                       >
                         
                         <span
-                          class=""
+                          class="status status--with-title status--success"
+                          data-testid="status-badge"
                         >
-                          Status
+                          <span
+                            class=""
+                          >
+                            online
+                          </span>
                         </span>
                         
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
+                      </td>
+                      <td
+                        class=""
                       >
                         
-                        <span
-                          class=""
-                        >
-                          Name
-                        </span>
                         
-                        <!---->
-                      </span>
-                    </th>
+                        zone-ingress-1
+                        
+                        
+                      </td>
+                      
+                    </tr>
                     
-                  </tr>
-                </thead>
-                <tbody>
-                  
-                  <tr
-                    class="is-selected"
-                    role="link"
-                    tabindex="0"
-                  >
-                    
-                    <td
-                      class=""
-                    >
-                      
-                      <span
-                        class="status status--with-title status--success"
-                        data-testid="status-badge"
-                      >
-                        <span
-                          class=""
-                        >
-                          online
-                        </span>
-                      </span>
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      zone-ingress-1
-                      
-                      
-                    </td>
-                    
-                  </tr>
-                  
-                </tbody>
-              </table>
-              <!---->
-            </section>
+                  </tbody>
+                </table>
+                <!---->
+              </section>
+            </div>
+            <div
+              class="pagination"
+            >
+              <!--v-if-->
+              <!--v-if-->
+            </div>
           </div>
-          <div
-            class="pagination"
-          >
-            <!--v-if-->
-            <!--v-if-->
-          </div>
+          <!--v-if-->
+          <!--v-if-->
         </div>
-        <!--v-if-->
-        <!--v-if-->
       </div>
     </div>
-  </div>
-  <div
-    class="kcard-border mt-4"
-  >
     <div
-      class="tab-container"
-      data-testid="tab-container"
+      class="kcard-border"
     >
-      
-      <header
-        class="tab__header"
-      >
-        
-        <h1
-          class="entity-heading"
-        >
-           Zone Ingress: zone-ingress-1
-        </h1>
-        
-      </header>
       <div
-        class="tab__content-container"
+        class="tab-container"
+        data-testid="tab-container"
       >
-        <div
-          class="k-tabs"
+        
+        <header
+          class="tab__header"
         >
-          <ul
-            aria-label="Tabs"
-            role="tablist"
-          >
-            
-            <li
-              aria-controls="panel-0"
-              aria-selected="true"
-              class="tab-item active"
-              id="overview-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Overview
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-1"
-              aria-selected="false"
-              class="tab-item"
-              id="insights-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Zone Ingress Insights
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-2"
-              aria-selected="false"
-              class="tab-item"
-              id="xds-configuration-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                XDS Configuration
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-3"
-              aria-selected="false"
-              class="tab-item"
-              id="envoy-stats-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Stats
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-4"
-              aria-selected="false"
-              class="tab-item"
-              id="envoy-clusters-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Clusters
-                
-              </a>
-            </li>
-            
-          </ul>
           
-          <div
-            aria-labelledby="overview-tab"
-            class="tab-container"
-            id="panel-0"
-            role="tabpanel"
-            tabindex="0"
+          <h1
+            class="entity-heading"
           >
-            
-            <section
-              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-              class="kong-card noBorder"
+             Zone Ingress: zone-ingress-1
+          </h1>
+          
+        </header>
+        <div
+          class="tab__content-container"
+        >
+          <div
+            class="k-tabs"
+          >
+            <ul
+              aria-label="Tabs"
+              role="tablist"
             >
-              <!---->
-              <!---->
-              <div
-                class="k-card-content d-flex"
+              
+              <li
+                aria-controls="panel-0"
+                aria-selected="true"
+                class="tab-item active"
+                id="overview-tab"
+                role="tab"
+                tabindex="0"
               >
-                <div
-                  class="k-card-body"
-                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                <a
+                  class="tab-link"
                 >
                   
+                  Overview
                   
-                  <div
-                    class="label-list"
-                  >
-                    <div
-                      class="label-list__content"
-                    >
-                      
-                      <div>
-                        <ul>
-                          
-                          <li>
-                            <h4>
-                              type
-                            </h4>
-                            <p>
-                              ZoneIngressOverview
-                            </p>
-                          </li>
-                          <li>
-                            <h4>
-                              name
-                            </h4>
-                            <p>
-                              zone-ingress-1
-                            </p>
-                          </li>
-                          
-                        </ul>
-                      </div>
-                      
-                    </div>
-                  </div>
+                </a>
+              </li>
+              <li
+                aria-controls="panel-1"
+                aria-selected="false"
+                class="tab-item"
+                id="insights-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
                   
+                  Zone Ingress Insights
                   
-                </div>
+                </a>
+              </li>
+              <li
+                aria-controls="panel-2"
+                aria-selected="false"
+                class="tab-item"
+                id="xds-configuration-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
+                  XDS Configuration
+                  
+                </a>
+              </li>
+              <li
+                aria-controls="panel-3"
+                aria-selected="false"
+                class="tab-item"
+                id="envoy-stats-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
+                  Stats
+                  
+                </a>
+              </li>
+              <li
+                aria-controls="panel-4"
+                aria-selected="false"
+                class="tab-item"
+                id="envoy-clusters-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
+                  Clusters
+                  
+                </a>
+              </li>
+              
+            </ul>
+            
+            <div
+              aria-labelledby="overview-tab"
+              class="tab-container"
+              id="panel-0"
+              role="tabpanel"
+              tabindex="0"
+            >
+              
+              <section
+                aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                class="kong-card noBorder"
+              >
                 <!---->
-              </div>
-            </section>
+                <!---->
+                <div
+                  class="k-card-content d-flex"
+                >
+                  <div
+                    class="k-card-body"
+                    id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                  >
+                    
+                    
+                    <div
+                      class="label-list"
+                    >
+                      <div
+                        class="label-list__content"
+                      >
+                        
+                        <div>
+                          <ul>
+                            
+                            <li>
+                              <h4>
+                                type
+                              </h4>
+                              <p>
+                                ZoneIngressOverview
+                              </p>
+                            </li>
+                            <li>
+                              <h4>
+                                name
+                              </h4>
+                              <p>
+                                zone-ingress-1
+                              </p>
+                            </li>
+                            
+                          </ul>
+                        </div>
+                        
+                      </div>
+                    </div>
+                    
+                    
+                  </div>
+                  <!---->
+                </div>
+              </section>
+              
+            </div>
+            <div
+              aria-labelledby="insights-tab"
+              class="tab-container"
+              id="panel-1"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
+            <div
+              aria-labelledby="xds-configuration-tab"
+              class="tab-container"
+              id="panel-2"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
+            <div
+              aria-labelledby="envoy-stats-tab"
+              class="tab-container"
+              id="panel-3"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
+            <div
+              aria-labelledby="envoy-clusters-tab"
+              class="tab-container"
+              id="panel-4"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
             
           </div>
-          <div
-            aria-labelledby="insights-tab"
-            class="tab-container"
-            id="panel-1"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          <div
-            aria-labelledby="xds-configuration-tab"
-            class="tab-container"
-            id="panel-2"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          <div
-            aria-labelledby="envoy-stats-tab"
-            class="tab-container"
-            id="panel-3"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          <div
-            aria-labelledby="envoy-clusters-tab"
-            class="tab-container"
-            id="panel-4"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          
         </div>
+        
       </div>
-      
     </div>
   </div>
   

--- a/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
@@ -7,9 +7,8 @@ exports[`ZoneIngresses.vue renders snapshot when multizone 1`] = `
   
   <!-- Zone CPs information for when Multicluster is enabled -->
   <div
-    class="component-frame"
+    class="kcard-border"
   >
-    
     <div
       class="data-overview"
       data-testid="data-overview"
@@ -176,6 +175,10 @@ exports[`ZoneIngresses.vue renders snapshot when multizone 1`] = `
         <!--v-if-->
       </div>
     </div>
+  </div>
+  <div
+    class="kcard-border mt-4"
+  >
     <div
       class="tab-container"
       data-testid="tab-container"
@@ -390,7 +393,6 @@ exports[`ZoneIngresses.vue renders snapshot when multizone 1`] = `
       </div>
       
     </div>
-    
   </div>
   
 </div>

--- a/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
@@ -5,11 +5,9 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
   class="zones"
 >
   
-  <!-- Zone CPs information for when Multicluster is enabled -->
   <div
-    class="component-frame"
+    class="kcard-border"
   >
-    
     <div
       class="data-overview"
       data-testid="data-overview"
@@ -627,6 +625,10 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
         <!--v-if-->
       </div>
     </div>
+  </div>
+  <div
+    class="kcard-border mt-4"
+  >
     <div
       class="tab-container"
       data-testid="tab-container"
@@ -921,7 +923,6 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
       </div>
       
     </div>
-    
   </div>
   
 </div>

--- a/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
@@ -4,927 +4,929 @@ exports[`ZonesView.vue renders snapshot when multizone 1`] = `
 <div
   class="zones"
 >
-  
   <div
-    class="kcard-border"
+    class="kcard-stack"
   >
     <div
-      class="data-overview"
-      data-testid="data-overview"
+      class="kcard-border"
     >
       <div
-        class="data-table-controls mb-2"
+        class="data-overview"
+        data-testid="data-overview"
       >
-        
-        
-        <button
-          class="k-button medium rounded primary refresh-button"
-          data-testid="data-overview-refresh-button"
-          type="button"
-        >
-          
-          <span
-            class="k-button-icon kong-icon kong-icon-redo"
-          >
-            <svg
-              fill="white"
-              height="16"
-              role="img"
-              viewBox="0 0 17 14"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              
-  
-              <title>
-                Redo
-              </title>
-              
-  
-              <path
-                clip-rule="evenodd"
-                d="M12.466 12.06a6.868 6.868 0 112.196-5.676l.85-.85a.847.847 0 011.201-.017c.327.327.315.869-.017 1.2L14.233 9.18c-.342.342-.88.35-1.208.023L10.654 6.83c-.324-.324-.314-.859.028-1.2.34-.34.881-.348 1.2-.029l.847.846a4.938 4.938 0 10-1.63 4.245l1.367 1.367z"
-                fill="white"
-                fill-rule="evenodd"
-              />
-              
-
-            </svg>
-            
-
-          </span>
-          
-          
-           Refresh 
-          
-          <!---->
-        </button>
-      </div>
-      <div
-        class="data-overview-content"
-      >
-        <!-- data -->
         <div
-          class="data-overview-table"
+          class="data-table-controls mb-2"
         >
-          <div
-            class="k-table-container data-overview-table"
-            data-testid="data-overview-table"
-            is-clickable=""
+          
+          
+          <button
+            class="k-button medium rounded primary refresh-button"
+            data-testid="data-overview-refresh-button"
+            type="button"
           >
-            <!---->
-            <section
-              class="k-table-wrapper"
+            
+            <span
+              class="k-button-icon kong-icon kong-icon-redo"
             >
-              <table
-                class="k-table has-hover is-clickable"
-                data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+              <svg
+                fill="white"
+                height="16"
+                role="img"
+                viewBox="0 0 17 14"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <thead
-                  class=""
-                >
-                  <tr
-                    class=""
-                  >
-                    
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        
-                        <span
-                          class=""
-                        >
-                          Status
-                        </span>
-                        
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        
-                        <span
-                          class=""
-                        >
-                          Name
-                        </span>
-                        
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        
-                        <span
-                          class=""
-                        >
-                          Zone CP Version
-                        </span>
-                        
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        
-                        <span
-                          class=""
-                        >
-                          Storage type
-                        </span>
-                        
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        
-                        <span
-                          class=""
-                        >
-                          Ingress
-                        </span>
-                        
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        
-                        <span
-                          class=""
-                        >
-                          Egress
-                        </span>
-                        
-                        <!---->
-                      </span>
-                    </th>
-                    <th
-                      class=""
-                    >
-                      <span
-                        class="d-flex align-items-center"
-                      >
-                        
-                        <span
-                          class="sr-only"
-                        >
-                          Warnings
-                        </span>
-                        
-                        <!---->
-                      </span>
-                    </th>
-                    
-                  </tr>
-                </thead>
-                <tbody>
-                  
-                  <tr
-                    class="is-selected"
-                    role="link"
-                    tabindex="0"
-                  >
-                    
-                    <td
-                      class=""
-                    >
-                      
-                      <span
-                        class="status status--with-title status--success"
-                        data-testid="status-badge"
-                      >
-                        <span
-                          class=""
-                        >
-                          online
-                        </span>
-                      </span>
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      cluster-1
-                      
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      1.0.0-rc2-211-g823fe8ce
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      memory
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      No
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      No
-                      
-                    </td>
-                    <td
-                      class="text-center"
-                    >
-                      
-                      <span
-                        class="mr-1 kong-icon kong-icon-warning"
-                      >
-                        <svg
-                          height="20"
-                          role="img"
-                          version="1.1"
-                          viewBox="0 0 48 42"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                          xmlns:xlink="http://www.w3.org/1999/xlink"
-                        >
-                          
+                
   
-                          <title>
-                            Warning
-                          </title>
-                          
+                <title>
+                  Redo
+                </title>
+                
   
-                          <g
-                            fill="var(--black-75)"
-                            fill-rule="evenodd"
-                            id="Page-1"
-                            stroke="none"
-                            stroke-width="1"
-                          >
-                            
-    
-                            <g
-                              id="icn-warning-64x"
-                            >
-                              
-      
-                              <path
-                                d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z M26.8565586,1.63656862 L47.5511049,37.0538196 C48.4690879,38.6248825 47.9342141,40.6394832 46.3564308,41.5535561 C45.8517121,41.8459599 45.2782053,42 44.6942755,42 L3.30518292,42 C1.4797808,42 3.66949018e-16,40.5265221 0,38.7088951 C0,38.1274525 0.154699044,37.5563885 0.448353557,37.0538196 L21.1428999,1.63656862 C22.0608829,0.0655056975 24.0841012,-0.467089888 25.6618845,0.446983085 C26.1568841,0.733756171 26.5685588,1.14367738 26.8565586,1.63656862 Z"
-                                fill="var(--black-75)"
-                                fill-rule="nonzero"
-                                id="Triangle"
-                              />
-                              
-      
-                              <path
-                                d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z"
-                                fill="var(--yellow-300)"
-                                fill-rule="nonzero"
-                                id="Path"
-                                type="secondary"
-                              />
-                              
-      
-                              <path
-                                d="M23,13 L25,13 C25.5522847,13 26,13.4477153 26,14 C26,16 26,18 26,20 C26,22.6594889 25.7904331,25.0570193 25.3712994,27.192591 C25.2792336,27.6616739 24.8680521,28 24.3900199,28 L23.6099609,27.9999816 C23.1319364,27.9999816 22.7207615,27.6616608 22.6286994,27.1925851 C22.2095665,25.0570148 22,22.6594864 22,20 C22,18 22,16 22,14 C22,13.4477153 22.4477153,13 23,13 Z M24,31 C25.1045695,31 26,31.8954305 26,33 C26,34.1045695 25.1045695,35 24,35 C22.8954305,35 22,34.1045695 22,33 C22,31.8954305 22.8954305,31 24,31 Z"
-                                fill="var(--black-75)"
-                                id="!"
-                              />
-                              
-    
-                            </g>
-                            
-  
-                          </g>
-                          
+                <path
+                  clip-rule="evenodd"
+                  d="M12.466 12.06a6.868 6.868 0 112.196-5.676l.85-.85a.847.847 0 011.201-.017c.327.327.315.869-.017 1.2L14.233 9.18c-.342.342-.88.35-1.208.023L10.654 6.83c-.324-.324-.314-.859.028-1.2.34-.34.881-.348 1.2-.029l.847.846a4.938 4.938 0 10-1.63 4.245l1.367 1.367z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+                
 
-                        </svg>
-                        
+              </svg>
+              
 
-                      </span>
-                      
-                    </td>
-                    
-                  </tr>
-                  <tr
-                    class=""
-                    role="link"
-                    tabindex="0"
-                  >
-                    
-                    <td
-                      class=""
-                    >
-                      
-                      <span
-                        class="status status--with-title status--success"
-                        data-testid="status-badge"
-                      >
-                        <span
-                          class=""
-                        >
-                          online
-                        </span>
-                      </span>
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      zone-1
-                      
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      1.0.0-rc2-211-g823fe8ce
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      memory
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      Yes
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      Yes
-                      
-                    </td>
-                    <td
-                      class="text-center"
-                    >
-                      
-                      
-                      
-                    </td>
-                    
-                  </tr>
-                  <tr
-                    class=""
-                    role="link"
-                    tabindex="0"
-                  >
-                    
-                    <td
-                      class=""
-                    >
-                      
-                      <span
-                        class="status status--with-title status--success"
-                        data-testid="status-badge"
-                      >
-                        <span
-                          class=""
-                        >
-                          online
-                        </span>
-                      </span>
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      zone-2
-                      
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      1.0.0-rc2-211-g823fe8ce
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      memory
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      No
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      No
-                      
-                    </td>
-                    <td
-                      class="text-center"
-                    >
-                      
-                      <span
-                        class="mr-1 kong-icon kong-icon-warning"
-                      >
-                        <svg
-                          height="20"
-                          role="img"
-                          version="1.1"
-                          viewBox="0 0 48 42"
-                          width="20"
-                          xmlns="http://www.w3.org/2000/svg"
-                          xmlns:xlink="http://www.w3.org/1999/xlink"
-                        >
-                          
-  
-                          <title>
-                            Warning
-                          </title>
-                          
-  
-                          <g
-                            fill="var(--black-75)"
-                            fill-rule="evenodd"
-                            id="Page-1"
-                            stroke="none"
-                            stroke-width="1"
-                          >
-                            
-    
-                            <g
-                              id="icn-warning-64x"
-                            >
-                              
-      
-                              <path
-                                d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z M26.8565586,1.63656862 L47.5511049,37.0538196 C48.4690879,38.6248825 47.9342141,40.6394832 46.3564308,41.5535561 C45.8517121,41.8459599 45.2782053,42 44.6942755,42 L3.30518292,42 C1.4797808,42 3.66949018e-16,40.5265221 0,38.7088951 C0,38.1274525 0.154699044,37.5563885 0.448353557,37.0538196 L21.1428999,1.63656862 C22.0608829,0.0655056975 24.0841012,-0.467089888 25.6618845,0.446983085 C26.1568841,0.733756171 26.5685588,1.14367738 26.8565586,1.63656862 Z"
-                                fill="var(--black-75)"
-                                fill-rule="nonzero"
-                                id="Triangle"
-                              />
-                              
-      
-                              <path
-                                d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z"
-                                fill="var(--yellow-300)"
-                                fill-rule="nonzero"
-                                id="Path"
-                                type="secondary"
-                              />
-                              
-      
-                              <path
-                                d="M23,13 L25,13 C25.5522847,13 26,13.4477153 26,14 C26,16 26,18 26,20 C26,22.6594889 25.7904331,25.0570193 25.3712994,27.192591 C25.2792336,27.6616739 24.8680521,28 24.3900199,28 L23.6099609,27.9999816 C23.1319364,27.9999816 22.7207615,27.6616608 22.6286994,27.1925851 C22.2095665,25.0570148 22,22.6594864 22,20 C22,18 22,16 22,14 C22,13.4477153 22.4477153,13 23,13 Z M24,31 C25.1045695,31 26,31.8954305 26,33 C26,34.1045695 25.1045695,35 24,35 C22.8954305,35 22,34.1045695 22,33 C22,31.8954305 22.8954305,31 24,31 Z"
-                                fill="var(--black-75)"
-                                id="!"
-                              />
-                              
-    
-                            </g>
-                            
-  
-                          </g>
-                          
-
-                        </svg>
-                        
-
-                      </span>
-                      
-                    </td>
-                    
-                  </tr>
-                  <tr
-                    class=""
-                    role="link"
-                    tabindex="0"
-                  >
-                    
-                    <td
-                      class=""
-                    >
-                      
-                      <span
-                        class="status status--with-title status--success"
-                        data-testid="status-badge"
-                      >
-                        <span
-                          class=""
-                        >
-                          online
-                        </span>
-                      </span>
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      zone-3
-                      
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      1.0.0-rc2-211-g823fe8ce
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      No
-                      
-                    </td>
-                    <td
-                      class=""
-                    >
-                      
-                      No
-                      
-                    </td>
-                    <td
-                      class="text-center"
-                    >
-                      
-                      
-                      
-                    </td>
-                    
-                  </tr>
-                  
-                </tbody>
-              </table>
-              <!---->
-            </section>
-          </div>
-          <div
-            class="pagination"
-          >
-            <!--v-if-->
-            <!--v-if-->
-          </div>
+            </span>
+            
+            
+             Refresh 
+            
+            <!---->
+          </button>
         </div>
-        <!--v-if-->
-        <!--v-if-->
+        <div
+          class="data-overview-content"
+        >
+          <!-- data -->
+          <div
+            class="data-overview-table"
+          >
+            <div
+              class="k-table-container data-overview-table"
+              data-testid="data-overview-table"
+              is-clickable=""
+            >
+              <!---->
+              <section
+                class="k-table-wrapper"
+              >
+                <table
+                  class="k-table has-hover is-clickable"
+                  data-tableid="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                >
+                  <thead
+                    class=""
+                  >
+                    <tr
+                      class=""
+                    >
+                      
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Status
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Name
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Zone CP Version
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Storage type
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Ingress
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class=""
+                          >
+                            Egress
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      <th
+                        class=""
+                      >
+                        <span
+                          class="d-flex align-items-center"
+                        >
+                          
+                          <span
+                            class="sr-only"
+                          >
+                            Warnings
+                          </span>
+                          
+                          <!---->
+                        </span>
+                      </th>
+                      
+                    </tr>
+                  </thead>
+                  <tbody>
+                    
+                    <tr
+                      class="is-selected"
+                      role="link"
+                      tabindex="0"
+                    >
+                      
+                      <td
+                        class=""
+                      >
+                        
+                        <span
+                          class="status status--with-title status--success"
+                          data-testid="status-badge"
+                        >
+                          <span
+                            class=""
+                          >
+                            online
+                          </span>
+                        </span>
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        
+                        cluster-1
+                        
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        1.0.0-rc2-211-g823fe8ce
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        memory
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        No
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        No
+                        
+                      </td>
+                      <td
+                        class="text-center"
+                      >
+                        
+                        <span
+                          class="mr-1 kong-icon kong-icon-warning"
+                        >
+                          <svg
+                            height="20"
+                            role="img"
+                            version="1.1"
+                            viewBox="0 0 48 42"
+                            width="20"
+                            xmlns="http://www.w3.org/2000/svg"
+                            xmlns:xlink="http://www.w3.org/1999/xlink"
+                          >
+                            
+  
+                            <title>
+                              Warning
+                            </title>
+                            
+  
+                            <g
+                              fill="var(--black-75)"
+                              fill-rule="evenodd"
+                              id="Page-1"
+                              stroke="none"
+                              stroke-width="1"
+                            >
+                              
+    
+                              <g
+                                id="icn-warning-64x"
+                              >
+                                
+      
+                                <path
+                                  d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z M26.8565586,1.63656862 L47.5511049,37.0538196 C48.4690879,38.6248825 47.9342141,40.6394832 46.3564308,41.5535561 C45.8517121,41.8459599 45.2782053,42 44.6942755,42 L3.30518292,42 C1.4797808,42 3.66949018e-16,40.5265221 0,38.7088951 C0,38.1274525 0.154699044,37.5563885 0.448353557,37.0538196 L21.1428999,1.63656862 C22.0608829,0.0655056975 24.0841012,-0.467089888 25.6618845,0.446983085 C26.1568841,0.733756171 26.5685588,1.14367738 26.8565586,1.63656862 Z"
+                                  fill="var(--black-75)"
+                                  fill-rule="nonzero"
+                                  id="Triangle"
+                                />
+                                
+      
+                                <path
+                                  d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z"
+                                  fill="var(--yellow-300)"
+                                  fill-rule="nonzero"
+                                  id="Path"
+                                  type="secondary"
+                                />
+                                
+      
+                                <path
+                                  d="M23,13 L25,13 C25.5522847,13 26,13.4477153 26,14 C26,16 26,18 26,20 C26,22.6594889 25.7904331,25.0570193 25.3712994,27.192591 C25.2792336,27.6616739 24.8680521,28 24.3900199,28 L23.6099609,27.9999816 C23.1319364,27.9999816 22.7207615,27.6616608 22.6286994,27.1925851 C22.2095665,25.0570148 22,22.6594864 22,20 C22,18 22,16 22,14 C22,13.4477153 22.4477153,13 23,13 Z M24,31 C25.1045695,31 26,31.8954305 26,33 C26,34.1045695 25.1045695,35 24,35 C22.8954305,35 22,34.1045695 22,33 C22,31.8954305 22.8954305,31 24,31 Z"
+                                  fill="var(--black-75)"
+                                  id="!"
+                                />
+                                
+    
+                              </g>
+                              
+  
+                            </g>
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                      </td>
+                      
+                    </tr>
+                    <tr
+                      class=""
+                      role="link"
+                      tabindex="0"
+                    >
+                      
+                      <td
+                        class=""
+                      >
+                        
+                        <span
+                          class="status status--with-title status--success"
+                          data-testid="status-badge"
+                        >
+                          <span
+                            class=""
+                          >
+                            online
+                          </span>
+                        </span>
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        
+                        zone-1
+                        
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        1.0.0-rc2-211-g823fe8ce
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        memory
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        Yes
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        Yes
+                        
+                      </td>
+                      <td
+                        class="text-center"
+                      >
+                        
+                        
+                        
+                      </td>
+                      
+                    </tr>
+                    <tr
+                      class=""
+                      role="link"
+                      tabindex="0"
+                    >
+                      
+                      <td
+                        class=""
+                      >
+                        
+                        <span
+                          class="status status--with-title status--success"
+                          data-testid="status-badge"
+                        >
+                          <span
+                            class=""
+                          >
+                            online
+                          </span>
+                        </span>
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        
+                        zone-2
+                        
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        1.0.0-rc2-211-g823fe8ce
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        memory
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        No
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        No
+                        
+                      </td>
+                      <td
+                        class="text-center"
+                      >
+                        
+                        <span
+                          class="mr-1 kong-icon kong-icon-warning"
+                        >
+                          <svg
+                            height="20"
+                            role="img"
+                            version="1.1"
+                            viewBox="0 0 48 42"
+                            width="20"
+                            xmlns="http://www.w3.org/2000/svg"
+                            xmlns:xlink="http://www.w3.org/1999/xlink"
+                          >
+                            
+  
+                            <title>
+                              Warning
+                            </title>
+                            
+  
+                            <g
+                              fill="var(--black-75)"
+                              fill-rule="evenodd"
+                              id="Page-1"
+                              stroke="none"
+                              stroke-width="1"
+                            >
+                              
+    
+                              <g
+                                id="icn-warning-64x"
+                              >
+                                
+      
+                                <path
+                                  d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z M26.8565586,1.63656862 L47.5511049,37.0538196 C48.4690879,38.6248825 47.9342141,40.6394832 46.3564308,41.5535561 C45.8517121,41.8459599 45.2782053,42 44.6942755,42 L3.30518292,42 C1.4797808,42 3.66949018e-16,40.5265221 0,38.7088951 C0,38.1274525 0.154699044,37.5563885 0.448353557,37.0538196 L21.1428999,1.63656862 C22.0608829,0.0655056975 24.0841012,-0.467089888 25.6618845,0.446983085 C26.1568841,0.733756171 26.5685588,1.14367738 26.8565586,1.63656862 Z"
+                                  fill="var(--black-75)"
+                                  fill-rule="nonzero"
+                                  id="Triangle"
+                                />
+                                
+      
+                                <path
+                                  d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z"
+                                  fill="var(--yellow-300)"
+                                  fill-rule="nonzero"
+                                  id="Path"
+                                  type="secondary"
+                                />
+                                
+      
+                                <path
+                                  d="M23,13 L25,13 C25.5522847,13 26,13.4477153 26,14 C26,16 26,18 26,20 C26,22.6594889 25.7904331,25.0570193 25.3712994,27.192591 C25.2792336,27.6616739 24.8680521,28 24.3900199,28 L23.6099609,27.9999816 C23.1319364,27.9999816 22.7207615,27.6616608 22.6286994,27.1925851 C22.2095665,25.0570148 22,22.6594864 22,20 C22,18 22,16 22,14 C22,13.4477153 22.4477153,13 23,13 Z M24,31 C25.1045695,31 26,31.8954305 26,33 C26,34.1045695 25.1045695,35 24,35 C22.8954305,35 22,34.1045695 22,33 C22,31.8954305 22.8954305,31 24,31 Z"
+                                  fill="var(--black-75)"
+                                  id="!"
+                                />
+                                
+    
+                              </g>
+                              
+  
+                            </g>
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                      </td>
+                      
+                    </tr>
+                    <tr
+                      class=""
+                      role="link"
+                      tabindex="0"
+                    >
+                      
+                      <td
+                        class=""
+                      >
+                        
+                        <span
+                          class="status status--with-title status--success"
+                          data-testid="status-badge"
+                        >
+                          <span
+                            class=""
+                          >
+                            online
+                          </span>
+                        </span>
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        
+                        zone-3
+                        
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        1.0.0-rc2-211-g823fe8ce
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        No
+                        
+                      </td>
+                      <td
+                        class=""
+                      >
+                        
+                        No
+                        
+                      </td>
+                      <td
+                        class="text-center"
+                      >
+                        
+                        
+                        
+                      </td>
+                      
+                    </tr>
+                    
+                  </tbody>
+                </table>
+                <!---->
+              </section>
+            </div>
+            <div
+              class="pagination"
+            >
+              <!--v-if-->
+              <!--v-if-->
+            </div>
+          </div>
+          <!--v-if-->
+          <!--v-if-->
+        </div>
       </div>
     </div>
-  </div>
-  <div
-    class="kcard-border mt-4"
-  >
     <div
-      class="tab-container"
-      data-testid="tab-container"
+      class="kcard-border"
     >
-      
-      <header
-        class="tab__header"
-      >
-        
-        <h1
-          class="entity-heading"
-        >
-           Zone: cluster-1
-        </h1>
-        
-      </header>
       <div
-        class="tab__content-container"
+        class="tab-container"
+        data-testid="tab-container"
       >
-        <div
-          class="k-tabs"
+        
+        <header
+          class="tab__header"
         >
-          <ul
-            aria-label="Tabs"
-            role="tablist"
+          
+          <h1
+            class="entity-heading"
           >
-            
-            <li
-              aria-controls="panel-0"
-              aria-selected="true"
-              class="tab-item active"
-              id="overview-tab"
-              role="tab"
-              tabindex="0"
+             Zone: cluster-1
+          </h1>
+          
+        </header>
+        <div
+          class="tab__content-container"
+        >
+          <div
+            class="k-tabs"
+          >
+            <ul
+              aria-label="Tabs"
+              role="tablist"
             >
-              <a
-                class="tab-link"
+              
+              <li
+                aria-controls="panel-0"
+                aria-selected="true"
+                class="tab-item active"
+                id="overview-tab"
+                role="tab"
+                tabindex="0"
               >
-                
-                Overview
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-1"
-              aria-selected="false"
-              class="tab-item"
-              id="insights-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Zone Insights
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-2"
-              aria-selected="false"
-              class="tab-item"
-              id="config-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                Config
-                
-              </a>
-            </li>
-            <li
-              aria-controls="panel-3"
-              aria-selected="false"
-              class="tab-item"
-              id="warnings-tab"
-              role="tab"
-              tabindex="0"
-            >
-              <a
-                class="tab-link"
-              >
-                
-                <span
-                  class="flex items-center with-warnings"
+                <a
+                  class="tab-link"
                 >
+                  
+                  Overview
+                  
+                </a>
+              </li>
+              <li
+                aria-controls="panel-1"
+                aria-selected="false"
+                class="tab-item"
+                id="insights-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
+                  Zone Insights
+                  
+                </a>
+              </li>
+              <li
+                aria-controls="panel-2"
+                aria-selected="false"
+                class="tab-item"
+                id="config-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
+                  Config
+                  
+                </a>
+              </li>
+              <li
+                aria-controls="panel-3"
+                aria-selected="false"
+                class="tab-item"
+                id="warnings-tab"
+                role="tab"
+                tabindex="0"
+              >
+                <a
+                  class="tab-link"
+                >
+                  
                   <span
-                    class="mr-1 kong-icon kong-icon-warning"
+                    class="flex items-center with-warnings"
                   >
-                    <svg
-                      height="16"
-                      role="img"
-                      version="1.1"
-                      viewBox="0 0 48 42"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                    <span
+                      class="mr-1 kong-icon kong-icon-warning"
                     >
-                      
-  
-                      <title>
-                        Warning
-                      </title>
-                      
-  
-                      <g
-                        fill="var(--black-75)"
-                        fill-rule="evenodd"
-                        id="Page-1"
-                        stroke="none"
-                        stroke-width="1"
+                      <svg
+                        height="16"
+                        role="img"
+                        version="1.1"
+                        viewBox="0 0 48 42"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
                       >
                         
-    
-                        <g
-                          id="icn-warning-64x"
-                        >
-                          
-      
-                          <path
-                            d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z M26.8565586,1.63656862 L47.5511049,37.0538196 C48.4690879,38.6248825 47.9342141,40.6394832 46.3564308,41.5535561 C45.8517121,41.8459599 45.2782053,42 44.6942755,42 L3.30518292,42 C1.4797808,42 3.66949018e-16,40.5265221 0,38.7088951 C0,38.1274525 0.154699044,37.5563885 0.448353557,37.0538196 L21.1428999,1.63656862 C22.0608829,0.0655056975 24.0841012,-0.467089888 25.6618845,0.446983085 C26.1568841,0.733756171 26.5685588,1.14367738 26.8565586,1.63656862 Z"
-                            fill="var(--black-75)"
-                            fill-rule="nonzero"
-                            id="Triangle"
-                          />
-                          
-      
-                          <path
-                            d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z"
-                            fill="var(--yellow-300)"
-                            fill-rule="nonzero"
-                            id="Path"
-                            type="secondary"
-                          />
-                          
-      
-                          <path
-                            d="M23,13 L25,13 C25.5522847,13 26,13.4477153 26,14 C26,16 26,18 26,20 C26,22.6594889 25.7904331,25.0570193 25.3712994,27.192591 C25.2792336,27.6616739 24.8680521,28 24.3900199,28 L23.6099609,27.9999816 C23.1319364,27.9999816 22.7207615,27.6616608 22.6286994,27.1925851 C22.2095665,25.0570148 22,22.6594864 22,20 C22,18 22,16 22,14 C22,13.4477153 22.4477153,13 23,13 Z M24,31 C25.1045695,31 26,31.8954305 26,33 C26,34.1045695 25.1045695,35 24,35 C22.8954305,35 22,34.1045695 22,33 C22,31.8954305 22.8954305,31 24,31 Z"
-                            fill="var(--black-75)"
-                            id="!"
-                          />
-                          
-    
-                        </g>
+  
+                        <title>
+                          Warning
+                        </title>
                         
   
-                      </g>
-                      
-
-                    </svg>
-                    
-
-                  </span>
-                  <span>
-                    Warnings
-                  </span>
-                </span>
-                
-              </a>
-            </li>
-            
-          </ul>
-          
-          <div
-            aria-labelledby="overview-tab"
-            class="tab-container"
-            id="panel-0"
-            role="tabpanel"
-            tabindex="0"
-          >
-            
-            <section
-              aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-              class="kong-card noBorder"
-            >
-              <!---->
-              <!---->
-              <div
-                class="k-card-content d-flex"
-              >
-                <div
-                  class="k-card-body"
-                  id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-                >
-                  
-                  
-                  <div
-                    class="label-list"
-                  >
-                    <div
-                      class="label-list__content"
-                    >
-                      
-                      <div>
-                        <ul>
+                        <g
+                          fill="var(--black-75)"
+                          fill-rule="evenodd"
+                          id="Page-1"
+                          stroke="none"
+                          stroke-width="1"
+                        >
                           
-                          <li>
-                            <h4>
-                              type
-                            </h4>
-                            <p>
-                              ZoneOverview
-                            </p>
-                          </li>
-                          <li>
-                            <h4>
-                              name
-                            </h4>
-                            <p>
-                              cluster-1
-                            </p>
-                          </li>
-                          <li>
-                            <h4>
-                              status
-                            </h4>
-                            <p>
-                              <div
-                                class="k-badge d-inline-flex k-badge-success k-badge-rounded"
-                                tabindex="0"
-                              >
+    
+                          <g
+                            id="icn-warning-64x"
+                          >
+                            
+      
+                            <path
+                              d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z M26.8565586,1.63656862 L47.5511049,37.0538196 C48.4690879,38.6248825 47.9342141,40.6394832 46.3564308,41.5535561 C45.8517121,41.8459599 45.2782053,42 44.6942755,42 L3.30518292,42 C1.4797808,42 3.66949018e-16,40.5265221 0,38.7088951 C0,38.1274525 0.154699044,37.5563885 0.448353557,37.0538196 L21.1428999,1.63656862 C22.0608829,0.0655056975 24.0841012,-0.467089888 25.6618845,0.446983085 C26.1568841,0.733756171 26.5685588,1.14367738 26.8565586,1.63656862 Z"
+                              fill="var(--black-75)"
+                              fill-rule="nonzero"
+                              id="Triangle"
+                            />
+                            
+      
+                            <path
+                              d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z"
+                              fill="var(--yellow-300)"
+                              fill-rule="nonzero"
+                              id="Path"
+                              type="secondary"
+                            />
+                            
+      
+                            <path
+                              d="M23,13 L25,13 C25.5522847,13 26,13.4477153 26,14 C26,16 26,18 26,20 C26,22.6594889 25.7904331,25.0570193 25.3712994,27.192591 C25.2792336,27.6616739 24.8680521,28 24.3900199,28 L23.6099609,27.9999816 C23.1319364,27.9999816 22.7207615,27.6616608 22.6286994,27.1925851 C22.2095665,25.0570148 22,22.6594864 22,20 C22,18 22,16 22,14 C22,13.4477153 22.4477153,13 23,13 Z M24,31 C25.1045695,31 26,31.8954305 26,33 C26,34.1045695 25.1045695,35 24,35 C22.8954305,35 22,34.1045695 22,33 C22,31.8954305 22.8954305,31 24,31 Z"
+                              fill="var(--black-75)"
+                              id="!"
+                            />
+                            
+    
+                          </g>
+                          
+  
+                        </g>
+                        
+
+                      </svg>
+                      
+
+                    </span>
+                    <span>
+                      Warnings
+                    </span>
+                  </span>
+                  
+                </a>
+              </li>
+              
+            </ul>
+            
+            <div
+              aria-labelledby="overview-tab"
+              class="tab-container"
+              id="panel-0"
+              role="tabpanel"
+              tabindex="0"
+            >
+              
+              <section
+                aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                class="kong-card noBorder"
+              >
+                <!---->
+                <!---->
+                <div
+                  class="k-card-content d-flex"
+                >
+                  <div
+                    class="k-card-body"
+                    id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+                  >
+                    
+                    
+                    <div
+                      class="label-list"
+                    >
+                      <div
+                        class="label-list__content"
+                      >
+                        
+                        <div>
+                          <ul>
+                            
+                            <li>
+                              <h4>
+                                type
+                              </h4>
+                              <p>
+                                ZoneOverview
+                              </p>
+                            </li>
+                            <li>
+                              <h4>
+                                name
+                              </h4>
+                              <p>
+                                cluster-1
+                              </p>
+                            </li>
+                            <li>
+                              <h4>
+                                status
+                              </h4>
+                              <p>
                                 <div
-                                  class="k-badge-text truncate"
+                                  class="k-badge d-inline-flex k-badge-success k-badge-rounded"
+                                  tabindex="0"
                                 >
                                   <div
                                     class="k-badge-text truncate"
                                   >
-                                    
-                                    online
-                                    
+                                    <div
+                                      class="k-badge-text truncate"
+                                    >
+                                      
+                                      online
+                                      
+                                    </div>
                                   </div>
+                                  <!---->
                                 </div>
-                                <!---->
-                              </div>
-                            </p>
-                          </li>
-                          <li>
-                            <h4>
-                              Authentication Type
-                            </h4>
-                            <p>
-                              dpToken
-                            </p>
-                          </li>
-                          
-                        </ul>
+                              </p>
+                            </li>
+                            <li>
+                              <h4>
+                                Authentication Type
+                              </h4>
+                              <p>
+                                dpToken
+                              </p>
+                            </li>
+                            
+                          </ul>
+                        </div>
+                        
                       </div>
-                      
                     </div>
+                    
+                    
                   </div>
-                  
-                  
+                  <!---->
                 </div>
-                <!---->
-              </div>
-            </section>
+              </section>
+              
+            </div>
+            <div
+              aria-labelledby="insights-tab"
+              class="tab-container"
+              id="panel-1"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
+            <div
+              aria-labelledby="config-tab"
+              class="tab-container"
+              id="panel-2"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
+            <div
+              aria-labelledby="warnings-tab"
+              class="tab-container"
+              id="panel-3"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <!---->
+            </div>
             
           </div>
-          <div
-            aria-labelledby="insights-tab"
-            class="tab-container"
-            id="panel-1"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          <div
-            aria-labelledby="config-tab"
-            class="tab-container"
-            id="panel-2"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          <div
-            aria-labelledby="warnings-tab"
-            class="tab-container"
-            id="panel-3"
-            role="tabpanel"
-            tabindex="0"
-          >
-            <!---->
-          </div>
-          
         </div>
+        
       </div>
-      
     </div>
   </div>
-  
 </div>
 `;
 

--- a/src/assets/styles/_components.scss
+++ b/src/assets/styles/_components.scss
@@ -1,5 +1,6 @@
-.component-frame {
+// To be used in places where we solely need KCard’s frame properties.
+.kcard-border {
   border: var(--KCardBorder);
-  border-radius: 3px;
-  background-color: var(--white);
+  border-radius: --KCardBorderRadius;
+  background-color: var(--KCardBackground);
 }

--- a/src/assets/styles/_components.scss
+++ b/src/assets/styles/_components.scss
@@ -1,6 +1,43 @@
-// To be used in places where we solely need KCard’s frame properties.
+/*
+.kcard-border
+
+To be used in places where we solely need KCard’s frame properties.
+*/
+
 .kcard-border {
   border: var(--KCardBorder);
   border-radius: --KCardBorderRadius;
   background-color: var(--KCardBackground);
+}
+
+/*
+.kcard-stack
+
+For stacking elements with consistent space between.
+
+Adapted from https://every-layout.dev/layouts/stack/.
+*/
+
+.kcard-stack>*+* {
+  margin-block-start: var(--spacing-md);
+}
+
+/*
+.kcard-list
+
+For horizontally listing elements with consistent space between. Once the space defined by `--threshold` is exhausted, the elements will start to wrap.
+
+Adapted from https://every-layout.dev/layouts/switcher/.
+*/
+
+.kcard-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+  --threshold: 30rem;
+}
+
+.kcard-list>* {
+  flex-grow: 1;
+  flex-basis: calc((var(--threshold) - 100%) * 999);
 }

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -30,5 +30,7 @@
   // Removes the default max width of 200 pixels because badges should never be cut-off.
   --KBadgeMaxWidth: auto;
   // Sets a default border style for commonly used component frames/panels.
+  --KCardBorderRadius: 3px;
+  --KCardBackground: var(--white);
   --KCardBorder: 1px solid var(--grey-300);
 }


### PR DESCRIPTION
## Changes

**refactor: uses cards consistently**

Makes use of `KCard` with default border variant as much as possible only resorting to `div.kcard-border` where necessary.

Separates lists of resources and a summary of one selected resource (i.e. the common layout found in list views) visually by placing both blocks in their own frames.

Makes the spacing between some cards/panels consistently use `--spacing-md` (note, this is largely superseded by the following commit).

**refactor: uses consistent gaps between cards**

Adds two new classes for managing the horizontal and vertical grouping of card-like elements (e.g. a list of `KCard`s) and uses it in place of custom listing/stacking logic and manual use of utility classes (like `mt-4`).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Follow-up to https://github.com/kumahq/kuma-gui/pull/754, specifically point 1 from https://github.com/kumahq/kuma-gui/pull/754#issuecomment-1485060891:

> 1. Consistent grouping of content in panels/cards: We should consistently place content in panels (i.e. KCards). in some places, content appears outside of panels (most notably: the home page and the meshes overview).
>    1. (Separating lists from summaries/details: In views where we display both a list of resources and a summary of a selected row, we should display the list and the summary in a separate panel to clearly indicate this boundary visually.)

## Notes

The following is a succinct overview of the places that changed and how.

- **Home, Meshes overview**: puts charts into a card
- **Zone CPs, Zone Ingresses, zone Egresses, policy list view**: splits list and detail into two cards
- **Mesh overview**: establishes consistent spacing around the mesh resources elements.
- **Services list view, gateway list view, DPP list view**: establishes consistent spacing between main content and sidebar
- **Diagnostics**: uses bordered card

## Screenshots

### Home

https://deploy-preview-764--kuma-gui.netlify.app/gui/

| Before | After |
|--------|-------|
| ![Screenshot from 2023-03-29 11-20-42](https://user-images.githubusercontent.com/5774638/228488390-6e737d5f-4ce7-467c-92fc-9998b61627c6.png) | ![Screenshot from 2023-03-29 11-20-45](https://user-images.githubusercontent.com/5774638/228488385-f399d689-6b06-48ae-a852-317477743688.png) |

### Mesh overview

https://deploy-preview-764--kuma-gui.netlify.app/gui/mesh/default

| Before | After |
|--------|-------|
| ![Screenshot from 2023-03-29 11-22-32](https://user-images.githubusercontent.com/5774638/228488932-db65e5ea-e6fc-46aa-8b82-e8a7014de465.png) | ![Screenshot from 2023-03-29 11-22-34](https://user-images.githubusercontent.com/5774638/228488921-ee8ce38e-06ed-4aac-b712-c620af171983.png) |

### Zone CPs

https://deploy-preview-764--kuma-gui.netlify.app/gui/zones?zone=cluster-1

| Before | After |
|--------|-------|
| ![Screenshot from 2023-03-29 11-23-26](https://user-images.githubusercontent.com/5774638/228489148-ef62ab45-2b93-4aca-bef7-279f479e6fee.png) | ![Screenshot from 2023-03-29 11-23-23](https://user-images.githubusercontent.com/5774638/228489153-eb194aec-2f75-4997-9ba0-44ba8046e7d6.png) |
