### PR TITLE
chore: Updates name of branch protection rule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,9 +90,9 @@ jobs:
           yarn run test:browser
 
   post-checks:
-    # There is a branch protection rule on the repo that requires "Tests" to
+    # There is a branch protection rule on the repo that requires "branch-protection" to
     # be successful
-    name: Tests
+    name: branch-protection
     #
     needs:
       - lint-tests


### PR DESCRIPTION
See title, uses a more descriptive name resulting in clearer code, and brings this in sync with other things.

Note: Once this is approved the GH UIs branch protection rule will need to be tweaked as a result of this and then, once merged, all currently open PRs will need rebasing.

Signed-off-by: John Cowen <john.cowen@konghq.com>