### PR TITLE
feat: moves zones into tabs

### DIFF
--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -21,32 +21,6 @@ Feature: index
       | zone-ingress-list-view | standalone | doesn't exist   |
       | zone-egress-list-view  | standalone | exists          |
 
-  Scenario Outline: The navigation shows numbers correctly
-    Given the URL "/global-insights" responds with
-      """
-      body:
-        resources:
-          Zone:
-            total: <Count>
-          ZoneEgress:
-            total: <Count>
-          ZoneIngress:
-            total: <Count>
-      """
-    When I visit the "/" URL
-    Then the "$main-nav .nav-item-<RouteName>" element contains "<Text>"
-    Examples:
-      | RouteName              | Count  | Text |
-      | zone-list-view         | 0      | 0    |
-      | zone-egress-list-view  | 0      | 0    |
-      | zone-ingress-list-view | 0      | 0    |
-      | zone-list-view         | 50     | 50   |
-      | zone-egress-list-view  | 122    | 99+  |
-      | zone-ingress-list-view | 1      | 1    |
-      | zone-list-view         | 100    | 99+  |
-      | zone-egress-list-view  | 100    | 99+  |
-      | zone-ingress-list-view | 100    | 99+  |
-
   Scenario Outline: Visiting the "<Title>" page
     Given the URL "/mesh-insights/default" responds with
       """

--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -14,10 +14,10 @@ Feature: index
     Then the "$main-nav .nav-item-<RouteName>" element <ExistsAssertion>
     Examples:
       | RouteName              | Mode       | ExistsAssertion |
-      | zone-list-view         | global     | exists          |
-      | zone-ingress-list-view | global     | exists          |
-      | zone-egress-list-view  | global     | exists          |
-      | zone-list-view         | standalone | doesn't exist   |
+      | zone-cp-list-view      | global     | exists          |
+      | zone-ingress-list-view | global     | doesn't exists  |
+      | zone-egress-list-view  | global     | doesn't exists  |
+      | zone-cp-list-view      | standalone | doesn't exist   |
       | zone-ingress-list-view | standalone | doesn't exist   |
       | zone-egress-list-view  | standalone | exists          |
 
@@ -64,7 +64,5 @@ Feature: index
     Examples:
       | Selector                                     | Title              |
       | $main-nav .nav-item-home a                   | Overview           |
-      | $main-nav .nav-item-zone-list-view a         | Zone CPs           |
-      | $main-nav .nav-item-zone-egress-list-view a  | Zone Egresses      |
-      | $main-nav .nav-item-zone-ingress-list-view a | Zone Ingresses     |
+      | $main-nav .nav-item-zone-cp-list-view a      | Zone CPs           |
       | [data-testid='nav-item-diagnostics']         | Diagnostics        |

--- a/features/application/Titles.feature
+++ b/features/application/Titles.feature
@@ -7,9 +7,9 @@ Feature: The HTML title is correct on each page
       | URL                                     | Title              |
       | /                                       | Overview           |
       | /diagnostics                            | Diagnostics        |
-      | /zones                                  | Zone CPs           |
-      | /zone-ingresses                         | Zone Ingresses     |
-      | /zone-egresses                          | Zone Egresses      |
+      | /zones/zone-cps                         | Zone CPs           |
+      | /zones/zone-ingresses                   | Zone Ingresses     |
+      | /zones/zone-egresses                    | Zone Egresses      |
 
       | /mesh                                   | Meshes             |
       | /mesh/default                           | Mesh overview      |

--- a/features/zones/Index.feature
+++ b/features/zones/Index.feature
@@ -8,7 +8,7 @@ Feature: The create Zone flow works
       | environment-kubernetes-radio-button | [data-testid='environment-kubernetes-radio-button'] |
       | ingress-input-switch                | [data-testid='ingress-input-switch']                |
       | egress-input-switch                 | [data-testid='egress-input-switch']                 |
-    When I visit the "/zones/-create" URL
+    When I visit the "/zone-cps/-create" URL
 
   Scenario: The form shows only the initial elements
     Then the "$name-input" element exists

--- a/features/zones/Index.feature
+++ b/features/zones/Index.feature
@@ -8,7 +8,7 @@ Feature: The create Zone flow works
       | environment-kubernetes-radio-button | [data-testid='environment-kubernetes-radio-button'] |
       | ingress-input-switch                | [data-testid='ingress-input-switch']                |
       | egress-input-switch                 | [data-testid='egress-input-switch']                 |
-    When I visit the "/zone-cps/-create" URL
+    When I visit the "/zones/-create" URL
 
   Scenario: The form shows only the initial elements
     Then the "$name-input" element exists

--- a/src/app/AppNavItem.vue
+++ b/src/app/AppNavItem.vue
@@ -13,14 +13,6 @@
       @click="onNavItemClick"
     >
       {{ name }}
-
-      <span
-        v-if="amount"
-        class="amount"
-        :class="{ 'amount--empty': amount === '0' }"
-      >
-        {{ amount }}
-      </span>
     </router-link>
   </div>
 </template>
@@ -30,13 +22,10 @@ import { computed } from 'vue'
 import { useRoute, RouteLocationNamedRaw } from 'vue-router'
 
 import { logEvents } from '@/services/logger/Logger'
-import { useStore } from '@/store/store'
 import { useLogger } from '@/utilities'
-import { get } from '@/utilities/get'
 
 const logger = useLogger()
 const route = useRoute()
-const store = useStore()
 
 const props = defineProps({
   name: {
@@ -54,21 +43,6 @@ const props = defineProps({
     required: false,
     default: '',
   },
-
-  insightsFieldAccessor: {
-    type: String,
-    required: false,
-    default: '',
-  },
-})
-
-const amount = computed(() => {
-  if (props.insightsFieldAccessor) {
-    const value = get(store.state.sidebar.insights, props.insightsFieldAccessor, 0)
-    return value > 99 ? '99+' : String(value)
-  } else {
-    return ''
-  }
 })
 
 const targetRoute = computed<RouteLocationNamedRaw>(() => ({ name: props.routeName }))
@@ -116,22 +90,5 @@ function onNavItemClick() {
 .nav-link:hover,
 .nav-link--is-active {
   background-color: var(--grey-300);
-}
-
-.amount {
-  width: 1.5rem;
-  height: 1.25rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border: 1px solid var(--white);
-  border-radius: 0.25rem;
-  font-size: 0.75rem;
-  font-weight: var(--font-weight-regular);
-  background-color: var(--purple-100);
-}
-
-.amount--empty {
-  background-color: var(--grey-200);
 }
 </style>

--- a/src/app/AppSidebar.vue
+++ b/src/app/AppSidebar.vue
@@ -7,7 +7,6 @@
         :name="item.name"
         :route-name="item.routeName"
         :anchor-route-name="item.anchorRouteName"
-        :insights-field-accessor="item.insightsFieldAccessor"
       />
     </aside>
   </div>

--- a/src/app/common/DataOverview.spec.ts
+++ b/src/app/common/DataOverview.spec.ts
@@ -121,7 +121,7 @@ describe('DataOverview.vue', () => {
               },
             },
             detailViewRoute: {
-              name: 'zone-detail-view',
+              name: 'zone-cp-detail-view',
               params: {
                 zone: 'bandwidth-49',
               },

--- a/src/app/common/TagList.vue
+++ b/src/app/common/TagList.vue
@@ -58,7 +58,7 @@ function getRoute(tag: LabelValue): RouteLocation | undefined {
     switch (tag.label) {
       case 'kuma.io/zone': {
         return router.resolve({
-          name: 'zone-detail-view',
+          name: 'zone-cp-detail-view',
           params: {
             zone: tag.value,
           },

--- a/src/app/common/__snapshots__/DataOverview.spec.ts.snap
+++ b/src/app/common/__snapshots__/DataOverview.spec.ts.snap
@@ -354,7 +354,7 @@ exports[`DataOverview.vue renders all custom templates for data 1`] = `
                                 <a
                                   class="k-dropdown-item-trigger"
                                   data-testid="k-dropdown-item-trigger"
-                                  href="/zone-cps/bandwidth-49"
+                                  href="/zones/zone-cps/bandwidth-49"
                                 >
                                   
                                   View details

--- a/src/app/common/__snapshots__/DataOverview.spec.ts.snap
+++ b/src/app/common/__snapshots__/DataOverview.spec.ts.snap
@@ -354,7 +354,7 @@ exports[`DataOverview.vue renders all custom templates for data 1`] = `
                                 <a
                                   class="k-dropdown-item-trigger"
                                   data-testid="k-dropdown-item-trigger"
-                                  href="/zones/bandwidth-49"
+                                  href="/zone-cps/bandwidth-49"
                                 >
                                   
                                   View details

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -412,7 +412,7 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
     let zoneRoute: RouteLocationNamedRaw | undefined
     if (zone !== undefined) {
       zoneRoute = {
-        name: 'zone-detail-view',
+        name: 'zone-cp-detail-view',
         params: {
           zone,
         },

--- a/src/app/getNavItems.ts
+++ b/src/app/getNavItems.ts
@@ -1,4 +1,3 @@
-
 interface NavItem {
   name: string
   routeName: string
@@ -21,29 +20,24 @@ export function getNavItems(isMultizoneMode: boolean): NavItem[] {
     ...(isMultizoneMode
       ? [
         {
-          name: 'Zone CPs',
-          routeName: 'zone-list-view',
-          anchorRouteName: 'zone-abstract-view',
+          name: 'Zones',
+          routeName: 'zone-cp-list-view',
+          anchorRouteName: 'zone-index-view',
           insightsFieldAccessor: 'global.Zone',
         },
-        {
-          name: 'Zone Ingresses',
-          routeName: 'zone-ingress-list-view',
-          anchorRouteName: 'zone-ingress-abstract-view',
-          insightsFieldAccessor: 'global.ZoneIngress',
-        },
       ]
-      : []),
-    {
-      name: 'Zone Egresses',
-      routeName: 'zone-egress-list-view',
-      anchorRouteName: 'zone-egress-abstract-view',
-      insightsFieldAccessor: 'global.ZoneEgress',
-    },
+      : [
+        {
+          name: 'Zone Egresses',
+          routeName: 'zone-egress-list-view',
+          anchorRouteName: 'zone-index-view',
+          insightsFieldAccessor: 'global.ZoneEgress',
+        },
+      ]),
     {
       name: 'Meshes',
       routeName: 'mesh-list-view',
-      anchorRouteName: 'mesh-abstract-view',
+      anchorRouteName: 'mesh-index-view',
     },
   ]
 }

--- a/src/app/getNavItems.ts
+++ b/src/app/getNavItems.ts
@@ -8,7 +8,6 @@ interface NavItem {
    * An anchor route represents the route record that holds routes of a module; for example, the route “zone-abstract-view” holds all routes related to zones.
    */
   anchorRouteName?: string
-  insightsFieldAccessor?: string
 }
 
 export function getNavItems(isMultizoneMode: boolean): NavItem[] {
@@ -23,7 +22,6 @@ export function getNavItems(isMultizoneMode: boolean): NavItem[] {
           name: 'Zones',
           routeName: 'zone-cp-list-view',
           anchorRouteName: 'zone-index-view',
-          insightsFieldAccessor: 'global.Zone',
         },
       ]
       : [
@@ -31,7 +29,6 @@ export function getNavItems(isMultizoneMode: boolean): NavItem[] {
           name: 'Zone Egresses',
           routeName: 'zone-egress-list-view',
           anchorRouteName: 'zone-index-view',
-          insightsFieldAccessor: 'global.ZoneEgress',
         },
       ]),
     {

--- a/src/app/meshes/views/MeshView.vue
+++ b/src/app/meshes/views/MeshView.vue
@@ -28,13 +28,14 @@
     />
   </RouterView>
 </template>
+
 <script lang="ts" setup>
 import { KTabs } from '@kong/kongponents'
 import { useRouter } from 'vue-router'
 
 import { useI18n } from '@/utilities'
-const { t } = useI18n()
 
+const { t } = useI18n()
 const router = useRouter()
 
 const meshRoutes = router.getRoutes().find((route) => route.name === 'mesh-abstract-view')?.children ?? []
@@ -54,8 +55,8 @@ const items = meshRoutes.map((item) => {
     hash: name,
   }
 })
-//
 </script>
+
 <style scoped>
 .tab-link a {
   display: block;
@@ -63,10 +64,12 @@ const items = meshRoutes.map((item) => {
   text-decoration: none;
   color: var(--KTabsColor)
 }
+
 li.active .tab-link a {
   color: var(--KTabsActiveColor)
 }
 </style>
+
 <style lang="scss">
 .route-mesh-view-tabs > ul .tab-item {
   padding: 0 !important;

--- a/src/app/zones/components/ZoneDetails.vue
+++ b/src/app/zones/components/ZoneDetails.vue
@@ -121,7 +121,7 @@ const props = defineProps({
 })
 
 const detailViewRoute = computed(() => ({
-  name: 'zone-detail-view',
+  name: 'zone-cp-detail-view',
   params: {
     zone: props.zoneOverview.name,
   },

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -1,4 +1,8 @@
 zones:
+  navigation:
+    zone-cp-list-view: Zone CPs
+    zone-ingress-list-view: Zone Ingresses
+    zone-egress-list-view: Zone Egresses
   form:
     exit: 'Exit'
     nameLabel: 'Name'

--- a/src/app/zones/routes.ts
+++ b/src/app/zones/routes.ts
@@ -29,7 +29,7 @@ export const routes = (
       redirect: () => ({ name: 'zone-cp-list-view' }),
       children: [
         {
-          path: '/zone-cps',
+          path: 'zone-cps',
           name: 'zone-cp-abstract-view',
           meta: {
             title: 'Zone CPs',
@@ -61,7 +61,7 @@ export const routes = (
           ],
         },
         {
-          path: '/zone-ingresses',
+          path: 'zone-ingresses',
           name: 'zone-ingress-abstract-view',
           meta: {
             title: 'Zone Ingresses',
@@ -93,7 +93,7 @@ export const routes = (
           ],
         },
         {
-          path: '/zone-egresses',
+          path: 'zone-egresses',
           name: 'zone-egress-abstract-view',
           meta: {
             title: 'Zone Egresses',

--- a/src/app/zones/routes.ts
+++ b/src/app/zones/routes.ts
@@ -3,7 +3,7 @@ import type { RouteRecordRaw } from 'vue-router'
 
 export const actions = (): RouteRecordRaw[] => {
   return [{
-    path: '/zone-cps/-create',
+    path: '/zones/-create',
     name: 'zone-create-view',
     meta: {
       title: 'Create & connect Zone',

--- a/src/app/zones/routes.ts
+++ b/src/app/zones/routes.ts
@@ -1,8 +1,9 @@
 import { getLastNumberParameter } from '@/router/getLastParameter'
 import type { RouteRecordRaw } from 'vue-router'
+
 export const actions = (): RouteRecordRaw[] => {
   return [{
-    path: '-create',
+    path: '/zone-cps/-create',
     name: 'zone-create-view',
     meta: {
       title: 'Create & connect Zone',
@@ -16,22 +17,28 @@ export const routes = (
   actions: RouteRecordRaw[],
 ): RouteRecordRaw[] => {
   return [
+    ...actions,
     {
       path: '/zones',
-      name: 'zone-abstract-view',
+      name: 'zone-index-view',
+      meta: {
+        title: 'Zones',
+        isBreadcrumb: true,
+      },
+      component: () => import('@/app/zones/views/ZoneIndexView.vue'),
+      redirect: () => ({ name: 'zone-cp-list-view' }),
       children: [
         {
-          path: '',
+          path: '/zone-cps',
+          name: 'zone-cp-abstract-view',
           meta: {
-            title: 'Zones',
+            title: 'Zone CPs',
             isBreadcrumb: true,
           },
-          redirect: () => ({ name: 'zone-list-view' }),
-          name: 'zone-view',
           children: [
             {
               path: '',
-              name: 'zone-list-view',
+              name: 'zone-cp-list-view',
               meta: {
                 title: 'Zone CPs',
               },
@@ -41,11 +48,9 @@ export const routes = (
               }),
               component: () => import('@/app/zones/views/ZoneListView.vue'),
             },
-            ...actions,
-
             {
               path: ':zone',
-              name: 'zone-detail-view',
+              name: 'zone-cp-detail-view',
               meta: {
                 title: 'Zone',
                 isBreadcrumb: true,
@@ -55,20 +60,13 @@ export const routes = (
             },
           ],
         },
-      ],
-    },
-    {
-      path: '/zone-ingresses',
-      name: 'zone-ingress-abstract-view',
-      children: [
         {
-          path: '',
+          path: '/zone-ingresses',
+          name: 'zone-ingress-abstract-view',
           meta: {
             title: 'Zone Ingresses',
             isBreadcrumb: true,
           },
-          redirect: () => ({ name: 'zone-ingress-list-view' }),
-          name: 'zone-ingress-view',
           children: [
             {
               path: '',
@@ -94,20 +92,13 @@ export const routes = (
             },
           ],
         },
-      ],
-    },
-    {
-      path: '/zone-egresses',
-      name: 'zone-egress-abstract-view',
-      children: [
         {
-          path: '',
+          path: '/zone-egresses',
+          name: 'zone-egress-abstract-view',
           meta: {
             title: 'Zone Egresses',
             isBreadcrumb: true,
           },
-          redirect: () => ({ name: 'zone-egress-list-view' }),
-          name: 'zone-egress-view',
           children: [
             {
               path: '',

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -7,7 +7,7 @@
     <template #actions>
       <KButton
         appearance="outline"
-        :to="{ name: 'zone-list-view' }"
+        :to="{ name: 'zone-cp-list-view' }"
       >
         {{ i18n.t('zones.form.exit') }}
       </KButton>
@@ -164,7 +164,7 @@
             <KButton
               appearance="primary"
               :to="{
-                name: 'zone-detail-view',
+                name: 'zone-cp-detail-view',
                 params: {
                   zone: name
                 },

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -40,14 +40,14 @@ const error = ref<Error | null>(null)
 
 watch(() => route.params.mesh, function () {
   // Don’t trigger a load when the user is navigating to another route.
-  if (route.name === 'zone-detail-view') {
+  if (route.name === 'zone-cp-detail-view') {
     loadData()
   }
 })
 
 watch(() => route.params.name, function () {
   // Don’t trigger a load when the user is navigating to another route.
-  if (route.name === 'zone-detail-view') {
+  if (route.name === 'zone-cp-detail-view') {
     loadData()
   }
 })

--- a/src/app/zones/views/ZoneIndexView.vue
+++ b/src/app/zones/views/ZoneIndexView.vue
@@ -1,5 +1,6 @@
 <template>
   <KTabs
+    v-if="store.getters['config/getMulticlusterStatus']"
     class="nav-tabs"
     :tabs="kTabs"
     :model-value="currentTabHash"
@@ -28,10 +29,12 @@ import { KTabs, Tab } from '@kong/kongponents'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
+import { useStore } from '@/store/store'
 import { useI18n } from '@/utilities'
 
 const i18n = useI18n()
 const currentRoute = useRoute()
+const store = useStore()
 
 const TABS = [
   {

--- a/src/app/zones/views/ZoneIndexView.vue
+++ b/src/app/zones/views/ZoneIndexView.vue
@@ -1,0 +1,95 @@
+<template>
+  <KTabs
+    class="nav-tabs"
+    :tabs="kTabs"
+    :model-value="currentTabHash"
+  >
+    <template
+      v-for="tab in TABS"
+      :key="`${tab.routeName}-anchor`"
+      #[`${tab.routeName}-anchor`]
+    >
+      <router-link :to="{ name: tab.routeName }">
+        {{ tab.title }}
+      </router-link>
+    </template>
+  </KTabs>
+
+  <RouterView v-slot="{ Component, route }">
+    <component
+      :is="Component"
+      :key="route.path"
+    />
+  </RouterView>
+</template>
+
+<script lang="ts" setup>
+import { KTabs, Tab } from '@kong/kongponents'
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+import { useI18n } from '@/utilities'
+
+const i18n = useI18n()
+const currentRoute = useRoute()
+
+const TABS = [
+  {
+    routeName: 'zone-cp-list-view',
+    activeRouteNames: ['zone-cp-detail-view'],
+  },
+  {
+    routeName: 'zone-ingress-list-view',
+    activeRouteNames: ['zone-ingress-detail-view'],
+  },
+  {
+    routeName: 'zone-egress-list-view',
+    activeRouteNames: ['zone-egress-detail-view'],
+  },
+].map((tab) => ({ ...tab, title: i18n.t(`zones.navigation.${tab.routeName}`) }))
+
+const kTabs = computed<Tab[]>(() => TABS.map((tab) => {
+  const { title, routeName } = tab
+
+  return {
+    title,
+    hash: '#' + routeName,
+  }
+}))
+const currentTabHash = computed(() => {
+  const activeTab = TABS.find((tab) => {
+    if (tab.routeName === currentRoute.name) {
+      return true
+    }
+
+    if (Array.isArray(tab.activeRouteNames) && tab.activeRouteNames.includes(currentRoute.name as string)) {
+      return true
+    }
+
+    return false
+  })
+  const routeName = activeTab?.routeName ?? TABS[0].routeName
+
+  return '#' + routeName
+})
+</script>
+
+<style scoped>
+.tab-link a {
+  display: block;
+  padding: var(--spacing-md);
+  text-decoration: none;
+  color: var(--KTabsColor)
+}
+
+.tab-item.active .tab-link a {
+  color: var(--KTabsActiveColor)
+}
+</style>
+
+<style lang="scss">
+// Resets the padding on tab items so we can add the padding to the tab item links instead.
+.nav-tabs > ul > .tab-item {
+  padding: 0 !important;
+}
+</style>

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -147,7 +147,7 @@ const pageOffset = ref(props.offset)
 
 watch(() => route.params.mesh, function () {
   // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== 'zone-list-view') {
+  if (route.name !== 'zone-cp-list-view') {
     return
   }
 
@@ -209,7 +209,7 @@ function transformToTableData(zoneOverviews: ZoneOverview[], zoneIngressOverview
   return zoneOverviews.map((entity) => {
     const { name } = entity
     const detailViewRoute: RouteLocationNamedRaw = {
-      name: 'zone-detail-view',
+      name: 'zone-cp-detail-view',
       params: {
         zone: name,
       },

--- a/src/app/zones/views/__snapshots__/ZoneEgressListView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneEgressListView.spec.ts.snap
@@ -154,7 +154,7 @@ exports[`ZoneEgressListView renders snapshot when multizone 1`] = `
                         <a
                           class=""
                           data-testid="detail-view-link"
-                          href="/zone-egresses/zoneegress-1"
+                          href="/zones/zone-egresses/zoneegress-1"
                         >
                           zoneegress-1
                         </a>
@@ -202,7 +202,7 @@ exports[`ZoneEgressListView renders snapshot when multizone 1`] = `
               
               <a
                 class=""
-                href="/zone-egresses/zoneegress-1"
+                href="/zones/zone-egresses/zoneegress-1"
               >
                 zoneegress-1
               </a>
@@ -684,7 +684,7 @@ exports[`ZoneEgressListView renders snapshot when no multizone 1`] = `
                         <a
                           class=""
                           data-testid="detail-view-link"
-                          href="/zone-egresses/zoneegress-1"
+                          href="/zones/zone-egresses/zoneegress-1"
                         >
                           zoneegress-1
                         </a>
@@ -732,7 +732,7 @@ exports[`ZoneEgressListView renders snapshot when no multizone 1`] = `
               
               <a
                 class=""
-                href="/zone-egresses/zoneegress-1"
+                href="/zones/zone-egresses/zoneegress-1"
               >
                 zoneegress-1
               </a>
@@ -1080,7 +1080,7 @@ exports[`ZoneEgressListView renders zoneegress insights 1`] = `
         
         <a
           class=""
-          href="/zone-egresses/zoneegress-1"
+          href="/zones/zone-egresses/zoneegress-1"
         >
           zoneegress-1
         </a>

--- a/src/app/zones/views/__snapshots__/ZoneIngressListView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneIngressListView.spec.ts.snap
@@ -156,7 +156,7 @@ exports[`ZoneIngressListView renders snapshot when multizone 1`] = `
                         <a
                           class=""
                           data-testid="detail-view-link"
-                          href="/zone-ingresses/zone-ingress-1"
+                          href="/zones/zone-ingresses/zone-ingress-1"
                         >
                           zone-ingress-1
                         </a>
@@ -204,7 +204,7 @@ exports[`ZoneIngressListView renders snapshot when multizone 1`] = `
               
               <a
                 class=""
-                href="/zone-ingresses/zone-ingress-1"
+                href="/zones/zone-ingresses/zone-ingress-1"
               >
                 zone-ingress-1
               </a>
@@ -645,7 +645,7 @@ exports[`ZoneIngressListView renders zoneingress insights 1`] = `
         
         <a
           class=""
-          href="/zone-ingresses/zone-ingress-1"
+          href="/zones/zone-ingresses/zone-ingress-1"
         >
           zone-ingress-1
         </a>

--- a/src/app/zones/views/__snapshots__/ZoneListView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneListView.spec.ts.snap
@@ -250,7 +250,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                         <a
                           class=""
                           data-testid="detail-view-link"
-                          href="/zone-cps/cluster-1"
+                          href="/zones/zone-cps/cluster-1"
                         >
                           cluster-1
                         </a>
@@ -466,7 +466,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                                       <a
                                         class="k-dropdown-item-trigger"
                                         data-testid="k-dropdown-item-trigger"
-                                        href="/zone-cps/cluster-1"
+                                        href="/zones/zone-cps/cluster-1"
                                       >
                                         
                                         View details
@@ -516,7 +516,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                         <a
                           class=""
                           data-testid="detail-view-link"
-                          href="/zone-cps/zone-1"
+                          href="/zones/zone-cps/zone-1"
                         >
                           zone-1
                         </a>
@@ -732,7 +732,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                                       <a
                                         class="k-dropdown-item-trigger"
                                         data-testid="k-dropdown-item-trigger"
-                                        href="/zone-cps/zone-1"
+                                        href="/zones/zone-cps/zone-1"
                                       >
                                         
                                         View details
@@ -782,7 +782,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                         <a
                           class=""
                           data-testid="detail-view-link"
-                          href="/zone-cps/zone-2"
+                          href="/zones/zone-cps/zone-2"
                         >
                           zone-2
                         </a>
@@ -998,7 +998,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                                       <a
                                         class="k-dropdown-item-trigger"
                                         data-testid="k-dropdown-item-trigger"
-                                        href="/zone-cps/zone-2"
+                                        href="/zones/zone-cps/zone-2"
                                       >
                                         
                                         View details
@@ -1048,7 +1048,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                         <a
                           class=""
                           data-testid="detail-view-link"
-                          href="/zone-cps/zone-3"
+                          href="/zones/zone-cps/zone-3"
                         >
                           zone-3
                         </a>
@@ -1264,7 +1264,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                                       <a
                                         class="k-dropdown-item-trigger"
                                         data-testid="k-dropdown-item-trigger"
-                                        href="/zone-cps/zone-3"
+                                        href="/zones/zone-cps/zone-3"
                                       >
                                         
                                         View details
@@ -1326,7 +1326,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
               
               <a
                 class=""
-                href="/zone-cps/cluster-1"
+                href="/zones/zone-cps/cluster-1"
               >
                 cluster-1
               </a>
@@ -1866,7 +1866,7 @@ exports[`ZoneListView renders zone insights 1`] = `
         
         <a
           class=""
-          href="/zone-cps/cluster-1"
+          href="/zones/zone-cps/cluster-1"
         >
           cluster-1
         </a>

--- a/src/app/zones/views/__snapshots__/ZoneListView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneListView.spec.ts.snap
@@ -250,7 +250,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                         <a
                           class=""
                           data-testid="detail-view-link"
-                          href="/zones/cluster-1"
+                          href="/zone-cps/cluster-1"
                         >
                           cluster-1
                         </a>
@@ -466,7 +466,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                                       <a
                                         class="k-dropdown-item-trigger"
                                         data-testid="k-dropdown-item-trigger"
-                                        href="/zones/cluster-1"
+                                        href="/zone-cps/cluster-1"
                                       >
                                         
                                         View details
@@ -516,7 +516,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                         <a
                           class=""
                           data-testid="detail-view-link"
-                          href="/zones/zone-1"
+                          href="/zone-cps/zone-1"
                         >
                           zone-1
                         </a>
@@ -732,7 +732,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                                       <a
                                         class="k-dropdown-item-trigger"
                                         data-testid="k-dropdown-item-trigger"
-                                        href="/zones/zone-1"
+                                        href="/zone-cps/zone-1"
                                       >
                                         
                                         View details
@@ -782,7 +782,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                         <a
                           class=""
                           data-testid="detail-view-link"
-                          href="/zones/zone-2"
+                          href="/zone-cps/zone-2"
                         >
                           zone-2
                         </a>
@@ -998,7 +998,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                                       <a
                                         class="k-dropdown-item-trigger"
                                         data-testid="k-dropdown-item-trigger"
-                                        href="/zones/zone-2"
+                                        href="/zone-cps/zone-2"
                                       >
                                         
                                         View details
@@ -1048,7 +1048,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                         <a
                           class=""
                           data-testid="detail-view-link"
-                          href="/zones/zone-3"
+                          href="/zone-cps/zone-3"
                         >
                           zone-3
                         </a>
@@ -1264,7 +1264,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                                       <a
                                         class="k-dropdown-item-trigger"
                                         data-testid="k-dropdown-item-trigger"
-                                        href="/zones/zone-3"
+                                        href="/zone-cps/zone-3"
                                       >
                                         
                                         View details
@@ -1326,7 +1326,7 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
               
               <a
                 class=""
-                href="/zones/cluster-1"
+                href="/zone-cps/cluster-1"
               >
                 cluster-1
               </a>
@@ -1866,7 +1866,7 @@ exports[`ZoneListView renders zone insights 1`] = `
         
         <a
           class=""
-          href="/zones/cluster-1"
+          href="/zone-cps/cluster-1"
         >
           cluster-1
         </a>

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -396,7 +396,7 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
               title: ONLINE,
               data: globalInsights.resources.Zone?.total ?? 0,
               route: {
-                name: 'zone-list-view',
+                name: 'zone-cp-list-view',
               },
             },
           ]
@@ -494,7 +494,7 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
                 title: 'Zone',
                 data: 1,
                 route: {
-                  name: 'zone-list-view',
+                  name: 'zone-cp-list-view',
                 },
               },
             ]
@@ -504,7 +504,7 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
                 title: getters['config/getVersion'],
                 data: 1,
                 route: {
-                  name: 'zone-list-view',
+                  name: 'zone-cp-list-view',
                 },
               },
             ]
@@ -556,7 +556,7 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
             title: ONLINE,
             data: online,
             route: {
-              name: 'zone-list-view',
+              name: 'zone-cp-list-view',
             },
           })
 
@@ -565,7 +565,7 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
               title: OFFLINE,
               data: total - online,
               route: {
-                name: 'zone-list-view',
+                name: 'zone-cp-list-view',
               },
             })
           }
@@ -656,7 +656,7 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
               title: lastSubscription.version.kumaCp.version,
               data: 1,
               route: {
-                name: 'zone-list-view',
+                name: 'zone-cp-list-view',
               },
             })
           } else {


### PR DESCRIPTION
**feat: moves zones into tabs**:

Renames the routes associated to the Zone CP views to include the `-cp` bit to make it more clear this is a view of Zone CPs.

Moves the Zone sidebar items into a Zones page with navigational tabs which shows the Zone CPs view by default (i.e. like we’ve done for mesh-related items).

**chore: removes sidebar item counts**:

Removes the sidebar item counts as they’re really not useful anymore.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>