### PR TITLE
fix: onUnmounted > onBeforeUnmount

### DIFF
--- a/src/app/application/components/app-view/AppView.vue
+++ b/src/app/application/components/app-view/AppView.vue
@@ -21,7 +21,7 @@
 </template>
 <script lang="ts" setup>
 import { KBreadcrumbs, BreadcrumbItem } from '@kong/kongponents'
-import { provide, inject, PropType, watch, ref, onUnmounted } from 'vue'
+import { provide, inject, PropType, watch, ref, onBeforeUnmount } from 'vue'
 
 import { useMainView } from '@/components'
 
@@ -77,7 +77,7 @@ watch(() => props.breadcrumbs, (items: BreadcrumbItem[] | null) => {
   }
 }, { immediate: true })
 
-onUnmounted(() => {
+onBeforeUnmount(() => {
   parent.removeBreadcrumbs(symbol)
 })
 

--- a/src/app/application/components/route-view/RouteTitle.vue
+++ b/src/app/application/components/route-view/RouteTitle.vue
@@ -6,7 +6,7 @@
   </template>
 </template>
 <script lang="ts" setup>
-import { inject, watch, onUnmounted } from 'vue'
+import { inject, watch, onBeforeUnmount } from 'vue'
 
 import { RouteView } from './RouteView.vue'
 
@@ -26,7 +26,7 @@ if (typeof routeView !== 'undefined') {
       routeView.addTitle(title, symbol)
     }
   }, { immediate: true })
-  onUnmounted(() => {
+  onBeforeUnmount(() => {
     routeView.removeTitle(symbol)
   })
 }


### PR DESCRIPTION
Moves to use `onBeforeUnmount` rather than `onUnmounted` in both `AppView` and `RouteTitle`

Signed-off-by: John Cowen <john.cowen@konghq.com>
