### PR TITLE
fix: Re-add semver package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "deepmerge": "^4.3.1",
     "js-yaml": "^4.1.0",
     "prismjs": "^1.29.0",
+    "semver": "^7.5.1",
     "tailwindcss": "^3.3.2",
     "vue": "^3.3.2",
     "vue-chartjs": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7411,6 +7411,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.5.1:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
+  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
Re-adds `semver` dependency which was removed a while back in https://github.com/kumahq/kuma-gui/pull/698 by accident even though it was still being used in our store (https://github.com/kumahq/kuma-gui/pull/575/files#diff-7487c8e94db54374c1bf362cbee3cce6a715793c1b2fba31289e684994fd154cR2)

Not a breaking change as such as we still use `semver` as an indirect dependency, but it will eventually cause issues elsewhere if we don't specify it directly.

Longer term we probably shouldn't use this considering none of our "version-looking-things" use ranges we could probably use something smaller/simpler and avoid the dependency.
