### PR TITLE
fix: not correctly resolving unnamed routes

### DIFF
--- a/src/app/AppBreadcrumbs.vue
+++ b/src/app/AppBreadcrumbs.vue
@@ -8,7 +8,7 @@
 <script lang="ts" setup>
 import { KBreadcrumbs, BreadcrumbItem } from '@kong/kongponents'
 import { computed } from 'vue'
-import { useRoute, useRouter, RouteLocationNormalizedLoaded, RouteLocationMatched, RouteLocationNamedRaw } from 'vue-router'
+import { useRoute, useRouter, RouteLocationNormalizedLoaded, RouteLocationMatched, RouteLocationRaw } from 'vue-router'
 
 import { useStore } from '@/store/store'
 
@@ -23,8 +23,8 @@ const breadcrumbItems = computed(() => {
       try {
         // In order to link to routes using KBreadcrumbs, we need to resolve the objects in `route.matched`: This is necessary because we can’t pass matched route objects as-is to KBreadcrumbs and have it create correct links. Matched route objects are more akin to route records. Their `path` is unresolved (e.g. `/mesh/:mesh/policies` instead of `/mesh/default/policies`) and they don’t have `params`. Furthermore, while they might be a named route, they are *not* necessarily the correct one: a nested named route with an empty string path will actually be the resolved route and the one we want to navigate to.
         const resolvedRoute = router.resolve(matchedRoute)
-        if (typeof resolvedRoute.name === 'string') {
-          const to: RouteLocationNamedRaw = { name: resolvedRoute.name }
+        if (typeof resolvedRoute.path === 'string' && resolvedRoute.path !== '') {
+          const to: RouteLocationRaw = { path: resolvedRoute.path }
 
           return { matchedRoute, to }
         } else {

--- a/src/app/AppNavItem.vue
+++ b/src/app/AppNavItem.vue
@@ -38,14 +38,13 @@
 <script lang="ts" setup>
 import { datadogLogs } from '@datadog/browser-logs'
 import { computed, PropType } from 'vue'
-import { useRoute, useRouter, RouteLocationNamedRaw } from 'vue-router'
+import { useRoute, RouteLocationNamedRaw } from 'vue-router'
 
 import { useStore } from '@/store/store'
 import { datadogLogEvents } from '@/utilities/datadogLogEvents'
 import { get } from '@/utilities/get'
 
 const route = useRoute()
-const router = useRouter()
 const store = useStore()
 
 const props = defineProps({
@@ -55,6 +54,12 @@ const props = defineProps({
   },
 
   routeName: {
+    type: String,
+    required: false,
+    default: '',
+  },
+
+  anchorRouteName: {
     type: String,
     required: false,
     default: '',
@@ -117,21 +122,13 @@ const isActive = computed(() => {
     return true
   }
 
-  const currentRouteSubpath = route.path.split('/')[2]
-  if (currentRouteSubpath === targetRoute.value.name) {
+  const hasAnchorRoute = props.anchorRouteName !== '' && route.matched.some((matchedRoute) => matchedRoute.name === props.anchorRouteName)
+
+  if (hasAnchorRoute) {
     return true
   }
 
-  try {
-    return props.routeName && route.matched.some((matchedRoute) => {
-      const resolvedRoute = router.resolve(matchedRoute)
-
-      return props.routeName === resolvedRoute.name
-    })
-  } catch (err) {
-    console.error(err)
-    return false
-  }
+  return false
 })
 
 function onNavItemClick() {

--- a/src/app/getNavItems.ts
+++ b/src/app/getNavItems.ts
@@ -3,6 +3,13 @@ interface NavItem {
   name: string
   categoryTier?: 'primary' | 'secondary'
   routeName?: string
+
+  /**
+   * Name of an anchor route to look for in `route.matched` to determine whether a route belongs to a nav item.
+   *
+   * An anchor route represents the route record that holds routes of a module; for example, the route “zone-abstract-view” holds all routes related to zones.
+   */
+  anchorRouteName?: string
   usesMeshParam?: boolean
   insightsFieldAccessor?: string
   isMeshSelector?: boolean
@@ -19,16 +26,19 @@ export function getNavItems(isMultizoneMode: boolean, hasMeshes: boolean): NavIt
       {
         name: 'Zone CPs',
         routeName: 'zone-list-view',
+        anchorRouteName: 'zone-abstract-view',
         insightsFieldAccessor: 'global.Zone',
       },
       {
         name: 'Zone Ingresses',
         routeName: 'zone-ingress-list-view',
+        anchorRouteName: 'zone-ingress-abstract-view',
         insightsFieldAccessor: 'global.ZoneIngress',
       },
       {
         name: 'Zone Egresses',
         routeName: 'zone-egress-list-view',
+        anchorRouteName: 'zone-egress-abstract-view',
         insightsFieldAccessor: 'global.ZoneEgress',
       },
     ]
@@ -52,24 +62,28 @@ export function getNavItems(isMultizoneMode: boolean, hasMeshes: boolean): NavIt
       {
         name: 'Services',
         routeName: 'service-list-view',
+        anchorRouteName: 'service-abstract-view',
         insightsFieldAccessor: 'mesh.services.total',
         usesMeshParam: true,
       },
       {
         name: 'Gateways',
         routeName: 'gateway-list-view',
+        anchorRouteName: 'gateway-abstract-view',
         usesMeshParam: true,
         insightsFieldAccessor: 'mesh.dataplanes.gateway',
       },
       {
         name: 'Data Plane Proxies',
         routeName: 'data-plane-list-view',
+        anchorRouteName: 'data-plane-abstract-view',
         usesMeshParam: true,
         insightsFieldAccessor: 'mesh.dataplanes.standard',
       },
       {
         name: 'Policies',
         routeName: 'policies',
+        anchorRouteName: 'policy-type-abstract-view',
         usesMeshParam: true,
         insightsFieldAccessor: 'mesh.policies.total',
       },

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -34,6 +34,7 @@ export default (store: Store<State>): RouteRecordRaw[] => {
     },
     {
       path: '/zones',
+      name: 'zone-abstract-view',
       meta: {
         title: 'Zones',
         isBreadcrumb: true,
@@ -65,6 +66,7 @@ export default (store: Store<State>): RouteRecordRaw[] => {
     },
     {
       path: '/zone-ingresses',
+      name: 'zone-ingress-abstract-view',
       meta: {
         title: 'Zone Ingresses',
         isBreadcrumb: true,
@@ -96,6 +98,7 @@ export default (store: Store<State>): RouteRecordRaw[] => {
     },
     {
       path: '/zone-egresses',
+      name: 'zone-egress-abstract-view',
       meta: {
         title: 'Zone Egresses',
         isBreadcrumb: true,
@@ -138,6 +141,7 @@ export default (store: Store<State>): RouteRecordRaw[] => {
         },
         {
           path: 'gateways',
+          name: 'gateway-abstract-view',
           meta: {
             title: 'Gateways',
             isBreadcrumb: true,
@@ -171,6 +175,7 @@ export default (store: Store<State>): RouteRecordRaw[] => {
         },
         {
           path: 'data-planes',
+          name: 'data-plane-abstract-view',
           meta: {
             title: 'Data plane proxies',
             isBreadcrumb: true,
@@ -202,6 +207,7 @@ export default (store: Store<State>): RouteRecordRaw[] => {
         },
         {
           path: 'services',
+          name: 'service-abstract-view',
           meta: {
             title: 'Services',
             isBreadcrumb: true,
@@ -236,6 +242,7 @@ export default (store: Store<State>): RouteRecordRaw[] => {
         },
         {
           path: 'policies',
+          name: 'policy-type-abstract-view',
           meta: {
             title: 'Policies',
             isBreadcrumb: true,
@@ -276,6 +283,7 @@ export default (store: Store<State>): RouteRecordRaw[] => {
             },
             {
               path: ':policyPath',
+              name: 'policy-abstract-view',
               meta: {
                 isBreadcrumb: true,
                 getBreadcrumbTitle: (route, store) => {


### PR DESCRIPTION
Fixes a few edge cases where the breadcrumbs component couldn’t properly resolve unnamed routes. For some reason that’s unclear to me, routes that are definitely defined and loaded only resolve to a proper route location with a resolved `path` property (e.g. the actual mesh name instead of `:mesh`) if they have a name. For this reason, I’ve added a `name` property to all routes that didn’t have one, yet.

Furthermore, changes how breadcrumbs create route targets so that instead of `{ name: '...' }`, they now use `{ path: '...' }` as navigating to, for example, `{ name: 'zone-abstract-view' }` will **only** navigate to that particular route without further resolving children routes for any routes with empty path. However, this _does_ happen when navigating to paths which is what we want here. All in all, `router.resolve` has some surprising and confusing behavior that we address with these changes.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
