### PR TITLE
fix: Uses a decorator for cookied env rather than overwriting

### DIFF
--- a/src/services/development.ts
+++ b/src/services/development.ts
@@ -1,6 +1,7 @@
 import { setupWorker, MockedRequest, rest } from 'msw'
 
-import CookiedEnv from '@/services/env/CookiedEnv'
+import cookied from '@/services/env/CookiedEnv'
+import type Env from '@/services/env/Env'
 import debugI18n from '@/services/i18n/DebugI18n'
 import Logger from '@/services/logger/DatadogLogger'
 import { disabledLogger } from '@/services/logger/DisabledLogger'
@@ -31,7 +32,7 @@ type SupportedTokens = {
   logger: Token
   msw: Token
   bootstrap: Token
-  env: Token<Alias<CookiedEnv['var']>>
+  env: Token<Alias<Env['var']>>
 }
 
 export const services: ServiceConfigurator<SupportedTokens> = (app) => [
@@ -60,11 +61,11 @@ export const services: ServiceConfigurator<SupportedTokens> = (app) => [
     decorates: app.i18n,
   }],
 
-  [app.Env, {
-    service: CookiedEnv,
-    arguments: [
-      app.EnvVars,
-    ],
+  [token<Alias<Env['var']>>('env.debug'), {
+    service: (env: () => Alias<Env['var']>) => {
+      return cookied(env())
+    },
+    decorates: app.env,
   }],
 
   [app.logger, {

--- a/src/services/env/CookiedEnv.ts
+++ b/src/services/env/CookiedEnv.ts
@@ -1,18 +1,19 @@
-import Env from './Env'
-export default class CookiedEnv extends Env {
-  var(...rest: Parameters<Env['var']>) {
-    const cookies = document.cookie.split(';')
-      .map((item) => item.trim())
-      .filter((item) => item !== '')
-      .reduce((prev, item) => {
-        const [key, value] = item.split('=')
-        prev[key] = value
-        return prev
-      }, {} as Record<string, string>)
-    const key = rest[0]
-    if (key in cookies) {
-      return cookies[key]
-    }
-    return super.var(...rest)
+import type { EnvVars } from './Env'
+export default (
+  env: (str: keyof EnvVars, d?: string) => string,
+  cookie: string = document.cookie,
+) => (...rest: Parameters<typeof env>) => {
+  const cookies = cookie.split(';')
+    .map((item) => item.trim())
+    .filter((item) => item !== '')
+    .reduce((prev, item) => {
+      const [key, value] = item.split('=')
+      prev[key] = value
+      return prev
+    }, {} as Record<string, string>)
+  const key = rest[0]
+  if (key in cookies) {
+    return cookies[key]
   }
+  return env(...rest)
 }


### PR DESCRIPTION
TLDR; Uses a decorator for cookied env rather than overwriting, which prevents our development "additionally check the cookies for env vars" from overwriting any different implementation of Env that might be different upstream.

---

Longer form:

A while back we added very basic decorator functionality to our service config. This means we can stop overwriting services and instead configure a decorator for it if we are just adding extra functionality we also can decorate a service that might not even exist yet, or a service that might be overwritten in another environment. Generally avoiding service configuration ordering issues.

Whilst we added that functionality, we didn't go back and update the services that should really have been using decorators rather than overwriting. This means that, depending on the ordering of things upstream, things we overwrite for production can then get re-overwritten by a development utility.

Note: This is only a fix for development environment such as local development and PR previews etc.


(As a follow up here, I would like to change all of our `env.var` usage to just use `env` (cookies now only work if you are using `env`). @kleinfreund FYI I had a different opinion on this previously but I've been slowly thinking we should always use `env`, there's a longer thought process here but this is the most important bit.)

Signed-off-by: John Cowen <john.cowen@konghq.com>