### PR TITLE
chore: Merge mock and fakeApi

### DIFF
--- a/src/services/testing.ts
+++ b/src/services/testing.ts
@@ -1,10 +1,9 @@
 import { setupServer } from 'msw/node'
 
-import { ServiceConfigurator, token } from './utils'
+import { Alias, ServiceConfigurator, token } from './utils'
 import CliEnv from '@/services/env/CliEnv'
-import { mocker } from '@/test-support'
+import { mocker, fakeApi, FS } from '@/test-support'
 import type { Mocker } from '@/test-support'
-import type { RestHandler } from 'msw'
 
 const $ = {
   mock: token<Mocker>('mocker'),
@@ -12,11 +11,13 @@ const $ = {
 
 export const services: ServiceConfigurator = (app) => [
   [app.msw, {
-    service: (handlers: RestHandler[]) => {
-      return setupServer(...handlers)
+    service: (env: Alias<CliEnv['var']>, fs: FS) => {
+      const mock = fakeApi(env, fs)
+      return setupServer(...mock('*'))
     },
     arguments: [
-      app.mswHandlers,
+      app.env,
+      app.fakeFS,
     ],
   }],
   [$.mock, {

--- a/src/test-support/intercept.ts
+++ b/src/test-support/intercept.ts
@@ -20,7 +20,14 @@ class Router<T> {
       const _url = `data:${path}`
       if (pattern.test(_url)) {
         const args = pattern.exec(_url)
-        return { route, params: args?.pathname.groups }
+        const params = args?.pathname.groups || {}
+        return {
+          route,
+          params: Object.entries(params).reduce((prev: Record<string, string>, [key, value]) => {
+            prev[key] = value || ''
+            return prev
+          }, {}),
+        }
       }
     }
     throw new Error(`Matching route for '${path}' not found`)
@@ -56,9 +63,7 @@ export const mocker = (env: (key: AppEnvKeys, d?: string) => string, cy: Server,
             params,
             url,
           }
-          // @ts-ignore
           const _response = fetch(request)
-          // @ts-ignore
           const response = cb(createMerge(_response), request, _response)
           req.reply({
             statusCode: parseInt(response.headers['Status-Code'] ?? '200'),


### PR DESCRIPTION
Several code improvements to mocking functions. Basically - "now I'm pretty much done for the moment with the e2e stuff, clean a few things up that I never got around to doing":

1. Splits and combines code in relation to `fakeAPI` and `mocker`, both of which used to do the almost the same thing with different code. As of this PR, they are split up enough to both use the same code. The aim being to use the same code for Cypress also (therefore they may still change shape slightly once we come to do that)
2. Removes `mswFakeHandlers` token. This was only here so we could support "collecting" both types of mock endpoints at the same time, the old static ones and the new dynamic ones. We no longer need this so there's slight reworking here to remove. This generally reduces the code in the service container, but as this token isn't used anywhere else, removing it and reworking the code slightly doesn't affect any other service containers in other environments.
3. Adds our own `RestRequest` type and therefore removes the need for a couple of ts-ignores which were temporarily being used to deal with the different Cypress and MSW request shapes.

These were mostly done back in https://github.com/kumahq/kuma-gui/pull/803#issuecomment-1511503701, but I've brought everything up to date with the changes made since then. Seeing as the main part of the e2e infra work is now done, I decided now was a good time to get this noodling in before it was lost and forgotten.


Signed-off-by: John Cowen <john.cowen@konghq.com>