### PR TITLE
fix(charts): Avoid throwing an error when clicking the middle of a chart

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -184,6 +184,9 @@ Then('the page title contains {string}', function (title: string) {
 Then('pause', function () {
   cy.pause()
 })
+Then(/^(everything is )?ok$/, function () {
+  expect(true).to.equal(true)
+})
 Then('log {string}', function (message: string) {
   console.log(message)
 })

--- a/features/home/Index.feature
+++ b/features/home/Index.feature
@@ -1,0 +1,11 @@
+Feature: The create Zone flow works
+  Background:
+    Given the CSS selectors
+      | Alias  | Selector |
+      | services-chart | [data-testid='services'] canvas   |
+    When I visit the "/" URL
+
+  Scenario: Clicking the charts
+    When I click the "$services-chart" element
+    Then everything is ok
+

--- a/src/app/common/charts/DoughnutChart.vue
+++ b/src/app/common/charts/DoughnutChart.vue
@@ -153,10 +153,13 @@ const chartOptions = computed<ChartOptions<'doughnut'>>(function () {
       },
     },
     onClick: function (_event, elements) {
-      const dataPoint = props.data.dataPoints[elements[0].index]
+      const $el = elements[0]
+      if (typeof $el !== 'undefined') {
+        const dataPoint = props.data.dataPoints[$el.index]
 
-      if (dataPoint.route) {
-        router.push(dataPoint.route)
+        if (dataPoint.route) {
+          router.push(dataPoint.route)
+        }
       }
     },
   }

--- a/src/app/main-overview/components/OverviewCharts.vue
+++ b/src/app/main-overview/components/OverviewCharts.vue
@@ -4,37 +4,44 @@
       <div class="chart-box-list">
         <DoughnutChart
           v-if="isMultizoneMode"
+          data-testid="zones"
           class="chart chart-1/2 chart-offset-left-1/6"
           :data="zonesChartData"
         />
 
         <DoughnutChart
           v-if="isMultizoneMode"
+          data-testid="zone-versions"
           class="chart chart-1/2 chart-offset-right-1/6"
           :data="zonesCPVersionsChartData"
         />
 
         <DoughnutChart
+          data-testid="meshes"
           class="chart chart-1/3"
           :data="meshesChartData"
         />
 
         <DoughnutChart
+          data-testid="services"
           class="chart chart-1/3"
           :data="servicesChartData"
         />
 
         <DoughnutChart
+          data-testid="data-planes"
           class="chart chart-1/3"
           :data="dataplanesChartData"
         />
 
         <DoughnutChart
+          data-testid="data-plane-versions"
           class="chart chart-1/2 chart-offset-left-1/6"
           :data="kumaDPVersionsChartData"
         />
 
         <DoughnutChart
+          data-testid="envoy-versions"
           class="chart chart-1/2 chart-offset-right-1/6"
           :data="envoyVersionsChartData"
         />

--- a/src/app/main-overview/views/__snapshots__/MainOverviewView.spec.ts.snap
+++ b/src/app/main-overview/views/__snapshots__/MainOverviewView.spec.ts.snap
@@ -43,6 +43,7 @@ exports[`MainOverviewView.vue renders basic snapshot 1`] = `
               <!--v-if-->
               <div
                 class="chart chart chart-1/3"
+                data-testid="meshes"
               >
                 <div
                   class="chart-canvas-container"
@@ -77,6 +78,7 @@ exports[`MainOverviewView.vue renders basic snapshot 1`] = `
               </div>
               <div
                 class="chart chart chart-1/3"
+                data-testid="services"
               >
                 <div
                   class="chart-canvas-container"
@@ -111,6 +113,7 @@ exports[`MainOverviewView.vue renders basic snapshot 1`] = `
               </div>
               <div
                 class="chart chart chart-1/3"
+                data-testid="data-planes"
               >
                 <div
                   class="chart-canvas-container"
@@ -145,6 +148,7 @@ exports[`MainOverviewView.vue renders basic snapshot 1`] = `
               </div>
               <div
                 class="chart chart chart-1/2 chart-offset-left-1/6"
+                data-testid="data-plane-versions"
               >
                 <div
                   class="chart-canvas-container"
@@ -179,6 +183,7 @@ exports[`MainOverviewView.vue renders basic snapshot 1`] = `
               </div>
               <div
                 class="chart chart chart-1/2 chart-offset-right-1/6"
+                data-testid="envoy-versions"
               >
                 <div
                   class="chart-canvas-container"


### PR DESCRIPTION
We noticed that clicking in the middle of a chart (instead of the ring itself) would cause a JS error to be thrown. This fixes that up.

---

Notes:

I added what usually would be a "debug" step, but I used it here to say "I click this and everything is still ok!", I kept the short form `ok`, as I sometimes use this for debug, but in this case it reads better in the long form seeing as we are keeping it in the test permanently.

The reason there is nothing really to assert after it, is because kinda luckily if you use Cypress to click on the `canvas` it reproduces the error. As these charts use `canvas` and not SVG it wasn't immediately clear to me how I could select the ring of the chart separately, guessing we would need to provide something in the application code, which I'm not keen on if its just for test purposes, but also could just be as I'm not super knowledgable around canvas stuff (I usually prefer SVG).

Overall this fixes the immediate error and provides a test for it, so I'm good with this.

Closes https://github.com/kumahq/kuma-gui/issues/702
