### PR TITLE
fix(zones): Don't disable the submit button on duplicate name

### DIFF
--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -4,13 +4,13 @@ Feature: Zones: Zone create flow
       | Alias                               | Selector                                            |
       | name-input                          | [data-testid='name-input']                          |
       | create-zone-button                  | [data-testid='create-zone-button']                  |
-      | create-zone-error                   | [data-testid='create-zone-error']                   |
-      | connect-zone-instructions           | [data-testid='connect-zone-instructions']           |
       | environment-universal-radio-button  | [data-testid='environment-universal-radio-button']  |
       | environment-kubernetes-radio-button | [data-testid='environment-kubernetes-radio-button'] |
       | ingress-input-switch                | [for='zone-ingress-enabled']                        |
       | egress-input-switch                 | [for='zone-egress-enabled']                         |
       | zone-connected-scanner              | [data-testid='zone-connected-scanner']              |
+      | error                               | [data-testid='create-zone-error']                   |
+      | instructions                        | [data-testid='connect-zone-instructions']           |
     When I visit the "/zones/create" URL
 
   Scenario: The form shows only the initial elements
@@ -79,21 +79,14 @@ Feature: Zones: Zone create flow
       """
     Then the "$zone-connected-scanner" element contains "The Zone “test” is now connected"
 
-  Scenario: The form shows expected error for <StatusCode> response
-    When the URL "/provision-zone" responds with
+  Scenario: The form shows an error
+    Given the URL "/provision-zone" responds with
       """
       headers:
-        Status-Code: '<StatusCode>'
+        Status-Code: '409'
       """
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
+    Then the "$error" element exists
+    Then the "$instructions" element doesn't exist
 
-    Then the "$create-zone-button" element is <CreateButtonAssertion>
-    And the "$create-zone-error" element contains "<ErrorTitle>"
-    And the "$connect-zone-instructions" element doesn't exist
-
-    Examples:
-      | StatusCode | CreateButtonAssertion | ErrorTitle                                     |
-      | 400        | enabled               | The Zone name test is invalid                  |
-      | 409        | disabled              | A Zone with the name test already exists       |
-      | 500        | enabled               | An error occurred while creating the Zone test |

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -264,8 +264,7 @@ const base64EncodedToken = computed(() => token.value !== '' ? window.btoa(token
 const isCreateButtonDisabled = computed(() => {
   return name.value === '' ||
     isChangingZone.value ||
-    zone.value !== null ||
-    (errorState.value.error instanceof ApiError && errorState.value.error.status === 409)
+    zone.value !== null
 })
 
 /**


### PR DESCRIPTION
Stops disabling the zone submit button on error.

We show a warning as to why there was an error, and you _could_ resolve that error using something other than the browser you are currently using, so it doesn't make sense to stop the user from hitting the button again. We show an error message, if the user wants to keep trying (maybe they've deleted the zone via other means) then thats up to them.

Note: I think if anything a completely _invalid_ zone name makes more sense to use as a signal to disable the button more than anything, but this should probably be done via frontend validation (that's guessing we know the rules for invalid names and we can recreate that validation on the frontend)

See https://github.com/kumahq/kuma-gui/pull/1104#discussion_r1241910208

Signed-off-by: John Cowen <john.cowen@konghq.com>