### PR TITLE
fix(zone-status): fix zone status badge variant when zone is offline

### DIFF
--- a/src/app/zones/components/ZoneDetails.vue
+++ b/src/app/zones/components/ZoneDetails.vue
@@ -21,7 +21,7 @@
         >
           <KBadge
             v-if="property === 'status'"
-            :appearance="value === 'Offline' ? 'danger' : 'success'"
+            :appearance="value === 'offline' ? 'danger' : 'success'"
           >
             {{ value }}
           </KBadge>


### PR DESCRIPTION
Zone is shown as offline but in green color

![image](https://github.com/kumahq/kuma-gui/assets/2753650/8c58afa1-587e-4c1a-a7bd-1b04d96eb013)

this PR should fix it, status is lowercase but we compare it uppercase https://github.com/kumahq/kuma-gui/blob/master/src/types/index.d.ts#L58

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
