### PR TITLE
refactor: uses DataSource for DPP detail view

### DIFF
--- a/src/app/data-planes/components/DataPlaneDetails.spec.ts
+++ b/src/app/data-planes/components/DataPlaneDetails.spec.ts
@@ -2,11 +2,9 @@ import { describe, expect, test } from '@jest/globals'
 import { flushPromises, mount } from '@vue/test-utils'
 
 import DataPlaneDetails from './DataPlaneDetails.vue'
-import { createDataPlane } from '@/test-data/createDataPlane'
 import { createDataPlaneOverview } from '@/test-data/createDataPlaneOverview'
 import { useStore, useRouter } from '@/utilities'
 
-const dataPlane = createDataPlane()
 const dataPlaneOverview = createDataPlaneOverview()
 
 const store = useStore()
@@ -17,14 +15,13 @@ async function renderComponent(props = {}) {
     name: 'data-plane-detail-view',
     params: {
       mesh: 'default',
-      dataPlane: dataPlane.name,
+      dataPlane: dataPlaneOverview.name,
     },
   })
 
   return mount(DataPlaneDetails, {
     props: {
-      dataPlane,
-      dataPlaneOverview,
+      dataplaneOverview: dataPlaneOverview,
       ...props,
     },
   })

--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -4,9 +4,9 @@
       <h1 class="entity-heading">
         DPP:
 
-        <TextWithCopyButton :text="dataPlane.name">
+        <TextWithCopyButton :text="props.dataplaneOverview.name">
           <router-link :to="detailViewRoute">
-            {{ dataPlane.name }}
+            {{ props.dataplaneOverview.name }}
           </router-link>
         </TextWithCopyButton>
       </h1>
@@ -61,7 +61,7 @@
         id="code-block-data-plane"
         class="mt-4"
         :resource-fetcher="fetchDataPlaneProxy"
-        :resource-fetcher-watch-key="props.dataPlane.name"
+        :resource-fetcher-watch-key="props.dataplaneOverview.name"
         is-searchable
       />
     </template>
@@ -89,14 +89,14 @@
     </template>
 
     <template #dpp-policies>
-      <DataplanePolicies :data-plane="dataPlane" />
+      <DataplanePolicies :dataplane-overview="dataplaneOverview" />
     </template>
 
     <template #xds-configuration>
       <EnvoyData
         data-path="xds"
-        :mesh="dataPlane.mesh"
-        :dpp-name="dataPlane.name"
+        :mesh="dataplaneOverview.mesh"
+        :dpp-name="dataplaneOverview.name"
         query-key="envoy-data-data-plane"
       />
     </template>
@@ -104,8 +104,8 @@
     <template #envoy-stats>
       <EnvoyData
         data-path="stats"
-        :mesh="dataPlane.mesh"
-        :dpp-name="dataPlane.name"
+        :mesh="dataplaneOverview.mesh"
+        :dpp-name="dataplaneOverview.name"
         query-key="envoy-data-data-plane"
       />
     </template>
@@ -113,8 +113,8 @@
     <template #envoy-clusters>
       <EnvoyData
         data-path="clusters"
-        :mesh="dataPlane.mesh"
-        :dpp-name="dataPlane.name"
+        :mesh="dataplaneOverview.mesh"
+        :dpp-name="dataplaneOverview.name"
         query-key="envoy-data-data-plane"
       />
     </template>
@@ -176,7 +176,6 @@ import { useStore } from '@/store/store'
 import type { SingleResourceParameters } from '@/types/api.d'
 import {
   Compatibility,
-  DataPlane,
   DataPlaneOverview,
 } from '@/types/index.d'
 import { useI18n, useKumaApi } from '@/utilities'
