### PR TITLE
refactor: uses DataSource for mesh detail view

### DIFF
--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -37,8 +37,7 @@ export const sources = (api: KumaApi) => {
     '/:mesh/dataplanes': async (params: CollectionParams & PaginationParams, source: Closeable) => {
       source.close()
 
-      const mesh = params.mesh
-      const size = params.size
+      const { mesh, size } = params
       const offset = params.size * (params.page - 1)
       const gateway = 'false'
       const filterParams = Object.fromEntries(normalizeFilterFields(JSON.parse(params.search || '[]')))
@@ -54,8 +53,7 @@ export const sources = (api: KumaApi) => {
     '/:mesh/dataplane-overviews/:name': (params: DetailParams, source: Closeable) => {
       source.close()
 
-      const mesh = params.mesh
-      const name = params.name
+      const { mesh, name } = params
 
       return api.getDataplaneOverviewFromMesh({ mesh, name })
     },
@@ -63,8 +61,7 @@ export const sources = (api: KumaApi) => {
     '/:mesh/dataplanes/for/:service/of/:type': async (params: CollectionParams & ServiceParams & PaginationParams & DataplaneTypeParams, source: Closeable) => {
       source.close()
 
-      const mesh = params.mesh
-      const size = params.size
+      const { mesh, size } = params
       const offset = params.size * (params.page - 1)
 
       // here 'all' means both proxies/sidecars and gateways this currently fits

--- a/src/app/meshes/components/MeshDetails.vue
+++ b/src/app/meshes/components/MeshDetails.vue
@@ -1,0 +1,186 @@
+<template>
+  <div class="stack">
+    <KCard>
+      <template #body>
+        <MeshCharts :mesh-insight="meshInsight" />
+      </template>
+    </KCard>
+
+    <KCard>
+      <template #body>
+        <div class="columns">
+          <DefinitionList>
+            <DefinitionListItem
+              v-for="(value, property) in basicMesh"
+              :key="property"
+              :term="t(`http.api.property.${property}`)"
+            >
+              <KBadge
+                v-if="typeof value === 'boolean'"
+                :appearance="value ? 'success' : 'danger'"
+              >
+                {{ value ? 'Enabled' : 'Disabled' }}
+              </KBadge>
+
+              <template v-else-if="property === 'name' && typeof value === 'string'">
+                <TextWithCopyButton :text="value" />
+              </template>
+
+              <template v-else>
+                {{ value }}
+              </template>
+            </DefinitionListItem>
+          </DefinitionList>
+
+          <DefinitionList>
+            <DefinitionListItem
+              v-for="(value, property) in extendedMesh"
+              :key="property"
+              :term="t(`http.api.property.${property}`)"
+            >
+              <KBadge
+                v-if="typeof value === 'boolean'"
+                :appearance="value ? 'success' : 'danger'"
+              >
+                {{ value ? 'Enabled' : 'Disabled' }}
+              </KBadge>
+
+              <template v-else>
+                {{ value }}
+              </template>
+            </DefinitionListItem>
+          </DefinitionList>
+
+          <DefinitionList>
+            <DefinitionListItem :term="`Policies (${totalPolicyCount})`">
+              <ul>
+                <li
+                  v-for="(policyType, index) in policyTypes"
+                  :key="index"
+                >
+                  <router-link
+                    :to="{
+                      name: 'policies-list-view',
+                      params: {
+                        policyPath: policyType.path
+                      }
+                    }"
+                  >
+                    {{ policyType.name }}: {{ policyType.total }}
+                  </router-link>
+                </li>
+              </ul>
+            </DefinitionListItem>
+          </DefinitionList>
+        </div>
+      </template>
+    </KCard>
+
+    <KCard>
+      <template #body>
+        <ResourceCodeBlock
+          id="code-block-mesh"
+          :resource-fetcher="fetchMesh"
+          :resource-fetcher-watch-key="mesh?.name || null"
+        />
+      </template>
+    </KCard>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { KBadge, KCard } from '@kong/kongponents'
+import { PropType, computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+import MeshCharts from '../components/MeshCharts.vue'
+import DefinitionList from '@/app/common/DefinitionList.vue'
+import DefinitionListItem from '@/app/common/DefinitionListItem.vue'
+import ResourceCodeBlock from '@/app/common/ResourceCodeBlock.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+import { useStore } from '@/store/store'
+import type { SingleResourceParameters } from '@/types/api.d'
+import type { Mesh, MeshInsight } from '@/types/index.d'
+import { useKumaApi, useI18n } from '@/utilities'
+import { notEmpty } from '@/utilities/notEmpty'
+
+const { t, formatIsoDate } = useI18n()
+const kumaApi = useKumaApi()
+const route = useRoute()
+const store = useStore()
+
+const props = defineProps({
+  mesh: {
+    type: Object as PropType<Mesh>,
+    required: true,
+  },
+
+  meshInsight: {
+    type: Object as PropType<MeshInsight>,
+    required: true,
+  },
+})
+
+const basicMesh = computed(() => {
+  const { name, creationTime, modificationTime } = props.mesh
+  return {
+    name,
+    created: formatIsoDate(creationTime),
+    modified: formatIsoDate(modificationTime),
+    'Data Plane Proxies': props.meshInsight.dataplanes.total,
+  }
+})
+
+const extendedMesh = computed(() => {
+  const mtls = getBackendData(props.mesh, 'mtls')
+  const logging = getBackendData(props.mesh, 'logging')
+  const metrics = getBackendData(props.mesh, 'metrics')
+  const tracing = getBackendData(props.mesh, 'tracing')
+  const localityAwareLoadBalancing = Boolean(props.mesh.routing?.localityAwareLoadBalancing)
+
+  return {
+    mtls,
+    logging,
+    metrics,
+    tracing,
+    localityAwareLoadBalancing,
+  }
+})
+
+const totalPolicyCount = computed(() => {
+  return Object.values(props.meshInsight.policies ?? {}).reduce((total, stat) => total + stat.total, 0)
+})
+const policyTypes = computed(() => {
+  return Object.entries(props.meshInsight.policies ?? {})
+    .map(([policyTypeName, stat]) => {
+      const policyType = store.state.policyTypesByName[policyTypeName]
+
+      if (policyType && stat.total !== 0) {
+        return {
+          name: policyType.name,
+          path: policyType.path,
+          total: stat.total,
+        }
+      }
+
+      return null
+    })
+    .filter(notEmpty)
+})
+
+function getBackendData(mesh: Mesh, field: 'mtls' | 'logging' | 'metrics' | 'tracing'): string | boolean {
+  if (mesh[field] === undefined) {
+    return false
+  }
+
+  const enabledBackendName = mesh[field].enabledBackend ?? mesh[field].defaultBackend ?? mesh[field].backends[0].name
+  const enabledBackend = mesh[field].backends.find((backend: any) => backend.name === enabledBackendName)
+
+  return `${enabledBackend.type} / ${enabledBackend.name}`
+}
+
+async function fetchMesh(params?: SingleResourceParameters) {
+  const name = route.params.mesh as string
+  return await kumaApi.getMesh({ name }, params)
+}
+</script>

--- a/src/app/meshes/components/MeshDetails.vue
+++ b/src/app/meshes/components/MeshDetails.vue
@@ -39,15 +39,21 @@
               :term="t(`http.api.property.${property}`)"
             >
               <KBadge
-                v-if="typeof value === 'boolean'"
-                :appearance="value ? 'success' : 'danger'"
+                v-if="value === ''"
+                appearance="danger"
               >
-                {{ value ? 'Enabled' : 'Disabled' }}
+                Disabled
               </KBadge>
 
               <template v-else>
                 {{ value }}
               </template>
+            </DefinitionListItem>
+
+            <DefinitionListItem :term="t('http.api.property.localityAwareLoadBalancing')">
+              <KBadge :appearance="hasLocalityAwareLoadBalancing ? 'success' : 'danger'">
+                {{ hasLocalityAwareLoadBalancing ? 'Enabled' : 'Disabled' }}
+              </KBadge>
             </DefinitionListItem>
           </DefinitionList>
 
@@ -131,21 +137,14 @@ const basicMesh = computed(() => {
   }
 })
 
-const extendedMesh = computed(() => {
-  const mtls = getBackendData(props.mesh, 'mtls')
-  const logging = getBackendData(props.mesh, 'logging')
-  const metrics = getBackendData(props.mesh, 'metrics')
-  const tracing = getBackendData(props.mesh, 'tracing')
-  const localityAwareLoadBalancing = Boolean(props.mesh.routing?.localityAwareLoadBalancing)
+const hasLocalityAwareLoadBalancing = computed(() => Boolean(props.mesh.routing?.localityAwareLoadBalancing))
 
-  return {
-    mtls,
-    logging,
-    metrics,
-    tracing,
-    localityAwareLoadBalancing,
-  }
-})
+const extendedMesh = computed(() => ({
+  mtls: getBackendData(props.mesh, 'mtls'),
+  logging: getBackendData(props.mesh, 'logging'),
+  metrics: getBackendData(props.mesh, 'metrics'),
+  tracing: getBackendData(props.mesh, 'tracing'),
+}))
 
 const totalPolicyCount = computed(() => {
   return Object.values(props.meshInsight.policies ?? {}).reduce((total, stat) => total + stat.total, 0)
@@ -168,9 +167,9 @@ const policyTypes = computed(() => {
     .filter(notEmpty)
 })
 
-function getBackendData(mesh: Mesh, field: 'mtls' | 'logging' | 'metrics' | 'tracing'): string | boolean {
+function getBackendData(mesh: Mesh, field: 'mtls' | 'logging' | 'metrics' | 'tracing') {
   if (mesh[field] === undefined) {
-    return false
+    return ''
   }
 
   const enabledBackendName = mesh[field].enabledBackend ?? mesh[field].defaultBackend ?? mesh[field].backends[0].name

--- a/src/app/meshes/sources.ts
+++ b/src/app/meshes/sources.ts
@@ -25,7 +25,7 @@ export const sources = (api: KumaApi) => {
     '/meshes': async (params: PaginationParams, source: Closeable) => {
       source.close()
 
-      const size = params.size
+      const { size } = params
       const offset = params.size * (params.page - 1)
 
       return api.getAllMeshes({ size, offset })
@@ -34,7 +34,7 @@ export const sources = (api: KumaApi) => {
     '/meshes/:name': (params: DetailParams, source: Closeable) => {
       source.close()
 
-      const name = params.name
+      const { name } = params
 
       return api.getMesh({ name })
     },
@@ -42,7 +42,7 @@ export const sources = (api: KumaApi) => {
     '/mesh-insights/:name': async (params: DetailParams, source: Closeable) => {
       source.close()
 
-      const name = params.name
+      const { name } = params
 
       return api.getMeshInsights({ name })
     },

--- a/src/app/meshes/sources.ts
+++ b/src/app/meshes/sources.ts
@@ -1,22 +1,18 @@
 import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
 import type KumaApi from '@/services/kuma-api/KumaApi'
-import type {
-  PaginatedApiListResponse as CollectionResponse,
-} from '@/types/api.d'
-import type {
-  Mesh,
-  MeshInsight,
-} from '@/types/index.d'
+import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
+import type { Mesh, MeshInsight } from '@/types/index.d'
 
-type MeshParams = {
-  mesh: string
+type DetailParams = {
+  name: string
 }
+
 type PaginationParams = {
   size: number
   page: number
 }
 
-type Closeable = {close: () => void}
+type Closeable = { close: () => void }
 
 export type MeshSource = DataSourceResponse<Mesh>
 export type MeshCollection = CollectionResponse<Mesh>
@@ -26,21 +22,29 @@ export type MeshInsightSource = DataSourceResponse<MeshInsight>
 
 export const sources = (api: KumaApi) => {
   return {
-    '/meshes': async (params: MeshParams & PaginationParams, source: Closeable) => {
+    '/meshes': async (params: PaginationParams, source: Closeable) => {
       source.close()
+
+      const size = params.size
       const offset = params.size * (params.page - 1)
-      return api.getAllMeshes({
-        size: params.size,
-        offset,
-      })
+
+      return api.getAllMeshes({ size, offset })
     },
-    '/:mesh/mesh': (params: MeshParams, source: Closeable) => {
+
+    '/meshes/:name': (params: DetailParams, source: Closeable) => {
       source.close()
-      return api.getMesh({ name: params.mesh })
+
+      const name = params.name
+
+      return api.getMesh({ name })
     },
-    '/:mesh/insights': async (params: MeshParams, source: Closeable) => {
+
+    '/mesh-insights/:name': async (params: DetailParams, source: Closeable) => {
       source.close()
-      return api.getMeshInsights({ name: params.mesh })
+
+      const name = params.name
+
+      return api.getMeshInsights({ name })
     },
 
   }

--- a/src/app/meshes/views/MeshDetailView.vue
+++ b/src/app/meshes/views/MeshDetailView.vue
@@ -1,242 +1,51 @@
 <template>
-  <RouteView>
-    <RouteTitle
-      :title="t('meshes.routes.overview.title')"
-    />
+  <RouteView
+    v-slot="{ route }"
+    name="mesh-overview-view"
+  >
+    <RouteTitle :title="t('meshes.routes.overview.title')" />
+
     <AppView>
-      <div class="stack">
-        <KCard>
-          <template #body>
-            <MeshCharts />
-          </template>
-        </KCard>
+      <DataSource
+        v-slot="{ data: mesh, isLoading: isLoadingMesh, error: meshError }: MeshSource"
+        :src="`/meshes/${route.params.mesh}`"
+      >
+        <DataSource
+          v-slot="{ data: meshInsight, isLoading: isLoadingMeshInsight, error: meshInsightError }: MeshInsightSource"
+          :src="`/mesh-insights/${route.params.mesh}`"
+        >
+          <LoadingBlock v-if="isLoadingMesh || isLoadingMeshInsight" />
 
-        <KCard v-if="mesh !== null">
-          <template #body>
-            <div class="columns">
-              <StatusInfo
-                :is-loading="isLoading"
-                :error="error"
-                :is-empty="mesh === null || meshInsights === null"
-              >
-                <DefinitionList>
-                  <DefinitionListItem
-                    v-for="(value, property) in basicMesh"
-                    :key="property"
-                    :term="t(`http.api.property.${property}`)"
-                  >
-                    <KBadge
-                      v-if="typeof value === 'boolean'"
-                      :appearance="value ? 'success' : 'danger'"
-                    >
-                      {{ value ? 'Enabled' : 'Disabled' }}
-                    </KBadge>
+          <ErrorBlock
+            v-else-if="meshError ?? meshInsightError"
+            :error="meshError ?? meshInsightError"
+          />
 
-                    <template v-else-if="property === 'name' && typeof value === 'string'">
-                      <TextWithCopyButton :text="value" />
-                    </template>
+          <EmptyBlock v-else-if="mesh === undefined || meshInsight === undefined" />
 
-                    <template v-else>
-                      {{ value }}
-                    </template>
-                  </DefinitionListItem>
-                </DefinitionList>
-              </StatusInfo>
-
-              <DefinitionList>
-                <DefinitionListItem
-                  v-for="(value, property) in extendedMesh"
-                  :key="property"
-                  :term="t(`http.api.property.${property}`)"
-                >
-                  <KBadge
-                    v-if="typeof value === 'boolean'"
-                    :appearance="value ? 'success' : 'danger'"
-                  >
-                    {{ value ? 'Enabled' : 'Disabled' }}
-                  </KBadge>
-
-                  <template v-else>
-                    {{ value }}
-                  </template>
-                </DefinitionListItem>
-              </DefinitionList>
-
-              <DefinitionList>
-                <DefinitionListItem :term="`Policies (${totalPolicyCount})`">
-                  <ul>
-                    <li
-                      v-for="(policyType, index) in policyTypes"
-                      :key="index"
-                    >
-                      <router-link
-                        :to="{
-                          name: 'policies-list-view',
-                          params: {
-                            policyPath: policyType.path
-                          }
-                        }"
-                      >
-                        {{ policyType.name }}: {{ policyType.total }}
-                      </router-link>
-                    </li>
-                  </ul>
-                </DefinitionListItem>
-              </DefinitionList>
-            </div>
-          </template>
-        </KCard>
-
-        <KCard>
-          <template #body>
-            <ResourceCodeBlock
-              id="code-block-mesh"
-              :resource-fetcher="fetchMesh"
-              :resource-fetcher-watch-key="mesh?.name || null"
-            />
-          </template>
-        </KCard>
-      </div>
+          <MeshDetails
+            v-else
+            :mesh="mesh"
+            :mesh-insight="meshInsight"
+            data-testid="detail-view-details"
+          />
+        </DataSource>
+      </DataSource>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import { KBadge, KCard } from '@kong/kongponents'
-import { computed, ref } from 'vue'
-import { useRoute } from 'vue-router'
-
-import MeshCharts from '../components/MeshCharts.vue'
+import MeshDetails from '../components/MeshDetails.vue'
+import type { MeshSource, MeshInsightSource } from '../sources'
 import AppView from '@/app/application/components/app-view/AppView.vue'
+import DataSource from '@/app/application/components/data-source/DataSource.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
-import DefinitionList from '@/app/common/DefinitionList.vue'
-import DefinitionListItem from '@/app/common/DefinitionListItem.vue'
-import ResourceCodeBlock from '@/app/common/ResourceCodeBlock.vue'
-import StatusInfo from '@/app/common/StatusInfo.vue'
-import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import { useStore } from '@/store/store'
-import type { SingleResourceParameters } from '@/types/api.d'
-import { Mesh, MeshInsight } from '@/types/index.d'
-import { useKumaApi, useI18n } from '@/utilities'
-import { notEmpty } from '@/utilities/notEmpty'
+import EmptyBlock from '@/app/common/EmptyBlock.vue'
+import ErrorBlock from '@/app/common/ErrorBlock.vue'
+import LoadingBlock from '@/app/common/LoadingBlock.vue'
+import { useI18n } from '@/utilities'
 
-const { t, formatIsoDate } = useI18n()
-
-const kumaApi = useKumaApi()
-const route = useRoute()
-const store = useStore()
-
-const isLoading = ref(true)
-const error = ref<Error | null>(null)
-const mesh = ref<Mesh | null>(null)
-const meshInsights = ref<MeshInsight | null>(null)
-
-const basicMesh = computed(() => {
-  if (mesh.value === null || meshInsights.value === null) {
-    return null
-  }
-
-  const { name, creationTime, modificationTime } = mesh.value
-  return {
-    name,
-    created: formatIsoDate(creationTime),
-    modified: formatIsoDate(modificationTime),
-    'Data Plane Proxies': meshInsights.value.dataplanes.total,
-  }
-})
-
-const extendedMesh = computed(() => {
-  if (mesh.value === null) {
-    return null
-  }
-
-  const mtls = getBackendData(mesh.value, 'mtls')
-  const logging = getBackendData(mesh.value, 'logging')
-  const metrics = getBackendData(mesh.value, 'metrics')
-  const tracing = getBackendData(mesh.value, 'tracing')
-  const localityAwareLoadBalancing = Boolean(mesh.value.routing?.localityAwareLoadBalancing)
-
-  return {
-    mtls,
-    logging,
-    metrics,
-    tracing,
-    localityAwareLoadBalancing,
-  }
-})
-
-const totalPolicyCount = computed(() => {
-  if (meshInsights.value === null) {
-    return 0
-  }
-
-  return Object.values(meshInsights.value.policies ?? {}).reduce((total, stat) => total + stat.total, 0)
-})
-const policyTypes = computed(() => {
-  if (meshInsights.value === null) {
-    return []
-  }
-
-  return Object.entries(meshInsights.value.policies ?? {})
-    .map(([policyTypeName, stat]) => {
-      const policyType = store.state.policyTypesByName[policyTypeName]
-
-      if (policyType && stat.total !== 0) {
-        return {
-          name: policyType.name,
-          path: policyType.path,
-          total: stat.total,
-        }
-      }
-
-      return null
-    })
-    .filter(notEmpty)
-})
-
-loadMesh()
-
-async function loadMesh(): Promise<void> {
-  isLoading.value = true
-  error.value = null
-
-  const name = route.params.mesh as string
-
-  try {
-    mesh.value = await kumaApi.getMesh({ name })
-    meshInsights.value = await kumaApi.getMeshInsights({ name })
-  } catch (err) {
-    if (err instanceof Error) {
-      error.value = err
-    } else {
-      console.error(error)
-    }
-    mesh.value = null
-    meshInsights.value = null
-  } finally {
-    isLoading.value = false
-  }
-}
-
-function getBackendData(mesh: Mesh, field: 'mtls' | 'logging' | 'metrics' | 'tracing'): string | boolean {
-  if (mesh === null || mesh[field] === undefined) {
-    return false
-  }
-
-  const enabledBackendName = mesh[field].enabledBackend ?? mesh[field].defaultBackend ?? mesh[field].backends[0].name
-  const enabledBackend = mesh[field].backends.find((backend: any) => backend.name === enabledBackendName)
-
-  return `${enabledBackend.type} / ${enabledBackend.name}`
-}
-
-async function fetchMesh(params?: SingleResourceParameters) {
-  const name = route.params.mesh as string
-  return await kumaApi.getMesh({ name }, params)
-}
+const { t } = useI18n()
 </script>
-<style scoped>
-  .policy-counts li li {
-    margin: 0;
-  }
-</style>

--- a/src/app/services/sources.ts
+++ b/src/app/services/sources.ts
@@ -29,8 +29,7 @@ export const sources = (api: KumaApi) => {
     '/:mesh/service-insights': async (params: CollectionParams & PaginationParams, source: Closeable) => {
       source.close()
 
-      const mesh = params.mesh
-      const size = params.size
+      const { mesh, size } = params
       const offset = params.size * (params.page - 1)
 
       return api.getAllServiceInsightsFromMesh({ mesh }, { size, offset })
@@ -39,8 +38,7 @@ export const sources = (api: KumaApi) => {
     '/:mesh/service-insights/:name': (params: DetailParams, source: Closeable) => {
       source.close()
 
-      const mesh = params.mesh
-      const name = params.name
+      const { mesh, name } = params
 
       return api.getServiceInsight({ mesh, name })
     },
@@ -48,8 +46,7 @@ export const sources = (api: KumaApi) => {
     '/:mesh/external-services/:name': (params: DetailParams, source: Closeable) => {
       source.close()
 
-      const mesh = params.mesh
-      const name = params.name
+      const { mesh, name } = params
 
       return api.getExternalServiceByServiceInsightName(mesh, name)
     },

--- a/src/app/zones/sources.ts
+++ b/src/app/zones/sources.ts
@@ -31,7 +31,7 @@ export const sources = (api: KumaApi) => {
     '/zone-cps': async (params: PaginationParams, source: Closeable) => {
       source.close()
 
-      const size = params.size
+      const { size } = params
       const offset = params.size * (params.page - 1)
 
       return await api.getAllZoneOverviews({ size, offset })
@@ -40,7 +40,7 @@ export const sources = (api: KumaApi) => {
     '/zone-cps/:name': async (params: DetailParams, source: Closeable) => {
       source.close()
 
-      const name = params.name
+      const { name } = params
 
       return await api.getZoneOverview({ name })
     },
@@ -48,7 +48,7 @@ export const sources = (api: KumaApi) => {
     '/zone-ingresses': async (params: PaginationParams, source: Closeable) => {
       source.close()
 
-      const size = params.size
+      const { size } = params
       const offset = params.size * (params.page - 1)
 
       return await api.getAllZoneIngressOverviews({ size, offset })
@@ -57,7 +57,7 @@ export const sources = (api: KumaApi) => {
     '/zone-egresses/:name': async (params: DetailParams, source: Closeable) => {
       source.close()
 
-      const name = params.name
+      const { name } = params
 
       return await api.getZoneEgressOverview({ name })
     },
@@ -65,7 +65,7 @@ export const sources = (api: KumaApi) => {
     '/zone-egresses': async (params: PaginationParams, source: Closeable) => {
       source.close()
 
-      const size = params.size
+      const { size } = params
       const offset = params.size * (params.page - 1)
 
       return await api.getAllZoneEgressOverviews({ size, offset })
@@ -74,7 +74,7 @@ export const sources = (api: KumaApi) => {
     '/zone-ingresses/:name': async (params: DetailParams, source: Closeable) => {
       source.close()
 
-      const name = params.name
+      const { name } = params
 
       return await api.getZoneIngressOverview({ name })
     },


### PR DESCRIPTION
Changes MeshOverviewView to use DataSource and to solely be responsible for fetching data. All further presentational purposes where moved into the new MeshDetails and the existing MeshCharts components.

Adds the new MeshDetails component for the presentational purposes of the mesh detail view. Its pretty much a copy of what used to be in MeshOverviewView.

Changes MeshCharts to receive `meshInsight` as a prop instead of fetching the data itself. The mesh detail view always loads that data anyway, so this removes an unnecessary request from this view.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
