### PR TITLE
ci: uploads Cypress screenshots and videos on failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,15 @@ jobs:
           yarn build:staging
       - run: |
           yarn preview:built &
-          yarn run test:browser
+          CYPRESS_video=true yarn run test:browser
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-artifacts
+          retention-days: ${{ github.event_name == 'pull_request' && 3 || 30 }}
+          path: |
+            cypress/screenshots
+            cypress/videos
 
   post-checks:
     # There is a branch protection rule on the repo that requires "branch-protection" to


### PR DESCRIPTION
Uploads Cypress screenshots and videos on failure of the test run.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Workflow run summary in failure case (has uploaded artifacts): https://github.com/kumahq/kuma-gui/actions/runs/5552202267

Workflow run summary in success case (doesn't have uploaded artifacts): https://github.com/kumahq/kuma-gui/actions/runs/5552247266?pr=1178