### PR TITLE
fix: prematurely accessing policy types

### DIFF
--- a/features/application/Titles.feature
+++ b/features/application/Titles.feature
@@ -15,6 +15,4 @@ Feature: The HTML title is correct on each page
       | /mesh/default/services                  | Services           |
       | /mesh/default/gateways                  | Gateways           |
       | /mesh/default/data-planes               | Data plane proxies |
-      # TODO: This should say Circuit Breakers
-      | /mesh/default/policies/circuit-breakers | Manager            |
-      # | /mesh/default/policies/circuit-breakers | Circuit Breakers   |
+      | /mesh/default/policies/circuit-breakers | CircuitBreaker     |

--- a/src/app/data-planes/components/DataplanePolicies.vue
+++ b/src/app/data-planes/components/DataplanePolicies.vue
@@ -178,7 +178,7 @@ function getPolicyRoutes(policies: Record<string, MatchedPolicyType> | undefined
   const policyRoutes: MeshGatewayRoutePolicy[] = []
 
   for (const policy of Object.values(policies)) {
-    const policyType = store.state.policyTypesByName[policy.type]
+    const policyType = store.state.policyTypesByName[policy.type] as PolicyType
 
     policyRoutes.push({
       type: policy.type,
@@ -220,7 +220,7 @@ function getPolicyTypeEntries(sidecarDataplanes: SidecarDataplane[]): PolicyType
       }
 
       const policyTypeEntry = policyTypeEntriesByType.get(policyTypeName) as PolicyTypeEntry
-      const policyType = store.state.policyTypesByName[policyTypeName]
+      const policyType = store.state.policyTypesByName[policyTypeName] as PolicyType
 
       for (const policy of policies) {
         const connections = getPolicyTypeEntryConnections(policy, policyType, sidecarDataplane, destinationTags, name)
@@ -287,7 +287,7 @@ function getRuleEntries(rules: DataplaneRule[]): RuleEntry[] {
     }
 
     const policyTypeEntry = policyTypeEntriesByType.get(rule.policyType) as RuleEntry
-    const policyType = store.state.policyTypesByName[rule.policyType]
+    const policyType = store.state.policyTypesByName[rule.policyType] as PolicyType
     const connections = getRuleEntryConnections(rule, policyType)
 
     policyTypeEntry.connections.push(...connections)

--- a/src/app/policies/components/PolicyConnections.spec.ts
+++ b/src/app/policies/components/PolicyConnections.spec.ts
@@ -4,8 +4,19 @@ import { rest } from 'msw'
 
 import PolicyConnections from './PolicyConnections.vue'
 import { useServer, useMock } from '@/../jest/jest-setup-after-env'
+import { useRouter } from '@/utilities'
 
-function renderComponent(props = {}) {
+async function renderComponent() {
+  const router = useRouter()
+  await router.push({
+    name: 'policy-detail-view',
+    params: {
+      mesh: 'default',
+      policyPath: 'circuit-breakers',
+      policy: 'foo',
+    },
+  })
+
   return mount(PolicyConnections, {
     props: {
       mesh: 'foo',
@@ -19,7 +30,7 @@ function renderComponent(props = {}) {
 describe('PolicyConnections.vue', () => {
   const mock = useMock()
   test('renders snapshot', async () => {
-    const wrapper = renderComponent()
+    const wrapper = await renderComponent()
 
     await flushPromises()
 
@@ -52,7 +63,7 @@ describe('PolicyConnections.vue', () => {
         ],
       },
     }))
-    const wrapper = renderComponent()
+    const wrapper = await renderComponent()
 
     await flushPromises()
 
@@ -66,8 +77,8 @@ describe('PolicyConnections.vue', () => {
     expect(wrapper.findAll('[data-testid="dataplane-name"]').length).toBe(2)
   })
 
-  test('renders loading', () => {
-    const wrapper = renderComponent()
+  test('renders loading', async () => {
+    const wrapper = await renderComponent()
 
     expect(wrapper.find('[data-testid="loading-block"]').exists()).toBe(true)
   })
@@ -80,7 +91,7 @@ describe('PolicyConnections.vue', () => {
       ),
     )
 
-    const wrapper = renderComponent()
+    const wrapper = await renderComponent()
 
     await flushPromises()
 
@@ -95,7 +106,7 @@ describe('PolicyConnections.vue', () => {
       ),
     )
 
-    const wrapper = renderComponent()
+    const wrapper = await renderComponent()
 
     await flushPromises()
 

--- a/src/app/policies/components/PolicyConnections.spec.ts
+++ b/src/app/policies/components/PolicyConnections.spec.ts
@@ -20,9 +20,8 @@ async function renderComponent() {
   return mount(PolicyConnections, {
     props: {
       mesh: 'foo',
-      policyType: 'circuit-breakers',
+      policyPath: 'circuit-breakers',
       policyName: 'foo',
-      ...props,
     },
   })
 }
@@ -86,7 +85,7 @@ describe('PolicyConnections.vue', () => {
   test('renders error', async () => {
     const server = useServer()
     server.use(
-      rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/:policyType/:policyName/dataplanes', (req, res, ctx) =>
+      rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/:policyPath/:policyName/dataplanes', (req, res, ctx) =>
         res(ctx.status(500), ctx.json({})),
       ),
     )
@@ -101,7 +100,7 @@ describe('PolicyConnections.vue', () => {
   test('renders no item', async () => {
     const server = useServer()
     server.use(
-      rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/:policyType/:policyName/dataplanes', (req, res, ctx) =>
+      rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/:policyPath/:policyName/dataplanes', (req, res, ctx) =>
         res(ctx.status(200), ctx.json({ total: 0, items: [] })),
       ),
     )

--- a/src/app/policies/components/PolicyConnections.vue
+++ b/src/app/policies/components/PolicyConnections.vue
@@ -52,7 +52,7 @@ const props = defineProps({
     required: true,
   },
 
-  policyType: {
+  policyPath: {
     type: String,
     required: true,
   },
@@ -90,7 +90,7 @@ async function fetchPolicyConnections(): Promise<void> {
   try {
     const { items, total } = await kumaApi.getPolicyConnections({
       mesh: props.mesh,
-      policyType: props.policyType,
+      policyPath: props.policyPath,
       policyName: props.policyName,
     })
 

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -46,7 +46,7 @@
         <PolicyConnections
           :mesh="policy.mesh"
           :policy-name="policy.name"
-          :policy-type="props.policyPath"
+          :policy-path="props.policyPath"
         />
       </template>
     </TabsWidget>

--- a/src/app/policies/views/PolicyListView.spec.ts
+++ b/src/app/policies/views/PolicyListView.spec.ts
@@ -8,7 +8,14 @@ import { useStore, useRouter } from '@/utilities'
 const store = useStore()
 async function createWrapper(props = {}) {
   const router = useRouter()
-  await router.push({ name: 'mesh-detail-view', params: { mesh: 'default' } })
+  await router.push({
+    name: 'policy-detail-view',
+    params: {
+      mesh: 'default',
+      policyPath: 'circuit-breakers',
+      policy: 'foo',
+    },
+  })
   await store.dispatch('fetchPolicyTypes')
 
   return mount(PolicyListView, {

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -141,7 +141,7 @@ import TabsWidget from '@/app/common/TabsWidget.vue'
 import YamlView from '@/app/common/YamlView.vue'
 import { PAGE_SIZE_DEFAULT } from '@/constants'
 import { useStore } from '@/store/store'
-import { PolicyEntity, TableHeader } from '@/types/index.d'
+import { PolicyEntity, PolicyType, TableHeader } from '@/types/index.d'
 import { useEnv, useKumaApi } from '@/utilities'
 import { getSome, stripTimes } from '@/utilities/helpers'
 import { QueryParameter } from '@/utilities/QueryParameter'
@@ -231,8 +231,10 @@ watch(() => route.params.mesh, function () {
 start()
 
 function start() {
-  if (policyType.value !== undefined) {
-    store.dispatch('updatePageTitle', policyType.value.name)
+  const policyType = store.state.policyTypesByPath[props.policyPath]
+
+  if (policyType !== undefined) {
+    store.dispatch('updatePageTitle', policyType.name)
   }
 
   loadData(props.offset)
@@ -247,7 +249,7 @@ async function loadData(offset: number) {
   error.value = null
 
   const mesh = route.params.mesh as string
-  const path = policyType.value.path
+  const path = route.params.policyPath as string
   const size = PAGE_SIZE_DEFAULT
 
   try {
@@ -273,12 +275,11 @@ async function loadData(offset: number) {
 function transformToTableData(policies: PolicyEntity[]): PolicyEntityTableRow[] {
   return policies.map((entity) => {
     const { type, name } = entity
-    const policyType = store.state.policyTypesByName[type]
     const detailViewRoute: RouteLocationNamedRaw = {
       name: 'policy-detail-view',
       params: {
         mesh: entity.mesh,
-        policyPath: policyType.path,
+        policyPath: route.params.policyPath as string,
         policy: name,
       },
     }
@@ -292,8 +293,9 @@ function transformToTableData(policies: PolicyEntity[]): PolicyEntityTableRow[] 
 }
 
 async function handleTableAction(entity: PolicyEntity) {
-  const { name, mesh } = entity
-  const path = policyType.value.path
+  const { name, mesh, type } = entity
+  const policyType = store.state.policyTypesByName[type] as PolicyType
+  const path = policyType.path
 
   await loadEntity({ name, mesh, path })
 }

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -114,7 +114,7 @@
               v-if="rawEntity !== null"
               :mesh="rawEntity.mesh"
               :policy-name="rawEntity.name"
-              :policy-type="policyType.path"
+              :policy-path="policyType.path"
             />
           </template>
         </TabsWidget>

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -281,7 +281,7 @@ export default (store: Store<State>): RouteRecordRaw[] => {
                 getBreadcrumbTitle: (route, store) => {
                   const policyType = store.state.policyTypesByPath[route.params.policyPath as string]
 
-                  return policyType.name
+                  return policyType?.name ?? route.params.policyPath
                 },
               },
               children: [

--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -199,8 +199,8 @@ export default class KumaApi extends Api {
     }
   }
 
-  getPolicyConnections({ mesh, policyType, policyName }: { mesh: string; policyType: string; policyName: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<any>> {
-    return this.client.get(`/meshes/${mesh}/${policyType}/${policyName}/dataplanes`, { params })
+  getPolicyConnections({ mesh, policyPath, policyName }: { mesh: string; policyPath: string; policyName: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<any>> {
+    return this.client.get(`/meshes/${mesh}/${policyPath}/${policyName}/dataplanes`, { params })
   }
 
   getAllPolicyEntitiesFromMesh({ mesh, path }: { mesh: string, path: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<PolicyEntity>> {

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -89,8 +89,8 @@ interface BareRootState {
   externalServicesFetching: boolean
   zonesInsightsFetching: boolean
   policyTypes: PolicyType[]
-  policyTypesByPath: Record<string, PolicyType>
-  policyTypesByName: Record<string, PolicyType>
+  policyTypesByPath: Record<string, PolicyType | undefined>
+  policyTypesByName: Record<string, PolicyType | undefined>
 }
 
 const initialState: BareRootState = {


### PR DESCRIPTION
**fix: prematurely accessing policy types**

Fixes some premature accesses of the current policy type in `PolicyListView`. Some instances were replaces with `route.params.policyPath` (i.e. when specifically the policy path was required). Other instances received additional type guard checks.

**chore: renames some incorrect references to policy types**

Renames some instances where the policy (type) path (e.g. circuit-breakers) was incorrectly referred to as policy type (e.g. CircuitBreaker).

**test(e2e): switches to more accurate title test case**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>