### PR TITLE
fix(deps): update lock file

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7367,7 +7367,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.1.10, postcss@^8.4.23, postcss@^8.4.25:
+postcss@^8.1.10, postcss@^8.4.23, postcss@^8.4.24, postcss@^8.4.25:
   version "8.4.25"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.25.tgz#4a133f5e379eda7f61e906c3b1aaa9b81292726f"
   integrity sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==


### PR DESCRIPTION
After a bunch of dependabot upgrades, I was testing everything out locally and noticed that we still get a `yarn.lock` update on `master` when running `yarn` locally, this commit adds that missing change.

I'm unclear as to why this is necessary but I would rather use the local output of `yarn` and commit it rather than not.

Signed-off-by: John Cowen <john.cowen@konghq.com>