### PR TITLE
fix(deps): Includes fix for kongponents sass issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@kong-ui-public/i18n": "^0.6.1",
-    "@kong/kongponents": "^8.84.0",
+    "@kong/kongponents": "^8.84.2",
     "brandi": "^5.0.0",
     "chart.js": "^4.3.0",
     "deepmerge": "^4.3.1",

--- a/src/app/common/__snapshots__/DataOverview.spec.ts.snap
+++ b/src/app/common/__snapshots__/DataOverview.spec.ts.snap
@@ -79,7 +79,7 @@ exports[`DataOverview.vue renders all custom templates for data 1`] = `
         class="k-button-icon kong-icon kong-icon-redo"
       >
         <svg
-          fill="white"
+          fill="var(--kui-color-text-inverse, #ffffff)"
           height="16"
           role="img"
           viewBox="0 0 17 14"
@@ -96,7 +96,7 @@ exports[`DataOverview.vue renders all custom templates for data 1`] = `
           <path
             clip-rule="evenodd"
             d="M12.466 12.06a6.868 6.868 0 112.196-5.676l.85-.85a.847.847 0 011.201-.017c.327.327.315.869-.017 1.2L14.233 9.18c-.342.342-.88.35-1.208.023L10.654 6.83c-.324-.324-.314-.859.028-1.2.34-.34.881-.348 1.2-.029l.847.846a4.938 4.938 0 10-1.63 4.245l1.367 1.367z"
-            fill="white"
+            fill="var(--kui-color-text-inverse, #ffffff)"
             fill-rule="evenodd"
           />
           

--- a/yarn.lock
+++ b/yarn.lock
@@ -1922,10 +1922,10 @@
     flat "^5.0.2"
     intl-messageformat "^10.5.0"
 
-"@kong/kongponents@^8.84.0":
-  version "8.84.0"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.84.0.tgz#4a728c440c10afcb1c6c0f1ec8fdccf9f47a2089"
-  integrity sha512-n0ZQXz/pfTz1277/S17VXaf8Z53V1wrr7eefNBEQhEQIK8ssQxO6ARXFm9irvjBJiElfGwfkXqEwaoj51AcN4g==
+"@kong/kongponents@^8.84.2":
+  version "8.84.2"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.84.2.tgz#e583a4a7aea1ca7e748b996dbc0a57c5cb007096"
+  integrity sha512-kmfkUsARxrl2Jl0TyCAQDgxmm9OFSkOuzhBHHfsQoFYaArPFHyYz04NmJqqW3fEDfiZBpPFuZXxFQ9FPLf0YXg==
   dependencies:
     axios "^0.27.2"
     date-fns "^2.29.3"


### PR DESCRIPTION
See https://github.com/Kong/kongponents/pull/1501

Longer term we need to stop using any `dist/*.scss` files from `@kong/kongponents` (see https://github.com/kumahq/kuma-gui/issues/1160)

Signed-off-by: John Cowen <john.cowen@konghq.com>
