### PR TITLE
chore: cleans up zone control plane list view

### DIFF
--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -15,6 +15,7 @@ Feature: Zones: List view content
       """
       body:
         mode: global
+        environment: kubernetes
       """
     And the URL "/zones+insights" responds with
       """
@@ -25,7 +26,6 @@ Feature: Zones: List view content
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  config: '{"store":{"type":"memory"}}'
                   status: {}
                   version:
                     kumaCp:
@@ -34,7 +34,6 @@ Feature: Zones: List view content
                       gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
                       buildDate: 2021-02-18T13:22:30Z
                 - connectTime: 2020-07-28T16:18:09.743141Z
-                  config: '{"store":{"type":"memory"}}'
                   status: {}
                   version:
                     kumaCp:
@@ -47,7 +46,6 @@ Feature: Zones: List view content
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  config: '{"store":{"type":"memory"}}'
                   status: {}
                   version:
                     kumaCp:
@@ -57,7 +55,6 @@ Feature: Zones: List view content
                       buildDate: 2021-02-18T13:22:30Z
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  config: '{"store":{"type":"memory"}}'
                   status: {}
                   version:
                     kumaCp:
@@ -73,12 +70,12 @@ Feature: Zones: List view content
     Then the "$zone-cp-table-row:nth-child(1) .status-column" element contains "online"
     Then the "$zone-cp-table-row:nth-child(1) .name-column" element contains "zone-cp-1"
     Then the "$zone-cp-table-row:nth-child(1) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
-    Then the "$zone-cp-table-row:nth-child(1) .storeType-column" element contains "memory"
+    Then the "$zone-cp-table-row:nth-child(1) .type-column" element contains "kubernetes"
 
     Then the "$zone-cp-table-row:nth-child(2) .status-column" element contains "offline"
     Then the "$zone-cp-table-row:nth-child(2) .name-column" element contains "zone-cp-2"
     Then the "$zone-cp-table-row:nth-child(2) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
-    Then the "$zone-cp-table-row:nth-child(2) .storeType-column" element contains "memory"
+    Then the "$zone-cp-table-row:nth-child(2) .type-column" element contains "kubernetes"
 
   Scenario Outline: Zone Ingress list view has expected content
     Given the environment

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -8,6 +8,8 @@ zone-cps:
     items:
       title: Zone Control Planes
       breadcrumbs: Zone Control Planes
+  list:
+    version_mismatch: 'Version mismatch'
 
 zone-ingresses:
   routes:

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -41,6 +41,8 @@ zones:
         zone-cp-list-view: Zone Control Planes
         zone-ingress-list-view: Ingresses
         zone-egress-list-view: Egresses
+  index:
+    create: 'Create Zone'
   form:
     exit: 'Exit'
     nameLabel: 'Name'

--- a/src/app/zones/views/ZoneIndexView.vue
+++ b/src/app/zones/views/ZoneIndexView.vue
@@ -19,6 +19,19 @@
         </h1>
       </template>
 
+      <template
+        v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
+        #actions
+      >
+        <KButton
+          appearance="creation"
+          icon="plus"
+          :to="{ name: 'zone-create-view' }"
+        >
+          {{ t('zones.index.create') }}
+        </KButton>
+      </template>
+
       <NavTabs
         v-if="store.getters['config/getMulticlusterStatus']"
         :tabs="tabs"
@@ -35,13 +48,16 @@
 </template>
 
 <script lang="ts" setup>
+import { KButton } from '@kong/kongponents'
+
 import AppView from '@/app/application/components/app-view/AppView.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import NavTabs, { NavTab } from '@/app/common/NavTabs.vue'
 import { useStore } from '@/store/store'
-import { useI18n } from '@/utilities'
+import { useEnv, useI18n } from '@/utilities'
 
+const env = useEnv()
 const { t } = useI18n()
 const store = useStore()
 

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -49,19 +49,6 @@
                 :error="error"
                 @change="route.update"
               >
-                <template
-                  v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
-                  #toolbar
-                >
-                  <KButton
-                    appearance="creation"
-                    icon="plus"
-                    :to="{ name: 'zone-create-view' }"
-                  >
-                    Create Zone
-                  </KButton>
-                </template>
-
                 <template #name="{ row, rowValue }">
                   <RouterLink
                     :to="row.detailViewRoute"

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -78,14 +78,19 @@
                 </template>
 
                 <template #warnings="{ rowValue }">
-                  <KIcon
+                  <KTooltip
                     v-if="rowValue"
-                    class="mr-1"
-                    icon="warning"
-                    color="var(--black-500)"
-                    secondary-color="var(--yellow-300)"
-                    size="20"
-                  />
+                    :label="t('zone-cps.list.version_mismatch')"
+                  >
+                    <KIcon
+                      class="mr-1"
+                      icon="warning"
+                      color="var(--black-500)"
+                      secondary-color="var(--yellow-300)"
+                      size="20"
+                      hide-title
+                    />
+                  </KTooltip>
 
                   <template v-else>
                     &nbsp;
@@ -167,7 +172,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
+import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon, KTooltip } from '@kong/kongponents'
 import { computed, ref } from 'vue'
 import { type RouteLocationNamedRaw } from 'vue-router'
 

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -37,7 +37,7 @@
                 :headers="[
                   { label: 'Name', key: 'name' },
                   { label: 'Zone CP Version', key: 'zoneCpVersion' },
-                  { label: 'Storage type', key: 'storeType' },
+                  { label: 'Type', key: 'type' },
                   { label: 'Status', key: 'status' },
                   { label: 'Warnings', key: 'warnings', hideLabel: true },
                   { label: 'Actions', key: 'actions', hideLabel: true },
@@ -75,7 +75,7 @@
                   {{ rowValue || '—' }}
                 </template>
 
-                <template #storeType="{ rowValue }">
+                <template #type="{ rowValue }">
                   {{ rowValue || '—' }}
                 </template>
 
@@ -181,7 +181,7 @@
 
 <script lang="ts" setup>
 import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { type RouteLocationNamedRaw } from 'vue-router'
 
 import MultizoneInfo from '../components/MultizoneInfo.vue'
@@ -203,7 +203,7 @@ type ZoneOverviewTableRow = {
   name: string
   status: StatusKeyword
   zoneCpVersion: string
-  storeType: string
+  type: 'universal' | 'kubernetes'
   warnings: boolean
 }
 
@@ -227,6 +227,8 @@ const props = defineProps({
 const isDeleteModalVisible = ref(false)
 const deleteZoneName = ref('')
 
+const environment = computed(() => store.getters['config/getEnvironment'])
+
 function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableRow[] {
   return zoneOverviews.map((zoneOverview) => {
     const { name } = zoneOverview
@@ -237,7 +239,7 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
       },
     }
     let zoneCpVersion = ''
-    let storeType = ''
+    const type = environment.value
     let cpCompat = true
 
     const subscriptions = zoneOverview.zoneInsight?.subscriptions ?? []
@@ -248,9 +250,6 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
         const { kumaCpGlobalCompatible = true } = item.version.kumaCp
 
         cpCompat = kumaCpGlobalCompatible
-        if (item.config) {
-          storeType = JSON.parse(item.config).store.type
-        }
       }
     })
 
@@ -261,7 +260,7 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
       name,
       status,
       zoneCpVersion,
-      storeType,
+      type,
       warnings: !cpCompat,
     }
   })


### PR DESCRIPTION
**feat(zones): replaces store type column with type column**

Removes the store type column from the Zone Control Plane list view.

Adds a type column to the Zone Control Plane list view showing the environment ("universal" or "kubernetes").

**chore(zones): moves Create Zone button into title bar**

Moves the "Create Zone" button into the top-level title bar.

**feat(zones): adds tooltip to warning icons**

Adds a tooltip with the label "Version mismatch" to the warning icons in the Zone Control Plane list view.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>