### PR TITLE
refactor: types service tokens

### DIFF
--- a/cypress/main.ts
+++ b/cypress/main.ts
@@ -1,16 +1,20 @@
 import { TOKENS as DEV_TOKENS, services as development } from '@/services/development'
-import { TOKENS, services as e2e } from '@/services/e2e'
-import { build, token } from '@/services/utils'
+import { TOKENS as E2E_TOKENS, services as e2e } from '@/services/e2e'
+import { build } from '@/services/utils'
+
+/**
+ * Note: This service *should* be constructed with the chain "production + development + e2e" (for the token creation and the service build call). However, our Cypress setup currently doesn’t handle .vue files (discovered via the routes service) and the way to “solve” this is for our tests is to not include the production service. That makes it necessary to use `@ts-ignore` below as the types expect the tokens from the production service that are missing here.
+ */
 
 (async () => {
   const $ = {
-    // cypress doesn't need i18n but this quietens TS temporarily
-    i18n: token('i18n'),
     ...DEV_TOKENS,
-    ...TOKENS,
+    ...E2E_TOKENS,
   }
   build(
+    // @ts-ignore
     development($),
+    // @ts-ignore
     e2e($),
   )
 })()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,28 +1,28 @@
-import { TOKENS as $, services as production } from '@/services/production'
+import { TOKENS as PROD_TOKENS, services as production } from '@/services/production'
 import { build } from '@/services/utils'
 
 async function mountVueApplication() {
   const get = build(
     // production service container configuration
-    production($),
+    production(PROD_TOKENS),
     // any DEV-time only service container configuration
     import.meta.env.MODE !== 'production'
       ? await (async () => {
         const dev = await import('@/services/development')
         return dev.services({
-          ...$,
+          ...PROD_TOKENS,
           ...dev.TOKENS,
         })
       })()
       : [],
   )
 
-  const app = await get($.app)((await import('./app/App.vue')).default)
+  const app = await get(PROD_TOKENS.app)((await import('./app/App.vue')).default)
   app.mount('#app')
 
-  const store = get($.store)
+  const store = get(PROD_TOKENS.store)
   await store.dispatch('updateGlobalLoading', true)
-  const bootstrap = get($.bootstrap)
+  const bootstrap = get(PROD_TOKENS.bootstrap)
   await bootstrap()
   await store.dispatch('updateGlobalLoading', false)
 }

--- a/src/services/development.ts
+++ b/src/services/development.ts
@@ -4,8 +4,9 @@ import Logger from './logger/Logger'
 import cookied from '@/services/env/CookiedEnv'
 import type Env from '@/services/env/Env'
 import debugI18n from '@/services/i18n/DebugI18n'
+import type { ProductionTokens } from '@/services/production'
 import { token, get } from '@/services/utils'
-import type { ServiceConfigurator, ReturnDecorated, Decorator, Alias, Token, TokenType } from '@/services/utils'
+import type { ServiceConfigurator, ReturnDecorated, Decorator, Alias, TokenType } from '@/services/utils'
 import type { FS } from '@/test-support'
 import { fakeApi } from '@/test-support'
 import { fs } from '@/test-support/mocks/fs'
@@ -23,17 +24,11 @@ const $ = {
   fakeFS: token<FS>('fake.fs'),
   kumaFS: token<FS>('fake.fs.kuma'),
 }
-type I18n = ReturnType<typeof debugI18n>
-type SupportedTokens = {
-  Env: Token
-  EnvVars: Token
-  i18n: Token
-  logger: Token
-  msw: Token
-  bootstrap: Token
-  env: Token<Alias<Env['var']>>
-}
+export type DevelopmentTokens = typeof $
 
+type I18n = ReturnType<typeof debugI18n>
+
+type SupportedTokens = ProductionTokens & DevelopmentTokens
 export const services: ServiceConfigurator<SupportedTokens> = (app) => [
 
   [token<Decorator<typeof app.bootstrap>>('bootstrap.with.mockServer'), {

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -67,7 +67,9 @@ const $ = {
   app: token<ReturnType<typeof useApp>>('app'),
   bootstrap: token<ReturnType<typeof useBootstrap>>('bootstrap'),
 }
-type SupportedTokens = typeof $
+export type ProductionTokens = typeof $
+
+type SupportedTokens = ProductionTokens
 export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   // Env
   [$.EnvVars, {

--- a/src/services/testing.ts
+++ b/src/services/testing.ts
@@ -2,16 +2,21 @@ import { setupServer } from 'msw/node'
 
 import createDisabledLogger from './logger/DisabledLogger'
 import { Alias, ServiceConfigurator, token } from './utils'
+import type { DevelopmentTokens } from '@/services/development'
 import CliEnv from '@/services/env/CliEnv'
 import Logger from '@/services/logger/Logger'
+import type { ProductionTokens } from '@/services/production'
 import { mocker, fakeApi, FS } from '@/test-support'
 import type { Mocker } from '@/test-support'
 
 const $ = {
   mock: token<Mocker>('mocker'),
 }
+export type TestingTokens = typeof $
 
-export const services: ServiceConfigurator = (app) => [
+type SupportedTokens = ProductionTokens & DevelopmentTokens & TestingTokens
+
+export const services: ServiceConfigurator<SupportedTokens> = (app) => [
   [token<Logger>('logger'), {
     service: createDisabledLogger,
     decorates: app.logger,


### PR DESCRIPTION
## Changes

Exports a type for a service’s _specific_ tokens so that other services can easily create a `ServiceConfigurator<SupportedTokens>` type for their own service definition. This makes it much easier to work with composed services and stops us from needing to add artificial `service: Token` types just to satisfy the TypeScript compiler.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

- Initially I tried adding the production service to the Cypress `build` call, but that leads to errors related to stuff Cypress can’t handle presently (i.e. in our setup: the presence of .vue files in the router). However, now that the `build` calls will have stricter type checking for the services and their tokens, leaving it out causes errors. For now I `@ts-ignore`d the two erros in the Cypress entrypoint. Not great, might work.