### PR TITLE
refactor: migrates zone lists to use DataSource

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -178,7 +178,7 @@ Then(/^the "(.*)" element contains "(.*)"$/, (selector: string, value: string) =
 })
 
 Then('the page title contains {string}', function (title: string) {
-  $('head title').contains(title)
+  cy.title().should('contain', title)
 })
 
 // debug

--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -36,7 +36,7 @@ Feature: MainNavigation
     Then the page title contains "<Title>"
 
     Examples:
-      | Selector                                | Title       |
-      | $main-nav .nav-item-home a              | Overview    |
-      | $main-nav .nav-item-zone-cp-list-view a | Zone CPs    |
-      | [data-testid='nav-item-diagnostics']    | Diagnostics |
+      | Selector                                | Title          |
+      | $main-nav .nav-item-home a              | Overview       |
+      | $main-nav .nav-item-zone-cp-list-view a | Control Planes |
+      | [data-testid='nav-item-diagnostics']    | Diagnostics    |

--- a/features/application/Titles.feature
+++ b/features/application/Titles.feature
@@ -19,12 +19,12 @@ Feature: The HTML title is correct on each page
       | /onboarding/completed                               | Completed                     |
 
       | /zones/create                                       | Create & connect Zone         |
-      | /zones/zone-cps                                     | Zone CPs                      |
-      | /zones/zone-cps/zone-cp-name                        | Zone CP                       |
-      | /zones/zone-ingresses                               | Zone Ingresses                |
-      | /zones/zone-ingresses/zone-ingress-name             | Zone Ingress                  |
-      | /zones/zone-egresses                                | Zone Egresses                 |
-      | /zones/zone-egresses/zone-egress-name               | Zone Egress                   |
+      | /zones/zone-cps                                     | Control Planes                |
+      | /zones/zone-cps/zone-cp-name                        | Control Plane                 |
+      | /zones/zone-ingresses                               | Ingresses                     |
+      | /zones/zone-ingresses/zone-ingress-name             | Ingress                       |
+      | /zones/zone-egresses                                | Egresses                      |
+      | /zones/zone-egresses/zone-egress-name               | Egress                        |
 
       | /mesh                                               | Meshes                        |
       | /mesh/default                                       | Mesh overview                 |
@@ -39,4 +39,4 @@ Feature: The HTML title is correct on each page
       | /mesh/default/data-plane/data-plane-name            | Data plane proxy              |
 
       | /mesh/default/policies/circuit-breakers             | CircuitBreaker                |
-      | /mesh/default/policy/circuit-breakers/program-0 | Policy                        |
+      | /mesh/default/policy/circuit-breakers/program-0     | Policy                        |

--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -1,11 +1,12 @@
 Feature: Zones: List view content
   Background:
     Given the CSS selectors
-      | Alias             | Selector                               |
-      | summary           | [data-testid='list-view-summary']      |
-      | table             | [data-testid='data-overview-table']    |
-      | table-row         | $table tbody tr                        |
-      | zone-cp-table-row | [data-testid='zone-cp-table'] tbody tr |
+      | Alias                  | Selector                                    |
+      | summary                | [data-testid='list-view-summary']           |
+      | table                  | [data-testid='data-overview-table']         |
+      | table-row              | $table tbody tr                             |
+      | zone-cp-table-row      | [data-testid='zone-cp-table'] tbody tr      |
+      | zone-ingress-table-row | [data-testid='zone-ingress-table'] tbody tr |
 
   Scenario Outline: Zone CP list view has expected content
     Given the environment
@@ -115,13 +116,11 @@ Feature: Zones: List view content
     When I visit the "/zones/zone-ingresses" URL
     Then the page title contains "Zone Ingresses"
 
-    Then the "$table-row:nth-child(1) .status-column" element contains "online"
-    Then the "$table-row:nth-child(1) .entity-column" element contains "zone-ingress-1"
+    Then the "$zone-ingress-table-row:nth-child(1) .status-column" element contains "online"
+    Then the "$zone-ingress-table-row:nth-child(1) .name-column" element contains "zone-ingress-1"
 
-    Then the "$table-row:nth-child(2) .status-column" element contains "offline"
-    Then the "$table-row:nth-child(2) .entity-column" element contains "zone-ingress-2"
-
-    Then the "$summary" element contains "Zone Ingress: zone-ingress-1"
+    Then the "$zone-ingress-table-row:nth-child(2) .status-column" element contains "offline"
+    Then the "$zone-ingress-table-row:nth-child(2) .name-column" element contains "zone-ingress-2"
 
   Scenario Outline: Zone Egress list view has expected content
     Given the environment

--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -45,12 +45,12 @@ Feature: Zones: List view content
     Then the "$zone-cp-table-row:nth-child(1) .status-column" element contains "online"
     Then the "$zone-cp-table-row:nth-child(1) .name-column" element contains "zone-cp-1"
     Then the "$zone-cp-table-row:nth-child(1) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
-    Then the "$zone-cp-table-row:nth-child(1) .storetype-column" element contains "memory"
+    Then the "$zone-cp-table-row:nth-child(1) .storeType-column" element contains "memory"
 
     Then the "$zone-cp-table-row:nth-child(2) .status-column" element contains "offline"
     Then the "$zone-cp-table-row:nth-child(2) .name-column" element contains "zone-cp-2"
     Then the "$zone-cp-table-row:nth-child(2) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
-    Then the "$zone-cp-table-row:nth-child(2) .storetype-column" element contains "memory"
+    Then the "$zone-cp-table-row:nth-child(2) .storeType-column" element contains "memory"
 
   Scenario Outline: Zone Ingress list view has expected content
     Given the environment

--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -45,12 +45,12 @@ Feature: Zones: List view content
     Then the "$zone-cp-table-row:nth-child(1) .status-column" element contains "online"
     Then the "$zone-cp-table-row:nth-child(1) .name-column" element contains "zone-cp-1"
     Then the "$zone-cp-table-row:nth-child(1) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
-    Then the "$zone-cp-table-row:nth-child(1) .storeType-column" element contains "memory"
+    Then the "$zone-cp-table-row:nth-child(1) .storetype-column" element contains "memory"
 
     Then the "$zone-cp-table-row:nth-child(2) .status-column" element contains "offline"
     Then the "$zone-cp-table-row:nth-child(2) .name-column" element contains "zone-cp-2"
     Then the "$zone-cp-table-row:nth-child(2) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
-    Then the "$zone-cp-table-row:nth-child(2) .storeType-column" element contains "memory"
+    Then the "$zone-cp-table-row:nth-child(2) .storetype-column" element contains "memory"
 
   Scenario Outline: Zone Ingress list view has expected content
     Given the environment

--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -10,8 +10,6 @@ Feature: Zones: List view content
     Given the environment
       """
       KUMA_ZONE_COUNT: 2
-      KUMA_ZONEINGRESS_COUNT: 1
-      KUMA_ZONEEGRESS_COUNT: 1
       """
     And the URL "/config" responds with
       """
@@ -40,22 +38,6 @@ Feature: Zones: List view content
                   disconnectTime: 2020-07-28T16:18:09.743141Z
                   status: {}
       """
-    And the URL "/zoneingresses+insights" responds with
-      """
-      body:
-        items:
-          - name: zone-ingress-1
-            zoneIngress:
-              zone: zone-cp-1
-      """
-    And the URL "/zoneegressoverviews" responds with
-      """
-      body:
-        items:
-          - name: zone-egress-1
-            zoneEgress:
-              zone: zone-cp-2
-      """
 
     When I visit the "/zones/zone-cps" URL
     Then the page title contains "Zone CPs"
@@ -64,15 +46,11 @@ Feature: Zones: List view content
     Then the "$zone-cp-table-row:nth-child(1) .name-column" element contains "zone-cp-1"
     Then the "$zone-cp-table-row:nth-child(1) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
     Then the "$zone-cp-table-row:nth-child(1) .storeType-column" element contains "memory"
-    Then the "$zone-cp-table-row:nth-child(1) .hasIngress-column" element contains "Yes"
-    Then the "$zone-cp-table-row:nth-child(1) .hasEgress-column" element contains "No"
 
     Then the "$zone-cp-table-row:nth-child(2) .status-column" element contains "offline"
     Then the "$zone-cp-table-row:nth-child(2) .name-column" element contains "zone-cp-2"
     Then the "$zone-cp-table-row:nth-child(2) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
     Then the "$zone-cp-table-row:nth-child(2) .storeType-column" element contains "memory"
-    Then the "$zone-cp-table-row:nth-child(2) .hasIngress-column" element contains "No"
-    Then the "$zone-cp-table-row:nth-child(2) .hasEgress-column" element contains "Yes"
 
   Scenario Outline: Zone Ingress list view has expected content
     Given the environment

--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -2,11 +2,9 @@ Feature: Zones: List view content
   Background:
     Given the CSS selectors
       | Alias                  | Selector                                    |
-      | summary                | [data-testid='list-view-summary']           |
-      | table                  | [data-testid='data-overview-table']         |
-      | table-row              | $table tbody tr                             |
       | zone-cp-table-row      | [data-testid='zone-cp-table'] tbody tr      |
       | zone-ingress-table-row | [data-testid='zone-ingress-table'] tbody tr |
+      | zone-egress-table-row  | [data-testid='zone-egress-table'] tbody tr  |
 
   Scenario Outline: Zone CP list view has expected content
     Given the environment
@@ -162,10 +160,8 @@ Feature: Zones: List view content
     When I visit the "/zones/zone-egresses" URL
     Then the page title contains "Zone Egresses"
 
-    Then the "$table-row:nth-child(1) .status-column" element contains "online"
-    Then the "$table-row:nth-child(1) .entity-column" element contains "zone-egress-1"
+    Then the "$zone-egress-table-row:nth-child(1) .status-column" element contains "online"
+    Then the "$zone-egress-table-row:nth-child(1) .name-column" element contains "zone-egress-1"
 
-    Then the "$table-row:nth-child(2) .status-column" element contains "offline"
-    Then the "$table-row:nth-child(2) .entity-column" element contains "zone-egress-2"
-
-    Then the "$summary" element contains "Zone Egress: zone-egress-1"
+    Then the "$zone-egress-table-row:nth-child(2) .status-column" element contains "offline"
+    Then the "$zone-egress-table-row:nth-child(2) .name-column" element contains "zone-egress-2"

--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -1,10 +1,10 @@
 Feature: Zones: List view content
   Background:
     Given the CSS selectors
-      | Alias                  | Selector                                    |
-      | zone-cp-table-row      | [data-testid='zone-cp-table'] tbody tr      |
-      | zone-ingress-table-row | [data-testid='zone-ingress-table'] tbody tr |
-      | zone-egress-table-row  | [data-testid='zone-egress-table'] tbody tr  |
+      | Alias                  | Selector                                         |
+      | zone-cp-table-row      | [data-testid='zone-cp-collection'] tbody tr      |
+      | zone-ingress-table-row | [data-testid='zone-ingress-collection'] tbody tr |
+      | zone-egress-table-row  | [data-testid='zone-egress-collection'] tbody tr  |
 
   Scenario Outline: Zone CP list view has expected content
     Given the environment

--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -1,10 +1,11 @@
 Feature: Zones: List view content
   Background:
     Given the CSS selectors
-      | Alias     | Selector                            |
-      | summary   | [data-testid='list-view-summary']   |
-      | table     | [data-testid='data-overview-table'] |
-      | table-row | $table tbody tr                     |
+      | Alias             | Selector                               |
+      | summary           | [data-testid='list-view-summary']      |
+      | table             | [data-testid='data-overview-table']    |
+      | table-row         | $table tbody tr                        |
+      | zone-cp-table-row | [data-testid='zone-cp-table'] tbody tr |
 
   Scenario Outline: Zone CP list view has expected content
     Given the environment
