### PR TITLE
chore: Adds AppCollectionActions

### DIFF
--- a/src/app/application/components/app-collection/AppCollectionAction.vue
+++ b/src/app/application/components/app-collection/AppCollectionAction.vue
@@ -1,8 +1,37 @@
 <template>
-  <KDropdownItem />
+  <KDropdownItem
+    v-bind="props"
+  />
 </template>
 <script lang="ts" setup>
 import {
   KDropdownItem,
 } from '@kong/kongponents'
+
+import type { DropdownItem } from '@kong/kongponents'
+import type { PropType } from 'vue'
+
+const props = defineProps({
+  item: {
+    type: Object as PropType<DropdownItem>,
+    default: null,
+    validator: (item: DropdownItem) => item.label !== undefined,
+  },
+  hasDivider: {
+    type: Boolean,
+    default: false,
+  },
+  isDangerous: {
+    type: Boolean,
+    default: false,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  selected: {
+    type: Boolean,
+    default: false,
+  },
+})
 </script>

--- a/src/app/application/components/app-collection/AppCollectionAction.vue
+++ b/src/app/application/components/app-collection/AppCollectionAction.vue
@@ -1,0 +1,8 @@
+<template>
+  <KDropdownItem />
+</template>
+<script lang="ts" setup>
+import {
+  KDropdownItem,
+} from '@kong/kongponents'
+</script>

--- a/src/app/application/components/app-collection/AppCollectionActions.vue
+++ b/src/app/application/components/app-collection/AppCollectionActions.vue
@@ -1,0 +1,33 @@
+<template>
+  <KDropdownMenu
+    class="actions-dropdown"
+    :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
+    width="150"
+  >
+    <template #default>
+      <KButton
+        class="non-visual-button"
+        appearance="secondary"
+        size="small"
+      >
+        <template #icon>
+          <KIcon
+            color="var(--black-400)"
+            icon="more"
+            size="16"
+          />
+        </template>
+      </KButton>
+    </template>
+    <template #items>
+      <slot name="default" />
+    </template>
+  </KDropdownMenu>
+</template>
+<script lang="ts" setup>
+import {
+  KDropdownMenu,
+  KButton,
+  KIcon,
+} from '@kong/kongponents'
+</script>

--- a/src/app/application/components/app-collection/AppCollectionActions.vue
+++ b/src/app/application/components/app-collection/AppCollectionActions.vue
@@ -12,9 +12,9 @@
       >
         <template #icon>
           <KIcon
-            color="var(--black-400)"
+            :color="KUI_COLOR_TEXT_NEUTRAL_STRONGER"
             icon="more"
-            size="16"
+            :size="KUI_ICON_SIZE_30"
           />
         </template>
       </KButton>
@@ -25,6 +25,7 @@
   </KDropdownMenu>
 </template>
 <script lang="ts" setup>
+import { KUI_COLOR_TEXT_NEUTRAL_STRONGER, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import {
   KDropdownMenu,
   KButton,

--- a/src/app/application/components/app-collection/README.md
+++ b/src/app/application/components/app-collection/README.md
@@ -1,4 +1,64 @@
 # AppCollection
 
 'Simple-ish' wrapper around KTable with a default common configuration
-specific to our application to save repitition.
+specific to our application to save repetition.
+
+## AppCollectionActions
+
+'Simple-ish' wrapper around KDropdownMenu with a default common configuration
+specific to our application to save repetition.
+
+## Example
+
+In the below example, `data` and `error` would usually come from a `<DataSource />`
+component, but `data` could be anything and `error` should be a standard
+shaped error that also could come from anywhere.
+
+`route.update` comes from our `<RouteView />`
+
+```vue
+<AppCollection
+  :headers="[
+    { label: 'Name', key: 'name' },
+    /* other headers/slots should be added here */
+    { label: 'Actions', key: 'actions', hideLabel: true },
+  ]"
+  :page-number="props.page"
+  :page-size="props.size"
+  :total="data?.total"
+  :items="data?.items"
+  :error="error"
+  @change="route.update"
+
+>
+  <template #name="{ row: item }">
+    <RouterLink
+      :to="{
+        name: 'data-plane-detail-view',
+        params: {
+          dataPlane: item.name
+        }
+      }"
+    >
+      {{ item.name }}
+    </RouterLink>
+  </template>
+  <!--- other slots should be added here --->
+  <template #actions="{ row: item }">
+    <AppCollectionActions>
+      <AppCollectionAction
+        :item="{
+          to: {
+            name: 'data-plane-detail-view',
+            params: {
+              dataPlane: item.name,
+            },
+          },
+          label: t('common.collection.actions.view'),
+        }"
+      />
+    </AppCollectionActions>
+  </template>
+</AppCollection>
+
+```


### PR DESCRIPTION
This is to avoid too much repeated setup of KDropdownMenu specifically for all our many AppCollections. I've tested this locally but wanted to get a draft of this up before rolling out everywhere incase there are any review comments.

I've included an example in the AppCollection docs to show the reduction.

Signed-off-by: John Cowen <john.cowen@konghq.com>
