### PR TITLE
chore: Use-ify app components

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -54,15 +54,15 @@
 import { computed, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
-import AppErrorMessage from './AppErrorMessage.vue'
-import AppLoadingBar from './AppLoadingBar.vue'
-import AppOnboardingNotification from './AppOnboardingNotification.vue'
 import AppView from '@/app/application/components/app-view/AppView.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
-import NotificationManager from '@/app/notification-manager/components/NotificationManager.vue'
 import {
   useAppSidebar,
   useAppHeader,
+  useAppLoadingBar,
+  useAppErrorMessage,
+  useNotificationManager,
+  useAppOnboardingNotification,
 } from '@/components'
 import { useStore } from '@/store/store'
 const props = defineProps({
@@ -75,9 +75,17 @@ const props = defineProps({
 const [
   AppSidebar,
   AppHeader,
+  AppLoadingBar,
+  AppErrorMessage,
+  NotificationManager,
+  AppOnboardingNotification,
 ] = [
   useAppSidebar(),
   useAppHeader(),
+  useAppLoadingBar(),
+  useAppErrorMessage(),
+  useNotificationManager(),
+  useAppOnboardingNotification(),
 ]
 const store = useStore()
 const route = useRoute()

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,10 +1,14 @@
 import GithubButton from 'vue-github-button'
 
+import AppErrorMessage from '@/app/AppErrorMessage.vue'
 import AppHeader from '@/app/AppHeader.vue'
 import MainView from '@/app/application/components/app-view/MainView.vue'
+import AppLoadingBar from '@/app/AppLoadingBar.vue'
+import AppOnboardingNotification from '@/app/AppOnboardingNotification.vue'
 import AppSidebar from '@/app/AppSidebar.vue'
 import KumaLogo from '@/app/common/KumaLogo.vue'
 import OverviewCharts from '@/app/main-overview/components/OverviewCharts.vue'
+import NotificationManager from '@/app/notification-manager/components/NotificationManager.vue'
 import KubernetesGraph from '@/app/onboarding/components/graphs/KubernetesGraph.vue'
 import MemoryGraph from '@/app/onboarding/components/graphs/MemoryGraph.vue'
 import MultizoneGraph from '@/app/onboarding/components/graphs/MultizoneGraph.vue'
@@ -23,6 +27,10 @@ export const TOKENS = {
   StandaloneGraph: constant(StandaloneGraph, { description: 'StandaloneGraph' }),
   AppSidebar: constant(AppSidebar, { description: 'AppSidebar' }),
   AppHeader: constant(AppHeader, { description: 'AppHeader' }),
+  AppLoadingBar: constant(AppLoadingBar, { description: 'AppLoadingBar' }),
+  AppErrorMessage: constant(AppErrorMessage, { description: 'AppErrorMessage' }),
+  NotificationManager: constant(NotificationManager, { description: 'NotificationManager' }),
+  AppOnboardingNotification: constant(AppOnboardingNotification, { description: 'AppOnboardingNotification' }),
   MainView: constant(MainView, { description: 'MainView' }),
 }
 export const [
@@ -36,6 +44,10 @@ export const [
   useStandaloneGraph,
   useAppSidebar,
   useAppHeader,
+  useAppLoadingBar,
+  useAppErrorMessage,
+  useNotificationManager,
+  useAppOnboardingNotification,
   useMainView,
 ] = createInjections(
   TOKENS.KumaLogo,
@@ -48,5 +60,9 @@ export const [
   TOKENS.StandaloneGraph,
   TOKENS.AppSidebar,
   TOKENS.AppHeader,
+  TOKENS.AppLoadingBar,
+  TOKENS.AppErrorMessage,
+  TOKENS.NotificationManager,
+  TOKENS.AppOnboardingNotification,
   TOKENS.MainView,
 )


### PR DESCRIPTION
Turns the remaining statically imported components (apart from RouteView/RouteTitle/AppView) in App.vue into composable like `use*` usage.