### PR TITLE
chore: Set top-level classes from RouteView

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, watch } from 'vue'
+import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 import AppView from '@/app/application/components/app-view/AppView.vue'
@@ -108,30 +108,4 @@ const shouldShowAppError = computed(() => store.getters.shouldShowAppError)
 const shouldShowNotificationManager = computed(() => store.getters.shouldShowNotificationManager)
 const shouldShowOnboardingNotification = computed(() => store.getters.shouldShowOnboardingNotification)
 
-watch(() => isWizard.value, setIsWizardPageClass, { immediate: true })
-
-/**
- * Adds a class for wizard pages to the body element. This is used to control certain layout aspects of the app.
- */
-function setIsWizardPageClass(isWizard: boolean) {
-  const hasClass = document.body.classList.contains('is-wizard-page')
-
-  if (isWizard && !hasClass) {
-    document.body.classList.add('is-wizard-page')
-  } else if (!isWizard && hasClass) {
-    document.body.classList.remove('is-wizard-page')
-  }
-}
 </script>
-
-<style lang="scss" scoped>
-body:not(.is-wizard-page) .app-content-container {
-  padding-top: var(--AppHeaderHeight, initial);
-  display: grid;
-  grid-template-columns: var(--AppSidebarWidth) 1fr;
-}
-
-body:not(.is-wizard-page) .app-main-content {
-  padding: var(--AppGap);
-}
-</style>

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -117,6 +117,6 @@ const shouldShowOnboardingNotification = computed(() => store.getters.shouldShow
 }
 
 .app-main-content {
-  padding: var(--AppGap);
+  padding: var(--AppContentPadding);
 }
 </style>

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -109,3 +109,14 @@ const shouldShowNotificationManager = computed(() => store.getters.shouldShowNot
 const shouldShowOnboardingNotification = computed(() => store.getters.shouldShowOnboardingNotification)
 
 </script>
+<style lang="scss" scoped>
+.app-content-container {
+  padding-top: var(--AppHeaderHeight, initial);
+  display: var(--AppDisplay);
+  grid-template-columns: var(--AppSidebarWidth) 1fr;
+}
+
+.app-main-content {
+  padding: var(--AppGap);
+}
+</style>

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -25,7 +25,7 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { provide, inject, ref, watch, onUnmounted } from 'vue'
+import { provide, inject, ref, watch, onBeforeUnmount } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { useI18n } from '@/utilities'
@@ -149,7 +149,7 @@ watch(() => props.attrs, (attrs) => {
     parent.addAttrs(attrs, sym)
   }
 }, { immediate: true })
