### PR TITLE
chore: Makes mesh tabs autogenerated

### DIFF
--- a/src/app/data-planes/routes.ts
+++ b/src/app/data-planes/routes.ts
@@ -33,23 +33,18 @@ export const routes = () => {
           children: [
             {
               path: '',
-              children: [
-                {
-                  path: '',
-                  name: `${prefix}-list-view`,
-                  meta: {
-                    title: 'Data plane proxies',
-                  },
-                  props: (route) => ({
-                    selectedDppName: route.query.dpp,
-                    offset: getLastNumberParameter(route.query.offset),
-                  }),
-                  component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
-                  // children: [
-                  //   ...(item(prefix)[0]).children ?? [],
-                  // ],
-                },
-              ],
+              name: `${prefix}-list-view`,
+              meta: {
+                title: 'Data plane proxies',
+              },
+              props: (route) => ({
+                selectedDppName: route.query.dpp,
+                offset: getLastNumberParameter(route.query.offset),
+              }),
+              component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
+              // children: [
+              //   ...(item(prefix)[0]).children ?? [],
+              // ],
             },
           ],
         },

--- a/src/app/gateways/routes.ts
+++ b/src/app/gateways/routes.ts
@@ -33,25 +33,20 @@ export const routes = () => {
           children: [
             {
               path: '',
-              children: [
-                {
-                  path: '',
-                  name: `${prefix}-list-view`,
-                  meta: {
-                    title: 'Gateways',
-                  },
-                  props: (route) => ({
-                    selectedDppName: route.query.gateway,
-                    gatewayType: route.query.gatewayType === 'all' ? 'true' : route.query.gatewayType,
-                    offset: getLastNumberParameter(route.query.offset),
-                    isGatewayView: true,
-                  }),
-                  component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
-                  // children: [
-                  //   ...(item(prefix)[0]).children ?? [],
-                  // ],
-                },
-              ],
+              name: `${prefix}-list-view`,
+              meta: {
+                title: 'Gateways',
+              },
+              props: (route) => ({
+                selectedDppName: route.query.gateway,
+                gatewayType: route.query.gatewayType === 'all' ? 'true' : route.query.gatewayType,
+                offset: getLastNumberParameter(route.query.offset),
+                isGatewayView: true,
+              }),
+              component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
+              // children: [
+              //   ...(item(prefix)[0]).children ?? [],
+              // ],
             },
           ],
         },

--- a/src/app/meshes/locales/en-us/index.yaml
+++ b/src/app/meshes/locales/en-us/index.yaml
@@ -1,4 +1,10 @@
 meshes:
+  navigation:
+    mesh-overview-view: Overview
+    services-list-view: Services
+    data-planes-list-view: Data Plane Proxies
+    gateways-list-view: Gateways
+    policies: Policies
   list:
     emptyState:
       title: 'No data'

--- a/src/app/meshes/views/MeshView.vue
+++ b/src/app/meshes/views/MeshView.vue
@@ -32,18 +32,12 @@
 import { KTabs } from '@kong/kongponents'
 import { useRouter } from 'vue-router'
 
-import { useMeshRoutes, useI18n } from '@/utilities'
+import { useI18n } from '@/utilities'
 const { t } = useI18n()
 
 const router = useRouter()
 
