### PR TITLE
ci: fixes CodeQL workflow in release-2.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,15 +1,16 @@
-name: "CodeQL"
+name: 'Run CodeQL'
 
 on:
   push:
-    branches: [ master, 'release-[0-9]+.[0-9]+' ]
-  pull_request: [ master, 'release-[0-9]+.[0-9]+' ]
+    branches: [master, 'release-[0-9]+.[0-9]+']
+  pull_request:
+    branches: [master, 'release-[0-9]+.[0-9]+']
   schedule:
     - cron: '31 11 * * 4'
 
 jobs:
   analyze:
-    name: Analyze
+    name: Run CodeQL
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -19,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: [javascript]
 
     steps:
     - name: Checkout repository
@@ -36,4 +37,4 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
-        category: "/language:${{matrix.language}}"
+        category: '/language:${{matrix.language}}'


### PR DESCRIPTION
Updates the CodeQL workflow to match the one in `master` and `release-2.2` which includes a fix to the `on.pull_request` syntax being incorrect currently causing the workflow to fail.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
