### PR TITLE
fix(zones): Put the parent "Zone" breadcrumb back

### DIFF
--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -19,6 +19,7 @@ zones:
     create:
       title: 'Create & connect Zone'
     items:
+      breadcrumbs: Zones
       navigation:
         zone-cp-list-view: Zone CPs
         zone-ingress-list-view: Zone Ingresses

--- a/src/app/zones/views/ZoneIndexView.vue
+++ b/src/app/zones/views/ZoneIndexView.vue
@@ -6,7 +6,7 @@
           to: {
             name: 'zone-index-view',
           },
-          text: t('zone-cps.routes.items.breadcrumbs')
+          text: t('zones.routes.items.breadcrumbs')
         },
 
       ]"


### PR DESCRIPTION
Following https://github.com/kumahq/kuma-gui/pull/1034/files#diff-b74e52e340de40ac28d9f03911b3150dd6e2a60629b55351d4d160735bda2fcbL22, we then fixed this the wrong way around in https://github.com/kumahq/kuma-gui/pull/1039, resulting in:

`Zone CPs > Zone CPs`

![Screenshot 2023-06-12 at 10 39 25](https://github.com/kumahq/kuma-gui/assets/554604/d6bf516f-faff-4641-a077-959c83f6c925)

This PR put it all back to how it should be, resulting in:

`Zones > Zone CPs`

![Screenshot 2023-06-12 at 10 39 05](https://github.com/kumahq/kuma-gui/assets/554604/329e3fe6-8cef-4e9f-8435-0bf11f4afd58)

Closes https://github.com/kumahq/kuma-gui/issues/1043

Signed-off-by: John Cowen <john.cowen@konghq.com>