-// dig down into where our mesh tabs are and automatically
-// convert the routes to tabs
-const meshRoutes = useMeshRoutes()
-  .find(item => item.name === 'mesh-index-view')?.children
-  ?.find(item => item.name === 'mesh-detail-view')?.children
-  ?.find(item => item.name === 'mesh-abstract-view')?.children ?? []
-
+const meshRoutes = router.getRoutes().find((route) => route.name === 'mesh-abstract-view')?.children ?? []
 const items = meshRoutes.map((item) => {
   if (typeof item.name === 'undefined') {
     const route = item.children?.[0]

--- a/src/app/meshes/views/MeshView.vue
+++ b/src/app/meshes/views/MeshView.vue
@@ -32,29 +32,35 @@
 import { KTabs } from '@kong/kongponents'
 import { useRouter } from 'vue-router'
 
+import { useMeshRoutes, useI18n } from '@/utilities'
+const { t } = useI18n()
+
 const router = useRouter()
-const items = [
-  {
-    hash: 'mesh-detail-view',
-    title: 'Overview',
-  },
-  {
-    hash: 'services-list-view',
-    title: 'Services',
-  },
-  {
-    hash: 'gateways-list-view',
-    title: 'Gateways',
-  },
-  {
-    hash: 'data-planes-list-view',
-    title: 'Data Plane Proxies',
-  },
-  {
-    hash: 'policies',
-    title: 'Policies',
-  },
-]
+
+// dig down into where our mesh tabs are and automatically
+// convert the routes to tabs
+const meshRoutes = useMeshRoutes()
+  .find(item => item.name === 'mesh-index-view')?.children
+  ?.find(item => item.name === 'mesh-detail-view')?.children
+  ?.find(item => item.name === 'mesh-abstract-view')?.children ?? []
+
+const items = meshRoutes.map((item) => {
+  if (typeof item.name === 'undefined') {
+    const route = item.children?.[0]
+    const name = String(route?.name)
+
+    return {
+      title: t(`meshes.navigation.${name}`),
+      hash: name,
+    }
+  }
+  const name = String(item.name)
+  return {
+    title: t(`meshes.navigation.${name}`),
+    hash: name,
+  }
+})
+//
 </script>
 <style scoped>
 .tab-link a {

--- a/src/app/policies/routes.ts
+++ b/src/app/policies/routes.ts
@@ -38,57 +38,51 @@ export const routes = (store: Store<State>) => {
           children: [
             {
               path: '',
+              name: `${prefix}`,
+              meta: {
+                title: 'Policies',
+              },
+              redirect: (to) => {
+                let item = store.state.policyTypes.find((item) => {
+                  if (!(item.name in store.state.sidebar.insights.mesh.policies)) {
+                    return false
+                  }
+
+                  return store.state.sidebar.insights.mesh.policies[item.name] !== 0
+                })
+
+                if (item === undefined) {
+                  item = store.state.policyTypes[0]
+                }
+
+                if (item === undefined) {
+                  return { name: 'home' }
+                }
+
+                return {
+                  ...to,
+                  params: {
+                    ...to.params,
+                    policyPath: item.path,
+                  },
+                  name: 'policies-list-view',
+                }
+              },
               children: [
                 {
-                  path: '',
-                  name: `${prefix}`,
-                  meta: {
-                    title: 'Policies',
-                  },
-                  redirect: (to) => {
-                    let item = store.state.policyTypes.find((item) => {
-                      if (!(item.name in store.state.sidebar.insights.mesh.policies)) {
-                        return false
-                      }
+                  path: ':policyPath',
 
-                      return store.state.sidebar.insights.mesh.policies[item.name] !== 0
-                    })
-
-                    if (item === undefined) {
-                      item = store.state.policyTypes[0]
-                    }
-
-                    if (item === undefined) {
-                      return { name: 'home' }
-                    }
-
-                    return {
-                      ...to,
-                      params: {
-                        ...to.params,
-                        policyPath: item.path,
-                      },
-                      name: 'policies-list-view',
-                    }
-                  },
-                  children: [
-                    {
-                      path: ':policyPath',
-
-                      name: `${prefix}-list-view`,
-                      component: () => import('@/app/policies/views/PolicyListView.vue'),
-                      props: (route) => ({
-                        policyPath: route.params.policyPath,
-                        selectedPolicyName: route.query.policy,
-                        offset: getLastNumberParameter(route.query.offset),
-                      }),
-                      // children: [
-                      //   ...(item(prefix)[0]).children ?? [],
-                      // ],
-                    },
-                  ],
+                  name: `${prefix}-list-view`,
+                  component: () => import('@/app/policies/views/PolicyListView.vue'),
+                  props: (route) => ({
+                    policyPath: route.params.policyPath,
+                    selectedPolicyName: route.query.policy,
+                    offset: getLastNumberParameter(route.query.offset),
+                  }),
+                  // children: [
+                  //   ...(item(prefix)[0]).children ?? [],
+                  // ],
                 },
-
               ],
             },
           ],

--- a/src/app/services/routes.ts
+++ b/src/app/services/routes.ts
@@ -34,23 +34,18 @@ export const routes = () => {
           children: [
             {
               path: '',
-              children: [
-                {
-                  path: '',
-                  name: `${prefix}-list-view`,
-                  meta: {
-                    title: 'Services',
-                  },
-                  props: (route) => ({
-                    selectedServiceName: route.query.service,
-                    offset: getLastNumberParameter(route.query.offset),
-                  }),
-                  component: () => import('@/app/services/views/ServiceListView.vue'),
-                  // children: [
-                  //   ...(item(prefix)[0]).children ?? [],
-                  // ],
-                },
-              ],
+              name: `${prefix}-list-view`,
+              meta: {
+                title: 'Services',
+              },
+              props: (route) => ({
+                selectedServiceName: route.query.service,
+                offset: getLastNumberParameter(route.query.offset),
+              }),
+              component: () => import('@/app/services/views/ServiceListView.vue'),
+              // children: [
+              //   ...(item(prefix)[0]).children ?? [],
+              // ],
             },
           ],
         },

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -7,7 +7,8 @@ export const [
   useKumaApi,
   useStore,
   useRouter,
+  useMeshRoutes,
   useBootstrap,
   useI18n,
   useGetGlobalKdsAddress,
-] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api, TOKENS.store, TOKENS.router, TOKENS.bootstrap, TOKENS.i18n, TOKENS.getGlobalKdsAddress)
+] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api, TOKENS.store, TOKENS.router, TOKENS.meshRoutes, TOKENS.bootstrap, TOKENS.i18n, TOKENS.getGlobalKdsAddress)

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -7,8 +7,7 @@ export const [
   useKumaApi,
   useStore,
   useRouter,
-  useMeshRoutes,
   useBootstrap,
   useI18n,
   useGetGlobalKdsAddress,
-] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api, TOKENS.store, TOKENS.router, TOKENS.meshRoutes, TOKENS.bootstrap, TOKENS.i18n, TOKENS.getGlobalKdsAddress)
+] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api, TOKENS.store, TOKENS.router, TOKENS.bootstrap, TOKENS.i18n, TOKENS.getGlobalKdsAddress)


