### PR TITLE
fix: determining wrong policy type route to redirect to

### DIFF
--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -403,7 +403,6 @@ export default (store: Store<State>): RouteRecordRaw[] => {
           name: 'create-mesh',
           meta: {
             title: 'Create a new mesh',
-            isWizard: true,
           },
           component: () => import('@/app/wizard/views/MeshWizard.vue'),
         },
@@ -412,7 +411,6 @@ export default (store: Store<State>): RouteRecordRaw[] => {
           name: 'kubernetes-dataplane',
           meta: {
             title: 'Create a new data plane proxy on Kubernetes',
-            isWizard: true,
           },
           component: () => import('@/app/wizard/views/DataplaneKubernetes.vue'),
         },
@@ -421,7 +419,6 @@ export default (store: Store<State>): RouteRecordRaw[] => {
           name: 'universal-dataplane',
           meta: {
             title: 'Create a new data plane proxy on Universal',
-            isWizard: true,
           },
           component: () => import('@/app/wizard/views/DataplaneUniversal.vue'),
         },

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -248,11 +248,22 @@ export default (store: Store<State>): RouteRecordRaw[] => {
                 title: 'Policies',
               },
               redirect: (to) => {
-                let item = store.state.policyTypes
-                  .find((item) => store.state.sidebar.insights.mesh.policies[item.name] !== 0)
+                let item = store.state.policyTypes.find((item) => {
+                  if (!(item.name in store.state.sidebar.insights.mesh.policies)) {
+                    return false
+                  }
+
+                  return store.state.sidebar.insights.mesh.policies[item.name] !== 0
+                })
+
                 if (item === undefined) {
                   item = store.state.policyTypes[0]
                 }
+
+                if (item === undefined) {
+                  return { name: 'home' }
+                }
+
                 return {
                   ...to,
                   params: {


### PR DESCRIPTION
chore: removes isWizard prop from old-style wizards

fix: determining wrong policy type route to redirect to

Makes sure that a policy type for which no property exists on `store.state.sidebar.insights.mesh.policies` isn’t actually returned as the policy type to redirect to.

Also makes sure that, in the unlikely case that the policies redirect is triggered before `store.state.policyTypes` is populated, no error happens on account of accessing `item.path`: the redirect will then go to the home route. Technically, application logic should ensure that the policy types are present at that point, so this is just a safety measure.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>