### PR TITLE
chore: removes redundant fields

### DIFF
--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -13,64 +13,49 @@
     </template>
 
     <template #overview>
-      <div
-        class="columns"
-        style="--columns: 2;"
-      >
-        <DefinitionList>
-          <DefinitionListItem
-            v-for="(value, property) in processedDataPlane"
-            :key="property"
-            :term="t(`http.api.property.${property}`)"
-          >
-            {{ value }}
-          </DefinitionListItem>
-        </DefinitionList>
+      <DefinitionList>
+        <DefinitionListItem
+          v-if="dataPlaneTags.length > 0"
+          term="Tags"
+        >
+          <TagList :tags="dataPlaneTags" />
+        </DefinitionListItem>
 
-        <DefinitionList>
-          <DefinitionListItem
-            v-if="dataPlaneTags.length > 0"
-            term="Tags"
-          >
-            <TagList :tags="dataPlaneTags" />
-          </DefinitionListItem>
+        <DefinitionListItem
+          v-if="statusWithReason.status"
+          term="Status"
+        >
+          <StatusBadge :status="statusWithReason.status" />
+        </DefinitionListItem>
 
-          <DefinitionListItem
-            v-if="statusWithReason.status"
-            term="Status"
+        <DefinitionListItem
+          v-if="statusWithReason.reason.length > 0"
+          term="Reason"
+        >
+          <div
+            v-for="(reason, index) in statusWithReason.reason"
+            :key="index"
+            class="reason"
           >
-            <StatusBadge :status="statusWithReason.status" />
-          </DefinitionListItem>
+            {{ reason }}
+          </div>
+        </DefinitionListItem>
 
-          <DefinitionListItem
-            v-if="statusWithReason.reason.length > 0"
-            term="Reason"
-          >
-            <div
-              v-for="(reason, index) in statusWithReason.reason"
-              :key="index"
-              class="reason"
+        <DefinitionListItem
+          v-if="dataPlaneVersions !== null"
+          term="Dependencies"
+        >
+          <ul>
+            <li
+              v-for="(version, dependency) in dataPlaneVersions"
+              :key="dependency"
+              class="tag-cols"
             >
-              {{ reason }}
-            </div>
-          </DefinitionListItem>
-
-          <DefinitionListItem
-            v-if="dataPlaneVersions !== null"
-            term="Dependencies"
-          >
-            <ul>
-              <li
-                v-for="(version, dependency) in dataPlaneVersions"
-                :key="dependency"
-                class="tag-cols"
-              >
-                {{ dependency }}: {{ version }}
-              </li>
-            </ul>
-          </DefinitionListItem>
-        </DefinitionList>
-      </div>
+              {{ dependency }}: {{ version }}
+            </li>
+          </ul>
+        </DefinitionListItem>
+      </DefinitionList>
 
       <ResourceCodeBlock
         id="code-block-data-plane"
@@ -268,16 +253,6 @@ const detailViewRoute = computed(() => ({
     dataPlane: props.dataPlane.name,
   },
 }))
-
-const processedDataPlane = computed(() => {
-  const { type, name, mesh } = props.dataPlane
-
-  return {
-    type,
-    name,
-    mesh,
-  }
-})
 
 const statusWithReason = computed(() => getStatusAndReason(props.dataPlane, props.dataPlaneOverview.dataplaneInsight))
 const dataPlaneTags = computed(() => dpTags(props.dataPlane))

--- a/src/app/data-planes/components/DataPlaneEntitySummary.vue
+++ b/src/app/data-planes/components/DataPlaneEntitySummary.vue
@@ -21,10 +21,6 @@
           </h3>
 
           <DefinitionList class="mt-4">
-            <DefinitionListItem term="Mesh">
-              {{ dataPlaneOverview.mesh }}
-            </DefinitionListItem>
-
             <DefinitionListItem
               v-if="dataPlaneTags !== null"
               term="Tags"

