### PR TITLE
chore: Turn disabled logger into a proper decorator instead of overwrite

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,11 +38,9 @@ export function useBootstrap(
     await store.dispatch('updateGlobalLoading', true)
 
     if (isAllowedToMakeApiCalls) {
-      if (import.meta.env.PROD) {
-        kumaApi.getConfig().then((config) => {
-          logger.setup(config)
-        })
-      }
+      kumaApi.getConfig().then((config) => {
+        logger.setup(config)
+      })
       await Promise.all([
         // Fetches basic resources before setting up the router and mounting the
         // application. This is mainly needed to properly redirect users to the

--- a/src/services/development.ts
+++ b/src/services/development.ts
@@ -3,8 +3,8 @@ import { setupWorker, MockedRequest, rest } from 'msw'
 import cookied from '@/services/env/CookiedEnv'
 import type Env from '@/services/env/Env'
 import debugI18n from '@/services/i18n/DebugI18n'
-import Logger from '@/services/logger/DatadogLogger'
-import { disabledLogger } from '@/services/logger/DisabledLogger'
+import type Logger from '@/services/logger/DatadogLogger'
+import disabled from '@/services/logger/DisabledLogger'
 import { token, get } from '@/services/utils'
 import type { ServiceConfigurator, ReturnDecorated, Decorator, Alias, Token, TokenType } from '@/services/utils'
 import type { FS } from '@/test-support'
@@ -61,18 +61,18 @@ export const services: ServiceConfigurator<SupportedTokens> = (app) => [
     decorates: app.i18n,
   }],
 
-  [token<Alias<Env['var']>>('env.debug'), {
+  [token<ReturnType<typeof cookied>>('env.debug'), {
     service: (env: () => Alias<Env['var']>) => {
       return cookied(env())
     },
     decorates: app.env,
   }],
 
-  [app.logger, {
-    service: disabledLogger(Logger),
-    arguments: [
-      app.Env,
-    ],
+  [token<ReturnType<typeof disabled>>('logger.disabled'), {
+    service: (logger: () => Logger) => {
+      return disabled(logger())
+    },
+    decorates: app.logger,
   }],
 
   // Mock Service Worker

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -61,8 +61,6 @@ export default class Env {
     // payload or non-replaced template, or during CLI tests when there is no
     // HTML file.
 
-    // TODO: Uncomment noisy console errors (we don't want them during testing
-    // but we do want them for our users)
     let config!: PathConfig
     if (pathConfigNode instanceof HTMLScriptElement && pathConfigNode.textContent) {
       try {

--- a/src/services/kuma-api/Api.ts
+++ b/src/services/kuma-api/Api.ts
@@ -1,12 +1,18 @@
 import { RestClient } from './RestClient'
-import type Env from '@/services/env/Env'
+import type { EnvVars } from '@/services/env/Env'
 
+type Env = (
+  key: keyof Pick<EnvVars,
+  'KUMA_API_URL' |
+  'KUMA_VERSION_URL'
+  >
+) => string
 export class Api {
   client: RestClient
   env: Env
 
   constructor(env: Env) {
-    this.client = new RestClient(env.var('KUMA_API_URL'))
+    this.client = new RestClient(env('KUMA_API_URL'))
     this.env = env
   }
 

--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -44,7 +44,7 @@ export default class KumaApi extends Api {
   }
 
   async getLatestVersion(): Promise<string> {
-    return this.client.get(this.env.var('KUMA_VERSION_URL'))
+    return this.client.get(this.env('KUMA_VERSION_URL'))
   }
 
   getConfig(): Promise<ClientConfigInterface> {

--- a/src/services/logger/DatadogLogger.ts
+++ b/src/services/logger/DatadogLogger.ts
@@ -1,8 +1,13 @@
 import { datadogLogs } from '@datadog/browser-logs'
 
-import type Env from '@/services/env/Env'
+import type { EnvVars } from '@/services/env/Env'
 import type { ClientConfigInterface } from '@/store/modules/config/config.types'
 
+type Env = (
+  key: keyof Pick<EnvVars,
+  'KUMA_PRODUCT_NAME'
+  >
+) => string
 export default class DatadogLogger {
   env: Env
   constructor(env: Env) {
@@ -15,7 +20,7 @@ export default class DatadogLogger {
         clientToken: 'pub94a0029259f79f29a5d881a06d1e9653',
         site: 'datadoghq.com',
         forwardErrorsToLogs: true,
-        service: this.env.var('KUMA_PRODUCT_NAME'),
+        service: this.env('KUMA_PRODUCT_NAME'),
         sampleRate: 100,
         env: 'production', // logging is currently disabled in anything other than production
       })

--- a/src/services/logger/DisabledLogger.ts
+++ b/src/services/logger/DisabledLogger.ts
@@ -1,13 +1,14 @@
-import type { ClientConfigInterface } from '@/store/modules/config/config.types'
-const c = class {
-  // eslint-disable-next-line no-useless-constructor
-  constructor(..._args: any[]) {
-  }
-}
-export const disabledLogger = function (parent: typeof c) {
-  return class DisabledLogger extends parent {
-    setup(_config: ClientConfigInterface) {
-      console.log('Logging disabled')
+import type Logger from '@/services/logger/DatadogLogger'
+// eslint-disable-next-line no-useless-constructor
+const c = class {constructor(..._args: any[]) {}}
+type Parent = typeof c;
+export default (
+  logger: Logger,
+) => {
+  class DisabledLogger extends (logger.constructor as Parent) {
+    setup() {
+      console.warn('Logging is disabled')
     }
   }
+  return new DisabledLogger(logger.env)
 }

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -85,7 +85,7 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   [$.api, {
     service: KumaApi,
     arguments: [
-      $.Env,
+      $.env,
     ],
   }],
 
@@ -93,7 +93,7 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   [$.logger, {
     service: Logger,
     arguments: [
-      $.Env,
+      $.env,
     ],
   }],
 


### PR DESCRIPTION
We noticed that things that weren't decorators (but should have been) were overwriting services completely due to a change in ordering of service config (see https://github.com/kumahq/kuma-gui/pull/924 for more info). These weren't written as decorators originally just due to timings of things and how things have shaken out.

Decorators avoid this problem by decorating/augmenting services rather than overwriting them completely.

We should use decorators for development only modifications/augmentation over completely overwriting. So I've changed our remaining non-decorator service here - the logging disabling. This one specifically didn't really matter that it completely overwrites any other implementations as its a "disable logger completely, no matter what it is", but I prefer consistency.

Additionally, in https://github.com/kumahq/kuma-gui/pull/924 we only decorated `env` with extra cookie functionality. This means we should always use `env()` over `Env.var`. I've previously said we should only use `env` in Vue components, but without spending too much time on my thoughts, I think we should stick to using `env` always - please ask if you want further background/plans.

Lastly the `PROD` fork I removed here was still there because when I originally added the prod/dev service config functionality I wasn't totally aware of the entire codebase so I left that there incase. Super sure we can remove this now, so I figured I could just do it here (also see https://github.com/kumahq/kuma-gui/issues/825)



