### PR TITLE
chore: removes console.error for some handled scenarios

### DIFF
--- a/src/app/common/CopyButton.vue
+++ b/src/app/common/CopyButton.vue
@@ -70,7 +70,6 @@ async function copy(event: Event, copyToClipboard: (text: string) => Promise<boo
     hasCopiedCodeSuccessfully = await copyToClipboard(text)
   } catch (err) {
     hasCopiedCodeSuccessfully = false
-    console.error(err)
   } finally {
     const text = hasCopiedCodeSuccessfully ? props.tooltipSuccessText : props.tooltipFailText
 

--- a/src/app/common/DeleteResourceModal.vue
+++ b/src/app/common/DeleteResourceModal.vue
@@ -85,7 +85,6 @@ async function deleteResource() {
     await props.deleteFunction()
     emit('delete')
   } catch (err) {
-    console.error(err)
     hasError.value = true
   }
 }

--- a/src/app/meshes/views/MeshOverviewView.vue
+++ b/src/app/meshes/views/MeshOverviewView.vue
@@ -16,7 +16,7 @@
             <div class="columns">
               <StatusInfo
                 :is-loading="isLoading"
-                :has-error="hasError"
+                :error="error"
                 :is-empty="mesh === null || meshInsights === null"
               >
                 <DefinitionList>
@@ -129,7 +129,7 @@ const route = useRoute()
 const store = useStore()
 
 const isLoading = ref(true)
-const hasError = ref(false)
+const error = ref<Error | null>(null)
 const mesh = ref<Mesh | null>(null)
 const meshInsights = ref<MeshInsight | null>(null)
 
@@ -200,19 +200,21 @@ loadMesh()
 
 async function loadMesh(): Promise<void> {
   isLoading.value = true
-  hasError.value = false
+  error.value = null
 
   const name = route.params.mesh as string
 
   try {
     mesh.value = await kumaApi.getMesh({ name })
     meshInsights.value = await kumaApi.getMeshInsights({ name })
-  } catch (error) {
-    hasError.value = true
+  } catch (err) {
+    if (err instanceof Error) {
+      error.value = err
+    } else {
+      console.error(error)
+    }
     mesh.value = null
     meshInsights.value = null
-
-    console.error(error)
   } finally {
     isLoading.value = false
   }


### PR DESCRIPTION
Removes some calls to `console.error` where the error is already adequately handled.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
