### PR TITLE
chore: Small Cypress additions

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,6 +3,8 @@ import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-prepro
 import createEsbuildPlugin from '@badeball/cypress-cucumber-preprocessor/esbuild'
 import createBundler from '@bahmutov/cypress-esbuild-preprocessor'
 import { defineConfig } from 'cypress'
+import dotenv from 'dotenv'
+const env = dotenv.config().parsed as {[key: string]: string}
 
 export default defineConfig({
   e2e: {
@@ -15,6 +17,11 @@ export default defineConfig({
       on: Cypress.PluginEvents,
       config: Cypress.PluginConfigOptions,
     ) {
+      // propagate env to Cypress.env
+      Object.entries(env).forEach(([prop, value]) => {
+        config.env[prop] = value
+      })
+
       // This is required for the preprocessor to be able to generate JSON reports after each run, and more,
       await addCucumberPreprocessorPlugin(on, config)
 

--- a/src/services/e2e.ts
+++ b/src/services/e2e.ts
@@ -1,20 +1,21 @@
-import { token, ServiceDefinition, createInjections } from '@/services/utils'
+import type { EnvVars } from '@/services/env/Env'
 import type { Callback, Options } from '@/test-support'
+
+import { token, ServiceDefinition, createInjections } from '@/services/utils'
 import { mocker } from '@/test-support/intercept'
 
 // this needs to come from testing
-const env = () => (key: string, d = '') => {
-  switch (key) {
-    case 'KUMA_API_URL':
-      return 'http://localhost:5681'
-  }
-  return d
+const env = (
+  env: EnvVars,
+) => (key: keyof EnvVars, d = '') => {
+  return env[key] || d
 }
 type AEnv = ReturnType<typeof env>
 type Server = typeof cy
 // temporary intercept returning Mocker
 type Mocker = (route: string, opts?: Options, cb?: Callback) => ReturnType<typeof cy['intercept']>
 const $ = {
+  EnvVars: token<EnvVars>('EnvVars'),
   env: token<AEnv>('env'),
 
   cy: token<Server>('cy'),
@@ -23,11 +24,22 @@ const $ = {
   Env: token('Env'),
 
   logger: token('logger'),
-  EnvVars: token('EnvVars'),
   bootstrap: token('bootstrap'),
 }
 type Token = ReturnType<typeof token>
 export const services = <T extends Record<string, Token>>(app: T): ServiceDefinition[] => [
+  [$.EnvVars, {
+    constant: {
+      KUMA_API_URL: Cypress.env('VITE_KUMA_API_SERVER_URL'),
+      KUMA_PRODUCT_NAME: Cypress.env('VITE_NAMESPACE'),
+      KUMA_FEEDBACK_URL: Cypress.env('VITE_FEEDBACK_URL'),
+      KUMA_CHAT_URL: Cypress.env('VITE_CHAT_URL'),
+      KUMA_INSTALL_URL: Cypress.env('VITE_INSTALL_URL'),
+      KUMA_VERSION_URL: Cypress.env('VITE_VERSION_URL'),
+      KUMA_DOCS_URL: Cypress.env('VITE_DOCS_BASE_URL'),
+      KUMA_MOCK_API_ENABLED: Cypress.env('VITE_MOCK_API_ENABLED'),
+    },
+  }],
   [app.cy, {
     constant: cy,
   }],
@@ -50,6 +62,9 @@ export const services = <T extends Record<string, Token>>(app: T): ServiceDefini
   // this will eventually come from testing
   [app.env, {
     service: env,
+    arguments: [
+      $.EnvVars,
+    ],
   }],
 
 ]

--- a/src/test-support/fake.ts
+++ b/src/test-support/fake.ts
@@ -75,7 +75,7 @@ export const fakeApi = (env: AEnv, server: Server, fs: FS) => {
   const mockEnv: Env = (key, d = '') => env(key as AppEnvKeys, d)
 
   return Object.entries(fs).map(([route, endpoint]) => {
-    return server.all(`${route.startsWith('https://') ? '' : baseUrl}${escapeRoute(route)}`, async (req, res, ctx) => {
+    return server.all(`${route.includes('://') ? '' : baseUrl}${escapeRoute(route)}`, async (req, res, ctx) => {
       const fetch = endpoint({
         ...dependencies,
         env: mockEnv,

--- a/src/test-support/intercept.ts
+++ b/src/test-support/intercept.ts
@@ -44,14 +44,15 @@ export const mocker = (env: (key: AppEnvKeys, d?: string) => string, cy: Server,
       (req) => {
         try {
           const mockEnv: Env = (key, d = '') => (opts[key as MockEnvKeys] ?? '') || env(key as AppEnvKeys, d)
-          const url = new URL(req.url)
-          const { route, params } = router.match(url.pathname)
+          const { route, params } = router.match(req.url.replace(baseUrl, ''))
           const endpoint = route
           const fetch = endpoint({
             ...dependencies,
             env: mockEnv,
           })
+          const url = new URL(req.url)
           const request = {
+            method: req.method,
             params,
             url,
           }


### PR DESCRIPTION
1. Starts to integrate .env/process.env into Cypress.env and then `env`, note we aren't running in `vite` here but we are re-using the `VITE_` prefixed values from `.env`. In the application itself this is hidden and they remain `KUMA_` prefixed.
2. Uses `includes('://')` instead of `https://` which is a more reliable catch for "anything with a base url already"
3. Adds `req.method` for when we need to start mocking/testing on methods as well as other HTTP things.
4. Added some more steps

This remains a work in progress and the more we can use the same code for everything the easier things will be. I've tried to keep the things that are additional code as close to the places where we do similar.

Signed-off-by: John Cowen <john.cowen@konghq.com>