### PR TITLE
fix: DataOverview error states

### DIFF
--- a/src/app/common/DataOverview.vue
+++ b/src/app/common/DataOverview.vue
@@ -18,12 +18,11 @@
       </KButton>
     </div>
 
-    <LoadingBlock v-if="isLoading" />
-
     <ErrorBlock
-      v-else-if="error !== null"
+      v-if="error"
       :error="error"
     />
+    <LoadingBlock v-else-if="isLoading" />
 
     <EmptyBlock v-else-if="isEmpty" />
 


### PR DESCRIPTION
The Error/Loading states in our very very commonly used DataOverview component don't seem to work as intended.

Currently, if it is in a loading state and you pass the component an error, the component remains in its loading state. This sounds wrong to me. If we have an error then surely we are not loading any more. Consequently I have seen this behaviour resulting a surprising issue in code I have been working on (DataSource work).

I am unsure if the change here has an effect elsewhere, or whether we are relying on this what I see as strange behaviour (if we have an error we shouldn't be loading anymore). But I am little cautious about this as I still don't know whether we are relying on this elsewhere.

If component should be in a loading state even if you pass it an error, then please let me know and I'd be happy to close the PR.


