### PR TITLE
ci: Use mode !== 'production' to decide whether to use development env

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ async function mountVueApplication() {
     // production service container configuration
     production($),
     // any DEV-time only service container configuration
-    import.meta.env.DEV
+    import.meta.env.MODE !== 'production'
       ? await (async () => {
         const dev = await import('@/services/development')
         return dev.services({

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ async function mountVueApplication() {
     // production service container configuration
     production($),
     // any DEV-time only service container configuration
-    import.meta.env.MODE !== 'production'
+    !import.meta.env.PROD
       ? await (async () => {
         const dev = await import('@/services/development')
         return dev.services({

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ async function mountVueApplication() {
     // production service container configuration
     production($),
     // any DEV-time only service container configuration
-    !import.meta.env.PROD
+    import.meta.env.MODE !== 'production'
       ? await (async () => {
         const dev = await import('@/services/development')
         return dev.services({


### PR DESCRIPTION
Uses `import.meta.env.MODE !== 'production' ?` rather than just `import.meta.env.DEV ?`

This makes sure that our development service config is included in "everything apart from prod" instead of "only dev", which makes sure the config is included for our PR preview sites.

I did a quick check on the prod build again to ensure that the development service config wasn't being included there.

Also see https://github.com/kumahq/kuma-gui/pull/818

Signed-off-by: John Cowen <john.cowen@konghq.com>