### PR TITLE
chore: removes unnecessary route watchers

### DIFF
--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import DataPlaneDetails from '../components/DataPlaneDetails.vue'
@@ -69,6 +69,9 @@ const props = defineProps({
     default: false,
   },
 })
+
+loadData()
+
 async function loadData() {
   error.value = null
   isLoading.value = true
@@ -91,19 +94,4 @@ async function loadData() {
     isLoading.value = false
   }
 }
-
-watch(() => route.params.mesh, function () {
-  if (route.name === 'data-plane-detail-view') {
-    loadData()
-  }
-})
-
-watch(() => route.params.dataPlane, function () {
-  if (route.name === 'data-plane-detail-view') {
-    loadData()
-  }
-})
-
-loadData()
-
 </script>

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import DataPlaneList from '../components/DataPlaneList.vue'
@@ -91,15 +91,6 @@ const dppFilterFields = computed(() => {
     ...BASE_FILTER_FIELDS,
     ...(props.isGatewayView ? GATEWAY_FILTER_FIELDS : DPP_FILTER_FIELDS),
   }
-})
-
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== 'data-planes-list-view' && route.name !== 'gateways-list-view') {
-    return
-  }
-
-  loadData(0)
 })
 
 function start() {

--- a/src/app/meshes/components/MeshCharts.vue
+++ b/src/app/meshes/components/MeshCharts.vue
@@ -12,7 +12,7 @@
 
 <script lang="ts" setup>
 import semverCompare from 'semver/functions/compare'
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import DoughnutChart from '@/app/common/charts/DoughnutChart.vue'
@@ -165,17 +165,15 @@ const envoyVersionsChartData = computed(() => {
   }
 })
 
-watch(() => route.params.mesh, function (newMesh) {
-  if (typeof newMesh === 'string') {
-    loadData(newMesh)
-  }
-}, { immediate: true })
+loadData()
 
-async function loadData(mesh: string) {
+async function loadData() {
   isLoading.value = true
 
+  const name = route.params.mesh as string
+
   try {
-    const originalMeshInsight = await kumaApi.getMeshInsights({ name: mesh })
+    const originalMeshInsight = await kumaApi.getMeshInsights({ name })
     const meshInsight = mergeInsightsReducer([originalMeshInsight])
 
     setDataPlaneProxyStatus(meshInsight)

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -33,8 +33,8 @@
 </template>
 
 <script lang="ts" setup>
-import { PropType, ref, watch } from 'vue'
-import { RouteLocationNamedRaw, useRoute } from 'vue-router'
+import { PropType, ref } from 'vue'
+import { RouteLocationNamedRaw } from 'vue-router'
 
 import AppView from '@/app/application/components/app-view/AppView.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
@@ -57,8 +57,6 @@ const EMPTY_STATE = {
   title: t('common.emptyState.title'),
   message: t('common.emptyState.message', { type: 'Meshes' }),
 }
-
-const route = useRoute()
 
 const props = defineProps({
   selectedMeshName: {
@@ -84,15 +82,6 @@ const tableData = ref<{ headers: TableHeader[], data: MeshTableRow[] }>({
 })
 const nextUrl = ref<string | null>(null)
 const pageOffset = ref(props.offset)
-
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== 'mesh-list-view') {
-    return
-  }
-
-  loadData(0)
-})
 
 start()
 

--- a/src/app/meshes/views/MeshOverviewView.vue
+++ b/src/app/meshes/views/MeshOverviewView.vue
@@ -109,7 +109,7 @@
 
 <script lang="ts" setup>
 import { KBadge, KCard } from '@kong/kongponents'
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import MeshCharts from '../components/MeshCharts.vue'
@@ -181,15 +181,6 @@ const policyCounts = computed(() => {
     ...policyType,
     length: meshInsights.value?.policies[policyType.name]?.total ?? 0,
   }))
-})
-
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== 'single-mesh-overview') {
-    return
-  }
-
-  loadMesh()
 })
 
 loadMesh()

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -98,7 +98,7 @@ import {
   KSelect,
   SelectItem,
 } from '@kong/kongponents'
-import { computed, PropType, ref, watch } from 'vue'
+import { computed, PropType, ref } from 'vue'
 import { RouteLocationNamedRaw, useRoute, useRouter } from 'vue-router'
 
 import PolicyDetails from '../components/PolicyDetails.vue'
@@ -172,15 +172,6 @@ const policyTypeNamesWithNoPolicies = computed(() => {
   return store.state.policyTypes
     .filter((policyType) => (store.state.sidebar.insights.mesh.policies[policyType.name] ?? 0) === 0)
     .map((policyType) => policyType.name)
-})
-
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== props.policyPath) {
-    return
-  }
-
-  loadData(0)
 })
 
 start()

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import ServiceDetails from '../components/ServiceDetails.vue'
@@ -85,23 +85,7 @@ const dataPlaneOverviews = ref<DataPlaneOverview[] | null>(null)
 const isLoading = ref(true)
 const error = ref<Error | null>(null)
 
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== 'service-detail-view') {
-    return
-  }
-
-  loadData(0)
-})
-
-watch(() => route.params.name, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== 'service-detail-view') {
-    return
-  }
-
-  loadData(0)
-})
+start()
 
 function start() {
   const filterFields = QueryParameter.get('filterFields')
@@ -109,8 +93,6 @@ function start() {
 
   loadData(0, dppParams)
 }
-
-start()
 
 async function loadData(offset: number, dppParams: DataPlaneOverviewParameters = {}) {
   isLoading.value = true

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { useRoute, RouteLocationNamedRaw } from 'vue-router'
 
 import ServiceSummary from '../components/ServiceSummary.vue'
@@ -96,15 +96,6 @@ const externalService = ref<ExternalService | null>(null)
 const tableData = ref<{ headers: TableHeader[], data: ServiceInsightTableRow[] }>({
   headers,
   data: [],
-})
-
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== 'services-list-view') {
-    return
-  }
-
-  loadData(0)
 })
 
 loadData(props.offset)

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import ZoneDetails from '../components/ZoneDetails.vue'
@@ -58,20 +58,6 @@ const { t } = useI18n()
 const zoneOverview = ref<ZoneOverview | null>(null)
 const isLoading = ref(true)
 const error = ref<Error | null>(null)
