### PR TITLE
fix: amount sometimes being incorrectly positioned

### DIFF
--- a/src/app/AppNavItem.vue
+++ b/src/app/AppNavItem.vue
@@ -2,7 +2,7 @@
   <div
     class="nav-item"
     :class="{
-      [`nav-item-${props.routeName}`]: true,
+      [`nav-item-${props.routeName}`]: props.routeName !== '',
       'nav-item--is-category': targetRoute === null,
       [`nav-item--is-${props.categoryTier}-category`]: props.categoryTier !== null,
     }"

--- a/src/app/AppNavItem.vue
+++ b/src/app/AppNavItem.vue
@@ -2,10 +2,11 @@
   <div
     class="nav-item"
     :class="{
+      [`nav-item-${props.routeName}`]: true,
       'nav-item--is-category': targetRoute === null,
       [`nav-item--is-${props.categoryTier}-category`]: props.categoryTier !== null,
     }"
-    :data-testid="props.routeName"
+    :data-testid="props.routeName || undefined"
   >
     <router-link
       v-if="targetRoute !== null"

--- a/src/app/AppNavItem.vue
+++ b/src/app/AppNavItem.vue
@@ -183,8 +183,9 @@ function onNavItemClick() {
 }
 
 .nav-link {
-  display: flex;
   width: 100%;
+  display: flex;
+  justify-content: space-between;
   align-items: center;
   padding: var(--spacing-xs) var(--spacing-md);
   border-radius: 5px;
@@ -204,13 +205,8 @@ function onNavItemClick() {
 }
 
 .amount {
-  position: absolute;
-  top: 0;
-  right: 8px;
-  bottom: 0;
   width: 1.5rem;
   height: 1.25rem;
-  margin: auto;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/app/AppNavItem.vue
+++ b/src/app/AppNavItem.vue
@@ -3,7 +3,6 @@
     class="nav-item"
     :class="{
       'nav-item--is-category': targetRoute === null,
-      'nav-item--has-bottom-offset': props.shouldOffsetFromFollowingItems,
       [`nav-item--is-${props.categoryTier}-category`]: props.categoryTier !== null,
     }"
     :data-testid="props.routeName"
@@ -76,12 +75,6 @@ const props = defineProps({
     type: String,
     required: false,
     default: '',
-  },
-
-  shouldOffsetFromFollowingItems: {
-    type: Boolean,
-    required: false,
-    default: false,
   },
 })
 
@@ -168,8 +161,8 @@ function onNavItemClick() {
   text-transform: uppercase;
 }
 
-.nav-item--is-primary-category ~ .nav-item--is-primary-category {
-  margin-top: var(--spacing-md);
+.nav-item--is-primary-category:not(:first-child) {
+  margin-top: var(--spacing-lg);
 }
 
 .nav-item--is-secondary-category {

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -333,7 +333,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         
         
         <div
-          class="nav-item"
+          class="nav-item nav-item-home"
           data-testid="home"
         >
           <a
@@ -348,8 +348,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         
         
         <div
-          class="nav-item nav-item--is-category nav-item--is-primary-category"
-          data-testid=""
+          class="nav-item nav-item- nav-item--is-category nav-item--is-primary-category"
         >
           <div
             class="nav-category"
@@ -406,7 +405,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         
         
         <div
-          class="nav-item"
+          class="nav-item nav-item-mesh-detail-view"
           data-testid="mesh-detail-view"
         >
           <a
@@ -420,7 +419,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         
         
         <div
-          class="nav-item"
+          class="nav-item nav-item-service-list-view"
           data-testid="service-list-view"
         >
           <a
@@ -438,7 +437,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         
         
         <div
-          class="nav-item"
+          class="nav-item nav-item-gateway-list-view"
           data-testid="gateway-list-view"
         >
           <a
@@ -456,7 +455,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         
         
         <div
-          class="nav-item"
+          class="nav-item nav-item-data-plane-list-view"
           data-testid="data-plane-list-view"
         >
           <a
@@ -474,7 +473,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         
         
         <div
-          class="nav-item"
+          class="nav-item nav-item-policies"
           data-testid="policies"
         >
           <a

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -333,7 +333,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         
         
         <div
-          class="nav-item nav-item--has-bottom-offset"
+          class="nav-item"
           data-testid="home"
         >
           <a

--- a/src/app/__snapshots__/App.spec.ts.snap
+++ b/src/app/__snapshots__/App.spec.ts.snap
@@ -348,7 +348,7 @@ exports[`App.vue fails to renders basic view 1`] = `
         
         
         <div
-          class="nav-item nav-item- nav-item--is-category nav-item--is-primary-category"
+          class="nav-item nav-item--is-category nav-item--is-primary-category"
         >
           <div
             class="nav-category"

--- a/src/app/__snapshots__/AppNavItem.spec.ts.snap
+++ b/src/app/__snapshots__/AppNavItem.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`AppNavItem.vue renders snapshot with link to selected mesh 1`] = `
 <div
-  class="nav-item"
+  class="nav-item nav-item-data-plane-list-view"
   data-testid="data-plane-list-view"
 >
   <a

--- a/src/app/__snapshots__/AppSidebar.spec.ts.snap
+++ b/src/app/__snapshots__/AppSidebar.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`AppSidebar.vue renders snapshot 1`] = `
     
     
     <div
-      class="nav-item nav-item--has-bottom-offset"
+      class="nav-item"
       data-testid="home"
     >
       <a

--- a/src/app/__snapshots__/AppSidebar.spec.ts.snap
+++ b/src/app/__snapshots__/AppSidebar.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`AppSidebar.vue renders snapshot 1`] = `
     
     
     <div
-      class="nav-item"
+      class="nav-item nav-item-home"
       data-testid="home"
     >
       <a

--- a/src/app/getNavItems.ts
+++ b/src/app/getNavItems.ts
@@ -6,7 +6,6 @@ interface NavItem {
   usesMeshParam?: boolean
   insightsFieldAccessor?: string
   isMeshSelector?: boolean
-  shouldOffsetFromFollowingItems?: boolean
 }
 
 export function getNavItems(isMultizoneMode: boolean, hasMeshes: boolean): NavItem[] {
@@ -80,7 +79,6 @@ export function getNavItems(isMultizoneMode: boolean, hasMeshes: boolean): NavIt
     {
       name: 'Home',
       routeName: 'home',
-      shouldOffsetFromFollowingItems: true,
     },
     ...zoneItems,
     ...meshItems,


### PR DESCRIPTION
**fix: amount sometimes being incorrectly positioned**

Removes the absolute positioning from the nav item amount which caused it to be pulled down with an increase in bottom padding.

**chore: removes border bottom from nav items**

Removes the functionality for adding a bottom border to certain nav items and tweaks the space between groups of nav items a little to account for it.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>