### PR TITLE
refactor: simplifies storing of global KDS address

### DIFF
--- a/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
+++ b/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
@@ -109,16 +109,16 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 import CodeBlock from '@/app/common/CodeBlock.vue'
+import { useStore } from '@/store/store'
 import {
   useEnv,
   useI18n,
-  useGetGlobalKdsAddress,
 } from '@/utilities'
 
 const env = useEnv()
-const getGlobalKdsAddress = useGetGlobalKdsAddress()
 const i18n = useI18n()
 const route = useRoute()
+const store = useStore()
 
 const props = defineProps({
   zoneName: {
@@ -153,7 +153,7 @@ const kubernetesCreateSecretCommand = computed(() => i18n.t('zones.form.kubernet
 const kubernetesConfig = computed(() => {
   const placeholders: Record<string, string> = {
     zoneName: props.zoneName,
-    globalKdsAddress: getGlobalKdsAddress(),
+    globalKdsAddress: store.state.globalKdsAddress,
     zoneIngressEnabled: String(props.zoneIngressEnabled),
     zoneEgressEnabled: String(props.zoneEgressEnabled),
   }

--- a/src/app/zones/components/ZoneCreateUniversalInstructions.vue
+++ b/src/app/zones/components/ZoneCreateUniversalInstructions.vue
@@ -52,14 +52,12 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 import CodeBlock from '@/app/common/CodeBlock.vue'
-import {
-  useI18n,
-  useGetGlobalKdsAddress,
-} from '@/utilities'
+import { useStore } from '@/store/store'
+import { useI18n } from '@/utilities'
 
-const getGlobalKdsAddress = useGetGlobalKdsAddress()
 const i18n = useI18n()
 const route = useRoute()
+const store = useStore()
 
 const props = defineProps({
   zoneName: {
@@ -81,7 +79,7 @@ const props = defineProps({
 const universalConfig = computed(() => {
   const placeholders: Record<string, string> = {
     zoneName: props.zoneName,
-    globalKdsAddress: getGlobalKdsAddress(),
+    globalKdsAddress: store.state.globalKdsAddress,
     token: props.base64EncodedToken,
   }
 

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -23,7 +23,6 @@ import Logger from '@/services/logger/Logger'
 import type { Alias, ServiceConfigurator } from '@/services/utils'
 import { token, get, constant } from '@/services/utils'
 import { storeConfig, State } from '@/store/storeConfig'
-import { useGetGlobalKdsAddress } from '@/utilities/useGetGlobalKdsAddress'
 import type {
   Router,
 } from 'vue-router'
@@ -64,8 +63,6 @@ const $ = {
 
   app: token<ReturnType<typeof useApp>>('app'),
   bootstrap: token<ReturnType<typeof useBootstrap>>('bootstrap'),
-
-  getGlobalKdsAddress: token<ReturnType<typeof useGetGlobalKdsAddress>>('getGlobalKdsAddress'),
 }
 type SupportedTokens = typeof $
 export const services: ServiceConfigurator<SupportedTokens> = ($) => [
@@ -221,10 +218,6 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
     arguments: [
       $.store,
     ],
-  }],
-
-  [$.getGlobalKdsAddress, {
-    service: useGetGlobalKdsAddress,
   }],
 ]
 

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -91,6 +91,7 @@ interface BareRootState {
   policyTypes: PolicyType[]
   policyTypesByPath: Record<string, PolicyType | undefined>
   policyTypesByName: Record<string, PolicyType | undefined>
+  globalKdsAddress: string
 }
 
 const initialState: BareRootState = {
@@ -159,6 +160,7 @@ const initialState: BareRootState = {
   policyTypes: [],
   policyTypesByPath: {},
   policyTypesByName: {},
+  globalKdsAddress: 'grpcs://<global-kds-address>:5685',
 }
 
 /**
@@ -277,6 +279,7 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
       },
       SET_POLICY_TYPES_BY_PATH: (state, policyTypesByPath: typeof state.policyTypesByPath) => (state.policyTypesByPath = policyTypesByPath),
       SET_POLICY_TYPES_BY_NAME: (state, policyTypesByName: typeof state.policyTypesByName) => (state.policyTypesByName = policyTypesByName),
+      SET_GLOBAL_KDS_ADDRESS: (state, globalKdsAddress: typeof state.globalKdsAddress) => (state.globalKdsAddress = globalKdsAddress),
     },
 
     actions: {
@@ -719,6 +722,10 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
         })
 
         commit('SET_OVERVIEW_CHART_DATA', { chartName: 'kumaDPVersions', data })
+      },
+
+      updateGlobalKdsAddress({ commit }, globalKdsAddress: string) {
+        commit('SET_GLOBAL_KDS_ADDRESS', globalKdsAddress)
       },
     },
   }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -9,6 +9,5 @@ export const [
   useRouter,
   useBootstrap,
   useI18n,
-  useGetGlobalKdsAddress,
   useLogger,
-] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api, TOKENS.store, TOKENS.router, TOKENS.bootstrap, TOKENS.i18n, TOKENS.getGlobalKdsAddress, TOKENS.logger)
+] = createInjections(TOKENS.env, TOKENS.nav, TOKENS.api, TOKENS.store, TOKENS.router, TOKENS.bootstrap, TOKENS.i18n, TOKENS.logger)

--- a/src/utilities/useGetGlobalKdsAddress.ts
+++ b/src/utilities/useGetGlobalKdsAddress.ts
@@ -1,3 +1,0 @@
-export function useGetGlobalKdsAddress() {
-  return () => 'grpcs://<global-kds-address>:5685'
-}


### PR DESCRIPTION
Changes where the global KDS address is sourced from to the Vuex store instead of a DI layer service utility. This is more flexible because we can arbitrarily update the value from code.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
