### PR TITLE
chore: defines standard heading font sizes

### DIFF
--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -39,10 +39,35 @@ h6 {
   font-weight: var(--font-weight-semi-bold);
 }
 
+h1 {
+  font-size: 2.5rem;
+}
+
+h2 {
+  font-size: 2rem;
+}
+
+h3 {
+  font-size: 1.75rem;
+}
+
+h4 {
+  font-size: 1.5rem;
+}
+
+h5 {
+  font-size: 1.25rem;
+}
+
+h6 {
+  font-size: 1rem;
+}
+
 a {
   text-decoration: none;
   color: var(--blue-500);
 }
+
 a:hover,
 a:focus {
   text-decoration: underline

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -40,27 +40,27 @@ h6 {
 }
 
 h1 {
-  font-size: 2.5rem;
-}
-
-h2 {
   font-size: 2rem;
 }
 
-h3 {
-  font-size: 1.75rem;
-}
-
-h4 {
+h2 {
   font-size: 1.5rem;
 }
 
+h3 {
+  font-size: 1.17rem;
+}
+
+h4 {
+  font-size: 1rem;
+}
+
 h5 {
-  font-size: 1.25rem;
+  font-size: 0.83rem;
 }
 
 h6 {
-  font-size: 1rem;
+  font-size: 0.67rem;
 }
 
 a {


### PR DESCRIPTION
Defines the user agent style default font sizes explicitly in our code. Most notably this avoids user agent styles of the style `:any(section, ...) h1` to apply to our headings.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
