### PR TITLE
feat: handles Zone Control Plane `zone.enabled` field

### DIFF
--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -9,7 +9,7 @@ Feature: Zones: List view content
   Scenario Outline: Zone CP list view has expected content
     Given the environment
       """
-      KUMA_ZONE_COUNT: 2
+      KUMA_ZONE_COUNT: 3
       """
     And the URL "/config" responds with
       """
@@ -21,6 +21,8 @@ Feature: Zones: List view content
       body:
         items:
           - name: zone-cp-1
+            zone:
+              enabled: true
             zoneInsight:
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
@@ -43,6 +45,8 @@ Feature: Zones: List view content
                       gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
                       buildDate: 2021-02-18T13:22:30Z
           - name: zone-cp-2
+            zone:
+              enabled: true
             zoneInsight:
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
@@ -55,6 +59,21 @@ Feature: Zones: List view content
                       gitTag: 1.0.0-rc2-211-g823fe8ce
                       gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
                       buildDate: 2021-02-18T13:22:30Z
+                - connectTime: 2020-07-28T16:18:09.743141Z
+                  disconnectTime: 2020-07-28T16:18:09.743141Z
+                  config: '{"environment":"kubernetes"}'
+                  status: {}
+                  version:
+                    kumaCp:
+                      version: 1.0.0-rc2-211-g823fe8ce
+                      gitTag: 1.0.0-rc2-211-g823fe8ce
+                      gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
+                      buildDate: 2021-02-18T13:22:30Z
+          - name: zone-cp-3
+            zone:
+              enabled: false
+            zoneInsight:
+              subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
                   config: '{"environment":"kubernetes"}'
@@ -79,6 +98,9 @@ Feature: Zones: List view content
     Then the "$zone-cp-table-row:nth-child(2) .name-column" element contains "zone-cp-2"
     Then the "$zone-cp-table-row:nth-child(2) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
     Then the "$zone-cp-table-row:nth-child(2) .type-column" element contains "kubernetes"
+
+    Then the "$zone-cp-table-row:nth-child(3) .status-column" element contains "disabled"
+    Then the "$zone-cp-table-row:nth-child(3) .name-column" element contains "zone-cp-3"
 
   Scenario Outline: Zone Ingress list view has expected content
     Given the environment

--- a/src/app/common/StatusBadge.vue
+++ b/src/app/common/StatusBadge.vue
@@ -17,16 +17,17 @@ import { useI18n } from '@/utilities'
 
 const i18n = useI18n()
 
-const BADGE_APPEARANCE: Record<StatusKeyword, BadgeAppearance> = {
+const BADGE_APPEARANCE: Record<StatusKeyword | 'disabled', BadgeAppearance> = {
   online: 'success',
   offline: 'danger',
   partially_degraded: 'warning',
   not_available: 'neutral',
+  disabled: 'neutral',
 }
 
 const props = defineProps({
   status: {
-    type: String as PropType<StatusKeyword>,
+    type: String as PropType<StatusKeyword | 'disabled'>,
     required: true,
   },
 })

--- a/src/app/main-overview/components/ZoneControlPlanesDetails.vue
+++ b/src/app/main-overview/components/ZoneControlPlanesDetails.vue
@@ -39,7 +39,7 @@ import { KTable } from '@kong/kongponents'
 import { PropType, computed } from 'vue'
 
 import StatusBadge from '@/app/common/StatusBadge.vue'
-import type { ZoneOverview } from '@/types/index.d'
+import type { StatusKeyword, ZoneOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
@@ -55,7 +55,13 @@ const props = defineProps({
 const tableData = computed(() => props.zoneOverviews.map((zoneOverview) => {
   const { name } = zoneOverview
 
-  const status = getItemStatusFromInsight(zoneOverview.zoneInsight)
+  let status: StatusKeyword | 'disabled'
+
+  if (zoneOverview.zone.enabled === false) {
+    status = 'disabled'
+  } else {
+    status = getItemStatusFromInsight(zoneOverview.zoneInsight)
+  }
 
   return {
     name,

--- a/src/app/main-overview/components/ZoneControlPlanesDetails.vue
+++ b/src/app/main-overview/components/ZoneControlPlanesDetails.vue
@@ -55,11 +55,9 @@ const props = defineProps({
 const tableData = computed(() => props.zoneOverviews.map((zoneOverview) => {
   const { name } = zoneOverview
 
-  let status: StatusKeyword | 'disabled'
+  let status: StatusKeyword | 'disabled' = 'disabled'
 
-  if (zoneOverview.zone.enabled === false) {
-    status = 'disabled'
-  } else {
+  if (zoneOverview.zone.enabled === true) {
     status = getItemStatusFromInsight(zoneOverview.zoneInsight)
   }
 

--- a/src/app/zones/components/ZoneDetails.vue
+++ b/src/app/zones/components/ZoneDetails.vue
@@ -7,14 +7,7 @@
           :key="property"
           :term="t(`http.api.property.${property}`)"
         >
-          <KBadge
-            v-if="property === 'status'"
-            :appearance="value === 'offline' ? 'danger' : 'success'"
-          >
-            {{ value }}
-          </KBadge>
-
-          <template v-else-if="property === 'name'">
+          <template v-if="property === 'name'">
             <TextWithCopyButton :text="props.zoneOverview.name">
               <RouterLink
                 :to="{
@@ -32,6 +25,10 @@
           <template v-else>
             {{ value }}
           </template>
+        </DefinitionListItem>
+
+        <DefinitionListItem :term="t('http.api.property.status')">
+          <StatusBadge :status="status" />
         </DefinitionListItem>
       </DefinitionList>
     </template>
@@ -80,7 +77,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KBadge, KAlert } from '@kong/kongponents'
+import { KAlert } from '@kong/kongponents'
 import { computed, PropType } from 'vue'
 
 import AccordionItem from '@/app/common/AccordionItem.vue'
@@ -88,6 +85,7 @@ import AccordionList from '@/app/common/AccordionList.vue'
 import CodeBlock from '@/app/common/CodeBlock.vue'
 import DefinitionList from '@/app/common/DefinitionList.vue'
 import DefinitionListItem from '@/app/common/DefinitionListItem.vue'
+import StatusBadge from '@/app/common/StatusBadge.vue'
 import SubscriptionDetails from '@/app/common/subscriptions/SubscriptionDetails.vue'
 import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
@@ -129,13 +127,19 @@ const props = defineProps({
 
 const processedZoneOverview = computed(() => {
   const { type, name } = props.zoneOverview
-  const status = getItemStatusFromInsight(props.zoneOverview.zoneInsight)
 
   return {
     type,
     name,
-    status,
     'Authentication Type': getZoneDpServerAuthType(props.zoneOverview),
+  }
+})
+
+const status = computed(() => {
+  if (props.zoneOverview.zone.enabled === false) {
+    return 'disabled'
+  } else {
+    return getItemStatusFromInsight(props.zoneOverview.zoneInsight)
   }
 })
 

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -252,11 +252,9 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
       }
     })
 
-    let status: StatusKeyword | 'disabled'
+    let status: StatusKeyword | 'disabled' = 'disabled'
 
-    if (zoneOverview.zone.enabled === false) {
-      status = 'disabled'
-    } else {
+    if (zoneOverview.zone.enabled === true) {
       status = getItemStatusFromInsight(zoneOverview.zoneInsight)
     }
 

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -198,7 +198,7 @@ import { getItemStatusFromInsight } from '@/utilities/dataplane'
 type ZoneOverviewTableRow = {
   detailViewRoute: RouteLocationNamedRaw
   name: string
-  status: StatusKeyword
+  status: StatusKeyword | 'disabled'
   zoneCpVersion: string
   type: string
   warnings: boolean
@@ -252,7 +252,13 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
       }
     })
 
-    const status = getItemStatusFromInsight(zoneOverview.zoneInsight)
+    let status: StatusKeyword | 'disabled'
+
+    if (zoneOverview.zone.enabled === false) {
+      status = 'disabled'
+    } else {
+      status = getItemStatusFromInsight(zoneOverview.zoneInsight)
+    }
 
     return {
       detailViewRoute,

--- a/src/locales/en-us/http/index.yaml
+++ b/src/locales/en-us/http/index.yaml
@@ -24,3 +24,4 @@ http:
       partially_degraded: 'partially degraded'
       notAvailable: 'information not available'
       not_available: 'information not available'
+      disabled: 'disabled'

--- a/src/test-support/mocks/src/zones+insights.ts
+++ b/src/test-support/mocks/src/zones+insights.ts
@@ -21,7 +21,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
           creationTime: '2021-02-19T08:06:15.380674+01:00',
           modificationTime: '2021-02-19T08:06:15.380674+01:00',
           zone: {
-            enabled: true,
+            enabled: fake.datatype.boolean(),
           },
           ...(shouldHaveZoneInsight && {
             zoneInsight: {


### PR DESCRIPTION
Treats a Zone Control Plane's `zone.enabled` field as a signal to show its status as "disabled" when its value is `false`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
