### PR TITLE
chore: tweaks kcard-list usage

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -115,6 +115,6 @@ function setDocumentTitle(title: string | undefined): void {
 }
 
 .app-main-content {
-  padding: var(--spacing-lg);
+  padding: var(--AppGap);
 }
 </style>

--- a/src/app/common/ContentWrapper.vue
+++ b/src/app/common/ContentWrapper.vue
@@ -25,7 +25,7 @@ const slots = useSlots()
   // Allows the contained flex items to wrap when their sizing requirements can’t be satisfied any longer.
   flex-wrap: wrap;
   align-items: flex-start;
-  gap: var(--spacing-md);
+  gap: var(--AppGap);
 }
 
 .content-wrapper__content {

--- a/src/app/common/MeshResources.vue
+++ b/src/app/common/MeshResources.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="kcard-list">
+  <div class="kcard-switcher">
     <KCard title="Create a virtual mesh">
       <template #body>
         <p>

--- a/src/app/common/subscriptions/SubscriptionDetails.vue
+++ b/src/app/common/subscriptions/SubscriptionDetails.vue
@@ -29,7 +29,10 @@
     </div>
 
     <div v-if="detailsIterator">
-      <ul class="overview-stat-grid">
+      <ul
+        class="columns"
+        style="--columns: 4;"
+      >
         <li
           v-for="(item, label) in detailsIterator"
           :key="label"
@@ -136,15 +139,5 @@ function formatError(value: string): string {
   font-weight: 600;
   color: var(--grey-500);
   margin: var(--spacing-xs) 0;
-}
-
-.overview-stat-grid {
-  display: grid;
-  margin: var(--spacing-md) 0 0 0;
-
-  @media (min-width: 1140px) {
-    grid-template-columns: repeat(3, 1fr);
-    grid-gap: 10px 20px;
-  }
 }
 </style>

--- a/src/app/common/subscriptions/SubscriptionDetails.vue
+++ b/src/app/common/subscriptions/SubscriptionDetails.vue
@@ -33,24 +33,26 @@
         class="columns"
         style="--columns: 4;"
       >
-        <li
+        <template
           v-for="(item, label) in detailsIterator"
           :key="label"
         >
-          <h6 class="overview-tertiary-title">
-            {{ label }}:
-          </h6>
+          <li v-if="Object.keys(item).length > 0">
+            <h6 class="overview-tertiary-title">
+              {{ label }}:
+            </h6>
 
-          <ul>
-            <li
-              v-for="(k, v) in item"
-              :key="v"
-            >
-              <strong>{{ v }}:</strong>
-              <span>{{ formatError(formatValue(k)) }}</span>
-            </li>
-          </ul>
-        </li>
+            <ul>
+              <li
+                v-for="(k, v) in item"
+                :key="v"
+              >
+                <strong>{{ v }}:</strong>
+                <span>{{ formatError(formatValue(k)) }}</span>
+              </li>
+            </ul>
+          </li>
+        </template>
       </ul>
     </div>
 

--- a/src/app/main-overview/views/__snapshots__/MainOverviewView.spec.ts.snap
+++ b/src/app/main-overview/views/__snapshots__/MainOverviewView.spec.ts.snap
@@ -200,7 +200,7 @@ exports[`MainOverviewView.vue renders basic snapshot 1`] = `
     </div>
   </section>
   <div
-    class="kcard-list"
+    class="kcard-switcher"
   >
     <section
       aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"

--- a/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneEgresses.spec.ts.snap
@@ -1007,8 +1007,10 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                         </div>
                         <div>
                           <ul
-                            class="overview-stat-grid"
+                            class="columns"
+                            style="--columns: 4;"
                           >
+                            
                             
                             <li>
                               <h6
@@ -1037,6 +1039,8 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1064,6 +1068,8 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1091,17 +1097,10 @@ exports[`ZoneEgresses.vue renders zoneegress insights 1`] = `
                                 
                               </ul>
                             </li>
-                            <li>
-                              <h6
-                                class="overview-tertiary-title"
-                              >
-                                rds: 
-                              </h6>
-                              <ul>
-                                
-                                
-                              </ul>
-                            </li>
+                            
+                            
+                            <!--v-if-->
+                            
                             
                           </ul>
                         </div>

--- a/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneIngresses.spec.ts.snap
@@ -703,8 +703,10 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                         </div>
                         <div>
                           <ul
-                            class="overview-stat-grid"
+                            class="columns"
+                            style="--columns: 4;"
                           >
+                            
                             
                             <li>
                               <h6
@@ -733,6 +735,8 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -760,6 +764,8 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -787,17 +793,10 @@ exports[`ZoneIngresses.vue renders zoneingress insights 1`] = `
                                 
                               </ul>
                             </li>
-                            <li>
-                              <h6
-                                class="overview-tertiary-title"
-                              >
-                                rds: 
-                              </h6>
-                              <ul>
-                                
-                                
-                              </ul>
-                            </li>
+                            
+                            
+                            <!--v-if-->
+                            
                             
                           </ul>
                         </div>

--- a/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZonesView.spec.ts.snap
@@ -1420,8 +1420,10 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                         </div>
                         <div>
                           <ul
-                            class="overview-stat-grid"
+                            class="columns"
+                            style="--columns: 4;"
                           >
+                            
                             
                             <li>
                               <h6
@@ -1450,6 +1452,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1477,6 +1481,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1504,6 +1510,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1531,6 +1539,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1558,6 +1568,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1585,6 +1597,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1612,6 +1626,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1639,6 +1655,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1666,6 +1684,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1693,6 +1713,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1720,6 +1742,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1747,6 +1771,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1774,6 +1800,8 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
+                            
                             <li>
                               <h6
                                 class="overview-tertiary-title"
@@ -1801,6 +1829,7 @@ exports[`ZonesView.vue renders zone insights 1`] = `
                                 
                               </ul>
                             </li>
+                            
                             
                           </ul>
                         </div>

--- a/src/assets/styles/_components.scss
+++ b/src/assets/styles/_components.scss
@@ -19,7 +19,7 @@ Adapted from https://every-layout.dev/layouts/stack/.
 */
 
 .kcard-stack>*+* {
-  margin-block-start: var(--spacing-md);
+  margin-block-start: var(--AppGap);
 }
 
 /*
@@ -31,19 +31,18 @@ Adapted from https://every-layout.dev/layouts/switcher/.
 */
 
 .columns {
-  --gap: var(--spacing-md);
   --threshold: 30rem;
   --columns: 3;
 
   display: flex;
   flex-wrap: wrap;
-  gap: var(--gap);
+  gap: var(--AppGap);
 }
 
 .columns>* {
   min-inline-size: min(var(--threshold), 100%);
   // Accounts for the gaps.
-  inline-size: calc((100% - ((var(--columns) - 1) * var(--gap))) / var(--columns));
+  inline-size: calc((100% - ((var(--columns) - 1) * var(--AppGap))) / var(--columns));
 }
 
 /*
@@ -55,12 +54,11 @@ Adapted from https://every-layout.dev/layouts/switcher/.
 */
 
 .kcard-switcher {
-  --gap: var(--spacing-md);
   --threshold: 70rem;
 
   display: flex;
   flex-wrap: wrap;
-  gap: var(--gap);
+  gap: var(--AppGap);
 }
 
 .kcard-switcher>* {

--- a/src/assets/styles/_components.scss
+++ b/src/assets/styles/_components.scss
@@ -23,21 +23,47 @@ Adapted from https://every-layout.dev/layouts/stack/.
 }
 
 /*
-.kcard-list
+.columns
 
-For horizontally listing elements with consistent space between. Once the space defined by `--threshold` is exhausted, the elements will start to wrap.
+For horizontally listing elements with consistent space between. Once the space defined by `--threshold` is exhausted, the elements will **start** to wrap.
 
 Adapted from https://every-layout.dev/layouts/switcher/.
 */
 
-.kcard-list {
+.columns {
+  --gap: var(--spacing-md);
+  --threshold: 30rem;
+  --columns: 3;
+
   display: flex;
   flex-wrap: wrap;
-  gap: var(--spacing-md);
-  --threshold: 30rem;
+  gap: var(--gap);
 }
 
-.kcard-list>* {
+.columns>* {
+  min-inline-size: min(var(--threshold), 100%);
+  // Accounts for the gaps.
+  inline-size: calc((100% - ((var(--columns) - 1) * var(--gap))) / var(--columns));
+}
+
+/*
+.kcard-switcher
+
+For horizontally listing elements with consistent space between. Once the space defined by `--threshold` is exhausted, **all** elements will wrap.
+
+Adapted from https://every-layout.dev/layouts/switcher/.
+*/
+
+.kcard-switcher {
+  --gap: var(--spacing-md);
+  --threshold: 70rem;
+
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap);
+}
+
+.kcard-switcher>* {
   flex-grow: 1;
   flex-basis: calc((var(--threshold) - 100%) * 999);
 }

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -5,6 +5,7 @@
   // COMPONENTS
   --AppHeaderHeight: 60px;
   --AppSidebarWidth: 280px;
+  --AppGap: var(--spacing-lg);
 
   // ONBOARDING
   --onboarding-accent: #822dc5;
@@ -30,6 +31,8 @@
   // Removes the default max width of 200 pixels because badges should never be cut-off.
   --KBadgeMaxWidth: auto;
   // Sets a default border style for commonly used component frames/panels.
+  --KCardPaddingX: var(--AppGap);
+  --KCardPaddingY: var(--KCardPaddingX);
   --KCardBorderRadius: 3px;
   --KCardBackground: var(--white);
   --KCardBorder: 1px solid var(--grey-300);


### PR DESCRIPTION
**chore: tweaks kcard-list usage**

Renames `kcard-list` to `kcard-switcher` and tweaks its threshold to be more applicable to our use cases (e.g. for wrapping the mesh resources items).

Adds a new `columns` class for laying out a list of items using a preferred number of columns (3 by default). These items will wrap one by one (as opposed to all at the same time with `kcard-switcher`) when their space requirements are no longer met.

**fix(zones): showing empty entry**

Fixes showing an empty entry in the zone ingress insights if its data is `{}` (this manifested in showing an empty "rds" entry using mock data).

**refactor: uses AppGap property for consistent gaps**

Introduces a global `--AppGap` property (with value `--spacing-lg`) and uses it for gaps between cards and general "top-level" spacing. This provides a central place to configure this kind of spacing. This changes the spaces between cards from `--spacing-md` to `--spacing-lg`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>