### PR TITLE
refactor: renames kcard-stack to stack

### DIFF
--- a/src/app/common/warnings/WarningsWidget.vue
+++ b/src/app/common/warnings/WarningsWidget.vue
@@ -1,9 +1,11 @@
 <template>
-  <ul>
-    <li
+  <div
+    v-if="props.warnings.length > 0"
+    class="stack"
+  >
+    <div
       v-for="(warning, index) in props.warnings"
       :key="`${warning.kind}/${index}`"
-      class="mb-1"
     >
       <KAlert appearance="warning">
         <template #alertMessage>
@@ -13,8 +15,8 @@
           />
         </template>
       </KAlert>
-    </li>
-  </ul>
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/src/app/main-overview/views/MainOverviewView.vue
+++ b/src/app/main-overview/views/MainOverviewView.vue
@@ -4,7 +4,7 @@
       :title="t('main-overview.routes.item.title')"
     />
     <AppView>
-      <div class="kcard-stack">
+      <div class="stack">
         <OverviewCharts />
       </div>
     </AppView>

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -13,7 +13,7 @@
         }
       ]"
     >
-      <div class="kcard-stack">
+      <div class="stack">
         <div class="kcard-border">
           <DataOverview
             :page-size="PAGE_SIZE_DEFAULT"

--- a/src/app/meshes/views/MeshOverviewView.vue
+++ b/src/app/meshes/views/MeshOverviewView.vue
@@ -4,7 +4,7 @@
       :title="t('meshes.routes.overview.title')"
     />
     <AppView>
-      <div class="kcard-stack">
+      <div class="stack">
         <KCard>
           <template #body>
             <MeshCharts />

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -33,7 +33,7 @@
                 class="relative"
                 :class="selected.path"
               >
-                <div class="kcard-stack">
+                <div class="stack">
                   <div class="kcard-border">
                     <KCard
                       v-if="selected.isExperimental"

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -14,7 +14,7 @@
       ]"
     >
       <div class="zoneegresses">
-        <div class="kcard-stack">
+        <div class="stack">
           <div class="kcard-border">
             <DataOverview
               :selected-entity-name="entity?.name"

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -19,7 +19,7 @@
         <!-- Zone CPs information for when Multicluster is enabled -->
         <div
           v-else
-          class="kcard-stack"
+          class="stack"
         >
           <div class="kcard-border">
             <DataOverview

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -18,7 +18,7 @@
 
         <div
           v-else
-          class="kcard-stack"
+          class="stack"
         >
           <div class="kcard-border">
             <DataOverview

--- a/src/assets/styles/_components.scss
+++ b/src/assets/styles/_components.scss
@@ -11,14 +11,14 @@ To be used in places where we solely need KCard’s frame properties.
 }
 
 /*
-.kcard-stack
+.stack
 
 For stacking elements with consistent space between.
 
 Adapted from https://every-layout.dev/layouts/stack/.
 */
 
-.kcard-stack>*+* {
+.stack>*+* {
   margin-block-start: var(--AppGap);
 }
 


### PR DESCRIPTION
Renames `kcard-stack` to `stack` to avoid the implication that it somehow needs to be used with KCards only.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
