### PR TITLE
feat: adds mesh list view

### DIFF
--- a/features/application/Titles.feature
+++ b/features/application/Titles.feature
@@ -11,6 +11,7 @@ Feature: The HTML title is correct on each page
       | /zone-ingresses                         | Zone Ingresses     |
       | /zone-egresses                          | Zone Egresses      |
 
+      | /mesh                                   | Meshes             |
       | /mesh/default                           | Mesh overview      |
       | /mesh/default/services                  | Services           |
       | /mesh/default/gateways                  | Gateways           |

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="kcard-stack">
+    <div class="kcard-border">
+      <DataOverview
+        :selected-entity-name="entity?.name"
+        :page-size="PAGE_SIZE_DEFAULT"
+        :is-loading="isLoading"
+        :error="error"
+        :empty-state="EMPTY_STATE"
+        :table-data="tableData"
+        :table-data-is-empty="tableData.data.length === 0"
+        :next="nextUrl"
+        :page-offset="pageOffset"
+        @table-action="loadEntity"
+        @load-data="loadData"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { PropType, ref, watch } from 'vue'
+import { RouteLocationNamedRaw, useRoute } from 'vue-router'
+
+import DataOverview from '@/app/common/DataOverview.vue'
+import { PAGE_SIZE_DEFAULT } from '@/constants'
+import { MeshInsight, TableHeader } from '@/types/index.d'
+import { useI18n, useKumaApi } from '@/utilities'
+import { QueryParameter } from '@/utilities/QueryParameter'
+
+type MeshTableRow = {
+  entity: MeshInsight
+  detailViewRoute: RouteLocationNamedRaw
+  services: number
+  dataPlaneProxies: number
+}
+
+const i18n = useI18n()
+const kumaApi = useKumaApi()
+
+const EMPTY_STATE = {
+  title: i18n.t('meshes.list.emptyState.title'),
+  message: i18n.t('meshes.list.emptyState.message'),
+}
+
+const route = useRoute()
+
+const props = defineProps({
+  selectedMeshName: {
+    type: [String, null] as PropType<string | null>,
+    required: false,
+    default: null,
+  },
+
+  offset: {
+    type: Number,
+    required: false,
+    default: 0,
+  },
+})
+
+const isLoading = ref(true)
+const error = ref<Error | null>(null)
+const tableData = ref<{ headers: TableHeader[], data: MeshTableRow[] }>({
+  headers: [
+    { label: 'Name', key: 'entity' },
+    { label: 'Services', key: 'services' },
+    { label: 'Data Plane Proxies', key: 'dataPlaneProxies' },
+  ],
+  data: [],
+})
+const entity = ref<MeshInsight | null>(null)
+const nextUrl = ref<string | null>(null)
+const pageOffset = ref(props.offset)
+
+watch(() => route.params.mesh, function () {
+  // Don’t trigger a load when the user is navigating to another route.
+  if (route.name !== 'mesh-list-view') {
+    return
+  }
+
+  loadData(0)
+})
+
+start()
+
+function start() {
+  loadData(props.offset)
+}
+
+async function loadData(offset: number) {
+  pageOffset.value = offset
+  // Puts the offset parameter in the URL so it can be retrieved when the user reloads the page.
+  QueryParameter.set('offset', offset > 0 ? offset : null)
+
+  isLoading.value = true
+  error.value = null
+
+  const size = PAGE_SIZE_DEFAULT
+
+  try {
+    const { items, next } = await kumaApi.getAllMeshInsights({ size, offset })
+
+    nextUrl.value = next
+    tableData.value.data = transformToTableData(items ?? [])
+    await loadEntity({ name: props.selectedMeshName ?? tableData.value.data[0]?.entity.name })
+  } catch (err) {
+    tableData.value.data = []
+    entity.value = null
+
+    if (err instanceof Error) {
+      error.value = err
+    } else {
+      console.error(err)
+    }
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function transformToTableData(meshInsights: MeshInsight[]): MeshTableRow[] {
+  return meshInsights.map((entity) => {
+    const { name, services: serviceTotals, dataplanes: dataPlaneProxyTotals } = entity
+    const detailViewRoute: RouteLocationNamedRaw = {
+      name: 'mesh-detail-view',
+      params: {
+        mesh: name,
+      },
+    }
+    const services = serviceTotals.total ?? 0
+    const dataPlaneProxies = dataPlaneProxyTotals.total ?? 0
+
+    return {
+      entity,
+      detailViewRoute,
+      services,
+      dataPlaneProxies,
+    }
+  })
+}
+
+async function loadEntity({ name }: { name?: string | undefined }) {
+  if (name === undefined) {
+    entity.value = null
+    QueryParameter.set('zone', null)
+    return
+  }
+
+  try {
+    entity.value = await kumaApi.getMeshInsights({ name })
+    QueryParameter.set('zone', name)
+  } catch (err) {
+    console.error(err)
+  }
+}
+</script>

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -158,6 +158,18 @@ export default (store: Store<State>, env: Env): RouteRecordRaw[] => {
       },
       children: [
         {
+          path: '',
+          name: 'mesh-list-view',
+          meta: {
+            title: 'Meshes',
+          },
+          props: (route) => ({
+            page: getLastNumberParameter(route.query.page),
+            selectedMeshName: route.query.mesh,
+          }),
+          component: () => import('@/app/meshes/views/MeshListView.vue'),
+        },
+        {
           path: ':mesh',
           name: 'mesh-abstract-view',
           meta: {

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -151,193 +151,208 @@ export default (store: Store<State>, env: Env): RouteRecordRaw[] => {
       ],
     },
     {
-      path: '/mesh/:mesh',
+      path: '/mesh',
+      meta: {
+        title: 'Meshes',
+        isBreadcrumb: true,
+      },
       children: [
         {
-          path: '',
-          name: 'mesh-detail-view',
+          path: ':mesh',
+          name: 'mesh-abstract-view',
           meta: {
             title: 'Mesh overview',
-          },
-          component: () => import('@/app/mesh-overview/views/MeshOverviewView.vue'),
-        },
-        {
-          path: 'gateways',
-          name: 'gateway-abstract-view',
-          meta: {
-            title: 'Gateways',
             isBreadcrumb: true,
+            breadcrumbTitleParam: 'mesh',
           },
           children: [
             {
               path: '',
-              name: 'gateway-list-view',
+              name: 'mesh-detail-view',
+              meta: {
+                title: 'Mesh overview',
+              },
+              component: () => import('@/app/mesh-overview/views/MeshOverviewView.vue'),
+            },
+            {
+              path: 'gateways',
+              name: 'gateway-abstract-view',
               meta: {
                 title: 'Gateways',
-              },
-              props: (route) => ({
-                selectedDppName: route.query.gateway,
-                gatewayType: route.query.gatewayType === 'all' ? 'true' : route.query.gatewayType,
-                offset: getLastNumberParameter(route.query.offset),
-                isGatewayView: true,
-              }),
-              component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
-            },
-            {
-              path: ':dataPlane',
-              name: 'gateway-detail-view',
-              meta: {
-                title: 'Gateway',
                 isBreadcrumb: true,
-                breadcrumbTitleParam: 'dataPlane',
-              },
-              component: () => import('@/app/data-planes/views/DataPlaneDetailView.vue'),
-            },
-          ],
-        },
-        {
-          path: 'data-planes',
-          name: 'data-plane-abstract-view',
-          meta: {
-            title: 'Data plane proxies',
-            isBreadcrumb: true,
-          },
-          children: [
-            {
-              path: '',
-              name: 'data-plane-list-view',
-              meta: {
-                title: 'Data plane proxies',
-              },
-              props: (route) => ({
-                selectedDppName: route.query.dpp,
-                offset: getLastNumberParameter(route.query.offset),
-              }),
-              component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
-            },
-            {
-              path: ':dataPlane',
-              name: 'data-plane-detail-view',
-              meta: {
-                title: 'Data plane proxy',
-                isBreadcrumb: true,
-                breadcrumbTitleParam: 'dataPlane',
-              },
-              component: () => import('@/app/data-planes/views/DataPlaneDetailView.vue'),
-            },
-          ],
-        },
-        {
-          path: 'services',
-          name: 'service-abstract-view',
-          meta: {
-            title: 'Services',
-            isBreadcrumb: true,
-          },
-          children: [
-            {
-              path: '',
-              name: 'service-list-view',
-              meta: {
-                title: 'Services',
-              },
-              props: (route) => ({
-                selectedServiceName: route.query.service,
-                offset: getLastNumberParameter(route.query.offset),
-              }),
-              component: () => import('@/app/services/views/ServiceListView.vue'),
-            },
-            {
-              path: ':service',
-              name: 'service-detail-view',
-              meta: {
-                title: 'Internal service',
-                isBreadcrumb: true,
-                breadcrumbTitleParam: 'service',
-              },
-              props: (route) => ({
-                selectedDppName: route.query.dpp,
-              }),
-              component: () => import('@/app/services/views/ServiceDetailView.vue'),
-            },
-          ],
-        },
-        {
-          path: 'policies',
-          name: 'policy-type-abstract-view',
-          meta: {
-            title: 'Policies',
-            isBreadcrumb: true,
-          },
-          children: [
-            {
-              path: '',
-              name: 'policies',
-              meta: {
-                title: 'Policies',
-              },
-              redirect: (to) => {
-                let item = store.state.policyTypes.find((item) => {
-                  if (!(item.name in store.state.sidebar.insights.mesh.policies)) {
-                    return false
-                  }
-
-                  return store.state.sidebar.insights.mesh.policies[item.name] !== 0
-                })
-
-                if (item === undefined) {
-                  item = store.state.policyTypes[0]
-                }
-
-                if (item === undefined) {
-                  return { name: 'home' }
-                }
-
-                return {
-                  ...to,
-                  params: {
-                    ...to.params,
-                    policyPath: item.path,
-                  },
-                  name: 'policy-list-view',
-                }
-              },
-            },
-            {
-              path: ':policyPath',
-              name: 'policy-abstract-view',
-              meta: {
-                isBreadcrumb: true,
-                getBreadcrumbTitle: (route, store) => {
-                  const policyType = store.state.policyTypesByPath[route.params.policyPath as string]
-
-                  return policyType?.name ?? route.params.policyPath
-                },
               },
               children: [
                 {
                   path: '',
-                  name: 'policy-list-view',
-                  component: () => import('@/app/policies/views/PolicyListView.vue'),
-                  props: (route) => ({
-                    policyPath: route.params.policyPath,
-                    selectedPolicyName: route.query.policy,
-                    offset: getLastNumberParameter(route.query.offset),
-                  }),
-                },
-                {
-                  path: ':policy',
-                  name: 'policy-detail-view',
+                  name: 'gateway-list-view',
                   meta: {
-                    isBreadcrumb: true,
-                    breadcrumbTitleParam: 'policy',
+                    title: 'Gateways',
                   },
                   props: (route) => ({
-                    mesh: route.params.mesh,
-                    policyPath: route.params.policyPath,
-                    policyName: route.params.policy,
+                    selectedDppName: route.query.gateway,
+                    gatewayType: route.query.gatewayType === 'all' ? 'true' : route.query.gatewayType,
+                    offset: getLastNumberParameter(route.query.offset),
+                    isGatewayView: true,
                   }),
-                  component: () => import('@/app/policies/views/PolicyDetailView.vue'),
+                  component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
+                },
+                {
+                  path: ':dataPlane',
+                  name: 'gateway-detail-view',
+                  meta: {
+                    title: 'Gateway',
+                    isBreadcrumb: true,
+                    breadcrumbTitleParam: 'dataPlane',
+                  },
+                  component: () => import('@/app/data-planes/views/DataPlaneDetailView.vue'),
+                },
+              ],
+            },
+            {
+              path: 'data-planes',
+              name: 'data-plane-abstract-view',
+              meta: {
+                title: 'Data plane proxies',
+                isBreadcrumb: true,
+              },
+              children: [
+                {
+                  path: '',
+                  name: 'data-plane-list-view',
+                  meta: {
+                    title: 'Data plane proxies',
+                  },
+                  props: (route) => ({
+                    selectedDppName: route.query.dpp,
+                    offset: getLastNumberParameter(route.query.offset),
+                  }),
+                  component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
+                },
+                {
+                  path: ':dataPlane',
+                  name: 'data-plane-detail-view',
+                  meta: {
+                    title: 'Data plane proxy',
+                    isBreadcrumb: true,
+                    breadcrumbTitleParam: 'dataPlane',
+                  },
+                  component: () => import('@/app/data-planes/views/DataPlaneDetailView.vue'),
+                },
+              ],
+            },
+            {
+              path: 'services',
+              name: 'service-abstract-view',
+              meta: {
+                title: 'Services',
+                isBreadcrumb: true,
+              },
+              children: [
+                {
+                  path: '',
+                  name: 'service-list-view',
+                  meta: {
+                    title: 'Services',
+                  },
+                  props: (route) => ({
+                    selectedServiceName: route.query.service,
+                    offset: getLastNumberParameter(route.query.offset),
+                  }),
+                  component: () => import('@/app/services/views/ServiceListView.vue'),
+                },
+                {
+                  path: ':service',
+                  name: 'service-detail-view',
+                  meta: {
+                    title: 'Internal service',
+                    isBreadcrumb: true,
+                    breadcrumbTitleParam: 'service',
+                  },
+                  props: (route) => ({
+                    selectedDppName: route.query.dpp,
+                  }),
+                  component: () => import('@/app/services/views/ServiceDetailView.vue'),
+                },
+              ],
+            },
+            {
+              path: 'policies',
+              name: 'policy-type-abstract-view',
+              meta: {
+                title: 'Policies',
+                isBreadcrumb: true,
+              },
+              children: [
+                {
+                  path: '',
+                  name: 'policies',
+                  meta: {
+                    title: 'Policies',
+                  },
+                  redirect: (to) => {
+                    let item = store.state.policyTypes.find((item) => {
+                      if (!(item.name in store.state.sidebar.insights.mesh.policies)) {
+                        return false
+                      }
+
+                      return store.state.sidebar.insights.mesh.policies[item.name] !== 0
+                    })
+
+                    if (item === undefined) {
+                      item = store.state.policyTypes[0]
+                    }
+
+                    if (item === undefined) {
+                      return { name: 'home' }
+                    }
+
+                    return {
+                      ...to,
+                      params: {
+                        ...to.params,
+                        policyPath: item.path,
+                      },
+                      name: 'policy-list-view',
+                    }
+                  },
+                },
+                {
+                  path: ':policyPath',
+                  name: 'policy-abstract-view',
+                  meta: {
+                    isBreadcrumb: true,
+                    getBreadcrumbTitle: (route, store) => {
+                      const policyType = store.state.policyTypesByPath[route.params.policyPath as string]
+
+                      return policyType?.name ?? route.params.policyPath
+                    },
+                  },
+                  children: [
+                    {
+                      path: '',
+                      name: 'policy-list-view',
+                      component: () => import('@/app/policies/views/PolicyListView.vue'),
+                      props: (route) => ({
+                        policyPath: route.params.policyPath,
+                        selectedPolicyName: route.query.policy,
+                        offset: getLastNumberParameter(route.query.offset),
+                      }),
+                    },
+                    {
+                      path: ':policy',
+                      name: 'policy-detail-view',
+                      meta: {
+                        isBreadcrumb: true,
+                        breadcrumbTitleParam: 'policy',
+                      },
+                      props: (route) => ({
+                        mesh: route.params.mesh,
+                        policyPath: route.params.policyPath,
+                        policyName: route.params.policy,
+                      }),
+                      component: () => import('@/app/policies/views/PolicyDetailView.vue'),
+                    },
+                  ],
                 },
               ],
             },

--- a/src/store/modules/sidebar/util.spec.ts
+++ b/src/store/modules/sidebar/util.spec.ts
@@ -40,6 +40,7 @@ describe('sidebar utils', () => {
               partiallyDegraded: 5,
             },
             dataplanesByType: {
+              standard: {},
               gateway: {
                 total: 5,
                 online: 1,
@@ -143,7 +144,10 @@ describe('sidebar utils', () => {
                 total: 1,
               },
             },
-            dpVersions: {},
+            dpVersions: {
+              kumaDp: {},
+              envoy: {},
+            },
             mTLS: {},
             services: {
               total: 2,

--- a/src/store/reducers/mesh-insights.spec.ts
+++ b/src/store/reducers/mesh-insights.spec.ts
@@ -101,7 +101,14 @@ describe('mesh-insights', () => {
             },
           },
         },
-        { policies: {}, dataplanes: {}, dpVersions: {} },
+        {
+          policies: {},
+          dataplanes: {},
+          dpVersions: {
+            kumaDp: {},
+            envoy: {},
+          },
+        },
       ]),
     ).toMatchSnapshot()
   })

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -63,6 +63,55 @@ export class KumaModule {
       ],
     )
   }
+
+  /**
+   * Returns a random DPP (or gateway) status object with self-consistent values (i.e. total = online + partiallyDegraded + offline).
+   */
+  dataPlaneProxyStatus(maxTotal: number = 30) {
+    const total = this.faker.datatype.number({ min: 1, max: maxTotal })
+    const online = this.faker.datatype.number({ min: 0, max: total })
+    const partiallyDegraded = this.faker.datatype.number({ min: 0, max: total - online })
+    const offline = total - online - partiallyDegraded
+
+    const values = [
+      ['total', total],
+      ['online', online],
+      ['partiallyDegraded', partiallyDegraded],
+      ['offline', offline],
+    ].filter(([_key, value]) => value !== 0)
+
+    return Object.fromEntries(values)
+  }
+
+  /**
+   * Returns a random service status object with self-consistent values (i.e. total = internal + external).
+   */
+  serviceStatus(maxTotal: number = 30) {
+    const total = this.faker.datatype.number({ min: 1, max: maxTotal })
+    const internal = this.faker.datatype.number({ min: 0, max: total })
+    const external = total - internal
+
+    const values = [
+      ['total', total],
+      ['internal', internal],
+      ['external', external],
+    ].filter(([_key, value]) => value !== 0)
+
+    return Object.fromEntries(values)
+  }
+
+  /**
+   * Returns a random policy type status object.
+   */
+  policyTypeStatus(maxTotal: number = 10) {
+    const total = this.faker.datatype.number({ min: 0, max: maxTotal })
+
+    const values = [
+      ['total', total],
+    ]
+
+    return Object.fromEntries(values)
+  }
 }
 export default class FakeKuma extends Faker {
   kuma = new KumaModule(this)

--- a/src/test-support/mocks/src/mesh-insights.ts
+++ b/src/test-support/mocks/src/mesh-insights.ts
@@ -1,5 +1,6 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
 export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (req) => {
+  // TODO: Setting different values here doesn’t seem to work. The mock always returns 14 objects.
   const { total, next, pageTotal } = pager(
     env('KUMA_MESH_COUNT', `${fake.datatype.number({ min: 1, max: 20 })}`),
     req,
@@ -12,75 +13,37 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const mesh = `${fake.hacker.noun()}-${i}`
+        const dataPlaneProxyStatus = fake.kuma.dataPlaneProxyStatus()
+        const standardDataPlaneProxies = fake.kuma.dataPlaneProxyStatus(dataPlaneProxyStatus.total)
+        const gateways = fake.kuma.dataPlaneProxyStatus(standardDataPlaneProxies.total)
+
         return {
           type: 'MeshInsight',
           name: mesh,
           creationTime: '2021-01-29T07:10:02.339031+01:00',
           modificationTime: '2021-01-29T07:29:02.314448+01:00',
           lastSync: '2021-01-29T06:29:02.314447Z',
-          dataplanes: {
-            total: 10,
-            online: 9,
-            partiallyDegraded: 1,
-          },
+          dataplanes: dataPlaneProxyStatus,
           dataplanesByType: {
-            standard: {
-              total: 9,
-              online: 8,
-              partiallyDegraded: 1,
-            },
-            gateway: {
-              total: 1,
-              online: 1,
-              partiallyDegraded: 0,
-            },
+            standard: standardDataPlaneProxies,
+            gateway: gateways,
           },
           policies: {
-            CircuitBreaker: {
-              total: 2,
-            },
-            FaultInjection: {
-              total: 2,
-            },
-            HealthCheck: {
-              total: 4,
-            },
-            MeshGatewayRoute: {
-              total: 1,
-            },
-            MeshGateway: {
-              total: 1,
-            },
-            ProxyTemplate: {
-              total: 1,
-            },
-            RateLimit: {
-              total: 0,
-            },
-            Retry: {
-              total: 1,
-            },
-            Timeout: {
-              total: 1,
-            },
-            TrafficLog: {
-              total: 1,
-            },
-            TrafficPermission: {
-              total: 3,
-            },
-            TrafficRoute: {
-              total: 1,
-            },
-            TrafficTrace: {
-              total: 3,
-            },
-            VirtualOutbound: {
-              total: 0,
-            },
-            Secret: {
-              total: 6,
-            },
+            CircuitBreaker: fake.kuma.policyTypeStatus(),
+            FaultInjection: fake.kuma.policyTypeStatus(),
+            HealthCheck: fake.kuma.policyTypeStatus(),
+            MeshGatewayRoute: fake.kuma.policyTypeStatus(),
+            MeshGateway: fake.kuma.policyTypeStatus(),
+            ProxyTemplate: fake.kuma.policyTypeStatus(),
+            RateLimit: fake.kuma.policyTypeStatus(),
+            Retry: fake.kuma.policyTypeStatus(),
+            Timeout: fake.kuma.policyTypeStatus(),
+            TrafficLog: fake.kuma.policyTypeStatus(),
+            TrafficPermission: fake.kuma.policyTypeStatus(),
+            TrafficRoute: fake.kuma.policyTypeStatus(),
+            TrafficTrace: fake.kuma.policyTypeStatus(),
+            VirtualOutbound: fake.kuma.policyTypeStatus(),
+            Secret: fake.kuma.policyTypeStatus(),
           },
           dpVersions: {
             kumaDp: {
@@ -134,15 +97,10 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               },
             },
           },
-          services: {
-            total: 5,
-            internal: 3,
-            external: 2,
-          },
+          services: fake.kuma.serviceStatus(),
         }
       }),
       next,
-
     },
   }
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -81,11 +81,17 @@ export interface ZoneInsight {
   subscriptions: KDSSubscription[]
 }
 
-export interface UnitStatus {
+export interface DataPlaneProxyStatus {
   total?: number
   online?: number
   offline?: number
   partiallyDegraded?: number
+}
+
+export interface ServiceStatus {
+  total?: number
+  internal?: number
+  external?: number
 }
 
 export interface ResourceStat {
@@ -484,15 +490,21 @@ export interface Mesh extends Entity {
 export interface MeshInsight extends Entity {
   type: 'MeshInsight'
   lastSync: string
-  dataplanes: UnitStatus
-  dataplanesByType: Record<string, UnitStatus>
-  policies: Record<string, ResourceStat>
-  dpVersions: Record<string, Record<string, UnitStatus>>
-  mTLS: {
-    issuedBackends?: Record<string, UnitStatus>
-    supportedBackends?: Record<string, UnitStatus>
+  dataplanes: DataPlaneProxyStatus
+  dataplanesByType: {
+    standard: DataPlaneProxyStatus
+    gateway: DataPlaneProxyStatus
   }
-  services: Record<string, number>
+  policies: Record<string, ResourceStat>
+  dpVersions: {
+    kumaDp: Record<string, DataPlaneProxyStatus>
+    envoy: Record<string, DataPlaneProxyStatus>
+  }
+  mTLS: {
+    issuedBackends?: Record<string, DataPlaneProxyStatus>
+    supportedBackends?: Record<string, DataPlaneProxyStatus>
+  }
+  services: ServiceStatus
 }
 
 export interface PolicyEntity extends MeshEntity {}

--- a/src/utilities/useI18n.ts
+++ b/src/utilities/useI18n.ts
@@ -125,6 +125,14 @@ export function getI18nMessages(): I18nMessages {
         },
       },
     },
+    meshes: {
+      list: {
+        emptyState: {
+          title: 'No data',
+          message: 'There are no Meshes present.',
+        },
+      },
+    },
   }
 }
 


### PR DESCRIPTION
## Changes

**chore: updates mesh-insights mock**

Updates the mesh-insights mock to have a bunch more random status values.

**chore(types): matches MeshInsight close to backend**

Updates the `MeshInsight` type and some related types to be close to the backend.

**refactor: nests mesh routes to match usual structure**

Splits the `/mesh/:mesh` route record into a `/mesh` record with only one children route record which is the `:mesh` route record which allows for adding routes _next_ to `:mesh` without inheriting the `mesh` route parameter (e.g. for the mesh list view route).

Adds the Meshes breadcrumbs item when on a page under or directly on `/mesh`. Adds the current mesh (e.g. default) when on a page under `/mesh`.

**feat: adds mesh list view**

Adds a MeshListView component at `/mesh`.

Resolves #892.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Screenshots

![image](https://github.com/kumahq/kuma-gui/assets/5774638/6b366851-ff04-402d-9153-a532f5648741)
