### PR TITLE
chore: Moves Mesh detail pages back underneath tabs

### DIFF
--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -86,13 +86,12 @@ if (!hasParent) {
   provide('route-view-parent', routeView)
 }
 
-const iParent: ImmediateParent | undefined = inject('route-view-immediate-parent', undefined)
+const iParent = inject<ImmediateParent | undefined>('route-view-immediate-parent', undefined)
 
 const immediateParent: ImmediateParent = {
   addChild: (module, sym) => {
     children.value.push(module)
     if (typeof iParent !== 'undefined') {
-      // @ts-ignore
       iParent.addChild(module, sym)
     }
   },
@@ -106,7 +105,6 @@ watch(() => props.module, (module = '') => {
     typeof iParent !== 'undefined' &&
     module.length > 0
   ) {
-    // @ts-ignore
     iParent.addChild(module, sym)
   }
 }, { immediate: true })

--- a/src/app/data-planes/routes.ts
+++ b/src/app/data-planes/routes.ts
@@ -23,10 +23,18 @@ export const routes = () => {
       return [
         {
           path: `${prefix}`,
+          name: `${prefix}-abstract-view`,
+          meta: {
+            module: 'data-planes',
+          },
+          redirect: () => ({ name: 'data-planes-list-view' }),
           children: [
             {
               path: '',
               name: `${prefix}-list-view`,
+              meta: {
+                module: 'data-planes',
+              },
               props: (route) => ({
                 selectedDppName: route.query.dpp,
                 offset: getLastNumberParameter(route.query.offset),

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -1,6 +1,7 @@
 <template>
   <RouteView
     v-slot="{route: _route}"
+    :module="props.isGatewayView ? 'gateways' : 'data-planes'"
   >
     <RouteTitle
       :title="t(`${props.isGatewayView ? 'gateways' : 'data-planes'}.routes.item.title`, {name: _route.params.dataPlane})"

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -1,5 +1,7 @@
 <template>
-  <RouteView>
+  <RouteView
+    :module="props.isGatewayView ? 'gateways' : 'data-planes'"
+  >
     <RouteTitle
       :title="t(`${props.isGatewayView ? 'gateways' : 'data-planes'}.routes.items.title`)"
     />

--- a/src/app/gateways/routes.ts
+++ b/src/app/gateways/routes.ts
@@ -26,6 +26,11 @@ export const routes = () => {
       return [
         {
           path: `${prefix}`,
+          name: `${prefix}-abstract-view`,
+          meta: {
+            module: 'gateways',
+          },
+          redirect: () => ({ name: 'gateways-list-view' }),
           children: [
             {
               path: '',

--- a/src/app/meshes/locales/en-us/index.yaml
+++ b/src/app/meshes/locales/en-us/index.yaml
@@ -5,10 +5,10 @@ meshes:
       breadcrumbs: Meshes
       navigation:
         mesh-overview-view: Overview
-        services-list-view: Services
-        data-planes-list-view: Data Plane Proxies
-        gateways-list-view: Gateways
-        policies: Policies
+        services-abstract-view: Services
+        data-planes-abstract-view: Data Plane Proxies
+        gateways-abstract-view: Gateways
+        policies-abstract-view: Policies
 
     items:
       title: Meshes

--- a/src/app/meshes/routes.ts
+++ b/src/app/meshes/routes.ts
@@ -25,22 +25,26 @@ export const routes = (
     {
       path: '/mesh',
       name: 'mesh-index-view',
+      component: () => import('@/app/meshes/views/MeshView.vue'),
+      // if no mesh is specified redirect to /meshes
       redirect: () => ({ name: 'mesh-list-view' }),
       children: [
         {
           path: ':mesh',
-          name: 'mesh-detail-view',
-          redirect: () => ({ name: 'mesh-overview-view' }),
+          name: 'mesh-abstract-view',
+          redirect: () => ({ name: 'mesh-detail-view' }),
           component: () => import('@/app/meshes/views/MeshItemView.vue'),
           children: [
             {
-              name: 'mesh-abstract-view',
               path: '',
+              name: 'mesh-detail-view',
               redirect: () => ({ name: 'mesh-overview-view' }),
-              component: () => import('@/app/meshes/views/MeshView.vue'),
               children: [
                 {
                   path: 'overview',
+                  meta: {
+                    module: 'meshes',
+                  },
                   name: 'mesh-overview-view',
                   component: () => import('@/app/meshes/views/MeshOverviewView.vue'),
                 },

--- a/src/app/meshes/views/MeshOverviewView.vue
+++ b/src/app/meshes/views/MeshOverviewView.vue
@@ -1,5 +1,7 @@
 <template>
-  <RouteView>
+  <RouteView
+    module="meshes"
+  >
     <RouteTitle
       :title="t('meshes.routes.overview.title')"
     />

--- a/src/app/meshes/views/MeshView.vue
+++ b/src/app/meshes/views/MeshView.vue
@@ -4,7 +4,6 @@
       children
     }"
   >
-    {{ children }}
     <AppView>
       <KTabs
         class="route-mesh-view-tabs"

--- a/src/app/policies/routes.ts
+++ b/src/app/policies/routes.ts
@@ -9,7 +9,7 @@ export const routes = (store: Store<State>) => {
       {
         path: `${prefix}`,
         name: `${prefix}-abstract-view`,
-        redirect: () => ({ name: 'policies-list-view' }),
+        redirect: () => ({ name: 'policies' }),
         children: [
           {
             path: `${prefix === 'policy' ? ':policyPath/' : ''}:policy`,
@@ -31,6 +31,11 @@ export const routes = (store: Store<State>) => {
       return [
         {
           path: `${prefix}`,
+          name: `${prefix}-abstract-view`,
+          meta: {
+            module: 'policies',
+          },
+          redirect: () => ({ name: 'policies' }),
           children: [
             {
               path: '',

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -1,6 +1,7 @@
 <template>
   <RouteView
     v-slot="{route: _route}"
+    module="policies"
   >
     <RouteTitle
       :title="t('policies.routes.item.title')"

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -1,5 +1,7 @@
 <template>
-  <RouteView>
+  <RouteView
+    module="policies"
+  >
     <RouteTitle
       :title="t('policies.routes.items.title', {name: policyType?.name})"
     />

--- a/src/app/services/routes.ts
+++ b/src/app/services/routes.ts
@@ -7,6 +7,9 @@ export const routes = () => {
       {
         path: `${prefix}`,
         name: `${prefix}-abstract-view`,
+        meta: {
+          module: 'services',
+        },
         redirect: () => ({ name: 'services-list-view' }),
         children: [
           {
@@ -24,6 +27,11 @@ export const routes = () => {
       return [
         {
           path: `${prefix}`,
+          name: `${prefix}-abstract-view`,
+          meta: {
+            module: 'services',
+          },
+          redirect: () => ({ name: 'services-list-view' }),
           children: [
             {
               path: '',

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -1,6 +1,7 @@
 <template>
   <RouteView
     v-slot="{route: _route}"
+    module="services"
   >
     <RouteTitle
       :title="t('services.routes.item.title', {name: _route.params.service})"

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -1,5 +1,7 @@
 <template>
-  <RouteView>
+  <RouteView
+    module="services"
+  >
     <RouteTitle
       :title="t('services.routes.items.title')"
     />

--- a/src/shims-vue-router.d.ts
+++ b/src/shims-vue-router.d.ts
@@ -11,5 +11,10 @@ declare module 'vue-router' {
      * Whether a route is part of a wizard (e.g. “Create mesh” or “Create data plane proxy”).
      */
     isWizard?: boolean
+
+    /**
+     * The module this route belongs to
+     */
+    module?: string
   }
 }


### PR DESCRIPTION
Ideally I would have split this up into 2 separate PRs as there are two things here:

1. We originally decided that detail pages would not have tabs, we've since decided that they should have tabs, so this PR puts the Mesh Service, Dataplane, Gateway, Policy detail pages back underneath the tabs.
2. Instead of hardcoding more and more potential "this route means that this tabs should be selected". I'd rather do something more automatic, i.e. because of nested routing/route views we know that this thing is related to this tab (its a child of the route the tab is linked to), so select it. <= This is the bit I would rather have worked on first, and is "this is fine for now" so we can move on with this. e.g. child removal probably needs adding plus some other things. The eventual plan is this can be easily used for not just tabs but for other navigation elements also.

Eventually the extra code in `MeshView.vue` will be reduced to nothing.

I may add some inline comments

Closes https://github.com/kumahq/kuma-gui/issues/1029