### PR TITLE
fix: not loading zones correctly

### DIFF
--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onBeforeMount, PropType, ref, watch } from 'vue'
+import { PropType, ref, watch } from 'vue'
 import { RouteLocationNamedRaw, useRoute } from 'vue-router'
 
 import ZoneEgressDetails from '../components/ZoneEgressDetails.vue'
@@ -90,9 +90,7 @@ watch(() => route.params.mesh, function () {
   loadData(0)
 })
 
-onBeforeMount(function () {
-  loadData(props.offset)
-})
+loadData(props.offset)
 
 async function loadData(offset: number) {
   pageOffset.value = offset

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onBeforeMount, PropType, ref, watch } from 'vue'
+import { PropType, ref, watch } from 'vue'
 import { RouteLocationNamedRaw, useRoute } from 'vue-router'
 
 import MultizoneInfo from '../components/MultizoneInfo.vue'
@@ -96,16 +96,11 @@ watch(() => route.params.mesh, function () {
     loadData(0)
   }
 })
-
-onBeforeMount(function () {
-  init(props.offset)
-})
-
-function init(offset: number): void {
-  if (store.getters['config/getMulticlusterStatus']) {
-    loadData(offset)
+watch(() => store.getters['config/getMulticlusterStatus'], function (isMultizoneMode) {
+  if (isMultizoneMode) {
+    loadData(props.offset)
   }
-}
+}, { immediate: true })
 
 async function loadData(offset: number) {
   pageOffset.value = offset

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -72,7 +72,7 @@
 
 <script lang="ts" setup>
 import { KButton } from '@kong/kongponents'
-import { onBeforeMount, PropType, ref, watch } from 'vue'
+import { PropType, ref, watch } from 'vue'
 import { RouteLocationNamedRaw, useRoute } from 'vue-router'
 
 import MultizoneInfo from '../components/MultizoneInfo.vue'
@@ -151,18 +151,13 @@ watch(() => route.params.mesh, function () {
     return
   }
 
-  init(0)
+  loadData(0)
 })
-
-onBeforeMount(function () {
-  init(props.offset)
-})
-
-function init(offset: number): void {
-  if (store.getters['config/getMulticlusterStatus']) {
-    loadData(offset)
+watch(() => store.getters['config/getMulticlusterStatus'], function (isMultizoneMode) {
+  if (isMultizoneMode) {
+    loadData(props.offset)
   }
-}
+}, { immediate: true })
 
 async function loadData(offset: number) {
   pageOffset.value = offset


### PR DESCRIPTION
Fixes an issues where the Zone and Zone Ingress list views wouldn’t load data if the state for multizone mode wasn’t populated, yet.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>