### PR TITLE
fix: certificates not showing correctly

### DIFF
--- a/src/locales/en-us/http/index.yaml
+++ b/src/locales/en-us/http/index.yaml
@@ -14,3 +14,6 @@ http:
       responsesSent: Responses sent
       responsesAcknowledged: Responses acknowledged
       responsesRejected: Responses rejected
+      certificateExpirationTime: Expiration time
+      lastCertificateRegeneration: Last generated
+      certificateRegenerations: Regenerations

--- a/src/test-support/mocks/src/meshes/_/dataplanes+insights/_.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes+insights/_.ts
@@ -79,6 +79,11 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
             },
           }
         }),
+        mTLS: {
+          certificateExpirationTime: '2025-02-02T10:59:26.640498+01:00',
+          lastCertificateRegeneration: '2021-02-02T10:59:26.640498+01:00',
+          certificateRegenerations: fake.number.int({ min: 0, max: 5 }),
+        },
       },
     },
   }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -207,21 +207,6 @@ export type PolicyType = {
 
 export type DataPlaneStatus = 'Online' | 'Offline' | 'Partially degraded'
 
-export type DataPlaneEntityMtls = {
-  certificateExpirationTime: {
-    label: 'Expiration Time'
-    value: string
-  }
-  lastCertificateRegeneration: {
-    label: 'Last Generated'
-    value: string
-  }
-  certificateRegenerations: {
-    label: 'Regenerations'
-    value: number
-  }
-}
-
 export type Compatibility = {
   kind: 'COMPATIBLE' | 'INCOMPATIBLE_UNSUPPORTED_KUMA_DP' | 'INCOMPATIBLE_UNSUPPORTED_ENVOY' | 'INCOMPATIBLE_WRONG_FORMAT' | 'INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS'
   payload?: {

--- a/src/utilities/dataplane.ts
+++ b/src/utilities/dataplane.ts
@@ -1,6 +1,5 @@
 import {
   Compatibility,
-  DataPlaneEntityMtls,
   DataPlaneInsight,
   DataPlaneNetworking,
   DataPlaneOverview,
@@ -142,7 +141,7 @@ export function getVersions(dataPlaneInsight: DataPlaneInsight | undefined): Rec
   return versions
 }
 
-export function parseMTLSData(dataPlaneOverview: DataPlaneOverview): DataPlaneEntityMtls | null {
+export function parseMTLSData(dataPlaneOverview: DataPlaneOverview) {
   if (dataPlaneOverview.dataplaneInsight === undefined || dataPlaneOverview.dataplaneInsight.mTLS === undefined) {
     return null
   }
@@ -155,18 +154,9 @@ export function parseMTLSData(dataPlaneOverview: DataPlaneOverview): DataPlaneEn
   const assembledExpDate = `${fixedExpDate.toLocaleDateString('en-US')} ${fixedExpDate.getHours()}:${fixedExpDate.getMinutes()}:${fixedExpDate.getSeconds()}`
 
   return {
-    certificateExpirationTime: {
-      label: 'Expiration Time',
-      value: assembledExpDate,
-    },
-    lastCertificateRegeneration: {
-      label: 'Last Generated',
-      value: humanReadableDate(mTLS.lastCertificateRegeneration),
-    },
-    certificateRegenerations: {
-      label: 'Regenerations',
-      value: mTLS.certificateRegenerations,
-    },
+    certificateExpirationTime: assembledExpDate,
+    lastCertificateRegeneration: humanReadableDate(mTLS.lastCertificateRegeneration),
+    certificateRegenerations: mTLS.certificateRegenerations,
   }
 }
 


### PR DESCRIPTION
Fixes the issue of not showing the mTLS certificates data correctly and also takes that moment to move the label text into the i18n layer.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>