### PR TITLE
chore: clean up general table styles

### DIFF
--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -76,7 +76,7 @@
       />
 
       <template v-else>
-        —
+        {{ t('common.collection.none') }}
       </template>
     </template>
     <template #actions="{ row: item }">
@@ -299,20 +299,20 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
       name,
       detailViewRoute,
       type,
-      zone: { title: zone ?? '—', route: zoneRoute },
-      service: { title: service ?? '—', route: serviceInsightRoute },
-      protocol: protocol ?? '—',
+      zone: { title: zone ?? t('common.collection.none'), route: zoneRoute },
+      service: { title: service ?? t('common.collection.none'), route: serviceInsightRoute },
+      protocol: protocol ?? t('common.collection.none'),
       status,
       totalUpdates: summary.totalUpdates,
       totalRejectedUpdates: summary.totalRejectedUpdates,
-      dpVersion: summary.dpVersion ?? '—',
-      envoyVersion: summary.envoyVersion ?? '—',
+      dpVersion: summary.dpVersion ?? t('common.collection.none'),
+      envoyVersion: summary.envoyVersion ?? t('common.collection.none'),
       warnings: [],
       unsupportedEnvoyVersion: false,
       unsupportedKumaDPVersion: false,
       kumaDpAndKumaCpMismatch: false,
-      lastUpdated: summary.selectedUpdateTime ? formatIsoDate(new Date(summary.selectedUpdateTime).toUTCString()) : '—',
-      lastConnected: summary.selectedTime ? formatIsoDate(new Date(summary.selectedTime).toUTCString()) : '—',
+      lastUpdated: summary.selectedUpdateTime ? formatIsoDate(new Date(summary.selectedUpdateTime).toUTCString()) : t('common.collection.none'),
+      lastConnected: summary.selectedTime ? formatIsoDate(new Date(summary.selectedTime).toUTCString()) : t('common.collection.none'),
       overview: dataPlaneOverview,
     }
 

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -12,7 +12,7 @@
       { label: 'Kuma DP version', key: 'dpVersion' },
       { label: 'Status', key: 'status' },
       { label: 'Actions', key: 'actions', hideLabel: true },
-    ].filter(Boolean)"
+    ].filter(notEmpty)"
     :page-number="props.pageNumber"
     :page-size="props.pageSize"
     :total="props.total"
@@ -144,6 +144,7 @@ import {
   INCOMPATIBLE_UNSUPPORTED_KUMA_DP,
   INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS,
 } from '@/utilities/dataplane'
+import { notEmpty } from '@/utilities/notEmpty'
 const store = useStore()
 const { t, formatIsoDate } = useI18n()
 

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -88,17 +88,3 @@ const props = defineProps<{
   flex-grow: 1;
 }
 </style>
-
-<style lang="scss">
-.data-plane-collection {
-  .actions-column {
-    width: 5%;
-    min-width: 80px;
-    text-align: end;
-  }
-  .status-column {
-    width: 10%;
-    min-width: 200px;
-  }
-}
-</style>

--- a/src/app/gateways/views/GatewayListView.vue
+++ b/src/app/gateways/views/GatewayListView.vue
@@ -123,16 +123,3 @@ const props = defineProps<{
   flex-grow: 1;
 }
 </style>
-<style lang="scss">
-.gateway-collection {
-  .actions-column {
-    width: 5%;
-    min-width: 80px;
-    text-align: end;
-  }
-  .status-column {
-    width: 10%;
-    min-width: 200px;
-  }
-}
-</style>

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -126,18 +126,3 @@ const props = defineProps<{
   display: inline-block;
 }
 </style>
-
-<style lang="scss">
-.mesh-collection {
-  .actions-column {
-    width: 5%;
-    min-width: 80px;
-    text-align: end;
-  }
-
-  .status-column {
-    width: 10%;
-    min-width: 200px;
-  }
-}
-</style>

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -87,7 +87,7 @@
                               mesh: item.name,
                             },
                           },
-                          label: 'View',
+                          label: t('common.collection.actions.view'),
                         }"
                       />
                     </template>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -229,13 +229,3 @@ const props = defineProps<{
   display: inline-block;
 }
 </style>
-
-<style lang="scss">
-.policy-collection {
-  .actions-column {
-    width: 5%;
-    min-width: 80px;
-    text-align: end;
-  }
-}
-</style>

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -197,16 +197,3 @@ async function loadData() {
   flex-grow: 1;
 }
 </style>
-<style lang="scss">
-.data-plane-collection {
-  .actions-column {
-    width: 5%;
-    min-width: 80px;
-    text-align: end;
-  }
-  .status-column {
-    width: 10%;
-    min-width: 200px;
-  }
-}
-</style>

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -153,18 +153,3 @@ const props = defineProps<{
   display: inline-block;
 }
 </style>
