### PR TITLE
chore: Make router injectable and pullable baseURL 

### DIFF
--- a/src/app/__snapshots__/AppOnboardingNotification.spec.ts.snap
+++ b/src/app/__snapshots__/AppOnboardingNotification.spec.ts.snap
@@ -30,7 +30,7 @@ exports[`AppOnboardingNotification renders snapshot 1`] = `
           <div>
             <a
               class="k-button small rounded primary action-button"
-              href="/onboarding/welcome"
+              href="/gui/onboarding/welcome"
               type="button"
             >
               

--- a/src/app/common/__snapshots__/DataOverview.spec.ts.snap
+++ b/src/app/common/__snapshots__/DataOverview.spec.ts.snap
@@ -355,7 +355,7 @@ exports[`DataOverview.vue renders all custom templates for data 1`] = `
                                 <a
                                   class="k-dropdown-item-trigger"
                                   data-testid="k-dropdown-item-trigger"
-                                  href="/zones/zone-cps/bandwidth-49"
+                                  href="/gui/zones/zone-cps/bandwidth-49"
                                 >
                                   <span
                                     class="k-dropdown-item-trigger-label"

--- a/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
@@ -20,7 +20,7 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
         
         <a
           class=""
-          href="/mesh/test-mesh/data-plane/backend"
+          href="/gui/mesh/test-mesh/data-plane/backend"
         >
           backend
         </a>
@@ -296,7 +296,7 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
                             
                             <a
                               class=""
-                              href="/mesh/default/service/backend"
+                              href="/gui/mesh/default/service/backend"
                             >
                               kuma.io/service:
                               <b>

--- a/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneEntitySummary.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`DataPlaneEntitySummary matches snapshot 1`] = `
                 
                 <a
                   class=""
-                  href="/mesh/test-mesh/data-plane/backend"
+                  href="/gui/mesh/test-mesh/data-plane/backend"
                 >
                   backend
                 </a>
@@ -161,7 +161,7 @@ exports[`DataPlaneEntitySummary matches snapshot 1`] = `
                         
                         <a
                           class=""
-                          href="/mesh/default/service/backend"
+                          href="/gui/mesh/default/service/backend"
                         >
                           kuma.io/service:
                           <b>

--- a/src/app/data-planes/components/__snapshots__/DataplanePolicies.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataplanePolicies.spec.ts.snap
@@ -184,7 +184,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                                 
                                 <a
                                   class=""
-                                  href="/mesh/default/service/service-a"
+                                  href="/gui/mesh/default/service/service-a"
                                 >
                                   kuma.io/service:
                                   <b>
@@ -221,7 +221,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                                 
                                 <a
                                   class=""
-                                  href="/mesh/default/service/web"
+                                  href="/gui/mesh/default/service/web"
                                 >
                                   kuma.io/service:
                                   <b>
@@ -391,7 +391,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                           <li>
                             <a
                               class=""
-                              href="/mesh/default/policy/fault-injections/fi1.kuma-system"
+                              href="/gui/mesh/default/policy/fault-injections/fi1.kuma-system"
                             >
                               fi1.kuma-system
                             </a>
@@ -425,7 +425,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                                 
                                 <a
                                   class=""
-                                  href="/mesh/default/service/service-b"
+                                  href="/gui/mesh/default/service/service-b"
                                 >
                                   kuma.io/service:
                                   <b>
@@ -462,7 +462,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                                 
                                 <a
                                   class=""
-                                  href="/mesh/default/service/web"
+                                  href="/gui/mesh/default/service/web"
                                 >
                                   kuma.io/service:
                                   <b>
@@ -632,7 +632,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                           <li>
                             <a
                               class=""
-                              href="/mesh/default/policy/fault-injections/fi1.kuma-system"
+                              href="/gui/mesh/default/policy/fault-injections/fi1.kuma-system"
                             >
                               fi1.kuma-system
                             </a>
@@ -700,7 +700,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                                 
                                 <a
                                   class=""
