### PR TITLE
refactor: logger setup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import { RouteRecordRaw } from 'vue-router'
 import { Store, storeKey } from 'vuex'
 
 import { createRouter } from './router/router'
-import type Logger from './services/logger/Logger'
 import type { EnvVars } from '@/services/env/Env'
 import type { State } from '@/store/storeConfig'
 
@@ -28,13 +27,8 @@ export function useApp(
   }
 }
 
-export function useBootstrap(
-  logger: Logger,
-  store: Store<State>,
-) {
+export function useBootstrap(store: Store<State>) {
   return async (isAllowedToMakeApiCalls: boolean = true) => {
-    logger.setup()
-
     if (isAllowedToMakeApiCalls) {
       await Promise.all([
         // Fetches basic resources before setting up the router and mounting the

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,9 +17,6 @@ async function mountVueApplication() {
       : [],
   )
 
-  const logger = get($.logger)
-  logger.setup()
-
   const app = await get($.app)((await import('./app/App.vue')).default)
   app.mount('#app')
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,10 @@ async function mountVueApplication() {
       })()
       : [],
   )
+
+  const logger = get($.logger)
+  logger.setup()
+
   const app = await get($.app)((await import('./app/App.vue')).default)
   app.mount('#app')
 

--- a/src/services/logger/Logger.ts
+++ b/src/services/logger/Logger.ts
@@ -10,10 +10,6 @@ export const logEvents: Record<string, string> = {
 type LogFunction = (message: string, messageContext?: object | undefined, error?: Error | undefined) => void
 
 export default class Logger {
-  setup() {
-    // Currently, there is no setup code here. This could contain Datadog Logs setup code, for example.
-  }
-
   info(...args: Parameters<LogFunction>) {
     this._log('info', ...args)
   }

--- a/src/services/logger/Logger.ts
+++ b/src/services/logger/Logger.ts
@@ -14,10 +14,6 @@ export default class Logger {
     // Currently, there is no setup code here. This could contain Datadog Logs setup code, for example.
   }
 
-  log(...args: Parameters<LogFunction>) {
-    this._log('log', ...args)
-  }
-
   info(...args: Parameters<LogFunction>) {
     this._log('info', ...args)
   }
@@ -30,7 +26,7 @@ export default class Logger {
     this._log('error', ...args)
   }
 
-  protected _log(type: 'log' | 'info' | 'warn' | 'error', ...args: Parameters<LogFunction>) {
+  protected _log(type: 'info' | 'warn' | 'error', ...args: Parameters<LogFunction>) {
     console[type](...args)
   }
 }

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -219,7 +219,6 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   [$.bootstrap, {
     service: useBootstrap,
     arguments: [
-      $.logger,
       $.store,
     ],
   }],


### PR DESCRIPTION
**refactor: moves logger setup into main.ts**

Moves the logger setup call to a place where it can’t happen multiple times.

**chore: removes logger.log method**

Removes the log method as it’s not very useful with an `info` method already present.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>