### PR TITLE
chore: makes filter bar take up full width in toolbar

### DIFF
--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -111,7 +111,7 @@ const click = (e: MouseEvent) => {
 .app-collection-toolbar {
   display: flex;
   justify-content: flex-end;
-  align-items: center;
+  align-items: stretch;
   flex-wrap: wrap;
   gap: var(--spacing-md);
   padding: var(--spacing-sm) var(--spacing-sm) 0 var(--spacing-sm);

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -114,7 +114,6 @@ const click = (e: MouseEvent) => {
   align-items: stretch;
   flex-wrap: wrap;
   gap: var(--spacing-md);
-  padding: var(--spacing-sm) var(--spacing-sm) 0 var(--spacing-sm);
   font-size: var(--type-md);
   color: var(--black-500);
 }

--- a/src/app/common/KFilterBar.vue
+++ b/src/app/common/KFilterBar.vue
@@ -417,7 +417,6 @@ function areFieldsSemanticallyIdentical(fieldsA: Fields, fieldB: Fields): boolea
 <style lang="scss" scoped>
 .k-filter-bar {
   position: relative;
-  max-width: 700px;
   display: inline-flex;
   align-items: stretch;
   background-color: var(--white);

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -86,7 +86,6 @@ const props = defineProps<{
 .data-plane-proxy-filter {
   flex-basis: 350px;
   flex-grow: 1;
-  margin-right: auto;
 }
 </style>
 

--- a/src/app/gateways/views/GatewayListView.vue
+++ b/src/app/gateways/views/GatewayListView.vue
@@ -37,7 +37,6 @@
             >
               <template #toolbar>
                 <KFilterBar
-                  data-testid="gateway-type-filter"
                   class="data-plane-proxy-filter"
                   :placeholder="`tag: 'kuma.io/protocol: http'`"
                   :query="props.query"
@@ -122,7 +121,6 @@ const props = defineProps<{
 .data-plane-proxy-filter {
   flex-basis: 350px;
   flex-grow: 1;
-  margin-right: auto;
 }
 </style>
 <style lang="scss">

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -195,10 +195,6 @@ async function loadData() {
 .data-plane-proxy-filter {
   flex-basis: 350px;
   flex-grow: 1;
-  margin-right: auto;
-}
-.actions-dropdown {
-  display: inline-block;
 }
 </style>
 <style lang="scss">


### PR DESCRIPTION
**chore: makes filter bar take up full width in toolbar**

**chore: makes toolbar action items take up same height**

**chore: removes incorrect padding from toolbar**

The toolbar shouldn’t have additional padding according to the designs.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Before:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/d52720e5-bcf6-4b36-91c9-349607dd51cd)

After:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/ff9ebb82-a199-4e5f-aa75-64209e21e1c8)