### PR TITLE
chore: Changes zone creation to use `/provision-zone` rather than just `/zones`

### DIFF
--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -71,7 +71,7 @@ export default class KumaApi extends Api {
   }
 
   createZone(zone: UnsavedZone): Promise<Zone> {
-    return this.client.post('/zones', zone)
+    return this.client.post('/provision-zone', zone)
   }
 
   updateZone(zone: Zone): Promise<Zone> {

--- a/src/test-support/mocks/fs.ts
+++ b/src/test-support/mocks/fs.ts
@@ -46,6 +46,7 @@ import _45 from './src/meshes/_/traffic-traces'
 import _46 from './src/meshes/_/traffic-traces/_'
 import _47 from './src/meshes/_/virtual-outbounds'
 import _2 from './src/policies'
+import _51 from './src/provision-zone'
 import _7 from './src/service-insights'
 import _10 from './src/zoneegressoverviews'
 import _49 from './src/zoneegressoverviews/_'
@@ -69,6 +70,7 @@ export const fs: FS = {
   '/service-insights': _7,
   '/zones': _8,
   '/zones/:name': _50,
+  '/provision-zone': _51,
   '/zoneingresses+insights': _9,
   '/zoneingresses+insights/:name': _48,
   '/zoneegressoverviews': _10,

--- a/src/test-support/mocks/src/provision-zone.ts
+++ b/src/test-support/mocks/src/provision-zone.ts
@@ -1,0 +1,10 @@
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+
+export default (_deps: EndpointDependencies): MockResponder => (_req) => {
+  return {
+    headers: {},
+    body: {
+      token: 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjEiLCJ0eXAiOiJKV1QifQ.eyJab25lIjoid2VzdCIsIlNjb3BlIjpbImNwIl0sImV4cCI6MTY2OTU0NjkzOSwibmJmIjoxNjY2OTU0NjM5LCJpYXQiOjE2NjY5NTQ5MzksImp0aSI6IjZiYWYyYzkwLTBlODYtNGM2Mi05N2E3LTc4MzU4NTU4MzRiYyJ9.DJfA0M6uUfO4oytp8jHtzngiVggQWQR88YQxWVU1ujc0Zv-XStRDwvpdEoFGOzWVn4EUfI3gcv9qS2MxqIzQjJ83k5Jq85w4hkPyLGr-0jNS1UZF6yXz7lB_As8f91gMVHbRAoFuoybV5ndDtfYzwZknyzott7doxk-SjTes2GDvpg0-kFNGc4MBR2EprGl7YKO0vhFxQjln5AyCAhmAA7-PM7WRCzhmS-pUXacfZtP2VulWYhmTAuLPnkJrJN-ZWPkIpnV1MZmsgWbzTpnW-PhmCMQfD5m2im1c_3OlFwa9P9rZQQhdhbTp0ofMvW-cdCAcG_lOJI5j60cqPh2DGg',
+    },
+  }
+}

--- a/src/test-support/mocks/src/zones.ts
+++ b/src/test-support/mocks/src/zones.ts
@@ -1,19 +1,6 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
-import { RestRequest } from '@/test-support/fake'
 
-export default (deps: EndpointDependencies): MockResponder => (req) => {
-  switch (req.method) {
-    case 'POST': {
-      return createZone(req, deps)
-    }
-    case 'GET':
-    default: {
-      return getZones(req, deps)
-    }
-  }
-}
-
-function getZones(_req: RestRequest, { fake }: EndpointDependencies) {
+export default ({ fake }: EndpointDependencies): MockResponder => (_req) => {
   const total = fake.number.int(10)
 
   return {
@@ -31,19 +18,6 @@ function getZones(_req: RestRequest, { fake }: EndpointDependencies) {
         }
       }),
       next: null,
-    },
-  }
-}
-
-function createZone(req: RestRequest, _deps: EndpointDependencies) {
-  return {
-    headers: {},
-    body: {
-      name: req.body.name,
-      creationTime: '2020-07-22T19:37:28.442793+03:00',
-      modificationTime: '2020-07-22T19:37:28.442793+03:00',
-      enabled: false,
-      token: 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjEiLCJ0eXAiOiJKV1QifQ.eyJab25lIjoid2VzdCIsIlNjb3BlIjpbImNwIl0sImV4cCI6MTY2OTU0NjkzOSwibmJmIjoxNjY2OTU0NjM5LCJpYXQiOjE2NjY5NTQ5MzksImp0aSI6IjZiYWYyYzkwLTBlODYtNGM2Mi05N2E3LTc4MzU4NTU4MzRiYyJ9.DJfA0M6uUfO4oytp8jHtzngiVggQWQR88YQxWVU1ujc0Zv-XStRDwvpdEoFGOzWVn4EUfI3gcv9qS2MxqIzQjJ83k5Jq85w4hkPyLGr-0jNS1UZF6yXz7lB_As8f91gMVHbRAoFuoybV5ndDtfYzwZknyzott7doxk-SjTes2GDvpg0-kFNGc4MBR2EprGl7YKO0vhFxQjln5AyCAhmAA7-PM7WRCzhmS-pUXacfZtP2VulWYhmTAuLPnkJrJN-ZWPkIpnV1MZmsgWbzTpnW-PhmCMQfD5m2im1c_3OlFwa9P9rZQQhdhbTp0ofMvW-cdCAcG_lOJI5j60cqPh2DGg',
     },
   }
 }


### PR DESCRIPTION
Changes zone creation to use `/provision-zone` rather than just `/zones`

![Screenshot 2023-05-18 at 11 35 06](https://github.com/kumahq/kuma-gui/assets/554604/88c93226-04cb-4663-8b06-e7bb66730bfe)

Signed-off-by: John Cowen <john.cowen@konghq.com>
