### PR TITLE
refactor: internalizes data management for mesh charts

### DIFF
--- a/src/app/meshes/components/MeshCharts.vue
+++ b/src/app/meshes/components/MeshCharts.vue
@@ -11,32 +11,159 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, watch } from 'vue'
+import semverCompare from 'semver/functions/compare'
+import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
 import DoughnutChart from '@/app/common/charts/DoughnutChart.vue'
+import { MergedMeshInsights, mergeInsightsReducer } from '@/store/reducers/mesh-insights'
 import { useStore } from '@/store/store'
+import type { ChartDataPoint, DataPlaneProxyStatus, ServiceStatus } from '@/types/index.d'
+import { useI18n, useKumaApi } from '@/utilities'
 
+const i18n = useI18n()
+const kumaApi = useKumaApi()
 const route = useRoute()
 const store = useStore()
 
-const servicesChartData = computed(() => store.getters.getChart('services', {
-  title: 'Services',
-  showTotal: true,
-}))
-const dataplanesChartData = computed(() => store.getters.getChart('dataplanes', {
-  title: 'DP Proxies',
-  showTotal: true,
-  isStatusChart: true,
-}))
-const kumaDPVersionsChartData = computed(() => store.getters.getChart('kumaDPVersions', {
-  title: 'Kuma DP',
-  subtitle: 'versions',
-}))
-const envoyVersionsChartData = computed(() => store.getters.getChart('envoyVersions', {
-  title: 'Envoy',
-  subtitle: 'versions',
-}))
+const isLoading = ref(false)
+const dataPlaneProxyStatus = ref<Required<DataPlaneProxyStatus>>({
+  total: 0,
+  online: 0,
+  partiallyDegraded: 0,
+  offline: 0,
+})
+const serviceStatus = ref<Required<ServiceStatus>>({
+  total: 0,
+  internal: 0,
+  external: 0,
+})
+const dpVersions = ref<{
+  kumaDp: Record<string, DataPlaneProxyStatus>
+  envoy: Record<string, DataPlaneProxyStatus>
+}>({
+  kumaDp: {},
+  envoy: {},
+})
+
+const servicesChartData = computed(() => {
+  const dataPoints: ChartDataPoint[] = []
+  const { internal, external } = serviceStatus.value
+
+  if (internal && store.state.selectedMesh !== null) {
+    dataPoints.push({
+      title: i18n.t('common.charts.services.internalLabel'),
+      data: internal,
+      route: {
+        name: 'services-list-view',
+        params: {
+          mesh: store.state.selectedMesh,
+        },
+      },
+    })
+  }
+
+  if (external && store.state.selectedMesh !== null) {
+    dataPoints.push({
+      title: i18n.t('common.charts.services.externalLabel'),
+      data: external,
+      route: {
+        name: 'services-list-view',
+        params: {
+          mesh: store.state.selectedMesh,
+        },
+      },
+    })
+  }
+
+  return {
+    title: i18n.t('common.charts.services.title'),
+    showTotal: true,
+    dataPoints,
+  }
+})
+
+const dataplanesChartData = computed(() => {
+  const dataPoints: ChartDataPoint[] = []
+
+  const { total, online, partiallyDegraded } = dataPlaneProxyStatus.value
+  if (total > 0) {
+    dataPoints.push({
+      title: i18n.t('http.api.value.online'),
+      statusKeyword: 'online',
+      data: online,
+    })
+
+    if (partiallyDegraded > 0) {
+      dataPoints.push({
+        title: i18n.t('http.api.value.partially_degraded'),
+        statusKeyword: 'partially_degraded',
+        data: partiallyDegraded,
+      })
+    }
+
+    const offline = total - partiallyDegraded - online
+    if (offline > 0) {
+      dataPoints.push({
+        title: i18n.t('http.api.value.offline'),
+        statusKeyword: 'offline',
+        data: offline,
+      })
+    }
+  }
+
+  return {
+    title: i18n.t('common.charts.dataPlaneProxies.title'),
+    showTotal: true,
+    dataPoints,
+  }
+})
+
+const kumaDPVersionsChartData = computed(() => {
+  const dataPoints: ChartDataPoint[] = Object.entries(dpVersions.value.kumaDp).map(([version, status]) => ({
+    title: version,
+    data: status.total ?? 0,
+  }))
+
+  dataPoints.sort((dataPointA, dataPointB) => {
+    if (dataPointA.title === 'unknown') {
+      return 1
+    } else if (dataPointB.title === 'unknown') {
+      return -1
+    }
+
+    return semverCompare(dataPointA.title, dataPointB.title)
+  })
+
+  return {
+    title: i18n.t('common.charts.kumaDp.title'),
+    subtitle: i18n.t('common.charts.kumaDp.subtitle'),
+    dataPoints,
+  }
+})
+
+const envoyVersionsChartData = computed(() => {
+  const dataPoints: ChartDataPoint[] = Object.entries(dpVersions.value.envoy).map(([version, status]) => ({
+    title: version,
+    data: status.total ?? 0,
+  }))
+
+  dataPoints.sort((dataPointA, dataPointB) => {
+    if (dataPointA.title === 'unknown') {
+      return 1
+    } else if (dataPointB.title === 'unknown') {
+      return -1
+    }
+
+    return semverCompare(dataPointA.title, dataPointB.title)
+  })
+
+  return {
+    title: i18n.t('common.charts.envoy.title'),
+    subtitle: i18n.t('common.charts.envoy.subtitle'),
+    dataPoints,
+  }
+})
 
 watch(() => route.params.mesh, function (newMesh) {
   if (typeof newMesh === 'string') {
@@ -44,9 +171,60 @@ watch(() => route.params.mesh, function (newMesh) {
   }
 }, { immediate: true })
 
-function loadData(mesh: string) {
-  store.dispatch('fetchMeshInsights', mesh)
-  store.dispatch('fetchServices', mesh)
+async function loadData(mesh: string) {
+  isLoading.value = true
+
+  try {
+    const originalMeshInsight = await kumaApi.getMeshInsights({ name: mesh })
+    const meshInsight = mergeInsightsReducer([originalMeshInsight])
+
+    setDataPlaneProxyStatus(meshInsight)
+    setServiceStatus(meshInsight)
+    setDpVersions(meshInsight)
+  } catch {
+    dataPlaneProxyStatus.value = {
+      total: 0,
+      online: 0,
+      partiallyDegraded: 0,
+      offline: 0,
+    }
+    serviceStatus.value = {
+      total: 0,
+      internal: 0,
+      external: 0,
+    }
+    dpVersions.value = {
+      kumaDp: {},
+      envoy: {},
+    }
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function setDataPlaneProxyStatus(meshInsight: MergedMeshInsights) {
+  const { total, online, partiallyDegraded } = meshInsight.dataplanes
+
+  dataPlaneProxyStatus.value = {
+    total,
+    online,
+    partiallyDegraded,
+    offline: total - online - partiallyDegraded,
+  }
+}
+
+function setServiceStatus(meshInsight: MergedMeshInsights) {
+  const { total, internal, external } = meshInsight.services
+
+  serviceStatus.value = {
+    total,
+    internal,
+    external,
+  }
+}
+
+function setDpVersions(meshInsight: MergedMeshInsights) {
+  dpVersions.value = meshInsight.dpVersions
 }
 </script>
 

--- a/src/store/modules/notifications/notifications.spec.ts
+++ b/src/store/modules/notifications/notifications.spec.ts
@@ -17,6 +17,7 @@ describe('notifications module', () => {
             },
           ],
         },
+        currentMeshPolicies: {},
       }
       const getters = {
         meshNotificationItemMap: {
@@ -28,13 +29,7 @@ describe('notifications module', () => {
           },
         },
       }
-
-      const rootGetters = {
-        getMeshInsight: {
-          policies: {},
-        },
-      }
-      const result = notificationsModule.getters.singleMeshNotificationItems(notificationsModule.state(), getters, rootState, rootGetters)
+      const result = notificationsModule.getters.singleMeshNotificationItems(notificationsModule.state(), getters, rootState, {})
 
       expect(result).toMatchInlineSnapshot(`
 [

--- a/src/store/modules/notifications/notifications.ts
+++ b/src/store/modules/notifications/notifications.ts
@@ -48,7 +48,7 @@ const getters: GetterTree<NotificationsInterface, State> = {
     )
   },
 
-  singleMeshNotificationItems(_state, getters, rootState, rootGetters): NotificationItem[] {
+  singleMeshNotificationItems(_state, getters, rootState): NotificationItem[] {
     if (rootState.selectedMesh === null || !(rootState.selectedMesh in getters.meshNotificationItemMap)) {
       return []
     }
@@ -57,7 +57,7 @@ const getters: GetterTree<NotificationsInterface, State> = {
 
     // if MeshAccessLog or MeshTrace are > 0 then we have logging
     // totals default to zero via the frontend
-    const hasPolicyBasedLogging = Object.entries(rootGetters.getMeshInsight.policies as {total: number}[])
+    const hasPolicyBasedLogging = Object.entries(rootState.currentMeshPolicies)
       .filter(([key, _item]) => ['MeshAccessLog', 'MeshTrace'].includes(key))
       .some(([_key, item]) => item.total > 0)
 

--- a/src/store/reducers/mesh-insights.ts
+++ b/src/store/reducers/mesh-insights.ts
@@ -80,20 +80,6 @@ const sumVersions = (curr: DpVersions = { kumaDp: {}, envoy: {} }, next: DpVersi
   envoy: sumDependencyVersion(curr.envoy, next.envoy),
 })
 
-export function getEmptyInsight(): MergedMeshInsights {
-  return {
-    meshesTotal: 0,
-    dataplanes: { online: 0, partiallyDegraded: 0, total: 0 },
-    policies: {},
-    dpVersions: { kumaDp: {}, envoy: {} },
-    services: { total: 0, internal: 0, external: 0 },
-  }
-}
-
-export function parseInsightReducer(insight?: MeshInsight) {
-  return mergeInsightsReducer(insight ? [insight] : [])
-}
-
 export function mergeInsightsReducer(insights: MeshInsight[]): MergedMeshInsights {
   return insights.reduce(
     (acc, insight) => ({

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -18,7 +18,6 @@ export type DoughnutChartData = {
   title: string
   subtitle?: string
   showTotal?: boolean // Default: `false`
-  isStatusChart?: boolean // Default: `false`
   dataPoints: ChartDataPoint[]
 }
 


### PR DESCRIPTION
refactor: internalizes data management for mesh charts

Moves all the data fetching and chart data computation out of storeConfig and into MeshCharts as there is no advantage in having handled via the Vuex store.

Depends on (and includes) https://github.com/kumahq/kuma-gui/pull/997.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>