--- a/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
@@ -227,201 +227,140 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
             >
               
               
-              <div
-                class="columns"
-                style="--columns: 2;"
+              <dl
+                class="definition-list"
               >
-                <dl
-                  class="definition-list"
+                
+                <div
+                  class="definition-list-item"
                 >
-                  
-                  
-                  <div
-                    class="definition-list-item"
+                  <dt
+                    class="definition-list-item__term"
                   >
-                    <dt
-                      class="definition-list-item__term"
-                    >
-                      Type
-                    </dt>
-                    <dd
-                      class="definition-list-item__details"
-                    >
-                      
-                      Dataplane
-                      
-                    </dd>
-                  </div>
-                  <div
-                    class="definition-list-item"
+                    Tags
+                  </dt>
+                  <dd
+                    class="definition-list-item__details"
                   >
-                    <dt
-                      class="definition-list-item__term"
-                    >
-                      Name
-                    </dt>
-                    <dd
-                      class="definition-list-item__details"
+                    
+                    <span
+                      class="tag-list"
                     >
                       
-                      backend
-                      
-                    </dd>
-                  </div>
-                  <div
-                    class="definition-list-item"
-                  >
-                    <dt
-                      class="definition-list-item__term"
-                    >
-                      Mesh
-                    </dt>
-                    <dd
-                      class="definition-list-item__details"
-                    >
-                      
-                      test-mesh
-                      
-                    </dd>
-                  </div>
-                  
-                  
-                </dl>
-                <dl
-                  class="definition-list"
-                >
-                  
-                  <div
-                    class="definition-list-item"
-                  >
-                    <dt
-                      class="definition-list-item__term"
-                    >
-                      Tags
-                    </dt>
-                    <dd
-                      class="definition-list-item__details"
-                    >
-                      
-                      <span
-                        class="tag-list"
+                      <div
+                        class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
+                        tabindex="0"
                       >
-                        
                         <div
-                          class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
-                          tabindex="0"
+                          class="k-badge-text truncate"
                         >
                           <div
                             class="k-badge-text truncate"
                           >
-                            <div
-                              class="k-badge-text truncate"
-                            >
-                              
-                              <span>
-                                kuma.io/protocol:
-                                <b>
-                                  http
-                                </b>
-                              </span>
-                              
-                            </div>
+                            
+                            <span>
+                              kuma.io/protocol:
+                              <b>
+                                http
+                              </b>
+                            </span>
+                            
                           </div>
-                          <!---->
                         </div>
+                        <!---->
+                      </div>
+                      <div
+                        class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
+                        tabindex="0"
+                      >
                         <div
-                          class="k-badge d-inline-flex k-badge-default k-badge-rounded tag-badge"
-                          tabindex="0"
+                          class="k-badge-text truncate"
                         >
                           <div
                             class="k-badge-text truncate"
                           >
-                            <div
-                              class="k-badge-text truncate"
+                            
+                            <a
+                              class=""
+                              href="/mesh/default/service/backend"
                             >
-                              
-                              <a
-                                class=""
-                                href="/mesh/default/service/backend"
-                              >
-                                kuma.io/service:
-                                <b>
-                                  backend
-                                </b>
-                              </a>
-                              
-                            </div>
+                              kuma.io/service:
+                              <b>
+                                backend
+                              </b>
+                            </a>
+                            
                           </div>
-                          <!---->
                         </div>
-                        
-                      </span>
+                        <!---->
+                      </div>
                       
-                    </dd>
-                  </div>
-                  <div
-                    class="definition-list-item"
+                    </span>
+                    
+                  </dd>
+                </div>
+                <div
+                  class="definition-list-item"
+                >
+                  <dt
+                    class="definition-list-item__term"
                   >
