### PR TITLE
fix: not reading zones and meshes data from global insights

### DIFF
--- a/src/app/main-overview/components/OverviewCharts.vue
+++ b/src/app/main-overview/components/OverviewCharts.vue
@@ -91,7 +91,8 @@ watch(() => isMultizoneMode.value, function () {
 
 loadData()
 
-function loadData() {
+async function loadData() {
+  await store.dispatch('fetchGlobalInsights')
   store.dispatch('fetchMeshInsights')
   store.dispatch('fetchServices')
   store.dispatch('fetchZonesInsights', isMultizoneMode.value)


### PR DESCRIPTION
Adds a layer to OverviewCharts that fetches global insights and uses it to populate the chart data for Zones and Meshes so we show more accurate data before mesh insights are available. For this to work, the `fetchMeshInsights` and `fetchZonesInsights` actions were adjusted to only set data when they contain objects in the associated responses.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
