### PR TITLE
chore: switches Datadog instances

### DIFF
--- a/src/services/logger/DatadogLogger.ts
+++ b/src/services/logger/DatadogLogger.ts
@@ -12,14 +12,17 @@ export default class DatadogLogger {
 
   setup(config: ClientConfigInterface) {
     if (config.reports.enabled) {
+      const service = this.env('KUMA_PRODUCT_NAME').toLowerCase().replaceAll(' ', '-') + '-ui'
+
       datadogLogs.init({
-        // This token is called “kuma-gui” in Datadog
-        clientToken: 'pub94a0029259f79f29a5d881a06d1e9653',
+        // The current client token is called “kuma-ui” in the Datadog UI.
+        // Previous versions of the application used a different client token attached to a different Datadog instance. This client token was called “kuma-gui” in the Datadog UI.
+        clientToken: 'pub1aadd2cab84c05bf9959e00a35b213a1',
         site: 'datadoghq.com',
         forwardErrorsToLogs: true,
-        service: this.env('KUMA_PRODUCT_NAME'),
         sampleRate: 100,
-        env: 'production', // logging is currently disabled in anything other than production
+        service,
+        env: import.meta.env.MODE,
       })
     }
   }

--- a/src/services/logger/DatadogLogger.ts
+++ b/src/services/logger/DatadogLogger.ts
@@ -1,22 +1,19 @@
 import { datadogLogs } from '@datadog/browser-logs'
 
-import type { EnvVars } from '@/services/env/Env'
+import type Env from '@/services/env/Env'
 import type { ClientConfigInterface } from '@/store/modules/config/config.types'
 
-type Env = (
-  key: keyof Pick<EnvVars,
-  'KUMA_PRODUCT_NAME'
-  >
-) => string
 export default class DatadogLogger {
-  env: Env
-  constructor(env: Env) {
+  env: Env['var']
+
+  constructor(env: Env['var']) {
     this.env = env
   }
 
   setup(config: ClientConfigInterface) {
     if (config.reports.enabled) {
       datadogLogs.init({
+        // This token is called “kuma-gui” in Datadog
         clientToken: 'pub94a0029259f79f29a5d881a06d1e9653',
         site: 'datadoghq.com',
         forwardErrorsToLogs: true,


### PR DESCRIPTION
**refactor: uses the correct types for DatadogLogger**

**chore: switches Datadog instances**

Updates the Datadog Logs initialization code to use a new client token associated with a different Datadog instance.

Also makes sure the environment will always be set correctly.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>