### PR TITLE
feat: stores response on ApiError

### DIFF
--- a/src/app/common/ErrorBlock.vue
+++ b/src/app/common/ErrorBlock.vue
@@ -60,7 +60,7 @@
       </KBadge>
 
       <KBadge :appearance="props.badgeAppearance">
-        {{ error.status }}
+        {{ error.response.status }}
       </KBadge>
     </div>
   </div>

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -277,13 +277,13 @@ async function createZone() {
   try {
     zone.value = await kumaApi.createZone({ name: name.value })
   } catch (err) {
-    if (err instanceof ApiError && HANDLED_STATUS_CODES.includes(err.status)) {
+    if (err instanceof ApiError && HANDLED_STATUS_CODES.includes(err.response.status)) {
       errorState.value = {
         error: err,
-        title: t(`zones.create.statusError.${err.status}.title`, { zoneName: name.value }),
-        description: t(`zones.create.statusError.${err.status}.description`).trim(),
-        icon: err.status === 500 ? 'warning' : 'errorFilled',
-        badgeAppearance: err.status === 500 ? 'warning' : 'danger',
+        title: t(`zones.create.statusError.${err.response.status}.title`, { zoneName: name.value }),
+        description: t(`zones.create.statusError.${err.response.status}.description`).trim(),
+        icon: err.response.status === 500 ? 'warning' : 'errorFilled',
+        badgeAppearance: err.response.status === 500 ? 'warning' : 'danger',
       }
     } else if (err instanceof Error) {
       errorState.value = {

--- a/src/services/kuma-api/ApiError.spec.ts
+++ b/src/services/kuma-api/ApiError.spec.ts
@@ -6,7 +6,7 @@ describe('ApiError', () => {
   test.each([
     [
       new ApiError({
-        status: 200,
+        response: new Response(undefined, { status: 200 }),
         title: 'Error message',
       }),
       {
@@ -20,7 +20,7 @@ describe('ApiError', () => {
     ],
     [
       new ApiError({
-        status: 400,
+        response: new Response(undefined, { status: 400 }),
         type: 'https://kongapi.info/konnect/invalid-request',
         title: 'Invalid Request',
         detail: 'Some of the fields provided were invalid',

--- a/src/services/kuma-api/ApiError.ts
+++ b/src/services/kuma-api/ApiError.ts
@@ -6,7 +6,7 @@ export interface InvalidParameter {
 }
 
 type ApiErrorConstructorOptions = {
-  status: number
+  response: Response
   type?: string | null
   title: string
   detail?: string | null
@@ -18,7 +18,7 @@ type ApiErrorConstructorOptions = {
  * Standard API error object following https://kong-aip.netlify.app/aip/193/.
  */
 export class ApiError extends Error {
-  status: number
+  response: Response
   type: string | null
   title: string
   detail: string | null
@@ -26,7 +26,7 @@ export class ApiError extends Error {
   invalidParameters: InvalidParameter[]
 
   constructor({
-    status,
+    response,
     type = null,
     title,
     detail = null,
@@ -36,7 +36,7 @@ export class ApiError extends Error {
     super(title)
 
     this.name = 'ApiError'
-    this.status = status
+    this.response = response
     this.type = type
     this.title = title
     this.detail = detail
@@ -46,7 +46,7 @@ export class ApiError extends Error {
 
   toJSON() {
     return {
-      status: this.status,
+      status: this.response.status,
       type: this.type,
       title: this.title,
       detail: this.detail,

--- a/src/services/kuma-api/makeRequest.spec.ts
+++ b/src/services/kuma-api/makeRequest.spec.ts
@@ -121,7 +121,7 @@ describe('makeRequest', () => {
       },
       new ApiError({
         type: 'great_misfortune',
-        status: 400,
+        response: new Response(undefined, { status: 400 }),
         title: 'An error has occurred while trying to load this data.',
         detail: 'A most terrible error',
       }),
@@ -141,7 +141,7 @@ describe('makeRequest', () => {
       },
       new ApiError({
         type: 'great_misfortune',
-        status: 400,
+        response: new Response(undefined, { status: 400 }),
         title: 'Validation error',
         detail: 'A most terrible error',
       }),
@@ -177,7 +177,7 @@ describe('makeRequest', () => {
       },
       new ApiError({
         type: 'great_misfortune',
-        status: 400,
+        response: new Response(undefined, { status: 400 }),
         title: 'Validation error',
         detail: 'A most terrible error',
         invalidParameters: [
@@ -202,7 +202,7 @@ describe('makeRequest', () => {
         return Promise.resolve(response)
       },
       new ApiError({
-        status: 400,
+        response: new Response(undefined, { status: 400 }),
         title: 'An error has occurred while trying to load this data.',
       }),
     ],
@@ -214,7 +214,7 @@ describe('makeRequest', () => {
         return Promise.resolve(response)
       },
       new ApiError({
-        status: 404,
+        response: new Response(undefined, { status: 404 }),
         title: 'Not found!',
       }),
     ],

--- a/src/services/kuma-api/makeRequest.ts
+++ b/src/services/kuma-api/makeRequest.ts
@@ -54,7 +54,6 @@ function createNetworkError(error: unknown): Error {
 }
 
 function createApiError(response: Response, data: unknown): ApiError {
-  const status = response.status
   let type
   let title
   let detail
@@ -86,7 +85,7 @@ function createApiError(response: Response, data: unknown): ApiError {
   }
 
   // TODO: Sets the error message for 403 errors until we implement better errors in the backend.
-  if (status === 403) {
+  if (response.status === 403) {
     title = 'You currently don’t have access to this data.'
   }
 
@@ -94,5 +93,5 @@ function createApiError(response: Response, data: unknown): ApiError {
     title = 'An error has occurred while trying to load this data.'
   }
 
-  return new ApiError({ status, type, title, detail, instance, invalidParameters })
+  return new ApiError({ response, type, title, detail, instance, invalidParameters })
 }


### PR DESCRIPTION
Stores the full fetch `Response` object on `ApiError` instances. This allows us to reacting to more than just the response status (e.g. for implementing response header-based retrying logic).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