@@ -60,21 +61,19 @@ Feature: Zones: List view content
     When I visit the "/zones/zone-cps" URL
     Then the page title contains "Zone CPs"
 
-    Then the "$table-row:nth-child(1) .status-column" element contains "online"
-    Then the "$table-row:nth-child(1) .entity-column" element contains "zone-cp-1"
-    Then the "$table-row:nth-child(1) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
-    Then the "$table-row:nth-child(1) .storeType-column" element contains "memory"
-    Then the "$table-row:nth-child(1) .hasIngress-column" element contains "Yes"
-    Then the "$table-row:nth-child(1) .hasEgress-column" element contains "No"
+    Then the "$zone-cp-table-row:nth-child(1) .status-column" element contains "online"
+    Then the "$zone-cp-table-row:nth-child(1) .name-column" element contains "zone-cp-1"
+    Then the "$zone-cp-table-row:nth-child(1) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
+    Then the "$zone-cp-table-row:nth-child(1) .storeType-column" element contains "memory"
+    Then the "$zone-cp-table-row:nth-child(1) .hasIngress-column" element contains "Yes"
+    Then the "$zone-cp-table-row:nth-child(1) .hasEgress-column" element contains "No"
 
-    Then the "$table-row:nth-child(2) .status-column" element contains "offline"
-    Then the "$table-row:nth-child(2) .entity-column" element contains "zone-cp-2"
-    Then the "$table-row:nth-child(2) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
-    Then the "$table-row:nth-child(2) .storeType-column" element contains "memory"
-    Then the "$table-row:nth-child(2) .hasIngress-column" element contains "No"
-    Then the "$table-row:nth-child(2) .hasEgress-column" element contains "Yes"
-
-    Then the "$summary" element contains "Zone CP: zone-cp-1"
+    Then the "$zone-cp-table-row:nth-child(2) .status-column" element contains "offline"
+    Then the "$zone-cp-table-row:nth-child(2) .name-column" element contains "zone-cp-2"
+    Then the "$zone-cp-table-row:nth-child(2) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
+    Then the "$zone-cp-table-row:nth-child(2) .storeType-column" element contains "memory"
+    Then the "$zone-cp-table-row:nth-child(2) .hasIngress-column" element contains "No"
+    Then the "$zone-cp-table-row:nth-child(2) .hasEgress-column" element contains "Yes"
 
   Scenario Outline: Zone Ingress list view has expected content
     Given the environment

--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -40,7 +40,7 @@ Feature: Zones: List view content
       """
 
     When I visit the "/zones/zone-cps" URL
-    Then the page title contains "Zone CPs"
+    Then the page title contains "Control Planes"
 
     Then the "$zone-cp-table-row:nth-child(1) .status-column" element contains "online"
     Then the "$zone-cp-table-row:nth-child(1) .name-column" element contains "zone-cp-1"
@@ -90,7 +90,7 @@ Feature: Zones: List view content
       """
 
     When I visit the "/zones/zone-ingresses" URL
-    Then the page title contains "Zone Ingresses"
+    Then the page title contains "Ingresses"
 
     Then the "$zone-ingress-table-row:nth-child(1) .status-column" element contains "online"
     Then the "$zone-ingress-table-row:nth-child(1) .name-column" element contains "zone-ingress-1"
@@ -136,7 +136,7 @@ Feature: Zones: List view content
       """
 
     When I visit the "/zones/zone-egresses" URL
-    Then the page title contains "Zone Egresses"
+    Then the page title contains "Egresses"
 
     Then the "$zone-egress-table-row:nth-child(1) .status-column" element contains "online"
     Then the "$zone-egress-table-row:nth-child(1) .name-column" element contains "zone-egress-1"

--- a/features/zones/PageNavigation.feature
+++ b/features/zones/PageNavigation.feature
@@ -39,7 +39,7 @@ Feature: Zones: Page navigation
     Then the page title contains "Control Planes"
 
     Examples:
-      | RouteName              | TableSelector                      | DetailViewTitle | ListViewTitle  |
-      | zone-cp-list-view      | [data-testid='zone-cp-table']      | Control Plane   | Control Planes |
-      | zone-ingress-list-view | [data-testid='zone-ingress-table'] | Ingress         | Ingresses      |
-      | zone-egress-list-view  | [data-testid='zone-egress-table']  | Egress          | Egresses       |
+      | RouteName              | TableSelector                           | DetailViewTitle | ListViewTitle  |
+      | zone-cp-list-view      | [data-testid='zone-cp-collection']      | Control Plane   | Control Planes |
+      | zone-ingress-list-view | [data-testid='zone-ingress-collection'] | Ingress         | Ingresses      |
+      | zone-egress-list-view  | [data-testid='zone-egress-collection']  | Egress          | Egresses       |

--- a/features/zones/PageNavigation.feature
+++ b/features/zones/PageNavigation.feature
@@ -5,7 +5,6 @@ Feature: Zones: Page navigation
       | breadcrumbs | .k-breadcrumbs                      |
       | main-nav    | .app-sidebar                        |
       | nav-tabs    | [data-testid='nav-tabs']            |
-      | summary     | [data-testid='list-view-summary']   |
       | table       | [data-testid='data-overview-table'] |
       | table-row   | $table tbody tr                     |
 
@@ -22,25 +21,25 @@ Feature: Zones: Page navigation
         mode: global
       """
 
-    When I visit the "/" URL
-    And I click the "$main-nav .nav-item-zone-cp-list-view > a" element
+    When I visit the "/zones" URL
+    # This `cy.wait` stabilizes the test significantly. For some reason, it can happen that the subsequent navigation to via nav tab is never triggered.
+    Then I wait for 1000 milliseconds
 
     When I click the "$nav-tabs #<RouteName>-tab a" element
     Then the page title contains "<ListViewTitle>"
 
-    When I click the "$table-row:nth-child(1) [data-testid='detail-view-link']" element
+    When I click the "<TableSelector> tbody tr:nth-child(1) [data-testid='detail-view-link']" element
     Then the page title contains "<DetailViewTitle>"
 
     When I click the "$nav-tabs #<RouteName>-tab a" element
     Then the page title contains "<ListViewTitle>"
-    Then the "$table" element exists
-    And the "$summary" element exists
+    Then the "<TableSelector>" element exists
 
     When I click the "$breadcrumbs > .k-breadcrumbs-item:nth-child(1) > a" element
     Then the page title contains "Zone CPs"
 
     Examples:
-      | RouteName              | DetailViewTitle | ListViewTitle  |
-      | zone-cp-list-view      | Zone CP         | Zone CPs       |
-      | zone-ingress-list-view | Zone Ingress    | Zone Ingresses |
-      | zone-egress-list-view  | Zone Egress     | Zone Egresses  |
+      | RouteName              | TableSelector                      | DetailViewTitle | ListViewTitle  |
+      | zone-cp-list-view      | [data-testid='zone-cp-table']      | Zone CP         | Zone CPs       |
+      | zone-ingress-list-view | [data-testid='zone-ingress-table'] | Zone Ingress    | Zone Ingresses |
+      | zone-egress-list-view  | [data-testid='zone-egress-table']  | Zone Egress     | Zone Egresses  |

--- a/features/zones/PageNavigation.feature
+++ b/features/zones/PageNavigation.feature
@@ -36,10 +36,10 @@ Feature: Zones: Page navigation
     Then the "<TableSelector>" element exists
 
     When I click the "$breadcrumbs > .k-breadcrumbs-item:nth-child(1) > a" element
-    Then the page title contains "Zone CPs"
+    Then the page title contains "Control Planes"
 
     Examples:
       | RouteName              | TableSelector                      | DetailViewTitle | ListViewTitle  |
-      | zone-cp-list-view      | [data-testid='zone-cp-table']      | Zone CP         | Zone CPs       |
-      | zone-ingress-list-view | [data-testid='zone-ingress-table'] | Zone Ingress    | Zone Ingresses |
-      | zone-egress-list-view  | [data-testid='zone-egress-table']  | Zone Egress     | Zone Egresses  |
+      | zone-cp-list-view      | [data-testid='zone-cp-table']      | Control Plane   | Control Planes |
+      | zone-ingress-list-view | [data-testid='zone-ingress-table'] | Ingress         | Ingresses      |
+      | zone-egress-list-view  | [data-testid='zone-egress-table']  | Egress          | Egresses       |

