### PR TITLE
chore: Removes a check for empty states from all tests

### DIFF
--- a/cypress/support/step_definitions/visit.ts
+++ b/cypress/support/step_definitions/visit.ts
@@ -12,8 +12,6 @@ When('I visit the {string} URL', function (path: string) {
   cy.visit(`${config.BASE_URL}${path}`)
   // currently use this to denote "the page has initially rendered"
   cy.get('.app-main-content').should('be.visible')
-  cy.wait(1000)
-  cy.get('.empty-state-wrapper').should('not.exist')
 })
 When('I load the {string} URL', function (path: string) {
   cy.viewport(1366, 768)


### PR DESCRIPTION
The PR removes a check for an empty not existing on every test that is run.

This was originally added as a bit of a sledgehammer test to make sure we actually got something on the page. But we are getting to the point now that we need to test and assert that the empty state should actually be there, and in order to do that that this can't exist in this step anymore.