### PR TITLE
fix(zones): zone name not being quoted in YAML

### DIFF
--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -77,7 +77,7 @@ zones:
           mode: zone
           multizone:
             zone:
-              name: {zoneName}
+              name: "{zoneName}"
               globalAddress: {globalKdsAddress}
           experimental:
             kdsDeltaEnabled: true
@@ -125,7 +125,7 @@ zones:
         config: |
           controlPlane:
             mode: zone
-            zone: {zoneName}
+            zone: "{zoneName}"
             kdsGlobalAddress: {globalKdsAddress}
             secrets:
               - Env: KUMA_MULTIZONE_ZONE_KDS_AUTH_CP_TOKEN_INLINE


### PR DESCRIPTION
Fixes the zone name not being quoted in certain YAML files leading to numerical values being treated as numbers.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
