### PR TITLE
chore: Adds merging mocker function and uses for DataPlaneListView.spec

### DIFF
--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -2,77 +2,93 @@ import { afterAll, afterEach, beforeAll, beforeEach, expect, jest } from '@jest/
 // Polyfills `window.fetch` for Jest because it runs in a Node environment where fetch isn’t available. It initially looked like this would change with Node.js 18, but that is not so.
 import 'isomorphic-fetch'
 import { config } from '@vue/test-utils'
-import { rest, MockedRequest as Request } from 'msw'
 import { setupServer } from 'msw/node'
 
 import { replaceAttributesSnapshotSerializer } from './jest-replace-attribute-snapshot-serializer'
 import { TOKENS as COMPONENT_TOKENS } from '../src/components'
-import { createRouter } from '../src/router/router'
-import { TOKENS, get, container, build } from '../src/services/development'
+import { TOKENS, get, container, build, merge, createInjections } from '../src/services/development'
+import { token } from '../src/services/utils'
 import Env from '@/services/env/Env'
-
-type MockFunction = (_opts: Record<string, unknown>, cb: (req: Request, resp: Record <string, any>) => Record<string, unknown>) => void
+import { mocker } from '@/test-support'
+import type { Mocker } from '@/test-support'
+import type { RestHandler } from 'msw'
 
 // jest can't import this module properly due to transpiling issues
 // mock this out with a blank element
 jest.mock('vue-github-button', () => ({ template: '<span />' }))
-
-/**
- * Adds the application’s router to vue test utils. This way tests don’t have to set-up a new router instance on their own.
- */
-const router = createRouter(get(TOKENS.routes), get(TOKENS.store))
-config.global.plugins.push(router)
-
-/**
- * Kongponents uses generated UUIDs for several attribute values.
- * This breaks the project’s snapshot tests since they’re based on fully-mounted components
- * which also includes those from external sources like Kongponents.
- *
- * In order to stabilize the tests which otherwise fail because the attribute values are different every run,
- * we use a custom snapshot serializer to replace those attribute values with one fixed value.
- */
-expect.addSnapshotSerializer(replaceAttributesSnapshotSerializer([
-  'id',
-  'aria-describedby',
-  'aria-labelledby',
-  'aria-controls',
-  'data-tableid',
-]))
-
-const server = setupServer(...get(TOKENS.mswHandlers))
-
-beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
-afterAll(() => server.close())
-
-// unless we actually use COMPONENT_TOKENS it won't actually get executed
-// probably due to tree shaking/rollup import ordering. This mixed with
-// container capturing/restoring to make our tests isolated means that
-// potentially we can capture an empty container before all the tokens are set,
-// then set the TOKENS/fill the container during a test then the container can
-// get restored to empty whilst we still have TOKENS with now non-existent
-// services accessing TOKENS before we do anything means we set the TOKENS and
-// fill the container with the default services i.e. before we capture if we
-// ever make a test mocking utility to mock out components (similar to
-// withVersion) will will then use COMPONENT_TOKENS here also, which means we
-// can remove the following line
-beforeAll((_ = COMPONENT_TOKENS) => {})
 //
-beforeEach(() => container.capture?.())
-afterEach(() => container.restore?.())
 
-// add a utility to easily setup/mock out API endpoints
-const re = /\+/g
+const $ = {
+  ...TOKENS,
+  mock: token<Mocker>('mocker'),
+};
 
