### PR TITLE
chore: Add configurable exponential error backoff to all read requests

### DIFF
--- a/features/mesh/policies/Data.feature
+++ b/features/mesh/policies/Data.feature
@@ -45,7 +45,7 @@ Feature: mesh / policies / data
     Given the URL "/meshes/default/circuit-breakers" responds with
       """
       headers:
-        Status-Code: '503'
+        Status-Code: '520'
       """
     When I visit the "/mesh/default/policies/circuit-breakers" URL
     Then the "$state-error" element exists

--- a/src/app/application/components/data-source/DataSource.spec.ts
+++ b/src/app/application/components/data-source/DataSource.spec.ts
@@ -23,12 +23,12 @@ describe('DataSourcePool', () => {
     let res = SUCCESS
     withSources(() => {
       return {
-        '/success': (_params: any, source: any) => {
+        '/success': async (_params: any, source: any) => {
+          const r = await Promise.resolve(res)
           source.close()
-          return Promise.resolve(res)
+          return r
         },
-        '/error': (_params: any, source: any) => {
-          source.close()
+        '/error': (_params: any, _source: any) => {
           throw err
         },
       }

--- a/src/app/application/services/data-source/CallableEventSource.ts
+++ b/src/app/application/services/data-source/CallableEventSource.ts
@@ -18,7 +18,11 @@ export default class CallableEventSource extends EventTarget {
 
   constructor(
     protected source: () => AsyncGenerator,
-    _configuration = {},
+    public configuration = {
+      attempts: 0,
+      maxAttempts: 3,
+      power: 1,
+    },
   ) {
     super()
     this._open()

--- a/src/app/application/services/data-source/index.ts
+++ b/src/app/application/services/data-source/index.ts
@@ -9,24 +9,68 @@ export const create: Creator = (src, router) => {
   const _source = new CallableEventSource(async function * (this: CallableEventSource) {
     while (true) {
       this.readyState = 1
-      // `.route` here is the function call to the 'source' i.e. the Promise
-      // returning call that can be polled, in our case right now the HTTP
-      // calls but in the future could also be 'listeners' on localStorage, or
-      // 'listeners' on a session
-      yield route.route({
-        ...{
-          offset: parseInt(queryParams.get('offset') || '0'),
-          size: parseInt(queryParams.get('size') || '0'),
-          page: parseInt(queryParams.get('page') || '0'),
-          search: queryParams.get('search') || '',
-        },
-        ...route.params,
-      }, this)
-      if (!isClosed(this)) {
+      try {
+        // `.route` here is the function call to the 'source' i.e. the Promise
+        // returning call that can be polled, in our case right now the HTTP
+        // calls but in the future could also be 'listeners' on localStorage, or
+        // 'listeners' on a session
+        yield route.route({
+          ...{
+            offset: parseInt(queryParams.get('offset') || '0'),
+            size: parseInt(queryParams.get('size') || '0'),
+            page: parseInt(queryParams.get('page') || '0'),
+            search: queryParams.get('search') || '',
+          },
+          ...route.params,
+        }, this)
+        // if we get a successful response
+        // reset the retry count back to zero
+        this.configuration.attempts = 0
+        //
+        if (!isClosed(this)) {
         // right now any polling has a 5s interval, we currently just hardcode
         // here but if/when we use this more this should be a user setting
         // that we can save/retrieve from localStorage
-        await new Promise(resolve => setTimeout(resolve, 5000))
+          await new Promise(resolve => setTimeout(resolve, 5000))
+        }
+      } catch (e) {
+        const error = (e as {status: number | undefined})
+        if (typeof error.status !== 'undefined') {
+          const status = String(error.status)
+          switch (true) {
+            case status.startsWith('50'): {
+              this.configuration.attempts++
+              // if we reach the end of attempts
+              // 1. close the source entirely
+              // 2. reset attempts to zero
+              // 3. throw the error to be picked up by the application
+              if (this.configuration.attempts > this.configuration.maxAttempts) {
+                this.close()
+                this.configuration.attempts = 0
+                throw e
+              }
+              const delay = 3000 * Math.pow(this.configuration.attempts, this.configuration.power)
+              await new Promise(resolve => setTimeout(resolve, delay))
+              break
+            }
+            default:
+              // if we are not a 50x
+              // 1. close the source entirely
+              // 2. reset attempts to zero
+              // 3. throw the error to be picked up by the application
+              this.close()
+              this.configuration.attempts = 0
+              throw e
+          }
+        } else {
+          // if we don't have a status at all
+          // 1. close the source entirely
+          // 2. reset attempts to zero
+          // 3. throw the error to be picked up by the application
+          this.close()
+          this.configuration.attempts = 0
+          throw e
+        }
       }
     }
   })

--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -30,9 +30,8 @@ export type DataPlaneCollectionSource = DataSourceResponse<DataPlaneCollection>
 export const sources = (api: KumaApi) => {
   return {
     '/:mesh/dataplanes': async (params: MeshParams & PaginationParams, source: Closeable) => {
-      source.close()
       const offset = params.size * (params.page - 1)
-      return api.getAllDataplaneOverviewsFromMesh({
+      const res = await api.getAllDataplaneOverviewsFromMesh({
         mesh: params.mesh,
       }, {
         ...Object.fromEntries(normalizeFilterFields(JSON.parse(params.search || '[]'))),
@@ -40,9 +39,10 @@ export const sources = (api: KumaApi) => {
         gateway: 'false',
         size: params.size,
       })
+      source.close()
+      return res
     },
     '/:mesh/dataplanes/for/:service/of/:type': async (params: MeshParams & ServiceParams & PaginationParams & DataplaneTypeParams, source: Closeable) => {
-      source.close()
       const offset = params.size * (params.page - 1)
       // here 'all' means both proxies/sidecars and gateways this currently fits
       // our usecases but we should probably include `gateway | sidecar` or
@@ -54,7 +54,7 @@ export const sources = (api: KumaApi) => {
       search.tag = search.tag.filter((item) => !item.startsWith('kuma.io/service:'))
       search.tag.push(`kuma.io/service:${params.service}`)
 
-      return api.getAllDataplaneOverviewsFromMesh({
+      const res = await api.getAllDataplaneOverviewsFromMesh({
         mesh: params.mesh,
       }, {
         offset,
@@ -66,6 +66,8 @@ export const sources = (api: KumaApi) => {
         ),
         size: params.size,
       })
+      source.close()
+      return res
     },
 
   }

--- a/src/app/gateways/sources.ts
+++ b/src/app/gateways/sources.ts
@@ -26,20 +26,20 @@ export type GatewayCollectionSource = DataSourceResponse<GatewayCollection>
 export const sources = (api: KumaApi) => {
   return {
     '/:mesh/gateways': async (params: MeshParams & PaginationParams, source: Closeable) => {
-      source.close()
       const offset = params.size * (params.page - 1)
-      return api.getAllDataplaneOverviewsFromMesh({
+      const res = await api.getAllDataplaneOverviewsFromMesh({
         mesh: params.mesh,
       }, {
         gateway: 'true',
         offset,
         size: params.size,
       })
+      source.close()
+      return res
     },
     '/:mesh/gateways/of/:type': async (params: MeshParams & DataplaneTypeParams & PaginationParams, source: Closeable) => {
-      source.close()
       const offset = params.size * (params.page - 1)
-      return api.getAllDataplaneOverviewsFromMesh({
+      const res = await api.getAllDataplaneOverviewsFromMesh({
         mesh: params.mesh,
       }, {
         ...Object.fromEntries(normalizeFilterFields(JSON.parse(params.search || '[]'))),
@@ -47,6 +47,8 @@ export const sources = (api: KumaApi) => {
         offset,
         size: params.size,
       })
+      source.close()
+      return res
     },
   }
 }

--- a/src/app/meshes/sources.ts
+++ b/src/app/meshes/sources.ts
@@ -27,20 +27,23 @@ export type MeshInsightSource = DataSourceResponse<MeshInsight>
 export const sources = (api: KumaApi) => {
   return {
     '/meshes': async (params: MeshParams & PaginationParams, source: Closeable) => {
-      source.close()
       const offset = params.size * (params.page - 1)
-      return api.getAllMeshes({
+      const res = await api.getAllMeshes({
         size: params.size,
         offset,
       })
-    },
-    '/:mesh/mesh': (params: MeshParams, source: Closeable) => {
       source.close()
-      return api.getMesh({ name: params.mesh })
+      return res
+    },
+    '/:mesh/mesh': async (params: MeshParams, source: Closeable) => {
+      const res = await api.getMesh({ name: params.mesh })
+      source.close()
+      return res
     },
     '/:mesh/insights': async (params: MeshParams, source: Closeable) => {
+      const res = await api.getMeshInsights({ name: params.mesh })
       source.close()
-      return api.getMeshInsights({ name: params.mesh })
+      return res
     },
 
   }

--- a/src/app/policies/sources.ts
+++ b/src/app/policies/sources.ts
@@ -30,19 +30,21 @@ export type PolicyCollectionSource = DataSourceResponse<PolicyCollection>
 export const sources = (api: KumaApi) => {
   return {
     '/*/policy-types': async (_params: {}, source: {close: () => void}) => {
+      const res = await api.getPolicyTypes()
       source.close()
-      return api.getPolicyTypes()
+      return res
     },
     '/:mesh/policy-type/:policyType': async (params: MeshParams & PolicyTypeParams & PaginationParams, source: {close: () => void}) => {
-      source.close()
       const offset = params.size * (params.page - 1)
-      return api.getAllPolicyEntitiesFromMesh({
+      const res = await api.getAllPolicyEntitiesFromMesh({
         mesh: params.mesh,
         path: params.policyType,
       }, {
         offset,
         size: params.size,
       })
+      source.close()
+      return res
     },
     // '/:mesh/policy/:policy': async (params: MeshParams & PolicyParams) => {
     // },

--- a/src/app/services/sources.ts
+++ b/src/app/services/sources.ts
@@ -21,14 +21,15 @@ export type ServiceInsightCollectionSource = DataSourceResponse<ServiceInsightCo
 export const sources = (api: KumaApi) => {
   return {
     '/:mesh/services': async (params: MeshParams & PaginationParams, source: Closeable) => {
-      source.close()
       const offset = params.size * (params.page - 1)
-      return api.getAllServiceInsightsFromMesh({
+      const res = await api.getAllServiceInsightsFromMesh({
         mesh: params.mesh,
       }, {
         size: params.size,
         offset,
       })
+      source.close()
+      return res
     },
   }
 }

--- a/src/app/zones/sources.ts
+++ b/src/app/zones/sources.ts
@@ -23,30 +23,30 @@ export type ZoneEgressOverviewCollectionSource = DataSourceResponse<ZoneEgressOv
 export const sources = (api: KumaApi) => {
   return {
     '/zone-cps': async (params: PaginationParams, source: { close: () => void }) => {
-      source.close()
-
       const size = params.size
       const offset = params.size * (params.page - 1)
 
-      return await api.getAllZoneOverviews({ size, offset })
+      const res = await api.getAllZoneOverviews({ size, offset })
+      source.close()
+      return res
     },
 
     '/zone-ingresses': async (params: PaginationParams, source: { close: () => void }) => {
-      source.close()
-
       const size = params.size
       const offset = params.size * (params.page - 1)
 
-      return await api.getAllZoneIngressOverviews({ size, offset })
+      const res = await api.getAllZoneIngressOverviews({ size, offset })
+      source.close()
+      return res
     },
 
     '/zone-egresses': async (params: PaginationParams, source: { close: () => void }) => {
-      source.close()
-
       const size = params.size
       const offset = params.size * (params.page - 1)
 
-      return await api.getAllZoneEgressOverviews({ size, offset })
+      const res = await api.getAllZoneEgressOverviews({ size, offset })
+      source.close()
+      return res
     },
   }
 }


### PR DESCRIPTION
Closes all sources after the response has been received, also adds a configurable exponential error 50x backoff to all read HTTP requests.

