### PR TITLE
chore: Adds tests for Mesh plus some tweaks to Cypress steps

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -68,36 +68,13 @@ When('I wait for {int} milliseconds/ms', function (ms: number) {
 })
 
 When(/^I click the "(.*)" element(?: and select "(.*)")?$/, (selector: string, value?: string) => {
+  const event = 'click'
   if (value !== undefined) {
     $(selector).select(value)
   } else {
-    $(selector).then(($el) => {
-      const el = $el[0]
-      const label = getLabel(el)
-
-      cy.wrap(label ?? el).click()
-    })
+    $(selector)[event]({ force: true })
   }
 })
-
-/**
- * Finds the `label` element associated with an form control.
- */
-function getLabel(element: HTMLElement) {
-  if (element.id) {
-    const label = document.querySelector(`label[for="${element.id}"]`)
-    if (label !== null) {
-      return label
-    }
-  }
-
-  const label = element.closest('label')
-  if (label !== null) {
-    return label
-  }
-
-  return null
-}
 
 When('I {string} {string} into the {string} element', (event: string, text: string, selector: string) => {
   switch (event) {

--- a/features/mesh/Index.feature
+++ b/features/mesh/Index.feature
@@ -1,10 +1,13 @@
 Feature: mesh / index
   Background:
     Given the CSS selectors
-      | Alias           | Selector       |
-      | mesh-breadcrumb | .k-breadcrumbs |
+      | Alias          | Selector                                     |
+      | items          | [data-testid='data-overview-table']          |
+      | item           | $items tbody tr                              |
+      | breadcrumb     | .k-breadcrumbs                               |
+      | button-refresh | [data-testid='data-overview-refresh-button'] |
+      | navigation | .route-mesh-view-tabs ul > |
 
-  Scenario: Mesh Selection
     Given the environment
       """
       KUMA_MESH_COUNT: 2
@@ -18,11 +21,36 @@ Feature: mesh / index
       """
     When I visit the "/meshes" URL
 
-    When I click the "<Selector>" element
+  Scenario: Clicking a mesh and back again for <Mesh>
+
+    Then the "$item" element exists 2 times
+    Then I click the "<Selector>" element
     Then the URL contains "/mesh/<Mesh>"
-    And the "$mesh-breadcrumb" element contains "<Mesh>"
+    And the "$breadcrumb" element contains "<Mesh>"
+
+
+    Then I click the "$navigation li:nth-child(2) a" element
+    Then I click the "$navigation li:nth-child(3) a" element
+    Then I click the "$navigation li:nth-child(4) a" element
+    Then I click the "$navigation li:nth-child(5) a" element
+    Then I click the "$navigation li:nth-child(1) a" element
+
+    And I click the "$breadcrumb li:nth-child(1) a" element
+    Then the "$item" element exists 2 times
 
     Examples:
       | Mesh         | Selector |
-      | another-mesh | [data-testid='data-overview-table'] tbody tr:nth-child(2) [data-testid='detail-view-link'] |
-      | default      | [data-testid='data-overview-table'] tbody tr:nth-child(1) [data-testid='detail-view-link'] |
+      | another-mesh | $item:nth-child(2) a |
+      | default      | $item:nth-child(1) a |
+
+  Scenario: Refreshing the listing
+    Then the "$item" element exists 2 times
+    Given the environment
+      """
+      KUMA_MESH_COUNT: 10
+      """
+    And the URL "/meshes" responds with
+      """
+      """
+    Then I click the "$button-refresh" element
+    Then the "$item" element exists 10 times

--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -6,8 +6,8 @@ Feature: The create Zone flow works
       | create-zone-button                  | [data-testid='create-zone-button']                  |
       | environment-universal-radio-button  | [data-testid='environment-universal-radio-button']  |
       | environment-kubernetes-radio-button | [data-testid='environment-kubernetes-radio-button'] |
-      | ingress-input-switch                | [data-testid='ingress-input-switch']                |
-      | egress-input-switch                 | [data-testid='egress-input-switch']                 |
+      | ingress-input-switch                | [for='zone-ingress-enabled']                |
+      | egress-input-switch                 | [for='zone-egress-enabled']                 |
       | zone-connected-scanner              | [data-testid='zone-connected-scanner']              |
     When I visit the "/zones/create" URL
 
@@ -46,21 +46,21 @@ Feature: The create Zone flow works
       """
     Then the "$environment-universal-radio-button" element isn't checked
     Then the "$environment-kubernetes-radio-button" element is checked
-    Then the "$ingress-input-switch" element is checked
-    Then the "$egress-input-switch" element is checked
+    Then the "$ingress-input-switch input" element is checked
+    Then the "$egress-input-switch input" element is checked
     Then the "$zone-connected-scanner" element contains "Waiting for Zone to be connected"
 
     When I click the "$ingress-input-switch" element
-    Then the "$ingress-input-switch" element isn't checked
-    Then the "$egress-input-switch" element is checked
+    Then the "$ingress-input-switch input" element isn't checked
+    Then the "$egress-input-switch input" element is checked
 
     When I click the "$egress-input-switch" element
-    Then the "$ingress-input-switch" element isn't checked
-    Then the "$egress-input-switch" element isn't checked
+    Then the "$ingress-input-switch input" element isn't checked
+    Then the "$egress-input-switch input" element isn't checked
 
-    When I click the "$environment-universal-radio-button" element
-    Then the "$ingress-input-switch" element doesn't exist
-    Then the "$egress-input-switch" element doesn't exist
+    When I click the "$environment-universal-radio-button + label" element
+    Then the "$ingress-input-switch input" element doesn't exist
+    Then the "$egress-input-switch input" element doesn't exist
 
     When the URL "/zones+insights/test" responds with
       """

--- a/src/app/meshes/views/MeshView.vue
+++ b/src/app/meshes/views/MeshView.vue
@@ -1,7 +1,10 @@
 <template>
   <RouteView>
     <AppView>
-      <NavTabs :tabs="tabs" />
+      <NavTabs
+        class="route-mesh-view-tabs"
+        :tabs="tabs"
+      />
 
       <RouterView
         v-slot="child"


### PR DESCRIPTION
TLDR; Tweaks Cypress click and adds some tests for Mesh Tabs

---

This PR began as adding further tests to our Mesh page/Tabs, but led to something else.

I've left the tests in here that led to these changes to provide context and easier repro of the issue if thats something people want to do.

More info:

Whilst writing a test click through multiple tabs in a single page (see https://github.com/kumahq/kuma-gui/pull/1070/files#diff-b0fab4bf9af5f7083dc7f148815082ea223aaeab7f5a7785d5889c4368ee086aR32) I came across a Cypress error related to the element that was selected having changed between it being selected and then trying to click on it.

I believe this is related to 2 issues, one of which I can fix relatively easily here. (The other is potentially related to how our application is built that I don't 100% understand as yet and not worth going into as yet incase I'm barking up the wrong tree, but feel free to ask).

Removing the Cypress "fake promise" here:

```javascript
    $(selector).then(($el) => {
      const el = $el[0]
      const label = getLabel(el)

      cy.wrap(label ?? el).click()
    })
```
...between the selection and the click/event solved the immediate Cypress issue for me, and felt like the description of the error message I was getting.

I also had to fix up places in the zone tests where we where clicking on input elements instead of labels, which was the reasoning behind having this Cypress code in the first place (see https://github.com/kumahq/kuma-gui/pull/869#discussion_r1188817896 for some more convo). I think this is the only place where we do this but I'm about to check elsewhere to see if there's further similar work required there.

This then got deeper.

I also noticed that `{ force: true }` was also removed in the above https://github.com/kumahq/kuma-gui/pull/869 PR, which was also proving problematic. I decided to re-add this here as it fixes a flake and is in the exact same code I'm changing and is "fix Cypress clicking". I also originally put this code back to how it was here https://github.com/kumahq/kuma-gui/blob/971c0ab364ece32a96017129f2f2bb9896ab76f4/cypress/support/step_definitions/index.ts#L68

This then got deeper.

I found that using `trigger('click')` does not have the exact same effect as `.click()` and seemed to add further test issues, which was very surprising/interesting to me.

To avoid going deeper into that rabbit hole I decided here was a good time to PR this as everything seems to be at the least problematic point (I could prove that the mixture of no promises/force and click didn't fail any tests)

A last note on `force: true`, I agree that ideally we wouldn't have to do this, but at this point having it is solving way more problems than it causes (it's not caused a single one yet).

P.S. sorry! just wanted to note that I'll probably tweak these actual tests a little more in a follow up PR.




