### PR TITLE
fix: nav tab bar having border bottom

### DIFF
--- a/src/app/meshes/views/MeshView.vue
+++ b/src/app/meshes/views/MeshView.vue
@@ -56,7 +56,7 @@ const items = [
   },
 ]
 </script>
-<style scoped>
+<style lang="scss" scoped>
 .tab-link a {
   display: block;
   padding: var(--spacing-md);
@@ -68,6 +68,10 @@ li.active .tab-link a {
 }
 </style>
 <style lang="scss">
+.route-mesh-view-tabs ul:not(.increase-specificity) {
+  border-bottom: none;
+}
+
 .route-mesh-view-tabs > ul .tab-item {
   padding: 0 !important;
 }


### PR DESCRIPTION
Removes the bottom border from the KTabs component forming our nav tabs in the MeshView component. This is most notable in the views with a summary sidebar (i.e. services and DPPs).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
