### PR TITLE
refactor: Cleans up RouteView code and adds basic docs

### DIFF
--- a/src/app/application/components/app-view/README.md
+++ b/src/app/application/components/app-view/README.md
@@ -1,0 +1,55 @@
+# AppView
+
+Similar `RouteView` the `AppView` component should be used in every routable
+`*View.vue` component. But it does not need to be used in a particular position
+although its likely that it would be a fairly close child of the `RouteView`
+component for the route:
+
+```vue
+<RouteView
+  v-slot="{route}"
+>
+  <AppView
+    :breadcrumbs="[]"
+  >
+    <h1>
+      <RouteTitle
+        :title="route.params.service"
+      />
+      {{ route.params.service }}
+    </h1>
+    ...
+  </AppView>
+</RouteView>
+```
+
+It contains functionality to set the breadcrumbs for the application.
+
+## Setting breadcrumbs for the application
+
+Only the topmost `AppView` (usually in `App.vue`) contains an instance of
+`KBreadcrumbs`, all other instances of `AppView` automatically forward its
+breadcrumbs to the top most `AppView` in order to be combined and rendered using
+`KBreadcrumbs`.
+
+Therefore you only need to specify the breadcrumbs for your `*View.vue`
+route/view component, the breadcrumbs will automatically be prepended with the
+breadcrumbs from any parent components in a nested route structure.
+
+You can of course specify mutiple breadcrumbs for a single route/view component.
+
+```vue
+<AppView
+  :breadcrumbs="[
+    {
+      to: {
+        name: 'route-name-view',
+      },
+      text: 'The Breadcrumb Text'
+    },
+  ]"
+>
+...
+</AppView>
+```
+

--- a/src/app/application/components/route-view/README.md
+++ b/src/app/application/components/route-view/README.md
@@ -1,0 +1,92 @@
+# RouteView
+
+Our `RouteView` component should be used as the top-most component for every
+routable `*View.vue` component.
+
+It contains functionality to make it easy to set top-level DOM values that you
+usually woudn't have direct access to.
+
+## Setting HTML node attributes
+
+**Note: Currently we only support setting the className if you need to add
+further attributes PRs are welcome**
+
+```vue
+<RouteView
+  :attrs="{
+    class: 'my-html-class'
+  }"
+>
+...
+</RouteView>
+```
+
+Using the `attrs` attribute in the above code will result in the following
+HTML:
+
+```html
+<html class="my-html-class">
+...
+</html>
+```
+
+The logic is careful not to remove/change any statically added attributes that
+existed on the node previously, and any attributes you add will be automatically
+removed when the `*View.vue` route/view component is removed from the page/DOM.
+
+## Setting the `<title>` of the page
+
+`RouteView` works in tandem with `RouteTitle` allowing you to set the HTML title for
+the page from anywhere in your `*View.vue` component.
+
+```vue
+<RouteView>
+  <h1>
+    <RouteTitle
+      title="The title"
+    />
+    The title
+  </h1>
+...
+</RouteView>
+```
+
+Titles are automatically joined together as you would expect in a nested route
+structure and finally suffixed by the title of the product (taken from our i18n
+strings). The above code, depending on nested routes could end up like:
+
+
+```vue
+<html>
+  <head>
+    <title>The title | Parent title | Kuma Manager</title>
+  </head>
+  ...
+</html>
+```
+
+We **currently do not render** the contents of the `title=""` attribute in the same
+place that you use the `RouteTitle`, but in the future we might. Therefore you
+would only have to set the title once, and it will be render both to the HTML
+`<title>` and to your page header (say inside a `<h1>`)
+
+## v-slot="{route}"
+
+RouteView also exports a subset of the `route`. **This is not an entire
+`vue-router` route as you know it!**. This lets you easily set titles (or other
+things) based on the route params (or load data using the route params to set
+your title)
+
+```vue
+<RouteView
+  v-slot="{route}"
+>
+  <h1>
+    <RouteTitle
+      :title="route.params.service"
+    />
+  </h1>
+...
+</RouteView>
+```
+

