### PR TITLE
fix: Remove the fact that `items` in HTTP responses can be `null`

### DIFF
--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -8,7 +8,7 @@
  * ```
  */
 export interface ApiListResponse<ResourceType> {
-  items: ResourceType[] | null
+  items: ResourceType[]
   total: number
 }
 


### PR DESCRIPTION
See https://github.com/kumahq/kuma/issues/6639 (specifically https://github.com/kumahq/kuma/issues/6639#issuecomment-1527731778) and https://github.com/kumahq/kuma/pull/6648

I'm guessing there are a load of places where we no longer need null guards anymore. I haven't gone through and amended if there are as I'm guessing these will eventually be removed during natural tech debt work.

Signed-off-by: John Cowen <john.cowen@konghq.com>
