### PR TITLE
fix: moves experimental alert into card

### DIFF
--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -45,14 +45,13 @@
                 class="relative"
                 :class="selected.path"
               >
-                <div class="stack">
-                  <KCard
-                    v-if="selected.isExperimental"
-                    border-variant="noBorder"
-                    class="mb-4"
-                  >
-                    <template #body>
-                      <KAlert appearance="warning">
+                <KCard>
+                  <template #body>
+                    <div class="stack">
+                      <KAlert
+                        v-if="selected.isExperimental"
+                        appearance="warning"
+                      >
                         <template #alertMessage>
                           <p>
                             <strong>Warning</strong> This policy is experimental. If you encountered any problem please open an
@@ -64,10 +63,7 @@
                           </p>
                         </template>
                       </KAlert>
-                    </template>
-                  </KCard>
-                  <KCard>
-                    <template #body>
+
                       <AppCollection
                         class="policy-collection"
                         data-testid="policy-collection"
@@ -181,9 +177,9 @@
                           </KDropdownMenu>
                         </template>
                       </AppCollection>
-                    </template>
-                  </KCard>
-                </div>
+                    </div>
+                  </template>
+                </KCard>
               </div>
             </AppView>
           </DataSource>


### PR DESCRIPTION
Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Before:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/290c7304-e1e0-4e39-93d2-05b01ffa71a6)

After:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/bda8ce9d-7dfa-4108-a653-f2f86fbdb9cd)