### PR TITLE
feat: adds CP ID to Zone connection command

### DIFF
--- a/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
+++ b/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
@@ -106,14 +106,19 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 
 import CodeBlock from '@/app/common/CodeBlock.vue'
-import { useEnv, useI18n } from '@/utilities'
-import { useGetGlobalKdsAddress } from '@/utilities/useGetGlobalKdsAddress'
+import {
+  useEnv,
+  useI18n,
+  useGetGlobalKdsAddress,
+} from '@/utilities'
 
 const env = useEnv()
 const getGlobalKdsAddress = useGetGlobalKdsAddress()
 const i18n = useI18n()
+const route = useRoute()
 
 const props = defineProps({
   zoneName: {
@@ -145,12 +150,20 @@ const props = defineProps({
 const kubernetesCreateSecretCommand = computed(() => i18n.t('zones.form.kubernetes.secret.command', {
   token: props.base64EncodedToken,
 }).trim())
-const kubernetesConfig = computed(() => i18n.t('zones.form.kubernetes.connectZone.config', {
-  zoneName: props.zoneName,
-  globalKdsAddress: getGlobalKdsAddress(),
-  zoneIngressEnabled: String(props.zoneIngressEnabled),
-  zoneEgressEnabled: String(props.zoneEgressEnabled),
-}).trim())
+const kubernetesConfig = computed(() => {
+  const placeholders: Record<string, string> = {
+    zoneName: props.zoneName,
+    globalKdsAddress: getGlobalKdsAddress(),
+    zoneIngressEnabled: String(props.zoneIngressEnabled),
+    zoneEgressEnabled: String(props.zoneEgressEnabled),
+  }
+
+  if (typeof route.params.virtualControlPlaneId === 'string') {
+    placeholders.controlPlaneId = route.params.virtualControlPlaneId
+  }
+
+  return i18n.t('zones.form.kubernetes.connectZone.config', placeholders).trim()
+})
 
 </script>
 

--- a/src/app/zones/components/ZoneCreateUniversalInstructions.vue
+++ b/src/app/zones/components/ZoneCreateUniversalInstructions.vue
@@ -49,13 +49,17 @@
 <script lang="ts" setup>
 import { KAlert } from '@kong/kongponents'
 import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 
 import CodeBlock from '@/app/common/CodeBlock.vue'
-import { useI18n } from '@/utilities'
-import { useGetGlobalKdsAddress } from '@/utilities/useGetGlobalKdsAddress'
+import {
+  useI18n,
+  useGetGlobalKdsAddress,
+} from '@/utilities'
 
 const getGlobalKdsAddress = useGetGlobalKdsAddress()
 const i18n = useI18n()
+const route = useRoute()
 
 const props = defineProps({
   zoneName: {
@@ -74,11 +78,19 @@ const props = defineProps({
   },
 })
 
-const universalConfig = computed(() => i18n.t('zones.form.universal.connectZone.config', {
-  zoneName: props.zoneName,
-  globalKdsAddress: getGlobalKdsAddress(),
-  token: props.base64EncodedToken,
-}).trim())
+const universalConfig = computed(() => {
+  const placeholders: Record<string, string> = {
+    zoneName: props.zoneName,
+    globalKdsAddress: getGlobalKdsAddress(),
+    token: props.base64EncodedToken,
+  }
+
+  if (typeof route.params.virtualControlPlaneId === 'string') {
+    placeholders.controlPlaneId = route.params.virtualControlPlaneId
+  }
+
+  return i18n.t('zones.form.universal.connectZone.config', placeholders).trim()
+})
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Changes

Adds the CP ID to the Zone connection command if it’s present. This enables us to update the commands in `src/app/zones/locales/en-us/index.yaml` to use the CP ID if needed.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

I’m not happy with this approach. Maybe we could add a small service to our DI layer (or actually a constant?) that lets us inject arbitrary additional placeholders depending on environment which, if present, would automatically be picked up in our i18n utility and added to the provided placeholders of the `i18n.t` call (if any).

```js
const additionalPlaceholders = {
  'zones.form.kubernetes.connectZone.config': /* a custom function returning `Record<string, string>` perhaps? */,
}
```