-                    <dt
-                      class="definition-list-item__term"
+                    Status
+                  </dt>
+                  <dd
+                    class="definition-list-item__details"
+                  >
+                    
+                    <span
+                      class="status status--with-title status--success"
+                      data-testid="status-badge"
                     >
-                      Status
-                    </dt>
-                    <dd
-                      class="definition-list-item__details"
-                    >
-                      
                       <span
-                        class="status status--with-title status--success"
-                        data-testid="status-badge"
+                        class=""
                       >
-                        <span
-                          class=""
-                        >
-                          online
-                        </span>
+                        online
                       </span>
-                      
-                    </dd>
-                  </div>
-                  <!--v-if-->
-                  <div
-                    class="definition-list-item"
+                    </span>
+                    
+                  </dd>
+                </div>
+                <!--v-if-->
+                <div
+                  class="definition-list-item"
+                >
+                  <dt
+                    class="definition-list-item__term"
                   >
-                    <dt
-                      class="definition-list-item__term"
-                    >
-                      Dependencies
-                    </dt>
-                    <dd
-                      class="definition-list-item__details"
-                    >
+                    Dependencies
+                  </dt>
+                  <dd
+                    class="definition-list-item__details"
+                  >
+                    
+                    <ul>
                       
-                      <ul>
-                        
-                        <li
-                          class="tag-cols"
-                        >
-                          envoy: 1.16.2
-                        </li>
-                        <li
-                          class="tag-cols"
-                        >
-                          kumaDp: 1.0.7
-                        </li>
-                        <li
-                          class="tag-cols"
-                        >
-                          coredns: 1.8.3
-                        </li>
-                        
-                      </ul>
+                      <li
+                        class="tag-cols"
+                      >
+                        envoy: 1.16.2
+                      </li>
+                      <li
+                        class="tag-cols"
+                      >
+                        kumaDp: 1.0.7
+                      </li>
+                      <li
+                        class="tag-cols"
+                      >
+                        coredns: 1.8.3
+                      </li>
                       
-                    </dd>
-                  </div>
-                  
-                </dl>
-              </div>
+                    </ul>
+                    
+                  </dd>
+                </div>
+                
+              </dl>
               <div
                 class="mt-4"
               >

--- a/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
@@ -108,22 +108,6 @@ exports[`DataPlaneEntitySummary matches snapshot 1`] = `
               <dt
                 class="definition-list-item__term"
               >
-                Mesh
-              </dt>
-              <dd
-                class="definition-list-item__details"
-              >
-                
-                test-mesh
-                
-              </dd>
-            </div>
-            <div
-              class="definition-list-item"
-            >
-              <dt
-                class="definition-list-item__term"
-              >
                 Tags
               </dt>
               <dd

--- a/src/app/meshes/views/MeshOverviewView.vue
+++ b/src/app/meshes/views/MeshOverviewView.vue
@@ -132,10 +132,9 @@ const basicMesh = computed(() => {
     return null
   }
 
-  const { name, type, creationTime, modificationTime } = mesh.value
+  const { name, creationTime, modificationTime } = mesh.value
   return {
     name,
-    type,
     created: humanReadableDate(creationTime),
     modified: humanReadableDate(modificationTime),
     'Data Plane Proxies': store.state.meshInsight.dataplanes.total,

--- a/src/app/services/components/ServiceSummary.vue
+++ b/src/app/services/components/ServiceSummary.vue
@@ -19,10 +19,6 @@
           </h1>
 
           <DefinitionList class="mt-4">
-            <DefinitionListItem term="Mesh">
-              {{ props.service.mesh }}
-            </DefinitionListItem>
-
             <DefinitionListItem term="Address">
               <template v-if="address !== null">
                 {{ address }}


### PR DESCRIPTION
Removes some redundant fields from the UI as they’re either very clear from the page’s context or shown right beneath it in a resource code block. Removes type, name, and mesh from DPP details. Removes mesh from DPP and service summaries. Removes type from mesh details.

Resolves #753.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>