### PR TITLE
fix: passing invalid data to mutations

### DIFF
--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -419,7 +419,7 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
 
           commit('SET_INTERNAL_SERVICE_SUMMARY', await fetchAllResources(endpoint))
         } catch {
-          commit('SET_INTERNAL_SERVICE_SUMMARY')
+          commit('SET_INTERNAL_SERVICE_SUMMARY', {})
         }
 
         commit('SET_SERVICE_INSIGHTS_FETCHING', false)
@@ -435,7 +435,7 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
 
           commit('SET_EXTERNAL_SERVICE_SUMMARY', await fetchAllResources(endpoint))
         } catch {
-          commit('SET_EXTERNAL_SERVICE_SUMMARY')
+          commit('SET_EXTERNAL_SERVICE_SUMMARY', {})
         }
 
         commit('SET_EXTERNAL_SERVICES_FETCHING', false)


### PR DESCRIPTION
Fixes two `commit` calls that weren’t passing any arguments to their respective mutation implementations which would lead to an exception.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
