### PR TITLE
feat: adds interceptor support to makeRequest

### DIFF
--- a/src/services/kuma-api/RestClient.spec.ts
+++ b/src/services/kuma-api/RestClient.spec.ts
@@ -91,7 +91,10 @@ describe('RestClient', () => {
     const restClient = new RestClient(() => 'http://localhost:5681')
     restClient.raw('/path', undefined, { params })
 
-    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith('http://localhost:5681/path', expectedOptions, undefined)
+    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith({
+      url: 'http://localhost:5681/path',
+      options: expectedOptions,
+    })
   })
 
   test.each([
@@ -111,6 +114,11 @@ describe('RestClient', () => {
     const restClient = new RestClient(() => baseUrlOrPath)
     restClient.raw(requestPath)
 
-    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith(expectedRequestUrl, { method: 'GET' }, undefined)
+    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith({
+      url: expectedRequestUrl,
+      options: {
+        method: 'GET',
+      },
+    })
   })
 })

--- a/src/services/kuma-api/makeRequest.ts
+++ b/src/services/kuma-api/makeRequest.ts
@@ -1,7 +1,50 @@
 import { ApiError } from './ApiError'
 
-export async function makeRequest(url: string, options: RequestInit & { params?: any } = {}, payload?: any) {
-  const init = options
+type FetchParams = [url: string, init: RequestInit]
+export type MakeRequestResponseObject = { response: Response, data: any }
+
+export type ResponseInterceptor = {
+  onFulfilled?: (responseObj: MakeRequestResponseObject) => MakeRequestResponseObject | Promise<MakeRequestResponseObject>
+
+  onRejected?: (error: ApiError, responseObj: MakeRequestResponseObject, ...fetchParams: FetchParams) => Promise<Response>
+}
+
+export interface MakeRequestConfig {
+  url: string,
+  options?: RequestInit & { params?: any },
+  payload?: any,
+  responseInterceptor?: ResponseInterceptor,
+}
+
+/**
+ * ## Interceptors
+ *
+ * ### Response interceptors
+ *
+ * Allows intercepting responses with an error code (i.e. status code is not between 200 and 299).
+ *
+ * The return value of `onRejected` is awaited. A rejected promise is treated as yielding the (possibly altered) error. A fulfilled promise is treated as correcting the error and the promise’s value is expected to be a new `Response` object (e.g. `return Promise.resolve(fetch(url, init))`).
+ *
+ * **Interceptor for yielding error**:
+ *
+ * ```js
+ * (error, responseObj) => {
+ *   error.traceId = responseObj.response.headers.get('x-datadog-trace-id')
+ *   return Promise.reject(error)
+ * }
+ * ```
+ *
+ * **Interceptor for correcting error**:
+ *
+ * ```js
+ * (error, responseObj, url, init) => {
+ *   // Do something to correct the failing fetch call.
+ *   return Promise.resolve(fetch(url, init))
+ * }
+ * ```
+ */
+export async function makeRequest(config: MakeRequestConfig): Promise<MakeRequestResponseObject> {
+  const init = { ...config.options }
   const method = init.method ?? 'GET'
 
   // Streamlines the headers data structure for simplified use throughout this function.
@@ -12,45 +55,73 @@ export async function makeRequest(url: string, options: RequestInit & { params?:
     init.headers.set('content-type', 'application/json')
   }
 
-  let completeUrl = url
+  let completeUrl = config.url
 
-  if ('params' in options && options.params !== undefined && method === 'GET') {
+  if ('params' in init && init.params !== undefined && method === 'GET') {
     // Turns `params` into query parameters for GET requests.
-    completeUrl += `?${new URLSearchParams(options.params).toString()}`
+    completeUrl += `?${new URLSearchParams(init.params).toString()}`
+    delete init.params
   }
 
-  if (payload !== undefined) {
+  if (config.payload !== undefined) {
     if (init.headers.get('content-type')?.startsWith('application/json')) {
       // Sets the request body to the JSON representation of `payload`.
-      init.body = JSON.stringify(payload)
+      init.body = JSON.stringify(config.payload)
     } else {
-      init.body = payload
+      init.body = config.payload
     }
   }
 
-  let response
+  const fetchParams: FetchParams = [completeUrl, init]
+  let response: Response
 
   try {
-    response = await fetch(completeUrl, init)
+    response = await fetch(...fetchParams)
   } catch (error) {
     throw createNetworkError(error)
   }
 
-  const contentType = response.headers.get('content-type')
-  const isJson = contentType !== null ? contentType.startsWith('application/json') || contentType.startsWith('application/problem+json') : false
-  const data = isJson ? await response.json() : await response.text()
+  let responseObject = await createResponseObject(response)
 
-  if (response.ok) {
-    return { response, data }
-  } else {
-    throw createApiError(response, data)
+  if (responseObject.response.ok) {
+    if (config.responseInterceptor?.onFulfilled) {
+      responseObject = await config.responseInterceptor.onFulfilled(responseObject)
+    }
+
+    return responseObject
   }
+
+  let responseError = createApiError(responseObject.response, responseObject.data)
+
+  if (config.responseInterceptor?.onRejected) {
+    try {
+      const newResponse = await config.responseInterceptor.onRejected(responseError, responseObject, ...fetchParams)
+
+      return createResponseObject(newResponse)
+    } catch (error) {
+      if (error instanceof ApiError) {
+        responseError = error
+      } else {
+        throw new Error('Response interceptor raised unknown error (should be ApiError)')
+      }
+    }
+  }
+
+  throw responseError
 }
 
 function createNetworkError(error: unknown): Error {
   const requestErrorMessage = error instanceof Error ? error.message : 'An unknown network error occurred.'
 
   return new Error(requestErrorMessage)
+}
+
+async function createResponseObject(response: Response): Promise<MakeRequestResponseObject> {
+  const contentType = response.headers.get('content-type')
+  const isJsonResponse = contentType !== null ? contentType.startsWith('application/json') || contentType.startsWith('application/problem+json') : false
+  const data = isJsonResponse ? await response.json() : await response.text()
+
+  return { response, data }
 }
 
 /**


### PR DESCRIPTION
Adds support for response interceptors on the `makeRequest` utility. Response interceptors support a `onFulfilled` and `onRejected` callback which are processed like this:

- **response interceptor onFulfilled**: after processing the response from a successful `fetch` call with a non-error response into a response object and serializing the JSON body (if applicable)
- **response interceptor onRejected**: after processing the response from a successful `fetch` call with an error response into a response object and serializing the JSON body (if applicable)

Adds an axios-like interface to `RestClient` so the interceptors can be added on a per-client basis. Note that at the moment only a single response interceptor is supported. We might decide to switch to using `axios` in place of the `makeRequest` function so I didn’t want to go too far with adding logic here.

Changes the `makeRequest`’s list of positional parameters to a config object because that’s much easier to handle and makes our live writing tests easier.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
