### PR TITLE
chore: Adds the ability to add some latency to dev/preview via KUMA_LATENCY

### DIFF
--- a/src/test-support/index.ts
+++ b/src/test-support/index.ts
@@ -45,7 +45,10 @@ const useResponder = <T extends RestRequest>(fs: FS, env: AEnv) => {
     })
     return async (req: T): Promise<MockResponse> => {
       const _response = fetch(req)
-      await new Promise(resolve => setTimeout(resolve, parseInt(mockEnv('KUMA_LATENCY', '0'))))
+      const latency = parseInt(mockEnv('KUMA_LATENCY', '0'))
+      if (latency !== 0) {
+        await new Promise(resolve => setTimeout(resolve, latency))
+      }
       return cb(createMerge(_response), req, _response)
     }
   }


### PR DESCRIPTION
Sometimes when testing things out locally or on the PR preview sites its nice to introduce a little latency.

This lets you add a little HTTP latency by adding a `KUMA_LATENCY=1000` cookie (value is millis) to any build that has our mocks enabled (usually local dev and PR previews)

I added this whilst reviewing a PR locally but it would be nice to have it for PR preview sites also.