### PR TITLE
refactor: changes approach to setting document titles

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -92,16 +92,28 @@ const shouldShowOnboardingNotification = computed(() => store.getters.shouldShow
 const shouldShowBreadcrumbs = computed(() => store.getters.shouldShowBreadcrumbs)
 
 watch(() => isWizard.value, setIsWizardPageClass, { immediate: true })
+watch(() => [route.meta.title, route.meta.getTitle, store.state.policyTypesByPath], setDocumentTitle, { immediate: true })
 
-watch(() => route.meta.title, function (pageTitle) {
-  setDocumentTitle(pageTitle)
-})
+// Fetches policy types as they’re used to set document titles.
+fetchPolicyTypes()
 
-watch(() => store.state.pageTitle, function (pageTitle) {
-  setDocumentTitle(pageTitle)
-})
+async function fetchPolicyTypes() {
+  try {
+    await store.dispatch('fetchPolicyTypes')
+  } catch (err) {
+    console.error(err)
+  }
+}
 
-function setDocumentTitle(title: string | undefined): void {
+function setDocumentTitle() {
+  let title
+
+  if (route.meta.getTitle) {
+    title = route.meta.getTitle(route, store)
+  } else {
+    title = route.meta.title
+  }
+
   const siteTitle = `${import.meta.env.VITE_NAMESPACE} Manager`
 
   document.title = title ? `${title} | ${siteTitle}` : siteTitle

--- a/src/app/data-planes/routes.ts
+++ b/src/app/data-planes/routes.ts
@@ -16,7 +16,7 @@ export const routes = () => {
             path: ':dataPlane',
             name: `${prefix}-detail-view`,
             meta: {
-              title: 'Data plane proxy',
+              getTitle: (route) => route.params.dataPlane as string,
             },
             component: () => import('@/app/data-planes/views/DataPlaneDetailView.vue'),
           },

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -25,13 +25,11 @@ import DataPlaneDetails from '../components/DataPlaneDetails.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { useStore } from '@/store/store'
 import { DataPlane, DataPlaneOverview } from '@/types/index.d'
 import { useKumaApi } from '@/utilities'
 
 const kumaApi = useKumaApi()
 const route = useRoute()
-const store = useStore()
 
 const dataPlane = ref<DataPlane | null>(null)
 const dataPlaneOverview = ref<DataPlaneOverview | null>(null)
@@ -74,6 +72,4 @@ watch(() => route.params.dataPlane, function () {
 })
 
 loadData()
-
-store.dispatch('updatePageTitle', route.params.dataPlane)
 </script>

--- a/src/app/policies/routes.ts
+++ b/src/app/policies/routes.ts
@@ -23,6 +23,9 @@ export const routes = (store: Store<State>) => {
               policyPath: route.params.policyPath,
               policyName: route.params.policy,
             }),
+            meta: {
+              getTitle: (route) => route.params.policy as string,
+            },
             component: () => import('@/app/policies/views/PolicyDetailView.vue'),
           },
         ],
