### PR TITLE
chore: turns on TS-specific useless constructor rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,7 +87,6 @@ const INLINE_NON_VOID_ELEMENTS = [
         caseInsensitive: true,
       },
     }],
-    'no-useless-constructor': 'off',
   },
   overrides: [
     {
@@ -119,6 +118,10 @@ const INLINE_NON_VOID_ELEMENTS = [
           argsIgnorePattern: '^_',
           ignoreRestSiblings: true,
         }],
+
+        'no-useless-constructor': 'off',
+        '@typescript-eslint/no-useless-constructor': 'error',
+
         '@typescript-eslint/type-annotation-spacing': ['error', {
           before: false,
           after: true,


### PR DESCRIPTION
Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
