### PR TITLE
chore: Expose some commonly used utilities/components

### DIFF
--- a/src/app/application/components/route-view/README.md
+++ b/src/app/application/components/route-view/README.md
@@ -6,6 +6,9 @@ routable `*View.vue` component.
 It contains functionality to make it easy to set top-level DOM values that you
 usually woudn't have direct access to.
 
+When using this you should specify the name of the route you are creating as
+the RouteView's `name` property.
+
 ## Setting HTML node attributes
 
 **Note: Currently we only support setting the className if you need to add
@@ -13,6 +16,7 @@ further attributes PRs are welcome**
 
 ```vue
 <RouteView
+  name="route-name"
   :attrs="{
     class: 'my-html-class'
   }"
@@ -40,7 +44,9 @@ removed when the `*View.vue` route/view component is removed from the page/DOM.
 the page from anywhere in your `*View.vue` component.
 
 ```vue
-<RouteView>
+<RouteView
+  name="route-name"
+>
   <h1>
     <RouteTitle
       title="The title"
@@ -70,7 +76,7 @@ place that you use the `RouteTitle`, but in the future we might. Therefore you
 would only have to set the title once, and it will be render both to the HTML
 `<title>` and to your page header (say inside a `<h1>`)
 
-## v-slot="{route}"
+## v-slot="{route, t, env}"
 
 RouteView also exports a subset of the `route`. **This is not an entire
 `vue-router` route as you know it!**. This lets you easily set titles (or other
@@ -79,6 +85,7 @@ your title)
 
 ```vue
 <RouteView
+  name="route-name"
   v-slot="{route}"
 >
   <h1>
@@ -89,4 +96,21 @@ your title)
 ...
 </RouteView>
 ```
+## Props
+
+| Name  | Description |
+| --- | --- |
+| `name` | The name of the current route file as specified in your routing configuration i.e. `services-list-view` |
+
+## Slots
+
+### default
+
+#### exports
+
+| Name  | Description |
+| --- | --- |
+| `route` | an object with route based utilties (this, is **not** vue route, see above) |
+| `t` | A reference to our `t` function/service |
+| `env` | A reference to our `env` function/service |
 

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -12,6 +12,8 @@
     </div>
     <slot
       name="default"
+      :t="t"
+      :env="env"
       :route="{
         update: (params: Record<string, string | undefined>) => {
           router.push(
@@ -45,8 +47,9 @@ import {
   createAttrsSetter,
   createTitleSetter,
 } from '../../utilities'
-import { useI18n } from '@/utilities'
+import { useI18n, useEnv } from '@/utilities'
 
+const env = useEnv()
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import Kongponents from '@kong/kongponents'
 import { Component, createApp } from 'vue'
 import { RouteRecordRaw } from 'vue-router'
 import { Store, storeKey } from 'vuex'
@@ -21,6 +22,7 @@ export function useApp(
     const router = await createRouter(routes, store, env('KUMA_BASE_PATH'))
     app.use(store, storeKey)
     app.use(router)
+    app.use(Kongponents)
     return app
   }
 }


### PR DESCRIPTION
Exposes `t` and `env` from RouteView as we pretty much always need these in Route components and we want to default to 'generally' not using them anywhere but Route components (we will need to occasionally use them in non-route components, so want to stress the 'generally')

Also installs Kongponents as a Vue plugin.
