### PR TITLE
fix: browser back navigation not working

### DIFF
--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -16,12 +16,10 @@
       :env="env"
       :route="{
         update: (params: Record<string, string | undefined>) => {
-          router.push(
-            {
-              name: props.name,
-              query: cleanQuery(params, route.query),
-            }
-          )
+          router.replace({
+            name: props.name,
+            query: cleanQuery(params, route.query),
+          })
         },
         replace: (...args: Parameters<typeof router['push']>) => {
           router.push(...args)
@@ -116,5 +114,4 @@ watch(() => props.attrs, (attrs) => {
 onBeforeUnmount(() => {
   parent.removeAttrs(sym)
 })
-
 </script>


### PR DESCRIPTION
## Changes

**fix: browser back navigation not working**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## To reproduce

Navigate from the home page to a list view (e.g. via one of the "view all" links) and press the Back button in the browser. You will stay in the list view when you should move back to the initial page.