-
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name === 'zone-cp-detail-view') {
-    loadData()
-  }
-})
-
-watch(() => route.params.name, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name === 'zone-cp-detail-view') {
-    loadData()
-  }
-})
 
 start()
 

--- a/src/app/zones/views/ZoneEgressDetailView.vue
+++ b/src/app/zones/views/ZoneEgressDetailView.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import ZoneEgressDetails from '../components/ZoneEgressDetails.vue'
@@ -58,20 +58,6 @@ const { t } = useI18n()
 const zoneEgressOverview = ref<ZoneEgressOverview | null>(null)
 const isLoading = ref(true)
 const error = ref<Error | null>(null)
-
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name === 'zone-egress-detail-view') {
-    loadData()
-  }
-})
-
-watch(() => route.params.name, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name === 'zone-egress-detail-view') {
-    loadData()
-  }
-})
 
 start()
 

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -45,8 +45,8 @@
 </template>
 
 <script lang="ts" setup>
-import { PropType, ref, watch } from 'vue'
-import { RouteLocationNamedRaw, useRoute } from 'vue-router'
+import { PropType, ref } from 'vue'
+import { RouteLocationNamedRaw } from 'vue-router'
 
 import ZoneEgressDetails from '../components/ZoneEgressDetails.vue'
 import AppView from '@/app/application/components/app-view/AppView.vue'
@@ -72,8 +72,6 @@ const EMPTY_STATE = {
   title: 'No Data',
   message: 'There are no Zone Egresses present.',
 }
-
-const route = useRoute()
 
 const props = defineProps({
   selectedZoneEgressName: {
@@ -101,15 +99,6 @@ const tableData = ref<{ headers: TableHeader[], data: ZoneEgressOverviewTableRow
 const entity = ref<ZoneEgressOverview | null>(null)
 const nextUrl = ref<string | null>(null)
 const pageOffset = ref(props.offset)
-
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== 'zone-egress-list-view') {
-    return
-  }
-
-  loadData(0)
-})
 
 loadData(props.offset)
 

--- a/src/app/zones/views/ZoneIngressDetailView.vue
+++ b/src/app/zones/views/ZoneIngressDetailView.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import ZoneIngressDetails from '../components/ZoneIngressDetails.vue'
@@ -58,20 +58,6 @@ const { t } = useI18n()
 const zoneIngressOverview = ref<ZoneIngressOverview | null>(null)
 const isLoading = ref(true)
 const error = ref<Error | null>(null)
-
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name === 'zone-ingress-detail-view') {
-    loadData()
-  }
-})
-
-watch(() => route.params.name, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name === 'zone-ingress-detail-view') {
-    loadData()
-  }
-})
 
 start()
 

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -52,7 +52,7 @@
 
 <script lang="ts" setup>
 import { PropType, ref, watch } from 'vue'
-import { RouteLocationNamedRaw, useRoute } from 'vue-router'
+import { RouteLocationNamedRaw } from 'vue-router'
 
 import MultizoneInfo from '../components/MultizoneInfo.vue'
 import ZoneIngressDetails from '../components/ZoneIngressDetails.vue'
@@ -81,7 +81,6 @@ const EMPTY_STATE = {
   message: 'There are no Zone Ingresses present.',
 }
 
-const route = useRoute()
 const store = useStore()
 
 const props = defineProps({
@@ -111,12 +110,6 @@ const entity = ref<ZoneIngressOverview | null>(null)
 const nextUrl = ref<string | null>(null)
 const pageOffset = ref(props.offset)
 
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name === 'zone-ingress-list-view') {
-    loadData(0)
-  }
-})
 watch(() => store.getters['config/getMulticlusterStatus'], function (isMultizoneMode) {
   if (isMultizoneMode) {
     loadData(props.offset)

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -90,7 +90,7 @@
 <script lang="ts" setup>
 import { KButton } from '@kong/kongponents'
 import { PropType, ref, watch } from 'vue'
-import { RouteLocationNamedRaw, useRoute } from 'vue-router'
+import { RouteLocationNamedRaw } from 'vue-router'
 
 import MultizoneInfo from '../components/MultizoneInfo.vue'
 import ZoneDetails from '../components/ZoneDetails.vue'
@@ -127,7 +127,6 @@ const EMPTY_STATE = {
   message: 'There are no Zones present.',
 }
 
-const route = useRoute()
 const store = useStore()
 
 const props = defineProps({
@@ -165,14 +164,6 @@ const entity = ref<ZoneOverview | null>(null)
 const nextUrl = ref<string | null>(null)
 const pageOffset = ref(props.offset)
 
-watch(() => route.params.mesh, function () {
-  // Don’t trigger a load when the user is navigating to another route.
-  if (route.name !== 'zone-cp-list-view') {
-    return
-  }
-
-  loadData(0)
-})
 watch(() => store.getters['config/getMulticlusterStatus'], function (isMultizoneMode) {
   if (isMultizoneMode) {
     loadData(props.offset)


### PR DESCRIPTION
**chore: removes unnecessary watchers from Meshes views**

Removes some unnecessary watches from Zone views as there is never a condition where these parameters can change while on such a view.

**chore: removes unnecessary watchers from Meshes views**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>