### PR TITLE
chore: disables logger in prod, enables console logger in dev (#1102)

### DIFF
--- a/src/services/development.ts
+++ b/src/services/development.ts
@@ -1,9 +1,9 @@
 import { setupWorker, MockedRequest, rest } from 'msw'
 
+import Logger from './logger/Logger'
 import cookied from '@/services/env/CookiedEnv'
 import type Env from '@/services/env/Env'
 import debugI18n from '@/services/i18n/DebugI18n'
-import createDisabledLogger from '@/services/logger/DisabledLogger'
 import { token, get } from '@/services/utils'
 import type { ServiceConfigurator, ReturnDecorated, Decorator, Alias, Token, TokenType } from '@/services/utils'
 import type { FS } from '@/test-support'
@@ -67,10 +67,8 @@ export const services: ServiceConfigurator<SupportedTokens> = (app) => [
     decorates: app.env,
   }],
 
-  [token<ReturnType<typeof createDisabledLogger>>('logger.disabled'), {
-    service: () => {
-      return createDisabledLogger()
-    },
+  [token<Logger>('logger'), {
+    service: Logger,
     decorates: app.logger,
   }],
 

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -1,6 +1,7 @@
 import { RouteRecordRaw } from 'vue-router'
 import { createStore, StoreOptions, Store } from 'vuex'
 
+import createDisabledLogger from './logger/DisabledLogger'
 import { useApp, useBootstrap } from '../index'
 import { routes as dataplaneRoutes } from '@/app/data-planes'
 import { routes as diagnosticsRoutes } from '@/app/diagnostics'
@@ -112,7 +113,7 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
 
   // Logger
   [$.logger, {
-    service: Logger,
+    service: createDisabledLogger,
   }],
 
   // Store


### PR DESCRIPTION
Disables the logger service in prod. Enables the logger service in dev.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Note: Let’s wait with merging this until the release of 2.3 is complete to not interfere with that.