-                                  href="/mesh/default/service/web"
+                                  href="/gui/mesh/default/service/web"
                                 >
                                   kuma.io/service:
                                   <b>
@@ -875,7 +875,7 @@ exports[`DataplanePolicies.vue renders snapshot 1`] = `
                           <li>
                             <a
                               class=""
-                              href="/mesh/default/policy/fault-injections/web-to-backend.kuma-system"
+                              href="/gui/mesh/default/policy/fault-injections/web-to-backend.kuma-system"
                             >
                               web-to-backend.kuma-system
                             </a>

--- a/src/app/onboarding/components/__snapshots__/OnboardingNavigation.spec.ts.snap
+++ b/src/app/onboarding/components/__snapshots__/OnboardingNavigation.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`OnboardingNavigation.vue renders snapshot 1`] = `
   <a
     class="k-button medium rounded secondary"
     data-testid="onboarding-previous-button"
-    href="/onboarding/welcome"
+    href="/gui/onboarding/welcome"
     type="button"
   >
     
@@ -24,7 +24,7 @@ exports[`OnboardingNavigation.vue renders snapshot 1`] = `
     <a
       class="k-button medium rounded outline"
       data-testid="onboarding-skip-button"
-      href="/"
+      href="/gui/"
       type="button"
     >
       
@@ -38,7 +38,7 @@ exports[`OnboardingNavigation.vue renders snapshot 1`] = `
     <a
       class="k-button medium rounded primary"
       data-testid="onboarding-next-button"
-      href="/onboarding/configuration-types"
+      href="/gui/onboarding/configuration-types"
       type="button"
     >
       

--- a/src/app/onboarding/views/__snapshots__/AddNewServices.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/AddNewServices.spec.ts.snap
@@ -109,7 +109,7 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
               <a
                 class="k-button medium rounded secondary"
                 data-testid="onboarding-previous-button"
-                href="/onboarding/create-mesh"
+                href="/gui/onboarding/create-mesh"
                 type="button"
               >
                 
@@ -126,7 +126,7 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
                 <a
                   class="k-button medium rounded outline"
                   data-testid="onboarding-skip-button"
-                  href="/"
+                  href="/gui/"
                   type="button"
                 >
                   
@@ -140,7 +140,7 @@ exports[`AddNewServices.vue renders snapshot 1`] = `
                 <a
                   class="k-button medium rounded primary"
                   data-testid="onboarding-next-button"
-                  href="/onboarding/add-services-code"
+                  href="/gui/onboarding/add-services-code"
                   type="button"
                 >
                   

--- a/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
@@ -219,7 +219,7 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
               <a
                 class="k-button medium rounded secondary"
                 data-testid="onboarding-previous-button"
-                href="/onboarding/add-services"
+                href="/gui/onboarding/add-services"
                 type="button"
               >
                 
@@ -237,7 +237,7 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
                   aria-current="page"
                   class="router-link-active router-link-exact-active k-button medium rounded outline"
                   data-testid="onboarding-skip-button"
-                  href="/"
+                  href="/gui/"
                   type="button"
                 >
                   
@@ -251,7 +251,7 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
                 <a
                   class="k-button medium rounded primary"
                   data-testid="onboarding-next-button"
-                  href="/onboarding/dataplanes-overview"
+                  href="/gui/onboarding/dataplanes-overview"
                   type="button"
                 >
                   

--- a/src/app/onboarding/views/__snapshots__/CompletedView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/CompletedView.spec.ts.snap
@@ -75,7 +75,7 @@ exports[`CompletedView.vue renders snapshot 1`] = `
                 <a
                   class="k-button medium rounded creation"
                   data-testid="onboarding-next-button"
-                  href="/"
+                  href="/gui/"
                   type="button"
                 >
                   

--- a/src/app/onboarding/views/__snapshots__/ConfigurationTypes.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/ConfigurationTypes.spec.ts.snap
@@ -996,7 +996,7 @@ exports[`ConfigurationTypes.vue renders snapshot 1`] = `
               <a
                 class="k-button medium rounded secondary"
                 data-testid="onboarding-previous-button"
-                href="/onboarding/deployment-types"
+                href="/gui/onboarding/deployment-types"
                 type="button"
               >
                 
@@ -1013,7 +1013,7 @@ exports[`ConfigurationTypes.vue renders snapshot 1`] = `
                 <a
                   class="k-button medium rounded outline"
                   data-testid="onboarding-skip-button"
