### PR TITLE
fix: Revert "chore(deps): Bump @kong/kongponents from 8.83.3 to 8.84.0 (#154)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@kong-ui-public/i18n": "^0.6.1",
-    "@kong/kongponents": "^8.84.0",
+    "@kong/kongponents": "^8.83.3",
     "brandi": "^5.0.0",
     "chart.js": "^4.3.0",
     "deepmerge": "^4.3.1",

--- a/src/app/common/__snapshots__/EnvoyData.spec.ts.snap
+++ b/src/app/common/__snapshots__/EnvoyData.spec.ts.snap
@@ -108,13 +108,7 @@ exports[`EnvoyData.vue renders snapshot 1`] = `
         class="empty-state-content"
       >
         <!---->
-        <div
-          class="k-empty-state-cta"
-        >
-          
-          <!---->
-          
-        </div>
+        <!---->
       </div>
     </section>
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1922,10 +1922,10 @@
     flat "^5.0.2"
     intl-messageformat "^10.5.0"
 
-"@kong/kongponents@^8.84.0":
-  version "8.84.0"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.84.0.tgz#4a728c440c10afcb1c6c0f1ec8fdccf9f47a2089"
-  integrity sha512-n0ZQXz/pfTz1277/S17VXaf8Z53V1wrr7eefNBEQhEQIK8ssQxO6ARXFm9irvjBJiElfGwfkXqEwaoj51AcN4g==
+"@kong/kongponents@^8.83.3":
+  version "8.83.3"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.83.3.tgz#89e77ddfaac7c2e509b944fac012b24624c10ea4"
+  integrity sha512-NDu6vZX2AIXLhNZLCcnmDcQHqaY7P+EEwpzeGz15xo4UZ+2BYByT32NWYi9KThvxq+xtQCfVujDnFU4m2KsBhw==
   dependencies:
     axios "^0.27.2"
     date-fns "^2.29.3"


### PR DESCRIPTION
See https://github.com/Kong/kongponents/pull/1500

TLDR; 8.84.0 is missing a dependency when installed as an indirect dependency.

Reverting for this moment