### PR TITLE
fix: table column styles leaking to other tables

### DIFF
--- a/features/mesh/Index.feature
+++ b/features/mesh/Index.feature
@@ -2,7 +2,7 @@ Feature: mesh / index
   Background:
     Given the CSS selectors
       | Alias          | Selector                                     |
-      | items          | [data-testid='mesh-collection']              |
+      | items          | [data-testid='mesh-table']                   |
       | item           | $items tbody tr                              |
       | breadcrumb     | .k-breadcrumbs                               |
       | button-refresh | [data-testid='data-overview-refresh-button'] |
@@ -38,7 +38,6 @@ Feature: mesh / index
     Then the "$item" element exists 2 times
 
     Examples:
-      | Mesh         | Selector |
+      | Mesh         | Selector                              |
       | another-mesh | $item:nth-child(2) td:first-of-type a |
       | default      | $item:nth-child(1) td:first-of-type a |
-

--- a/features/mesh/Index.feature
+++ b/features/mesh/Index.feature
@@ -2,7 +2,7 @@ Feature: mesh / index
   Background:
     Given the CSS selectors
       | Alias          | Selector                                     |
-      | items          | [data-testid='mesh-table']                   |
+      | items          | [data-testid='mesh-collection']              |
       | item           | $items tbody tr                              |
       | breadcrumb     | .k-breadcrumbs                               |
       | button-refresh | [data-testid='data-overview-refresh-button'] |

--- a/features/mesh/policies/Data.feature
+++ b/features/mesh/policies/Data.feature
@@ -2,7 +2,7 @@ Feature: mesh / policies / data
   Background:
     Given the CSS selectors
       | Alias         | Selector                            |
-      | items         | [data-testid='policy-table']        |
+      | items         | [data-testid='policy-collection']   |
       | item          | $items tbody tr                     |
       | state-empty   | [data-testid='k-table-empty-state'] |
       | state-error   | [data-testid='k-table-error-state'] |

--- a/features/mesh/policies/Data.feature
+++ b/features/mesh/policies/Data.feature
@@ -1,12 +1,12 @@
 Feature: mesh / policies / data
   Background:
     Given the CSS selectors
-      | Alias          | Selector                                     |
-      | items          | [data-testid='policy-collection']            |
-      | item           | $items tbody tr                              |
-      | state-empty    | [data-testid='k-table-empty-state']          |
-      | state-error    | [data-testid='k-table-error-state']          |
-      | state-loading  | [data-testid='loading-block']                |
+      | Alias         | Selector                            |
+      | items         | [data-testid='policy-table']        |
+      | item          | $items tbody tr                     |
+      | state-empty   | [data-testid='k-table-empty-state'] |
+      | state-error   | [data-testid='k-table-error-state'] |
+      | state-loading | [data-testid='loading-block']       |
     And the URL "/mesh-insights/default" responds with
       """
       body:

--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -2,7 +2,7 @@ Feature: mesh / policies / index
   Background:
     Given the CSS selectors
       | Alias               | Selector                                  |
-      | items               | [data-testid='policy-collection']         |
+      | items               | [data-testid='policy-table']              |
       | items-header        | $items th                                 |
       | item                | $items tbody tr                           |
       | button-docs         | [data-testid='policy-documentation-link'] |
@@ -10,9 +10,9 @@ Feature: mesh / policies / index
       | button-tab          | $navigation li:nth-child(5) a             |
       | button-tab-selected | $navigation li:nth-child(5).active        |
     And the environment
-    """
+      """
       KUMA_CIRCUITBREAKER_COUNT: 2
-    """
+      """
     # Makes ure that we only have CircuitBreakers so clicking back on the tabs
     # Always takes us to the CircuitBreaker listing
     And the URL "/mesh-insights/default" responds with

--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -2,7 +2,7 @@ Feature: mesh / policies / index
   Background:
     Given the CSS selectors
       | Alias               | Selector                                  |
-      | items               | [data-testid='policy-table']              |
+      | items               | [data-testid='policy-collection']         |
       | items-header        | $items th                                 |
       | item                | $items tbody tr                           |
       | button-docs         | [data-testid='policy-documentation-link'] |

--- a/features/mesh/services/Index.feature
+++ b/features/mesh/services/Index.feature
@@ -2,7 +2,7 @@ Feature: mesh / services / index
   Background:
     Given the CSS selectors
       | Alias               | Selector                            |
-      | items               | [data-testid='service-collection']  |
+      | items               | [data-testid='service-table']       |
       | children            | [data-testid='data-overview-table'] |
       | items-header        | $items th                           |
       | item                | $items tbody tr                     |
@@ -11,9 +11,9 @@ Feature: mesh / services / index
       | button-tab          | $navigation li:nth-child(2) a       |
       | button-tab-selected | $navigation li:nth-child(2).active  |
     And the environment
-    """
+      """
       KUMA_SERVICEINSIGHT_COUNT: 2
-    """
+      """
     And the URL "/meshes/default/service-insights" responds with
       """
       body:

--- a/features/mesh/services/Index.feature
+++ b/features/mesh/services/Index.feature
@@ -2,7 +2,7 @@ Feature: mesh / services / index
   Background:
     Given the CSS selectors
       | Alias               | Selector                            |
-      | items               | [data-testid='service-table']       |
+      | items               | [data-testid='service-collection']  |
       | children            | [data-testid='data-overview-table'] |
       | items-header        | $items th                           |
       | item                | $items tbody tr                     |

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -29,8 +29,8 @@
           <KCard>
             <template #body>
               <AppCollection
