### PR TITLE
feat: adds default slot to block components

### DIFF
--- a/src/app/common/EmptyBlock.vue
+++ b/src/app/common/EmptyBlock.vue
@@ -10,7 +10,9 @@
           size="42"
         />
 
-        <p>There is no data to display.</p>
+        <slot>
+          <p>There is no data to display.</p>
+        </slot>
       </slot>
     </template>
 

--- a/src/app/common/EnvoyData.vue
+++ b/src/app/common/EnvoyData.vue
@@ -13,7 +13,6 @@
     </div>
 
     <StatusInfo
-      :has-error="error !== null"
       :is-loading="isLoading"
       :error="error"
     >

--- a/src/app/common/ErrorBlock.vue
+++ b/src/app/common/ErrorBlock.vue
@@ -10,7 +10,9 @@
           size="42"
         />
 
-        <p>An error has occurred while trying to load this data.</p>
+        <slot>
+          <p>An error has occurred while trying to load this data.</p>
+        </slot>
       </template>
 
       <template

--- a/src/app/common/StatusInfo.vue
+++ b/src/app/common/StatusInfo.vue
@@ -3,7 +3,7 @@
     <LoadingBlock v-if="isLoading" />
 
     <ErrorBlock
-      v-else-if="hasError"
+      v-else-if="hasError || error !== null"
       :error="error"
     />
 


### PR DESCRIPTION
Wraps the title content of our block components in a default slot so you can set the content from the consumer side.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