-onUnmounted(() => {
+onBeforeUnmount(() => {
   parent.removeAttrs(sym)
 })
 

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -25,13 +25,15 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { provide, inject, ref, watch } from 'vue'
+import { provide, inject, ref, watch, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { useI18n } from '@/utilities'
 export interface RouteView {
   addTitle: (title: string, sym: Symbol) => void
   removeTitle: (sym: Symbol) => void
+  addAttrs: (attrs: Record<string, string>, sym: Symbol) => void
+  removeAttrs: (sym: Symbol) => void
 }
 export interface ImmediateParent {
   addChild: (str: string, sym: Symbol) => void
@@ -44,6 +46,11 @@ const props = defineProps({
     type: String,
     required: false,
     default: '',
+  },
+  attrs: {
+    type: Object,
+    required: false,
+    default: () => ({}),
   },
 })
 
@@ -65,8 +72,27 @@ const beforePaint = function (fn: (...args: any[]) => void) {
 const setTitle = beforePaint((title) => {
   document.title = title
 })
+const $html = document.querySelector('html')!
+const originalClasses = [...$html.classList]
+const setAttrs = beforePaint((attrs: Record<string, string>[]) => {
+  const flat = attrs.reduce<Record<string, string[]>>((prev, item) => {
+    return Object.entries(item).reduce(
+      (prev, [key, value]) => {
+        if (typeof prev[key] === 'undefined') {
+          prev[key] = []
+        }
+        prev[key].push(value)
+        return prev
+      }, prev,
+    )
+  }, {})
+
+  $html.classList.remove(...[...$html.classList].filter(item => !originalClasses.includes(item)))
+  $html.classList.add(...(flat.class || []))
+})
 
 const map = new Map<Symbol, string>()
+const attrsMap = new Map<Symbol, Record<string, string>>()
 const routeView: RouteView = {
   addTitle: (item: string, sym: Symbol) => {
     title.value = item
@@ -77,6 +103,14 @@ const routeView: RouteView = {
     map.delete(sym)
     setTitle([...map.values()].reverse().concat(t('components.route-view.title', { name: t('common.product.name') })).join(' | '))
   },
+  addAttrs: (item: Record<string, string>, sym: Symbol) => {
+    attrsMap.set(sym, item)
+    setAttrs([...attrsMap.values()])
+  },
+  removeAttrs: (sym: Symbol) => {
+    attrsMap.delete(sym)
+    setAttrs([...attrsMap.values()])
+  },
 }
 
 const hasParent: RouteView | undefined = inject('route-view-parent', undefined)
@@ -85,6 +119,7 @@ if (!hasParent) {
   setTitle(t('components.route-view.title', { name: t('common.product.name') }))
   provide('route-view-parent', routeView)
 }
+const parent: RouteView = hasParent || routeView
 
 const iParent = inject<ImmediateParent | undefined>('route-view-immediate-parent', undefined)
 
@@ -108,6 +143,15 @@ watch(() => props.module, (module = '') => {
     iParent.addChild(module, sym)
   }
 }, { immediate: true })
+
+watch(() => props.attrs, (attrs) => {
+  if (Object.keys(attrs).length > 0) {
+    parent.addAttrs(attrs, sym)
+  }
+}, { immediate: true })
+onUnmounted(() => {
+  parent.removeAttrs(sym)
+})
 
 const route = useRoute()
 const urlParam = function <T extends string | null> (param: T | T[]): string {

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -1,5 +1,9 @@
 <template>
-  <RouteView>
+  <RouteView
+    :attrs="{
+      class: 'is-fullscreen'
+    }"
+  >
     <RouteTitle
       :title="t('zones.routes.create.title')"
     />

--- a/src/assets/styles/_utilities.scss
+++ b/src/assets/styles/_utilities.scss
@@ -31,3 +31,13 @@
   border: none;
   cursor: pointer;
 }
+html:not(.is-fullscreen) .app-content-container {
+  padding-top: var(--AppHeaderHeight, initial);
+  display: grid;
+  grid-template-columns: var(--AppSidebarWidth) 1fr;
+}
+
+html:not(.is-fullscreen) .app-main-content {
+  padding: var(--AppGap);
+}
+

--- a/src/assets/styles/_utilities.scss
+++ b/src/assets/styles/_utilities.scss
@@ -31,13 +31,3 @@
   border: none;
   cursor: pointer;
 }
-html:not(.is-fullscreen) .app-content-container {
-  padding-top: var(--AppHeaderHeight, initial);
-  display: grid;
-  grid-template-columns: var(--AppSidebarWidth) 1fr;
-}
-
-html:not(.is-fullscreen) .app-main-content {
-  padding: var(--AppGap);
-}
-

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -10,6 +10,7 @@
   --AppHeaderHeight: 60px;
   --AppSidebarWidth: 280px;
   --AppGap: var(--spacing-lg);
+  --AppDisplay: grid;
 
   // ONBOARDING
   --onboarding-accent: #822dc5;
@@ -39,3 +40,11 @@
   --KCardBackground: var(--white);
   --KCardBorder: 1px solid var(--grey-300);
 }
+:root.is-fullscreen {
+  --AppHeaderHeight: 0;
+  --AppSidebarWidth: 0;
+  --AppGap: 0;
+  --AppDisplay: block;
+}
+
+

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -10,6 +10,7 @@
   --AppHeaderHeight: 60px;
   --AppSidebarWidth: 280px;
   --AppGap: var(--spacing-lg);
+  --AppContentPadding: var(--spacing-lg);
   --AppDisplay: grid;
 
   // ONBOARDING
@@ -43,7 +44,7 @@
 :root.is-fullscreen {
   --AppHeaderHeight: 0;
   --AppSidebarWidth: 0;
-  --AppGap: 0;
+  --AppContentPadding: 0;
   --AppDisplay: block;
 }
 


### PR DESCRIPTION
Adds functionality to be able to set top-level class names from our `RouteView` component

Previously we were doing this on a per-class basis i.e. `setWizardPageClass`. This PR does pretty much the same thing just at a more generic/reusable level and handily from our `RouteView` component which is available in every single view/route component.

At an application level, I went with `is-fullscreen` which better describes what the required CSS here does.

Notes:

- Whilst the plan is to be able to set any attrs on the root node, I haven't done this yet as we don't currently need it. This only currently works for `class`
- As all this code is centralized in `RouteView` I went with "I'm happy with the interface, lets get the thing working" whilst not worrying to much about the fact that RouteView is getting a little messier than I would like. There is still one more thing to finish off in `RouteView` and I'd rather finish that up before a cleanup/de-dupe and make the code in RouteView more consistent.

Signed-off-by: John Cowen <john.cowen@konghq.com>
