### PR TITLE
chore: Enables using Cypress/intercept against a running dev instance

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -20,6 +20,12 @@ export default defineConfig({
       // propagate env to Cypress.env
       Object.entries(env).forEach(([prop, value]) => {
         config.env[prop] = value
+      });
+      // additional non-dotenv environment vars
+      [
+        'KUMA_BASE_URL',
+      ].forEach(item => {
+        config.env[item] = process.env[item]
       })
 
       // This is required for the preprocessor to be able to generate JSON reports after each run, and more,

--- a/cypress/support/step_definitions/visit.ts
+++ b/cypress/support/step_definitions/visit.ts
@@ -6,6 +6,9 @@ const config = {
 
 When('I visit the {string} URL', function (path: string) {
   cy.viewport(1366, 768)
+  // turn off MSW in dev environments so we can use cy.intercept
+  cy.setCookie('KUMA_MOCK_API_ENABLED', 'false')
+  //
   cy.visit(`${config.BASE_URL}${path}`)
   // currently use this to denote "the page has initially rendered"
   cy.get('.app-main-content').should('be.visible')

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint:lockfile": "lockfile-lint --path yarn.lock --allowed-hosts yarn --validate-https",
     "lint:ts": "vue-tsc --noEmit",
     "test": "cross-env TZ=UTC jest",
-    "test:browser": "npx cypress run",
+    "test:browser": "cypress run",
+    "test:browser:view": "KUMA_BASE_URL=http://localhost:8080/gui cypress open",
     "test:watch": "yarn run test --watch"
   },
   "engines": {


### PR DESCRIPTION
All of our e2e tests run against a production build. This PR makes it easier to run our e2e/cypress tests against a running dev server for better local DX.

Since only dev builds have the "read env from cookies" enabled, this only effects dev builds. Prod builds mostly have no MSW available anyway.

Exact package script naming etc, I'm not super keen on but just went with something for now. I mentioned in a recent PR I wanted to get all the scripts we needed in first and then if we want to switch naming a little once they are all there we can.

Signed-off-by: John Cowen <john.cowen@konghq.com>