### PR TITLE
feat: change wording of status not available

### DIFF
--- a/src/app/common/StatusBadge.vue
+++ b/src/app/common/StatusBadge.vue
@@ -17,24 +17,15 @@
 import { computed, PropType } from 'vue'
 
 import { StatusKeyword } from '@/types/index.d'
+import { useI18n } from '@/utilities'
 
-const STATUS: Record<StatusKeyword, { title: string, appearance: string }> = {
-  not_available: {
-    title: 'not available',
-    appearance: 'warning',
-  },
-  partially_degraded: {
-    title: 'partially degraded',
-    appearance: 'warning',
-  },
-  offline: {
-    title: 'offline',
-    appearance: 'danger',
-  },
-  online: {
-    title: 'online',
-    appearance: 'success',
-  },
+const i18n = useI18n()
+
+const STATUS: Record<StatusKeyword, string> = {
+  not_available: 'not-available',
+  partially_degraded: 'warning',
+  offline: 'danger',
+  online: 'success',
 }
 
 const props = defineProps({
@@ -50,7 +41,10 @@ const props = defineProps({
   },
 })
 
-const statusObject = computed(() => STATUS[props.status])
+const statusObject = computed(() => ({
+  title: i18n.t(`http.api.property.${props.status}`),
+  appearance: STATUS[props.status],
+}))
 </script>
 
 <style lang="scss" scoped>
@@ -68,6 +62,10 @@ const statusObject = computed(() => STATUS[props.status])
 
 .status--with-title::before {
   margin-right: var(--spacing-xs);
+}
+
+.status--not-available {
+  color: var(--gray-400);
 }
 
 .status--success {

--- a/src/app/common/StatusBadge.vue
+++ b/src/app/common/StatusBadge.vue
@@ -2,12 +2,11 @@
   <span
     class="status"
     :class="{
-      'status--with-title': !props.shouldHideTitle,
       [`status--${props.status}`]: true,
     }"
     data-testid="status-badge"
   >
-    <span :class="{ 'visually-hidden': props.shouldHideTitle }">
+    <span>
       {{ i18n.t(`http.api.value.${props.status}`) }}
     </span>
   </span>
@@ -26,12 +25,6 @@ const props = defineProps({
     type: String as PropType<StatusKeyword>,
     required: true,
   },
-
-  shouldHideTitle: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
 })
 </script>
 
@@ -44,12 +37,9 @@ const props = defineProps({
   content: '';
   display: inline-block;
   vertical-align: middle;
+  margin-right: var(--spacing-xs);
   border: 4px solid currentColor;
   border-radius: 50%;
-}
-
-.status--with-title::before {
-  margin-right: var(--spacing-xs);
 }
 
 .status--not_available {

--- a/src/app/common/StatusBadge.vue
+++ b/src/app/common/StatusBadge.vue
@@ -42,7 +42,7 @@ const props = defineProps({
 })
 
 const statusObject = computed(() => ({
-  title: i18n.t(`http.api.property.${props.status}`),
+  title: i18n.t(`http.api.value.${props.status}`),
   appearance: STATUS[props.status],
 }))
 </script>

--- a/src/app/common/StatusBadge.vue
+++ b/src/app/common/StatusBadge.vue
@@ -3,30 +3,23 @@
     class="status"
     :class="{
       'status--with-title': !props.shouldHideTitle,
-      [`status--${statusObject.appearance}`]: true,
+      [`status--${props.status}`]: true,
     }"
     data-testid="status-badge"
   >
     <span :class="{ 'visually-hidden': props.shouldHideTitle }">
-      {{ statusObject.title }}
+      {{ i18n.t(`http.api.value.${props.status}`) }}
     </span>
   </span>
 </template>
 
 <script lang="ts" setup>
-import { computed, PropType } from 'vue'
+import { PropType } from 'vue'
 
 import { StatusKeyword } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 
 const i18n = useI18n()
-
-const STATUS: Record<StatusKeyword, string> = {
-  not_available: 'not-available',
-  partially_degraded: 'warning',
-  offline: 'danger',
-  online: 'success',
-}
 
 const props = defineProps({
   status: {
@@ -40,11 +33,6 @@ const props = defineProps({
     default: false,
   },
 })
-
-const statusObject = computed(() => ({
-  title: i18n.t(`http.api.value.${props.status}`),
-  appearance: STATUS[props.status],
-}))
 </script>
 
 <style lang="scss" scoped>
@@ -64,19 +52,19 @@ const statusObject = computed(() => ({
   margin-right: var(--spacing-xs);
 }
 
-.status--not-available {
+.status--not_available {
   color: var(--gray-400);
 }
 
-.status--success {
+.status--online {
   color: var(--green-500);
 }
 
-.status--warning {
+.status--partially_degraded {
   color: var(--yellow-500);
 }
 
-.status--danger {
+.status--offline {
   color:  var(--red-600);
 }
 </style>

--- a/src/app/common/__snapshots__/DataOverview.spec.ts.snap
+++ b/src/app/common/__snapshots__/DataOverview.spec.ts.snap
@@ -379,12 +379,10 @@ exports[`DataOverview.vue renders all custom templates for data 1`] = `
                 >
                   
                   <span
-                    class="status status--with-title status--danger"
+                    class="status status--offline"
                     data-testid="status-badge"
                   >
-                    <span
-                      class=""
-                    >
+                    <span>
                       offline
                     </span>
                   </span>

--- a/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
@@ -312,12 +312,10 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                   >
                     
                     <span
-                      class="status status--with-title status--success"
+                      class="status status--online"
                       data-testid="status-badge"
                     >
-                      <span
-                        class=""
-                      >
+                      <span>
                         online
                       </span>
                     </span>

--- a/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
@@ -88,12 +88,10 @@ exports[`DataPlaneEntitySummary matches snapshot 1`] = `
               </div>
             </span>
             <span
-              class="status status--with-title status--success"
+              class="status status--online"
               data-testid="status-badge"
             >
-              <span
-                class=""
-              >
+              <span>
                 online
               </span>
             </span>

--- a/src/app/onboarding/views/__snapshots__/DataplanesOverview.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/DataplanesOverview.spec.ts.snap
@@ -134,12 +134,10 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
                     <td>
                       
                       <span
-                        class="status status--with-title status--danger"
+                        class="status status--offline"
                         data-testid="status-badge"
                       >
-                        <span
-                          class=""
-                        >
+                        <span>
                           offline
                         </span>
                       </span>
@@ -162,12 +160,10 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
                     <td>
                       
                       <span
-                        class="status status--with-title status--danger"
+                        class="status status--offline"
                         data-testid="status-badge"
                       >
-                        <span
-                          class=""
-                        >
+                        <span>
                           offline
                         </span>
                       </span>
@@ -190,12 +186,10 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
                     <td>
                       
                       <span
-                        class="status status--with-title status--danger"
+                        class="status status--offline"
                         data-testid="status-badge"
                       >
-                        <span
-                          class=""
-                        >
+                        <span>
                           offline
                         </span>
                       </span>
@@ -218,12 +212,10 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
                     <td>
                       
                       <span
-                        class="status status--with-title status--danger"
+                        class="status status--offline"
                         data-testid="status-badge"
                       >
-                        <span
-                          class=""
-                        >
+                        <span>
                           offline
                         </span>
                       </span>
@@ -246,12 +238,10 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
                     <td>
                       
                       <span
-                        class="status status--with-title status--danger"
+                        class="status status--offline"
                         data-testid="status-badge"
                       >
-                        <span
-                          class=""
-                        >
+                        <span>
                           offline
                         </span>
                       </span>
@@ -274,12 +264,10 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
                     <td>
                       
                       <span
-                        class="status status--with-title status--danger"
+                        class="status status--offline"
                         data-testid="status-badge"
                       >
-                        <span
-                          class=""
-                        >
+                        <span>
                           offline
                         </span>
                       </span>
@@ -302,12 +290,10 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
                     <td>
                       
                       <span
-                        class="status status--with-title status--danger"
+                        class="status status--offline"
                         data-testid="status-badge"
                       >
-                        <span
-                          class=""
-                        >
+                        <span>
                           offline
                         </span>
                       </span>
@@ -330,12 +316,10 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
                     <td>
                       
                       <span
-                        class="status status--with-title status--danger"
+                        class="status status--offline"
                         data-testid="status-badge"
                       >
-                        <span
-                          class=""
-                        >
+                        <span>
                           offline
                         </span>
                       </span>

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -38,7 +38,7 @@ import { ExternalService, ServiceInsight, TableHeader } from '@/types/index.d'
 import { useKumaApi } from '@/utilities'
 import { QueryParameter } from '@/utilities/QueryParameter'
 
-type ServiceInsightTableRow = Pick<ServiceInsight, 'serviceType' | 'addressPort' | 'status'> & {
+type ServiceInsightTableRow = Required<Pick<ServiceInsight, 'serviceType' | 'addressPort' | 'status'>> & {
   entity: ServiceInsight
   detailViewRoute: RouteLocationNamedRaw
   dpProxiesStatus: string
@@ -130,7 +130,7 @@ async function loadData(offset: number) {
 
 function transformToTableData(serviceInsights: ServiceInsight[]): ServiceInsightTableRow[] {
   return serviceInsights.map((serviceInsight) => {
-    const { serviceType = 'internal', addressPort } = serviceInsight
+    const { serviceType = 'internal', addressPort = '', status = 'not_available' } = serviceInsight
     const detailViewRoute: RouteLocationNamedRaw = {
       name: 'service-detail-view',
       params: {
@@ -148,6 +148,7 @@ function transformToTableData(serviceInsights: ServiceInsight[]): ServiceInsight
     return {
       entity: serviceInsight,
       detailViewRoute,
+      status,
       serviceType,
       dpProxiesStatus,
       addressPort,

--- a/src/app/zones/views/__snapshots__/ZoneEgressListView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneEgressListView.spec.ts.snap
@@ -136,12 +136,10 @@ exports[`ZoneEgressListView renders snapshot when multizone 1`] = `
                       >
                         
                         <span
-                          class="status status--with-title status--success"
+                          class="status status--online"
                           data-testid="status-badge"
                         >
-                          <span
-                            class=""
-                          >
+                          <span>
                             online
                           </span>
                         </span>
@@ -666,12 +664,10 @@ exports[`ZoneEgressListView renders snapshot when no multizone 1`] = `
                       >
                         
                         <span
-                          class="status status--with-title status--success"
+                          class="status status--online"
                           data-testid="status-badge"
                         >
-                          <span
-                            class=""
-                          >
+                          <span>
                             online
                           </span>
                         </span>

--- a/src/app/zones/views/__snapshots__/ZoneIngressListView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneIngressListView.spec.ts.snap
@@ -138,12 +138,10 @@ exports[`ZoneIngressListView renders snapshot when multizone 1`] = `
                       >
                         
                         <span
-                          class="status status--with-title status--success"
+                          class="status status--online"
                           data-testid="status-badge"
                         >
-                          <span
-                            class=""
-                          >
+                          <span>
                             online
                           </span>
                         </span>

--- a/src/app/zones/views/__snapshots__/ZoneListView.spec.ts.snap
+++ b/src/app/zones/views/__snapshots__/ZoneListView.spec.ts.snap
@@ -232,12 +232,10 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                       >
                         
                         <span
-                          class="status status--with-title status--success"
+                          class="status status--online"
                           data-testid="status-badge"
                         >
-                          <span
-                            class=""
-                          >
+                          <span>
                             online
                           </span>
                         </span>
@@ -498,12 +496,10 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                       >
                         
                         <span
-                          class="status status--with-title status--success"
+                          class="status status--online"
                           data-testid="status-badge"
                         >
-                          <span
-                            class=""
-                          >
+                          <span>
                             online
                           </span>
                         </span>
@@ -764,12 +760,10 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                       >
                         
                         <span
-                          class="status status--with-title status--success"
+                          class="status status--online"
                           data-testid="status-badge"
                         >
-                          <span
-                            class=""
-                          >
+                          <span>
                             online
                           </span>
                         </span>
@@ -1030,12 +1024,10 @@ exports[`ZoneListView renders snapshot when multizone 1`] = `
                       >
                         
                         <span
-                          class="status status--with-title status--success"
+                          class="status status--online"
                           data-testid="status-badge"
                         >
-                          <span
-                            class=""
-                          >
+                          <span>
                             online
                           </span>
                         </span>

--- a/src/locales/en-us/http/index.yaml
+++ b/src/locales/en-us/http/index.yaml
@@ -17,6 +17,7 @@ http:
       certificateExpirationTime: Expiration time
       lastCertificateRegeneration: Last generated
       certificateRegenerations: Regenerations
+    value:
       online: 'online'
       offline: 'offline'
       partiallyDegraded: 'partially degraded'

--- a/src/locales/en-us/http/index.yaml
+++ b/src/locales/en-us/http/index.yaml
@@ -17,3 +17,9 @@ http:
       certificateExpirationTime: Expiration time
       lastCertificateRegeneration: Last generated
       certificateRegenerations: Regenerations
+      online: 'online'
+      offline: 'offline'
+      partiallyDegraded: 'partially degraded'
+      partially_degraded: 'partially degraded'
+      notAvailable: 'information not available'
+      not_available: 'information not available'


### PR DESCRIPTION
**fix: not showing status in services list view**

Fixes not showing a service’s status in the service list view at all.

**feat: changes wording for "not_available" status**

Changes the wording for the `not_available` status from "not available" to "information not available". (I’ve added both camel-cased and snake-cased variants to the messages file as we sometimes use one, sometimes the other. If we change this, we can drop one.)

Resolves #643.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
