### PR TITLE
fix(mesh): Places RouteView outside of tabs

### DIFF
--- a/src/app/meshes/views/MeshView.vue
+++ b/src/app/meshes/views/MeshView.vue
@@ -17,21 +17,16 @@
         {{ item.title }}
       </router-link>
     </template>
-    <template
-      v-for="item in items"
-      :key="item.hash"
-      #[item.hash]
-    >
-      <RouterView
-        v-slot="routerView"
-      >
-        <component
-          :is="routerView.Component"
-          :key="routerView.route.path"
-        />
-      </RouterView>
-    </template>
   </KTabs>
+
+  <RouterView
+    v-slot="{Component, route}"
+  >
+    <component
+      :is="Component"
+      :key="route.path"
+    />
+  </RouterView>
 </template>
 <script lang="ts" setup>
 import { KTabs } from '@kong/kongponents'


### PR DESCRIPTION
I noticed that following https://github.com/kumahq/kuma-gui/pull/922, the looping of multiple RouteViews inside the Tabs component caused the TabPanel not to update as quickly as it needed to. 

This PR moves to just use a single RouterView making for a better/less-flickery experience.

Part of https://github.com/kumahq/kuma-gui/issues/893