### PR TITLE
chore(e2e): adds title assertion wait again

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -213,6 +213,7 @@ Then(/^the "(.*)" element contains "(.*)"$/, (selector: string, value: string) =
 })
 
 Then('the page title contains {string}', function (title: string) {
+  cy.wait(1000)
   cy.title().should('contain', title)
 })
 


### PR DESCRIPTION
Adds the `cy.wait` call we had in the title assertion step back in as tests are still notably flaky without it.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
