### PR TITLE
ci: adds cypress-fail-fast plugin

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,20 +3,18 @@ import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-prepro
 import createEsbuildPlugin from '@badeball/cypress-cucumber-preprocessor/esbuild'
 import createBundler from '@bahmutov/cypress-esbuild-preprocessor'
 import { defineConfig } from 'cypress'
+import cypressFailFast from 'cypress-fail-fast/plugin'
 import dotenv from 'dotenv'
+
 const env = dotenv.config().parsed as {[key: string]: string}
 
 export default defineConfig({
   e2e: {
     specPattern: '**/*.feature',
-    supportFile: false,
     experimentalRunAllSpecs: true,
     // TODO Env var
     video: false,
-    async setupNodeEvents(
-      on: Cypress.PluginEvents,
-      config: Cypress.PluginConfigOptions,
-    ) {
+    async setupNodeEvents(on, config) {
       // propagate env to Cypress.env
       Object.entries(env).forEach(([prop, value]) => {
         config.env[prop] = value
@@ -44,6 +42,8 @@ export default defineConfig({
           plugins: [createEsbuildPlugin(config)],
         }),
       )
+
+      cypressFailFast(on, config)
 
       // Make sure to return the config object as it might have been modified by the plugin.
       return config

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,1 @@
+import 'cypress-fail-fast'

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "canvas": "^2.11.2",
     "cross-env": "^7.0.3",
     "cypress": "^12.17.1",
+    "cypress-fail-fast": "^7.0.1",
     "dotenv": "^16.3.1",
     "esbuild": "^0.18.11",
     "eslint": "^8.44.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,6 +3259,14 @@ chalk@4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -3267,14 +3275,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -3697,6 +3697,13 @@ csstype@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
+
+cypress-fail-fast@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cypress-fail-fast/-/cypress-fail-fast-7.0.1.tgz#9aa0cdbdf92b7ea3712588635f8b35e8f5f10f16"
+  integrity sha512-v68bfFTjPrn3+i+mEFmxC6Z2ble9+k8xIeEGeZJQS0HU8A9Q3oE1LEEv1SAqgyaYL06PKw4ifHw/aydO6rNFaw==
+  dependencies:
+    chalk "4.1.2"
 
 cypress@^12.17.1:
   version "12.17.1"


### PR DESCRIPTION
Adds the cypress-fail-fast plugin which will cause the entire Cypress test run to fail fast after 1 failed retry.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

![image](https://github.com/kumahq/kuma-gui/assets/5774638/e88106d6-9eed-4e42-a07c-07b907a202fc)