-const useMock = (url: string, response: Record<string, unknown>): MockFunction => {
-  return (_opts, cb) => {
-    server.use(
-      rest.get(`${import.meta.env.VITE_KUMA_API_SERVER_URL.slice(0, -1)}${url.replace(re, '\\+')}`, (req, res, ctx) => {
-        return res(ctx.json(cb(req, JSON.parse(JSON.stringify(response)))))
-      }),
-    )
-  }
-}
+(async () => {
+  const services = merge([
+    [$.msw, {
+      service: (handlers: RestHandler[]) => {
+        return setupServer(...handlers)
+      },
+      arguments: [
+        $.mswHandlers,
+      ],
+    }],
+    [$.mock, {
+      service: mocker,
+      arguments: [
+        $.env,
+        $.msw,
+        $.fakeFS,
+      ],
+    }],
+  ])
+
+  build(
+    services,
+  )
+
+  /**
+  * Adds the application’s router to vue test utils. This way tests don’t have to set-up a new router instance on their own.
+  */
+  config.global.plugins.push(get($.router))
+
+  /**
+  * Kongponents uses generated UUIDs for several attribute values.
+  * This breaks the project’s snapshot tests since they’re based on fully-mounted components
+  * which also includes those from external sources like Kongponents.
+  *
+  * In order to stabilize the tests which otherwise fail because the attribute values are different every run,
+  * we use a custom snapshot serializer to replace those attribute values with one fixed value.
+  */
+  expect.addSnapshotSerializer(replaceAttributesSnapshotSerializer([
+    'id',
+    'aria-describedby',
+    'aria-labelledby',
+    'aria-controls',
+    'data-tableid',
+  ]))
+
+  // unless we actually use COMPONENT_TOKENS it won't actually get executed
+  // probably due to tree shaking/rollup import ordering. This mixed with
+  // container capturing/restoring to make our tests isolated means that
+  // potentially we can capture an empty container before all the tokens are set,
+  // then set the TOKENS/fill the container during a test then the container can
+  // get restored to empty whilst we still have TOKENS with now non-existent
+  // services accessing TOKENS before we do anything means we set the TOKENS and
+  // fill the container with the default services i.e. before we capture if we
+  // ever make a test mocking utility to mock out components (similar to
+  // withVersion) will will then use COMPONENT_TOKENS here also, which means we
+  // can remove the following line
+  beforeAll((_ = COMPONENT_TOKENS) => {})
+  //
+  beforeEach(() => container.capture?.())
+  afterEach(() => container.restore?.())
+
+  const server = get($.msw)
+  beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+})()
 
 export const withVersion = (v: string) => {
   class TestEnv extends Env {
@@ -86,11 +102,15 @@ export const withVersion = (v: string) => {
   }
   build(
     [
-      [TOKENS.Env, {
+      [$.Env, {
         service: TestEnv,
         arguments: [TOKENS.EnvVars],
       }],
     ],
   )
 }
-export { router, server, useMock }
+
+export const [
+  useServer,
+  useMock,
+] = createInjections($.msw, $.mock)

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "babel-plugin-transform-vite-meta-env": "^1.0.3",
     "canvas": "^2.11.0",
     "cross-env": "^7.0.3",
+    "deepmerge": "^4.3.1",
     "dotenv": "^16.0.3",
     "eslint": "^8.36.0",
     "eslint-config-standard": "^17.0.0",

--- a/src/api/mocks/fs.ts
+++ b/src/api/mocks/fs.ts
@@ -1,0 +1,22 @@
+import type { FS } from './index'
+import _1 from '@/api/mocks/src/config'
+import _0 from '@/api/mocks/src/index'
+import _5 from '@/api/mocks/src/meshes/_/dataplanes/_'
+import _7 from '@/api/mocks/src/meshes/_/dataplanes/_/clusters'
+import _4 from '@/api/mocks/src/meshes/_/dataplanes/_/stats'
+import _8 from '@/api/mocks/src/meshes/_/dataplanes/_/xds'
+import _3 from '@/api/mocks/src/meshes/_/dataplanes+insights'
+import _6 from '@/api/mocks/src/meshes/_/dataplanes+insights/_'
+import _2 from '@/api/mocks/src/meshes/_/traffic-permissions'
+
+export const fs: FS = {
+  '/': _0,
+  '/config': _1,
+  '/meshes/:mesh/traffic-permissions': _2,
+  '/meshes/:mesh/dataplanes+insights': _3,
+  '/meshes/:mesh/dataplanes+insights/:name': _6,
+  '/meshes/:mesh/dataplanes/:name': _5,
+  '/meshes/:mesh/dataplanes/:name/clusters': _7,
+  '/meshes/:mesh/dataplanes/:name/stats': _4,
+  '/meshes/:mesh/dataplanes/:name/xds': _8,
+}

--- a/src/api/mocks/index.ts
+++ b/src/api/mocks/index.ts
@@ -1,31 +1,28 @@
 import { faker } from '@faker-js/faker'
 import { rest, RestRequest } from 'msw'
 
-import _1 from '@/api/mocks/src/config'
-import _0 from '@/api/mocks/src/index'
-import _5 from '@/api/mocks/src/meshes/_/dataplanes/_'
-import _7 from '@/api/mocks/src/meshes/_/dataplanes/_/clusters'
-import _4 from '@/api/mocks/src/meshes/_/dataplanes/_/stats'
-import _8 from '@/api/mocks/src/meshes/_/dataplanes/_/xds'
-import _3 from '@/api/mocks/src/meshes/_/dataplanes+insights'
-import _6 from '@/api/mocks/src/meshes/_/dataplanes+insights/_'
-import _2 from '@/api/mocks/src/meshes/_/traffic-permissions'
+import type Env from '@/services/env/Env'
 import FakeKuma from '@/services/kuma-api/FakeKuma'
+import type { Alias } from '@/services/utils'
 
-type Pager = (total: number, req: RestRequest, self: string) => {
+export { fs } from './fs'
+
+type Pager = (total: string | number, req: RestRequest, self: string) => {
   next: string | null,
   pageTotal: number,
   total: number,
   offset: number,
   size: number
 }
-const pager: Pager = (total, req: RestRequest, self) => {
+const pager: Pager = (_total: string | number, req: RestRequest, self) => {
+  const baseUrl = 'http://localhost:5681'
+  const total = parseInt(`${_total}`)
   const query = req.url.searchParams
   const size = parseInt(query.get('size') || '10')
   const offset = parseInt(query.get('offset') || '1')
   const remaining = total - offset
   const pageTotal = Math.min(size, remaining)
-  const next = remaining <= size ? null : `${self}?offset=${offset + size}`
+  const next = remaining <= size ? null : `${baseUrl}${self}?offset=${offset + size}`
   return {
     next,
     pageTotal,
@@ -35,27 +32,41 @@ const pager: Pager = (total, req: RestRequest, self) => {
   }
 }
 
+export type AEnv = Alias<Env['var']>
+export type MockEnvKeys = keyof {
+  FAKE_SEED: string
+  KUMA_DATAPLANE_COUNT: string
+}
+export type AppEnvKeys = Parameters<AEnv>[0]
 export type EndpointDependencies = {
   fake: FakeKuma
-  pager: Pager
+  pager: Pager,
+  env: (key: AppEnvKeys | MockEnvKeys, d: string) => string
 }
-type MockResponse = {
+export type MockResponse = {
   headers: Record<string, string>
   body: string | Record<string, unknown>
 }
 export type MockResponder = (req: RestRequest) => MockResponse
 export type FakeEndpoint = (deps: EndpointDependencies) => MockResponder
 
-function escapeRoute(route: string): string {
+export function escapeRoute(route: string): string {
   return route.replaceAll('+', '\\+')
 }
+export const dependencies = {
+  fake: new FakeKuma(faker),
+  pager,
+  env: (_key: AppEnvKeys | MockEnvKeys, d = '') => d,
+}
+export const fakeApi = (env: AEnv, fs: Record<string, FakeEndpoint>) => {
+  const baseUrl = env('KUMA_API_URL')
+  const mockEnv: EndpointDependencies['env'] = (key, d = '') => env(key as AppEnvKeys, d)
 
-export const fakeApi = (url: string, fs: Record<string, FakeEndpoint>) => {
   return Object.entries(fs).map(([route, endpoint]) => {
-    return rest.all(`${url}${escapeRoute(route)}`, async (req, res, ctx) => {
+    return rest.all(`${baseUrl}${escapeRoute(route)}`, async (req, res, ctx) => {
       const fetch = endpoint({
-        fake: new FakeKuma(faker),
-        pager,
+        ...dependencies,
+        env: mockEnv,
       })
       const response = fetch(req)
       return res(
@@ -65,15 +76,4 @@ export const fakeApi = (url: string, fs: Record<string, FakeEndpoint>) => {
     })
   })
 }
-
-export const fs: Record<string, FakeEndpoint> = {
-  '/': _0,
-  '/config': _1,
-  '/meshes/:mesh/traffic-permissions': _2,
-  '/meshes/:mesh/dataplanes+insights': _3,
-  '/meshes/:mesh/dataplanes+insights/:name': _6,
-  '/meshes/:mesh/dataplanes/:name': _5,
-  '/meshes/:mesh/dataplanes/:name/clusters': _7,
-  '/meshes/:mesh/dataplanes/:name/stats': _4,
-  '/meshes/:mesh/dataplanes/:name/xds': _8,
-}
+export type FS = Record<string, FakeEndpoint>

--- a/src/api/mocks/src/meshes/_/dataplanes+insights.ts
+++ b/src/api/mocks/src/meshes/_/dataplanes+insights.ts
@@ -1,25 +1,167 @@
-/* eslint-disable quote-props */
-/* eslint-disable object-shorthand */
-import all from '@/api/mock-data/meshes/default/dataplanes+insights.json'
-import gateways from '@/api/mock-data/meshes/default/dataplanes+insights__gateways-all.json'
-import builtin from '@/api/mock-data/meshes/default/dataplanes+insights__gateways-builtin.json'
-import delegated from '@/api/mock-data/meshes/default/dataplanes+insights__gateways-delegated.json'
-import type { MockResponder } from '@/api/mocks/index'
+import type { EndpointDependencies, MockResponder } from '@/api/mocks/index'
 
-export default (): MockResponder => (req) => {
-  const gateway = req.url.searchParams.get('gateway') ?? ''
-  const proxies = all
-  proxies.items = proxies.items.filter((item: any) => item.dataplane.networking.gateway === undefined)
-  proxies.total = proxies.items.length
-  const body: Record<string, Record<string, unknown>> = {
-    'true': gateways,
-    'builtin': builtin,
-    'delegated': delegated,
-    'false': proxies,
-    '': all,
-  }
+export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (req) => {
+  const params = req.params
+  const query = req.url.searchParams
+  const _gateway = query.get('gateway') ?? ''
+  const _name = query.get('name') ?? ''
+  const _tags = query.get('tags') ?? ''
+
+  const { offset, total, next, pageTotal } = pager(
+    env('KUMA_DATAPLANE_COUNT', `${fake.datatype.number({ min: 1, max: 1000 })}`),
+    req,
+    `/meshes/${params.mesh}/dataplanes+insights`,
+  )
+
+  const hasGateways = _gateway !== 'false'
+  const hasSidecars = !['true', 'builtin', 'delegated'].includes(_gateway)
+  const tags = _tags !== '' ? Object.fromEntries([_tags].filter(Boolean).map(item => { const [key, ...rest] = item.split(':'); return [key, rest.join(':')] })) : {}
+
   return {
     headers: {},
-    body: body[gateway],
+    body: {
+      total,
+      items: Array.from({ length: pageTotal }).map((_, i) => {
+        const id = offset + i
+        const isGateway = (!hasSidecars || (hasGateways && fake.datatype.boolean()))
+
+        const isMultizone = true && fake.datatype.boolean()
+        const service = tags['kuma.io/service'] ?? `${fake.hacker.noun()}`
+
+        const name = `${_name || fake.hacker.noun()}${isGateway ? '-gateway' : '-proxy'}-${id}`
+        const zone = `${fake.hacker.noun()}-${id}`
+
+        return {
+          type: 'DataplaneOverview',
+          mesh: params.mesh,
+          name,
+          creationTime: '2021-02-17T08:33:36.442044+01:00',
+          modificationTime: '2021-02-17T08:33:36.442044+01:00',
+          dataplane: {
+            networking: {
+              address: fake.internet.ip(),
+              ...(isGateway && {
+                gateway: {
+                  tags: {
+                    'kuma.io/service': name,
+                    ...(isMultizone && {
+                      'kuma.io/zone': zone,
+                    }),
+                  },
+                  type: _gateway === 'true' || _gateway === '' ? fake.helpers.arrayElement(['BUILTIN', 'DELEGATED']) : _gateway.toUpperCase(),
+                },
+              }),
+              inbound: [
+                {
+                  port: fake.internet.port(),
+                  servicePort: fake.internet.port(),
+                  serviceAddress: fake.internet.ip(),
+                  tags: {
+                    'kuma.io/protocol': fake.kuma.protocol(),
+                    'kuma.io/service': `${service}`,
+                  },
+                },
+              ],
+              outbound: [
+                {
+                  port: fake.internet.port(),
+                  tags: {
+                    'kuma.io/service': `${fake.hacker.noun()}-${i}`,
+                  },
+                },
+              ],
+            },
+          },
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
+                controlPlaneInstanceId: 'foo',
+                connectTime: '2021-02-17T07:33:36.412683Z',
+                disconnectTime: '2021-02-17T07:33:36.412683Z',
+                status: {
+                  lastUpdateTime: '2021-02-17T10:48:03.638434Z',
+                  total: {
+                    responsesSent: '5',
+                    responsesAcknowledged: '5',
+                  },
+                  cds: {
+                    responsesSent: '1',
+                    responsesAcknowledged: '1',
+                  },
+                  eds: {
+                    responsesSent: '2',
+                    responsesAcknowledged: '2',
+                  },
+                  lds: {
+                    responsesSent: '2',
+                    responsesAcknowledged: '2',
+                  },
+                  rds: {},
+                },
+                version: {
+                  kumaDp: {
+                    version: '1.0.7',
+                    gitTag: 'unknown',
+                    gitCommit: 'unknown',
+                    buildDate: 'unknown',
+                  },
+                  envoy: {
+                    version: '1.16.2',
+                    build: 'e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL',
+                  },
+                  dependencies: {
+                    coredns: '1.8.3',
+                  },
+                },
+              },
+              {
+                id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
+                controlPlaneInstanceId: 'foo',
+                connectTime: '2021-02-17T07:33:36.412683Z',
+                status: {
+                  lastUpdateTime: '2021-02-17T10:48:03.638434Z',
+                  total: {
+                    responsesSent: '5',
+                    responsesAcknowledged: '5',
+                  },
+                  cds: {
+                    responsesSent: '1',
+                    responsesAcknowledged: '1',
+                  },
+                  eds: {
+                    responsesSent: '2',
+                    responsesAcknowledged: '2',
+                  },
+                  lds: {
+                    responsesSent: '2',
+                    responsesAcknowledged: '2',
+                  },
+                  rds: {},
+                },
+                version: {
+                  kumaDp: {
+                    version: '1.0.7',
+                    gitTag: 'unknown',
+                    gitCommit: 'unknown',
+                    buildDate: 'unknown',
+                    kumaCpCompatible: true,
+                  },
+                  envoy: {
+                    version: '1.16.2',
+                    build: 'e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL',
+                    kumaDpCompatible: true,
+                  },
+                  dependencies: {
+                    coredns: '1.8.3',
+                  },
+                },
+              },
+            ],
+          },
+        }
+      }),
+      next,
+    },
   }
 }

--- a/src/app/common/EnvoyData.spec.ts
+++ b/src/app/common/EnvoyData.spec.ts
@@ -3,7 +3,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { rest } from 'msw'
 
 import EnvoyData from './EnvoyData.vue'
-import { server } from '@/../jest/jest-setup-after-env'
+import { useServer } from '@/../jest/jest-setup-after-env'
 
 function renderComponent(props = {}) {
   return mount(EnvoyData, {
@@ -22,6 +22,7 @@ describe('EnvoyData.vue', () => {
   })
 
   test('renders snapshot', async () => {
+    const server = useServer()
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/dataplanes/:dataplaneName/clusters', (req, res, ctx) =>
         res(ctx.status(200), ctx.json('')),
@@ -37,6 +38,7 @@ describe('EnvoyData.vue', () => {
   })
 
   test('renders loading', () => {
+    const server = useServer()
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/dataplanes/:dataplaneName/clusters', (req, res, ctx) =>
         res(ctx.status(200), ctx.json('')),
@@ -53,6 +55,7 @@ describe('EnvoyData.vue', () => {
   })
 
   test('renders error', async () => {
+    const server = useServer()
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/dataplanes/:dataplaneName/clusters', (req, res, ctx) =>
         res(ctx.status(500), ctx.json('')),

--- a/src/app/data-planes/components/DataplanePolicies.spec.ts
+++ b/src/app/data-planes/components/DataplanePolicies.spec.ts
@@ -3,7 +3,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { rest } from 'msw'
 
 import DataplanePolicies from './DataplanePolicies.vue'
-import { server } from '@/../jest/jest-setup-after-env'
+import { useServer } from '@/../jest/jest-setup-after-env'
 import {
   DataPlane,
 } from '@/types/index.d'
@@ -49,6 +49,7 @@ describe('DataplanePolicies.vue', () => {
   })
 
   test('renders error', async () => {
+    const server = useServer()
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/dataplanes/:dataplaneName/policies', (_req, res, ctx) =>
         res(ctx.status(500), ctx.json({})),
@@ -63,6 +64,7 @@ describe('DataplanePolicies.vue', () => {
   })
 
   test('renders no item', async () => {
+    const server = useServer()
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/dataplanes/:dataplaneName/policies', (req, res, ctx) =>
         res(ctx.status(200), ctx.json({ total: 0, items: [] })),

--- a/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
+++ b/src/app/data-planes/views/__snapshots__/DataPlaneListView.spec.ts.snap
@@ -635,9 +635,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/data-planes/backend"
+                        href="/mesh/default/data-planes/capacitor-proxy-0"
                       >
-                        backend
+                        capacitor-proxy-0
                       </a>
                       
                     </td>
@@ -647,9 +647,589 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/services/backend"
+                        href="/mesh/default/services/monitor"
                       >
-                        backend
+                        monitor
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/capacitor-proxy-0"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/system-proxy-1"
+                      >
+                        system-proxy-1
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/bus"
+                      >
+                        bus
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/system-proxy-1"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/capacitor-proxy-2"
+                      >
+                        capacitor-proxy-2
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/panel"
+                      >
+                        panel
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      kafka
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/capacitor-proxy-2"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/driver-proxy-3"
+                      >
+                        driver-proxy-3
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/transmitter"
+                      >
+                        transmitter
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/driver-proxy-3"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/panel-proxy-4"
+                      >
+                        panel-proxy-4
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/card"
+                      >
+                        card
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/panel-proxy-4"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/bandwidth-proxy-5"
+                      >
+                        bandwidth-proxy-5
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/program"
+                      >
+                        program
                       </a>
                       
                     </td>
@@ -684,7 +1264,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class="k-button medium rounded btn-link detail-link"
-                        href="/mesh/default/data-planes/backend"
+                        href="/mesh/default/data-planes/bandwidth-proxy-5"
                         type="button"
                       >
                         
@@ -751,9 +1331,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/data-planes/frontend"
+                        href="/mesh/default/data-planes/circuit-proxy-6"
                       >
-                        frontend
+                        circuit-proxy-6
                       </a>
                       
                     </td>
@@ -763,9 +1343,705 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/services/frontend"
+                        href="/mesh/default/services/program"
                       >
-                        frontend
+                        program
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/circuit-proxy-6"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/interface-proxy-7"
+                      >
+                        interface-proxy-7
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/firewall"
+                      >
+                        firewall
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/interface-proxy-7"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/circuit-proxy-8"
+                      >
+                        circuit-proxy-8
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/pixel"
+                      >
+                        pixel
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/circuit-proxy-8"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/application-proxy-9"
+                      >
+                        application-proxy-9
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/hard%20drive"
+                      >
+                        hard drive
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/application-proxy-9"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/circuit-proxy-10"
+                      >
+                        circuit-proxy-10
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/system"
+                      >
+                        system
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/circuit-proxy-10"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/program-proxy-11"
+                      >
+                        program-proxy-11
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/interface"
+                      >
+                        interface
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/program-proxy-11"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/sensor-proxy-12"
+                      >
+                        sensor-proxy-12
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/array"
+                      >
+                        array
                       </a>
                       
                     </td>
@@ -788,9 +2064,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                     >
                       
                       <div
-                        class="with-warnings"
+                        class=""
                       >
-                        1.0.6
+                        1.0.7
                       </div>
                       
                     </td>
@@ -800,68 +2076,29 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class="k-button medium rounded btn-link detail-link"
-                        href="/mesh/default/data-planes/frontend"
+                        href="/mesh/default/data-planes/sensor-proxy-12"
                         type="button"
                       >
                         
                         <span
-                          class="kong-icon kong-icon-warning"
+                          class="kong-icon kong-icon-info"
                         >
                           <svg
                             height="16"
                             role="img"
-                            version="1.1"
-                            viewBox="0 0 48 42"
+                            viewBox="0 0 16 16"
                             width="16"
                             xmlns="http://www.w3.org/2000/svg"
-                            xmlns:xlink="http://www.w3.org/1999/xlink"
                           >
                             
   
                             
   
-                            <g
-                              fill="var(--black-75)"
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
                               fill-rule="evenodd"
-                              id="Page-1"
-                              stroke="none"
-                              stroke-width="1"
-                            >
-                              
-    
-                              <g
-                                id="icn-warning-64x"
-                              >
-                                
-      
-                                <path
-                                  d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z M26.8565586,1.63656862 L47.5511049,37.0538196 C48.4690879,38.6248825 47.9342141,40.6394832 46.3564308,41.5535561 C45.8517121,41.8459599 45.2782053,42 44.6942755,42 L3.30518292,42 C1.4797808,42 3.66949018e-16,40.5265221 0,38.7088951 C0,38.1274525 0.154699044,37.5563885 0.448353557,37.0538196 L21.1428999,1.63656862 C22.0608829,0.0655056975 24.0841012,-0.467089888 25.6618845,0.446983085 C26.1568841,0.733756171 26.5685588,1.14367738 26.8565586,1.63656862 Z"
-                                  fill="var(--black-75)"
-                                  fill-rule="nonzero"
-                                  id="Triangle"
-                                />
-                                
-      
-                                <path
-                                  d="M25.129733,2.64556484 C25.0166566,2.45204254 24.8546193,2.29069544 24.6593031,2.17754095 C24.0339615,1.81525556 23.2314423,2.02651215 22.8697255,2.64556484 L2.17517915,38.0628158 C2.06036961,38.2593042 2,38.4821557 2,38.7088951 C2,39.4200371 2.58244376,40 3.30518292,40 L44.6942755,40 C44.9262204,40 45.1538685,39.9388552 45.3538494,39.8229983 C45.9741835,39.4636139 46.1830669,38.6768553 45.8242793,38.0628158 L25.129733,2.64556484 Z"
-                                  fill="var(--yellow-300)"
-                                  fill-rule="nonzero"
-                                  id="Path"
-                                  type="secondary"
-                                />
-                                
-      
-                                <path
-                                  d="M23,13 L25,13 C25.5522847,13 26,13.4477153 26,14 C26,16 26,18 26,20 C26,22.6594889 25.7904331,25.0570193 25.3712994,27.192591 C25.2792336,27.6616739 24.8680521,28 24.3900199,28 L23.6099609,27.9999816 C23.1319364,27.9999816 22.7207615,27.6616608 22.6286994,27.1925851 C22.2095665,25.0570148 22,22.6594864 22,20 C22,18 22,16 22,14 C22,13.4477153 22.4477153,13 23,13 Z M24,31 C25.1045695,31 26,31.8954305 26,33 C26,34.1045695 25.1045695,35 24,35 C22.8954305,35 22,34.1045695 22,33 C22,31.8954305 22.8954305,31 24,31 Z"
-                                  fill="var(--black-75)"
-                                  id="!"
-                                />
-                                
-    
-                              </g>
-                              
-  
-                            </g>
+                            />
                             
 
                           </svg>
@@ -906,9 +2143,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/data-planes/db"
+                        href="/mesh/default/data-planes/capacitor-proxy-13"
                       >
-                        db
+                        capacitor-proxy-13
                       </a>
                       
                     </td>
@@ -918,9 +2155,241 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/services/db"
+                        href="/mesh/default/services/monitor"
                       >
-                        db
+                        monitor
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/capacitor-proxy-13"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/interface-proxy-14"
+                      >
+                        interface-proxy-14
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/driver"
+                      >
+                        driver
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      kafka
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/interface-proxy-14"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/port-proxy-15"
+                      >
+                        port-proxy-15
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/program"
+                      >
+                        program
                       </a>
                       
                     </td>
@@ -945,7 +2414,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       <div
                         class=""
                       >
-                        unknown
+                        1.0.7
                       </div>
                       
                     </td>
@@ -955,7 +2424,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class="k-button medium rounded btn-link detail-link"
-                        href="/mesh/default/data-planes/db"
+                        href="/mesh/default/data-planes/port-proxy-15"
                         type="button"
                       >
                         
@@ -1005,13 +2474,13 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                     >
                       
                       <span
-                        class="status status--with-title status--danger"
+                        class="status status--with-title status--success"
                         data-testid="status-badge"
                       >
                         <span
                           class=""
                         >
-                          offline
+                          online
                         </span>
                       </span>
                       
@@ -1022,9 +2491,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/data-planes/no-subscriptions"
+                        href="/mesh/default/data-planes/system-proxy-16"
                       >
-                        no-subscriptions
+                        system-proxy-16
                       </a>
                       
                     </td>
@@ -1034,9 +2503,473 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/services/no-subscriptions"
+                        href="/mesh/default/services/interface"
                       >
-                        no-subscriptions
+                        interface
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      kafka
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/system-proxy-16"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/program-proxy-17"
+                      >
+                        program-proxy-17
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/application"
+                      >
+                        application
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/program-proxy-17"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/panel-proxy-18"
+                      >
+                        panel-proxy-18
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/port"
+                      >
+                        port
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/panel-proxy-18"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/transmitter-proxy-19"
+                      >
+                        transmitter-proxy-19
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/matrix"
+                      >
+                        matrix
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/transmitter-proxy-19"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/bandwidth-proxy-20"
+                      >
+                        bandwidth-proxy-20
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/matrix"
+                      >
+                        matrix
                       </a>
                       
                     </td>
@@ -1051,7 +2984,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       class=""
                     >
                       
-                      —
+                      February 17, 2021
                       
                     </td>
                     <td
@@ -1061,7 +2994,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       <div
                         class=""
                       >
-                        —
+                        1.0.7
                       </div>
                       
                     </td>
@@ -1071,7 +3004,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class="k-button medium rounded btn-link detail-link"
-                        href="/mesh/default/data-planes/no-subscriptions"
+                        href="/mesh/default/data-planes/bandwidth-proxy-20"
                         type="button"
                       >
                         
@@ -1138,9 +3071,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/data-planes/cluster-1.backend-02"
+                        href="/mesh/default/data-planes/alarm-proxy-21"
                       >
-                        cluster-1.backend-02
+                        alarm-proxy-21
                       </a>
                       
                     </td>
@@ -1150,9 +3083,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/services/backend"
+                        href="/mesh/default/services/program"
                       >
-                        backend
+                        program
                       </a>
                       
                     </td>
@@ -1160,14 +3093,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       class=""
                     >
                       
-                      —
+                      http
                       
                     </td>
                     <td
                       class=""
                     >
                       
-                      February 19, 2021
+                      February 17, 2021
                       
                     </td>
                     <td
@@ -1177,7 +3110,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       <div
                         class=""
                       >
-                        1.0.0-rc2-211-g823fe8ce
+                        1.0.7
                       </div>
                       
                     </td>
@@ -1187,7 +3120,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class="k-button medium rounded btn-link detail-link"
-                        href="/mesh/default/data-planes/cluster-1.backend-02"
+                        href="/mesh/default/data-planes/alarm-proxy-21"
                         type="button"
                       >
                         
@@ -1254,9 +3187,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/data-planes/cluster-1.backend-03"
+                        href="/mesh/default/data-planes/bus-proxy-22"
                       >
-                        cluster-1.backend-03
+                        bus-proxy-22
                       </a>
                       
                     </td>
@@ -1266,9 +3199,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/services/backend"
+                        href="/mesh/default/services/firewall"
                       >
-                        backend
+                        firewall
                       </a>
                       
                     </td>
@@ -1276,14 +3209,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       class=""
                     >
                       
-                      —
+                      http
                       
                     </td>
                     <td
                       class=""
                     >
                       
-                      February 19, 2021
+                      February 17, 2021
                       
                     </td>
                     <td
@@ -1293,7 +3226,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       <div
                         class=""
                       >
-                        1.0.0-rc2-211-g823fe8ce
+                        1.0.7
                       </div>
                       
                     </td>
@@ -1303,7 +3236,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class="k-button medium rounded btn-link detail-link"
-                        href="/mesh/default/data-planes/cluster-1.backend-03"
+                        href="/mesh/default/data-planes/bus-proxy-22"
                         type="button"
                       >
                         
@@ -1370,9 +3303,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/data-planes/cluster-1.ingress-02"
+                        href="/mesh/default/data-planes/program-proxy-23"
                       >
-                        cluster-1.ingress-02
+                        program-proxy-23
                       </a>
                       
                     </td>
@@ -1382,9 +3315,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/services/ingress"
+                        href="/mesh/default/services/system"
                       >
-                        ingress
+                        system
                       </a>
                       
                     </td>
@@ -1392,14 +3325,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       class=""
                     >
                       
-                      —
+                      tcp
                       
                     </td>
                     <td
                       class=""
                     >
                       
-                      February 19, 2021
+                      February 17, 2021
                       
                     </td>
                     <td
@@ -1409,7 +3342,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       <div
                         class=""
                       >
-                        1.0.0-rc2-211-g823fe8ce
+                        1.0.7
                       </div>
                       
                     </td>
@@ -1419,7 +3352,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class="k-button medium rounded btn-link detail-link"
-                        href="/mesh/default/data-planes/cluster-1.ingress-02"
+                        href="/mesh/default/data-planes/program-proxy-23"
                         type="button"
                       >
                         
@@ -1486,9 +3419,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/data-planes/dataplane-test-456"
+                        href="/mesh/default/data-planes/microchip-proxy-24"
                       >
-                        dataplane-test-456
+                        microchip-proxy-24
                       </a>
                       
                     </td>
@@ -1498,9 +3431,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/services/kuma-example-backend"
+                        href="/mesh/default/services/sensor"
                       >
-                        kuma-example-backend
+                        sensor
                       </a>
                       
                     </td>
@@ -1508,14 +3441,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       class=""
                     >
                       
-                      —
+                      http
                       
                     </td>
                     <td
                       class=""
                     >
                       
-                      October 24, 2019
+                      February 17, 2021
                       
                     </td>
                     <td
@@ -1525,7 +3458,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       <div
                         class=""
                       >
-                        —
+                        1.0.7
                       </div>
                       
                     </td>
@@ -1535,7 +3468,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class="k-button medium rounded btn-link detail-link"
-                        href="/mesh/default/data-planes/dataplane-test-456"
+                        href="/mesh/default/data-planes/microchip-proxy-24"
                         type="button"
                       >
                         
@@ -1602,9 +3535,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/data-planes/ingress-dp-test-123"
+                        href="/mesh/default/data-planes/panel-proxy-25"
                       >
-                        ingress-dp-test-123
+                        panel-proxy-25
                       </a>
                       
                     </td>
@@ -1614,9 +3547,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class=""
-                        href="/mesh/default/services/kuma-example-backend"
+                        href="/mesh/default/services/protocol"
                       >
-                        kuma-example-backend
+                        protocol
                       </a>
                       
                     </td>
@@ -1624,14 +3557,14 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       class=""
                     >
                       
-                      —
+                      http
                       
                     </td>
                     <td
                       class=""
                     >
                       
-                      October 24, 2019
+                      February 17, 2021
                       
                     </td>
                     <td
@@ -1641,7 +3574,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       <div
                         class=""
                       >
-                        —
+                        1.0.7
                       </div>
                       
                     </td>
@@ -1651,7 +3584,2791 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                       
                       <a
                         class="k-button medium rounded btn-link detail-link"
-                        href="/mesh/default/data-planes/ingress-dp-test-123"
+                        href="/mesh/default/data-planes/panel-proxy-25"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/circuit-proxy-26"
+                      >
+                        circuit-proxy-26
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/panel"
+                      >
+                        panel
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      http
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/circuit-proxy-26"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/hard%20drive-proxy-27"
+                      >
+                        hard drive-proxy-27
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/system"
+                      >
+                        system
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/hard%20drive-proxy-27"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/bus-proxy-28"
+                      >
+                        bus-proxy-28
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/transmitter"
+                      >
+                        transmitter
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      http
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/bus-proxy-28"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/feed-proxy-29"
+                      >
+                        feed-proxy-29
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/protocol"
+                      >
+                        protocol
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/feed-proxy-29"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/system-proxy-30"
+                      >
+                        system-proxy-30
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/hard%20drive"
+                      >
+                        hard drive
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      kafka
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/system-proxy-30"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/card-proxy-31"
+                      >
+                        card-proxy-31
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/driver"
+                      >
+                        driver
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/card-proxy-31"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/microchip-proxy-32"
+                      >
+                        microchip-proxy-32
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/system"
+                      >
+                        system
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      http
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/microchip-proxy-32"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/alarm-proxy-33"
+                      >
+                        alarm-proxy-33
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/application"
+                      >
+                        application
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/alarm-proxy-33"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/system-proxy-34"
+                      >
+                        system-proxy-34
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/firewall"
+                      >
+                        firewall
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/system-proxy-34"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/microchip-proxy-35"
+                      >
+                        microchip-proxy-35
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/protocol"
+                      >
+                        protocol
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/microchip-proxy-35"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/bus-proxy-36"
+                      >
+                        bus-proxy-36
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/program"
+                      >
+                        program
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/bus-proxy-36"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/monitor-proxy-37"
+                      >
+                        monitor-proxy-37
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/card"
+                      >
+                        card
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      http
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/monitor-proxy-37"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/application-proxy-38"
+                      >
+                        application-proxy-38
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/firewall"
+                      >
+                        firewall
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      kafka
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/application-proxy-38"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/firewall-proxy-39"
+                      >
+                        firewall-proxy-39
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/protocol"
+                      >
+                        protocol
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/firewall-proxy-39"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/microchip-proxy-40"
+                      >
+                        microchip-proxy-40
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/capacitor"
+                      >
+                        capacitor
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/microchip-proxy-40"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/application-proxy-41"
+                      >
+                        application-proxy-41
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/pixel"
+                      >
+                        pixel
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      kafka
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/application-proxy-41"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/protocol-proxy-42"
+                      >
+                        protocol-proxy-42
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/application"
+                      >
+                        application
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      kafka
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/protocol-proxy-42"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/hard%20drive-proxy-43"
+                      >
+                        hard drive-proxy-43
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/matrix"
+                      >
+                        matrix
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      tcp
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/hard%20drive-proxy-43"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/monitor-proxy-44"
+                      >
+                        monitor-proxy-44
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/array"
+                      >
+                        array
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/monitor-proxy-44"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/program-proxy-45"
+                      >
+                        program-proxy-45
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/port"
+                      >
+                        port
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      http
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/program-proxy-45"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/sensor-proxy-46"
+                      >
+                        sensor-proxy-46
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/card"
+                      >
+                        card
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      kafka
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/sensor-proxy-46"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/transmitter-proxy-47"
+                      >
+                        transmitter-proxy-47
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/monitor"
+                      >
+                        monitor
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/transmitter-proxy-47"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/array-proxy-48"
+                      >
+                        array-proxy-48
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/system"
+                      >
+                        system
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      kafka
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/array-proxy-48"
+                        type="button"
+                      >
+                        
+                        <span
+                          class="kong-icon kong-icon-info"
+                        >
+                          <svg
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            
+  
+                            
+  
+                            <path
+                              d="M16 8c0-4.418278-3.58172-8-8-8S0 3.581722 0 8s3.58172 8 8 8 8-3.581722 8-8zm-1.5 0c0 3.5898509-2.91015 6.5-6.5 6.5S1.5 11.5898509 1.5 8 4.41015 1.5 8 1.5s6.5 2.9101491 6.5 6.5zM6 12h4v-1H9V7H6v1h1v3H6v1zm1-6.5046844C7 5.7740451 7.21404 6 7.50468 6h.99064C8.77405 6 9 5.785965 9 5.4953156v-.9906312C9 4.2259549 8.78596 4 8.49532 4h-.99064C7.22595 4 7 4.214035 7 4.5046844v.9906312z"
+                              fill="var(--blue-500)"
+                              fill-rule="evenodd"
+                            />
+                            
+
+                          </svg>
+                          
+
+                        </span>
+                        
+                        
+                         Details 
+                        
+                        <!---->
+                      </a>
+                      
+                    </td>
+                    
+                  </tr>
+                  <tr
+                    class=""
+                    role="link"
+                    tabindex="0"
+                  >
+                    
+                    <td
+                      class=""
+                    >
+                      
+                      <span
+                        class="status status--with-title status--success"
+                        data-testid="status-badge"
+                      >
+                        <span
+                          class=""
+                        >
+                          online
+                        </span>
+                      </span>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/data-planes/transmitter-proxy-49"
+                      >
+                        transmitter-proxy-49
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <a
+                        class=""
+                        href="/mesh/default/services/transmitter"
+                      >
+                        transmitter
+                      </a>
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      grpc
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      February 17, 2021
+                      
+                    </td>
+                    <td
+                      class=""
+                    >
+                      
+                      <div
+                        class=""
+                      >
+                        1.0.7
+                      </div>
+                      
+                    </td>
+                    <td
+                      class="text-right"
+                    >
+                      
+                      <a
+                        class="k-button medium rounded btn-link detail-link"
+                        href="/mesh/default/data-planes/transmitter-proxy-49"
                         type="button"
                       >
                         
@@ -1786,9 +6503,9 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                        DPP: 
                       <a
                         class=""
-                        href="/mesh/default/data-planes/backend"
+                        href="/mesh/default/data-planes/capacitor-proxy-0"
                       >
-                        backend
+                        capacitor-proxy-0
                       </a>
                     </span>
                     <span
@@ -1835,7 +6552,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                           <span>
                             kuma.io/protocol:
                             <b>
-                              http
+                              tcp
                             </b>
                           </span>
                           
@@ -1856,11 +6573,11 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                           
                           <a
                             class=""
-                            href="/mesh/default/services/backend"
+                            href="/mesh/default/services/monitor"
                           >
                             kuma.io/service:
                             <b>
-                              backend
+                              monitor
                             </b>
                           </a>
                           
@@ -2430,7 +7147,24 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                               >
                                 :
                               </span>
-                               backend
+                               capacitor
+                              <span
+                                class="token punctuation"
+                              >
+                                -
+                              </span>
+                              proxy
+                              <span
+                                class="token punctuation"
+                              >
+                                -
+                              </span>
+                              <span
+                                class="token number"
+                              >
+                                0
+                              </span>
+                              
 
                               <span
                                 class="token key atrule"
@@ -2466,7 +7200,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                               >
                                 :
                               </span>
-                               127.0.0.1
+                               32.77.255.37
   
                               <span
                                 class="token key atrule"
@@ -2500,7 +7234,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                               <span
                                 class="token number"
                               >
-                                7776
+                                15472
                               </span>
                               
       
@@ -2518,7 +7252,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                               <span
                                 class="token number"
                               >
-                                7777
+                                6051
                               </span>
                               
       
@@ -2532,7 +7266,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                               >
                                 :
                               </span>
-                               127.0.0.1
+                               101.47.99.88
       
                               <span
                                 class="token key atrule"
@@ -2556,7 +7290,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                               >
                                 :
                               </span>
-                               http
+                               tcp
         
                               <span
                                 class="token key atrule"
@@ -2568,7 +7302,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                               >
                                 :
                               </span>
-                               backend
+                               monitor
   
                               <span
                                 class="token key atrule"
@@ -2602,7 +7336,7 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                               <span
                                 class="token number"
                               >
-                                10001
+                                26002
                               </span>
                               
       
@@ -2628,7 +7362,17 @@ exports[`DataPlaneListView matches snapshot 1`] = `
                               >
                                 :
                               </span>
-                               frontend
+                               capacitor
+                              <span
+                                class="token punctuation"
+                              >
+                                -
+                              </span>
+                              <span
+                                class="token number"
+                              >
+                                0
+                              </span>
                             </code>
                             
       

--- a/src/app/policies/components/PolicyConnections.spec.ts
+++ b/src/app/policies/components/PolicyConnections.spec.ts
@@ -3,7 +3,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { rest } from 'msw'
 
 import PolicyConnections from './PolicyConnections.vue'
-import { server } from '@/../jest/jest-setup-after-env'
+import { useServer } from '@/../jest/jest-setup-after-env'
 
 function renderComponent(props = {}) {
   return mount(PolicyConnections, {
@@ -49,6 +49,7 @@ describe('PolicyConnections.vue', () => {
   })
 
   test('renders error', async () => {
+    const server = useServer()
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/:policyType/:policyName/dataplanes', (req, res, ctx) =>
         res(ctx.status(500), ctx.json({})),
@@ -63,6 +64,7 @@ describe('PolicyConnections.vue', () => {
   })
 
   test('renders no item', async () => {
+    const server = useServer()
     server.use(
       rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/:policyType/:policyName/dataplanes', (req, res, ctx) =>
         res(ctx.status(200), ctx.json({ total: 0, items: [] })),

--- a/src/app/policies/views/PolicyListView.spec.ts
+++ b/src/app/policies/views/PolicyListView.spec.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import PolicyListView from './PolicyListView.vue'
-import { router } from '@/../jest/jest-setup-after-env'
-import { useStore } from '@/utilities'
+import { useStore, useRouter } from '@/utilities'
 
 const store = useStore()
 async function createWrapper(props = {}) {
+  const router = useRouter()
   await router.push({ name: 'mesh-detail-view', params: { mesh: 'default' } })
   await store.dispatch('fetchPolicyTypes')
 

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -1,25 +1,29 @@
 import { RouteRecordRaw } from 'vue-router'
 import { createStore, StoreOptions, Store } from 'vuex'
 
-import { ServiceDefinition, token, build } from './utils'
+import { Alias, ServiceDefinition, token, build, get, TokenType } from './utils'
 import { useApp, useBootstrap } from '../index'
 import { getNavItems } from '@/app/getNavItems'
+import { createRouter } from '@/router/router'
 import routes from '@/router/routes'
 import Env, { EnvArgs, EnvVars } from '@/services/env/Env'
 import KumaApi from '@/services/kuma-api/KumaApi'
 import Logger from '@/services/logger/DatadogLogger'
 import { storeConfig, State } from '@/store/storeConfig'
-
+import type {
+  Router,
+} from 'vue-router'
 const $ = {
   EnvVars: token<EnvVars>('EnvVars'),
   Env: token<Env>('Env'),
-  env: token<(key: keyof EnvVars) => string>('env'),
+  env: token<Alias<Env['var']>>('env'),
 
   api: token<KumaApi>('KumaApi'),
 
   storeConfig: token<StoreOptions<State>>('storeOptions'),
   store: token<Store<State>>('store'),
 
+  router: token<Router>('router'),
   routes: token<RouteRecordRaw[]>('routes'),
   nav: token<typeof getNavItems>('nav'),
 
@@ -49,10 +53,7 @@ export const services: ServiceDefinition[] = [
     ],
   }],
   [$.env, {
-    service: (env: Env) => (key: keyof EnvVars) => env.var(key),
-    arguments: [
-      $.Env,
-    ],
+    service: (): TokenType<typeof $.env> => (...rest) => get($.Env).var(...rest),
   }],
 
   // KumaAPI
@@ -82,6 +83,15 @@ export const services: ServiceDefinition[] = [
     service: createStore,
     arguments: [
       $.storeConfig,
+    ],
+  }],
+
+  // Router
+  [$.router, {
+    service: createRouter,
+    arguments: [
+      $.routes,
+      $.store,
     ],
   }],
 

--- a/src/test-support/index.ts
+++ b/src/test-support/index.ts
@@ -1,0 +1,57 @@
+import deepmerge from 'deepmerge'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { dependencies, escapeRoute } from '@/api/mocks/index'
+import type { MockResponse, FS, AEnv, AppEnvKeys, MockEnvKeys } from '@/api/mocks/index'
+import type { ArrayMergeOptions } from 'deepmerge'
+import type { RestRequest } from 'msw'
+
+type Merge = (obj: Partial<MockResponse>) => MockResponse
+type Callback = (merge: Merge, req: RestRequest, response: MockResponse) => MockResponse
+type Options = Record<string, string>
+type Server = ReturnType<typeof setupServer>
+
+// merges objects in array positions rather than replacing
+const combineMerge = (target: object[], source: object[], options: ArrayMergeOptions): object[] => {
+  const destination = target.slice()
+
+  source.forEach((item, index) => {
+    if (typeof destination[index] === 'undefined') {
+      destination[index] = options.cloneUnlessOtherwiseSpecified(item, options)
+    } else if (options.isMergeableObject(item)) {
+      destination[index] = deepmerge(target[index], item, options)
+    } else if (target.indexOf(item) === -1) {
+      destination.push(item)
+    }
+  })
+  return destination
+}
+
+const noop: Callback = (_merge, _req, response) => response
+const createMerge = (response: MockResponse): Merge => (obj) => deepmerge(response, obj, { arrayMerge: combineMerge })
+export const mocker = (env: AEnv, server: Server, fs: FS) => {
+  const baseUrl = env('KUMA_API_URL')
+
+  return (route: string, opts: Options, cb: Callback = noop) => {
+    if (typeof opts.FAKE_SEED !== 'undefined') {
+      dependencies.fake.seed(parseInt(opts.FAKE_SEED))
+    }
+    const endpoint = fs[route]
+    return server.use(
+      rest.all(`${baseUrl}${escapeRoute(route)}`, async (req, res, ctx) => {
+        const fetch = endpoint({
+          ...dependencies,
+          env: (key, d = '') => (opts[key as MockEnvKeys] ?? '') || env(key as AppEnvKeys, d),
+        })
+        const _response = fetch(req)
+        const response = cb(createMerge(_response), req, _response)
+        return res(
+          ctx.status(parseInt(response.headers['Status-Code'] ?? '200')),
+          ctx.json(response.body),
+        )
+      }),
+    )
+  }
+}
+export type Mocker = ReturnType<typeof mocker>

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -5,4 +5,5 @@ export const [
   useNav,
   useKumaApi,
   useStore,
-] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api, TOKENS.store)
+  useRouter,
+] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api, TOKENS.store, TOKENS.router)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2897,6 +2897,11 @@ deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
+deepmerge@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
 defaults@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.4.tgz#b0b02062c1e2aa62ff5d9528f0f98baa90978d7a"


### PR DESCRIPTION
This PR is a first draft at re-using our new dynamic mocks for testing whilst ensuring we can setup mocks with as little fixture-like code as possible, and still maintaining support for snapshotting (at least in the short term)

There are some things in this PR that are more important to me than others:

Important:

1. Start moving the jest-setup file to use a similar service container approach to our `main.ts` files. This file is almost '`main.ts` for tests'. Just to note: our spec files are similar to Vue components in that we cannot do any sort of constructor/parameter injection, so we will always need to use out `use*` service location functions in test files the same as with components.
2. Getting the functionality for the test mocker right: Provide a url, some env vars, and potentially a way to tweak the response. Note: I've noticed are beginning to get more reusable now we have our service container.
3. Keeping the same coverage for the test/spec that was changed here, but instead of relying on the fact that the mock had the expected data, explicitly setting up the exact data we expect inside the test for each test.

Semi-important:
1. Making sure we can keep snapshotting functionality along with dynamic mocks. Hardcoding a faker seed for the test keeps the data stable between snapshotting.

Still important but less so here but will become more important in a later PR:
1. The innards of the `mocker` function (and our `fakeApi` function). This is one of those things that will have to improve as things become clearer/come together a little more. Right now I can almost see which bits we can reuse or generalise to reduce `mocker` and `fakeApi` to the same function. I didn't want to do that here though. Firstly because punting this means I can work on adding more mocks _and_ generalising these functions at the same time (without this PR in I can't keep going with the mocks) and secondly, I want to have a think about how this would look from a Cypress/browser runner perspective. Ideally devmode/jest/vite/cypress etc etc would all use the same functionality/tests with or without mocks. Just to be clear, the code in `@/api/mocks/index` and `@/test-support/index` will probably end up being merged into one file/import path at `@/test-support`.

As always please ask if there are any questions or anything isn't clear.

I have one question myself:

Currently all our mocks and things live in `@/api` just due to historical reasons. You can probably see in this PR we also will have a handful of test utils (which I've started adding to a `@/test-support` path). I will probably move all test related/mocking things into the `@/test-support` folder, meaning we can remove `@/api` altogether once we've moved everything over to the new style mocks. Does anyone have any thoughts there?

(I may add some inline comment to help review)



Signed-off-by: John Cowen <john.cowen@konghq.com>