### PR TITLE
chore(e2e): removes unnecessary cy.wait calls

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -178,7 +178,6 @@ Then(/^the "(.*)" element contains "(.*)"$/, (selector: string, value: string) =
 })
 
 Then('the page title contains {string}', function (title: string) {
-  cy.wait(1000)
   $('head title').contains(title)
 })
 

--- a/features/application/Loading.feature
+++ b/features/application/Loading.feature
@@ -1,10 +1,10 @@
 Feature: index
   Background:
     Given the CSS selectors
-      | Alias         | Selector                         |
-      | loading       | [data-testid='app-progress-bar'] |
-      | logo          | [data-testid='logo']             |
-      | error         | [data-testid='app-error']        |
+      | Alias   | Selector                         |
+      | loading | [data-testid='app-progress-bar'] |
+      | logo    | [data-testid='logo']             |
+      | error   | [data-testid='app-error']        |
 
   Scenario: Application loading
     Given the environment
@@ -16,7 +16,6 @@ Feature: index
       """
     When I load the "/" URL
     Then the "$loading" element exists
-    And I wait for 2000 milliseconds
     Then the "$loading" element doesn't exist
     And the "$logo" element exists
 
@@ -34,6 +33,5 @@ Feature: index
       """
     When I visit the "/" URL
     Then the "$loading" element exists
-    And I wait for 2000 milliseconds
     Then the "$loading" element doesn't exist
     Then the "$error" element exists

--- a/features/mesh/policies/Data.feature
+++ b/features/mesh/policies/Data.feature
@@ -18,10 +18,10 @@ Feature: mesh / policies / data
       """
   Scenario: 2 items in the response shows 2 items
     Given the environment
-    """
+      """
       KUMA_CIRCUITBREAKER_COUNT: 2
       KUMA_LATENCY: 1000
-    """
+      """
     And the URL "/meshes/default/circuit-breakers" responds with
       """
       body:
@@ -31,13 +31,12 @@ Feature: mesh / policies / data
       """
     When I visit the "/mesh/default/policies/circuit-breakers" URL
     Then the "$state-loading" element exists
-    And I wait for 1100 milliseconds
     Then the "$item" element exists 2 times
   Scenario: Zero items shows the empty state
     Given the environment
-    """
+      """
       KUMA_CIRCUITBREAKER_COUNT: 0
-    """
+      """
     And the URL "/meshes/default/circuit-breakers" responds with
       """
       """


### PR DESCRIPTION
Removes a couple of calls to `cy.wait` from our tests.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
