### PR TITLE
chore: Adds vite-remove-console plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "urlpattern-polyfill": "^9.0.0",
     "vite": "^4.3.9",
     "vite-plugin-html": "^3.2.0",
+    "vite-plugin-remove-console": "^2.1.1",
     "vite-plugin-rewrite-all": "^1.0.1",
     "vite-svg-loader": "^4.0.0",
     "vue-tsc": "^1.8.2",

--- a/vite.config.development.ts
+++ b/vite.config.development.ts
@@ -1,12 +1,25 @@
-import { defineConfig, mergeConfig, UserConfigFn, UserConfig } from 'vite'
+import { defineConfig, mergeConfig, UserConfigFn, UserConfig, Plugin } from 'vite'
 
 import { config as prodConfig } from './vite.config'
 // https://vitejs.dev/config/
 export const config: UserConfigFn = (env) => {
-  return mergeConfig(
+  const c = mergeConfig(
     prodConfig(env),
     ({
     } as UserConfig),
   )
+  deletePlugin(c.plugins, 'vite:remove-console')
+  return c
 }
 export default defineConfig(config)
+function deletePlugin(plugins: Plugin[], pluginName: string): void {
+  for (let i = plugins.length - 1; i >= 0; i--) {
+    const plugin = plugins[i]
+
+    if (Array.isArray(plugin)) {
+      deletePlugin(plugin, pluginName)
+    } else if (plugin.name === pluginName) {
+      plugins.splice(i, 1)
+    }
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { marked } from 'marked'
 import { fileURLToPath, URL } from 'url'
 import { defineConfig, UserConfigFn } from 'vite'
 import { createHtmlPlugin } from 'vite-plugin-html'
+import removeConsole from 'vite-plugin-remove-console'
 import pluginRewriteAll from 'vite-plugin-rewrite-all'
 import svgLoader from 'vite-svg-loader'
 
@@ -50,6 +51,14 @@ export const config: UserConfigFn = ({ mode }) => {
           ),
         },
       ),
+      removeConsole({
+        includes: [
+          'log',
+          'info',
+          'warn',
+          'error',
+        ],
+      }),
       createHtmlPlugin({
         inject: {
           data: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8602,6 +8602,11 @@ vite-plugin-html@^3.2.0:
     node-html-parser "^5.3.3"
     pathe "^0.2.0"
 
+vite-plugin-remove-console@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/vite-plugin-remove-console/-/vite-plugin-remove-console-2.1.1.tgz#d5e20765bba7c9bfa6e4cf818e2d9209bd2dc464"
+  integrity sha512-AQOsKl9+1YO82otwSchf+P8SRo4RhMvPjOvjm9DXOnkff0SBwBPAzazEn06IUjhsm/zX4miMgicCQH1hPdktrw==
+
 vite-plugin-rewrite-all@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vite-plugin-rewrite-all/-/vite-plugin-rewrite-all-1.0.1.tgz#ee711a3d114634abb922a0e50e56736d7e9a324a"


### PR DESCRIPTION
This PR removes any `console.log/info/warn/errors` from any production builds (this includes our e2e testing). These calls are kept when in development, including the PR preview sites.

---

Currently these calls are also kept during CLI testing as they don't use `vite` as yet, but it would nice to remove them from there also so we can just use them for development purposes.

Note: I want us to keep removing/avoiding console.logs in code/git overall, as a rule we should not leave any of these things in the code at all. But sometimes/occasionally its useful to have `console.error/info/warn` during development in code/git. It also helps if any `console.logs` somehow find their way into production code.

Personally I'm unsure whether we should remove `console.error` at all as they can be useful to users when hitting a problem with the application, especially if our in-app UI error pages are not super explanatory, so happy to hear anyones thoughts on that.

I'm adding the plugin now, but we can always remove the `error` removal later if its not what we want.

Signed-off-by: John Cowen <john.cowen@konghq.com>
