### PR TITLE
refactor: use DataSource for policy detail view

### DIFF
--- a/src/app/policies/components/PolicyConnections.spec.ts
+++ b/src/app/policies/components/PolicyConnections.spec.ts
@@ -100,7 +100,7 @@ describe('PolicyConnections.vue', () => {
   test('renders no item', async () => {
     const server = useServer()
     server.use(
-      rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/:policyPath/:policyName/dataplanes', (req, res, ctx) =>
+      rest.get(import.meta.env.VITE_KUMA_API_SERVER_URL + '/meshes/:mesh/:policyPath/:policyName/dataplanes', (_req, res, ctx) =>
         res(ctx.status(200), ctx.json({ total: 0, items: [] })),
       ),
     )

--- a/src/app/policies/components/PolicyConnections.vue
+++ b/src/app/policies/components/PolicyConnections.vue
@@ -1,49 +1,60 @@
 <template>
-  <StatusInfo
-    :has-error="hasError"
-    :is-loading="isLoading"
-    :is-empty="!hasDataplanes"
+  <h2>Dataplanes</h2>
+
+  <input
+    id="dataplane-search"
+    v-model="searchInput"
+    type="text"
+    class="k-input mt-4"
+    placeholder="Filter by name"
+    required
+    data-testid="dataplane-search-input"
   >
-    <h2>Dataplanes</h2>
 
-    <input
-      id="dataplane-search"
-      v-model="searchInput"
-      type="text"
-      class="k-input mt-4"
-      placeholder="Filter by name"
-      required
-      data-testid="dataplane-search-input"
-    >
+  <DataSource
+    v-slot="{ data, isLoading, error }: PolicyDataplaneCollectionSource"
+    :src="`/${props.mesh}/${props.policyPath}/${props.policyName}/dataplanes`"
+  >
+    <LoadingBlock v-if="isLoading" />
 
-    <p
-      v-for="(dataplane, key) in filteredDataplanes"
-      :key="key"
-      class="mt-2"
-      data-testid="dataplane-name"
-    >
-      <router-link
-        :to="{
-          name: 'data-plane-detail-view',
-          params: {
-            mesh: dataplane.dataplane.mesh,
-            dataPlane: dataplane.dataplane.name,
-          },
-        }"
+    <ErrorBlock
+      v-else-if="error"
+      :error="error"
+    />
+
+    <EmptyBlock v-else-if="data === undefined || data.items.length === 0" />
+
+    <template v-else>
+      <p
+        v-for="(policyDataplane, key) in data.items.filter((policyDataplane) => policyDataplane.dataplane.name.toLowerCase().includes(searchInput.toLowerCase()))"
+        :key="key"
+        class="mt-2"
+        data-testid="dataplane-name"
       >
-        {{ dataplane.dataplane.name }}
-      </router-link>
-    </p>
-  </StatusInfo>
+        <RouterLink
+          :to="{
+            name: 'data-plane-detail-view',
+            params: {
+              mesh: policyDataplane.dataplane.mesh,
+              dataPlane: policyDataplane.dataplane.name,
+            },
+          }"
+        >
+          {{ policyDataplane.dataplane.name }}
+        </RouterLink>
+      </p>
+    </template>
+  </DataSource>
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref, watch } from 'vue'
+import { ref } from 'vue'
 
-import StatusInfo from '@/app/common/StatusInfo.vue'
-import { useKumaApi } from '@/utilities'
-
-const kumaApi = useKumaApi()
+import type { PolicyDataplaneCollectionSource } from '../sources'
+import DataSource from '@/app/application/components/data-source/DataSource.vue'
+import EmptyBlock from '@/app/common/EmptyBlock.vue'
+import ErrorBlock from '@/app/common/ErrorBlock.vue'
+import LoadingBlock from '@/app/common/LoadingBlock.vue'
 
 const props = defineProps({
   mesh: {
@@ -62,44 +73,5 @@ const props = defineProps({
   },
 })
 
-const hasDataplanes = ref(false)
-const isLoading = ref(true)
-const hasError = ref(false)
-const dataplanes = ref<any[]>([])
 const searchInput = ref('')
-
-const filteredDataplanes = computed(() => {
-  const lowerCasedInput = searchInput.value.toLowerCase()
-
-  return dataplanes.value.filter(({ dataplane }) => dataplane.name.toLowerCase().includes(lowerCasedInput))
-})
-
-watch(() => props.policyName, function () {
-  fetchPolicyConnections()
-})
-
-onMounted(function () {
-  fetchPolicyConnections()
-})
-
-async function fetchPolicyConnections(): Promise<void> {
-  hasError.value = false
-  isLoading.value = true
-
-  try {
-    const { items, total } = await kumaApi.getPolicyConnections({
-      mesh: props.mesh,
-      policyPath: props.policyPath,
-      policyName: props.policyName,
-    })
-
-    hasDataplanes.value = total > 0
-
-    dataplanes.value = items ?? []
-  } catch {
-    hasError.value = true
-  } finally {
-    isLoading.value = false
-  }
-}
 </script>

--- a/src/app/policies/components/__snapshots__/PolicyConnections.spec.ts.snap
+++ b/src/app/policies/components/__snapshots__/PolicyConnections.spec.ts.snap
@@ -2,55 +2,60 @@
 
 exports[`PolicyConnections.vue renders snapshot 1`] = `
 <div>
-  <div>
-    
-    <h2>
-      Dataplanes
-    </h2>
-    <input
-      class="k-input mt-4"
-      data-testid="dataplane-search-input"
-      id="dataplane-search"
-      placeholder="Filter by name"
-      required=""
-      type="text"
-    />
-    
-    <p
-      class="mt-2"
-      data-testid="dataplane-name"
+  
+  <h2>
+    Dataplanes
+  </h2>
+  <input
+    class="k-input mt-4"
+    data-testid="dataplane-search-input"
+    id="dataplane-search"
+    placeholder="Filter by name"
+    required=""
+    type="text"
+  />
+  
+  
+  
+  <p
+    class="mt-2"
+    data-testid="dataplane-name"
+  >
+    <a
+      class=""
+      href="/gui/mesh/default/data-plane/backend"
     >
-      <a
-        class=""
-        href="/gui/mesh/default/data-plane/backend"
-      >
-        backend
-      </a>
-    </p>
-    <p
-      class="mt-2"
-      data-testid="dataplane-name"
+      backend
+    </a>
+  </p>
+  <p
+    class="mt-2"
+    data-testid="dataplane-name"
+  >
+    <a
+      class=""
+      href="/gui/mesh/default/data-plane/db"
     >
-      <a
-        class=""
-        href="/gui/mesh/default/data-plane/db"
-      >
-        db
-      </a>
-    </p>
-    <p
-      class="mt-2"
-      data-testid="dataplane-name"
+      db
+    </a>
+  </p>
+  <p
+    class="mt-2"
+    data-testid="dataplane-name"
+  >
+    <a
+      class=""
+      href="/gui/mesh/default/data-plane/frontend"
     >
-      <a
-        class=""
-        href="/gui/mesh/default/data-plane/frontend"
-      >
-        frontend
-      </a>
-    </p>
-    
-    
-  </div>
+      frontend
+    </a>
+  </p>
+  
+  
+  <span
+    class="visually-hidden"
+  />
+  
+  
 </div>
 `;

--- a/src/app/policies/sources.ts
+++ b/src/app/policies/sources.ts
@@ -39,9 +39,7 @@ export const sources = (api: KumaApi) => {
     '/:mesh/:path': (params: CollectionParams & PaginationParams, source: Closeable) => {
       source.close()
 
-      const mesh = params.mesh
-      const path = params.path
-      const size = params.size
+      const { mesh, path, size } = params
       const offset = params.size * (params.page - 1)
 
       return api.getAllPolicyEntitiesFromMesh({ mesh, path }, { offset, size })
@@ -50,9 +48,7 @@ export const sources = (api: KumaApi) => {
     '/:mesh/:path/:name/dataplanes': (params: DetailParams, source: Closeable) => {
       source.close()
 
-      const mesh = params.mesh
-      const path = params.path
-      const name = params.name
+      const { mesh, path, name } = params
 
       return api.getPolicyConnections({ mesh, path, name })
     },

--- a/src/app/policies/sources.ts
+++ b/src/app/policies/sources.ts
@@ -1,48 +1,41 @@
 import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
 import type KumaApi from '@/services/kuma-api/KumaApi'
-import type {
-  PaginatedApiListResponse as CollectionResponse,
-} from '@/types/api.d'
-import type {
-  PolicyEntity as Policy,
-  PolicyType,
-} from '@/types/index.d'
+import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
+import type { PolicyEntity as Policy, PolicyType } from '@/types/index.d'
 
-type MeshParams = {
+type CollectionParams = {
   mesh: string
+  path: string
 }
 type PaginationParams = {
   page: number
   size: number
 }
 
-type PolicyTypeParams = {
-  policyType: string
-}
-// type PolicyParams = {
-//   policy: string
-// }
+type Closeable = { close: () => void }
+
 export type PolicyCollection = CollectionResponse<Policy>
 export type PolicySource = DataSourceResponse<Policy>
-export type PolicyTypeCollectionSource = DataSourceResponse<{policies: PolicyType[]}>
+export type PolicyTypeCollectionSource = DataSourceResponse<{ policies: PolicyType[] }>
 export type PolicyCollectionSource = DataSourceResponse<PolicyCollection>
 
 export const sources = (api: KumaApi) => {
   return {
-    '/*/policy-types': async (_params: {}, source: {close: () => void}) => {
+    '/*/policy-types': (_params: {}, source: Closeable) => {
       source.close()
+
       return api.getPolicyTypes()
     },
-    '/:mesh/policy-type/:policyType': async (params: MeshParams & PolicyTypeParams & PaginationParams, source: {close: () => void}) => {
+
+    '/:mesh/:path': (params: CollectionParams & PaginationParams, source: Closeable) => {
       source.close()
+
+      const mesh = params.mesh
+      const path = params.path
+      const size = params.size
       const offset = params.size * (params.page - 1)
-      return api.getAllPolicyEntitiesFromMesh({
-        mesh: params.mesh,
-        path: params.policyType,
-      }, {
-        offset,
-        size: params.size,
-      })
+
+      return api.getAllPolicyEntitiesFromMesh({ mesh, path }, { offset, size })
     },
     // '/:mesh/policy/:policy': async (params: MeshParams & PolicyParams) => {
     // },

--- a/src/app/policies/sources.ts
+++ b/src/app/policies/sources.ts
@@ -1,12 +1,17 @@
 import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
-import type { PolicyEntity as Policy, PolicyType } from '@/types/index.d'
+import type { PolicyEntity as Policy, PolicyDataplane, PolicyType } from '@/types/index.d'
 
 type CollectionParams = {
   mesh: string
   path: string
 }
+
+type DetailParams = CollectionParams & {
+  name: string
+}
+
 type PaginationParams = {
   page: number
   size: number
@@ -18,6 +23,10 @@ export type PolicyCollection = CollectionResponse<Policy>
 export type PolicySource = DataSourceResponse<Policy>
 export type PolicyTypeCollectionSource = DataSourceResponse<{ policies: PolicyType[] }>
 export type PolicyCollectionSource = DataSourceResponse<PolicyCollection>
+
+export type PolicyDataplaneCollection = CollectionResponse<PolicyDataplane>
+export type PolicyDataplaneSource = DataSourceResponse<PolicyDataplane>
+export type PolicyDataplaneCollectionSource = DataSourceResponse<PolicyDataplaneCollection>
 
 export const sources = (api: KumaApi) => {
   return {
@@ -37,7 +46,15 @@ export const sources = (api: KumaApi) => {
 
       return api.getAllPolicyEntitiesFromMesh({ mesh, path }, { offset, size })
     },
-    // '/:mesh/policy/:policy': async (params: MeshParams & PolicyParams) => {
-    // },
+
+    '/:mesh/:path/:name/dataplanes': (params: DetailParams, source: Closeable) => {
+      source.close()
+
+      const mesh = params.mesh
+      const path = params.path
+      const name = params.name
+
+      return api.getPolicyConnections({ mesh, path, name })
+    },
   }
 }

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -1,10 +1,10 @@
 <template>
   <RouteView
-    v-slot="{route}"
+    v-slot="{ route }"
+    name="policy-detail-view"
   >
-    <RouteTitle
-      :title="t('policies.routes.item.title', {name: route.params.policy})"
-    />
+    <RouteTitle :title="t('policies.routes.item.title', { name: route.params.policy })" />
+
     <AppView
       :breadcrumbs="[
         {
@@ -39,15 +39,15 @@ import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import { useStore } from '@/store/store'
 import { useI18n } from '@/utilities'
+
 const store = useStore()
 const { t } = useI18n()
 
 const props = defineProps<{
-  mesh: string,
-  policyPath: string,
-  policyName: string,
+  mesh: string
+  policyPath: string
+  policyName: string
 }>()
 
 const policyType = computed(() => store.state.policyTypesByPath[props.policyPath])
-
 </script>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -30,7 +30,7 @@
           -->
           <DataSource
             v-slot="{data, error}: PolicyCollectionSource"
-            :src="`/${route.params.mesh}/policy-type/${selected.path}?page=${props.page}&size=${props.size}`"
+            :src="`/${route.params.mesh}/${selected.path}?page=${props.page}&size=${props.size}`"
           >
             <AppView>
               <template #title>

--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -17,6 +17,7 @@ import type {
   Mesh,
   MeshGatewayDataplane,
   MeshInsight,
+  PolicyDataplane,
   PolicyEntity,
   PolicyType,
   ServiceInsight,
@@ -207,8 +208,8 @@ export default class KumaApi extends Api {
     }
   }
 
-  getPolicyConnections({ mesh, policyPath, policyName }: { mesh: string; policyPath: string; policyName: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<any>> {
-    return this.client.get(`/meshes/${mesh}/${policyPath}/${policyName}/dataplanes`, { params })
+  getPolicyConnections({ mesh, path, name }: { mesh: string; path: string; name: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<PolicyDataplane>> {
+    return this.client.get(`/meshes/${mesh}/${path}/${name}/dataplanes`, { params })
   }
 
   getAllPolicyEntitiesFromMesh({ mesh, path }: { mesh: string, path: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<PolicyEntity>> {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -483,3 +483,39 @@ export interface MeshInsight extends Entity {
 }
 
 export interface PolicyEntity extends MeshEntity {}
+
+export interface PolicyDataplaneAttachment {
+  type: string
+  name: string
+  service?: string
+}
+
+export interface PolicyDataplaneListenerHostRoute {
+  route: string
+  destinations?: Record<string, string>
+}
+
+export interface PolicyDataplaneListenerHost {
+  hostName: string
+  routes: PolicyDataplaneListenerHostRoute[]
+}
+
+export interface PolicyDataplaneListener {
+  port: number
+  protocol: string
+  host: PolicyDataplaneListenerHost[]
+}
+
+export interface PolicyDataplane {
+  kind: 'SidecarDataplane' | 'MeshGatewayDataplane'
+  dataplane: {
+    mesh: string
+    name: string
+  }
+  gateway?: {
+    mesh: string
+    name: string
+  }
+  attachments?: PolicyDataplaneAttachment[]
+  listeners?: PolicyDataplaneListener[]
+}


### PR DESCRIPTION
**refactor: uses DataSource for policy connections**

**chore(policies): cleans up list view**

**chore: cleans up policy detail view, adds name to route view**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>