### PR TITLE
chore: Add underlines on hover, use standard blue for most links

### DIFF
--- a/src/app/common/DataOverview.vue
+++ b/src/app/common/DataOverview.vue
@@ -489,4 +489,7 @@ function emitDeleteResourceEvent(row: any) {
 .actions-dropdown {
   display: inline-block;
 }
+td a {
+  color: var(--blue-700)
+}
 </style>

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -41,17 +41,11 @@ h6 {
 
 a {
   text-decoration: none;
-}
-
-a:link,
-a:visited {
-  color: var(--blue-700);
-}
-
-a:hover,
-a:active,
-a:focus {
   color: var(--blue-500);
+}
+a:hover,
+a:focus {
+  text-decoration: underline
 }
 
 b,

--- a/src/assets/styles/_kongponents-overrides.scss
+++ b/src/assets/styles/_kongponents-overrides.scss
@@ -28,8 +28,3 @@
   margin-top: 0 !important;
   margin-bottom: 0 !important;
 }
-
-.k-tabs .tab-link {
-  // Removes underline from the tab headers which functionally aren’t really links.
-  text-decoration: none;
-}


### PR DESCRIPTION
Adds underlines on hover and moves blue links to use our "standard" blue link color.

I left the tables as the darker blue color just as I think these will change soon anyway judging by other things.

Follow up from https://github.com/kumahq/kuma-gui/pull/991
