### PR TITLE
fix: handling of empty table cells

### DIFF
--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -25,18 +25,46 @@ Feature: Zones: List view content
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
+                  config: '{"store":{"type":"memory"}}'
                   status: {}
+                  version:
+                    kumaCp:
+                      version: 1.0.0-rc2-211-g823fe8ce
+                      gitTag: 1.0.0-rc2-211-g823fe8ce
+                      gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
+                      buildDate: 2021-02-18T13:22:30Z
                 - connectTime: 2020-07-28T16:18:09.743141Z
+                  config: '{"store":{"type":"memory"}}'
                   status: {}
+                  version:
+                    kumaCp:
+                      version: 1.0.0-rc2-211-g823fe8ce
+                      gitTag: 1.0.0-rc2-211-g823fe8ce
+                      gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
+                      buildDate: 2021-02-18T13:22:30Z
           - name: zone-cp-2
             zoneInsight:
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
+                  config: '{"store":{"type":"memory"}}'
                   status: {}
+                  version:
+                    kumaCp:
+                      version: 1.0.0-rc2-211-g823fe8ce
+                      gitTag: 1.0.0-rc2-211-g823fe8ce
+                      gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
+                      buildDate: 2021-02-18T13:22:30Z
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
+                  config: '{"store":{"type":"memory"}}'
                   status: {}
+                  version:
+                    kumaCp:
+                      version: 1.0.0-rc2-211-g823fe8ce
+                      gitTag: 1.0.0-rc2-211-g823fe8ce
+                      gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
+                      buildDate: 2021-02-18T13:22:30Z
       """
 
     When I visit the "/zones/zone-cps" URL

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -51,6 +51,26 @@
                 </RouterLink>
               </template>
 
+              <template #serviceType="{ rowValue }">
+                <template v-if="rowValue">
+                  {{ rowValue }}
+                </template>
+
+                <template v-else>
+                  —
+                </template>
+              </template>
+
+              <template #addressPort="{ rowValue }">
+                <template v-if="rowValue">
+                  {{ rowValue }}
+                </template>
+
+                <template v-else>
+                  —
+                </template>
+              </template>
+
               <template #online="{ row: item }">
                 <template
                   v-if="item.dataplanes"
@@ -65,14 +85,7 @@
               </template>
 
               <template #status="{ row: item }">
-                <StatusBadge
-                  v-if="item.status"
-                  :status="item.status"
-                />
-
-                <template v-else>
-                  —
-                </template>
+                <StatusBadge :status="item.status || 'not_available'" />
               </template>
 
               <template #actions="{ row: item }">

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -52,23 +52,11 @@
               </template>
 
               <template #serviceType="{ rowValue }">
-                <template v-if="rowValue">
-                  {{ rowValue }}
-                </template>
-
-                <template v-else>
-                  —
-                </template>
+                {{ rowValue || '—' }}
               </template>
 
               <template #addressPort="{ rowValue }">
-                <template v-if="rowValue">
-                  {{ rowValue }}
-                </template>
-
-                <template v-else>
-                  —
-                </template>
+                {{ rowValue || '—' }}
               </template>
 
               <template #online="{ row: item }">

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -72,23 +72,11 @@
                 </template>
 
                 <template #zoneCpVersion="{ rowValue }">
-                  <template v-if="rowValue">
-                    {{ rowValue }}
-                  </template>
-
-                  <template v-else>
-                    —
-                  </template>
+                  {{ rowValue || '—' }}
                 </template>
 
                 <template #storeType="{ rowValue }">
-                  <template v-if="rowValue">
-                    {{ rowValue }}
-                  </template>
-
-                  <template v-else>
-                    —
-                  </template>
+                  {{ rowValue || '—' }}
                 </template>
 
                 <template #status="{ rowValue }">

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -72,11 +72,23 @@
                 </template>
 
                 <template #zoneCpVersion="{ rowValue }">
-                  {{ rowValue }}
+                  <template v-if="rowValue">
+                    {{ rowValue }}
+                  </template>
+
+                  <template v-else>
+                    —
+                  </template>
                 </template>
 
                 <template #storeType="{ rowValue }">
-                  {{ rowValue }}
+                  <template v-if="rowValue">
+                    {{ rowValue }}
+                  </template>
+
+                  <template v-else>
+                    —
+                  </template>
                 </template>
 
                 <template #status="{ rowValue }">
@@ -99,6 +111,10 @@
                     secondary-color="var(--yellow-300)"
                     size="20"
                   />
+
+                  <template v-else>
+                    &nbsp;
+                  </template>
                 </template>
 
                 <template #actions="{ row }">
@@ -232,7 +248,7 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
         zone: name,
       },
     }
-    let zoneCpVersion = '-'
+    let zoneCpVersion = ''
     let storeType = ''
     let cpCompat = true
 

--- a/src/test-support/mocks/src/meshes/_/service-insights.ts
+++ b/src/test-support/mocks/src/meshes/_/service-insights.ts
@@ -18,21 +18,34 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const online = fake.number.int(100)
         const offline = fake.number.int(100)
 
-        return {
+        const serviceType = fake.kuma.serviceType()
+
+        const serviceInsight: any = {
           type: 'ServiceInsight',
-          serviceType: fake.kuma.serviceType(),
+          serviceType,
           mesh: params.mesh,
           name,
           creationTime: '2021-02-19T08:06:15.14624+01:00',
           modificationTime: '2021-02-19T08:07:37.539229+01:00',
-          addressPort: `${name}.mesh:${fake.internet.port()}`,
-          status: fake.kuma.status(),
-          dataplanes: {
+        }
+
+        if (fake.datatype.boolean()) {
+          serviceInsight.addressPort = `${name}.mesh:${fake.internet.port()}`
+        }
+
+        if (fake.datatype.boolean()) {
+          serviceInsight.status = fake.kuma.status()
+        }
+
+        if (serviceType === 'internal') {
+          serviceInsight.dataplanes = {
             total: online + offline,
             online,
             offline,
-          },
+          }
         }
+
+        return serviceInsight
       }),
       next,
     },

--- a/src/test-support/mocks/src/zones+insights.ts
+++ b/src/test-support/mocks/src/zones+insights.ts
@@ -13,6 +13,8 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
         const name = `${fake.hacker.noun()}-${id}`
+        const shouldHaveZoneInsight = fake.datatype.boolean()
+
         return {
           type: 'ZoneOverview',
           name,
@@ -21,7 +23,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
           zone: {
             enabled: true,
           },
-          ...(true && {
+          ...(shouldHaveZoneInsight && {
             zoneInsight: {
               subscriptions: [
                 {


### PR DESCRIPTION
**fix(zones): handling of empty table cells**

Fixes empty cells not rendering the right content.

Fixes the warnings cell showing `false` instead of nothing.

**fix(services): handling of empty table cells**

Randomizes presence of certain fields on service mocks and only sets dataplanes if the service is an external one.

Makes sure to always show a status badge.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

