### PR TITLE
refactor: defines all font-weights using custom properties

### DIFF
--- a/src/app/AppNavItem.vue
+++ b/src/app/AppNavItem.vue
@@ -126,7 +126,7 @@ function onNavItemClick() {
   border: 1px solid var(--white);
   border-radius: 0.25rem;
   font-size: 0.75rem;
-  font-weight: normal;
+  font-weight: var(--font-weight-regular);
   background-color: var(--purple-100);
 }
 

--- a/src/app/common/CopyButton.vue
+++ b/src/app/common/CopyButton.vue
@@ -108,7 +108,7 @@ async function copy(event: Event, copyToClipboard: (text: string) => Promise<boo
   border-radius: 3px;
   color: var(--tooltip-text-color);
   content: attr(data-tooltip-text);
-  font-weight: normal;
+  font-weight: var(--font-weight-regular);
   padding: var(--spacing-xs);
   position: absolute;
   right: calc(100% + var(--spacing-xs));

--- a/src/app/common/DefinitionListItem.vue
+++ b/src/app/common/DefinitionListItem.vue
@@ -38,7 +38,7 @@ const currentTerm = computed(() => t(`http.api.property.${props.term}`))
   flex-shrink: 0;
   flex-basis: var(--dl-term-width);
   margin-right: var(--spacing-sm);
-  font-weight: 600;
+  font-weight: var(--font-weight-semi-bold);
 }
 
 .definition-list-item__details {

--- a/src/app/common/FormProgressBar.vue
+++ b/src/app/common/FormProgressBar.vue
@@ -75,7 +75,7 @@ const props = defineProps({
   --step-orb-border-color: var(--teal-300);
   --step-text-color: currentColor;
 
-  font-weight: 600;
+  font-weight: var(--font-weight-semi-bold);
 }
 
 .step__icon {

--- a/src/app/common/WizardTitleBar.vue
+++ b/src/app/common/WizardTitleBar.vue
@@ -37,7 +37,7 @@ import { KIcon } from '@kong/kongponents'
   margin-left: var(--spacing-xs);
   padding-left: var(--spacing-xs);
   border-left: 1px solid var(--grey-300);
-  font-weight: bold;
+  font-weight: var(--font-weight-semi-bold);
   font-size: 20px;
 }
 

--- a/src/app/common/charts/DoughnutChart.vue
+++ b/src/app/common/charts/DoughnutChart.vue
@@ -207,7 +207,7 @@ const chartOptions = computed<ChartOptions<'doughnut'>>(function () {
 .chart-title__total {
   display: block;
   font-size: 1.2em;
-  font-weight: 600;
+  font-weight: var(--font-weight-semi-bold);
 }
 
 .chart-title__subtitle {

--- a/src/app/common/subscriptions/SubscriptionDetails.vue
+++ b/src/app/common/subscriptions/SubscriptionDetails.vue
@@ -147,7 +147,7 @@ function formatError(value: string): string {
 <style lang="scss" scoped>
 .overview-tertiary-title {
   font-size: var(--type-sm);
-  font-weight: 600;
+  font-weight: var(--font-weight-semi-bold);
   color: var(--grey-500);
   margin: var(--spacing-xs) 0;
 }

--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -337,7 +337,7 @@ async function fetchDataPlaneProxy(params?: SingleResourceParameters) {
 <style lang="scss" scoped>
 .entity-heading {
   font-size: inherit;
-  font-weight: normal;
+  font-weight: var(--font-weight-regular);
 }
 
 .reason {
@@ -357,7 +357,7 @@ async function fetchDataPlaneProxy(params?: SingleResourceParameters) {
   }
 
   span:first-of-type {
-    font-weight: 600;
+    font-weight: var(--font-weight-semi-bold);
   }
 }
 </style>

--- a/src/app/data-planes/components/MeshGatewayDataplanePolicyList.vue
+++ b/src/app/data-planes/components/MeshGatewayDataplanePolicyList.vue
@@ -162,7 +162,7 @@ h3, h4 {
   margin-bottom: var(--spacing-xs);
   text-transform: uppercase;
   font-size: var(--type-sm);
-  font-weight: 600;
+  font-weight: var(--font-weight-semi-bold);
   color: var(--grey-500);
 }
 </style>

--- a/src/app/data-planes/components/PolicyTypeEntryList.vue
+++ b/src/app/data-planes/components/PolicyTypeEntryList.vue
@@ -140,7 +140,7 @@ function getCellAttributes({ headerKey }: any): Record<string, string> {
 <style lang="scss" scoped>
 .policy-type-heading {
   font-size: inherit;
-  font-weight: normal;
+  font-weight: var(--font-weight-regular);
 }
 
 .policy-list {

--- a/src/app/data-planes/components/RuleEntryList.vue
+++ b/src/app/data-planes/components/RuleEntryList.vue
@@ -152,7 +152,7 @@ function getCellAttributes({ headerKey }: any): Record<string, string> {
 <style lang="scss" scoped>
 .policy-type-heading {
   font-size: inherit;
-  font-weight: normal;
+  font-weight: var(--font-weight-regular);
 }
 
 .policy-list {

--- a/src/app/onboarding/components/OnboardingHeading.vue
+++ b/src/app/onboarding/components/OnboardingHeading.vue
@@ -30,7 +30,7 @@ const slots = useSlots()
   text-align: center;
   font-size: 2.25rem;
   line-height: 2.5rem;
-  font-weight: 600;
+  font-weight: var(--font-weight-semi-bold);
   color: transparent;
   background-image: linear-gradient(to right, var(--onboarding-heading-1), var(--onboarding-heading-2));
   -webkit-background-clip: text;

--- a/src/app/onboarding/views/AddNewServices.vue
+++ b/src/app/onboarding/views/AddNewServices.vue
@@ -86,6 +86,6 @@ function setMode(newMode: typeof store.state.onboarding.mode): void {
 
 .service-mode-title {
   text-transform: uppercase;
-  font-weight: 600;
+  font-weight: var(--font-weight-semi-bold);
 }
 </style>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -263,6 +263,6 @@ function changePolicyType(item: SelectItem) {
 
 .entity-heading {
   font-size: inherit;
-  font-weight: normal;
+  font-weight: var(--font-weight-regular);
 }
 </style>

--- a/src/app/wizard/components/StepSkeleton.vue
+++ b/src/app/wizard/components/StepSkeleton.vue
@@ -172,7 +172,7 @@ function setStepSlug(stepIndex: number): void {
 
   h4 {
     font-size: inherit !important;
-    font-weight: 600;
+    font-weight: var(--font-weight-semi-bold);
     text-align: center;
     text-transform: uppercase;
     margin: 0 0 5px 0 !important;
@@ -197,7 +197,7 @@ function setStepSlug(stepIndex: number): void {
 
   .not-set {
     color: red;
-    font-weight: 600;
+    font-weight: var(--font-weight-semi-bold);
     font-style: italic;
   }
 }

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -36,7 +36,7 @@ h4,
 h5,
 h6 {
   line-height: 1.3;
-  font-weight: 600;
+  font-weight: var(--font-weight-semi-bold);
 }
 
 a {
@@ -56,7 +56,7 @@ a:focus {
 
 b,
 strong {
-  font-weight: 600;
+  font-weight: var(--font-weight-semi-bold);
 }
 
 small {

--- a/src/assets/styles/_utilities.scss
+++ b/src/assets/styles/_utilities.scss
@@ -26,7 +26,7 @@
 
 // remove button default styles for elements that act like buttons, but don't look like them
 .non-visual-button {
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   background-color: transparent;
   border: none;
   cursor: pointer;

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -1,5 +1,9 @@
 :root {
   --font-family-sans: Inter, Helvetica, Arial, sans-serif;
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semi-bold: 600;
+  --font-weight-bold: 700;
   --font-family-mono: 'Fira Mono', Menlo, Monaco, Consolas, Liberation Mono, 'Courier New', monospace;
 
   // COMPONENTS


### PR DESCRIPTION
Defines custom properties for all cuts of Inter we set-up and uses them everywhere we declare a `font-weight` property.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
