### PR TITLE
chore: Hard errors on missing i18n key, tmp adds tests for all titles

### DIFF
--- a/features/application/Titles.feature
+++ b/features/application/Titles.feature
@@ -4,16 +4,43 @@ Feature: The HTML title is correct on each page
     Then the page title contains "<Title>"
 
     Examples:
-      | URL                                     | Title              |
-      | /                                       | Overview           |
-      | /diagnostics                            | Diagnostics        |
-      | /zones/zone-cps                         | Zone CPs           |
-      | /zones/zone-ingresses                   | Zone Ingresses     |
-      | /zones/zone-egresses                    | Zone Egresses      |
+      | URL                                                 | Title                         |
+      | /                                                   | Overview                      |
+      | /diagnostics                                        | Diagnostics                   |
 
-      | /mesh                                   | Meshes             |
-      | /mesh/default                           | Mesh overview      |
-      | /mesh/default/services                  | Services           |
-      | /mesh/default/gateways                  | Gateways           |
-      | /mesh/default/data-planes               | Data plane proxies |
-      | /mesh/default/policies/circuit-breakers | CircuitBreaker     |
+      | /wizard/mesh                                        | Create a new mesh             |
+      | /wizard/universal-dataplane                         | Create a new data plane proxy |
+      | /wizard/kubernetes-dataplane                        | Create a new data plane proxy |
+
+      | /onboarding                                         | Welcome to Kuma!              |
+      | /onboarding/deployment-types                        | Deployment Types              |
+      | /onboarding/configuration-types                     | Configuration Types           |
+      | /onboarding/multi-zone                              | Multizone                     |
+      | /onboarding/create-mesh                             | Create the Mesh               |
+      | /onboarding/add-services                            | Add new services              |
+      | /onboarding/add-services-code                       | Add new services              |
+      | /onboarding/dataplanes-overview                     | Data plane overview           |
+      | /onboarding/completed                               | Completed                     |
+
+      | /zones/-create                                      | Create & connect Zone         |
+      | /zones/zone-cps                                     | Zone CPs                      |
+      | /zones/zone-cps/zone-cp-name                        | Zone CP                       |
+      | /zones/zone-ingresses                               | Zone Ingresses                |
+      | /zones/zone-ingresses/zone-ingress-name             | Zone Ingress                  |
+      | /zones/zone-egresses                                | Zone Egresses                 |
+      | /zones/zone-egresses/zone-egress-name               | Zone Egress                   |
+
+      | /mesh                                               | Meshes                        |
+      | /mesh/default                                       | Mesh overview                 |
+
+      | /mesh/default/services                              | Services                      |
+      | /mesh/default/service/service-name                  | Service                       |
+
+      | /mesh/default/gateways                              | Gateways                      |
+      | /mesh/default/gateway/gateway-name                  | Gateway                       |
+
+      | /mesh/default/data-planes                           | Data plane proxies            |
+      | /mesh/default/data-plane/data-plane-name            | Data plane proxy              |
+
+      | /mesh/default/policies/circuit-breakers             | CircuitBreaker                |
+      | /mesh/default/policy/circuit-breakers/program-0 | Policy                        |

--- a/src/services/i18n/I18n.ts
+++ b/src/services/i18n/I18n.ts
@@ -23,6 +23,8 @@ export default <T extends I18nRecord>(strs: T) => {
         if (typeof get(strs, key) === 'undefined') {
           if (key.startsWith('http.api.')) {
             throw new I18nError(key)
+          } else {
+            throw new Error(`Missing message: "${key}" for locale "en-us", using id as fallback`)
           }
         }
         return i18n.t(...rest)


### PR DESCRIPTION
Firstly, the tests in this PR should fail without https://github.com/kumahq/kuma-gui/pull/1032 and therefore requires that in first.

I've added a hard error for when we are missing translation keys here which will fail the tests (by default formatjs only `console.error`s), this is possibly temporary as I'd rather not do this in our own i18n service but instead rely on configuring formatjs. I'm looking into that separately and I'd like to get these tests in.

Additionally the tests here are probably temporary or at least temporary in this file. There are several reasons why this is so:

1. Ideally we would have separate files for absolutely every page, with way more e2e tests in them. Right now its easy to bung all these in one file and loop through them, eventually we will have all the separate files and these can be moved over there.
2. We are doing lots of testing on human strings. This makes editing i18n a lot harder as you also need to change the test. Right now we just need a fairly good coverage of these things, so hitting every page and checking the title is a fairly good way to test all this out temporarily. I would imagine further down the line we will have a better approach so we avoid asserting on human text. Right now, this gives us what we want, and for the moment editing the titles also means editing the tests.

As an aside this also gives us a very good reference to look at when deciding what every page title should be instead of a mish-mash of different things (capitalisation/style etc) depending on who wrote the code/when the code was written.



