### PR TITLE
chore: Removes last HTTP call to `/` and moves bootstrapping

### DIFF
--- a/features/application/Loading.feature
+++ b/features/application/Loading.feature
@@ -19,21 +19,16 @@ Feature: index
     And I wait for 2000 milliseconds
     Then the "$loading" element doesn't exist
     And the "$logo" element exists
-
-  # TODO: This test needs fixing it currently console.errors
-  @skip
   Scenario: Application errors
     Given the environment
       """
       KUMA_LATENCY: 1000
       """
-    And the URL "/" responds with
+    And the URL "/config" responds with
       """
       headers:
         Status-Code: 500
       """
     When I visit the "/" URL
-    Then the "$loading" element exists
-    And I wait for 2000 milliseconds
     Then the "$loading" element doesn't exist
     Then the "$error" element exists

--- a/src/app/AppHeader.vue
+++ b/src/app/AppHeader.vue
@@ -21,7 +21,6 @@
     </div>
 
     <div
-      v-if="!shouldShowAppError"
       class="horizontal-list"
     >
       <div class="app-status app-status--mobile">
@@ -120,7 +119,6 @@ const store = useStore()
 const env = useEnv()
 const { t } = useI18n()
 
-const shouldShowAppError = computed(() => store.getters.shouldShowAppError)
 const environmentName = computed(() => {
   const environment = store.getters['config/getEnvironment']
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,20 +25,7 @@ export function useApp(
   }
 }
 
-export function useBootstrap(store: Store<State>) {
-  return async (isAllowedToMakeApiCalls: boolean = true) => {
-    if (isAllowedToMakeApiCalls) {
-      await Promise.all([
-        // Fetches basic resources before setting up the router and mounting the
-        // application. This is mainly needed to properly redirect users to the
-        // onboarding flow in the appropriate scenarios.
-        store.dispatch('bootstrap'),
-        // Loads available policy types in order to populate the necessary
-        // information used for and policy lookups in the app.
-        store.dispatch('fetchPolicyTypes'),
-      ])
-    } else {
-      store.state.defaultVisibility.appError = false
-    }
+export function useBootstrap() {
+  return async () => {
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,11 @@ export function useApp(
   }
 }
 
+// whilst this is currently looks like an empty function/deadcode, this
+// function gets decorated during development only to add the MSW mocking
+// functionality. We should see if this development MSW code can be moved to
+// decorate createApp instead. At that point we can remove this empty
+// bootstrapping code altogether.
 export function useBootstrap() {
   return async () => {
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,13 +18,9 @@ async function mountVueApplication() {
   )
 
   const app = await get($.app)((await import('./app/App.vue')).default)
-  app.mount('#app')
 
-  const store = get($.store)
-  await store.dispatch('updateGlobalLoading', true)
-  const bootstrap = get($.bootstrap)
-  await bootstrap()
-  await store.dispatch('updateGlobalLoading', false)
+  await get($.bootstrap)()
+  app.mount('#app')
 }
 
 mountVueApplication()

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -220,9 +220,6 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   }],
   [$.bootstrap, {
     service: useBootstrap,
-    arguments: [
-      $.store,
-    ],
   }],
 ]
 

--- a/src/store/modules/config/config.spec.ts
+++ b/src/store/modules/config/config.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+import { describe, expect, test } from '@jest/globals'
 
 import _configModule from './config'
 import { get, TOKENS } from '@/services'
@@ -6,16 +6,6 @@ const configModule = _configModule(get(TOKENS.api))
 
 describe('config module', () => {
   describe('getters', () => {
-    test('tests getStatus getter', () => {
-      const state: any = {
-        status: 'foo',
-      }
-
-      const result = configModule.getters.getStatus(state, {}, {} as any, {})
-
-      expect(result).toBe('foo')
-    })
-
     test('tests getMulticlusterStatus getter when global mode', () => {
       const getters = {
         getMode: 'global',
@@ -34,28 +24,6 @@ describe('config module', () => {
       const result = configModule.getters.getMulticlusterStatus({} as any, getters, {} as any, {})
 
       expect(result).toBe(false)
-    })
-  })
-
-  describe('actions', () => {
-    beforeEach(() => {
-      jest.restoreAllMocks()
-    })
-
-    test('tests getStatus action', async () => {
-      const state: any = {
-        status: null,
-      }
-
-      function commit(type: string, status: any): void {
-        configModule.mutations[type](state, status)
-      }
-
-      // @ts-ignore I can’t be bothered to battle Vuex’s loose types right now.
-      await configModule.actions.getStatus({ commit })
-      const result = configModule.getters.getStatus(state, {}, {} as any, {})
-
-      expect(result).toBe('OK')
     })
   })
 

--- a/src/store/modules/config/config.ts
+++ b/src/store/modules/config/config.ts
@@ -11,11 +11,9 @@ const initialConfigState: ConfigInterface = {
 
 const mutations: MutationTree<ConfigInterface> = {
   SET_CONFIG_DATA: (state, config: ClientConfigInterface) => (state.clientConfig = config),
-  SET_STATUS: (state, status: 'OK' | null) => (state.status = status),
 }
 
 const getters: GetterTree<ConfigInterface, State> = {
-  getStatus: state => state.status,
   getConfig: state => state.clientConfig,
   getEnvironment: state => state.clientConfig?.environment,
   getMode: state => state.clientConfig?.mode,
@@ -34,13 +32,6 @@ const actions = (kumaApi: KumaApi): ActionTree<ConfigInterface, State> => ({
   getConfig({ commit }) {
     return kumaApi.getConfig().then((response) => {
       commit('SET_CONFIG_DATA', response)
-    })
-  },
-
-  // get the status of the API
-  getStatus({ commit }) {
-    return kumaApi.getStatus().then((response) => {
-      commit('SET_STATUS', response)
     })
   },
 

--- a/src/store/storeConfig.spec.ts
+++ b/src/store/storeConfig.spec.ts
@@ -18,7 +18,6 @@ describe('storeConfig', () => {
     const commit = jest.fn()
     const dispatch = jest.fn()
     const getters = {
-      'config/getStatus': 'OK',
     }
     const state = {
       meshes: {


### PR DESCRIPTION
This PR began as removing the last HTTP API call to `/` that we have. Whilst doing this I noticing that we just invisibly failed on any errors in our 'bootstrapping' HTTP calls. I decided it was finally time to move our bootstrapping functionality into `App.vue` where we could catch any errors and show a proper error state.

---

### Removing the last HTTP API call to `/`

Previous to this PR we would make a call to `/` to see if that call was successful, if it wasn't successful we would just do nothing and miss out a bunch of HTTP calls we depend on further into the application, not great.

If we were successful, we wouldn't use any of the data from the API call, but instead make another bunch of API calls. Then if any of those failed, do nothing, and therefore be missing a bunch of data we then depend on further into the application, not great.

I don't quite understand why we would make a call to an endpoint just to see if its successful even though we don't use any of its data, when it would make more sense to use an endpoint that we actually use data from.

All the loading and error problems here led me to also...

### Move our 'bootstrapping' HTTP calls to App.vue

As we've been wanting to do this for quite a while, I figured if I did this now I could also use all our existing loading and error states to fail gracefully. 

---

### Lastly:

There is still so much stuff we can remove here now, but as its really intertwined throughout the app it takes quite a bit of picking apart. i.e. we still get a list of meshes at the start of the application, when we shouldn't need to; we still get a load of policy information at the start of the application when we shouldn't need to. There is ongoing work to change things so that we only load information for the page we are on directly from the backend every single time we load a page (as we want our data to be up-to-date and not stale), so hopefully we can pick this stuff out once thats there.

Our `bootstrap` function now does nothing in production, it is decorated with MSW functionality in development. Whilst this looks a little weird having an empty function, we can at some point noodle around with this as well, just I didn't want to do too much more here.

Signed-off-by: John Cowen <john.cowen@konghq.com>