-                  href="/"
+                  href="/gui/"
                   type="button"
                 >
                   
@@ -1027,7 +1027,7 @@ exports[`ConfigurationTypes.vue renders snapshot 1`] = `
                 <a
                   class="k-button medium rounded primary"
                   data-testid="onboarding-next-button"
-                  href="/onboarding/create-mesh"
+                  href="/gui/onboarding/create-mesh"
                   type="button"
                 >
                   

--- a/src/app/onboarding/views/__snapshots__/CreateMesh.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/CreateMesh.spec.ts.snap
@@ -175,7 +175,7 @@ exports[`CreateMesh.vue renders snapshot 1`] = `
               <a
                 class="k-button medium rounded secondary"
                 data-testid="onboarding-previous-button"
-                href="/onboarding/configuration-types"
+                href="/gui/onboarding/configuration-types"
                 type="button"
               >
                 
@@ -193,7 +193,7 @@ exports[`CreateMesh.vue renders snapshot 1`] = `
                   aria-current="page"
                   class="router-link-active router-link-exact-active k-button medium rounded outline"
                   data-testid="onboarding-skip-button"
-                  href="/"
+                  href="/gui/"
                   type="button"
                 >
                   
@@ -207,7 +207,7 @@ exports[`CreateMesh.vue renders snapshot 1`] = `
                 <a
                   class="k-button medium rounded primary"
                   data-testid="onboarding-next-button"
-                  href="/onboarding/add-services"
+                  href="/gui/onboarding/add-services"
                   type="button"
                 >
                   

--- a/src/app/onboarding/views/__snapshots__/DataplanesOverview.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/DataplanesOverview.spec.ts.snap
@@ -449,7 +449,7 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
               <a
                 class="k-button medium rounded secondary"
                 data-testid="onboarding-previous-button"
-                href="/onboarding/add-services-code"
+                href="/gui/onboarding/add-services-code"
                 type="button"
               >
                 
@@ -467,7 +467,7 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
                   aria-current="page"
                   class="router-link-active router-link-exact-active k-button medium rounded outline"
                   data-testid="onboarding-skip-button"
-                  href="/"
+                  href="/gui/"
                   type="button"
                 >
                   
@@ -481,7 +481,7 @@ exports[`DataplanesOverview.vue renders snapshot 1`] = `
                 <a
                   class="k-button medium rounded primary"
                   data-testid="onboarding-next-button"
-                  href="/onboarding/completed"
+                  href="/gui/onboarding/completed"
                   type="button"
                 >
                   

--- a/src/app/onboarding/views/__snapshots__/DeploymentTypes.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/DeploymentTypes.spec.ts.snap
@@ -685,7 +685,7 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
               <a
                 class="k-button medium rounded secondary"
                 data-testid="onboarding-previous-button"
-                href="/onboarding/welcome"
+                href="/gui/onboarding/welcome"
                 type="button"
               >
                 
@@ -702,7 +702,7 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
                 <a
                   class="k-button medium rounded outline"
                   data-testid="onboarding-skip-button"
-                  href="/"
+                  href="/gui/"
                   type="button"
                 >
                   
@@ -716,7 +716,7 @@ exports[`DeploymentTypes.vue renders snapshot 1`] = `
                 <a
                   class="k-button medium rounded primary"
                   data-testid="onboarding-next-button"
-                  href="/onboarding/configuration-types"
+                  href="/gui/onboarding/configuration-types"
                   type="button"
                 >
                   

--- a/src/app/onboarding/views/__snapshots__/MultiZoneView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/MultiZoneView.spec.ts.snap
@@ -122,7 +122,7 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
               <a
                 class="k-button medium rounded secondary"
                 data-testid="onboarding-previous-button"
