### PR TITLE
chore(e2e): adds mockMergeStyle option

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -56,9 +56,10 @@ Given('the environment', (yaml: string) => {
     cy.setCookie(key, String(value))
   })
 })
-Given('the URL {string} responds with', (url: string, yaml: string) => {
+Given(/^the URL "(.*)" responds with( exactly)?$/, (url: string, exactly: string, yaml: string) => {
   const options: Options = {
     env,
+    mockMergeStyle: exactly ? 'replace' : 'deep',
   }
   const now = new Date().getTime()
   const mock = useMock()

--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -2,6 +2,7 @@ import { When, Then, Before, Given, DataTable } from '@badeball/cypress-cucumber
 import YAML from 'js-yaml'
 
 import { useServer, useMock } from '@/services/e2e'
+import type { Options } from '@/test-support'
 
 const console = {
   log: (message: unknown) => Cypress.log({ displayName: 'LOG', message: JSON.stringify(message) }),
@@ -56,10 +57,13 @@ Given('the environment', (yaml: string) => {
   })
 })
 Given('the URL {string} responds with', (url: string, yaml: string) => {
+  const options: Options = {
+    env,
+  }
   const now = new Date().getTime()
   const mock = useMock()
   urls.set(url, `spy-${now}`)
-  mock(url, env, (respond) => {
+  mock(url, options, (respond) => {
     const response = respond((YAML.load(yaml) || {}) as { headers?: Record<string, string>, body?: Record<string, unknown> })
     return response
   }).as(urls.get(url))

--- a/src/app/onboarding/views/DataplanesOverview.spec.ts
+++ b/src/app/onboarding/views/DataplanesOverview.spec.ts
@@ -11,7 +11,7 @@ function renderComponent() {
 describe('DataplanesOverview.vue', () => {
   const mock = useMock()
   test('renders snapshot', async () => {
-    mock('/dataplanes', { KUMA_DATAPLANE_COUNT: '1' }, (merge) => {
+    mock('/dataplanes', { env: { KUMA_DATAPLANE_COUNT: '1' } }, (merge) => {
       return merge({
         body: {
           items: [
@@ -22,7 +22,7 @@ describe('DataplanesOverview.vue', () => {
         },
       })
     })
-    mock('/meshes/:mesh/dataplanes+insights/:name', { KUMA_SUBSCRIPTION_COUNT: '1' }, (merge) => {
+    mock('/meshes/:mesh/dataplanes+insights/:name', { env: { KUMA_SUBSCRIPTION_COUNT: '1' } }, (merge) => {
       return merge({
         body: {
           name: 'dataplane-test-456',

--- a/src/app/zones/views/ZoneListView.spec.ts
+++ b/src/app/zones/views/ZoneListView.spec.ts
@@ -23,7 +23,9 @@ describe('ZoneListView', () => {
   test('updates list when deleting Zone', async () => {
     const firstZoneName = 'zone-1'
     mock('/zones+insights', {
-      KUMA_ZONE_COUNT: '3',
+      env: {
+        KUMA_ZONE_COUNT: '3',
+      },
     }, (merge) => {
       return merge({
         body: {

--- a/src/services/e2e.ts
+++ b/src/services/e2e.ts
@@ -12,7 +12,7 @@ const env = (
 type AEnv = ReturnType<typeof env>
 type Server = typeof cy
 // temporary intercept returning Mocker
-type Mocker = (route: string, opts?: Options, cb?: Callback) => ReturnType<typeof cy['intercept']>
+type Mocker = (route: string, opts?: Partial<Options>, cb?: Callback) => ReturnType<typeof cy['intercept']>
 const $ = {
   EnvVars: token<EnvVars>('EnvVars'),
   env: token<AEnv>('env'),

--- a/src/test-support/intercept.ts
+++ b/src/test-support/intercept.ts
@@ -1,6 +1,6 @@
 import { URLPattern } from 'urlpattern-polyfill'
 
-import { FS, Callback, createMerge, Mocker } from '@/test-support'
+import { FS, Callback, createMerge, Mocker, getOptions } from '@/test-support'
 import { dependencies, MockEnvKeys, AppEnvKeys, Env } from '@/test-support/fake'
 class Router<T> {
   routes: Map<URLPattern, T> = new Map()
@@ -40,6 +40,8 @@ const noop: Callback = (_merge, _req, response) => response
 export const mocker = (env: (key: AppEnvKeys, d?: string) => string, cy: Server, fs: FS): Mocker => {
   const router = new Router(fs)
   return (path, opts = {}, cb = noop) => {
+    const options = getOptions(opts)
+
     // if path is `*` then that means mock everything, which currently means
     // changing to `/`
     path = path === '*' ? '/' : path
@@ -51,8 +53,8 @@ export const mocker = (env: (key: AppEnvKeys, d?: string) => string, cy: Server,
       (req) => {
         try {
           const mockEnv: Env = (key, d = '') => {
-            if (typeof opts[key as MockEnvKeys] !== 'undefined') {
-              return opts[key as MockEnvKeys]
+            if (typeof options.env[key as MockEnvKeys] !== 'undefined') {
+              return options.env[key as MockEnvKeys]
             }
             return env(key as AppEnvKeys, d)
           }

--- a/src/test-support/intercept.ts
+++ b/src/test-support/intercept.ts
@@ -74,7 +74,7 @@ export const mocker = (env: (key: AppEnvKeys, d?: string) => string, cy: Server,
             url,
           }
           const _response = fetch(request)
-          const response = cb(createMerge(_response), request, _response)
+          const response = cb(createMerge(_response, options.mockMergeStyle), request, _response)
           req.reply({
             statusCode: parseInt(response.headers['Status-Code'] ?? '200'),
             delay: parseInt(mockEnv('KUMA_LATENCY', '0')),


### PR DESCRIPTION
**refactor(e2e): allows mock options to be expanded beyond env**

Changes the `Options` type and its use to allow for additional properties beyond just env.

**chore(e2e): adds mockMergeStyle option**

Adds a new mock option `mockMergeStyle` that controls the merging behavior for mocks. It adds support for a "replace" option opting out of merging mocks entirely so that tests can specify a full mock without interference of the default mocks.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
