### PR TITLE
Revert "fix: triggering global loading when re-running bootstrap (#929)"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ export function useBootstrap(
   store: Store<State>,
 ) {
   return async (isAllowedToMakeApiCalls: boolean = true) => {
+    await store.dispatch('updateGlobalLoading', true)
+
     if (isAllowedToMakeApiCalls) {
       if (import.meta.env.PROD) {
         kumaApi.getConfig().then((config) => {
@@ -52,5 +54,7 @@ export function useBootstrap(
     } else {
       store.state.defaultVisibility.appError = false
     }
+
+    await store.dispatch('updateGlobalLoading', false)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,11 +19,7 @@ async function mountVueApplication() {
   const app = await get($.app)((await import('./app/App.vue')).default)
   app.mount('#app')
 
-  const store = get($.store)
-  await store.dispatch('updateGlobalLoading', true)
-  const bootstrap = get($.bootstrap)
-  await bootstrap()
-  await store.dispatch('updateGlobalLoading', false)
+  get($.bootstrap)()
 }
 
 mountVueApplication()


### PR DESCRIPTION
This reverts commit fcc9fb000f2267a2a15e99b065c98cd052e449c2.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
