### PR TITLE
chore: clean up DPP list in service view

### DIFF
--- a/src/app/common/KFilterBar.vue
+++ b/src/app/common/KFilterBar.vue
@@ -444,7 +444,6 @@ function areFieldsSemanticallyIdentical(fieldsA: Fields, fieldB: Fields): boolea
   flex-grow: 1;
   width: 100%;
   border: none;
-  padding: 12px;
 }
 
 .k-filter-bar-input:focus {

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -30,92 +30,97 @@
         <template
           v-else
         >
-          <ServiceSummary
-            :service="item"
-            :external-service="externalService"
-          />
-          <template
-            v-if="item?.serviceType !== 'external'"
-          >
-            <DataSource
-              v-slot="{data, error: dataplanesError}"
-              :src="`/${route.params.mesh}/dataplanes/for/${route.params.service}/of/${props.gatewayType}?page=${props.page}&size=${props.size}&search=${props.search}`"
-            >
-              <template
-                v-for="gateways in [typeof data?.items?.[0].dataplane.networking.gateway === 'undefined']"
-                :key="gateways"
+          <div class="stack">
+            <ServiceSummary
+              :service="item"
+              :external-service="externalService"
+            />
+
+            <template v-if="item?.serviceType !== 'external'">
+              <DataSource
+                v-slot="{data, error: dataplanesError}"
+                :src="`/${route.params.mesh}/dataplanes/for/${route.params.service}/of/${props.gatewayType}?page=${props.page}&size=${props.size}&search=${props.search}`"
               >
-                <DataPlaneList
-                  data-testid="data-plane-collection"
-                  class="data-plane-collection"
-                  :page-number="props.page"
-                  :page-size="props.size"
-                  :total="data?.total"
-                  :items="data?.items"
-                  :error="dataplanesError"
-                  :gateways="gateways"
-                  @change="({page, size}) => {
-                    // @TODO: Should we remove s: undefined?
-                    route.update({
-                      page: String(page),
-                      size: String(size)
-                    })
-                  }"
+                <template
+                  v-for="gateways in [typeof data?.items?.[0].dataplane.networking.gateway === 'undefined']"
+                  :key="gateways"
                 >
-                  <template #toolbar>
-                    <KFilterBar
-                      class="data-plane-proxy-filter"
-                      :placeholder="`tag: 'kuma.io/protocol: http'`"
-                      :query="props.query"
-                      :fields="{
-                        name: { description: 'filter by name or parts of a name' },
-                        protocol: { description: 'filter by “kuma.io/protocol” value' },
-                        tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                        zone: { description: 'filter by “kuma.io/zone” value' },
-                      }"
-                      @fields-change="(val) => route.update({
-                        query: val.query,
-                        s: val.query.length > 0 ? JSON.stringify(val.fields) : ''
-                      })"
-                    />
-                    <template
-                      v-if="gateways"
-                    >
-                      <KSelect
-                        label="Type"
-                        :overlay-label="true"
-                        :items="[
-                          {
-                            label: 'All',
-                            value: 'all'
-                          },
-                          {
-                            label: 'Builtin',
-                            value: 'builtin'
-                          },
-                          {
-                            label: 'Delegated',
-                            value: 'delegated'
-                          }
-                        ].map(item => ({
-                          ...item,
-                          selected: item.value === props.gatewayType
-                        }))"
-                        appearance="select"
-                        @selected="(item: SelectItem) => route.update({
-                          gatewayType: String(item.value),
-                        })"
+                  <KCard>
+                    <template #body>
+                      <DataPlaneList
+                        data-testid="data-plane-collection"
+                        class="data-plane-collection"
+                        :page-number="props.page"
+                        :page-size="props.size"
+                        :total="data?.total"
+                        :items="data?.items"
+                        :error="dataplanesError"
+                        :gateways="gateways"
+                        @change="({page, size}) => {
+                          // @TODO: Should we remove s: undefined?
+                          route.update({
+                            page: String(page),
+                            size: String(size)
+                          })
+                        }"
                       >
-                        <template #item-template="{ item: value }">
-                          {{ value.label }}
+                        <template #toolbar>
+                          <KFilterBar
+                            class="data-plane-proxy-filter"
+                            :placeholder="`tag: 'kuma.io/protocol: http'`"
+                            :query="props.query"
+                            :fields="{
+                              name: { description: 'filter by name or parts of a name' },
+                              protocol: { description: 'filter by “kuma.io/protocol” value' },
+                              tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                              zone: { description: 'filter by “kuma.io/zone” value' },
+                            }"
+                            @fields-change="(val) => route.update({
+                              query: val.query,
+                              s: val.query.length > 0 ? JSON.stringify(val.fields) : ''
+                            })"
+                          />
+                          <template
+                            v-if="gateways"
+                          >
+                            <KSelect
+                              label="Type"
+                              :overlay-label="true"
+                              :items="[
+                                {
+                                  label: 'All',
+                                  value: 'all'
+                                },
+                                {
+                                  label: 'Builtin',
+                                  value: 'builtin'
+                                },
+                                {
+                                  label: 'Delegated',
+                                  value: 'delegated'
+                                }
+                              ].map(item => ({
+                                ...item,
+                                selected: item.value === props.gatewayType
+                              }))"
+                              appearance="select"
+                              @selected="(item: SelectItem) => route.update({
+                                gatewayType: String(item.value),
+                              })"
+                            >
+                              <template #item-template="{ item: value }">
+                                {{ value.label }}
+                              </template>
+                            </KSelect>
+                          </template>
                         </template>
-                      </KSelect>
+                      </DataPlaneList>
                     </template>
-                  </template>
-                </DataPlaneList>
-              </template>
-            </DataSource>
-          </template>
+                  </KCard>
+                </template>
+              </DataSource>
+            </template>
+          </div>
         </template>
       </div>
     </AppView>

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -56,7 +56,14 @@
               </template>
 
               <template #addressPort="{ rowValue }">
-                {{ rowValue || t('common.collection.none') }}
+                <TextWithCopyButton
+                  v-if="rowValue"
+                  :text="rowValue"
+                />
+
+                <template v-else>
+                  {{ t('common.collection.none') }}
+                </template>
               </template>
 
               <template #online="{ row: item }">
@@ -136,6 +143,7 @@ import DataSource from '@/app/application/components/data-source/DataSource.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import { useI18n } from '@/utilities'
 
 const { t } = useI18n()


### PR DESCRIPTION
**feat(services): adds copy button to address cells**

**fix: data plane list toolbar items misalignment**

**fix(services): data plane proxy list layout**

Fixes the DPP list within the service detail view for external services missing its wrapping KCard.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Before:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/9ee21428-7971-45b5-aa12-8b71afe1f19e)

After:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/7d2208f1-7a9e-40bc-ba59-60fe89426d72)
