### PR TITLE
chore: handles /provision-zone validation errors

### DIFF
--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -93,3 +93,24 @@ Feature: Zones: Zone create flow
     And I click the "$create-zone-button" element
     Then the "$error" element exists
     Then the "$instructions" element doesn't exist
+
+  Scenario: The form shows expected error for 400 response
+    Given the URL "/provision-zone" responds with
+      """
+      headers:
+        Status-Code: '400'
+      body:
+        type: '/std-errors'
+        status: 400
+        title: 'Invalid zone name'
+        detail: 'Resource is not valid'
+        invalid_parameters:
+          - field: 'name'
+            reason: "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols."
+      """
+
+    And I "type" "15" into the "$name-input" element
+    And I click the "$create-zone-button" element
+
+    Then the "$error" element contains "Invalid zone name"
+    And the "$instructions" element doesn't exist

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -47,7 +47,7 @@ zones:
   form:
     exit: 'Exit'
     nameLabel: 'Name'
-    name_tooltip: 'Zone names may contain alphanumerical characters, dashes (-), and underscores (_).'
+    name_tooltip: 'Zone names may contain lowercase alphanumerical characters, dashes (-), and underscores (_).'
     createZoneButtonLabel: 'Create Zone & generate token'
     environmentLabel: 'Environment'
     universalLabel: 'Universal'
@@ -147,9 +147,6 @@ zones:
     generalError:
       title: 'Could not create the Zone'
     statusError:
-      400:
-        title: 'The Zone name {zoneName} is invalid'
-        description: 'Zone names may contain alphanumerical characters, dashes (-), and underscores (_).'
       409:
         title: 'A Zone with the name {zoneName} already exists'
         description: 'If you want to connect a Zone with this name, you can delete the existing one and create a new one.'

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -47,6 +47,7 @@ zones:
   form:
     exit: 'Exit'
     nameLabel: 'Name'
+    name_tooltip: 'Zone names may contain alphanumerical characters, dashes (-), and underscores (_).'
     createZoneButtonLabel: 'Create Zone & generate token'
     environmentLabel: 'Environment'
     universalLabel: 'Universal'

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -31,8 +31,16 @@
 
         <div class="form-wrapper mt-4">
           <div>
-            <KLabel for="zone-name">
-              {{ t('zones.form.nameLabel') }} *
+            <KLabel
+              for="zone-name"
+              required
+              :tooltip-attributes="{ placement: 'right'}"
+            >
+              {{ t('zones.form.nameLabel') }}
+
+              <template #tooltip>
+                {{ t('zones.form.name_tooltip') }}
+              </template>
             </KLabel>
 
             <KInput

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -246,8 +246,6 @@ type ErrorState = {
 const { t } = useI18n()
 const kumaApi = useKumaApi()
 
-const HANDLED_STATUS_CODES = [400, 409, 500]
-
 const zone = ref<{ token: string } | null>(null)
 const isChangingZone = ref(false)
 const changingError = ref<Error | null>(null)
@@ -285,7 +283,7 @@ async function createZone() {
   try {
     zone.value = await kumaApi.createZone({ name: name.value })
   } catch (err) {
-    if (err instanceof ApiError && HANDLED_STATUS_CODES.includes(err.status)) {
+    if (err instanceof ApiError && [409, 500].includes(err.status)) {
       errorState.value = {
         error: err,
         title: t(`zones.create.statusError.${err.status}.title`, { zoneName: name.value }),
@@ -296,8 +294,8 @@ async function createZone() {
     } else if (err instanceof Error) {
       errorState.value = {
         error: err,
-        title: t('zones.create.generalError.title'),
-        icon: 'warning',
+        title: err instanceof ApiError ? err.title : t('zones.create.generalError.title'),
+        icon: 'errorFilled',
         badgeAppearance: 'danger',
       }
     } else {


### PR DESCRIPTION
**chore(zones): handles validation errors on /provision-zone**

**chore(zones): adds tooltip detailing naming rules**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
