### PR TITLE
chore: Expands Cypress e2e tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   e2e: {
     specPattern: '**/*.feature',
     supportFile: false,
+    experimentalRunAllSpecs: true,
     // TODO Env var
     video: false,
     async setupNodeEvents(

--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -47,13 +47,17 @@ Given('the URL {string} responds with', (url: string, yaml: string) => {
   const now = new Date().getTime()
   const mock = useMock()
   urls.set(url, `spy-${now}`)
-  mock(url, env, (respond) => {
-    const response = respond(YAML.load(yaml) as { headers?: Record<string, string>, body?: Record<string, unknown> })
+  mock(url, env, (respond, req) => {
+    const response = respond((YAML.load(yaml) || {}) as { headers?: Record<string, string>, body?: Record<string, unknown> })
     return response
   }).as(urls.get(url))
 })
 
 // act
+When('I wait for {int} milliseconds/ms', function (ms: number) {
+  cy.wait(ms)
+})
+
 When(/^I "(.*)"(.*)? on the "(.*)" element$/, (event: string, object: string | number | undefined, selector: string) => {
   switch (event) {
     case 'select':

--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -47,7 +47,7 @@ Given('the URL {string} responds with', (url: string, yaml: string) => {
   const now = new Date().getTime()
   const mock = useMock()
   urls.set(url, `spy-${now}`)
-  mock(url, env, (respond, req) => {
+  mock(url, env, (respond) => {
     const response = respond((YAML.load(yaml) || {}) as { headers?: Record<string, string>, body?: Record<string, unknown> })
     return response
   }).as(urls.get(url))

--- a/cypress/support/step_definitions/visit.ts
+++ b/cypress/support/step_definitions/visit.ts
@@ -7,7 +7,5 @@ const config = {
 When('I visit the {string} URL', function (path: string) {
   cy.viewport(1366, 768)
   cy.visit(`${config.BASE_URL}${path}`)
-  cy.get('.app-main-content').should('be.visible')
-  cy.wait(1000)
-  cy.get('.empty-state-wrapper').should('not.exist')
+  cy.wait(500)
 })

--- a/cypress/support/step_definitions/visit.ts
+++ b/cypress/support/step_definitions/visit.ts
@@ -7,5 +7,12 @@ const config = {
 When('I visit the {string} URL', function (path: string) {
   cy.viewport(1366, 768)
   cy.visit(`${config.BASE_URL}${path}`)
+  // currently use this to denote "the page has initially rendered"
+  cy.get('.app-main-content').should('be.visible')
   cy.wait(1000)
+  cy.get('.empty-state-wrapper').should('not.exist')
+})
+When('I load the {string} URL', function (path: string) {
+  cy.viewport(1366, 768)
+  cy.visit(`${config.BASE_URL}${path}`)
 })

--- a/cypress/support/step_definitions/visit.ts
+++ b/cypress/support/step_definitions/visit.ts
@@ -7,5 +7,5 @@ const config = {
 When('I visit the {string} URL', function (path: string) {
   cy.viewport(1366, 768)
   cy.visit(`${config.BASE_URL}${path}`)
-  cy.wait(500)
+  cy.wait(1000)
 })

--- a/features/application/Index.feature
+++ b/features/application/Index.feature
@@ -15,7 +15,7 @@ Feature: index
     And the URL "/meshes" responds with
       """
       """
-    When I visit the "/" URL
+    When I load the "/" URL
     Then the "$loading" element exists
     And I wait for 2000 milliseconds
     Then the "$loading" element doesn't exist
@@ -95,25 +95,25 @@ Feature: index
     Then the "$main-nav .nav-item-<RouteName>" element contains "<Text>"
     Examples:
       | RouteName            | Count  | Text |
-      | zones                | 0      | 0    |
-      | zoneegresses         | 0      | 0    |
-      | zoneingresses        | 0      | 0    |
-      | service-list-view    | 0      | 0    |
-      | data-plane-list-view | 0      | 0    |
-      | gateway-list-view    | 0      | 0    |
-      | policies             | 0      | 0    |
-      | zones                | 50     | 50   |
-      | zoneegresses         | 122    | 99+  |
-      | zoneingresses        | 1      | 1    |
-      | service-list-view    | 11     | 11   |
-      | data-plane-list-view | 100000 | 99+  |
-      | gateway-list-view    | 1001   | 99+  |
-      | policies             | 1      | 14   |
-      | zones                | 100    | 99+  |
-      | zoneegresses         | 100    | 99+  |
-      | zoneingresses        | 100    | 99+  |
-      | service-list-view    | 100    | 99+  |
-      | data-plane-list-view | 100    | 99+  |
-      | gateway-list-view    | 100    | 99+  |
-      | policies             | 100    | 99+  |
+      | zone-list-view         | 0      | 0   |
+      | zone-egress-list-view  | 0      | 0   |
+      | zone-ingress-list-view | 0      | 0   |
+      | service-list-view      | 0      | 0   |
+      | data-plane-list-view   | 0      | 0   |
+      | gateway-list-view      | 0      | 0   |
+      | policies               | 0      | 0   |
+      | zone-list-view         | 50     | 50  |
+      | zone-egress-list-view  | 122    | 99+ |
+      | zone-ingress-list-view | 1      | 1   |
+      | service-list-view      | 11     | 11  |
+      | data-plane-list-view   | 100000 | 99+ |
+      | gateway-list-view      | 1001   | 99+ |
+      | policies               | 1      | 14  |
+      | zone-list-view         | 100    | 99+ |
+      | zone-egress-list-view  | 100    | 99+ |
+      | zone-ingress-list-view | 100    | 99+ |
+      | service-list-view      | 100    | 99+ |
+      | data-plane-list-view   | 100    | 99+ |
+      | gateway-list-view      | 100    | 99+ |
+      | policies               | 100    | 99+ |
 

--- a/features/application/Index.feature
+++ b/features/application/Index.feature
@@ -1,0 +1,119 @@
+Feature: index
+  Background:
+    Given the CSS selectors
+      | Alias         | Selector                         |
+      | loading       | [data-testid="app-progress-bar"] |
+      | logo          | [data-testid="logo"]             |
+      | error         | [data-testid="app-error"]        |
+      | main-nav      | .app-sidebar                     |
+
+  Scenario: Application loading
+    Given the environment
+      """
+      KUMA_LATENCY: 1000
+      """
+    And the URL "/meshes" responds with
+      """
+      """
+    When I visit the "/" URL
+    Then the "$loading" element exists
+    And I wait for 2000 milliseconds
+    Then the "$loading" element doesn't exist
+    And the "$logo" element exists
+
+  # TODO: This test needs fixing it currently console.errors
+  @skip
+  Scenario: Application errors
+    Given the environment
+      """
+      KUMA_LATENCY: 1000
+      """
+    And the URL "/" responds with
+      """
+      headers:
+        Status-Code: 500
+      """
+    When I visit the "/" URL
+    Then the "$loading" element exists
+    And I wait for 2000 milliseconds
+    Then the "$loading" element doesn't exist
+    Then the "$error" element exists
+
+  Scenario Outline: The navigation shows numbers correctly
+    Given the URL "/global-insights" responds with
+      """
+      body:
+        resources:
+          Zone:
+            total: <Count>
+          ZoneEgress:
+            total: <Count>
+          ZoneIngress:
+            total: <Count>
+      """
+    And the URL "/mesh-insights/default" responds with
+      """
+      body:
+        dataplanesByType:
+          gateway:
+            total: <Count>
+          standard:
+            total: <Count>
+        policies:
+          CircuitBreaker:
+            total: <Count>
+          FaultInjection:
+            total: <Count>
+          HealthCheck:
+            total: <Count>
+          MeshGatewayRoute:
+            total: <Count>
+          MeshGateway:
+            total: <Count>
+          ProxyTemplate:
+            total: <Count>
+          RateLimit:
+            total: <Count>
+          Retry:
+            total: <Count>
+          Timeout:
+            total: <Count>
+          TrafficLog:
+            total: <Count>
+          TrafficPermission:
+            total: <Count>
+          TrafficRoute:
+            total: <Count>
+          TrafficTrace:
+            total: <Count>
+          VirtualOutbound:
+            total: <Count>
+        services:
+          total: <Count>
+      """
+    When I visit the "/" URL
+    Then the "$main-nav .nav-item-<RouteName>" element contains "<Text>"
+    Examples:
+      | RouteName            | Count  | Text |
+      | zones                | 0      | 0    |
+      | zoneegresses         | 0      | 0    |
+      | zoneingresses        | 0      | 0    |
+      | service-list-view    | 0      | 0    |
+      | data-plane-list-view | 0      | 0    |
+      | gateway-list-view    | 0      | 0    |
+      | policies             | 0      | 0    |
+      | zones                | 50     | 50   |
+      | zoneegresses         | 122    | 99+  |
+      | zoneingresses        | 1      | 1    |
+      | service-list-view    | 11     | 11   |
+      | data-plane-list-view | 100000 | 99+  |
+      | gateway-list-view    | 1001   | 99+  |
+      | policies             | 1      | 14   |
+      | zones                | 100    | 99+  |
+      | zoneegresses         | 100    | 99+  |
+      | zoneingresses        | 100    | 99+  |
+      | service-list-view    | 100    | 99+  |
+      | data-plane-list-view | 100    | 99+  |
+      | gateway-list-view    | 100    | 99+  |
+      | policies             | 100    | 99+  |
+

--- a/features/application/Loading.feature
+++ b/features/application/Loading.feature
@@ -1,0 +1,40 @@
+Feature: index
+  Background:
+    Given the CSS selectors
+      | Alias         | Selector                         |
+      | loading       | [data-testid="app-progress-bar"] |
+      | logo          | [data-testid="logo"]             |
+      | error         | [data-testid="app-error"]        |
+
+  Scenario: Application loading
+    Given the environment
+      """
+      KUMA_LATENCY: 1000
+      """
+    And the URL "/meshes" responds with
+      """
+      """
+    When I load the "/" URL
+    Then the "$loading" element exists
+    And I wait for 2000 milliseconds
+    Then the "$loading" element doesn't exist
+    And the "$logo" element exists
+
+  # TODO: This test needs fixing it currently console.errors
+  @skip
+  Scenario: Application errors
+    Given the environment
+      """
+      KUMA_LATENCY: 1000
+      """
+    And the URL "/" responds with
+      """
+      headers:
+        Status-Code: 500
+      """
+    When I visit the "/" URL
+    Then the "$loading" element exists
+    And I wait for 2000 milliseconds
+    Then the "$loading" element doesn't exist
+    Then the "$error" element exists
+

--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -84,18 +84,19 @@ Feature: index
 
   Scenario Outline: Visiting the "<Title>" page
     When I visit the "/" URL
-    When I "click" on the "$main-nav .nav-item-<RouteName> a" element
+    When I "click" on the "<Selector>" element
     Then the page title contains "<Title>"
 
     Examples:
-      | RouteName              | Title              |
-      | home                   | Overview           |
-      | zone-list-view         | Zones              |
-      | zone-egress-list-view  | Zone Egresses      |
-      | zone-ingress-list-view | Zone Ingresses     |
-      | service-list-view      | Services           |
-      | gateway-list-view      | Gateways           |
-      | data-plane-list-view   | Data plane proxies |
+      | Selector                                     | Title              |
+      | $main-nav .nav-item-home a                   | Overview           |
+      | $main-nav .nav-item-zone-list-view a         | Zones              |
+      | $main-nav .nav-item-zone-egress-list-view a  | Zone Egresses      |
+      | $main-nav .nav-item-zone-ingress-list-view a | Zone Ingresses     |
+      | $main-nav .nav-item-service-list-view a      | Services           |
+      | $main-nav .nav-item-gateway-list-view a      | Gateways           |
+      | $main-nav .nav-item-data-plane-list-view a   | Data plane proxies |
       # TODO: This should say Circuit Breakers
-      | policies               | Manager            |
-      # | policies               | Circuit Breakers |
+      | $main-nav .nav-item-policies a               | Manager            |
+      # | $main-nav .nav-item-policies               | Circuit Breakers |
+      | [data-testid="nav-item-diagnostics"]         | Diagnostics        |

--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -2,42 +2,7 @@ Feature: index
   Background:
     Given the CSS selectors
       | Alias         | Selector                         |
-      | loading       | [data-testid="app-progress-bar"] |
-      | logo          | [data-testid="logo"]             |
-      | error         | [data-testid="app-error"]        |
       | main-nav      | .app-sidebar                     |
-
-  Scenario: Application loading
-    Given the environment
-      """
-      KUMA_LATENCY: 1000
-      """
-    And the URL "/meshes" responds with
-      """
-      """
-    When I load the "/" URL
-    Then the "$loading" element exists
-    And I wait for 2000 milliseconds
-    Then the "$loading" element doesn't exist
-    And the "$logo" element exists
-
-  # TODO: This test needs fixing it currently console.errors
-  @skip
-  Scenario: Application errors
-    Given the environment
-      """
-      KUMA_LATENCY: 1000
-      """
-    And the URL "/" responds with
-      """
-      headers:
-        Status-Code: 500
-      """
-    When I visit the "/" URL
-    Then the "$loading" element exists
-    And I wait for 2000 milliseconds
-    Then the "$loading" element doesn't exist
-    Then the "$error" element exists
 
   Scenario Outline: The navigation shows numbers correctly
     Given the URL "/global-insights" responds with
@@ -117,3 +82,20 @@ Feature: index
       | gateway-list-view      | 100    | 99+ |
       | policies               | 100    | 99+ |
 
+  Scenario Outline: Visiting the "<Title>" page
+    When I visit the "/" URL
+    When I "click" on the "$main-nav .nav-item-<RouteName> a" element
+    Then the page title contains "<Title>"
+
+    Examples:
+      | RouteName              | Title              |
+      | home                   | Overview           |
+      | zone-list-view         | Zones              |
+      | zone-egress-list-view  | Zone Egresses      |
+      | zone-ingress-list-view | Zone Ingresses     |
+      | service-list-view      | Services           |
+      | gateway-list-view      | Gateways           |
+      | data-plane-list-view   | Data plane proxies |
+      # TODO: This should say Circuit Breakers
+      | policies               | Manager            |
+      # | policies               | Circuit Breakers |

--- a/features/application/Titles.feature
+++ b/features/application/Titles.feature
@@ -1,0 +1,20 @@
+Feature: The HTML title is correct on each page
+  Scenario Outline: Visiting the "<Title>" page
+    When I visit the "<URL>" URL
+    Then the page title contains "<Title>"
+
+    Examples:
+      | URL                                     | Title              |
+      | /                                       | Overview           |
+      | /diagnostics                            | Diagnostics        |
+      | /zones                                  | Zones              |
+      | /zone-ingresses                         | Zone Ingresses     |
+      | /zone-egresses                          | Zone Egresses      |
+
+      | /mesh/default                           | Mesh overview      |
+      | /mesh/default/services                  | Services           |
+      | /mesh/default/gateways                  | Gateways           |
+      | /mesh/default/data-planes               | Data plane proxies |
+      # TODO: This should say Circuit Breakers
+      | /mesh/default/policies/circuit-breakers | Manager            |
+      # | /mesh/default/policies/circuit-breakers | Circuit Breakers   |

--- a/features/mesh/Index.feature
+++ b/features/mesh/Index.feature
@@ -1,0 +1,38 @@
+Feature: mesh / index
+  Background:
+    Given the CSS selectors
+      | Alias         | Selector                         |
+      | main-nav      | .app-sidebar                     |
+      | mesh-selector | [data-testid="mesh-selector"]    |
+
+  Scenario: Mesh Selection
+    Given the environment
+      """
+      KUMA_MESH_COUNT: 2
+      """
+    And the URL "/meshes" responds with
+      """
+      body:
+        items:
+          - name: default
+          - name: aalphabetically-second-because-of-default
+      """
+    And the URL "/mesh-insights/default" responds with
+      """
+      body:
+        dataplanesByType:
+          gateway:
+            total: 1
+      """
+    And the URL "/mesh-insights/aalphabetically-second-because-of-default" responds with
+      """
+      body:
+        dataplanesByType:
+          gateway:
+            total: 10
+      """
+    When I visit the "/" URL
+    Then the "$main-nav .nav-item-gateway-list-view" element contains "1"
+    When I "select" 1 on the "$mesh-selector" element
+    Then the "$main-nav .nav-item-gateway-list-view" element contains "10"
+

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -15,7 +15,10 @@
       <AppSidebar />
 
       <main class="app-main-content">
-        <AppErrorMessage v-if="shouldShowAppError" />
+        <AppErrorMessage
+          v-if="shouldShowAppError"
+          data-testid="app-error"
+        />
 
         <NotificationManager v-if="shouldShowNotificationManager" />
 

--- a/src/app/AppHeader.vue
+++ b/src/app/AppHeader.vue
@@ -2,7 +2,9 @@
   <header class="app-header">
     <div class="horizontal-list">
       <router-link :to="{ name: 'home' }">
-        <KumaLogo />
+        <KumaLogo
+          data-testid="logo"
+        />
       </router-link>
 
       <GithubButton

--- a/src/app/AppHeader.vue
+++ b/src/app/AppHeader.vue
@@ -75,6 +75,7 @@
         :to="{ name: 'diagnostics' }"
         icon="gearFilled"
         button-appearance="btn-link"
+        data-testid="nav-item-diagnostics"
       >
         <template #icon>
           <KIcon

--- a/src/test-support/fake.ts
+++ b/src/test-support/fake.ts
@@ -18,7 +18,8 @@ const pager: Pager = (_total: string | number, req: RestRequest, self) => {
   const total = parseInt(`${_total}`)
   const query = req.url.searchParams
   const size = parseInt(query.get('size') || '10')
-  const offset = parseInt(query.get('offset') || '1')
+  const offset = parseInt(query.get('offset') || '0')
+
   const remaining = total - offset
   const pageTotal = Math.min(size, remaining)
   const next = remaining <= size ? null : `${baseUrl}${self}?offset=${offset + size}`


### PR DESCRIPTION
Replaces some old style CLI tests with full in-browser production E2E tests.