### PR TITLE
fix: zones not having correct breadcrumb title

### DIFF
--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -10,7 +10,9 @@
         {
           to: {
             name: `${props.isGatewayView ? 'gateways' : 'data-planes'}-list-view`,
-            params: _route.params
+            params: {
+              mesh: _route.params.mesh,
+            },
           },
           text: t(`${props.isGatewayView ? 'gateways' : 'data-planes'}.routes.item.breadcrumbs`)
         },

--- a/src/app/diagnostics/views/DiagnosticsView.vue
+++ b/src/app/diagnostics/views/DiagnosticsView.vue
@@ -1,7 +1,5 @@
 <template>
-  <RouteView
-    v-slot="{route: _route}"
-  >
+  <RouteView>
     <RouteTitle
       :title="t('diagnostics.routes.item.title')"
     />
@@ -10,7 +8,6 @@
         {
           to: {
             name: 'diagnostics',
-            params: _route.params
           },
           text: t('diagnostics.routes.item.breadcrumbs')
         },

--- a/src/app/meshes/views/MeshItemView.vue
+++ b/src/app/meshes/views/MeshItemView.vue
@@ -16,7 +16,9 @@
         {
           to: {
             name: 'mesh-detail-view',
-            params: route.params
+            params: {
+              mesh: route.params.mesh,
+            },
           },
           text: route.params.mesh
         }

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -10,7 +10,10 @@
         {
           to: {
             name: 'policies-list-view',
-            params: _route.params
+            params: {
+              mesh: _route.params.mesh,
+              policyPath: _route.params.policyPath,
+            },
           },
           text: t('policies.routes.item.breadcrumbs')
         },

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -10,7 +10,9 @@
         {
           to: {
             name: 'services-list-view',
-            params: _route.params
+            params: {
+              mesh: _route.params.mesh,
+            },
           },
           text: t('services.routes.item.breadcrumbs')
         },

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -18,7 +18,11 @@ zones:
   routes:
     create:
       title: 'Create & connect Zone'
+    item:
+      title: Zone CPs
+      breadcrumbs: Zone CPs
     items:
+      title: Zones
       breadcrumbs: Zones
       navigation:
         zone-cp-list-view: Zone CPs

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -19,8 +19,6 @@ zones:
     create:
       title: 'Create & connect Zone'
     items:
-      title: Zones
-      breadcrumbs: Zones
       navigation:
         zone-cp-list-view: Zone CPs
         zone-ingress-list-view: Zone Ingresses

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -18,9 +18,6 @@ zones:
   routes:
     create:
       title: 'Create & connect Zone'
-    item:
-      title: Zone CPs
-      breadcrumbs: Zone CPs
     items:
       title: Zones
       breadcrumbs: Zones

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -9,7 +9,7 @@
           to: {
             name: 'zone-cp-list-view',
           },
-          text: t('zones.routes.item.breadcrumbs')
+          text: t('zone-cps.routes.item.breadcrumbs')
         },
       ]"
     >

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -1,7 +1,5 @@
 <template>
-  <RouteView
-    v-slot="{route: _route}"
-  >
+  <RouteView>
     <RouteTitle
       :title="t('zone-cps.routes.item.title')"
     />
@@ -10,7 +8,6 @@
         {
           to: {
             name: 'zone-cp-list-view',
-            params: _route.params
           },
           text: t('zones.routes.item.breadcrumbs')
         },

--- a/src/app/zones/views/ZoneEgressDetailView.vue
+++ b/src/app/zones/views/ZoneEgressDetailView.vue
@@ -7,7 +7,7 @@
       :breadcrumbs="[
         {
           to: {
-            name: 'zone-cp-list-view',
+            name: 'zone-egress-list-view',
           },
           text: t('zone-egresses.routes.item.breadcrumbs')
         },

--- a/src/app/zones/views/ZoneEgressDetailView.vue
+++ b/src/app/zones/views/ZoneEgressDetailView.vue
@@ -1,7 +1,5 @@
 <template>
-  <RouteView
-    v-slot="{route: _route}"
-  >
+  <RouteView>
     <RouteTitle
       :title="t('zone-egresses.routes.item.title')"
     />
@@ -10,7 +8,6 @@
         {
           to: {
             name: 'zone-cp-list-view',
-            params: _route.params
           },
           text: t('zone-egresses.routes.item.breadcrumbs')
         },


### PR DESCRIPTION
**chore: fix providing superfluous route parameters**

Specifies the exact route parameters in the new breadcrumbs to avoid the vue-router warning about discarding invalid parameters.

**fix: zone egress breadcrumb using wrong route name**

**fix: zones not having correct breadcrumb title**

Adds the missing messages that are used zone detail view.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>