@@ -197,12 +196,7 @@ const kumaApi = useKumaApi()
 const store = useStore()
 
 const props = defineProps({
-  dataPlane: {
-    type: Object as PropType<DataPlane>,
-    required: true,
-  },
-
-  dataPlaneOverview: {
+  dataplaneOverview: {
     type: Object as PropType<DataPlaneOverview>,
     required: true,
   },
@@ -248,17 +242,17 @@ const warnings = ref<Compatibility[]>([])
 const detailViewRoute = computed(() => ({
   name: 'data-plane-detail-view',
   params: {
-    mesh: props.dataPlane.mesh,
-    dataPlane: props.dataPlane.name,
+    mesh: props.dataplaneOverview.mesh,
+    dataPlane: props.dataplaneOverview.name,
   },
 }))
 
-const statusWithReason = computed(() => getStatusAndReason(props.dataPlane, props.dataPlaneOverview.dataplaneInsight))
-const dataPlaneTags = computed(() => dpTags(props.dataPlane))
-const dataPlaneVersions = computed(() => getVersions(props.dataPlaneOverview.dataplaneInsight))
-const mtlsData = computed(() => parseMTLSData(props.dataPlaneOverview, formatIsoDate))
+const statusWithReason = computed(() => getStatusAndReason(props.dataplaneOverview.dataplane, props.dataplaneOverview.dataplaneInsight))
+const dataPlaneTags = computed(() => dpTags(props.dataplaneOverview.dataplane))
+const dataPlaneVersions = computed(() => getVersions(props.dataplaneOverview.dataplaneInsight))
+const mtlsData = computed(() => parseMTLSData(props.dataplaneOverview, formatIsoDate))
 const insightSubscriptions = computed(() => {
-  const subscriptions = Array.from(props.dataPlaneOverview.dataplaneInsight?.subscriptions ?? [])
+  const subscriptions = Array.from(props.dataplaneOverview.dataplaneInsight?.subscriptions ?? [])
 
   subscriptions.reverse()
 
@@ -268,7 +262,7 @@ const insightSubscriptions = computed(() => {
 const filteredTabs = computed(() => warnings.value.length === 0 ? tabs.filter((tab) => tab.hash !== '#warnings') : tabs)
 
 function setWarnings() {
-  const subscriptions = props.dataPlaneOverview.dataplaneInsight?.subscriptions ?? []
+  const subscriptions = props.dataplaneOverview.dataplaneInsight?.subscriptions ?? []
 
   if (subscriptions.length === 0 || !('version' in subscriptions[0])) {
     return
@@ -287,7 +281,7 @@ function setWarnings() {
   const isMulticluster = store.getters['config/getMulticlusterStatus']
 
   if (isMulticluster && version) {
-    const tags = dpTags(props.dataPlane)
+    const tags = dpTags(props.dataplaneOverview.dataplane)
     const zoneTag = tags.find(tag => tag.label === KUMA_ZONE_TAG_NAME)
 
     if (zoneTag && typeof version.kumaDp.kumaCpCompatible === 'boolean' && !version.kumaDp.kumaCpCompatible) {
@@ -304,7 +298,7 @@ function setWarnings() {
 setWarnings()
 
 async function fetchDataPlaneProxy(params?: SingleResourceParameters) {
-  const { mesh, name } = props.dataPlane
+  const { mesh, name } = props.dataplaneOverview
   return await kumaApi.getDataplaneFromMesh({ mesh, name }, params)
 }
 </script>

--- a/src/app/data-planes/components/DataplanePolicies.spec.ts
+++ b/src/app/data-planes/components/DataplanePolicies.spec.ts
@@ -4,21 +4,23 @@ import { rest } from 'msw'
 
 import DataplanePolicies from './DataplanePolicies.vue'
 import { useServer } from '@/../jest/jest-setup-after-env'
-import { DataPlane } from '@/types/index.d'
+import { DataPlaneOverview } from '@/types/index.d'
 import { useStore, useRouter } from '@/utilities'
 
 const store = useStore()
 async function renderComponent(props = {}) {
   await store.dispatch('fetchPolicyTypes')
 
-  const dataPlane: DataPlane = {
-    type: 'Dataplane',
+  const dataplaneOverview: DataPlaneOverview = {
+    type: 'DataplaneOverview',
     mesh: 'foo',
     name: 'dataplane-test-456',
     creationTime: '',
     modificationTime: '',
-    networking: {
-      address: '',
+    dataplane: {
+      networking: {
+        address: '',
+      },
     },
   }
 
@@ -27,13 +29,13 @@ async function renderComponent(props = {}) {
     name: 'data-plane-detail-view',
     params: {
       mesh: 'default',
-      dataPlane: dataPlane.name,
+      dataPlane: dataplaneOverview.name,
     },
   })
 
   return mount(DataplanePolicies, {
     props: {
-      dataPlane,
+      dataplaneOverview,
       ...props,
     },
   })

--- a/src/app/data-planes/components/DataplanePolicies.vue
+++ b/src/app/data-planes/components/DataplanePolicies.vue
@@ -11,7 +11,7 @@
     class="policies-list"
   >
     <SidecarDataplanePolicyList
-      :dpp-name="dataPlane.name"
+      :dpp-name="props.dataplaneOverview.name"
       :policy-type-entries="policyTypeEntries"
       :rule-entries="ruleEntries"
     />
@@ -41,7 +41,7 @@ import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import { useStore } from '@/store/store'
 import {
-  DataPlane,
+  DataPlaneOverview,
   DataplaneRule,
   LabelValue,
   MeshGatewayDataplane,
@@ -64,8 +64,8 @@ const kumaApi = useKumaApi()
 const store = useStore()
 
 const props = defineProps({
-  dataPlane: {
-    type: Object as PropType<DataPlane>,
+  dataplaneOverview: {
+    type: Object as PropType<DataPlaneOverview>,
     required: true,
   },
 })
@@ -78,7 +78,7 @@ const meshGatewayRoutePolicies = ref<MeshGatewayRoutePolicy[]>([])
 const isLoading = ref(true)
 const error = ref<Error | null>(null)
 
-watch(() => props.dataPlane.name, function () {
+watch(() => props.dataplaneOverview.name, function () {
   fetchPolicies()
 })
 
@@ -93,27 +93,27 @@ async function fetchPolicies(): Promise<void> {
   meshGatewayRoutePolicies.value = []
 
   try {
-    const isMeshGatewayDataplane = props.dataPlane.networking.gateway?.type?.toUpperCase() === 'BUILTIN'
+    const isMeshGatewayDataplane = props.dataplaneOverview.dataplane.networking.gateway?.type?.toUpperCase() === 'BUILTIN'
 
     if (isMeshGatewayDataplane) {
       meshGatewayDataplane.value = await kumaApi.getMeshGatewayDataplane({
-        mesh: props.dataPlane.mesh,
-        name: props.dataPlane.name,
+        mesh: props.dataplaneOverview.mesh,
+        name: props.dataplaneOverview.name,
       })
 
       meshGatewayListenerEntries.value = getMeshGatewayListenerEntries(meshGatewayDataplane.value)
       meshGatewayRoutePolicies.value = getPolicyRoutes(meshGatewayDataplane.value.policies)
     } else {
       const { items: sidecarDataplanes } = await kumaApi.getSidecarDataplanePolicies({
-        mesh: props.dataPlane.mesh,
-        name: props.dataPlane.name,
+        mesh: props.dataplaneOverview.mesh,
+        name: props.dataplaneOverview.name,
       })
 
       policyTypeEntries.value = getPolicyTypeEntries(sidecarDataplanes ?? [])
 
       const { items: rules } = await kumaApi.getDataplaneRules({
-        mesh: props.dataPlane.mesh,
-        name: props.dataPlane.name,
+        mesh: props.dataplaneOverview.mesh,
+        name: props.dataplaneOverview.name,
       })
 
       ruleEntries.value = getRuleEntries(rules ?? [])

--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -1,72 +1,89 @@
 import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
 import type KumaApi from '@/services/kuma-api/KumaApi'
-import type {
-  PaginatedApiListResponse as CollectionResponse,
-} from '@/types/api.d'
-import type {
-  DataPlaneOverview as DataplaneOverview,
-} from '@/types/index.d'
+import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
+import type { DataPlaneOverview as DataplaneOverview } from '@/types/index.d'
 import { normalizeFilterFields } from '@/utilities/normalizeFilterFields'
 
-type Closeable = { close: () => void }
+type CollectionParams = {
+  mesh: string
+}
+
+type DetailParams = CollectionParams & {
+  name: string
+}
+
 type PaginationParams = {
   size: number
   page: number
   search: string
 }
-type MeshParams = {
-  mesh: string
-}
+
 type ServiceParams = {
   service: string
 }
+
 type DataplaneTypeParams = {
   type: 'all' | 'delegated' | 'builtin'
 }
 
+type Closeable = { close: () => void }
+
+export type DataplaneOverviewSource = DataSourceResponse<DataplaneOverview>
 export type DataPlaneCollection = CollectionResponse<DataplaneOverview>
 export type DataPlaneCollectionSource = DataSourceResponse<DataPlaneCollection>
 
 export const sources = (api: KumaApi) => {
   return {
-    '/:mesh/dataplanes': async (params: MeshParams & PaginationParams, source: Closeable) => {
+    '/:mesh/dataplanes': async (params: CollectionParams & PaginationParams, source: Closeable) => {
       source.close()
+
+      const mesh = params.mesh
+      const size = params.size
       const offset = params.size * (params.page - 1)
-      return api.getAllDataplaneOverviewsFromMesh({
-        mesh: params.mesh,
-      }, {
-        ...Object.fromEntries(normalizeFilterFields(JSON.parse(params.search || '[]'))),
+      const gateway = 'false'
+      const filterParams = Object.fromEntries(normalizeFilterFields(JSON.parse(params.search || '[]')))
+
+      return api.getAllDataplaneOverviewsFromMesh({ mesh }, {
+        ...filterParams,
+        gateway,
         offset,
-        gateway: 'false',
-        size: params.size,
+        size,
       })
     },
-    '/:mesh/dataplanes/for/:service/of/:type': async (params: MeshParams & ServiceParams & PaginationParams & DataplaneTypeParams, source: Closeable) => {
+
+    '/:mesh/dataplane-overviews/:name': (params: DetailParams, source: Closeable) => {
       source.close()
+
+      const mesh = params.mesh
+      const name = params.name
+
+      return api.getDataplaneOverviewFromMesh({ mesh, name })
+    },
+
+    '/:mesh/dataplanes/for/:service/of/:type': async (params: CollectionParams & ServiceParams & PaginationParams & DataplaneTypeParams, source: Closeable) => {
+      source.close()
+
+      const mesh = params.mesh
+      const size = params.size
       const offset = params.size * (params.page - 1)
+
       // here 'all' means both proxies/sidecars and gateways this currently fits
       // our usecases but we should probably include `gateway | sidecar` or
       // similar
-      const search = Object.fromEntries(normalizeFilterFields(JSON.parse(params.search || '[]')))
-      if (typeof search.tag === 'undefined') {
-        search.tag = []
+      const filterParams = Object.fromEntries(normalizeFilterFields(JSON.parse(params.search || '[]')))
+      if (typeof filterParams.tag === 'undefined') {
+        filterParams.tag = []
       }
-      search.tag = search.tag.filter((item) => !item.startsWith('kuma.io/service:'))
-      search.tag.push(`kuma.io/service:${params.service}`)
+      filterParams.tag = filterParams.tag.filter((item) => !item.startsWith('kuma.io/service:'))
+      filterParams.tag.push(`kuma.io/service:${params.service}`)
+      const gatewayParams = params.type !== 'all' ? { gateway: params.type } : {}
 
-      return api.getAllDataplaneOverviewsFromMesh({
-        mesh: params.mesh,
-      }, {
+      return api.getAllDataplaneOverviewsFromMesh({ mesh }, {
+        ...filterParams,
+        ...gatewayParams,
         offset,
-        ...search,
-        ...(
-          params.type !== 'all' && {
-            gateway: params.type,
-          }
-        ),
-        size: params.size,
+        size,
       })
     },
-
   }
 }


### PR DESCRIPTION
Uses DataSource for data fetching purposes in the DPP detail view.

Also changes the child components slightly to no longer require a `Dataplane` object. All the data we need is already available on the `DataplaneOverview` object so we can save a request here.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
