### PR TITLE
chore(deps-dev): removes esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "cypress": "^12.17.2",
     "cypress-fail-fast": "^7.0.1",
     "dotenv": "^16.3.1",
-    "esbuild": "^0.18.13",
     "eslint": "^8.45.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-friendly-formatter": "^4.0.1",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.2.2).
+ * Mock Service Worker (1.2.3).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4298,7 +4298,7 @@ esbuild@^0.17.18:
     "@esbuild/win32-ia32" "0.17.19"
     "@esbuild/win32-x64" "0.17.19"
 
-esbuild@^0.18.10, esbuild@^0.18.13:
+esbuild@^0.18.10:
   version "0.18.13"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.18.13.tgz#59160add6c3420947fe008238140ed3480baf817"
   integrity sha512-vhg/WR/Oiu4oUIkVhmfcc23G6/zWuEQKFS+yiosSHe4aN6+DQRXIfeloYGibIfVhkr4wyfuVsGNLr+sQU1rWWw==


### PR DESCRIPTION
Removes esbuild as we don’t explicitly use it ourselves.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>