### PR TITLE
chore: update zone creation instructions for secrets

### DIFF
--- a/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
+++ b/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
@@ -59,15 +59,6 @@
 
     <h3>3. {{ i18n.t('zones.form.kubernetes.secret.title') }}</h3>
 
-    <p>{{ i18n.t('zones.form.kubernetes.secret.tokenDescription') }}</p>
-
-    <CodeBlock
-      id="zone-kubernetes-token"
-      class="mt-4"
-      :code="props.token"
-      language="bash"
-    />
-
     <p>{{ i18n.t('zones.form.kubernetes.secret.createSecretDescription') }}</p>
 
     <CodeBlock

--- a/src/app/zones/components/ZoneCreateUniversalInstructions.vue
+++ b/src/app/zones/components/ZoneCreateUniversalInstructions.vue
@@ -1,20 +1,13 @@
 <template>
   <div>
-    <h3>1. {{ i18n.t('zones.form.universal.copySaveToken.title') }}</h3>
+    <h3>1. {{ i18n.t('zones.form.universal.saveToken.title') }}</h3>
 
-    <KAlert
-      class="mt-4"
-      appearance="info"
-    >
-      <template #alertMessage>
-        {{ i18n.t('zones.form.universal.copySaveToken.alertMessage') }}
-      </template>
-    </KAlert>
+    <p>{{ i18n.t('zones.form.universal.saveToken.saveTokenDescription') }}</p>
 
     <CodeBlock
       id="zone-kubernetes-token"
       class="mt-4"
-      :code="props.token"
+      :code="saveTokenCommand"
       language="bash"
     />
 
@@ -47,7 +40,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KAlert } from '@kong/kongponents'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
@@ -71,11 +63,11 @@ const props = defineProps({
   },
 })
 
+const saveTokenCommand = computed(() => i18n.t('zones.form.universal.saveToken.saveTokenCommand', { token: props.token }).trim())
 const universalConfig = computed(() => {
   const placeholders: Record<string, string> = {
     zoneName: props.zoneName,
     globalKdsAddress: store.state.globalKdsAddress,
-    token: props.token,
   }
 
   if (typeof route.params.virtualControlPlaneId === 'string') {

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -44,9 +44,13 @@ zones:
       errorTitle: 'Could not connect Zone'
       errorDescription: 'We were unable to connect Zone.'
     universal:
-      copySaveToken:
-        title: 'Copy and save token'
-        alertMessage: 'You won’t see the token again! Make sure to save it somewhere now.'
+      saveToken:
+        title: 'Save token'
+        saveTokenDescription: 'Save the token to a file.'
+        saveTokenCommand: |
+          mkdir -p ~/kuma-cp \
+            && echo {token} > ~/kuma-cp/cpTokenFile \
+            && chmod 600 ~/kuma-cp/cpTokenFile
       connectZone:
         title: 'Connect Zone'
         configDescription: 'Copy and paste the following configuration into the config.yaml on your local machine.'
@@ -62,8 +66,8 @@ zones:
             kdsDeltaEnabled: true
         connectDescription: 'Next, download Kuma and connect the Zone'
         connectCommand: |
-          (export VERSION=0.0.0-preview.vabf3cdb72; curl -L https://kuma.io/installer.sh | sh - \
-            && kuma-$VERSION/bin/kuma-cp run -c config.yaml)
+          curl -L https://kuma.io/installer.sh | VERSION=0.0.0-preview.vabf3cdb72 sh - \
+            && kuma-0.0.0-preview.vabf3cdb72/bin/kuma-cp run -c config.yaml
     kubernetes:
       prerequisites:
         title: 'Prerequisites'

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -85,8 +85,7 @@ zones:
         step3Command: 'helm repo update'
       secret:
         title: 'Set-up secret'
-        tokenDescription: 'This is your token.'
-        createSecretDescription: 'Add it as a Kubernetes secret.'
+        createSecretDescription: 'Add the token as a Kubernetes secret.'
         createSecretCommand: |
           echo "
             apiVersion: v1


### PR DESCRIPTION
**chore: removes token from k8s instructions**

**chore: change universal instructions to use token from file**

Changes the universal instructions for the Zone creation flow to store the secret in a file and to refer to that file in the CP config.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>