### PR TITLE
chore: Composable Service Config

### DIFF
--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -5,7 +5,9 @@ import { config } from '@vue/test-utils'
 
 import { replaceAttributesSnapshotSerializer } from './jest-replace-attribute-snapshot-serializer'
 import { TOKENS as COMPONENT_TOKENS } from '../src/components'
-import { TOKENS as APP, get, container, build, createInjections } from '../src/services/development'
+import { get, container, build, createInjections } from '@/services/utils'
+import { TOKENS as PROD, services as production } from '@/services/production'
+import { TOKENS as DEV, services as development } from '@/services/development'
 import { TOKENS as TEST, services as testing } from '../src/services/testing'
 import Env from '@/services/env/Env'
 
@@ -15,16 +17,15 @@ jest.mock('vue-github-button', () => ({ template: '<span />' }))
 //
 
 const $ = {
-  ...APP,
+  ...PROD,
+  ...DEV,
   ...TEST,
 };
 
 (async () => {
-  // currently production and development containers
-  // are built within their definition files
   build(
-    // production($),
-    // development($),
+    production($),
+    development($),
     testing($),
   )
 

--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -5,11 +5,11 @@ import { config } from '@vue/test-utils'
 
 import { replaceAttributesSnapshotSerializer } from './jest-replace-attribute-snapshot-serializer'
 import { TOKENS as COMPONENT_TOKENS } from '../src/components'
-import { get, container, build, createInjections } from '@/services/utils'
-import { TOKENS as PROD, services as production } from '@/services/production'
-import { TOKENS as DEV, services as development } from '@/services/development'
 import { TOKENS as TEST, services as testing } from '../src/services/testing'
+import { TOKENS as DEV, services as development } from '@/services/development'
 import Env from '@/services/env/Env'
+import { TOKENS as PROD, services as production } from '@/services/production'
+import { get, container, build, createInjections } from '@/services/utils'
 
 // jest can't import this module properly due to transpiling issues
 // mock this out with a blank element

--- a/src/services/development.ts
+++ b/src/services/development.ts
@@ -1,10 +1,10 @@
 import { setupWorker, RestHandler, MockedRequest, rest } from 'msw'
 
-import { ServiceConfigurator, ReturnDecorated, Decorator, token, get } from './utils'
 import CookiedEnv from '@/services/env/CookiedEnv'
 import Logger from '@/services/logger/DatadogLogger'
 import { disabledLogger } from '@/services/logger/DisabledLogger'
-import type { Alias } from '@/services/utils'
+import { token, get } from '@/services/utils'
+import type { ServiceConfigurator, ReturnDecorated, Decorator, Alias, Token } from '@/services/utils'
 import type { FS } from '@/test-support'
 import { fakeApi } from '@/test-support'
 import { fs } from '@/test-support/mocks/fs'
@@ -34,12 +34,20 @@ const $ = {
   mswFakeApiHandlers: token<RestHandler[]>('msw.fake.handlers'),
   kumaFS: token<FS>('fake.fs.kuma'),
 }
+type SupportedTokens = {
+  Env: Token
+  EnvVars: Token
+  logger: Token
+  msw: Token
+  bootstrap: Token
+  env: Token<Alias<CookiedEnv['var']>>
+}
 
-export const services: ServiceConfigurator = (app) => [
+export const services: ServiceConfigurator<SupportedTokens> = (app) => [
 
   [token<Decorator<typeof app.bootstrap>>('bootstrap.with.mockServer'), {
     service: (bootstrap: ReturnDecorated<typeof app.bootstrap>) => {
-      const env = get(app.env) as Alias<CookiedEnv['var']>
+      const env = get(app.env)
       if (env('KUMA_MOCK_API_ENABLED') === 'true') {
         get($.msw)
       }

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -1,7 +1,7 @@
 import { RouteRecordRaw } from 'vue-router'
 import { createStore, StoreOptions, Store } from 'vuex'
 
-import { Alias, ServiceDefinition, token, build, get, TokenType } from './utils'
+import { Alias, ServiceConfigurator, token, get } from './utils'
 import { useApp, useBootstrap } from '../index'
 import { getNavItems } from '@/app/getNavItems'
 import { createRouter } from '@/router/router'
@@ -13,6 +13,7 @@ import { storeConfig, State } from '@/store/storeConfig'
 import type {
   Router,
 } from 'vue-router'
+
 const $ = {
   EnvVars: token<EnvVars>('EnvVars'),
   Env: token<Env>('Env'),
@@ -33,7 +34,7 @@ const $ = {
   bootstrap: token<ReturnType<typeof useBootstrap>>('bootstrap'),
 }
 
-export const services: ServiceDefinition[] = [
+export const services: ServiceConfigurator = () => [
   // Env
   [$.EnvVars, {
     constant: {
@@ -53,7 +54,7 @@ export const services: ServiceDefinition[] = [
     ],
   }],
   [$.env, {
-    service: (): TokenType<typeof $.env> => (...rest) => get($.Env).var(...rest),
+    service: (): Alias<Env['var']> => (...rest) => get($.Env).var(...rest),
   }],
 
   // KumaAPI
@@ -124,8 +125,7 @@ export const services: ServiceDefinition[] = [
       $.store,
     ],
   }],
-]
 
-build(services)
+]
 
 export const TOKENS = $

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -1,7 +1,7 @@
+
 import { RouteRecordRaw } from 'vue-router'
 import { createStore, StoreOptions, Store } from 'vuex'
 
-import { Alias, ServiceConfigurator, token, get } from './utils'
 import { useApp, useBootstrap } from '../index'
 import { getNavItems } from '@/app/getNavItems'
 import { createRouter } from '@/router/router'
@@ -9,6 +9,8 @@ import routes from '@/router/routes'
 import Env, { EnvArgs, EnvVars } from '@/services/env/Env'
 import KumaApi from '@/services/kuma-api/KumaApi'
 import Logger from '@/services/logger/DatadogLogger'
+import { token, get } from '@/services/utils'
+import type { Alias, ServiceConfigurator } from '@/services/utils'
 import { storeConfig, State } from '@/store/storeConfig'
 import type {
   Router,
@@ -33,8 +35,8 @@ const $ = {
   app: token<ReturnType<typeof useApp>>('app'),
   bootstrap: token<ReturnType<typeof useBootstrap>>('bootstrap'),
 }
-
-export const services: ServiceConfigurator = () => [
+type SupportedTokens = typeof $
+export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   // Env
   [$.EnvVars, {
     constant: {

--- a/src/services/testing.ts
+++ b/src/services/testing.ts
@@ -1,18 +1,15 @@
-
 import { setupServer } from 'msw/node'
 
-import { ServiceDefinition, token } from './utils'
+import { ServiceConfigurator, token } from './utils'
 import { mocker } from '@/test-support'
 import type { Mocker } from '@/test-support'
 import type { RestHandler } from 'msw'
 
-export const TOKENS = {
+const $ = {
   mock: token<Mocker>('mocker'),
 }
-const $ = TOKENS
 
-type Token = ReturnType<typeof token>
-export const services = <T extends Record<string, Token>>(app: T): ServiceDefinition[] => [
+export const services: ServiceConfigurator = (app) => [
   [app.msw, {
     service: (handlers: RestHandler[]) => {
       return setupServer(...handlers)
@@ -30,3 +27,4 @@ export const services = <T extends Record<string, Token>>(app: T): ServiceDefini
     ],
   }],
 ]
+export const TOKENS = $

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -37,23 +37,64 @@ type DependencyDefinition = {
   arguments?: Array<RequiredToken | OptionalToken>
   shared?: boolean
   labels?: Token[]
+  decorates?: Token
 }
 export type ServiceDefinition = [Token, DependencyDefinition]
+export type ServiceConfigurator = <T extends Record<string, Token>>(app: T) => ServiceDefinition[]
 export type Alias<T extends (...args: never[]) => unknown> = (...rest: Parameters<T>) => ReturnType<T>
-
+export type Decorator<T extends TokenValue> = TokenType<T>
+export type ReturnDecorated<T extends TokenValue> = () => TokenType<T>
 export const container = createContainer()
 
 //
 export const merge = (...definitions: Array<ServiceDefinition[]>): ServiceDefinition[] => {
   return [...new Map([...definitions.flat()]).entries()]
 }
-export const build = (...entries: Array<ServiceDefinition[]>): ServiceDefinition[] => {
-  const merged = merge(...entries)
+const decorate = (entries: ServiceDefinition[]) => {
+  const map = new Map(entries)
+  entries.forEach(([_token, definition]) => {
+    if (typeof definition.decorates !== 'undefined') {
+      const decoratedToken = definition.decorates
+      const decoratedDefinition = map.get(decoratedToken)
+      if (typeof decoratedDefinition !== 'undefined') {
+        // set up a structure that allows us to only get the decorated service
+        // when we want to. i.e. we might want to call/get the service then execute more code, or
+        // we might want to call/get the service last after executing code
+        const { labels, ...decorated } = decoratedDefinition
+        type DecoratedToken = typeof decoratedToken
+        const TOKEN = token<TokenType<DecoratedToken>>('inner')
+        const WRAPPER_TOKEN = token<ReturnDecorated<DecoratedToken>>('inner.wrapper')
+        map.set(TOKEN, {
+          ...decorated,
+        })
+        map.set(WRAPPER_TOKEN, {
+          service: (): ReturnDecorated<DecoratedToken> => () => get(TOKEN),
+        })
+
+        map.set(decoratedToken,
+          {
+            ...definition,
+            arguments: [
+              WRAPPER_TOKEN,
+              // adding further arguments is currently unsupported
+              // ...(definition.arguments || []),
+            ],
+            labels,
+          },
+        )
+      }
+      definition.decorates = undefined
+    }
+  })
+  return [...map.entries()]
+}
+export const get = <T extends TokenValue>(token: T): TokenType<T> => container.get(token)
+export const build = (...entries: Array<ServiceDefinition[]>): typeof get => {
+  const merged = decorate(merge(...entries))
   merged.forEach(item => service(...item))
-  return merged
+  return get
 }
 
-export const get = <T extends TokenValue>(token: T): TokenType<T> => container.get(token)
 export const createInjections = <T extends TokenValue[]>(
   ...tokens: T
 ): InjectionHooks<T> =>

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -15,6 +15,7 @@ export {
 } from 'brandi'
 export type {
   TokenType,
+  Token,
 } from 'brandi'
 
 type InjectionHooks<T extends TokenValue[]> = {
@@ -40,7 +41,7 @@ type DependencyDefinition = {
   decorates?: Token
 }
 export type ServiceDefinition = [Token, DependencyDefinition]
-export type ServiceConfigurator = <T extends Record<string, Token>>(app: T) => ServiceDefinition[]
+export type ServiceConfigurator<T = Record<string, Token>> = ($: T) => ServiceDefinition[]
 export type Alias<T extends (...args: never[]) => unknown> = (...rest: Parameters<T>) => ReturnType<T>
 export type Decorator<T extends TokenValue> = TokenType<T>
 export type ReturnDecorated<T extends TokenValue> = () => TokenType<T>
@@ -140,6 +141,11 @@ export const service = (t: Token, config: DependencyDefinition): void => {
     })
   }
   if (typeof config.arguments !== 'undefined' && typeof config.service !== 'undefined') {
+    config.arguments.forEach((item, i) => {
+      if (typeof item === 'undefined') {
+        throw new Error(`Unable to find token for argument[${i}]`)
+      }
+    })
     injected(...([config.service, ...config.arguments] as Parameters<typeof injected>))
   }
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,5 +1,6 @@
 import type { State } from './storeConfig'
-import { get, TOKENS } from '@/services'
+import { TOKENS } from '@/services/production'
+import { get } from '@/services/utils'
 import type { Store } from 'vuex'
 
 export function useStore(): Store<State> {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -7,4 +7,5 @@ export const [
   useKumaApi,
   useStore,
   useRouter,
-] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api, TOKENS.store, TOKENS.router)
+  useBootstrap,
+] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api, TOKENS.store, TOKENS.router, TOKENS.bootstrap)

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,4 +1,5 @@
-import { TOKENS, createInjections } from '@/services'
+import { TOKENS } from '@/services/production'
+import { createInjections } from '@/services/utils'
 
 export const [
   useEnv,

--- a/vite.config.development.ts
+++ b/vite.config.development.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath, URL } from 'url'
 import { defineConfig, mergeConfig, UserConfigFn, UserConfig } from 'vite'
 
 import { config as prodConfig } from './vite.config'
@@ -7,11 +6,6 @@ export const config: UserConfigFn = (env) => {
   return mergeConfig(
     prodConfig(env),
     ({
-      resolve: {
-        alias: [
-          { find: /^@\/services$/, replacement: fileURLToPath(new URL('./src/services/development.ts', import.meta.url)) },
-        ],
-      },
     } as UserConfig),
   )
 }


### PR DESCRIPTION
This PR moves our service config to use composition rather than inheritance.

We we began using a service container approach it was a lot quicker to get where we wanted to get to by having a pretty linear "inheritance-like" reuse structure of config (a development file would import the production file)

As we've moved forwards and added distinct `main`/wiring roots, expanded our usage and new usecases have appeared (using the parts of the same service config for our Cypress tests/mocks). We've kind of begun to outgrow the inheritance approach

This PR therefore does the following:

- Changes service config to be composable via `...services(TOKENS)` functions. This means we can pick and choose sets of config we need rather than using an "all or nothing" approach.
- Adds decorators for service config via `decorates` i.e. `decorates: $.bootstrap`. This means we don't have to keep repeatedly overwriting services again due to the `production is imported by/before development which is imported by/before production which is imported by/before development` etc. approach.
- Removes as much vite aliasing as possible. There are no more magic `@/services` files that switch between prod and dev 🎉 . Originally this was handy before we had a top-level main/wiring root, but now I'm pretty sure the aliasing is unnecessary and moreover confusing.
- Added `useBootstrap`. This probably should have been there from when I added bootstrap originally, all Vue components should use `use*` helpers not `get(TOKEN...)`. I'm hoping that eventually in the not too distant future, that `get` will no longer be an export. This will help us to keep us to "_in Vue Components use `use*` helpers, otherwise use constructor injection_". I _think_ there's only one place left that doesn't follow this.
- Added runtime error if undefined arguments are found during service container building (this happens at container build time, i.e. at the very start of the app).

Closes https://github.com/kumahq/kuma-gui/issues/798

One thing I've noticed whilst doing this, this frees up `@/services/index` (a.k.a `@/services`), and whilst there is no rush whatsoever to do this, it means we can move `@/utilities` to `@/services` which to me makes much more sense.

Lastly, I also added a bunch of inline comments to help review.


