### PR TITLE
fix: not cards missing border radius

### DIFF
--- a/src/app/common/NavTabs.vue
+++ b/src/app/common/NavTabs.vue
@@ -3,6 +3,7 @@
     :tabs="kTabs"
     :model-value="currentTabHash"
     :has-panels="false"
+    class="nav-tabs"
     data-testid="nav-tabs"
   >
     <template
@@ -63,3 +64,9 @@ const currentTabHash = computed(() => {
   return '#' + routeName
 })
 </script>
+
+<style lang="scss" scoped>
+.nav-tabs {
+  margin-bottom: var(--AppGap);
+}
+</style>

--- a/src/assets/styles/_components.scss
+++ b/src/assets/styles/_components.scss
@@ -6,7 +6,7 @@ To be used in places where we solely need KCard’s frame properties.
 
 .kcard-border {
   border: var(--KCardBorder);
-  border-radius: --KCardBorderRadius;
+  border-radius: var(--KCardBorderRadius);
   background-color: var(--KCardBackground);
 }
 


### PR DESCRIPTION
## Changes

Fixes cards often missing the intended border radius on account of a custom property being set incorrectly.

Also adds a bottom margin to `NavTabs` as the double-border issue would now look particularly bad.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Screenshots

Before:

![Screenshot from 2023-06-22 09-56-13](https://github.com/kumahq/kuma-gui/assets/5774638/b988510a-4e0a-4288-8574-43ee0acfe621)

After:

![Screenshot from 2023-06-22 09-56-03](https://github.com/kumahq/kuma-gui/assets/5774638/3052adb3-a12b-42d6-bd9a-a9643333cfa6)