--- a/features/zones/zone-cps/Item.feature
+++ b/features/zones/zone-cps/Item.feature
@@ -37,7 +37,7 @@ Feature: zones / zone-cps / item
       """
 
     When I visit the "/zones/zone-cps/zone-cp-1" URL
-    Then the page title contains "Zone CP"
+    Then the page title contains "Control Plane"
     Then the "$details" element contains "Zone CP: zone-cp-1"
 
     Then the "$tab-overview" element contains
@@ -63,4 +63,3 @@ Feature: zones / zone-cps / item
     When I visit the "/zones/zone-cps/zone-cp-1" URL
     And I click the "$nav-config" element
     Then the "$warning-no-subscriptions" element exists
-

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "lint:lockfile": "lockfile-lint --path yarn.lock --allowed-hosts yarn --validate-https",
     "lint:ts": "vue-tsc --noEmit",
     "test": "cross-env TZ=UTC VITE_ZONE_CREATION_FLOW=enabled jest",
-    "test:browser": "cross-env TZ=UTC cypress run",
-    "test:browser:view": "cross-env TZ=UTC KUMA_BASE_URL=http://localhost:8080/gui cypress open",
+    "test:browser": "cross-env TZ=UTC cypress run --browser chrome",
+    "test:browser:view": "cross-env TZ=UTC KUMA_BASE_URL=http://localhost:8080/gui cypress open --browser chrome",
     "test:watch": "yarn run test --watch"
   },
   "engines": {

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -103,7 +103,7 @@
                             service: item.name,
                           },
                         },
-                        label: t('common.collection.actions.view'),
+                        label: t('common.collection.actions.viewDetails'),
                       }"
                     />
                   </template>

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -103,7 +103,7 @@
                             service: item.name,
                           },
                         },
-                        label: t('common.collection.actions.viewDetails'),
+                        label: t('common.collection.actions.view'),
                       }"
                     />
                   </template>

--- a/src/app/zones/index.ts
+++ b/src/app/zones/index.ts
@@ -1,1 +1,27 @@
+import { sources } from './sources'
+import type { ServiceDefinition } from '@/services/utils'
+import { token } from '@/services/utils'
 export * from './routes'
+
+type Token = ReturnType<typeof token>
+type Sources = ReturnType<typeof sources>
+
+const $ = {
+  sources: token<Sources>('access-role.sources'),
+}
+
+export const services = (app: Record<string, Token>): ServiceDefinition[] => {
+  return [
+    [$.sources, {
+      service: sources,
+      arguments: [
+        app.api,
+      ],
+      labels: [
+        app.sources,
+      ],
+    }],
+  ]
+}
+
+export const TOKENS = $

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -10,8 +10,8 @@ zone-cps:
       breadcrumbs: Control Planes
       headers:
         name: 'Name'
-        zoneCpVersion: 'Zone CP Version'
-        storeType: 'Storage type'
+        zonecpversion: 'Zone CP Version'
+        storetype: 'Storage type'
         status: 'Status'
         warnings: 'Warnings'
         actions: 'Actions'

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -8,13 +8,6 @@ zone-cps:
     items:
       title: Control Planes
       breadcrumbs: Control Planes
-      headers:
-        name: 'Name'
-        zonecpversion: 'Zone CP Version'
-        storetype: 'Storage type'
-        status: 'Status'
-        warnings: 'Warnings'
-        actions: 'Actions'
 
 zone-ingresses:
   routes:
@@ -24,10 +17,6 @@ zone-ingresses:
     items:
       title: Ingresses
       breadcrumbs: Ingresses
-      headers:
-        name: 'Name'
-        status: 'Status'
-        actions: 'Actions'
 
 zone-egresses:
   routes:
@@ -37,10 +26,6 @@ zone-egresses:
     items:
       title: Egresses
       breadcrumbs: Egresses
-      headers:
-        name: 'Name'
-        status: 'Status'
-        actions: 'Actions'
 
 zones:
   href:

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -8,6 +8,15 @@ zone-cps:
     items:
       title: Control Planes
       breadcrumbs: Control Planes
+  list:
+    tableHeaders:
+      name: 'Name'
+      zoneCpVersion: 'Zone CP Version'
+      storeType: 'Storage type'
+      status: 'Status'
+      warnings: 'Warnings'
+      actions: 'Actions'
+
 zone-ingresses:
   routes:
     item:
@@ -16,6 +25,12 @@ zone-ingresses:
     items:
       title: Ingresses
       breadcrumbs: Ingresses
+  list:
+    tableHeaders:
+      name: 'Name'
+      status: 'Status'
+      actions: 'Actions'
+
 zone-egresses:
   routes:
     item:
@@ -24,6 +39,12 @@ zone-egresses:
     items:
       title: Egresses
       breadcrumbs: Egresses
+  list:
+    tableHeaders:
+      name: 'Name'
+      status: 'Status'
+      actions: 'Actions'
+
 zones:
   href:
     docs:
@@ -156,6 +177,3 @@ zones:
       proceedText: 'Yes, delete'
       title: 'Delete Zone'
       errorText: 'An unexpected error occurred'
-  list:
-    viewDetailsActionText: 'View details'
-    deleteActionText: 'Delete'

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -2,28 +2,28 @@ zone-cps:
   routes:
     item:
       title: "{name} Zone CP"
-      breadcrumbs: Zone CPs
+      breadcrumbs: Control Planes
       config:
         no-subscriptions: This zone has no subscriptions
     items:
-      title: Zone CPs
-      breadcrumbs: Zone CPs
+      title: Control Planes
+      breadcrumbs: Control Planes
 zone-ingresses:
   routes:
     item:
       title: "{name} Zone Ingress"
-      breadcrumbs: Zone Ingresses
+      breadcrumbs: Ingresses
     items:
-      title: Zone Ingresses
-      breadcrumbs: Zone Ingresses
+      title: Ingresses
+      breadcrumbs: Ingresses
 zone-egresses:
   routes:
     item:
       title: "{name} Zone Egress"
-      breadcrumbs: Zone Egresses
+      breadcrumbs: Egresses
     items:
-      title: Zone Egresses
-      breadcrumbs: Zone Egresses
+      title: Egresses
+      breadcrumbs: Egresses
 zones:
   href:
     docs:
@@ -32,11 +32,12 @@ zones:
     create:
       title: 'Create & connect Zone'
     items:
+      title: Zones
       breadcrumbs: Zones
       navigation:
-        zone-cp-list-view: Zone CPs
-        zone-ingress-list-view: Zone Ingresses
-        zone-egress-list-view: Zone Egresses
+        zone-cp-list-view: Control Planes
+        zone-ingress-list-view: Ingresses
+        zone-egress-list-view: Egresses
   form:
     exit: 'Exit'
     nameLabel: 'Name'

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 zone-cps:
   routes:
     item:
-      title: "{name} Zone CP"
+      title: "{name} Control Plane"
       breadcrumbs: Control Planes
       config:
         no-subscriptions: This zone has no subscriptions

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -8,14 +8,13 @@ zone-cps:
     items:
       title: Control Planes
       breadcrumbs: Control Planes
-  list:
-    tableHeaders:
-      name: 'Name'
-      zoneCpVersion: 'Zone CP Version'
-      storeType: 'Storage type'
-      status: 'Status'
-      warnings: 'Warnings'
-      actions: 'Actions'
+      headers:
+        name: 'Name'
+        zoneCpVersion: 'Zone CP Version'
+        storeType: 'Storage type'
+        status: 'Status'
+        warnings: 'Warnings'
+        actions: 'Actions'
 
 zone-ingresses:
   routes:
@@ -25,11 +24,10 @@ zone-ingresses:
     items:
       title: Ingresses
       breadcrumbs: Ingresses
-  list:
-    tableHeaders:
-      name: 'Name'
-      status: 'Status'
-      actions: 'Actions'
+      headers:
+        name: 'Name'
+        status: 'Status'
+        actions: 'Actions'
 
 zone-egresses:
   routes:
@@ -39,11 +37,10 @@ zone-egresses:
     items:
       title: Egresses
       breadcrumbs: Egresses
-  list:
-    tableHeaders:
-      name: 'Name'
-      status: 'Status'
-      actions: 'Actions'
+      headers:
+        name: 'Name'
+        status: 'Status'
+        actions: 'Actions'
 
 zones:
   href:

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -155,3 +155,6 @@ zones:
       proceedText: 'Yes, delete'
       title: 'Delete Zone'
       errorText: 'An unexpected error occurred'
+  list:
+    viewDetailsActionText: 'View details'
+    deleteActionText: 'Delete'

--- a/src/app/zones/routes.ts
+++ b/src/app/zones/routes.ts
@@ -1,3 +1,4 @@
+import { PAGE_SIZE_DEFAULT } from '@/constants'
 import { getLastNumberParameter } from '@/router/getLastParameter'
 import type { RouteRecordRaw } from 'vue-router'
 
@@ -34,8 +35,8 @@ export const routes = (
               path: '',
               name: 'zone-cp-list-view',
               props: (route) => ({
-                selectedZoneName: route.query.zone,
-                offset: getLastNumberParameter(route.query.offset),
+                page: getLastNumberParameter(route.query.page, 1),
+                size: getLastNumberParameter(route.query.size, PAGE_SIZE_DEFAULT),
               }),
               component: () => import('@/app/zones/views/ZoneListView.vue'),
             },

--- a/src/app/zones/routes.ts
+++ b/src/app/zones/routes.ts
@@ -58,8 +58,8 @@ export const routes = (
               path: '',
               name: 'zone-ingress-list-view',
               props: (route) => ({
-                selectedZoneIngressName: route.query.zoneIngress,
-                offset: getLastNumberParameter(route.query.offset),
+                page: getLastNumberParameter(route.query.page, 1),
+                size: getLastNumberParameter(route.query.size, PAGE_SIZE_DEFAULT),
               }),
               component: () => import('@/app/zones/views/ZoneIngressListView.vue'),
             },

--- a/src/app/zones/routes.ts
+++ b/src/app/zones/routes.ts
@@ -81,8 +81,8 @@ export const routes = (
               path: '',
               name: 'zone-egress-list-view',
               props: (route) => ({
-                selectedZoneEgressName: route.query.zoneEgress,
-                offset: getLastNumberParameter(route.query.offset),
+                page: getLastNumberParameter(route.query.page, 1),
+                size: getLastNumberParameter(route.query.size, PAGE_SIZE_DEFAULT),
               }),
               component: () => import('@/app/zones/views/ZoneEgressListView.vue'),
             },

--- a/src/app/zones/sources.ts
+++ b/src/app/zones/sources.ts
@@ -1,0 +1,47 @@
+import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
+import type KumaApi from '@/services/kuma-api/KumaApi'
+import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
+import type { ZoneOverview, ZoneIngressOverview, ZoneEgressOverview } from '@/types/index.d'
+import { fetchAllResources } from '@/utilities/helpers'
+
+type PaginationParams = {
+  size: number
+  page: number
+}
+
+export type ZoneOverviewCollection = CollectionResponse<ZoneOverview>
+export type ZoneOverviewSource = DataSourceResponse<ZoneOverview>
+export type ZoneOverviewCollectionSource = DataSourceResponse<ZoneOverviewCollection>
+
+export type AllZoneIngressOverviewCollection = CollectionResponse<ZoneIngressOverview>
+export type AllZoneIngressOverviewSource = DataSourceResponse<ZoneIngressOverview>
+export type AllZoneIngressOverviewCollectionSource = DataSourceResponse<AllZoneIngressOverviewCollection>
+
+export type AllZoneEgressOverviewCollection = CollectionResponse<ZoneEgressOverview>
+export type AllZoneEgressOverviewSource = DataSourceResponse<ZoneEgressOverview>
+export type AllZoneEgressOverviewCollectionSource = DataSourceResponse<AllZoneEgressOverviewCollection>
+
+export const sources = (api: KumaApi) => {
+  return {
+    '/zones/zone-cps': async (params: PaginationParams, source: { close: () => void }) => {
+      source.close()
+
+      const size = params.size
+      const offset = params.size * (params.page - 1)
+
+      return await api.getAllZoneOverviews({ size, offset })
+    },
+
+    '/zones/all-zone-ingresses': async (_params: unknown, source: { close: () => void }) => {
+      source.close()
+
+      return await fetchAllResources(api.getAllZoneIngressOverviews.bind(api))
+    },
+
+    '/zones/all-zone-egresses': async (_params: unknown, source: { close: () => void }) => {
+      source.close()
+
+      return await fetchAllResources(api.getAllZoneEgressOverviews.bind(api))
+    },
+  }
+}

--- a/src/app/zones/sources.ts
+++ b/src/app/zones/sources.ts
@@ -25,6 +25,10 @@ export type ZoneIngressOverviewCollection = CollectionResponse<ZoneIngressOvervi
 export type ZoneIngressOverviewSource = DataSourceResponse<ZoneIngressOverview>
 export type ZoneIngressOverviewCollectionSource = DataSourceResponse<ZoneIngressOverviewCollection>
 
+export type ZoneEgressOverviewCollection = CollectionResponse<ZoneEgressOverview>
+export type ZoneEgressOverviewSource = DataSourceResponse<ZoneEgressOverview>
+export type ZoneEgressOverviewCollectionSource = DataSourceResponse<ZoneEgressOverviewCollection>
+
 export const sources = (api: KumaApi) => {
   return {
     '/zones/zone-cps': async (params: PaginationParams, source: { close: () => void }) => {
@@ -55,6 +59,15 @@ export const sources = (api: KumaApi) => {
       const offset = params.size * (params.page - 1)
 
       return await api.getAllZoneIngressOverviews({ size, offset })
+    },
+
+    '/zones/zone-egresses': async (params: PaginationParams, source: { close: () => void }) => {
+      source.close()
+
+      const size = params.size
+      const offset = params.size * (params.page - 1)
+
+      return await api.getAllZoneEgressOverviews({ size, offset })
     },
   }
 }

--- a/src/app/zones/sources.ts
+++ b/src/app/zones/sources.ts
@@ -21,6 +21,10 @@ export type AllZoneEgressOverviewCollection = CollectionResponse<ZoneEgressOverv
 export type AllZoneEgressOverviewSource = DataSourceResponse<ZoneEgressOverview>
 export type AllZoneEgressOverviewCollectionSource = DataSourceResponse<AllZoneEgressOverviewCollection>
 
+export type ZoneIngressOverviewCollection = CollectionResponse<ZoneIngressOverview>
+export type ZoneIngressOverviewSource = DataSourceResponse<ZoneIngressOverview>
+export type ZoneIngressOverviewCollectionSource = DataSourceResponse<ZoneIngressOverviewCollection>
+
 export const sources = (api: KumaApi) => {
   return {
     '/zones/zone-cps': async (params: PaginationParams, source: { close: () => void }) => {
@@ -42,6 +46,15 @@ export const sources = (api: KumaApi) => {
       source.close()
 
       return await fetchAllResources(api.getAllZoneEgressOverviews.bind(api))
+    },
+
+    '/zones/zone-ingresses': async (params: PaginationParams, source: { close: () => void }) => {
+      source.close()
+
+      const size = params.size
+      const offset = params.size * (params.page - 1)
+
+      return await api.getAllZoneIngressOverviews({ size, offset })
     },
   }
 }

--- a/src/app/zones/sources.ts
+++ b/src/app/zones/sources.ts
@@ -2,7 +2,6 @@ import { DataSourceResponse } from '@/app/application/services/data-source/DataS
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
 import type { ZoneOverview, ZoneIngressOverview, ZoneEgressOverview } from '@/types/index.d'
-import { fetchAllResources } from '@/utilities/helpers'
 
 type PaginationParams = {
   size: number
@@ -12,14 +11,6 @@ type PaginationParams = {
 export type ZoneOverviewCollection = CollectionResponse<ZoneOverview>
 export type ZoneOverviewSource = DataSourceResponse<ZoneOverview>
 export type ZoneOverviewCollectionSource = DataSourceResponse<ZoneOverviewCollection>
-
-export type AllZoneIngressOverviewCollection = CollectionResponse<ZoneIngressOverview>
-export type AllZoneIngressOverviewSource = DataSourceResponse<ZoneIngressOverview>
-export type AllZoneIngressOverviewCollectionSource = DataSourceResponse<AllZoneIngressOverviewCollection>
-
-export type AllZoneEgressOverviewCollection = CollectionResponse<ZoneEgressOverview>
-export type AllZoneEgressOverviewSource = DataSourceResponse<ZoneEgressOverview>
-export type AllZoneEgressOverviewCollectionSource = DataSourceResponse<AllZoneEgressOverviewCollection>
 
 export type ZoneIngressOverviewCollection = CollectionResponse<ZoneIngressOverview>
 export type ZoneIngressOverviewSource = DataSourceResponse<ZoneIngressOverview>
@@ -38,18 +29,6 @@ export const sources = (api: KumaApi) => {
       const offset = params.size * (params.page - 1)
 
       return await api.getAllZoneOverviews({ size, offset })
-    },
-
-    '/zones/all-zone-ingresses': async (_params: unknown, source: { close: () => void }) => {
-      source.close()
-
-      return await fetchAllResources(api.getAllZoneIngressOverviews.bind(api))
-    },
-
-    '/zones/all-zone-egresses': async (_params: unknown, source: { close: () => void }) => {
-      source.close()
-
-      return await fetchAllResources(api.getAllZoneEgressOverviews.bind(api))
     },
 
     '/zones/zone-ingresses': async (params: PaginationParams, source: { close: () => void }) => {

--- a/src/app/zones/sources.ts
+++ b/src/app/zones/sources.ts
@@ -22,7 +22,7 @@ export type ZoneEgressOverviewCollectionSource = DataSourceResponse<ZoneEgressOv
 
 export const sources = (api: KumaApi) => {
   return {
-    '/zones/zone-cps': async (params: PaginationParams, source: { close: () => void }) => {
+    '/zone-cps': async (params: PaginationParams, source: { close: () => void }) => {
       source.close()
 
       const size = params.size
@@ -31,7 +31,7 @@ export const sources = (api: KumaApi) => {
       return await api.getAllZoneOverviews({ size, offset })
     },
 
-    '/zones/zone-ingresses': async (params: PaginationParams, source: { close: () => void }) => {
+    '/zone-ingresses': async (params: PaginationParams, source: { close: () => void }) => {
       source.close()
 
       const size = params.size
@@ -40,7 +40,7 @@ export const sources = (api: KumaApi) => {
       return await api.getAllZoneIngressOverviews({ size, offset })
     },
 
-    '/zones/zone-egresses': async (params: PaginationParams, source: { close: () => void }) => {
+    '/zone-egresses': async (params: PaginationParams, source: { close: () => void }) => {
       source.close()
 
       const size = params.size

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -43,19 +43,19 @@
               :error="error"
               @change="route.update"
             >
-              <template #name="{ row }">
+              <template #name="{ row, rowValue }">
                 <RouterLink
                   :to="row.detailViewRoute"
                   data-testid="detail-view-link"
                 >
-                  {{ row.name }}
+                  {{ rowValue }}
                 </RouterLink>
               </template>
 
-              <template #status="{ row }">
+              <template #status="{ rowValue }">
                 <StatusBadge
-                  v-if="row.status"
-                  :status="row.status"
+                  v-if="rowValue"
+                  :status="rowValue"
                 />
 
                 <template v-else>

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -29,6 +29,7 @@
         <KCard>
           <template #body>
             <AppCollection
+              class="zone-egress-table"
               data-testid="zone-egress-table"
               :headers="[
                 { label: 'Name', key: 'name' },
@@ -125,3 +126,24 @@ function transformToTableData(zoneEgressOverviews: ZoneEgressOverview[]): ZoneEg
   })
 }
 </script>
+
+<style lang="scss" scoped>
+.actions-dropdown {
+  display: inline-block;
+}
+</style>
+
+<style lang="scss">
+.zone-egress-table {
+  .actions-column {
+    width: 5%;
+    min-width: 80px;
+    text-align: end;
+  }
+
+  .status-column {
+    width: 10%;
+    min-width: 200px;
+  }
+}
+</style>

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -32,10 +32,10 @@
               class="zone-egress-collection"
               data-testid="zone-egress-collection"
               :headers="[
-                { key: 'name' },
-                { key: 'status' },
-                { key: 'actions', hideLabel: true },
-              ].map((header) => ({ ...header, label: t(`zone-egresses.routes.items.headers.${header.key}`) }))"
+                { label: 'Name', key: 'name' },
+                { label: 'Status', key: 'status' },
+                { label: 'Actions', key: 'actions', hideLabel: true },
+              ]"
               :page-number="props.page"
               :page-size="props.size"
               :total="data?.total"

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -90,7 +90,7 @@
                     <KDropdownItem
                       :item="{
                         to: row.detailViewRoute,
-                        label: t('common.collection.actions.viewDetails'),
+                        label: t('common.collection.actions.view'),
                       }"
                     />
                   </template>

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -16,18 +16,21 @@
       ]"
     >
       <DataSource
-        v-slot="{ data: zoneEgressOverviewData, error }: ZoneEgressOverviewCollectionSource"
-        :src="`/zones/zone-egresses?size=${props.size}&page=${props.page}`"
+        v-slot="{ data, error }: ZoneEgressOverviewCollectionSource"
+        :src="`/zone-egresses?size=${props.size}&page=${props.page}`"
       >
         <KCard>
           <template #body>
             <AppCollection
               data-testid="zone-egress-table"
-              :headers="HEADERS"
+              :headers="[
+                { label: 'Name', key: 'name' },
+                { label: 'Status', key: 'status' },
+              ]"
               :page-number="props.page"
               :page-size="props.size"
-              :total="zoneEgressOverviewData?.total"
-              :items="zoneEgressOverviewData ? transformToTableData(zoneEgressOverviewData.items) : []"
+              :total="data?.total"
+              :items="data ? transformToTableData(data.items) : []"
               :error="error"
               @change="route.update"
             >
@@ -69,7 +72,7 @@ import DataSource from '@/app/application/components/data-source/DataSource.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
-import { StatusKeyword, TableHeader, ZoneEgressOverview } from '@/types/index.d'
+import { StatusKeyword, ZoneEgressOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
@@ -81,11 +84,6 @@ type ZoneEgressOverviewTableRow = {
 }
 
 const { t } = useI18n()
-
-const HEADERS: TableHeader[] = [
-  { label: 'Name', key: 'name' },
-  { label: 'Status', key: 'status' },
-]
 
 const props = defineProps({
   page: {

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -35,7 +35,7 @@
                 { key: 'name' },
                 { key: 'status' },
                 { key: 'actions', hideLabel: true },
-              ].map((header) => ({ ...header, label: t(`zone-egresses.list.tableHeaders.${header.key}`) }))"
+              ].map((header) => ({ ...header, label: t(`zone-egresses.routes.items.headers.${header.key}`) }))"
               :page-number="props.page"
               :page-size="props.size"
               :total="data?.total"

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -120,7 +120,6 @@ import { useI18n } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 type ZoneEgressOverviewTableRow = {
-  id: string
   detailViewRoute: RouteLocationNamedRaw
   name: string
   status: StatusKeyword
@@ -143,7 +142,6 @@ const props = defineProps({
 function transformToTableData(zoneEgressOverviews: ZoneEgressOverview[]): ZoneEgressOverviewTableRow[] {
   return zoneEgressOverviews.map((entity) => {
     const { name } = entity
-    const id = name
     const detailViewRoute: RouteLocationNamedRaw = {
       name: 'zone-egress-detail-view',
       params: {
@@ -153,7 +151,6 @@ function transformToTableData(zoneEgressOverviews: ZoneEgressOverview[]): ZoneEg
     const status = getItemStatusFromInsight(entity.zoneEgressInsight ?? {})
 
     return {
-      id,
       detailViewRoute,
       name,
       status,

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -39,7 +39,7 @@
               :page-number="props.page"
               :page-size="props.size"
               :total="data?.total"
-              :items="data ? transformToTableData(data.items) : []"
+              :items="data ? transformToTableData(data.items) : undefined"
               :error="error"
               @change="route.update"
             >

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -32,9 +32,10 @@
               class="zone-egress-table"
               data-testid="zone-egress-table"
               :headers="[
-                { label: 'Name', key: 'name' },
-                { label: 'Status', key: 'status' },
-              ]"
+                { key: 'name' },
+                { key: 'status' },
+                { key: 'actions', hideLabel: true },
+              ].map((header) => ({ ...header, label: t(`zone-egresses.list.tableHeaders.${header.key}`) }))"
               :page-number="props.page"
               :page-size="props.size"
               :total="data?.total"
@@ -61,6 +62,40 @@
                   —
                 </template>
               </template>
+
+              <template #actions="{ row }">
+                <KDropdownMenu
+                  class="actions-dropdown"
+                  data-testid="actions-dropdown"
+                  :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
+                  width="150"
+                >
+                  <template #default>
+                    <KButton
+                      class="non-visual-button"
+                      appearance="secondary"
+                      size="small"
+                    >
+                      <template #icon>
+                        <KIcon
+                          color="var(--black-400)"
+                          icon="more"
+                          size="16"
+                        />
+                      </template>
+                    </KButton>
+                  </template>
+
+                  <template #items>
+                    <KDropdownItem
+                      :item="{
+                        to: row.detailViewRoute,
+                        label: t('common.collection.actions.viewDetails'),
+                      }"
+                    />
+                  </template>
+                </KDropdownMenu>
+              </template>
             </AppCollection>
           </template>
         </KCard>
@@ -70,7 +105,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KCard } from '@kong/kongponents'
+import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
 import { RouteLocationNamedRaw } from 'vue-router'
 
 import type { ZoneEgressOverviewCollectionSource } from '../sources'

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -3,8 +3,6 @@
     v-slot="{ route }"
     name="zone-egress-list-view"
   >
-    <RouteTitle :title="t('zone-egresses.routes.items.title')" />
-
     <AppView
       :breadcrumbs="[
         {
@@ -15,6 +13,15 @@
         },
       ]"
     >
+      <template #title>
+        <h2>
+          <RouteTitle
+            :title="t('zone-egresses.routes.items.title')"
+            :render="true"
+          />
+        </h2>
+      </template>
+
       <DataSource
         v-slot="{ data, error }: ZoneEgressOverviewCollectionSource"
         :src="`/zone-egresses?size=${props.size}&page=${props.page}`"

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -29,8 +29,8 @@
         <KCard>
           <template #body>
             <AppCollection
-              class="zone-egress-table"
-              data-testid="zone-egress-table"
+              class="zone-egress-collection"
+              data-testid="zone-egress-collection"
               :headers="[
                 { key: 'name' },
                 { key: 'status' },
@@ -169,7 +169,7 @@ function transformToTableData(zoneEgressOverviews: ZoneEgressOverview[]): ZoneEg
 </style>
 
 <style lang="scss">
-.zone-egress-table {
+.zone-egress-collection {
   .actions-column {
     width: 5%;
     min-width: 80px;

--- a/src/app/zones/views/ZoneIndexView.vue
+++ b/src/app/zones/views/ZoneIndexView.vue
@@ -6,10 +6,19 @@
           to: {
             name: 'zone-index-view',
           },
-          text: i18n.t('zones.routes.items.breadcrumbs')
+          text: t('zones.routes.items.breadcrumbs')
         },
       ]"
     >
+      <template #title>
+        <h1>
+          <RouteTitle
+            :title="t('zones.routes.items.title')"
+            :render="true"
+          />
+        </h1>
+      </template>
+
       <NavTabs
         v-if="store.getters['config/getMulticlusterStatus']"
         :tabs="tabs"
@@ -27,27 +36,28 @@
 
 <script lang="ts" setup>
 import AppView from '@/app/application/components/app-view/AppView.vue'
+import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import NavTabs, { NavTab } from '@/app/common/NavTabs.vue'
 import { useStore } from '@/store/store'
 import { useI18n } from '@/utilities'
 
-const i18n = useI18n()
+const { t } = useI18n()
 const store = useStore()
 
 const tabs: NavTab[] = [
   {
-    title: i18n.t('zones.routes.items.navigation.zone-cp-list-view'),
+    title: t('zones.routes.items.navigation.zone-cp-list-view'),
     routeName: 'zone-cp-list-view',
     module: 'zone-cps',
   },
   {
-    title: i18n.t('zones.routes.items.navigation.zone-ingress-list-view'),
+    title: t('zones.routes.items.navigation.zone-ingress-list-view'),
     routeName: 'zone-ingress-list-view',
     module: 'zone-ingresses',
   },
   {
-    title: i18n.t('zones.routes.items.navigation.zone-egress-list-view'),
+    title: t('zones.routes.items.navigation.zone-egress-list-view'),
     routeName: 'zone-egress-list-view',
     module: 'zone-egresses',
   },

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -32,6 +32,7 @@
           <KCard>
             <template #body>
               <AppCollection
+                class="zone-ingress-table"
                 data-testid="zone-ingress-table"
                 :headers="[
                   { label: 'Name', key: 'name' },
@@ -132,3 +133,24 @@ function transformToTableData(zoneIngressOverviews: ZoneIngressOverview[]): Zone
   })
 }
 </script>
+
+<style lang="scss" scoped>
+.actions-dropdown {
+  display: inline-block;
+}
+</style>
+
+<style lang="scss">
+.zone-ingress-table {
+  .actions-column {
+    width: 5%;
+    min-width: 80px;
+    text-align: end;
+  }
+
+  .status-column {
+    width: 10%;
+    min-width: 200px;
+  }
+}
+</style>

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -42,7 +42,7 @@
                 :page-number="props.page"
                 :page-size="props.size"
                 :total="data?.total"
-                :items="data ? transformToTableData(data.items) : []"
+                :items="data ? transformToTableData(data.items) : undefined"
                 :error="error"
                 @change="route.update"
               >

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -38,7 +38,7 @@
                   { label: 'Name', key: 'name' },
                   { label: 'Status', key: 'status' },
                   { label: 'Actions', key: 'actions', hideLabel: true },
-                ].map((header) => ({ ...header, label: t(`zone-ingresses.list.tableHeaders.${header.key}`) }))"
+                ].map((header) => ({ ...header, label: t(`zone-ingresses.routes.items.headers.${header.key}`) }))"
                 :page-number="props.page"
                 :page-size="props.size"
                 :total="data?.total"

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -35,10 +35,10 @@
                 class="zone-ingress-collection"
                 data-testid="zone-ingress-collection"
                 :headers="[
-                  { key: 'name' },
-                  { key: 'status' },
-                  { key: 'actions', hideLabel: true },
-                ].map((header) => ({ ...header, label: t(`zone-ingresses.routes.items.headers.${header.key}`) }))"
+                  { label: 'Name', key: 'name' },
+                  { label: 'Status', key: 'status' },
+                  { label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
                 :page-number="props.page"
                 :page-size="props.size"
                 :total="data?.total"

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -3,8 +3,6 @@
     v-slot="{ route }"
     name="zone-ingress-list-view"
   >
-    <RouteTitle :title="t('zone-ingresses.routes.items.title')" />
-
     <AppView
       :breadcrumbs="[
         {
@@ -15,6 +13,15 @@
         },
       ]"
     >
+      <template #title>
+        <h2>
+          <RouteTitle
+            :title="t('zone-ingresses.routes.items.title')"
+            :render="true"
+          />
+        </h2>
+      </template>
+
       <MultizoneInfo v-if="store.getters['config/getMulticlusterStatus'] === false" />
 
       <template v-else>

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -126,7 +126,6 @@ import { useI18n } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 type ZoneIngressOverviewTableRow = {
-  id: string
   detailViewRoute: RouteLocationNamedRaw
   name: string
   status: StatusKeyword
@@ -150,7 +149,6 @@ const props = defineProps({
 function transformToTableData(zoneIngressOverviews: ZoneIngressOverview[]): ZoneIngressOverviewTableRow[] {
   return zoneIngressOverviews.map((entity) => {
     const { name } = entity
-    const id = name
     const detailViewRoute: RouteLocationNamedRaw = {
       name: 'zone-ingress-detail-view',
       params: {
@@ -160,7 +158,6 @@ function transformToTableData(zoneIngressOverviews: ZoneIngressOverview[]): Zone
     const status = getItemStatusFromInsight(entity.zoneIngressInsight ?? {})
 
     return {
-      id,
       detailViewRoute,
       name,
       status,

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -93,7 +93,7 @@
                       <KDropdownItem
                         :item="{
                           to: row.detailViewRoute,
-                          label: t('common.collection.actions.viewDetails'),
+                          label: t('common.collection.actions.view'),
                         }"
                       />
                     </template>

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -19,18 +19,21 @@
 
       <template v-else>
         <DataSource
-          v-slot="{ data: zoneIngressOverviewData, error }: ZoneIngressOverviewCollectionSource"
-          :src="`/zones/zone-ingresses?size=${props.size}&page=${props.page}`"
+          v-slot="{ data, error }: ZoneIngressOverviewCollectionSource"
+          :src="`/zone-ingresses?size=${props.size}&page=${props.page}`"
         >
           <KCard>
             <template #body>
               <AppCollection
                 data-testid="zone-ingress-table"
-                :headers="HEADERS"
+                :headers="[
+                  { label: 'Name', key: 'name' },
+                  { label: 'Status', key: 'status' },
+                ]"
                 :page-number="props.page"
                 :page-size="props.size"
-                :total="zoneIngressOverviewData?.total"
-                :items="zoneIngressOverviewData ? transformToTableData(zoneIngressOverviewData.items) : []"
+                :total="data?.total"
+                :items="data ? transformToTableData(data.items) : []"
                 :error="error"
                 @change="route.update"
               >
@@ -75,7 +78,7 @@ import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import { useStore } from '@/store/store'
-import { StatusKeyword, TableHeader, ZoneIngressOverview } from '@/types/index.d'
+import { StatusKeyword, ZoneIngressOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
@@ -88,11 +91,6 @@ type ZoneIngressOverviewTableRow = {
 
 const { t } = useI18n()
 const store = useStore()
-
-const HEADERS: TableHeader[] = [
-  { label: 'Name', key: 'name' },
-  { label: 'Status', key: 'status' },
-]
 
 const props = defineProps({
   page: {

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -37,7 +37,8 @@
                 :headers="[
                   { label: 'Name', key: 'name' },
                   { label: 'Status', key: 'status' },
-                ]"
+                  { label: 'Actions', key: 'actions', hideLabel: true },
+                ].map((header) => ({ ...header, label: t(`zone-ingresses.list.tableHeaders.${header.key}`) }))"
                 :page-number="props.page"
                 :page-size="props.size"
                 :total="data?.total"
@@ -64,6 +65,40 @@
                     —
                   </template>
                 </template>
+
+                <template #actions="{ row }">
+                  <KDropdownMenu
+                    class="actions-dropdown"
+                    data-testid="actions-dropdown"
+                    :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
+                    width="150"
+                  >
+                    <template #default>
+                      <KButton
+                        class="non-visual-button"
+                        appearance="secondary"
+                        size="small"
+                      >
+                        <template #icon>
+                          <KIcon
+                            color="var(--black-400)"
+                            icon="more"
+                            size="16"
+                          />
+                        </template>
+                      </KButton>
+                    </template>
+
+                    <template #items>
+                      <KDropdownItem
+                        :item="{
+                          to: row.detailViewRoute,
+                          label: t('common.collection.actions.viewDetails'),
+                        }"
+                      />
+                    </template>
+                  </KDropdownMenu>
+                </template>
               </AppCollection>
             </template>
           </KCard>
@@ -74,7 +109,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KCard } from '@kong/kongponents'
+import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
 import { RouteLocationNamedRaw } from 'vue-router'
 
 import MultizoneInfo from '../components/MultizoneInfo.vue'

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -32,8 +32,8 @@
           <KCard>
             <template #body>
               <AppCollection
-                class="zone-ingress-table"
-                data-testid="zone-ingress-table"
+                class="zone-ingress-collection"
+                data-testid="zone-ingress-collection"
                 :headers="[
                   { label: 'Name', key: 'name' },
                   { label: 'Status', key: 'status' },
@@ -176,7 +176,7 @@ function transformToTableData(zoneIngressOverviews: ZoneIngressOverview[]): Zone
 </style>
 
 <style lang="scss">
-.zone-ingress-table {
+.zone-ingress-collection {
   .actions-column {
     width: 5%;
     min-width: 80px;

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -35,9 +35,9 @@
                 class="zone-ingress-collection"
                 data-testid="zone-ingress-collection"
                 :headers="[
-                  { label: 'Name', key: 'name' },
-                  { label: 'Status', key: 'status' },
-                  { label: 'Actions', key: 'actions', hideLabel: true },
+                  { key: 'name' },
+                  { key: 'status' },
+                  { key: 'actions', hideLabel: true },
                 ].map((header) => ({ ...header, label: t(`zone-ingresses.routes.items.headers.${header.key}`) }))"
                 :page-number="props.page"
                 :page-size="props.size"

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -46,19 +46,19 @@
                 :error="error"
                 @change="route.update"
               >
-                <template #name="{ row }">
+                <template #name="{ row, rowValue }">
                   <RouterLink
                     :to="row.detailViewRoute"
                     data-testid="detail-view-link"
                   >
-                    {{ row.name }}
+                    {{ rowValue }}
                   </RouterLink>
                 </template>
 
-                <template #status="{ row }">
+                <template #status="{ rowValue }">
                   <StatusBadge
-                    v-if="row.status"
-                    :status="row.status"
+                    v-if="rowValue"
+                    :status="rowValue"
                   />
 
                   <template v-else>

--- a/src/app/zones/views/ZoneListView.spec.ts
+++ b/src/app/zones/views/ZoneListView.spec.ts
@@ -59,7 +59,7 @@ describe('ZoneListView', () => {
 
     expect(kumaApi.getAllZoneOverviews).toHaveBeenCalledTimes(1)
 
-    expect(wrapper.findAll('[data-testid="zone-cp-table"] tbody tr').length).toBe(3)
+    expect(wrapper.findAll('[data-testid="zone-cp-collection"] tbody tr').length).toBe(3)
 
     // Opens the action dropdown
     const actionsDropdown = wrapper.find('[data-testid="actions-dropdown"] [data-testid="k-dropdown-menu-popover"]')

--- a/src/app/zones/views/ZoneListView.spec.ts
+++ b/src/app/zones/views/ZoneListView.spec.ts
@@ -8,7 +8,12 @@ import { useKumaApi, useStore } from '@/utilities'
 const kumaApi = useKumaApi()
 
 function renderComponent() {
-  return mount(ZoneListView)
+  return mount(ZoneListView, {
+    props: {
+      page: 1,
+      size: 50,
+    },
+  })
 }
 
 describe('ZoneListView', () => {
@@ -54,7 +59,7 @@ describe('ZoneListView', () => {
 
     expect(kumaApi.getAllZoneOverviews).toHaveBeenCalledTimes(1)
 
-    expect(wrapper.findAll('[data-testid="data-overview-table"] tbody tr').length).toBe(3)
+    expect(wrapper.findAll('[data-testid="zone-cp-table"] tbody tr').length).toBe(3)
 
     // Opens the action dropdown
     const actionsDropdown = wrapper.find('[data-testid="actions-dropdown"] [data-testid="k-dropdown-menu-popover"]')

--- a/src/app/zones/views/ZoneListView.spec.ts
+++ b/src/app/zones/views/ZoneListView.spec.ts
@@ -81,5 +81,7 @@ describe('ZoneListView', () => {
     await deleteButton.trigger('click')
 
     expect(kumaApi.getAllZoneOverviews).toHaveBeenCalledTimes(2)
+
+    expect(wrapper.find('[data-testid="delete-resource-modal"]').exists()).not.toBe(true)
   })
 })

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -89,7 +89,7 @@
                       <KDropdownItem
                         :item="{
                           to: row.detailViewRoute,
-                          label: t('common.collection.actions.viewDetails'),
+                          label: t('common.collection.actions.view'),
                         }"
                       />
 

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -149,7 +149,7 @@
             :action-button-text="t('zones.delete.confirmModal.proceedText')"
             :title="t('zones.delete.confirmModal.title')"
             @cancel="toggleDeleteModal"
-            @delete="refresh"
+            @delete="() => { toggleDeleteModal(); refresh() }"
           >
             <template #body-content>
               <p>{{ t('zones.delete.confirmModal.text1', { zoneName: deleteZoneName }) }}</p>

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -62,6 +62,45 @@
                   </KButton>
                 </template>
 
+                <template #name="{ row, rowValue }">
+                  <RouterLink
+                    :to="row.detailViewRoute"
+                    data-testid="detail-view-link"
+                  >
+                    {{ rowValue }}
+                  </RouterLink>
+                </template>
+
+                <template #zoneCpVersion="{ rowValue }">
+                  {{ rowValue }}
+                </template>
+
+                <template #storeType="{ rowValue }">
+                  {{ rowValue }}
+                </template>
+
+                <template #status="{ rowValue }">
+                  <StatusBadge
+                    v-if="rowValue"
+                    :status="rowValue"
+                  />
+
+                  <template v-else>
+                    —
+                  </template>
+                </template>
+
+                <template #warnings="{ rowValue }">
+                  <KIcon
+                    v-if="rowValue"
+                    class="mr-1"
+                    icon="warning"
+                    color="var(--black-500)"
+                    secondary-color="var(--yellow-300)"
+                    size="20"
+                  />
+                </template>
+
                 <template #actions="{ row }">
                   <KDropdownMenu
                     class="actions-dropdown"
@@ -104,37 +143,6 @@
                       </KDropdownItem>
                     </template>
                   </KDropdownMenu>
-                </template>
-
-                <template #name="{ row }">
-                  <RouterLink
-                    :to="row.detailViewRoute"
-                    data-testid="detail-view-link"
-                  >
-                    {{ row.name }}
-                  </RouterLink>
-                </template>
-
-                <template #status="{ row }">
-                  <StatusBadge
-                    v-if="row.status"
-                    :status="row.status"
-                  />
-
-                  <template v-else>
-                    —
-                  </template>
-                </template>
-
-                <template #warnings="{ row }">
-                  <KIcon
-                    v-if="row.withWarnings"
-                    class="mr-1"
-                    icon="warning"
-                    color="var(--black-500)"
-                    secondary-color="var(--yellow-300)"
-                    size="20"
-                  />
                 </template>
               </AppCollection>
             </template>
@@ -192,7 +200,7 @@ type ZoneOverviewTableRow = {
   status: StatusKeyword
   zoneCpVersion: string
   storeType: string
-  withWarnings: boolean
+  warnings: boolean
 }
 
 const env = useEnv()
@@ -250,7 +258,7 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
       status,
       zoneCpVersion,
       storeType,
-      withWarnings: !cpCompat,
+      warnings: !cpCompat,
     }
   })
 }

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -45,7 +45,7 @@
                 :page-number="props.page"
                 :page-size="props.size"
                 :total="data?.total"
-                :items="data ? transformToTableData(data.items) : []"
+                :items="data ? transformToTableData(data.items) : undefined"
                 :error="error"
                 @change="route.update"
               >

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -35,13 +35,13 @@
                 class="zone-cp-table"
                 data-testid="zone-cp-table"
                 :headers="[
-                  { label: 'Name', key: 'name' },
-                  { label: 'Zone CP Version', key: 'zoneCpVersion' },
-                  { label: 'Storage type', key: 'storeType' },
-                  { label: 'Status', key: 'status' },
-                  { label: 'Warnings', key: 'warnings', hideLabel: true },
-                  { label: 'Actions', key: 'actions', hideLabel: true },
-                ]"
+                  { key: 'name' },
+                  { key: 'zoneCpVersion' },
+                  { key: 'storeType' },
+                  { key: 'status' },
+                  { key: 'warnings', hideLabel: true },
+                  { key: 'actions', hideLabel: true },
+                ].map((header) => ({ ...header, label: t(`zone-cps.list.tableHeaders.${header.key}`) }))"
                 :page-number="props.page"
                 :page-size="props.size"
                 :total="data?.total"
@@ -89,7 +89,7 @@
                       <KDropdownItem
                         :item="{
                           to: row.detailViewRoute,
-                          label: t('zones.list.viewDetailsActionText'),
+                          label: t('common.collection.actions.viewDetails'),
                         }"
                       />
 
@@ -100,7 +100,7 @@
                         data-testid="dropdown-delete-item"
                         @click="setDeleteZoneName(row.name)"
                       >
-                        {{ t('zones.list.deleteActionText') }}
+                        {{ t('common.collection.actions.delete') }}
                       </KDropdownItem>
                     </template>
                   </KDropdownMenu>

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -1,8 +1,10 @@
 <template>
-  <RouteView>
-    <RouteTitle
-      :title="t('zone-cps.routes.items.title')"
-    />
+  <RouteView
+    v-slot="{ route }"
+    name="zone-cp-list-view"
+  >
+    <RouteTitle :title="t('zone-cps.routes.items.title')" />
+
     <AppView
       :breadcrumbs="[
         {
@@ -13,103 +15,180 @@
         },
       ]"
     >
-      <div class="zones">
-        <MultizoneInfo v-if="store.getters['config/getMulticlusterStatus'] === false" />
+      <MultizoneInfo v-if="store.getters['config/getMulticlusterStatus'] === false" />
 
-        <div
-          v-else
-          class="stack"
+      <template v-else>
+        <DataSource
+          v-slot="{ data: zoneOverviewData, error, refresh }: ZoneOverviewCollectionSource"
+          :src="`/zones/zone-cps?size=${props.size}&page=${props.page}`"
         >
-          <div class="kcard-border">
-            <DataOverview
-              :selected-entity-name="entity?.name"
-              :page-size="PAGE_SIZE_DEFAULT"
-              :is-loading="isLoading"
-              :error="error"
-              :empty-state="EMPTY_STATE"
-              :table-data="tableData"
-              :table-data-is-empty="tableData.data.length === 0"
-              :show-warnings="tableData.data.some((item) => item.withWarnings)"
-              :next="nextUrl"
-              :page-offset="pageOffset"
-              :show-delete-action="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
-              @delete-resource="toggleDeleteModal"
-              @table-action="loadEntity"
-              @load-data="loadData"
-            >
-              <template
-                v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
-                #additionalControls
-              >
-                <KButton
-                  appearance="creation"
-                  icon="plus"
-                  :to="{ name: 'zone-create-view' }"
-                >
-                  Create Zone
-                </KButton>
-              </template>
-            </DataOverview>
-          </div>
-
-          <div
-            v-if="entity !== null"
-            class="kcard-border"
-            data-testid="list-view-summary"
+          <DataSource
+            v-slot="{ data: allZoneIngressOverviewData }: AllZoneIngressOverviewCollectionSource"
+            :src="`/zones/all-zone-ingresses`"
           >
-            <ZoneDetails :zone-overview="entity" />
-          </div>
-        </div>
+            <DataSource
+              v-slot="{ data: allZoneEgressOverviewData }: AllZoneEgressOverviewCollectionSource"
+              :src="`/zones/all-zone-egresses`"
+            >
+              <KCard>
+                <template #body>
+                  <AppCollection
+                    data-testid="zone-cp-table"
+                    :headers="HEADERS"
+                    :page-number="props.page"
+                    :page-size="props.size"
+                    :total="zoneOverviewData?.total"
+                    :items="zoneOverviewData && allZoneIngressOverviewData && allZoneEgressOverviewData ? transformToTableData(
+                      zoneOverviewData.items,
+                      allZoneIngressOverviewData.items,
+                      allZoneEgressOverviewData.items
+                    ) : []"
+                    :error="error"
+                    @change="route.update"
+                  >
+                    <template
+                      v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
+                      #toolbar
+                    >
+                      <KButton
+                        appearance="creation"
+                        icon="plus"
+                        :to="{ name: 'zone-create-view' }"
+                      >
+                        Create Zone
+                      </KButton>
+                    </template>
 
-        <DeleteResourceModal
-          v-if="isDeleteModalVisible"
-          :confirmation-text="deleteZoneName"
-          :delete-function="deleteZone"
-          :is-visible="isDeleteModalVisible"
-          modal-id="delete-zone-modal"
-          :action-button-text="t('zones.delete.confirmModal.proceedText')"
-          :title="t('zones.delete.confirmModal.title')"
-          @cancel="toggleDeleteModal"
-          @delete="handleDelete"
-        >
-          <template #body-content>
-            <p>{{ t('zones.delete.confirmModal.text1', { zoneName: deleteZoneName }) }}</p>
+                    <template #actions="{ row }">
+                      <KDropdownMenu
+                        class="actions-dropdown"
+                        data-testid="actions-dropdown"
+                        :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
+                        width="150"
+                      >
+                        <template #default>
+                          <KButton
+                            class="non-visual-button"
+                            appearance="secondary"
+                            size="small"
+                          >
+                            <template #icon>
+                              <KIcon
+                                color="var(--black-400)"
+                                icon="more"
+                                size="16"
+                              />
+                            </template>
+                          </KButton>
+                        </template>
 
-            <p>{{ t('zones.delete.confirmModal.text2') }}</p>
-          </template>
+                        <template #items>
+                          <KDropdownItem
+                            :item="{
+                              to: row.detailViewRoute,
+                              label: t('zones.list.viewDetailsActionText'),
+                            }"
+                          />
 
-          <template #error>
-            {{ t('zones.delete.confirmModal.errorText') }}
-          </template>
-        </DeleteResourceModal>
-      </div>
+                          <KDropdownItem
+                            v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
+                            has-divider
+                            is-dangerous
+                            data-testid="dropdown-delete-item"
+                            @click="setDeleteZoneName(row.name)"
+                          >
+                            {{ t('zones.list.deleteActionText') }}
+                          </KDropdownItem>
+                        </template>
+                      </KDropdownMenu>
+                    </template>
+
+                    <template #name="{ row }">
+                      <RouterLink
+                        :to="row.detailViewRoute"
+                        data-testid="detail-view-link"
+                      >
+                        {{ row.name }}
+                      </RouterLink>
+                    </template>
+
+                    <template #status="{ row }">
+                      <StatusBadge
+                        v-if="row.status"
+                        :status="row.status"
+                      />
+
+                      <template v-else>
+                        —
+                      </template>
+                    </template>
+
+                    <template #warnings="{ row }">
+                      <KIcon
+                        v-if="row.withWarnings"
+                        class="mr-1"
+                        icon="warning"
+                        color="var(--black-500)"
+                        secondary-color="var(--yellow-300)"
+                        size="20"
+                      />
+                    </template>
+                  </AppCollection>
+                </template>
+              </KCard>
+
+              <DeleteResourceModal
+                v-if="isDeleteModalVisible"
+                :confirmation-text="deleteZoneName"
+                :delete-function="deleteZone"
+                :is-visible="isDeleteModalVisible"
+                modal-id="delete-zone-modal"
+                :action-button-text="t('zones.delete.confirmModal.proceedText')"
+                :title="t('zones.delete.confirmModal.title')"
+                @cancel="toggleDeleteModal"
+                @delete="refresh"
+              >
+                <template #body-content>
+                  <p>{{ t('zones.delete.confirmModal.text1', { zoneName: deleteZoneName }) }}</p>
+
+                  <p>{{ t('zones.delete.confirmModal.text2') }}</p>
+                </template>
+
+                <template #error>
+                  {{ t('zones.delete.confirmModal.errorText') }}
+                </template>
+              </DeleteResourceModal>
+            </DataSource>
+          </DataSource>
+        </DataSource>
+      </template>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import { KButton } from '@kong/kongponents'
-import { PropType, ref, watch } from 'vue'
-import { RouteLocationNamedRaw } from 'vue-router'
+import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
+import { ref } from 'vue'
+import { type RouteLocationNamedRaw } from 'vue-router'
 
 import MultizoneInfo from '../components/MultizoneInfo.vue'
-import ZoneDetails from '../components/ZoneDetails.vue'
+import type { ZoneOverviewCollectionSource, AllZoneIngressOverviewCollectionSource, AllZoneEgressOverviewCollectionSource } from '../sources'
+import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import AppView from '@/app/application/components/app-view/AppView.vue'
+import DataSource from '@/app/application/components/data-source/DataSource.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
-import DataOverview from '@/app/common/DataOverview.vue'
 import DeleteResourceModal from '@/app/common/DeleteResourceModal.vue'
-import { PAGE_SIZE_DEFAULT } from '@/constants'
+import StatusBadge from '@/app/common/StatusBadge.vue'
 import { useStore } from '@/store/store'
 import { StatusKeyword, TableHeader, ZoneEgressOverview, ZoneIngressOverview, ZoneOverview } from '@/types/index.d'
 import { useEnv, useI18n, useKumaApi } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
-import { fetchAllResources } from '@/utilities/helpers'
-import { QueryParameter } from '@/utilities/QueryParameter'
 
 type ZoneOverviewTableRow = {
-  entity: ZoneOverview
+  id: string
   detailViewRoute: RouteLocationNamedRaw
+  name: string
   status: StatusKeyword
   zoneCpVersion: string
   storeType: string
@@ -121,99 +200,41 @@ type ZoneOverviewTableRow = {
 const env = useEnv()
 const { t } = useI18n()
 const kumaApi = useKumaApi()
-
-const EMPTY_STATE = {
-  title: 'No Data',
-  message: 'There are no Zones present.',
-}
-
 const store = useStore()
 
+const HEADERS: TableHeader[] = [
+  { label: 'Name', key: 'name' },
+  { label: 'Status', key: 'status' },
+  { label: 'Zone CP Version', key: 'zoneCpVersion' },
+  { label: 'Storage type', key: 'storeType' },
+  { label: 'Ingress', key: 'hasIngress' },
+  { label: 'Egress', key: 'hasEgress' },
+  { label: 'Warnings', key: 'warnings', hideLabel: true },
+  { label: 'Actions', key: 'actions', hideLabel: true },
+]
+
 const props = defineProps({
-  selectedZoneName: {
-    type: [String, null] as PropType<string | null>,
-    required: false,
-    default: null,
+  page: {
+    type: Number,
+    required: true,
   },
 
-  offset: {
+  size: {
     type: Number,
-    required: false,
-    default: 0,
+    required: true,
   },
 })
 
-const isLoading = ref(true)
 const isDeleteModalVisible = ref(false)
 const deleteZoneName = ref('')
-const error = ref<Error | null>(null)
-const tableData = ref<{ headers: TableHeader[], data: ZoneOverviewTableRow[] }>({
-  headers: [
-    { label: 'Status', key: 'status' },
-    { label: 'Name', key: 'entity' },
-    { label: 'Zone CP Version', key: 'zoneCpVersion' },
-    { label: 'Storage type', key: 'storeType' },
-    { label: 'Ingress', key: 'hasIngress' },
-    { label: 'Egress', key: 'hasEgress' },
-    { label: 'Warnings', key: 'warnings', hideLabel: true },
-    { label: 'Actions', key: 'actions', hideLabel: true },
-  ],
-  data: [],
-})
-const entity = ref<ZoneOverview | null>(null)
-const nextUrl = ref<string | null>(null)
-const pageOffset = ref(props.offset)
-
-watch(() => store.getters['config/getMulticlusterStatus'], function (isMultizoneMode) {
-  if (isMultizoneMode) {
-    loadData(props.offset)
-  }
-}, { immediate: true })
-
-async function loadData(offset: number) {
-  pageOffset.value = offset
-  // Puts the offset parameter in the URL so it can be retrieved when the user reloads the page.
-  QueryParameter.set('offset', offset > 0 ? offset : null)
-
-  isLoading.value = true
-  error.value = null
-
-  const size = PAGE_SIZE_DEFAULT
-
-  try {
-    const [{ items, next }, { items: zoneIngressOverviews }, { items: zoneEgressOverviews }] = await Promise.all([
-      kumaApi.getAllZoneOverviews({ size, offset }),
-      fetchAllResources(kumaApi.getAllZoneIngressOverviews.bind(kumaApi)),
-      fetchAllResources(kumaApi.getAllZoneEgressOverviews.bind(kumaApi)),
-    ])
-
-    nextUrl.value = next
-    tableData.value.data = transformToTableData(
-      items ?? [],
-      zoneIngressOverviews ?? [],
-      zoneEgressOverviews ?? [],
-    )
-    await loadEntity({ name: props.selectedZoneName ?? tableData.value.data[0]?.entity.name })
-  } catch (err) {
-    entity.value = null
-    tableData.value.data = []
-
-    if (err instanceof Error) {
-      error.value = err
-    } else {
-      console.error(err)
-    }
-  } finally {
-    isLoading.value = false
-  }
-}
 
 function transformToTableData(zoneOverviews: ZoneOverview[], zoneIngressOverviews: ZoneIngressOverview[], zoneEgressOverviews: ZoneEgressOverview[]): ZoneOverviewTableRow[] {
   const zonesWithIngress = new Set(zoneIngressOverviews.map((zoneIngressOverview) => zoneIngressOverview.zoneIngress.zone))
   const zonesWithEgress = new Set(zoneEgressOverviews.map((zoneEgressOverview) => zoneEgressOverview.zoneEgress.zone))
 
-  return zoneOverviews.map((entity) => {
-    const { name } = entity
+  return zoneOverviews.map((zoneOverview) => {
+    const { name } = zoneOverview
+    const id = name
     const detailViewRoute: RouteLocationNamedRaw = {
       name: 'zone-cp-detail-view',
       params: {
@@ -224,7 +245,7 @@ function transformToTableData(zoneOverviews: ZoneOverview[], zoneIngressOverview
     let storeType = ''
     let cpCompat = true
 
-    const subscriptions = entity.zoneInsight?.subscriptions ?? []
+    const subscriptions = zoneOverview.zoneInsight?.subscriptions ?? []
 
     subscriptions.forEach((item: any) => {
       if (item.version && item.version.kumaCp) {
@@ -238,34 +259,20 @@ function transformToTableData(zoneOverviews: ZoneOverview[], zoneIngressOverview
       }
     })
 
-    const status = getItemStatusFromInsight(entity.zoneInsight)
+    const status = getItemStatusFromInsight(zoneOverview.zoneInsight)
 
     return {
-      entity,
+      id,
       detailViewRoute,
+      name,
       status,
       zoneCpVersion,
       storeType,
-      hasIngress: zonesWithIngress.has(entity.name) ? 'Yes' : 'No',
-      hasEgress: zonesWithEgress.has(entity.name) ? 'Yes' : 'No',
+      hasIngress: zonesWithIngress.has(zoneOverview.name) ? 'Yes' : 'No',
+      hasEgress: zonesWithEgress.has(zoneOverview.name) ? 'Yes' : 'No',
       withWarnings: !cpCompat,
     }
   })
-}
-
-async function loadEntity({ name }: { name?: string | undefined }) {
-  if (name === undefined) {
-    entity.value = null
-    QueryParameter.set('zone', null)
-    return
-  }
-
-  try {
-    entity.value = await kumaApi.getZoneOverview({ name })
-    QueryParameter.set('zone', name)
-  } catch (err) {
-    console.error(err)
-  }
 }
 
 async function deleteZone() {
@@ -273,16 +280,30 @@ async function deleteZone() {
   await kumaApi.deleteZone({ name: deleteZoneName.value })
 }
 
-function toggleDeleteModal(row?: Record<string, any>) {
-  const zoneName = row?.entity?.name ?? row?.name ?? ''
+function toggleDeleteModal() {
   isDeleteModalVisible.value = !isDeleteModalVisible.value
-
-  deleteZoneName.value = zoneName
 }
 
-function handleDelete() {
+function setDeleteZoneName(name: string) {
   toggleDeleteModal()
-
-  loadData(0)
+  deleteZoneName.value = name
 }
 </script>
+
+<style lang="scss" scoped>
+.actions-dropdown {
+  display: inline-block;
+}
+</style>
+
+<style lang="scss">
+.warnings-column,
+.actions-column {
+  width: 5%;
+  min-width: 80px;
+}
+
+.actions-column {
+  text-align: end;
+}
+</style>

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -191,8 +191,8 @@ type ZoneOverviewTableRow = {
   detailViewRoute: RouteLocationNamedRaw
   name: string
   status: StatusKeyword
-  zoneCpVersion: string
-  storeType: string
+  zonecpversion: string
+  storetype: string
   withWarnings: boolean
 }
 
@@ -226,20 +226,20 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
         zone: name,
       },
     }
-    let zoneCpVersion = '-'
-    let storeType = ''
+    let zonecpversion = '-'
+    let storetype = ''
     let cpCompat = true
 
     const subscriptions = zoneOverview.zoneInsight?.subscriptions ?? []
 
     subscriptions.forEach((item: any) => {
       if (item.version && item.version.kumaCp) {
-        zoneCpVersion = item.version.kumaCp.version
+        zonecpversion = item.version.kumaCp.version
         const { kumaCpGlobalCompatible = true } = item.version.kumaCp
 
         cpCompat = kumaCpGlobalCompatible
         if (item.config) {
-          storeType = JSON.parse(item.config).store.type
+          storetype = JSON.parse(item.config).store.type
         }
       }
     })
@@ -251,8 +251,8 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
       detailViewRoute,
       name,
       status,
-      zoneCpVersion,
-      storeType,
+      zonecpversion,
+      storetype,
       withWarnings: !cpCompat,
     }
   })

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -36,8 +36,8 @@
                 data-testid="zone-cp-collection"
                 :headers="[
                   { key: 'name' },
-                  { key: 'zoneCpVersion' },
-                  { key: 'storeType' },
+                  { key: 'zonecpversion' },
+                  { key: 'storetype' },
                   { key: 'status' },
                   { key: 'warnings', hideLabel: true },
                   { key: 'actions', hideLabel: true },

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -19,18 +19,25 @@
 
       <template v-else>
         <DataSource
-          v-slot="{ data: zoneOverviewData, error, refresh }: ZoneOverviewCollectionSource"
-          :src="`/zones/zone-cps?size=${props.size}&page=${props.page}`"
+          v-slot="{ data, error, refresh }: ZoneOverviewCollectionSource"
+          :src="`/zone-cps?size=${props.size}&page=${props.page}`"
         >
           <KCard>
             <template #body>
               <AppCollection
                 data-testid="zone-cp-table"
-                :headers="HEADERS"
+                :headers="[
+                  { label: 'Name', key: 'name' },
+                  { label: 'Status', key: 'status' },
+                  { label: 'Zone CP Version', key: 'zoneCpVersion' },
+                  { label: 'Storage type', key: 'storeType' },
+                  { label: 'Warnings', key: 'warnings', hideLabel: true },
+                  { label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
                 :page-number="props.page"
                 :page-size="props.size"
-                :total="zoneOverviewData?.total"
-                :items="zoneOverviewData ? transformToTableData(zoneOverviewData.items) : []"
+                :total="data?.total"
+                :items="data ? transformToTableData(data.items) : []"
                 :error="error"
                 @change="route.update"
               >
@@ -167,7 +174,7 @@ import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import DeleteResourceModal from '@/app/common/DeleteResourceModal.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import { useStore } from '@/store/store'
-import { StatusKeyword, TableHeader, ZoneOverview } from '@/types/index.d'
+import { StatusKeyword, ZoneOverview } from '@/types/index.d'
 import { useEnv, useI18n, useKumaApi } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
@@ -185,15 +192,6 @@ const env = useEnv()
 const { t } = useI18n()
 const kumaApi = useKumaApi()
 const store = useStore()
-
-const HEADERS: TableHeader[] = [
-  { label: 'Name', key: 'name' },
-  { label: 'Status', key: 'status' },
-  { label: 'Zone CP Version', key: 'zoneCpVersion' },
-  { label: 'Storage type', key: 'storeType' },
-  { label: 'Warnings', key: 'warnings', hideLabel: true },
-  { label: 'Actions', key: 'actions', hideLabel: true },
-]
 
 const props = defineProps({
   page: {

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -36,9 +36,9 @@
                 data-testid="zone-cp-table"
                 :headers="[
                   { label: 'Name', key: 'name' },
-                  { label: 'Status', key: 'status' },
                   { label: 'Zone CP Version', key: 'zoneCpVersion' },
                   { label: 'Storage type', key: 'storeType' },
+                  { label: 'Status', key: 'status' },
                   { label: 'Warnings', key: 'warnings', hideLabel: true },
                   { label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
@@ -288,8 +288,9 @@ function setDeleteZoneName(name: string) {
     text-align: end;
   }
 
-  .actions-column {
-    text-align: end;
+  .status-column {
+    width: 10%;
+    min-width: 200px;
   }
 }
 </style>

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -187,7 +187,6 @@ import { useEnv, useI18n, useKumaApi } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 type ZoneOverviewTableRow = {
-  id: string
   detailViewRoute: RouteLocationNamedRaw
   name: string
   status: StatusKeyword
@@ -219,7 +218,6 @@ const deleteZoneName = ref('')
 function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableRow[] {
   return zoneOverviews.map((zoneOverview) => {
     const { name } = zoneOverview
-    const id = name
     const detailViewRoute: RouteLocationNamedRaw = {
       name: 'zone-cp-detail-view',
       params: {
@@ -247,7 +245,6 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
     const status = getItemStatusFromInsight(zoneOverview.zoneInsight)
 
     return {
-      id,
       detailViewRoute,
       name,
       status,

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -3,8 +3,6 @@
     v-slot="{ route }"
     name="zone-cp-list-view"
   >
-    <RouteTitle :title="t('zone-cps.routes.items.title')" />
-
     <AppView
       :breadcrumbs="[
         {
@@ -15,6 +13,15 @@
         },
       ]"
     >
+      <template #title>
+        <h2>
+          <RouteTitle
+            :title="t('zone-cps.routes.items.title')"
+            :render="true"
+          />
+        </h2>
+      </template>
+
       <MultizoneInfo v-if="store.getters['config/getMulticlusterStatus'] === false" />
 
       <template v-else>

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -32,7 +32,7 @@
           <KCard>
             <template #body>
               <AppCollection
-                class="zone-cp-table"
+                class="zone-cp-collection"
                 data-testid="zone-cp-collection"
                 :headers="[
                   { label: 'Name', key: 'name' },

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -41,7 +41,7 @@
                   { key: 'status' },
                   { key: 'warnings', hideLabel: true },
                   { key: 'actions', hideLabel: true },
-                ].map((header) => ({ ...header, label: t(`zone-cps.list.tableHeaders.${header.key}`) }))"
+                ].map((header) => ({ ...header, label: t(`zone-cps.routes.items.headers.${header.key}`) }))"
                 :page-number="props.page"
                 :page-size="props.size"
                 :total="data?.total"

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -33,7 +33,7 @@
             <template #body>
               <AppCollection
                 class="zone-cp-table"
-                data-testid="zone-cp-table"
+                data-testid="zone-cp-collection"
                 :headers="[
                   { key: 'name' },
                   { key: 'zoneCpVersion' },
@@ -280,7 +280,7 @@ function setDeleteZoneName(name: string) {
 </style>
 
 <style lang="scss">
-.zone-cp-table {
+.zone-cp-collection {
   .warnings-column,
   .actions-column {
     width: 5%;

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -35,13 +35,13 @@
                 class="zone-cp-table"
                 data-testid="zone-cp-collection"
                 :headers="[
-                  { key: 'name' },
-                  { key: 'zonecpversion' },
-                  { key: 'storetype' },
-                  { key: 'status' },
-                  { key: 'warnings', hideLabel: true },
-                  { key: 'actions', hideLabel: true },
-                ].map((header) => ({ ...header, label: t(`zone-cps.routes.items.headers.${header.key}`) }))"
+                  { label: 'Name', key: 'name' },
+                  { label: 'Zone CP Version', key: 'zoneCpVersion' },
+                  { label: 'Storage type', key: 'storeType' },
+                  { label: 'Status', key: 'status' },
+                  { label: 'Warnings', key: 'warnings', hideLabel: true },
+                  { label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
                 :page-number="props.page"
                 :page-size="props.size"
                 :total="data?.total"
@@ -191,8 +191,8 @@ type ZoneOverviewTableRow = {
   detailViewRoute: RouteLocationNamedRaw
   name: string
   status: StatusKeyword
-  zonecpversion: string
-  storetype: string
+  zoneCpVersion: string
+  storeType: string
   withWarnings: boolean
 }
 
@@ -226,20 +226,20 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
         zone: name,
       },
     }
-    let zonecpversion = '-'
-    let storetype = ''
+    let zoneCpVersion = '-'
+    let storeType = ''
     let cpCompat = true
 
     const subscriptions = zoneOverview.zoneInsight?.subscriptions ?? []
 
     subscriptions.forEach((item: any) => {
       if (item.version && item.version.kumaCp) {
-        zonecpversion = item.version.kumaCp.version
+        zoneCpVersion = item.version.kumaCp.version
         const { kumaCpGlobalCompatible = true } = item.version.kumaCp
 
         cpCompat = kumaCpGlobalCompatible
         if (item.config) {
-          storetype = JSON.parse(item.config).store.type
+          storeType = JSON.parse(item.config).store.type
         }
       }
     })
@@ -251,8 +251,8 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
       detailViewRoute,
       name,
       status,
-      zonecpversion,
-      storetype,
+      zoneCpVersion,
+      storeType,
       withWarnings: !cpCompat,
     }
   })

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -32,6 +32,7 @@
           <KCard>
             <template #body>
               <AppCollection
+                class="zone-cp-table"
                 data-testid="zone-cp-table"
                 :headers="[
                   { label: 'Name', key: 'name' },
@@ -279,13 +280,16 @@ function setDeleteZoneName(name: string) {
 </style>
 
 <style lang="scss">
-.warnings-column,
-.actions-column {
-  width: 5%;
-  min-width: 80px;
-}
+.zone-cp-table {
+  .warnings-column,
+  .actions-column {
+    width: 5%;
+    min-width: 80px;
+    text-align: end;
+  }
 
-.actions-column {
-  text-align: end;
+  .actions-column {
+    text-align: end;
+  }
 }
 </style>

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -15,7 +15,7 @@ common:
     actions:
       delete: 'Delete'
       edit: 'Edit'
-      viewDetails: 'View details'
+      view: 'View details'
   charts:
     dataPlaneProxies:
       title: 'DP Proxies'

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -13,7 +13,9 @@ common:
     message: 'There are no {type} present.'
   collection:
     actions:
-      view: View details
+      delete: 'Delete'
+      edit: 'Edit'
+      viewDetails: 'View details'
   charts:
     dataPlaneProxies:
       title: 'DP Proxies'

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -13,8 +13,8 @@ import type { SplitRouteRecordRaw } from '@/app/meshes'
 import { routes as meshRoutes, services as meshes } from '@/app/meshes'
 import { routes as onboardingRoutes } from '@/app/onboarding'
 import { routes as policyRoutes, services as policies } from '@/app/policies'
-import { routes as serviceRoutes, services as serviceModule } from '@/app/services'
-import { routes as zoneRoutes, actions as zoneActionRoutes, services as zoneModule } from '@/app/zones'
+import { routes as serviceRoutes, services as servicesModule } from '@/app/services'
+import { routes as zoneRoutes, actions as zoneActionRoutes, services as zonesModule } from '@/app/zones'
 import i18nEnUs from '@/locales/en-us'
 import { createRouter } from '@/router/router'
 import routes from '@/router/routes'
@@ -241,9 +241,9 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   }],
 
   // Modules
-  ...zoneModule($),
+  ...zonesModule($),
   ...meshes($),
-  ...serviceModule($),
+  ...servicesModule($),
   ...policies($),
 ]
 

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -13,8 +13,8 @@ import type { SplitRouteRecordRaw } from '@/app/meshes'
 import { routes as meshRoutes, services as meshes } from '@/app/meshes'
 import { routes as onboardingRoutes } from '@/app/onboarding'
 import { routes as policyRoutes, services as policies } from '@/app/policies'
-import { routes as serviceRoutes, services as servicesModule } from '@/app/services'
-import { routes as zoneRoutes, actions as zoneActionRoutes } from '@/app/zones'
+import { routes as serviceRoutes, services as serviceModule } from '@/app/services'
+import { routes as zoneRoutes, actions as zoneActionRoutes, services as zoneModule } from '@/app/zones'
 import i18nEnUs from '@/locales/en-us'
 import { createRouter } from '@/router/router'
 import routes from '@/router/routes'
@@ -239,8 +239,11 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
       $.store,
     ],
   }],
+
+  // Modules
+  ...zoneModule($),
   ...meshes($),
-  ...servicesModule($),
+  ...serviceModule($),
   ...policies($),
 ]
 


### PR DESCRIPTION
**refactor: migrates Zone CP list to use DataSource**

Migrates Zone CP list view to use `DataSource` and `AppCollection`.

**refactor: migrates Zone Ingress list to use DataSource**

Migrates Zone Ingress list view to use `DataSource` and `AppCollection`.

**refactor: migrates Zone Egress list to use DataSource**

Migrates Zone Egress list view to use `DataSource` and `AppCollection`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>