### PR TITLE
chore: Ensures dev cookie changes don't require a refresh

### DIFF
--- a/src/services/env/CookiedEnv.ts
+++ b/src/services/env/CookiedEnv.ts
@@ -1,9 +1,9 @@
 import type { EnvVars } from './Env'
 export default (
   env: (str: keyof EnvVars, d?: string) => string,
-  cookie: string = document.cookie,
+  doc: { cookie: string } = document,
 ) => (...rest: Parameters<typeof env>) => {
-  const cookies = cookie.split(';')
+  const cookies = doc.cookie.split(';')
     .map((item) => item.trim())
     .filter((item) => item !== '')
     .reduce((prev, item) => {


### PR DESCRIPTION
Previously, during dev, you would have to refresh the page for `env` to read changed cookies, i.e. it would only read the cookies at init.

This amends it so `env` reads cookies on the fly without a browser refresh making it handier for debugging.
