### PR TITLE
fix(charts): Make sure charts have some sort of loading state

### DIFF
--- a/src/app/main-overview/components/OverviewCharts.vue
+++ b/src/app/main-overview/components/OverviewCharts.vue
@@ -1,7 +1,10 @@
 <template>
   <KCard>
     <template #body>
-      <div class="chart-box-list">
+      <div
+        v-if="!isLoading"
+        class="chart-box-list"
+      >
         <DoughnutChart
           v-if="isMultizoneMode"
           data-testid="zones"
@@ -46,6 +49,7 @@
           :data="envoyVersionsChartData"
         />
       </div>
+      <LoadingBlock v-else />
     </template>
   </KCard>
 </template>
@@ -56,6 +60,7 @@ import semverCompare from 'semver/functions/compare'
 import { computed, ref } from 'vue'
 
 import DoughnutChart from '@/app/common/charts/DoughnutChart.vue'
+import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import { MergedMeshInsights, mergeInsightsReducer } from '@/store/reducers/mesh-insights'
 import { useStore } from '@/store/store'
 import type {


### PR DESCRIPTION
The code around loading our data for the overview charts has javascript loading states, but those states are **_not_** used to block the visibility/rendering of the rendered vue components.

You can see the javascript loading state here.

https://github.com/kumahq/kuma-gui/blob/39a4d9bb85f7ef29889622e0d29467acbbd7e635/src/app/main-overview/components/OverviewCharts.vue#L319

You'll notice that we don't actually then use this state in the Vue template at all.

In OSS this doesn't cause issues, but when trying elsewhere it does. It seems as though this, along with some sort of additional strange-ness in the Chart plugin we use that it can result in charts with no coloring.

![Screenshot 2023-07-10 at 13 33 57](https://github.com/kumahq/kuma-gui/assets/554604/a330550c-374a-4491-8a02-a315f2be3375)

Theoretically, this should all work due to Vue's reactive state but for some reason Vue's reactiveness doesn't seem to be working. Actually using the loading state in the template makes it work.

This bug specifically is currently blocking me from merging https://github.com/kumahq/kuma-gui/pull/1157 as it has upstream consequences. So I need to get this in first before I can merge that one.

If there are any questions on this please ask.
