### PR TITLE
chore: moves status column towards the end

### DIFF
--- a/features/mesh/dataplanes/Index.feature
+++ b/features/mesh/dataplanes/Index.feature
@@ -7,9 +7,9 @@ Feature: mesh / dataplanes / index
       | table-row       | $table tbody tr                       |
       | dataplane-title | [data-testid='data-plane-collection'] |
     And the environment
-    """
+      """
       KUMA_DATAPLANE_COUNT: 9
-    """
+      """
     And the URL "/meshes/default/dataplanes+insights" responds with
       """
       body:
@@ -42,12 +42,12 @@ Feature: mesh / dataplanes / index
     Then the "$table-header" elements contain
       | Value           |
       | Name            |
-      | Status          |
       | Service         |
       | Protocol        |
       | Zone            |
       | Last Updated    |
       | Kuma DP version |
+      | Status          |
 
   Scenario: The Proxy listing has the expected content and UI elements
     Then the "$table-row" element exists 9 times
@@ -57,5 +57,3 @@ Feature: mesh / dataplanes / index
       | http              |
       | February 18, 2021 |
       | 1.0.8             |
-
-

--- a/features/mesh/gateways/Index.feature
+++ b/features/mesh/gateways/Index.feature
@@ -35,12 +35,12 @@ Feature: mesh / gateways / index
     Then the "$item-header" elements contain
       | Value           |
       | Name            |
-      | Status          |
       | Type            |
       | Service         |
       | Zone            |
       | Last Updated    |
       | Kuma DP version |
+      | Status          |
 
   Scenario: The Gateway listing has the expected content and UI elements
     When I click the "$select-type" element
@@ -66,9 +66,9 @@ Feature: mesh / gateways / index
         """
     Scenario: Filtering by "builtin"
       Given the environment
-      """
+        """
         KUMA_DATAPLANE_COUNT: 1
-      """
+        """
       And the URL "/meshes/default/dataplanes+insights" responds with
         """
         body:
@@ -95,9 +95,9 @@ Feature: mesh / gateways / index
 
     Scenario: Filtering by "delegated"
       Given the environment
-      """
+        """
         KUMA_DATAPLANE_COUNT: 1
-      """
+        """
       And the URL "/meshes/default/dataplanes+insights" responds with
         """
         body:

--- a/features/mesh/services/Index.feature
+++ b/features/mesh/services/Index.feature
@@ -30,8 +30,8 @@ Feature: mesh / services / index
       | Name                        |
       | Type                        |
       | Address                     |
-      | Status                      |
       | DP proxies (online / total) |
+      | Status                      |
 
   Scenario: The items have the expected content and UI elements
     Then the "$button-tab-selected" element exists

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -4,13 +4,13 @@
     :empty-state-message="t('common.emptyState.message', { type: props.gateways ? 'Gateways' : 'Data plane proxies' })"
     :headers="[
       { label: 'Name', key: 'name' },
-      { label: 'Status', key: 'status' },
       props.gateways ? { label: 'Type', key: 'type' } : undefined,
       { label: 'Service', key: 'service' },
       !props.gateways ? { label: 'Protocol', key: 'protocol' } : undefined,
       isMultiZoneMode ? { label: 'Zone', key: 'zone' } : undefined,
       { label: 'Last Updated', key: 'lastUpdated' },
       { label: 'Kuma DP version', key: 'dpVersion' },
+      { label: 'Status', key: 'status' },
       { label: 'Actions', key: 'actions', hideLabel: true },
     ].filter(Boolean)"
     :page-number="props.pageNumber"
@@ -352,5 +352,9 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
 <style lang="scss" scoped>
 .with-warnings {
   color: var(--yellow-500);
+}
+
+.actions-dropdown {
+  display: inline-block;
 }
 </style>

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -88,10 +88,8 @@ const props = defineProps<{
   flex-grow: 1;
   margin-right: auto;
 }
-.actions-dropdown {
-  display: inline-block;
-}
 </style>
+
 <style lang="scss">
 .data-plane-collection {
   .actions-column {

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -27,8 +27,8 @@
                 { label: 'Name', key: 'name' },
                 { label: 'Type', key: 'serviceType' },
                 { label: 'Address', key: 'addressPort' },
-                { label: 'Status', key: 'status' },
                 { label: 'DP proxies (online / total)', key: 'online' },
+                { label: 'Status', key: 'status' },
                 { label: 'Actions', key: 'actions', hideLabel: true },
               ]"
               :page-number="props.page"
@@ -50,16 +50,6 @@
                   {{ item.name }}
                 </RouterLink>
               </template>
-              <template #status="{ row: item }">
-                <StatusBadge
-                  v-if="item.status"
-                  :status="item.status"
-                />
-
-                <template v-else>
-                  —
-                </template>
-              </template>
 
               <template #online="{ row: item }">
                 <template
@@ -73,6 +63,18 @@
                   —
                 </template>
               </template>
+
+              <template #status="{ row: item }">
+                <StatusBadge
+                  v-if="item.status"
+                  :status="item.status"
+                />
+
+                <template v-else>
+                  —
+                </template>
+              </template>
+
               <template #actions="{ row: item }">
                 <KDropdownMenu
                   class="actions-dropdown"


### PR DESCRIPTION
Moves the status column in list views (if present) towards the end so it is the last column, but before warnings and actions columns.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
