### PR TITLE
chore: Make route guards injectable

### DIFF
--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -38,7 +38,7 @@ const redirectOldHashHistoryUrlPaths = (): NavigationGuard => (to, _from, next) 
  *
  * Redirects the user to the home view if they’re navigating to an onboarding route while having already completed onboarding. An exception is made when we suggest onboarding for users who don’t have data plane proxies, yet (we show an alert suggesting it and allow going to the onboarding again).
  */
-const onboardingRouteGuard = (store: Store<State>): NavigationGuard => (to, _from, next) => {
+export const onboardingRouteGuard = (store: Store<State>): NavigationGuard => (to, _from, next) => {
   const isOnboardingCompleted = store.state.onboarding.isCompleted
   const isOnboardingRoute = to.meta.onboardingProcess
   const shouldSuggestOnboarding = store.getters.shouldShowOnboardingNotification

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -1,4 +1,4 @@
-import { RouteRecordRaw } from 'vue-router'
+import { RouteRecordRaw, NavigationGuard } from 'vue-router'
 import { createStore, StoreOptions, Store } from 'vuex'
 
 import createDisabledLogger from './logger/DisabledLogger'
@@ -16,7 +16,7 @@ import { routes as policyRoutes, services as policies } from '@/app/policies'
 import { routes as serviceRoutes, services as servicesModule } from '@/app/services'
 import { routes as zoneRoutes, actions as zoneActionRoutes } from '@/app/zones'
 import i18nEnUs from '@/locales/en-us'
-import { createRouter } from '@/router/router'
+import { createRouter, onboardingRouteGuard } from '@/router/router'
 import routes from '@/router/routes'
 import Env, { EnvArgs, EnvVars } from '@/services/env/Env'
 import I18n from '@/services/i18n/I18n'
@@ -50,6 +50,7 @@ const $ = {
 
   router: token<Router>('router'),
   routes: token<RouteRecordRaw[]>('vue.routes'),
+  navigationGuards: token<NavigationGuard[]>('vue.routes.navigation.guards'),
 
   meshRoutes: token<RouteRecordRaw[]>('kuma.mesh.routes'),
 
@@ -62,6 +63,7 @@ const $ = {
 
   diagnosticsRoutes: token<RouteRecordRaw[]>('kuma.diagnostics.routes'),
   onboardingRoutes: token<RouteRecordRaw[]>('kuma.onboarding.routes'),
+  onboardingRouteGuards: token<NavigationGuard[]>('kuma.onboarding.routes'),
 
   nav: token<typeof getNavItems>('nav'),
 
@@ -159,6 +161,17 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
     arguments: [
       $.routes,
       $.store,
+    ],
+  }],
+  [$.onboardingRouteGuards, {
+    service: (store: Store<State>) => {
+      return [onboardingRouteGuard(store)]
+    },
+    arguments: [
+      $.store,
+    ],
+    labels: [
+      $.navigationGuards,
     ],
   }],
 


### PR DESCRIPTION
Takes 1 of a few steps to enable us to disable onboarding entirely i.e. not even compile it in if we wanted to do that.

~Currently awaiting merge of some other PRs (specifically https://github.com/kumahq/kuma-gui/pull/1221) but I wanted to get this up for visibility for the moment, it's likely to change a little.~

Signed-off-by: John Cowen <john.cowen@konghq.com>