@@ -74,8 +77,15 @@ export const routes = (store: Store<State>) => {
                   children: [
                     {
                       path: ':policyPath',
-
                       name: `${prefix}-list-view`,
+                      meta: {
+                        getTitle: (route, store) => {
+                          const policyPath = route.params.policyPath as string
+                          const policyType = store.state.policyTypesByPath[policyPath]
+
+                          return policyType?.name ?? policyPath
+                        },
+                      },
                       component: () => import('@/app/policies/views/PolicyListView.vue'),
                       props: (route) => ({
                         policyPath: route.params.policyPath,

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -10,11 +10,10 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
-import { useRoute } from 'vue-router'
 
 import PolicyDetails from '../components/PolicyDetails.vue'
 import { useStore } from '@/store/store'
-const route = useRoute()
+
 const store = useStore()
 
 const props = defineProps<{
@@ -24,10 +23,4 @@ const props = defineProps<{
 }>()
 
 const policyType = computed(() => store.state.policyTypesByPath[props.policyPath])
-
-start()
-
-function start() {
-  store.dispatch('updatePageTitle', route.params.policy)
-}
 </script>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -174,14 +174,6 @@ watch(() => route.params.mesh, function () {
 start()
 
 async function start() {
-  const policyType = store.state.policyTypesByPath[props.policyPath]
-
-  if (policyType !== undefined) {
-    // Makes sure to reset the title before setting it again so we’re sure it is applied.
-    await store.dispatch('updatePageTitle', '')
-    await store.dispatch('updatePageTitle', policyType.name)
-  }
-
   loadData(props.offset)
 }
 

--- a/src/app/services/routes.ts
+++ b/src/app/services/routes.ts
@@ -17,7 +17,7 @@ export const routes = () => {
             path: ':service',
             name: `${prefix}-detail-view`,
             meta: {
-              title: 'Internal service',
+              getTitle: (route) => route.params.service as string,
             },
             component: () => import('@/app/services/views/ServiceDetailView.vue'),
           },

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -30,7 +30,6 @@ import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import { FilterFields } from '@/app/common/KFilterBar.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { useStore } from '@/store/store'
 import { DataPlaneOverviewParameters } from '@/types/api.d'
 import { DataPlaneOverview, ExternalService, ServiceInsight } from '@/types/index.d'
 import { useKumaApi } from '@/utilities'
@@ -38,7 +37,6 @@ import { QueryParameter } from '@/utilities/QueryParameter'
 
 const kumaApi = useKumaApi()
 const route = useRoute()
-const store = useStore()
 
 const DPP_FILTER_FIELDS: FilterFields = {
   name: { description: 'filter by name or parts of a name' },
@@ -80,8 +78,6 @@ watch(() => route.params.name, function () {
 })
 
 function start() {
-  store.dispatch('updatePageTitle', route.params.service)
-
   const filterFields = QueryParameter.get('filterFields')
   const dppParams = filterFields !== null ? JSON.parse(filterFields) as DataPlaneOverviewParameters : {}
 

--- a/src/app/zones/routes.ts
+++ b/src/app/zones/routes.ts
@@ -42,12 +42,11 @@ export const routes = (
               component: () => import('@/app/zones/views/ZoneListView.vue'),
             },
             ...actions,
-
             {
               path: ':zone',
               name: 'zone-detail-view',
               meta: {
-                title: 'Zone',
+                getTitle: (route) => route.params.zone as string,
                 isBreadcrumb: true,
                 breadcrumbTitleParam: 'zone',
               },
@@ -86,7 +85,7 @@ export const routes = (
               path: ':zoneIngress',
               name: 'zone-ingress-detail-view',
               meta: {
-                title: 'Zone Ingress',
+                getTitle: (route) => route.params.zoneIngress as string,
                 isBreadcrumb: true,
                 breadcrumbTitleParam: 'zoneIngress',
               },
@@ -124,7 +123,7 @@ export const routes = (
             {
               path: ':zoneEgress',
               meta: {
-                title: 'Zone Egress',
+                getTitle: (route) => route.params.zoneEgress as string,
                 isBreadcrumb: true,
                 breadcrumbTitleParam: 'zoneEgress',
               },

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -26,13 +26,11 @@ import ZoneDetails from '../components/ZoneDetails.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { useStore } from '@/store/store'
 import type { ZoneOverview } from '@/types/index.d'
 import { useKumaApi } from '@/utilities'
 
 const kumaApi = useKumaApi()
 const route = useRoute()
-const store = useStore()
 
 const zoneOverview = ref<ZoneOverview | null>(null)
 const isLoading = ref(true)
@@ -55,8 +53,6 @@ watch(() => route.params.name, function () {
 start()
 
 function start() {
-  store.dispatch('updatePageTitle', route.params.zone)
-
   loadData()
 }
 

--- a/src/app/zones/views/ZoneEgressDetailView.vue
+++ b/src/app/zones/views/ZoneEgressDetailView.vue
@@ -26,13 +26,11 @@ import ZoneEgressDetails from '../components/ZoneEgressDetails.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { useStore } from '@/store/store'
 import type { ZoneEgressOverview } from '@/types/index.d'
 import { useKumaApi } from '@/utilities'
 
 const kumaApi = useKumaApi()
 const route = useRoute()
-const store = useStore()
 
 const zoneEgressOverview = ref<ZoneEgressOverview | null>(null)
 const isLoading = ref(true)
@@ -55,8 +53,6 @@ watch(() => route.params.name, function () {
 start()
 
 function start() {
-  store.dispatch('updatePageTitle', route.params.zoneEgress)
-
   loadData()
 }
 

--- a/src/app/zones/views/ZoneIngressDetailView.vue
+++ b/src/app/zones/views/ZoneIngressDetailView.vue
@@ -26,13 +26,11 @@ import ZoneIngressDetails from '../components/ZoneIngressDetails.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { useStore } from '@/store/store'
 import type { ZoneIngressOverview } from '@/types/index.d'
 import { useKumaApi } from '@/utilities'
 
 const kumaApi = useKumaApi()
 const route = useRoute()
-const store = useStore()
 
 const zoneIngressOverview = ref<ZoneIngressOverview | null>(null)
 const isLoading = ref(true)
@@ -55,8 +53,6 @@ watch(() => route.params.name, function () {
 start()
 
 function start() {
-  store.dispatch('updatePageTitle', route.params.zoneIngress)
-
   loadData()
 }
 

--- a/src/shims-vue-router.d.ts
+++ b/src/shims-vue-router.d.ts
@@ -8,6 +8,11 @@ declare module 'vue-router' {
     title?: string
 
     /**
+     * Allows setting the page title dynamically (e.g. using route parameters). Takes precedence of `meta.title`.
+     */
+    getTitle?: (route: RouteLocationNormalizedLoaded, store: Store<State>) => string
+
+    /**
      * Defines a route record as participating in breadcrumb creation. Defaults to `false`.
      */
     isBreadcrumb?: boolean

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -47,7 +47,6 @@ interface BareRootState {
     onboardingNotification: boolean
     breadcrumbs: boolean
   }
-  pageTitle: string
   meshes: {
     items: Mesh[]
     total: number
@@ -102,7 +101,6 @@ const initialState: BareRootState = {
     onboardingNotification: true,
     breadcrumbs: true,
   },
-  pageTitle: '',
   meshes: {
     total: 0,
     items: [],
@@ -227,7 +225,6 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
 
     mutations: {
       SET_GLOBAL_LOADING: (state, globalLoading: typeof state.globalLoading) => (state.globalLoading = globalLoading),
-      SET_PAGE_TITLE: (state, pageTitle: typeof state.pageTitle) => (state.pageTitle = pageTitle),
       SET_MESHES: (state, meshes: typeof state.meshes) => (state.meshes = meshes),
       SET_SELECTED_MESH: (state, mesh: typeof state.selectedMesh) => (state.selectedMesh = mesh),
       SET_TOTAL_DATAPLANE_COUNT: (state, totalDataplaneCount: typeof state.totalDataplaneCount) => (state.totalDataplaneCount = totalDataplaneCount),
@@ -321,10 +318,6 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
             await dispatch('updateSelectedMesh', null)
           }
         }
-      },
-
-      updatePageTitle({ commit }, pageTitle: string) {
-        commit('SET_PAGE_TITLE', pageTitle)
       },
 
       async fetchMeshList({ commit, state }) {


### PR DESCRIPTION
Makes the mechanism for setting document titles more robust by only relying on data from `route.meta`. Routes can now define a `getTitle` property on `meta` allowing them to determine the title dynamically. In App.vue, a watcher checks if the current route has `route.meta.getTitle` and uses it; otherwise, it uses `route.meta.title`. This mechanism allows all code responsible for setting document titles to be removed from components.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>