### PR TITLE
chore: Adds some new environment variables for `env`

### DIFF
--- a/src/pathConfigDefault.ts
+++ b/src/pathConfigDefault.ts
@@ -5,5 +5,9 @@ export function getPathConfigDefault(apiUrlDefault: string = ''): PathConfig {
     baseGuiPath: '/gui',
     apiUrl: apiUrlDefault,
     version: '1.7.0',
+    product: 'Kuma',
+    mode: 'standalone',
+    environment: 'universal',
+    apiReadOnly: false,
   }
 }

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -16,6 +16,8 @@ type EnvProps = {
   KUMA_BASE_PATH: string
   KUMA_API_URL: string
   KUMA_UTM_QUERY_PARAMS: string
+  KUMA_MODE: string
+  KUMA_ENVIRONMENT: string
 }
 export type EnvVars = EnvArgs & EnvProps
 
@@ -42,6 +44,8 @@ export default class Env {
       KUMA_VERSION: version.pre,
       KUMA_API_URL: env('KUMA_API_URL') || config.apiUrl,
       KUMA_BASE_PATH: env('KUMA_BASE_PATH') || config.baseGuiPath,
+      KUMA_MODE: env('KUMA_MODE') || config.mode,
+      KUMA_ENVIRONMENT: env('KUMA_ENVIRONMENT') || config.environment,
     }
   }
 

--- a/src/services/env/env.spec.ts
+++ b/src/services/env/env.spec.ts
@@ -19,6 +19,10 @@ describe('env', () => {
           baseGuiPath: '/not/gui',
           apiUrl: '/somewhere/else',
           version: '110.127.30',
+          product: 'Kuma',
+          mode: 'standalone',
+          environment: 'universal',
+          apiReadOnly: false,
         }
       }
     }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -41,6 +41,12 @@ export type PathConfig = {
    * **Example**: `'2.0.1'`
    */
   version: string
+
+  product: string,
+  mode: string,
+  environment: string,
+  apiReadOnly: boolean,
+
 }
 
 export type TableHeader = {


### PR DESCRIPTION
Adds some new static env vars that are sourced form the index.html file.

As yet this PR doesn't use them, but they will be used in a subsequent PR in place of variables sourced from a HTTP request.