### PR TITLE
chore: removes charts being clickable

### DIFF
--- a/src/app/common/charts/DoughnutChart.vue
+++ b/src/app/common/charts/DoughnutChart.vue
@@ -46,7 +46,6 @@ import {
 } from 'chart.js'
 import { computed, PropType } from 'vue'
 import { Doughnut } from 'vue-chartjs'
-import { useRouter } from 'vue-router'
 
 import { DoughnutChartData, StatusKeyword } from '@/types/index.d'
 
@@ -82,8 +81,6 @@ ChartJS.defaults.font = {
 ChartJS.defaults.plugins.tooltip.bodyFont = {
   size: 12,
 }
-
-const router = useRouter()
 
 const props = defineProps({
   data: {
@@ -152,16 +149,6 @@ const chartOptions = computed<ChartOptions<'doughnut'>>(function () {
           },
         },
       },
-    },
-    onClick: function (_event, elements) {
-      const $el = elements[0]
-      if (typeof $el !== 'undefined') {
-        const dataPoint = props.data.dataPoints[$el.index]
-
-        if (dataPoint?.route) {
-          router.push(dataPoint.route)
-        }
-      }
     },
   }
 

--- a/src/app/main-overview/components/OverviewCharts.vue
+++ b/src/app/main-overview/components/OverviewCharts.vue
@@ -115,29 +115,17 @@ const servicesChartData = computed(() => {
 
   const { internal, external } = serviceStatus.value
 
-  if (internal && store.state.selectedMesh !== null) {
+  if (internal) {
     dataPoints.push({
       title: i18n.t('common.charts.services.internalLabel'),
       data: internal,
-      route: {
-        name: 'services-list-view',
-        params: {
-          mesh: store.state.selectedMesh,
-        },
-      },
     })
   }
 
-  if (external && store.state.selectedMesh !== null) {
+  if (external) {
     dataPoints.push({
       title: i18n.t('common.charts.services.externalLabel'),
       data: external,
-      route: {
-        name: 'services-list-view',
-        params: {
-          mesh: store.state.selectedMesh,
-        },
-      },
     })
   }
 
@@ -207,9 +195,6 @@ const zonesChartData = computed<DoughnutChartData>(() => {
       title: i18n.t('http.api.value.online'),
       statusKeyword: 'online',
       data: online,
-      route: {
-        name: 'zone-cp-list-view',
-      },
     })
 
     if (online !== total) {
@@ -217,9 +202,6 @@ const zonesChartData = computed<DoughnutChartData>(() => {
         title: i18n.t('http.api.value.offline'),
         statusKeyword: 'offline',
         data: total - online,
-        route: {
-          name: 'zone-cp-list-view',
-        },
       })
     }
   }
@@ -246,9 +228,6 @@ const zonesCPVersionsChartData = computed(() => {
       dataPoints.push({
         title: lastSubscription.version.kumaCp.version,
         data: 1,
-        route: {
-          name: 'zone-cp-list-view',
-        },
       })
     } else {
       existingDataPoint.data++

--- a/src/app/meshes/components/MeshCharts.vue
+++ b/src/app/meshes/components/MeshCharts.vue
@@ -17,14 +17,12 @@ import { useRoute } from 'vue-router'
 
 import DoughnutChart from '@/app/common/charts/DoughnutChart.vue'
 import { MergedMeshInsights, mergeInsightsReducer } from '@/store/reducers/mesh-insights'
-import { useStore } from '@/store/store'
 import type { ChartDataPoint, DataPlaneProxyStatus, ServiceStatus } from '@/types/index.d'
 import { useI18n, useKumaApi } from '@/utilities'
 
 const i18n = useI18n()
 const kumaApi = useKumaApi()
 const route = useRoute()
-const store = useStore()
 
 const isLoading = ref(false)
 const dataPlaneProxyStatus = ref<Required<DataPlaneProxyStatus>>({
@@ -50,29 +48,17 @@ const servicesChartData = computed(() => {
   const dataPoints: ChartDataPoint[] = []
   const { internal, external } = serviceStatus.value
 
-  if (internal && store.state.selectedMesh !== null) {
+  if (internal) {
     dataPoints.push({
       title: i18n.t('common.charts.services.internalLabel'),
       data: internal,
-      route: {
-        name: 'services-list-view',
-        params: {
-          mesh: store.state.selectedMesh,
-        },
-      },
     })
   }
 
-  if (external && store.state.selectedMesh !== null) {
+  if (external) {
     dataPoints.push({
       title: i18n.t('common.charts.services.externalLabel'),
       data: external,
-      route: {
-        name: 'services-list-view',
-        params: {
-          mesh: store.state.selectedMesh,
-        },
-      },
     })
   }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -10,7 +10,6 @@ export type StatusKeyword = 'online' | 'offline' | 'partially_degraded' | 'not_a
 export type ChartDataPoint = {
   title: string
   data: number
-  route?: RouteLocationNamedRaw
   statusKeyword?: StatusKeyword
 }
 


### PR DESCRIPTION
Removes the feature making charts link to related pages which people were generally surprised existed in the first place and doesn't seem to serve much purpose.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Note: This removes one of the last uses of `store.state.selectedMesh`. The last one will be removed in a follow up in which I’m dropping the sidebar store module (its main purpose no longer exists and we only use a bit of its state).