### PR TITLE
chore: Refactor DefinitionListItem and usage to use `t` from The Outside

### DIFF
--- a/src/app/common/DefinitionListItem.vue
+++ b/src/app/common/DefinitionListItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="definition-list-item">
     <dt class="definition-list-item__term">
-      {{ currentTerm }}
+      {{ props.term }}
     </dt>
 
     <dd class="definition-list-item__details">
@@ -11,11 +11,6 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
-
-import { useI18n } from '@/utilities'
-
-const { t } = useI18n()
 
 const props = defineProps({
   term: {
@@ -24,7 +19,6 @@ const props = defineProps({
   },
 })
 
-const currentTerm = computed(() => t(`http.api.property.${props.term}`))
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/common/subscriptions/SubscriptionDetails.vue
+++ b/src/app/common/subscriptions/SubscriptionDetails.vue
@@ -8,28 +8,28 @@
       <DefinitionList>
         <DefinitionListItem
           v-if="details.globalInstanceId"
-          term="Global instance ID"
+          :term="t('http.api.property.globalInstanceId')"
         >
           {{ details.globalInstanceId }}
         </DefinitionListItem>
 
         <DefinitionListItem
           v-if="details.controlPlaneInstanceId"
-          term="CP instance ID"
+          :term="t('http.api.property.controlPlaneInstanceId')"
         >
           {{ details.controlPlaneInstanceId }}
         </DefinitionListItem>
 
         <DefinitionListItem
           v-if="details.connectTime"
-          term="Last connected"
+          :term="t('http.api.property.connectTime')"
         >
           {{ humanReadableDate(details.connectTime) }}
         </DefinitionListItem>
 
         <DefinitionListItem
           v-if="details.disconnectTime"
-          term="Last disconnected"
+          :term="t('http.api.property.disconnectTime')"
         >
           {{ humanReadableDate(details.disconnectTime) }}
         </DefinitionListItem>
@@ -47,14 +47,14 @@
       >
         <div v-if="Object.keys(item).length > 0">
           <h6 class="overview-tertiary-title">
-            {{ label }}:
+            {{ t(`http.api.property.${label}`) }}:
           </h6>
 
           <DefinitionList>
             <DefinitionListItem
               v-for="(value, property) in item"
               :key="property"
-              :term="property"
+              :term="t(`http.api.property.${property}`)"
             >
               {{ formatError(formatValue(value)) }}
             </DefinitionListItem>
@@ -85,13 +85,10 @@ import { computed } from 'vue'
 
 import DefinitionList from '@/app/common/DefinitionList.vue'
 import DefinitionListItem from '@/app/common/DefinitionListItem.vue'
+import { useI18n } from '@/utilities'
 import { humanReadableDate } from '@/utilities/helpers'
 
-const map: Record<string, string> = {
-  responsesSent: 'Responses sent',
-  responsesAcknowledged: 'Responses acknowledged',
-  responsesRejected: 'Responses rejected',
-}
+const { t } = useI18n()
 
 const props = defineProps({
   details: {
@@ -115,17 +112,6 @@ const detailsIterator = computed<Record<string, Record<string, any>>>(() => {
 
   if (props.details.status?.stat) {
     details = props.details.status?.stat
-  }
-
-  for (const detailProperty in details) {
-    const detail: any = details[detailProperty]
-
-    for (const prop in detail) {
-      if (prop in map) {
-        detail[map[prop]] = detail[prop]
-        delete detail[prop]
-      }
-    }
   }
 
   return details

--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -21,7 +21,7 @@
           <DefinitionListItem
             v-for="(value, property) in processedDataPlane"
             :key="property"
-            :term="property"
+            :term="t(`http.api.property.${property}`)"
           >
             {{ value }}
           </DefinitionListItem>
@@ -150,12 +150,11 @@
           </a>
         </template>
       </KAlert>
-
       <DefinitionList v-else>
         <DefinitionListItem
           v-for="(value, property) in mtlsData"
           :key="property"
-          :term="property"
+          :term="t(`http.api.property.${property}`)"
         >
           {{ value }}
         </DefinitionListItem>
@@ -195,7 +194,7 @@ import {
   DataPlane,
   DataPlaneOverview,
 } from '@/types/index.d'
-import { useEnv, useKumaApi } from '@/utilities'
+import { useEnv, useI18n, useKumaApi } from '@/utilities'
 import {
   compatibilityKind,
   COMPATIBLE,
@@ -206,6 +205,8 @@ import {
   INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS,
   parseMTLSData,
 } from '@/utilities/dataplane'
+
+const { t } = useI18n()
 
 const env = useEnv()
 const kumaApi = useKumaApi()

--- a/src/app/data-planes/components/DataPlaneEntitySummary.vue
+++ b/src/app/data-planes/components/DataPlaneEntitySummary.vue
@@ -92,7 +92,9 @@
                   {{ subscriptionWrapper.formattedDisconnectDate }}
                 </DefinitionListItem>
 
-                <DefinitionListItem term="CP instance ID">
+                <DefinitionListItem
+                  :term="t('http.api.property.controlPlaneInstanceId')"
+                >
                   {{ subscriptionWrapper.subscription.controlPlaneInstanceId }}
                 </DefinitionListItem>
               </DefinitionList>
@@ -143,11 +145,13 @@ import TagList from '@/app/common/TagList.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { SingleResourceParameters } from '@/types/api.d'
 import { DataPlaneOverview } from '@/types/index.d'
-import { useKumaApi } from '@/utilities'
+import { useKumaApi, useI18n } from '@/utilities'
 import { dpTags, getStatusAndReason, getVersions } from '@/utilities/dataplane'
 import { rawReadableDate } from '@/utilities/helpers'
 
 const kumaApi = useKumaApi()
+
+const { t } = useI18n()
 
 const props = defineProps({
   dataPlaneOverview: {
@@ -187,7 +191,6 @@ const subscriptionWrappers = computed(() => {
           responsesRejected: stats.responsesRejected ?? 0,
         }
       })
-
     return {
       subscription,
       formattedConnectDate,

--- a/src/app/meshes/routes.ts
+++ b/src/app/meshes/routes.ts
@@ -48,6 +48,7 @@ export const routes = (
             {
               name: 'mesh-abstract-view',
               path: '',
+              name: '-mesh',
               redirect: () => ({ name: 'mesh-overview-view' }),
               component: () => import('@/app/meshes/views/MeshView.vue'),
               children: [

--- a/src/app/meshes/routes.ts
+++ b/src/app/meshes/routes.ts
@@ -48,7 +48,6 @@ export const routes = (
             {
               name: 'mesh-abstract-view',
               path: '',
-              name: '-mesh',
               redirect: () => ({ name: 'mesh-overview-view' }),
               component: () => import('@/app/meshes/views/MeshView.vue'),
               children: [

--- a/src/app/meshes/views/MeshOverviewView.vue
+++ b/src/app/meshes/views/MeshOverviewView.vue
@@ -18,7 +18,7 @@
               <DefinitionListItem
                 v-for="(value, property) in basicMesh"
                 :key="property"
-                :term="property"
+                :term="t(`http.api.property.${property}`)"
               >
                 <KBadge
                   v-if="typeof value === 'boolean'"
@@ -42,7 +42,7 @@
             <DefinitionListItem
               v-for="(value, property) in extendedMesh"
               :key="property"
-              :term="property"
+              :term="t(`http.api.property.${property}`)"
             >
               <KBadge
                 v-if="typeof value === 'boolean'"
@@ -113,8 +113,10 @@ import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import { useStore } from '@/store/store'
 import type { SingleResourceParameters } from '@/types/api.d'
 import { Mesh, MeshInsight } from '@/types/index.d'
-import { useKumaApi } from '@/utilities'
+import { useKumaApi, useI18n } from '@/utilities'
 import { humanReadableDate } from '@/utilities/helpers'
+
+const { t } = useI18n()
 
 const kumaApi = useKumaApi()
 const route = useRoute()

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -14,7 +14,6 @@ import { useRoute } from 'vue-router'
 
 import PolicyDetails from '../components/PolicyDetails.vue'
 import { useStore } from '@/store/store'
-
 const route = useRoute()
 const store = useStore()
 

--- a/src/app/zones/components/ZoneDetails.vue
+++ b/src/app/zones/components/ZoneDetails.vue
@@ -17,7 +17,7 @@
         <DefinitionListItem
           v-for="(value, property) in processedZoneOverview"
           :key="property"
-          :term="property"
+          :term="t(`http.api.property.${property}`)"
         >
           <KBadge
             v-if="property === 'status'"
@@ -87,9 +87,11 @@ import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import WarningsWidget from '@/app/common/warnings/WarningsWidget.vue'
 import { useStore } from '@/store/store'
 import type { ZoneCompatibility, ZoneOverview } from '@/types/index.d'
+import { useI18n } from '@/utilities'
 import { getItemStatusFromInsight, INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS } from '@/utilities/dataplane'
 import { getZoneDpServerAuthType } from '@/utilities/helpers'
 
+const { t } = useI18n()
 const store = useStore()
 
 const TABS = [

--- a/src/app/zones/components/ZoneEgressDetails.vue
+++ b/src/app/zones/components/ZoneEgressDetails.vue
@@ -17,7 +17,7 @@
         <DefinitionListItem
           v-for="(value, property) in processedZoneEgressOverview"
           :key="property"
-          :term="property"
+          :term="t(`http.api.property.${property}`)"
         >
           <template v-if="property === 'name'">
             <TextWithCopyButton :text="value" />
@@ -89,6 +89,9 @@ import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vu
 import TabsWidget from '@/app/common/TabsWidget.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { ZoneEgressOverview } from '@/types/index.d'
+import { useI18n } from '@/utilities'
+
+const { t } = useI18n()
 
 const TABS = [
   {

--- a/src/app/zones/components/ZoneIngressDetails.vue
+++ b/src/app/zones/components/ZoneIngressDetails.vue
@@ -17,7 +17,7 @@
         <DefinitionListItem
           v-for="(value, property) in processedZoneIngressOverview"
           :key="property"
-          :term="property"
+          :term="t(`http.api.property.${property}`)"
         >
           <template v-if="property === 'name'">
             <TextWithCopyButton :text="value" />
@@ -89,7 +89,9 @@ import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vu
 import TabsWidget from '@/app/common/TabsWidget.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { ZoneIngressOverview } from '@/types/index.d'
+import { useI18n } from '@/utilities'
 
+const { t } = useI18n()
 const TABS = [
   {
     hash: '#overview',

--- a/src/app/zones/views/__snapshots__/ZoneEgressListView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneEgressListView.spec.ts.snap
@@ -1360,7 +1360,7 @@ exports[`ZoneEgressListView renders zoneegress insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              cds: 
+                              CDS: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -1409,7 +1409,7 @@ exports[`ZoneEgressListView renders zoneegress insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              eds: 
+                              EDS: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -1458,7 +1458,7 @@ exports[`ZoneEgressListView renders zoneegress insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              lds: 
+                              LDS: 
                             </h6>
                             <dl
                               class="definition-list"

--- a/src/app/zones/views/__snapshots__/ZoneIngressListView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneIngressListView.spec.ts.snap
@@ -925,7 +925,7 @@ exports[`ZoneIngressListView renders zoneingress insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              cds: 
+                              CDS: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -974,7 +974,7 @@ exports[`ZoneIngressListView renders zoneingress insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              eds: 
+                              EDS: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -1023,7 +1023,7 @@ exports[`ZoneIngressListView renders zoneingress insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              lds: 
+                              LDS: 
                             </h6>
                             <dl
                               class="definition-list"

--- a/src/app/zones/views/__snapshots__/ZoneListView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneListView.spec.ts.snap
@@ -2203,7 +2203,7 @@ exports[`ZoneListView renders zone insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              CircuitBreaker: 
+                              Circuit Breaker: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -2350,7 +2350,7 @@ exports[`ZoneListView renders zone insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              ExternalService: 
+                              External Service: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -2399,7 +2399,7 @@ exports[`ZoneListView renders zone insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              FaultInjection: 
+                              Fault Injection: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -2448,7 +2448,7 @@ exports[`ZoneListView renders zone insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              HealthCheck: 
+                              Health Check: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -2546,7 +2546,7 @@ exports[`ZoneListView renders zone insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              ProxyTemplate: 
+                              Proxy Template: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -2693,7 +2693,7 @@ exports[`ZoneListView renders zone insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              TrafficLog: 
+                              Traffic Log: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -2742,7 +2742,7 @@ exports[`ZoneListView renders zone insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              TrafficPermission: 
+                              Traffic Permission: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -2791,7 +2791,7 @@ exports[`ZoneListView renders zone insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              TrafficRoute: 
+                              Traffic Route: 
                             </h6>
                             <dl
                               class="definition-list"
@@ -2840,7 +2840,7 @@ exports[`ZoneListView renders zone insights 1`] = `
                             <h6
                               class="overview-tertiary-title"
                             >
-                              TrafficTrace: 
+                              Traffic Trace: 
                             </h6>
                             <dl
                               class="definition-list"

--- a/src/locales/en-us/http/index.yaml
+++ b/src/locales/en-us/http/index.yaml
@@ -10,6 +10,7 @@ http:
       cds: CDS
       eds: EDS
       lds: LDS
+      rds: RDS
       responsesSent: Responses sent
       responsesAcknowledged: Responses acknowledged
       responsesRejected: Responses rejected

--- a/src/locales/en-us/http/index.yaml
+++ b/src/locales/en-us/http/index.yaml
@@ -3,8 +3,8 @@ http:
     property:
       mtls: mTLS
       mTLS: mTLS
-      globalInstanceId: Global Instance ID
-      controlPlaneInstanceId: Control Plane Instance ID
+      globalInstanceId: Global instance ID
+      controlPlaneInstanceId: CP instance ID
       connectTime: Last connected
       disconnectTime: Disconnect time
       cds: CDS

--- a/src/locales/en-us/http/index.yaml
+++ b/src/locales/en-us/http/index.yaml
@@ -3,3 +3,13 @@ http:
     property:
       mtls: mTLS
       mTLS: mTLS
+      globalInstanceId: Global Instance ID
+      controlPlaneInstanceId: Control Plane Instance ID
+      connectTime: Last connected
+      disconnectTime: Disconnect time
+      cds: CDS
+      eds: EDS
+      lds: LDS
+      responsesSent: Responses sent
+      responsesAcknowledged: Responses acknowledged
+      responsesRejected: Responses rejected


### PR DESCRIPTION
Part of https://github.com/kumahq/kuma-gui/issues/843 i.e. the work to use `core/i18n` instead of our own custom 'machine to human' mapping functions.

This PR concentrates on unravelling `t` from `DefinitionListItem`. I've tried to only move the dynamic lookup things to use `t`. Any hardcode/static `term=""` instances I've left as is unless I saw an opportunity to move multiple occurrences to use a single source of truth (e.g. `controlPlaneInstanceId`)

I think this comment mostly explains it:

https://github.com/kumahq/kuma-gui/pull/826#discussion_r1173637069

But this was also called out in the MADR.

I thought of some other things we should probably change around DefinitionListItem, such as I noticed you wouldn't be able to do something like:

```html
<dl>
  <dt></dt>
  <dd></dd>
  <dd></dd>
  <dd></dd>
</dl>
```

if we needed to. Plus the aforementioned:

```html
<dl>
  <dt>Something I Don't Know About <a href="#">Documentation to the thing I don't know about</a></dt>
  <dd></dd>
  
</dl>
```

But I wanted to keep this PR concentrated on the unravelling of `t` thing.