-                href="/onboarding/configuration-types"
+                href="/gui/onboarding/configuration-types"
                 type="button"
               >
                 
@@ -139,7 +139,7 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
                 <a
                   class="k-button medium rounded outline"
                   data-testid="onboarding-skip-button"
-                  href="/"
+                  href="/gui/"
                   type="button"
                 >
                   
@@ -154,7 +154,7 @@ exports[`MultiZoneView.vue renders snapshot 1`] = `
                   class="k-button medium rounded primary"
                   data-testid="onboarding-next-button"
                   disabled="true"
-                  href="/onboarding/create-mesh"
+                  href="/gui/onboarding/create-mesh"
                   type="button"
                 >
                   

--- a/src/app/onboarding/views/__snapshots__/WelcomeView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/WelcomeView.spec.ts.snap
@@ -175,7 +175,7 @@ exports[`WelcomeView.vue renders snapshot 1`] = `
                   <a
                     class="k-button medium rounded outline"
                     data-testid="onboarding-skip-button"
-                    href="/"
+                    href="/gui/"
                     type="button"
                   >
                     
@@ -189,7 +189,7 @@ exports[`WelcomeView.vue renders snapshot 1`] = `
                   <a
                     class="k-button medium rounded primary"
                     data-testid="onboarding-next-button"
-                    href="/onboarding/deployment-types"
+                    href="/gui/onboarding/deployment-types"
                     type="button"
                   >
                     

--- a/src/app/policies/components/__snapshots__/PolicyConnections.spec.ts.snap
+++ b/src/app/policies/components/__snapshots__/PolicyConnections.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`PolicyConnections.vue renders snapshot 1`] = `
     >
       <a
         class=""
-        href="/mesh/default/data-plane/backend"
+        href="/gui/mesh/default/data-plane/backend"
       >
         backend
       </a>
@@ -33,7 +33,7 @@ exports[`PolicyConnections.vue renders snapshot 1`] = `
     >
       <a
         class=""
-        href="/mesh/default/data-plane/db"
+        href="/gui/mesh/default/data-plane/db"
       >
         db
       </a>
@@ -44,7 +44,7 @@ exports[`PolicyConnections.vue renders snapshot 1`] = `
     >
       <a
         class=""
-        href="/mesh/default/data-plane/frontend"
+        href="/gui/mesh/default/data-plane/frontend"
       >
         frontend
       </a>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,8 @@
 import { Component, createApp } from 'vue'
-import { RouteRecordRaw } from 'vue-router'
 import { Store, storeKey } from 'vuex'
 
-import { createRouter } from './router/router'
-import type { EnvVars } from '@/services/env/Env'
 import type { State } from '@/store/storeConfig'
