### PR TITLE
chore: Remove unused meta data

### DIFF
--- a/src/app/data-planes/routes.ts
+++ b/src/app/data-planes/routes.ts
@@ -11,9 +11,6 @@ export const routes = () => {
           {
             path: ':dataPlane',
             name: `${prefix}-detail-view`,
-            meta: {
-              title: 'Data plane proxy',
-            },
             component: () => import('@/app/data-planes/views/DataPlaneDetailView.vue'),
           },
         ],

--- a/src/app/meshes/routes.ts
+++ b/src/app/meshes/routes.ts
@@ -42,9 +42,6 @@ export const routes = (
                 {
                   path: 'overview',
                   name: 'mesh-overview-view',
-                  meta: {
-                    title: 'Mesh overview',
-                  },
                   component: () => import('@/app/meshes/views/MeshOverviewView.vue'),
                 },
                 ...services.items('services'),

--- a/src/app/zones/routes.ts
+++ b/src/app/zones/routes.ts
@@ -6,7 +6,6 @@ export const actions = (): RouteRecordRaw[] => {
     path: '/zones/-create',
     name: 'zone-create-view',
     meta: {
-      title: 'Create & connect Zone',
       isWizard: true,
     },
     component: () => import('@/app/zones/views/ZoneCreateView.vue'),
@@ -31,9 +30,6 @@ export const routes = (
             {
               path: '',
               name: 'zone-cp-list-view',
-              meta: {
-                title: 'Zone CPs',
-              },
               props: (route) => ({
                 selectedZoneName: route.query.zone,
                 offset: getLastNumberParameter(route.query.offset),
@@ -54,9 +50,6 @@ export const routes = (
             {
               path: '',
               name: 'zone-ingress-list-view',
-              meta: {
-                title: 'Zone Ingresses',
-              },
               props: (route) => ({
                 selectedZoneIngressName: route.query.zoneIngress,
                 offset: getLastNumberParameter(route.query.offset),
@@ -77,9 +70,6 @@ export const routes = (
             {
               path: '',
               name: 'zone-egress-list-view',
-              meta: {
-                title: 'Zone Egresses',
-              },
               props: (route) => ({
                 selectedZoneEgressName: route.query.zoneEgress,
                 offset: getLastNumberParameter(route.query.offset),

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -19,9 +19,6 @@ export default (
     {
       path: '/',
       name: 'home',
-      meta: {
-        title: 'Overview',
-      },
       component: () => import('@/app/main-overview/views/MainOverviewView.vue'),
     },
     ...zones,


### PR DESCRIPTION
~I spotted a few missing i18n problems probably following rebasing shenanigans that I guess I messed up on.~

~I wondered why this wasn't brought up in tests so I had this in draft with an eye to finding out why and making sure these things hard error for us during tests. When looking into this, it began to become a little bit of a rabbit hole that isn't just a simple "oh look, it because this particular page didn't have a test yet", so I've decided to take this out of draft to fix the issue first, and then continue down the rabbit hole separately to eventually fix the larger issue.~

This is no longer about that ^ as it was included in here https://github.com/kumahq/kuma-gui/pull/1034, but I have added tests for the original purpose of the PR here https://github.com/kumahq/kuma-gui/pull/1037

Now this just removes a bit of meta data we no longer need.