### PR TITLE
chore: Removes link underlines and uses pseudo-standard 16px font-size

### DIFF
--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -8,8 +8,9 @@ body {
   margin: 0;
   tab-size: 2;
   color: var(--black-500);
-  font-size: 1em;
   font-family: var(--font-family-sans);
+  font-weight: var(--font-weight-normal, 400);
+  font-size: 16px;
   line-height: 1.5;
 }
 
@@ -40,7 +41,7 @@ h6 {
 }
 
 a {
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 a:link,

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -30,8 +30,6 @@
   // KONGPONENTS
   // Reduces the excessive vertical padding.
   --KPopPaddingY: var(--spacing-xs);
-  // Sets the font size to the size of body copy as the default of 12 pixels is way too small.
-  --KBadgeFontSize: 1rem;
   // Removes the default max width of 200 pixels because badges should never be cut-off.
   --KBadgeMaxWidth: auto;
   // Sets a default border style for commonly used component frames/panels.


### PR DESCRIPTION
This PR removes underlines from links across the entire app, but does not go through and remove all the places where we then remove the `underlines` (this can be a follow up PR, or if folks think its better to do that here, I'm happy to add)

We also start using the pseudo-standard `font-size: 16px` on our `body` element.

Overall this should mean less overwriting, and things should automatically start to look similar/consistent across environments.

I also added a root font weight here using a `--font-weight-normal` which we don't actually set as yet, but this is more for consistency as I'd seen this being used elsewhere.

There's maybe some more things we could remove, but I didn't want to go there just yet.

For checking/testing I've gone over most of the app and things look fine, but I may have missed somewhere I wasn't aware of so extra 👀 would be much appreciated.

Example before/after (note breadcrumb underlines and (Disabled) badges font size):

## Before

![Screenshot 2023-05-31 at 11 57 50](https://github.com/kumahq/kuma-gui/assets/554604/768cc5e6-c8a9-4134-a2ab-3f071294a867)


## After

![Screenshot 2023-05-31 at 11 57 37](https://github.com/kumahq/kuma-gui/assets/554604/e3e90cf0-ffab-48d6-9b53-d9d5feb0fc4c)