+import type { Router } from 'vue-router'
 
 /**
  * This is a good place to run operations that should ideally be initiated or completed before the Vue application instance exists.
@@ -12,13 +10,11 @@ import type { State } from '@/store/storeConfig'
  * @returns a factory creating an initialized Vue application with installed store and router without mounting it.
  */
 export function useApp(
-  env: (key: keyof EnvVars) => string,
-  routes: RouteRecordRaw[],
   store: Store<State>,
+  router: Router,
 ) {
   return async (App: Component) => {
     const app = createApp(App)
-    const router = await createRouter(routes, store, env('KUMA_BASE_PATH'))
     app.use(store, storeKey)
     app.use(router)
     return app

--- a/src/services/kuma-api/Api.ts
+++ b/src/services/kuma-api/Api.ts
@@ -10,13 +10,4 @@ export class Api {
   get baseUrl() {
     return this.client.baseUrl
   }
-
-  /**
-   * Sets the API base URL for all network requests.
-   *
-   * URLs for requests will be constructed in the form `${baseUrl}/${path}`.
-   */
-  setBaseUrl(baseUrl: string): void {
-    this.client.baseUrl = baseUrl
-  }
 }

--- a/src/services/kuma-api/RestClient.spec.ts
+++ b/src/services/kuma-api/RestClient.spec.ts
@@ -8,23 +8,6 @@ describe('RestClient', () => {
     jest.restoreAllMocks()
   })
 
-  test('has expected initial base URL', () => {
-    const restClient = new RestClient(() => 'http://localhost:5681')
-
-    expect(restClient.baseUrl).toBe('http://localhost:5681')
-  })
-
-  test.each([
-    ['http://localhost:1234/api', 'http://localhost:1234/api'],
-    ['http://localhost:1234/test/api', 'http://localhost:1234/test/api'],
-  ])('sets expected base URL for “%s”', (newBaseUrl: string, expectedBaseUrl: string) => {
-    const restClient = new RestClient(() => 'http://localhost:5681')
-
-    restClient.baseUrl = newBaseUrl
-
-    expect(restClient.baseUrl).toBe(expectedBaseUrl)
-  })
-
   test.each([
     [
       undefined,

--- a/src/services/kuma-api/RestClient.ts
+++ b/src/services/kuma-api/RestClient.ts
@@ -2,32 +2,15 @@ import { makeRequest } from './makeRequest'
 import type Env from '@/services/env/Env'
 
 export class RestClient {
-  /**
-   * The API base URL.
-   */
-  _baseUrl: string
-
-  /**
-   * @param baseUrl an absolute API base URL. **Must not have trailing slashes**.
-   */
   constructor(
     protected env: Env['var'],
-  ) {
-    this._baseUrl = env('KUMA_API_URL')
-  }
+  ) {}
 
   /**
    * The absolute API base URL used in all requests. Includes its base path segment if one is set.
    */
   get baseUrl() {
-    return this._baseUrl
-  }
-
-  /**
-   * @param baseUrl the absolute API base URL. **Must not have trailing slashes**.
-   */
-  set baseUrl(baseUrl: string) {
-    this._baseUrl = baseUrl
+    return this.env('KUMA_API_URL')
   }
 
   async get(path: string, options?: RequestInit & { params?: any }): Promise<any> {

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -155,9 +155,31 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
 
   // Router
   [$.router, {
-    service: createRouter,
+    service: (routes: RouteRecordRaw[], store: Store<State>, env: Alias<Env['var']>) => {
+      return createRouter(routes, store, env('KUMA_BASE_PATH'))
+    },
     arguments: [
       $.routes,
+      $.store,
+      $.env,
+    ],
+  }],
+  // Nav
+  [$.nav, {
+    service: () => (multizone: boolean) => getNavItems(multizone),
+  }],
+
+  // App
+  [$.app, {
+    service: useApp,
+    arguments: [
+      $.store,
+      $.router,
+    ],
+  }],
+  [$.bootstrap, {
+    service: useBootstrap,
+    arguments: [
       $.store,
     ],
   }],
@@ -218,28 +240,6 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   [$.diagnosticsRoutes, {
     service: diagnosticsRoutes,
   }],
-
-  // Nav
-  [$.nav, {
-    service: () => (multizone: boolean) => getNavItems(multizone),
-  }],
-
-  // App
-  [$.app, {
-    service: useApp,
-    arguments: [
-      $.env,
-      $.routes,
-      $.store,
-    ],
-  }],
-  [$.bootstrap, {
-    service: useBootstrap,
-    arguments: [
-      $.store,
-    ],
-  }],
-
   // Modules
   ...zonesModule($),
   ...meshes($),


### PR DESCRIPTION
This PR does 2 things:

---

### Injectable router

Back in https://github.com/kumahq/kuma-gui/pull/765 I added an injectable `$.router` specifically for our CLI tests, but I'd always planned to then use that for our main application see (https://github.com/kumahq/kuma-gui/pull/765/files#r1151912562).

I also corrected it here to use our base path, hence the snapshot update.

We now feed the `$.router` into `useApp` just like the other Vue plugins, eventually we'll be able to add these sorts of plugins with some DI labelling.

---

### BaseUrl changes

I made baseUrl just pull straight from `env('KUMA_API_URL')` meaning we don't have to keep setting it in certain places, meaning we can remove a bunch of code elsewhere.


