### PR TITLE
chore: Make RestClient injectable, removes credentials: include

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,6 +87,7 @@ const INLINE_NON_VOID_ELEMENTS = [
         caseInsensitive: true,
       },
     }],
+    'no-useless-constructor': 'off',
   },
   overrides: [
     {

--- a/src/services/kuma-api/Api.ts
+++ b/src/services/kuma-api/Api.ts
@@ -1,16 +1,10 @@
 import { RestClient } from './RestClient'
-import type { EnvVars } from '@/services/env/Env'
+import type Env from '@/services/env/Env'
 
-type Env = (
-  key: keyof Pick<EnvVars,
-  'KUMA_API_URL' |
-  'KUMA_VERSION_URL'
-  >
-) => string
 export class Api {
   constructor(
     protected client: RestClient,
-    protected env: Env,
+    protected env: Env['var'],
   ) {}
 
   get baseUrl() {

--- a/src/services/kuma-api/Api.ts
+++ b/src/services/kuma-api/Api.ts
@@ -8,13 +8,10 @@ type Env = (
   >
 ) => string
 export class Api {
-  client: RestClient
-  env: Env
-
-  constructor(env: Env) {
-    this.client = new RestClient(env('KUMA_API_URL'))
-    this.env = env
-  }
+  constructor(
+    protected client: RestClient,
+    protected env: Env,
+  ) {}
 
   get baseUrl() {
     return this.client.baseUrl
@@ -27,14 +24,5 @@ export class Api {
    */
   setBaseUrl(baseUrl: string): void {
     this.client.baseUrl = baseUrl
-  }
-
-  /**
-   * Sets the default options to be used for [the fetch API’s `options` parameter][1].
-   *
-   * [1]: https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters
-   */
-  setOptions(options: RequestInit): void {
-    this.client.options = options
   }
 }

--- a/src/services/kuma-api/RestClient.spec.ts
+++ b/src/services/kuma-api/RestClient.spec.ts
@@ -9,7 +9,7 @@ describe('RestClient', () => {
   })
 
   test('has expected initial base URL', () => {
-    const restClient = new RestClient('http://localhost:5681')
+    const restClient = new RestClient(() => 'http://localhost:5681')
 
     expect(restClient.baseUrl).toBe('http://localhost:5681')
   })
@@ -18,7 +18,7 @@ describe('RestClient', () => {
     ['http://localhost:1234/api', 'http://localhost:1234/api'],
     ['http://localhost:1234/test/api', 'http://localhost:1234/test/api'],
   ])('sets expected base URL for “%s”', (newBaseUrl: string, expectedBaseUrl: string) => {
-    const restClient = new RestClient('http://localhost:5681')
+    const restClient = new RestClient(() => 'http://localhost:5681')
 
     restClient.baseUrl = newBaseUrl
 
@@ -30,7 +30,6 @@ describe('RestClient', () => {
       undefined,
       {
         method: 'GET',
-        credentials: 'include',
       },
     ],
     [
@@ -39,7 +38,6 @@ describe('RestClient', () => {
       },
       {
         method: 'GET',
-        credentials: 'include',
         params: [['tag', 'kuma.io/service:backend']],
       },
     ],
@@ -49,7 +47,6 @@ describe('RestClient', () => {
       },
       {
         method: 'GET',
-        credentials: 'include',
         params: [
           ['tag', 'kuma.io/service:backend'],
           ['tag', 'version:v1'],
@@ -63,7 +60,6 @@ describe('RestClient', () => {
       },
       {
         method: 'GET',
-        credentials: 'include',
         params: [
           ['gateway', true],
           ['tag', 'kuma.io/service:backend'],
@@ -79,7 +75,6 @@ describe('RestClient', () => {
       ],
       {
         method: 'GET',
-        credentials: 'include',
         params: [
           ['gateway', true],
           ['tag', 'kuma.io/service:backend'],
@@ -93,55 +88,8 @@ describe('RestClient', () => {
       data: null,
     }))
 
-    const restClient = new RestClient('http://localhost:5681')
+    const restClient = new RestClient(() => 'http://localhost:5681')
     restClient.raw('/path', undefined, { params })
-
-    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith('http://localhost:5681/path', expectedOptions, undefined)
-  })
-
-  test.each([
-    [
-      {
-        credentials: 'include',
-      } as RequestInit,
-      {
-        method: 'GET',
-        credentials: 'include',
-      },
-    ],
-    [
-      {
-        method: 'POST',
-        credentials: 'same-origin',
-      } as RequestInit,
-      {
-        method: 'GET', // Can’t override GET method
-        credentials: 'same-origin',
-      },
-    ],
-    [
-      {
-        headers: {
-          'Content-Type': 'text/html',
-        },
-      } as RequestInit,
-      {
-        method: 'GET',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'text/html',
-        },
-      },
-    ],
-  ])('sets fetch default options correctly', (options: RequestInit, expectedOptions) => {
-    jest.spyOn(MakeRequestModule, 'makeRequest').mockImplementation(() => Promise.resolve({
-      response: new Response(),
-      data: null,
-    }))
-
-    const restClient = new RestClient('http://localhost:5681')
-    restClient.options = options
-    restClient.get('/path')
 
     expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith('http://localhost:5681/path', expectedOptions, undefined)
   })
@@ -160,9 +108,9 @@ describe('RestClient', () => {
       data: null,
     }))
 
-    const restClient = new RestClient(baseUrlOrPath)
+    const restClient = new RestClient(() => baseUrlOrPath)
     restClient.raw(requestPath)
 
-    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith(expectedRequestUrl, { method: 'GET', credentials: 'include' }, undefined)
+    expect(MakeRequestModule.makeRequest).toHaveBeenCalledWith(expectedRequestUrl, { method: 'GET' }, undefined)
   })
 })

--- a/src/services/kuma-api/RestClient.ts
+++ b/src/services/kuma-api/RestClient.ts
@@ -1,11 +1,5 @@
 import { makeRequest } from './makeRequest'
-import type { EnvVars } from '@/services/env/Env'
-
-type Env = (
-  key: keyof Pick<EnvVars,
-  'KUMA_API_URL'
-  >
-) => string
+import type Env from '@/services/env/Env'
 
 export class RestClient {
   /**
@@ -17,7 +11,7 @@ export class RestClient {
    * @param baseUrl an absolute API base URL. **Must not have trailing slashes**.
    */
   constructor(
-    protected env: Env,
+    protected env: Env['var'],
   ) {
     this._baseUrl = env('KUMA_API_URL')
   }

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -19,6 +19,7 @@ import routes from '@/router/routes'
 import Env, { EnvArgs, EnvVars } from '@/services/env/Env'
 import I18n from '@/services/i18n/I18n'
 import KumaApi from '@/services/kuma-api/KumaApi'
+import { RestClient } from '@/services/kuma-api/RestClient'
 import Logger from '@/services/logger/Logger'
 import type { Alias, ServiceConfigurator } from '@/services/utils'
 import { token, get, constant } from '@/services/utils'
@@ -36,6 +37,7 @@ const $ = {
   enUs: token('i18n.locale.enUs'),
   kumaEnUs: token('kuma.locale.enUs'),
 
+  httpClient: token<RestClient>('httpClient'),
   api: token<KumaApi>('KumaApi'),
 
   storeConfig: token<StoreOptions<State>>('storeOptions'),
@@ -103,9 +105,16 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   }],
 
   // KumaAPI
+  [$.httpClient, {
+    service: RestClient,
+    arguments: [
+      $.env,
+    ],
+  }],
   [$.api, {
     service: KumaApi,
     arguments: [
+      $.httpClient,
       $.env,
     ],
   }],


### PR DESCRIPTION
1. Removes `credentials: include` from all our HTTP requests
2. Makes RestClient injectable.

Additionally we no longer need to tweak `options` for HTTP requests so I removed that code also, and the tests for it. If we find we need it again at a later date we can bring it back.

There is probably a certain amount of refactoring I would like to do here, but I would rather do this with as little code change as possible and come back to address any refactoring/noodling later.

Closes https://github.com/kumahq/kuma-gui/issues/799