### PR TITLE
chore: Removes last vestiges of old store based titling

### DIFF
--- a/src/app/data-planes/locales/en-us/index.yaml
+++ b/src/app/data-planes/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 data-planes:
   routes:
     item:
-      title: Data plane proxy
+      title: "{name} Data plane proxy"
       breadcrumbs: Data plane proxies
     items:
       title: Data plane proxies

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -50,13 +50,11 @@ import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { useStore } from '@/store/store'
 import { DataPlane, DataPlaneOverview } from '@/types/index.d'
 import { useKumaApi, useI18n } from '@/utilities'
 
 const kumaApi = useKumaApi()
 const route = useRoute()
-const store = useStore()
 const { t } = useI18n()
 
 const dataPlane = ref<DataPlane | null>(null)
@@ -108,5 +106,4 @@ watch(() => route.params.dataPlane, function () {
 
 loadData()
 
-store.dispatch('updatePageTitle', route.params.dataPlane)
 </script>

--- a/src/app/gateways/locales/en-us/index.yaml
+++ b/src/app/gateways/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 gateways:
   routes:
     item:
-      title: Gateway
+      title: "{name} Gateway"
       breadcrumbs: Gateways
     items:
       title: Gateways

--- a/src/app/meshes/locales/en-us/index.yaml
+++ b/src/app/meshes/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 meshes:
   routes:
     item:
-      title: "{name}"
+      title: "{name} Mesh"
       breadcrumbs: Meshes
       navigation:
         mesh-overview-view: Overview

--- a/src/app/policies/locales/en-us/index.yaml
+++ b/src/app/policies/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 policies:
   routes:
     item:
-      title: Policy
+      title: "{name} Policy"
       breadcrumbs: Policies
     items:
       title: "{name}"

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -1,10 +1,10 @@
 <template>
   <RouteView
-    v-slot="{route: _route}"
+    v-slot="{route}"
     module="policies"
   >
     <RouteTitle
-      :title="t('policies.routes.item.title')"
+      :title="t('policies.routes.item.title', {name: route.params.policy})"
     />
     <AppView
       :breadcrumbs="[
@@ -12,8 +12,8 @@
           to: {
             name: 'policies-list-view',
             params: {
-              mesh: _route.params.mesh,
-              policyPath: _route.params.policyPath,
+              mesh: route.params.mesh,
+              policyPath: route.params.policyPath,
             },
           },
           text: t('policies.routes.item.breadcrumbs')
@@ -33,7 +33,6 @@
 
 <script lang="ts" setup>
 import { computed } from 'vue'
-import { useRoute } from 'vue-router'
 
 import PolicyDetails from '../components/PolicyDetails.vue'
 import AppView from '@/app/application/components/app-view/AppView.vue'
@@ -41,7 +40,6 @@ import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import { useStore } from '@/store/store'
 import { useI18n } from '@/utilities'
-const route = useRoute()
 const store = useStore()
 const { t } = useI18n()
 
@@ -53,9 +51,4 @@ const props = defineProps<{
 
 const policyType = computed(() => store.state.policyTypesByPath[props.policyPath])
 
-start()
-
-function start() {
-  store.dispatch('updatePageTitle', route.params.policy)
-}
 </script>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -187,14 +187,6 @@ watch(() => route.params.mesh, function () {
 start()
 
 async function start() {
-  const policyType = store.state.policyTypesByPath[props.policyPath]
-
-  if (policyType !== undefined) {
-    // Makes sure to reset the title before setting it again so we’re sure it is applied.
-    await store.dispatch('updatePageTitle', '')
-    await store.dispatch('updatePageTitle', policyType.name)
-  }
-
   loadData(props.offset)
 }
 

--- a/src/app/services/locales/en-us/index.yaml
+++ b/src/app/services/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 services:
   routes:
     item:
-      title: Service
+      title: "{name} Service"
       breadcrumbs: Services
     items:
       title: Services

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -55,7 +55,6 @@ import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import { FilterFields } from '@/app/common/KFilterBar.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { useStore } from '@/store/store'
 import { DataPlaneOverviewParameters } from '@/types/api.d'
 import { DataPlaneOverview, ExternalService, ServiceInsight } from '@/types/index.d'
 import { useKumaApi, useI18n } from '@/utilities'
@@ -63,7 +62,6 @@ import { QueryParameter } from '@/utilities/QueryParameter'
 
 const kumaApi = useKumaApi()
 const route = useRoute()
-const store = useStore()
 const { t } = useI18n()
 
 const DPP_FILTER_FIELDS: FilterFields = {
@@ -106,8 +104,6 @@ watch(() => route.params.name, function () {
 })
 
 function start() {
-  store.dispatch('updatePageTitle', route.params.service)
-
   const filterFields = QueryParameter.get('filterFields')
   const dppParams = filterFields !== null ? JSON.parse(filterFields) as DataPlaneOverviewParameters : {}
 

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -1,7 +1,15 @@
+zone-cps:
+  routes:
+    item:
+      title: "{name} Zone CP"
+      breadcrumbs: Zone CPs
+    items:
+      title: Zone CPs
+      breadcrumbs: Zone CPs
 zone-ingresses:
   routes:
     item:
-      title: Zone Ingress
+      title: "{name} Zone Ingress"
       breadcrumbs: Zone Ingresses
     items:
       title: Zone Ingresses
@@ -9,7 +17,7 @@ zone-ingresses:
 zone-egresses:
   routes:
     item:
-      title: Zone Egress
+      title: "{name} Zone Egress"
       breadcrumbs: Zone Egresses
     items:
       title: Zone Egresses
@@ -131,11 +139,3 @@ zones:
       proceedText: 'Yes, delete'
       title: 'Delete Zone'
       errorText: 'An unexpected error occurred'
-zone-cps:
-  routes:
-    item:
-      title: Zone CP
-      breadcrumbs: Zone CPs
-    items:
-      title: Zone CPs
-      breadcrumbs: Zone CPs

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -1,7 +1,9 @@
 <template>
-  <RouteView>
+  <RouteView
+    v-slot="{route: _route}"
+  >
     <RouteTitle
-      :title="t('zone-cps.routes.item.title')"
+      :title="t('zone-cps.routes.item.title', {name: _route.params.zone})"
     />
     <AppView
       :breadcrumbs="[
@@ -46,13 +48,11 @@ import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { useStore } from '@/store/store'
 import type { ZoneOverview } from '@/types/index.d'
 import { useKumaApi, useI18n } from '@/utilities'
 
 const kumaApi = useKumaApi()
 const route = useRoute()
-const store = useStore()
 const { t } = useI18n()
 
 const zoneOverview = ref<ZoneOverview | null>(null)
@@ -76,8 +76,6 @@ watch(() => route.params.name, function () {
 start()
 
 function start() {
-  store.dispatch('updatePageTitle', route.params.zone)
-
   loadData()
 }
 

--- a/src/app/zones/views/ZoneEgressDetailView.vue
+++ b/src/app/zones/views/ZoneEgressDetailView.vue
@@ -1,7 +1,9 @@
 <template>
-  <RouteView>
+  <RouteView
+    v-slot="{route: _route}"
+  >
     <RouteTitle
-      :title="t('zone-egresses.routes.item.title')"
+      :title="t('zone-egresses.routes.item.title', {name: _route.params.zoneEgress})"
     />
     <AppView
       :breadcrumbs="[
@@ -46,13 +48,11 @@ import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { useStore } from '@/store/store'
 import type { ZoneEgressOverview } from '@/types/index.d'
 import { useKumaApi, useI18n } from '@/utilities'
 
 const kumaApi = useKumaApi()
 const route = useRoute()
-const store = useStore()
 const { t } = useI18n()
 
 const zoneEgressOverview = ref<ZoneEgressOverview | null>(null)
@@ -76,8 +76,6 @@ watch(() => route.params.name, function () {
 start()
 
 function start() {
-  store.dispatch('updatePageTitle', route.params.zoneEgress)
-
   loadData()
 }
 

--- a/src/app/zones/views/ZoneIngressDetailView.vue
+++ b/src/app/zones/views/ZoneIngressDetailView.vue
@@ -1,7 +1,9 @@
 <template>
-  <RouteView>
+  <RouteView
+    v-slot="{ route: _route }"
+  >
     <RouteTitle
-      :title="t('zone-ingresses.routes.item.title')"
+      :title="t('zone-ingresses.routes.item.title', {name: _route.params.zoneIngress})"
     />
     <AppView
       :breadcrumbs="[
@@ -46,13 +48,11 @@ import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { useStore } from '@/store/store'
 import type { ZoneIngressOverview } from '@/types/index.d'
 import { useKumaApi, useI18n } from '@/utilities'
 
 const kumaApi = useKumaApi()
 const route = useRoute()
-const store = useStore()
 const { t } = useI18n()
 
 const zoneIngressOverview = ref<ZoneIngressOverview | null>(null)
@@ -76,8 +76,6 @@ watch(() => route.params.name, function () {
 start()
 
 function start() {
-  store.dispatch('updatePageTitle', route.params.zoneIngress)
-
   loadData()
 }
 

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -45,7 +45,6 @@ interface BareRootState {
     notificationManager: boolean
     onboardingNotification: boolean
   }
-  pageTitle: string
   meshes: {
     items: Mesh[]
     total: number
@@ -100,7 +99,6 @@ const initialState: BareRootState = {
     notificationManager: true,
     onboardingNotification: true,
   },
-  pageTitle: '',
   meshes: {
     total: 0,
     items: [],
@@ -225,7 +223,6 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
 
     mutations: {
       SET_GLOBAL_LOADING: (state, globalLoading: typeof state.globalLoading) => (state.globalLoading = globalLoading),
-      SET_PAGE_TITLE: (state, pageTitle: typeof state.pageTitle) => (state.pageTitle = pageTitle),
       SET_MESHES: (state, meshes: typeof state.meshes) => (state.meshes = meshes),
       SET_SELECTED_MESH: (state, mesh: typeof state.selectedMesh) => (state.selectedMesh = mesh),
       SET_TOTAL_DATAPLANE_COUNT: (state, totalDataplaneCount: typeof state.totalDataplaneCount) => (state.totalDataplaneCount = totalDataplaneCount),
@@ -320,10 +317,6 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
             await dispatch('updateSelectedMesh', null)
           }
         }
-      },
-
-      updatePageTitle({ commit }, pageTitle: string) {
-        commit('SET_PAGE_TITLE', pageTitle)
       },
 
       async fetchMeshList({ commit, state }) {


### PR DESCRIPTION
I saw some bits of the old store based titling still existed but didn't really do anything anymore, so I went through and cleaned up.

While I was there I made it so all "detail" pages use the form `name-of-the-specific-thing Type of thing` (e.g. `program-0 Data plane proxy`) consistently. The shouldn't/doesn't require test amends seeing as we check titles contain the text rather than equals the text.

Just to note I much like the fact that we are getting rid of more code here and its much easier and more obvious how to set the title of the page, a small thing but all these little small improvements will gradually add up.

Signed-off-by: John Cowen <john.cowen@konghq.com>