### PR TITLE
fix: triggering global loading when re-running bootstrap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,8 +35,6 @@ export function useBootstrap(
   store: Store<State>,
 ) {
   return async (isAllowedToMakeApiCalls: boolean = true) => {
-    await store.dispatch('updateGlobalLoading', true)
-
     if (isAllowedToMakeApiCalls) {
       if (import.meta.env.PROD) {
         kumaApi.getConfig().then((config) => {
@@ -54,7 +52,5 @@ export function useBootstrap(
     } else {
       store.state.defaultVisibility.appError = false
     }
-
-    await store.dispatch('updateGlobalLoading', false)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,11 @@ async function mountVueApplication() {
   const app = await get($.app)((await import('./app/App.vue')).default)
   app.mount('#app')
 
-  get($.bootstrap)()
+  const store = get($.store)
+  await store.dispatch('updateGlobalLoading', true)
+  const bootstrap = get($.bootstrap)
+  await bootstrap()
+  await store.dispatch('updateGlobalLoading', false)
 }
 
 mountVueApplication()


### PR DESCRIPTION
Fixes triggering the global loading state when re-running the bootstrap function.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
