### PR TITLE
fix: reading Zone name from provision response

### DIFF
--- a/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
+++ b/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
@@ -105,10 +105,9 @@
 </template>
 
 <script lang="ts" setup>
-import { PropType, computed } from 'vue'
+import { computed } from 'vue'
 
 import CodeBlock from '@/app/common/CodeBlock.vue'
-import type { Zone } from '@/types/index.d'
 import { useEnv, useI18n } from '@/utilities'
 import { useGetGlobalKdsAddress } from '@/utilities/useGetGlobalKdsAddress'
 
@@ -117,8 +116,8 @@ const getGlobalKdsAddress = useGetGlobalKdsAddress()
 const i18n = useI18n()
 
 const props = defineProps({
-  zone: {
-    type: Object as PropType<Zone>,
+  zoneName: {
+    type: String,
     required: true,
   },
 
@@ -147,7 +146,7 @@ const kubernetesCreateSecretCommand = computed(() => i18n.t('zones.form.kubernet
   token: props.base64EncodedToken,
 }).trim())
 const kubernetesConfig = computed(() => i18n.t('zones.form.kubernetes.connectZone.config', {
-  zoneName: props.zone.name,
+  zoneName: props.zoneName,
   globalKdsAddress: getGlobalKdsAddress(),
   zoneIngressEnabled: String(props.zoneIngressEnabled),
   zoneEgressEnabled: String(props.zoneEgressEnabled),

--- a/src/app/zones/components/ZoneCreateUniversalInstructions.vue
+++ b/src/app/zones/components/ZoneCreateUniversalInstructions.vue
@@ -48,10 +48,9 @@
 
 <script lang="ts" setup>
 import { KAlert } from '@kong/kongponents'
-import { PropType, computed } from 'vue'
+import { computed } from 'vue'
 
 import CodeBlock from '@/app/common/CodeBlock.vue'
-import type { Zone } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 import { useGetGlobalKdsAddress } from '@/utilities/useGetGlobalKdsAddress'
 
@@ -59,8 +58,8 @@ const getGlobalKdsAddress = useGetGlobalKdsAddress()
 const i18n = useI18n()
 
 const props = defineProps({
-  zone: {
-    type: Object as PropType<Zone>,
+  zoneName: {
+    type: String,
     required: true,
   },
 
@@ -76,7 +75,7 @@ const props = defineProps({
 })
 
 const universalConfig = computed(() => i18n.t('zones.form.universal.connectZone.config', {
-  zoneName: props.zone.name,
+  zoneName: props.zoneName,
   globalKdsAddress: getGlobalKdsAddress(),
   token: props.base64EncodedToken,
 }).trim())

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -120,14 +120,14 @@
 
       <ZoneCreateUniversalInstructions
         v-if="environment === 'universal'"
-        :zone="zone"
+        :zone-name="name"
         :token="token"
         :base64-encoded-token="base64EncodedToken"
       />
 
       <ZoneCreateKubernetesInstructions
         v-else
-        :zone="zone"
+        :zone-name="name"
         :zone-ingress-enabled="zoneIngressEnabled"
         :zone-egress-enabled="zoneEgressEnabled"
         :token="token"
@@ -187,14 +187,13 @@ import ZoneCreateKubernetesInstructions from '../components/ZoneCreateKubernetes
 import ZoneCreateUniversalInstructions from '../components/ZoneCreateUniversalInstructions.vue'
 import WizardTitleBar from '@/app/common/WizardTitleBar.vue'
 import EntityScanner from '@/app/wizard/components/EntityScanner.vue'
-import type { Zone } from '@/types/index.d'
 import { useI18n, useKumaApi } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 const i18n = useI18n()
 const kumaApi = useKumaApi()
 
-const zone = ref<Zone | null>(null)
+const zone = ref<{ token: string } | null>(null)
 const isCreatingZone = ref(false)
 const error = ref<Error | null>(null)
 

--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -21,7 +21,6 @@ import type {
   PolicyType,
   ServiceInsight,
   SidecarDataplane,
-  UnsavedZone,
   Zone,
   ZoneEgressOverview,
   ZoneIngressOverview,
@@ -70,7 +69,7 @@ export default class KumaApi extends Api {
     return this.client.get(`/zones/${name}`)
   }
 
-  createZone(zone: UnsavedZone): Promise<Zone> {
+  createZone(zone: { name: string }): Promise<{ token: string }> {
     return this.client.post('/provision-zone', zone)
   }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -442,14 +442,7 @@ export interface ExternalService extends MeshEntity {
 export interface Zone {
   name: string
   enabled: boolean
-
-  /**
-   * Base64-encoded token.
-   */
-  token?: string
 }
-
-export interface UnsavedZone extends Omit<Unsaved<Zone>, 'enabled'> {}
 
 /**
  * Overview entity as returned via the `/zones+insights/:zone` endpoint.


### PR DESCRIPTION
Stops reading Zone name from the `/provision-zone` endpoint.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>