-
-<style lang="scss">
-.service-collection {
-  .actions-column {
-    width: 5%;
-    min-width: 80px;
-    text-align: end;
-  }
-
-  .status-column {
-    width: 10%;
-    min-width: 200px;
-  }
-}
-</style>

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -52,11 +52,11 @@
               </template>
 
               <template #serviceType="{ rowValue }">
-                {{ rowValue || '—' }}
+                {{ rowValue || t('common.collection.none') }}
               </template>
 
               <template #addressPort="{ rowValue }">
-                {{ rowValue || '—' }}
+                {{ rowValue || t('common.collection.none') }}
               </template>
 
               <template #online="{ row: item }">
@@ -68,7 +68,7 @@
                 <template
                   v-else
                 >
-                  —
+                  {{ t('common.collection.none') }}
                 </template>
               </template>
 

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -59,7 +59,7 @@
                 />
 
                 <template v-else>
-                  —
+                  {{ t('common.collection.none') }}
                 </template>
               </template>
 

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -164,18 +164,3 @@ function transformToTableData(zoneEgressOverviews: ZoneEgressOverview[]): ZoneEg
   display: inline-block;
 }
 </style>
-
-<style lang="scss">
-.zone-egress-collection {
-  .actions-column {
-    width: 5%;
-    min-width: 80px;
-    text-align: end;
-  }
-
-  .status-column {
-    width: 10%;
-    min-width: 200px;
-  }
-}
-</style>

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -171,18 +171,3 @@ function transformToTableData(zoneIngressOverviews: ZoneIngressOverview[]): Zone
   display: inline-block;
 }
 </style>
-
-<style lang="scss">
-.zone-ingress-collection {
-  .actions-column {
-    width: 5%;
-    min-width: 80px;
-    text-align: end;
-  }
-
-  .status-column {
-    width: 10%;
-    min-width: 200px;
-  }
-}
-</style>

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -62,7 +62,7 @@
                   />
 
                   <template v-else>
-                    —
+                    {{ t('common.collection.none') }}
                   </template>
                 </template>
 

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -59,11 +59,11 @@
                 </template>
 
                 <template #zoneCpVersion="{ rowValue }">
-                  {{ rowValue || '—' }}
+                  {{ rowValue || t('common.collection.none') }}
                 </template>
 
                 <template #type="{ rowValue }">
-                  {{ rowValue || '—' }}
+                  {{ rowValue || t('common.collection.none') }}
                 </template>
 
                 <template #status="{ rowValue }">
@@ -73,7 +73,7 @@
                   />
 
                   <template v-else>
-                    —
+                    {{ t('common.collection.none') }}
                   </template>
                 </template>
 
@@ -93,7 +93,7 @@
                   </KTooltip>
 
                   <template v-else>
-                    &nbsp;
+                    {{ t('common.collection.none') }}
                   </template>
                 </template>
 

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -278,19 +278,3 @@ function setDeleteZoneName(name: string) {
   display: inline-block;
 }
 </style>
-
-<style lang="scss">
-.zone-cp-collection {
-  .warnings-column,
-  .actions-column {
-    width: 5%;
-    min-width: 80px;
-    text-align: end;
-  }
-
-  .status-column {
-    width: 10%;
-    min-width: 200px;
-  }
-}
-</style>

--- a/src/assets/styles/_kongponents-overrides.scss
+++ b/src/assets/styles/_kongponents-overrides.scss
@@ -28,3 +28,8 @@
   margin-top: 0 !important;
   margin-bottom: 0 !important;
 }
+
+.kong-card .k-card-body:not(.increase-specificity) {
+  // Overrides the line-height of KCard bodies using a unitless (i.e. relative) value. KCard bodies have `font-size: 12px` and `line-height: 16px` (i.e. a ratio of 1.33333) by default; however, in some contexts (e.g. table cells), a different font size is specified without a matching line-height. This fixes it without changing the appearance of KCard in other contexts.
+  line-height: 1.33333;
+}

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -12,6 +12,7 @@ common:
     title: 'No data'
     message: 'There are no {type} present.'
   collection:
+    none: ' '
     actions:
       delete: 'Delete'
       edit: 'Edit'


### PR DESCRIPTION
**chore: uses non-breaking space for empty table cells**

**chore(meshes): uses i18n message for actions**

**chore: evenly spreads out columns of smallish tables**

Adds logic for evenly spreading out the columns of small-ish tables (i.e. column count lower than 5). Such tables will now have equally-sized columns with the two special columns (if present) taking up a fixed amount of space each.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>