--- a/src/app/application/components/route-view/RouteTitle.vue
+++ b/src/app/application/components/route-view/RouteTitle.vue
@@ -8,7 +8,8 @@
 <script lang="ts" setup>
 import { inject, watch, onBeforeUnmount } from 'vue'
 
-import { RouteView } from './RouteView.vue'
+import { ROUTE_VIEW_PARENT } from '.'
+import type { RouteView } from './RouteView.vue'
 
 const props = defineProps({
   title: {
@@ -19,7 +20,9 @@ const props = defineProps({
 })
 
 const symbol = Symbol('route-title')
-const routeView: RouteView | undefined = inject('route-view-parent')
+// find the top-most RouteView so we can use it to set the title if we can't
+// find the top-most, it means we are the top-most RouteView
+const routeView: RouteView | undefined = inject(ROUTE_VIEW_PARENT)
 if (typeof routeView !== 'undefined') {
   watch(() => props.title, (title) => {
     if (title.length > 0) {

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -34,7 +34,7 @@ import { useI18n } from '@/utilities'
 const { t } = useI18n()
 const route = useRoute()
 const setTitle = createTitleSetter(document)
-const setAttrs = createAttrsSetter(document.querySelector('html'))
+const setAttrs = createAttrsSetter(document.documentElement)
 const sym = Symbol('route-view')
 
 const title = ref<string>('')

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -20,7 +20,6 @@
           ]
         }))
       }"
-      :children="children"
     />
   </div>
 </template>
@@ -28,25 +27,45 @@
 import { provide, inject, ref, watch, onBeforeUnmount } from 'vue'
 import { useRoute } from 'vue-router'
 
+import { ROUTE_VIEW_PARENT } from '.'
+import { urlParam, createAttrsSetter, createTitleSetter } from '../../utilities'
 import { useI18n } from '@/utilities'
-export interface RouteView {
-  addTitle: (title: string, sym: Symbol) => void
-  removeTitle: (sym: Symbol) => void
-  addAttrs: (attrs: Record<string, string>, sym: Symbol) => void
-  removeAttrs: (sym: Symbol) => void
-}
-export interface ImmediateParent {
-  addChild: (str: string, sym: Symbol) => void
-}
 
 const { t } = useI18n()
+const route = useRoute()
+const setTitle = createTitleSetter(document)
+const setAttrs = createAttrsSetter(document.querySelector('html'))
+const sym = Symbol('route-view')
+
+const title = ref<string>('')
+const titles = new Map<Symbol, string>()
+const attributes = new Map<Symbol, Record<string, string>>()
+
+const joinTitle = (titles: string[]) => {
+  return titles.reverse().concat(t('components.route-view.title', { name: t('common.product.name') })).join(' | ')
+}
+const routeView = {
+  addTitle: (item: string, sym: Symbol) => {
+    title.value = item
+    titles.set(sym, item)
+    setTitle(joinTitle([...titles.values()]))
+  },
+  removeTitle: (sym: Symbol) => {
+    titles.delete(sym)
+    setTitle(joinTitle([...titles.values()]))
+  },
+  addAttrs: (item: Record<string, string>, sym: Symbol) => {
+    attributes.set(sym, item)
+    setAttrs([...attributes.values()])
+  },
+  removeAttrs: (sym: Symbol) => {
+    attributes.delete(sym)
+    setAttrs([...attributes.values()])
+  },
+}
+export type RouteView = typeof routeView
 
 const props = defineProps({
-  module: {
-    type: String,
-    required: false,
-    default: '',
-  },
   attrs: {
     type: Object,
     required: false,
@@ -54,107 +73,22 @@ const props = defineProps({
   },
 })
 
-const title = ref<string>('')
-const children = ref<string[]>([])
-
-// we use a raf to avoid a flickering title
-// this can also be achieved by using onMount in AppTitle
-// but we want to keep a consistent watch/immediate api
-const beforePaint = function (fn: (...args: any[]) => void) {
-  let num: number
-  return (...args: unknown[]) => {
-    if (num) {
-      window.cancelAnimationFrame(num)
-    }
-    num = window.requestAnimationFrame(fn.bind(fn, ...args))
-  }
-}
-const setTitle = beforePaint((title) => {
-  document.title = title
-})
-const $html = document.querySelector('html')!
-const originalClasses = [...$html.classList]
-const setAttrs = beforePaint((attrs: Record<string, string>[]) => {
-  const flat = attrs.reduce<Record<string, string[]>>((prev, item) => {
-    return Object.entries(item).reduce(
-      (prev, [key, value]) => {
-        if (typeof prev[key] === 'undefined') {
-          prev[key] = []
-        }
-        prev[key].push(value)
-        return prev
-      }, prev,
-    )
-  }, {})
-
-  $html.classList.remove(...[...$html.classList].filter(item => !originalClasses.includes(item)))
-  $html.classList.add(...(flat.class || []))
-})
-
-const map = new Map<Symbol, string>()
-const attrsMap = new Map<Symbol, Record<string, string>>()
-const routeView: RouteView = {
-  addTitle: (item: string, sym: Symbol) => {
-    title.value = item
-    map.set(sym, item)
-    setTitle([...map.values()].reverse().concat(t('components.route-view.title', { name: t('common.product.name') })).join(' | '))
-  },
-  removeTitle: (sym: Symbol) => {
-    map.delete(sym)
-    setTitle([...map.values()].reverse().concat(t('components.route-view.title', { name: t('common.product.name') })).join(' | '))
-  },
-  addAttrs: (item: Record<string, string>, sym: Symbol) => {
-    attrsMap.set(sym, item)
-    setAttrs([...attrsMap.values()])
-  },
-  removeAttrs: (sym: Symbol) => {
-    attrsMap.delete(sym)
-    setAttrs([...attrsMap.values()])
-  },
-}
-
-const hasParent: RouteView | undefined = inject('route-view-parent', undefined)
+const hasParent: RouteView | undefined = inject(ROUTE_VIEW_PARENT, undefined)
 if (!hasParent) {
   // use the default title if we are the topmost RouteView
   setTitle(t('components.route-view.title', { name: t('common.product.name') }))
-  provide('route-view-parent', routeView)
+  provide(ROUTE_VIEW_PARENT, routeView)
 }
 const parent: RouteView = hasParent || routeView
-
-const iParent = inject<ImmediateParent | undefined>('route-view-immediate-parent', undefined)
-
-const immediateParent: ImmediateParent = {
-  addChild: (module, sym) => {
-    children.value.push(module)
-    if (typeof iParent !== 'undefined') {
-      iParent.addChild(module, sym)
-    }
-  },
-
-}
-provide('route-view-immediate-parent', immediateParent)
-const sym = Symbol('route-view')
-
-watch(() => props.module, (module = '') => {
-  if (
-    typeof iParent !== 'undefined' &&
-    module.length > 0
-  ) {
-    iParent.addChild(module, sym)
-  }
-}, { immediate: true })
 
 watch(() => props.attrs, (attrs) => {
   if (Object.keys(attrs).length > 0) {
     parent.addAttrs(attrs, sym)
   }
 }, { immediate: true })
+
 onBeforeUnmount(() => {
   parent.removeAttrs(sym)
 })
 
-const route = useRoute()
-const urlParam = function <T extends string | null> (param: T | T[]): string {
-  return (Array.isArray(param) ? param[0] : param) ?? ''
-}
 </script>

--- a/src/app/application/components/route-view/index.ts
+++ b/src/app/application/components/route-view/index.ts
@@ -1,0 +1,1 @@
+export const ROUTE_VIEW_PARENT = Symbol('route-view-parent')

--- a/src/app/application/utilities/index.ts
+++ b/src/app/application/utilities/index.ts
@@ -15,7 +15,7 @@ export const createTitleSetter = ($doc = document) => {
     $doc.title = title
   })
 }
-export const createAttrsSetter = ($el = document.querySelector('html')) => {
+export const createAttrsSetter = ($el = document.documentElement) => {
   if (!$el) {
     return () => {}
   }

--- a/src/app/application/utilities/index.ts
+++ b/src/app/application/utilities/index.ts
@@ -1,0 +1,39 @@
+const beforePaint = function (fn: (...args: any[]) => void) {
+  let num: number
+  return (...args: unknown[]) => {
+    if (num) {
+      window.cancelAnimationFrame(num)
+    }
+    num = window.requestAnimationFrame(fn.bind(fn, ...args))
+  }
+}
+export const urlParam = function <T extends string | null> (param: T | T[]): string {
+  return (Array.isArray(param) ? param[0] : param) ?? ''
+}
+export const createTitleSetter = ($doc = document) => {
+  return beforePaint((title) => {
+    $doc.title = title
+  })
+}
+export const createAttrsSetter = ($el = document.querySelector('html')) => {
+  if (!$el) {
+    return () => {}
+  }
+  const originalClasses = [...$el.classList]
+  return beforePaint((attrs: Record<string, string>[]) => {
+    const flat = attrs.reduce<Record<string, string[]>>((prev, item) => {
+      return Object.entries(item).reduce(
+        (prev, [key, value]) => {
+          if (typeof prev[key] === 'undefined') {
+            prev[key] = []
+          }
+          prev[key].push(value)
+          return prev
+        }, prev,
+      )
+    }, {})
+
+    $el.classList.remove(...[...$el.classList].filter(item => !originalClasses.includes(item)))
+    $el.classList.add(...(flat.class || []))
+  })
+}

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -1,7 +1,6 @@
 <template>
   <RouteView
     v-slot="{route: _route}"
-    :module="props.isGatewayView ? 'gateways' : 'data-planes'"
   >
     <RouteTitle
       :title="t(`${props.isGatewayView ? 'gateways' : 'data-planes'}.routes.item.title`, {name: _route.params.dataPlane})"

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -1,7 +1,5 @@
 <template>
-  <RouteView
-    :module="props.isGatewayView ? 'gateways' : 'data-planes'"
-  >
+  <RouteView>
     <RouteTitle
       :title="t(`${props.isGatewayView ? 'gateways' : 'data-planes'}.routes.items.title`)"
     />

--- a/src/app/meshes/views/MeshOverviewView.vue
+++ b/src/app/meshes/views/MeshOverviewView.vue
@@ -1,7 +1,5 @@
 <template>
-  <RouteView
-    module="meshes"
-  >
+  <RouteView>
     <RouteTitle
       :title="t('meshes.routes.overview.title')"
     />

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -1,7 +1,6 @@
 <template>
   <RouteView
     v-slot="{route}"
-    module="policies"
   >
     <RouteTitle
       :title="t('policies.routes.item.title', {name: route.params.policy})"

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -1,7 +1,6 @@
 <template>
   <RouteView
     v-slot="{ route: _route}"
-    module="policies"
   >
     <DataSource
       v-slot="{data: policies, error: policyError, refresh: policyRefresh}: PolicyTypeCollectionSource"

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -1,7 +1,6 @@
 <template>
   <RouteView
     v-slot="{route: _route}"
-    module="services"
   >
     <RouteTitle
       :title="t('services.routes.item.title', {name: _route.params.service})"

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -1,7 +1,5 @@
 <template>
-  <RouteView
-    module="services"
-  >
+  <RouteView>
     <RouteTitle
       :title="t('services.routes.items.title')"
     />


### PR DESCRIPTION
The `RouteView`/`RouteTitle` and `AppView` components were initially made in a closed manner to PoC the different concept and then roll it out across the applications.

I'd always planned on coming back to tidy things up inside the components and add some documentation to help any external contributors or anyone unfamiliar with our codebase. This PR does that.

There was the initial concept of automatic navigation building/navigation selecting in `RouteView`, which we were using but pulled out and therefore we aren't using just yet. I decided to remove this entirely in this the clean up and add afresh at a later date. In the PR you will see things related to `children` and `module=""` being removed, this deletion is related to this.

Signed-off-by: John Cowen <john.cowen@konghq.com>
