### PR TITLE
chore: fix chart.js type breaking

### DIFF
--- a/src/app/common/charts/DoughnutChart.vue
+++ b/src/app/common/charts/DoughnutChart.vue
@@ -78,8 +78,10 @@ ChartJS.defaults.font = {
   family: "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
 }
 
-ChartJS.defaults.plugins.tooltip.bodyFont = {
-  size: 12,
+if (ChartJS.defaults.plugins.tooltip) {
+  ChartJS.defaults.plugins.tooltip.bodyFont = {
+    size: 12,
+  }
 }
 
 const props = defineProps({


### PR DESCRIPTION
Adds a type guard around a ChartJS default assignment to address `tooltip` now having `false |` in its type.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