-                class="mesh-collections"
-                data-testid="mesh-collections"
+                class="mesh-collection"
+                data-testid="mesh-collection"
                 :empty-state-title="t('common.emptyState.title')"
                 :empty-state-message="t('common.emptyState.message', { type: 'Meshes' })"
                 :headers="[

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -29,7 +29,8 @@
           <KCard>
             <template #body>
               <AppCollection
-                data-testid="mesh-collection"
+                class="mesh-table"
+                data-testid="mesh-table"
                 :empty-state-title="t('common.emptyState.title')"
                 :empty-state-message="t('common.emptyState.message', { type: 'Meshes' })"
                 :headers="[
@@ -118,19 +119,25 @@ const props = defineProps<{
   page: number
   size: number
 }>()
-
 </script>
-<style lang="scss">
-.name-column {
-  width: 90%;
-}
 
-.actions-column {
-  width: 10%;
-  text-align: end;
-}
-
+<style lang="scss" scoped>
 .actions-dropdown {
   display: inline-block;
+}
+</style>
+
+<style lang="scss">
+.mesh-table {
+  .actions-column {
+    width: 5%;
+    min-width: 80px;
+    text-align: end;
+  }
+
+  .status-column {
+    width: 10%;
+    min-width: 200px;
+  }
 }
 </style>

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -29,8 +29,8 @@
           <KCard>
             <template #body>
               <AppCollection
-                class="mesh-table"
-                data-testid="mesh-table"
+                class="mesh-collections"
+                data-testid="mesh-collections"
                 :empty-state-title="t('common.emptyState.title')"
                 :empty-state-message="t('common.emptyState.message', { type: 'Meshes' })"
                 :headers="[
@@ -128,7 +128,7 @@ const props = defineProps<{
 </style>
 
 <style lang="scss">
-.mesh-table {
+.mesh-collection {
   .actions-column {
     width: 5%;
     min-width: 80px;

--- a/src/app/meshes/views/MeshView.vue
+++ b/src/app/meshes/views/MeshView.vue
@@ -1,7 +1,5 @@
 <template>
-  <RouteView
-    v-slot="{route}"
-  >
+  <RouteView>
     <AppView>
       <template #title>
         <h1>{{ route.params.mesh }}</h1>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -69,7 +69,8 @@
                   <KCard>
                     <template #body>
                       <AppCollection
-                        data-testid="policy-collection"
+                        class="policy-table"
+                        data-testid="policy-table"
                         :empty-state-title="`No Data`"
                         :empty-state-message="`There are no ${selected.name} policies present.`"
                         :headers="[
@@ -223,7 +224,6 @@ const props = defineProps<{
   page: number
   size: number
 }>()
-
 </script>
 
 <style lang="scss" scoped>
@@ -231,21 +231,17 @@ const props = defineProps<{
   color: var(--grey-400);
 }
 
-</style>
-<style lang="scss">
-.name-column {
-  width: 45%;
-}
-.type-column {
-  width: 45%;
-}
-
-.actions-column {
-  width: 10%;
-  text-align: end;
-}
-
 .actions-dropdown {
   display: inline-block;
+}
+</style>
+
+<style lang="scss">
+.policy-table {
+  .actions-column {
+    width: 5%;
+    min-width: 80px;
+    text-align: end;
+  }
 }
 </style>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -69,8 +69,8 @@
                   <KCard>
                     <template #body>
                       <AppCollection
-                        class="policy-table"
-                        data-testid="policy-table"
+                        class="policy-collection"
+                        data-testid="policy-collection"
                         :empty-state-title="`No Data`"
                         :empty-state-message="`There are no ${selected.name} policies present.`"
                         :headers="[
@@ -237,7 +237,7 @@ const props = defineProps<{
 </style>
 
 <style lang="scss">
-.policy-table {
+.policy-collection {
   .actions-column {
     width: 5%;
     min-width: 80px;

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -19,7 +19,8 @@
         <KCard>
           <template #body>
             <AppCollection
-              data-testid="service-collection"
+              class="service-table"
+              data-testid="service-table"
               :empty-state-title="t('common.emptyState.title')"
               :empty-state-message="t('common.emptyState.message', { type: 'Services' })"
               :headers="[
@@ -142,5 +143,25 @@ const props = defineProps<{
   //
   mesh: string
 }>()
-
 </script>
+
+<style lang="scss" scoped>
+.actions-dropdown {
+  display: inline-block;
+}
+</style>
+
+<style lang="scss">
+.service-table {
+  .actions-column {
+    width: 5%;
+    min-width: 80px;
+    text-align: end;
+  }
+
+  .status-column {
+    width: 10%;
+    min-width: 200px;
+  }
+}
+</style>

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -19,8 +19,8 @@
         <KCard>
           <template #body>
             <AppCollection
-              class="service-table"
-              data-testid="service-table"
+              class="service-collection"
+              data-testid="service-collection"
               :empty-state-title="t('common.emptyState.title')"
               :empty-state-message="t('common.emptyState.message', { type: 'Services' })"
               :headers="[
@@ -152,7 +152,7 @@ const props = defineProps<{
 </style>
 
 <style lang="scss">
-.service-table {
+.service-collection {
   .actions-column {
     width: 5%;
     min-width: 80px;


### PR DESCRIPTION
**chore(meshes): address linter warning**

**fix(services): table column styles leaking to other tables**

**fix(meshes): table column styles leaking to other tables**

**fix(policies): table column styles leaking to other tables**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