### PR DESCRIPTION
This PR makes it so the new tabs in a Mesh view are auto generated from the routes, this means that as we add new routes they will automatically be added to the tab bar.

---

Notes:

The routing changes here are just as a consequence of making it easier to get closer to a more generic "find the routes we want" i.e. I just removed an empty nest. I 'think' this was here from https://github.com/kumahq/kuma-gui/pull/922 where I found it really difficult to get our current breadcrumbs setup to work:

> One thing I will note is that it took me quite a while to organize the routing configurations to get the breadcrumbs correct, for a long while I could get it to link to meshes properly (the URL would look literally like /mesh/:mesh). I don't know how I managed to get it to print it properly, but it seems to be fine now, but I think there is a degree of unnecessary nesting in the route configuration just to get the breadcrumbs correct. I would like to change how we do breadcrumbing, but again that is something I'm punting for the minute.

^ from https://github.com/kumahq/kuma-gui/pull/922

Apart from that this just adds some sort of "find the root Mesh route and its children" that we want and use those for the tabs, it also uses our new i18n support to give the tabs human readable titles that are configurable from The Outside 🎉 

Longer term, once we've addressed the issue with our current breadcrumbing configuration, I'd like to revisit our routing configs to make sure they are only nested as much as required, and I would still like to make all the naming consistent. I would have much rather had some sort of function here where I just go `route('meshes.item').children.map()` to be able to retrieve the tabs from the routing. So all in all this is more of a lets move forwards with the feature rather than re-arrange everything now, I would guess this will be made more re-usable once we have more instances of doing this.