### PR TITLE
refactor: standardizes TabsWidget usage

### DIFF
--- a/src/app/common/TabsWidget.vue
+++ b/src/app/common/TabsWidget.vue
@@ -1,66 +1,35 @@
 <template>
-  <div
-    class="tab-container"
-    data-testid="tab-container"
+  <KTabs
+    v-model="activeTabHash"
+    :tabs="tabs"
+    @changed="switchTab"
   >
-    <LoadingBlock v-if="isLoading" />
-
-    <ErrorBlock
-      v-else-if="error !== null"
-      :error="error"
-    />
-
-    <template v-else>
-      <header
-        v-if="$slots.tabHeader"
-        class="tab__header"
-      >
-        <slot name="tabHeader" />
-      </header>
-
-      <div class="tab__content-container">
-        <KTabs
-          v-model="activeTabHash"
-          :tabs="tabs"
-          @changed="switchTab"
-        >
-          <template
-            v-for="(tab, index) in tabsSlots"
-            :key="index"
-            #[tab]
-          >
-            <KCard border-variant="noBorder">
-              <template #body>
-                <slot :name="tab" />
-              </template>
-            </KCard>
-          </template>
-
-          <template #warnings-anchor>
-            <span class="flex items-center with-warnings">
-              <KIcon
-                class="mr-1"
-                icon="warning"
-                color="var(--black-500)"
-                secondary-color="var(--yellow-300)"
-                size="16"
-              />
-
-              <span>Warnings</span>
-            </span>
-          </template>
-        </KTabs>
-      </div>
+    <template
+      v-for="(tab, index) in tabsSlots"
+      :key="index"
+      #[tab]
+    >
+      <slot :name="tab" />
     </template>
-  </div>
+
+    <template #warnings-anchor>
+      <KIcon
+        class="mr-1"
+        icon="warning"
+        color="var(--black-500)"
+        secondary-color="var(--yellow-300)"
+        size="16"
+      />
+
+      <span class="with-warnings">Warnings</span>
+    </template>
+  </KTabs>
 </template>
 
 <script lang="ts" setup>
-import { KCard, KIcon, KTabs } from '@kong/kongponents'
+import { KIcon, KTabs } from '@kong/kongponents'
 import { computed, PropType, ref } from 'vue'
 
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import { logEvents } from '@/services/logger/Logger'
 import { useLogger } from '@/utilities'
 import { QueryParameter } from '@/utilities/QueryParameter'
@@ -71,42 +40,6 @@ const props = defineProps({
   tabs: {
     type: Array as PropType<Array<{ hash: string, title: string }>>,
     required: true,
-  },
-
-  isLoading: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-
-  isEmpty: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-
-  hasError: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-
-  error: {
-    type: [Error, null] as PropType<Error | null>,
-    required: false,
-    default: null,
-  },
-
-  hasBorder: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-
-  initialTabOverride: {
-    type: String,
-    required: false,
-    default: null,
   },
 })
 
@@ -123,8 +56,6 @@ function start() {
 
   if (tab !== null) {
     activeTabHash.value = `#${tab}`
-  } else if (props.initialTabOverride !== null) {
-    activeTabHash.value = `#${props.initialTabOverride}`
   }
 }
 
@@ -140,27 +71,13 @@ function switchTab(newActiveTabHash: string): void {
 </script>
 
 <style lang="scss" scoped>
-.tab-container {
-  margin: var(--spacing-lg) 0 0 0;
-}
-
-.tab__header {
-  display: flex;
-  align-items: center;
-  margin: 0 0 var(--spacing-md) 0;
-  padding: 0 var(--spacing-md);
-}
-
-.tab__header > :not(:first-child) {
-  margin-left: var(--spacing-md);
-}
-
-.tab__content-container {
-  position: relative;
-  z-index: 1;
-}
-
 .with-warnings {
   color: var(--yellow-500);
+}
+</style>
+
+<style lang="scss">
+.tab-container {
+  margin-top: var(--AppGap);
 }
 </style>

--- a/src/app/common/__snapshots__/TabsWidget.spec.ts.snap
+++ b/src/app/common/__snapshots__/TabsWidget.spec.ts.snap
@@ -2,106 +2,75 @@
 
 exports[`TabsWidget.vue renders basic snapshot 1`] = `
 <div
-  class="tab-container"
-  data-testid="tab-container"
+  class="k-tabs"
 >
-  
-  <!--v-if-->
-  <div
-    class="tab__content-container"
+  <ul
+    aria-label="Tabs"
+    role="tablist"
   >
-    <div
-      class="k-tabs"
+    
+    <li
+      aria-controls="panel-0"
+      aria-selected="true"
+      class="tab-item active"
+      id="universal-tab"
+      role="tab"
+      tabindex="0"
     >
-      <ul
-        aria-label="Tabs"
-        role="tablist"
-      >
-        
-        <li
-          aria-controls="panel-0"
-          aria-selected="true"
-          class="tab-item active"
-          id="universal-tab"
-          role="tab"
-          tabindex="0"
-        >
-          <div
-            class="tab-link has-panels"
-          >
-            
-            <span>
-              Universal
-            </span>
-            
-          </div>
-        </li>
-        <li
-          aria-controls="panel-1"
-          aria-selected="false"
-          class="tab-item"
-          id="kubernetes-tab"
-          role="tab"
-          tabindex="0"
-        >
-          <div
-            class="tab-link has-panels"
-          >
-            
-            <span>
-              Kubernetes
-            </span>
-            
-          </div>
-        </li>
-        
-      </ul>
-      
       <div
-        aria-labelledby="universal-tab"
-        class="tab-container"
-        id="panel-0"
-        role="tabpanel"
-        tabindex="0"
+        class="tab-link has-panels"
       >
         
-        <section
-          aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-          class="kong-card noBorder"
-        >
-          <!---->
-          <!---->
-          <div
-            class="k-card-content"
-          >
-            <div
-              class="k-card-body"
-              id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-            >
-              
-              
-              <div>
-                Universal
-              </div>
-              
-              
-            </div>
-            <!---->
-          </div>
-        </section>
+        <span>
+          Universal
+        </span>
         
       </div>
+    </li>
+    <li
+      aria-controls="panel-1"
+      aria-selected="false"
+      class="tab-item"
+      id="kubernetes-tab"
+      role="tab"
+      tabindex="0"
+    >
       <div
-        aria-labelledby="kubernetes-tab"
-        class="tab-container"
-        id="panel-1"
-        role="tabpanel"
-        tabindex="0"
+        class="tab-link has-panels"
       >
-        <!---->
+        
+        <span>
+          Kubernetes
+        </span>
+        
       </div>
-      
+    </li>
+    
+  </ul>
+  
+  <div
+    aria-labelledby="universal-tab"
+    class="tab-container"
+    id="panel-0"
+    role="tabpanel"
+    tabindex="0"
+  >
+    
+    
+    <div>
+      Universal
     </div>
+    
+    
+  </div>
+  <div
+    aria-labelledby="kubernetes-tab"
+    class="tab-container"
+    id="panel-1"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <!---->
   </div>
   
 </div>

--- a/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
@@ -2,3137 +2,3106 @@
 
 exports[`DataPlaneDetails matches snapshot 1`] = `
 <div
-  class="tab-container"
-  data-testid="tab-container"
+  class="k-tabs"
 >
-  
-  <!--v-if-->
-  <div
-    class="tab__content-container"
+  <ul
+    aria-label="Tabs"
+    role="tablist"
   >
-    <div
-      class="k-tabs"
+    
+    <li
+      aria-controls="panel-0"
+      aria-selected="true"
+      class="tab-item active"
+      id="overview-tab"
+      role="tab"
+      tabindex="0"
     >
-      <ul
-        aria-label="Tabs"
-        role="tablist"
+      <div
+        class="tab-link has-panels"
       >
         
-        <li
-          aria-controls="panel-0"
-          aria-selected="true"
-          class="tab-item active"
-          id="overview-tab"
-          role="tab"
-          tabindex="0"
-        >
-          <div
-            class="tab-link has-panels"
-          >
-            
-            <span>
-              Overview
-            </span>
-            
-          </div>
-        </li>
-        <li
-          aria-controls="panel-1"
-          aria-selected="false"
-          class="tab-item"
-          id="insights-tab"
-          role="tab"
-          tabindex="0"
-        >
-          <div
-            class="tab-link has-panels"
-          >
-            
-            <span>
-              DPP Insights
-            </span>
-            
-          </div>
-        </li>
-        <li
-          aria-controls="panel-2"
-          aria-selected="false"
-          class="tab-item"
-          id="dpp-policies-tab"
-          role="tab"
-          tabindex="0"
-        >
-          <div
-            class="tab-link has-panels"
-          >
-            
-            <span>
-              Policies
-            </span>
-            
-          </div>
-        </li>
-        <li
-          aria-controls="panel-3"
-          aria-selected="false"
-          class="tab-item"
-          id="xds-configuration-tab"
-          role="tab"
-          tabindex="0"
-        >
-          <div
-            class="tab-link has-panels"
-          >
-            
-            <span>
-              XDS Configuration
-            </span>
-            
-          </div>
-        </li>
-        <li
-          aria-controls="panel-4"
-          aria-selected="false"
-          class="tab-item"
-          id="envoy-stats-tab"
-          role="tab"
-          tabindex="0"
-        >
-          <div
-            class="tab-link has-panels"
-          >
-            
-            <span>
-              Stats
-            </span>
-            
-          </div>
-        </li>
-        <li
-          aria-controls="panel-5"
-          aria-selected="false"
-          class="tab-item"
-          id="envoy-clusters-tab"
-          role="tab"
-          tabindex="0"
-        >
-          <div
-            class="tab-link has-panels"
-          >
-            
-            <span>
-              Clusters
-            </span>
-            
-          </div>
-        </li>
-        <li
-          aria-controls="panel-6"
-          aria-selected="false"
-          class="tab-item"
-          id="mtls-tab"
-          role="tab"
-          tabindex="0"
-        >
-          <div
-            class="tab-link has-panels"
-          >
-            
-            <span>
-              Certificate Insights
-            </span>
-            
-          </div>
-        </li>
+        <span>
+          Overview
+        </span>
         
-      </ul>
+      </div>
+    </li>
+    <li
+      aria-controls="panel-1"
+      aria-selected="false"
+      class="tab-item"
+      id="insights-tab"
+      role="tab"
+      tabindex="0"
+    >
+      <div
+        class="tab-link has-panels"
+      >
+        
+        <span>
+          DPP Insights
+        </span>
+        
+      </div>
+    </li>
+    <li
+      aria-controls="panel-2"
+      aria-selected="false"
+      class="tab-item"
+      id="dpp-policies-tab"
+      role="tab"
+      tabindex="0"
+    >
+      <div
+        class="tab-link has-panels"
+      >
+        
+        <span>
+          Policies
+        </span>
+        
+      </div>
+    </li>
+    <li
+      aria-controls="panel-3"
+      aria-selected="false"
+      class="tab-item"
+      id="xds-configuration-tab"
+      role="tab"
+      tabindex="0"
+    >
+      <div
+        class="tab-link has-panels"
+      >
+        
+        <span>
+          XDS Configuration
+        </span>
+        
+      </div>
+    </li>
+    <li
+      aria-controls="panel-4"
+      aria-selected="false"
+      class="tab-item"
+      id="envoy-stats-tab"
+      role="tab"
+      tabindex="0"
+    >
+      <div
+        class="tab-link has-panels"
+      >
+        
+        <span>
+          Stats
+        </span>
+        
+      </div>
+    </li>
+    <li
+      aria-controls="panel-5"
+      aria-selected="false"
+      class="tab-item"
+      id="envoy-clusters-tab"
+      role="tab"
+      tabindex="0"
+    >
+      <div
+        class="tab-link has-panels"
+      >
+        
+        <span>
+          Clusters
+        </span>
+        
+      </div>
+    </li>
+    <li
+      aria-controls="panel-6"
+      aria-selected="false"
+      class="tab-item"
+      id="mtls-tab"
+      role="tab"
+      tabindex="0"
+    >
+      <div
+        class="tab-link has-panels"
+      >
+        
+        <span>
+          Certificate Insights
+        </span>
+        
+      </div>
+    </li>
+    
+  </ul>
+  
+  <div
+    aria-labelledby="overview-tab"
+    class="tab-container"
+    id="panel-0"
+    role="tabpanel"
+    tabindex="0"
+  >
+    
+    
+    <dl
+      class="definition-list"
+    >
       
       <div
-        aria-labelledby="overview-tab"
-        class="tab-container"
-        id="panel-0"
-        role="tabpanel"
-        tabindex="0"
+        class="definition-list-item"
       >
-        
-        <section
-          aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
-          class="kong-card noBorder"
+        <dt
+          class="definition-list-item__term"
         >
-          <!---->
-          <!---->
+          Name
+        </dt>
+        <dd
+          class="definition-list-item__details"
+        >
+          
           <div
-            class="k-card-content"
+            class="copy-button-wrapper"
           >
-            <div
-              class="k-card-body"
-              id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+            
+            <a
+              class=""
+              href="/gui/mesh/test-mesh/data-plane/backend"
+            >
+              backend
+            </a>
+            
+            
+            <button
+              class="k-button small outline copy-button non-visual-button"
+              data-testid="copy-button"
+              title="Copy"
+              type="button"
             >
               
+              <!---->
               
-              <dl
-                class="definition-list"
+              
+              <span
+                class="kong-icon kong-icon-copy"
               >
-                
-                <div
-                  class="definition-list-item"
+                <svg
+                  height="18"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width="18"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <dt
-                    class="definition-list-item__term"
-                  >
-                    Name
-                  </dt>
-                  <dd
-                    class="definition-list-item__details"
-                  >
-                    
-                    <div
-                      class="copy-button-wrapper"
-                    >
-                      
-                      <a
-                        class=""
-                        href="/gui/mesh/test-mesh/data-plane/backend"
-                      >
-                        backend
-                      </a>
-                      
-                      
-                      <button
-                        class="k-button small outline copy-button non-visual-button"
-                        data-testid="copy-button"
-                        title="Copy"
-                        type="button"
-                      >
-                        
-                        <!---->
-                        
-                        
-                        <span
-                          class="kong-icon kong-icon-copy"
-                        >
-                          <svg
-                            height="18"
-                            role="img"
-                            viewBox="0 0 32 32"
-                            width="18"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            
+                  
   
-                            <title>
-                              Copy
-                            </title>
-                            
+                  <title>
+                    Copy
+                  </title>
+                  
   
-                            <path
-                              d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
-                              fill="currentColor"
-                            />
-                            
+                  <path
+                    d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
+                    fill="currentColor"
+                  />
+                  
 
-                          </svg>
-                          
-
-                        </span>
-                        
-                        <span
-                          class="visually-hidden"
-                        >
-                          Copy
-                        </span>
-                        
-                        
-                        <!---->
-                      </button>
-                      
-                    </div>
-                    
-                  </dd>
-                </div>
-                <div
-                  class="definition-list-item"
-                >
-                  <dt
-                    class="definition-list-item__term"
-                  >
-                    Tags
-                  </dt>
-                  <dd
-                    class="definition-list-item__details"
-                  >
-                    
-                    <span
-                      class="tag-list"
-                    >
-                      
-                      <div
-                        class="k-badge k-badge-default k-badge-rounded tag-badge"
-                        tabindex="0"
-                      >
-                        <div
-                          class="k-badge-text"
-                        >
-                          <div
-                            class="k-badge-text"
-                          >
-                            
-                            <span>
-                              kuma.io/protocol:
-                              <b>
-                                http
-                              </b>
-                            </span>
-                            
-                          </div>
-                        </div>
-                        <!---->
-                      </div>
-                      <div
-                        class="k-badge k-badge-default k-badge-rounded tag-badge"
-                        tabindex="0"
-                      >
-                        <div
-                          class="k-badge-text"
-                        >
-                          <div
-                            class="k-badge-text"
-                          >
-                            
-                            <a
-                              class=""
-                              href="/gui/mesh/default/service/backend"
-                            >
-                              kuma.io/service:
-                              <b>
-                                backend
-                              </b>
-                            </a>
-                            
-                          </div>
-                        </div>
-                        <!---->
-                      </div>
-                      
-                    </span>
-                    
-                  </dd>
-                </div>
-                <div
-                  class="definition-list-item"
-                >
-                  <dt
-                    class="definition-list-item__term"
-                  >
-                    Status
-                  </dt>
-                  <dd
-                    class="definition-list-item__details"
-                  >
-                    
-                    <div
-                      class="k-badge k-badge-success k-badge-rounded status"
-                      data-testid="status-badge"
-                      tabindex="0"
-                    >
-                      <div
-                        class="k-badge-text"
-                      >
-                        <div
-                          class="k-badge-text"
-                        >
-                          
-                          online
-                          
-                        </div>
-                      </div>
-                      <!---->
-                    </div>
-                    
-                  </dd>
-                </div>
-                <!--v-if-->
-                <div
-                  class="definition-list-item"
-                >
-                  <dt
-                    class="definition-list-item__term"
-                  >
-                    Dependencies
-                  </dt>
-                  <dd
-                    class="definition-list-item__details"
-                  >
-                    
-                    <ul>
-                      
-                      <li
-                        class="tag-cols"
-                      >
-                        envoy: 1.16.2
-                      </li>
-                      <li
-                        class="tag-cols"
-                      >
-                        kumaDp: 1.0.7
-                      </li>
-                      <li
-                        class="tag-cols"
-                      >
-                        coredns: 1.8.3
-                      </li>
-                      
-                    </ul>
-                    
-                  </dd>
-                </div>
+                </svg>
                 
-              </dl>
+
+              </span>
+              
+              <span
+                class="visually-hidden"
+              >
+                Copy
+              </span>
+              
+              
+              <!---->
+            </button>
+            
+          </div>
+          
+        </dd>
+      </div>
+      <div
+        class="definition-list-item"
+      >
+        <dt
+          class="definition-list-item__term"
+        >
+          Tags
+        </dt>
+        <dd
+          class="definition-list-item__details"
+        >
+          
+          <span
+            class="tag-list"
+          >
+            
+            <div
+              class="k-badge k-badge-default k-badge-rounded tag-badge"
+              tabindex="0"
+            >
               <div
-                class="k-code-block theme-light code-block mt-4"
-                data-testid="k-code-block"
-                id="code-block-data-plane"
-                style="--maxLineNumberWidth: 2ch;"
-                tabindex="0"
+                class="k-badge-text"
               >
                 <div
-                  class="k-code-block-actions"
+                  class="k-badge-text"
                 >
-                  <p
-                    class="k-code-block-search-results"
-                  >
-                    
-                       
-                    
-                  </p>
-                  <div
-                    class="k-search-container"
-                  >
-                    <span
-                      class="k-search-icon theme-light kong-icon kong-icon-search"
-                      data-testid="k-code-block-search-icon"
-                    >
-                      <svg
-                        data-testid="k-code-block-search-icon"
-                        fill="currentColor"
-                        height="20px"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        width="20px"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        
-  
-                        <title>
-                          Search
-                        </title>
-                        
-  
-                        <path
-                          d="M10.88 18.75a7.88 7.88 0 1 0 0-15.75 7.88 7.88 0 0 0 0 15.75ZM16.44 16.44 21 21"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="3"
-                        />
-                        
-
-                      </svg>
-                      
-
-                    </span>
-                    <label
-                      class="k-code-block-search-label"
-                      for="code-block-data-plane-search-input"
-                    >
-                      <span
-                        class="visually-hidden"
-                      >
-                        Search
-                      </span>
-                    </label>
-                    <input
-                      class="k-code-block-search-input"
-                      data-testid="k-code-block-search-input"
-                      id="code-block-data-plane-search-input"
-                      type="text"
-                    />
-                    <!---->
-                    <span
-                      class="k-is-processing-icon theme-light kong-icon kong-icon-spinner"
-                      data-testid="k-code-block-is-processing-icon"
-                    >
-                      <svg
-                        data-testid="k-code-block-is-processing-icon"
-                        fill="currentColor"
-                        height="24px"
-                        role="img"
-                        viewBox="0 0 20 20"
-                        width="24px"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        
-  
-                        <title>
-                          Loading
-                        </title>
-                        
-  
-                        <g>
-                          
-    
-                          <path
-                            d="M5 10a5 5 0 1 0 5-5"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                          />
-                          
-  
-                        </g>
-                        
-
-                      </svg>
-                      
-
-                    </span>
-                    <!---->
-                  </div>
-                  <div
-                    class="k-search-actions"
-                  >
-                    <button
-                      aria-pressed="false"
-                      class="k-button small outline k-regexp-mode-button"
-                      data-testid="k-code-block-regexp-mode-button"
-                      title="Use regular expression (Alt+R)"
-                      type="button"
-                    >
-                      
-                      <!---->
-                      
-                      
-                      <span
-                        class="visually-hidden"
-                      >
-                        RegExp mode enabled
-                      </span>
-                       .* 
-                      
-                      <!---->
-                    </button>
-                    <button
-                      aria-pressed="false"
-                      class="k-button small outline k-filter-mode-button"
-                      data-testid="k-code-block-filter-mode-button"
-                      title="Filter results (Alt+F)"
-                      type="button"
-                    >
-                      
-                      <span
-                        class="k-button-icon kong-icon kong-icon-filter"
-                      >
-                        <svg
-                          height="16px"
-                          role="img"
-                          viewBox="0 0 14 11"
-                          width="16px"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          
-  
-                          <title>
-                            Filter results (Alt+F)
-                          </title>
-                          
-  
-                          <path
-                            d="M8 9v2H6V9h2zm2-3v2H4V6h6zm2-3v2H2V3h10zm2-3v2H0V0h14z"
-                            fill="currentColor"
-                            fill-rule="evenodd"
-                          />
-                          
-
-                        </svg>
-                        
-
-                      </span>
-                      
-                      
-                      <span
-                        class="visually-hidden"
-                      >
-                        Filter mode enabled
-                      </span>
-                      
-                      <!---->
-                    </button>
-                    <button
-                      class="k-button small outline k-previous-match-button"
-                      data-testid="k-code-block-previous-match-button"
-                      disabled=""
-                      title="Previous match (Shift+F3)"
-                      type="button"
-                    >
-                      
-                      <span
-                        class="k-button-icon kong-icon kong-icon-chevronUp"
-                      >
-                        <svg
-                          fill="currentColor"
-                          height="16px"
-                          role="img"
-                          viewBox="0 0 20 20"
-                          width="16px"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          
-  
-                          <title>
-                            Previous match (Shift+F3)
-                          </title>
-                          
-  
-                          <path
-                            d="M15 12 9.8 7l-5.2 5"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                          />
-                          
-
-                        </svg>
-                        
-
-                      </span>
-                      
-                      
-                      <span
-                        class="visually-hidden"
-                      >
-                        Previous match
-                      </span>
-                      
-                      <!---->
-                    </button>
-                    <button
-                      class="k-button small outline k-next-match-button"
-                      data-testid="k-code-block-next-match-button"
-                      disabled=""
-                      title="Next match (F3)"
-                      type="button"
-                    >
-                      
-                      <span
-                        class="k-button-icon kong-icon kong-icon-chevronDown"
-                      >
-                        <svg
-                          fill="currentColor"
-                          height="16px"
-                          role="img"
-                          viewBox="0 0 20 20"
-                          width="16px"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          
-  
-                          <title>
-                            Next match (F3)
-                          </title>
-                          
-  
-                          <path
-                            d="m4.6 7 5.2 5L15 7"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                          />
-                          
-
-                        </svg>
-                        
-
-                      </span>
-                      
-                      
-                      <span
-                        class="visually-hidden"
-                      >
-                        Next match
-                      </span>
-                      
-                      <!---->
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="k-code-block-content"
-                >
-                  <pre
-                    class="k-highlighted-code-block show-copy-button language-yaml"
-                    data-testid="k-code-block-highlighted-code-block"
-                    tabindex="0"
-                  >
-                            
-                    <span
-                      class="k-line-number-rows"
-                    >
-                      
-          
-                      
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L1"
-                        >
-                          1
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L2"
-                        >
-                          2
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L3"
-                        >
-                          3
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L4"
-                        >
-                          4
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L5"
-                        >
-                          5
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L6"
-                        >
-                          6
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L7"
-                        >
-                          7
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L8"
-                        >
-                          8
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L9"
-                        >
-                          9
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L10"
-                        >
-                          10
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L11"
-                        >
-                          11
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L12"
-                        >
-                          12
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L13"
-                        >
-                          13
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L14"
-                        >
-                          14
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L15"
-                        >
-                          15
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L16"
-                        >
-                          16
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L17"
-                        >
-                          17
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L18"
-                        >
-                          18
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L19"
-                        >
-                          19
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L20"
-                        >
-                          20
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L21"
-                        >
-                          21
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L22"
-                        >
-                          22
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L23"
-                        >
-                          23
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L24"
-                        >
-                          24
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L25"
-                        >
-                          25
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L26"
-                        >
-                          26
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L27"
-                        >
-                          27
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L28"
-                        >
-                          28
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L29"
-                        >
-                          29
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L30"
-                        >
-                          30
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L31"
-                        >
-                          31
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L32"
-                        >
-                          32
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L33"
-                        >
-                          33
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L34"
-                        >
-                          34
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L35"
-                        >
-                          35
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L36"
-                        >
-                          36
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L37"
-                        >
-                          37
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L38"
-                        >
-                          38
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L39"
-                        >
-                          39
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L40"
-                        >
-                          40
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L41"
-                        >
-                          41
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L42"
-                        >
-                          42
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L43"
-                        >
-                          43
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L44"
-                        >
-                          44
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L45"
-                        >
-                          45
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L46"
-                        >
-                          46
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L47"
-                        >
-                          47
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L48"
-                        >
-                          48
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L49"
-                        >
-                          49
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L50"
-                        >
-                          50
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L51"
-                        >
-                          51
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L52"
-                        >
-                          52
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L53"
-                        >
-                          53
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L54"
-                        >
-                          54
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L55"
-                        >
-                          55
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L56"
-                        >
-                          56
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L57"
-                        >
-                          57
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L58"
-                        >
-                          58
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L59"
-                        >
-                          59
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L60"
-                        >
-                          60
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L61"
-                        >
-                          61
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L62"
-                        >
-                          62
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L63"
-                        >
-                          63
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L64"
-                        >
-                          64
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L65"
-                        >
-                          65
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L66"
-                        >
-                          66
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L67"
-                        >
-                          67
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L68"
-                        >
-                          68
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L69"
-                        >
-                          69
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L70"
-                        >
-                          70
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L71"
-                        >
-                          71
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L72"
-                        >
-                          72
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L73"
-                        >
-                          73
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L74"
-                        >
-                          74
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L75"
-                        >
-                          75
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L76"
-                        >
-                          76
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L77"
-                        >
-                          77
-                        </a>
-                        
-          
-                      </span>
-                      <span
-                        class="k-line"
-                      >
-                        
-            
-                        <a
-                          class="k-line-anchor"
-                          id="code-block-data-plane-L78"
-                        >
-                          78
-                        </a>
-                        
-          
-                      </span>
-                      
-                      
-        
-                    </span>
-                    
-        
-                    <code
-                      class="language-yaml"
-                    >
-                      <span
-                        class="token key atrule"
-                      >
-                        type
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       DataplaneOverview
-
-                      <span
-                        class="token key atrule"
-                      >
-                        mesh
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       test
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                      mesh
-
-                      <span
-                        class="token key atrule"
-                      >
-                        name
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       backend
-
-                      <span
-                        class="token key atrule"
-                      >
-                        dataplane
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-  
-                      <span
-                        class="token key atrule"
-                      >
-                        networking
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-    
-                      <span
-                        class="token key atrule"
-                      >
-                        address
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       127.0.0.1
-    
-                      <span
-                        class="token key atrule"
-                      >
-                        inbound
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-      
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                       
-                      <span
-                        class="token key atrule"
-                      >
-                        port
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token number"
-                      >
-                        7776
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        servicePort
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token number"
-                      >
-                        7777
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        serviceAddress
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       127.0.0.1
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        tags
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        kuma.io/protocol
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       http
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        kuma.io/service
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       backend
-    
-                      <span
-                        class="token key atrule"
-                      >
-                        outbound
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-      
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                       
-                      <span
-                        class="token key atrule"
-                      >
-                        port
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token number"
-                      >
-                        10001
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        tags
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        kuma.io/service
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       frontend
-
-                      <span
-                        class="token key atrule"
-                      >
-                        dataplaneInsight
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-  
-                      <span
-                        class="token key atrule"
-                      >
-                        subscriptions
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-    
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                       
-                      <span
-                        class="token key atrule"
-                      >
-                        id
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       118b4d6f
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                      7a98
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                      4172
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                      96d9
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                      85ffb8b20b16
-      
-                      <span
-                        class="token key atrule"
-                      >
-                        controlPlaneInstanceId
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       foo
-      
-                      <span
-                        class="token key atrule"
-                      >
-                        connectTime
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2021-02-17T07:33:36.412683Z'
-                      </span>
-                      
-      
-                      <span
-                        class="token key atrule"
-                      >
-                        disconnectTime
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2021-02-17T07:33:36.412683Z'
-                      </span>
-                      
-      
-                      <span
-                        class="token key atrule"
-                      >
-                        status
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        lastUpdateTime
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2021-02-17T10:48:03.638434Z'
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        total
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesSent
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '5'
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesAcknowledged
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '5'
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        cds
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesSent
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '1'
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesAcknowledged
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '1'
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        eds
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesSent
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2'
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesAcknowledged
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2'
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        lds
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesSent
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2'
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesAcknowledged
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2'
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        rds
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token punctuation"
-                      >
-                        {
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        }
-                      </span>
-                      
-      
-                      <span
-                        class="token key atrule"
-                      >
-                        version
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        kumaDp
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        version
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       1.0.7
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        gitTag
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       unknown
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        gitCommit
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       unknown
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        buildDate
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       unknown
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        envoy
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        version
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       1.16.2
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        build
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        dependencies
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        coredns
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       1.8.3
-    
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                       
-                      <span
-                        class="token key atrule"
-                      >
-                        id
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       118b4d6f
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                      7a98
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                      4172
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                      96d9
-                      <span
-                        class="token punctuation"
-                      >
-                        -
-                      </span>
-                      85ffb8b20b16
-      
-                      <span
-                        class="token key atrule"
-                      >
-                        controlPlaneInstanceId
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       foo
-      
-                      <span
-                        class="token key atrule"
-                      >
-                        connectTime
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2021-02-17T07:33:36.412683Z'
-                      </span>
-                      
-      
-                      <span
-                        class="token key atrule"
-                      >
-                        status
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        lastUpdateTime
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2021-02-17T10:48:03.638434Z'
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        total
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesSent
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '5'
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesAcknowledged
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '5'
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        cds
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesSent
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '1'
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesAcknowledged
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '1'
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        eds
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesSent
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2'
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesAcknowledged
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2'
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        lds
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesSent
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2'
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        responsesAcknowledged
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token string"
-                      >
-                        '2'
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        rds
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       
-                      <span
-                        class="token punctuation"
-                      >
-                        {
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        }
-                      </span>
-                      
-      
-                      <span
-                        class="token key atrule"
-                      >
-                        version
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        kumaDp
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        version
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       1.0.7
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        gitTag
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       unknown
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        gitCommit
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       unknown
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        buildDate
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       unknown
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        envoy
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        version
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       1.16.2
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        build
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL
-        
-                      <span
-                        class="token key atrule"
-                      >
-                        dependencies
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                      
-          
-                      <span
-                        class="token key atrule"
-                      >
-                        coredns
-                      </span>
-                      <span
-                        class="token punctuation"
-                      >
-                        :
-                      </span>
-                       1.8.3
-                    </code>
-                    
-      
-                  </pre>
-                  <div
-                    class="k-code-block-secondary-actions"
-                  >
-                    <button
-                      class="k-button small outline k-code-block-copy-button"
-                      data-testid="k-code-block-copy-button"
-                      title="Copy (Alt+C)"
-                      type="button"
-                    >
-                      
-                      <!---->
-                      
-                      
-                      <span
-                        class="kong-icon kong-icon-copy"
-                      >
-                        <svg
-                          height="16px"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width="16px"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          
-  
-                          <title>
-                            Copy (Alt+C)
-                          </title>
-                          
-  
-                          <path
-                            d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
-                            fill="currentColor"
-                          />
-                          
-
-                        </svg>
-                        
-
-                      </span>
-                      <span
-                        class="visually-hidden"
-                      >
-                        Copy
-                      </span>
-                      
-                      <!---->
-                    </button>
-                    
-                    
-                    
-                    <button
-                      class="k-button small outline copy-button non-visual-button"
-                      data-testid="copy-button"
-                      title="Copy as Kubernetes"
-                      type="button"
-                    >
-                      
-                      <!---->
-                      
-                      
-                      <span
-                        class="kong-icon kong-icon-copy"
-                      >
-                        <svg
-                          height="18"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width="18"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          
-  
-                          <title>
-                            Copy as Kubernetes
-                          </title>
-                          
-  
-                          <path
-                            d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
-                            fill="currentColor"
-                          />
-                          
-
-                        </svg>
-                        
-
-                      </span>
-                      
-                      as k8s
-                      
-                      
-                      <!---->
-                    </button>
-                    
-                    
-                    
-                  </div>
+                  
+                  <span>
+                    kuma.io/protocol:
+                    <b>
+                      http
+                    </b>
+                  </span>
+                  
                 </div>
               </div>
-              
-              
+              <!---->
+            </div>
+            <div
+              class="k-badge k-badge-default k-badge-rounded tag-badge"
+              tabindex="0"
+            >
+              <div
+                class="k-badge-text"
+              >
+                <div
+                  class="k-badge-text"
+                >
+                  
+                  <a
+                    class=""
+                    href="/gui/mesh/default/service/backend"
+                  >
+                    kuma.io/service:
+                    <b>
+                      backend
+                    </b>
+                  </a>
+                  
+                </div>
+              </div>
+              <!---->
+            </div>
+            
+          </span>
+          
+        </dd>
+      </div>
+      <div
+        class="definition-list-item"
+      >
+        <dt
+          class="definition-list-item__term"
+        >
+          Status
+        </dt>
+        <dd
+          class="definition-list-item__details"
+        >
+          
+          <div
+            class="k-badge k-badge-success k-badge-rounded status"
+            data-testid="status-badge"
+            tabindex="0"
+          >
+            <div
+              class="k-badge-text"
+            >
+              <div
+                class="k-badge-text"
+              >
+                
+                online
+                
+              </div>
             </div>
             <!---->
           </div>
-        </section>
-        
+          
+        </dd>
       </div>
+      <!--v-if-->
       <div
-        aria-labelledby="insights-tab"
-        class="tab-container"
-        id="panel-1"
-        role="tabpanel"
-        tabindex="0"
+        class="definition-list-item"
       >
-        <!---->
-      </div>
-      <div
-        aria-labelledby="dpp-policies-tab"
-        class="tab-container"
-        id="panel-2"
-        role="tabpanel"
-        tabindex="0"
-      >
-        <!---->
-      </div>
-      <div
-        aria-labelledby="xds-configuration-tab"
-        class="tab-container"
-        id="panel-3"
-        role="tabpanel"
-        tabindex="0"
-      >
-        <!---->
-      </div>
-      <div
-        aria-labelledby="envoy-stats-tab"
-        class="tab-container"
-        id="panel-4"
-        role="tabpanel"
-        tabindex="0"
-      >
-        <!---->
-      </div>
-      <div
-        aria-labelledby="envoy-clusters-tab"
-        class="tab-container"
-        id="panel-5"
-        role="tabpanel"
-        tabindex="0"
-      >
-        <!---->
-      </div>
-      <div
-        aria-labelledby="mtls-tab"
-        class="tab-container"
-        id="panel-6"
-        role="tabpanel"
-        tabindex="0"
-      >
-        <!---->
+        <dt
+          class="definition-list-item__term"
+        >
+          Dependencies
+        </dt>
+        <dd
+          class="definition-list-item__details"
+        >
+          
+          <ul>
+            
+            <li
+              class="tag-cols"
+            >
+              envoy: 1.16.2
+            </li>
+            <li
+              class="tag-cols"
+            >
+              kumaDp: 1.0.7
+            </li>
+            <li
+              class="tag-cols"
+            >
+              coredns: 1.8.3
+            </li>
+            
+          </ul>
+          
+        </dd>
       </div>
       
+    </dl>
+    <div
+      class="k-code-block theme-light code-block mt-4"
+      data-testid="k-code-block"
+      id="code-block-data-plane"
+      style="--maxLineNumberWidth: 2ch;"
+      tabindex="0"
+    >
+      <div
+        class="k-code-block-actions"
+      >
+        <p
+          class="k-code-block-search-results"
+        >
+          
+             
+          
+        </p>
+        <div
+          class="k-search-container"
+        >
+          <span
+            class="k-search-icon theme-light kong-icon kong-icon-search"
+            data-testid="k-code-block-search-icon"
+          >
+            <svg
+              data-testid="k-code-block-search-icon"
+              fill="currentColor"
+              height="20px"
+              role="img"
+              viewBox="0 0 24 24"
+              width="20px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              
+  
+              <title>
+                Search
+              </title>
+              
+  
+              <path
+                d="M10.88 18.75a7.88 7.88 0 1 0 0-15.75 7.88 7.88 0 0 0 0 15.75ZM16.44 16.44 21 21"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="3"
+              />
+              
+
+            </svg>
+            
+
+          </span>
+          <label
+            class="k-code-block-search-label"
+            for="code-block-data-plane-search-input"
+          >
+            <span
+              class="visually-hidden"
+            >
+              Search
+            </span>
+          </label>
+          <input
+            class="k-code-block-search-input"
+            data-testid="k-code-block-search-input"
+            id="code-block-data-plane-search-input"
+            type="text"
+          />
+          <!---->
+          <span
+            class="k-is-processing-icon theme-light kong-icon kong-icon-spinner"
+            data-testid="k-code-block-is-processing-icon"
+          >
+            <svg
+              data-testid="k-code-block-is-processing-icon"
+              fill="currentColor"
+              height="24px"
+              role="img"
+              viewBox="0 0 20 20"
+              width="24px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              
+  
+              <title>
+                Loading
+              </title>
+              
+  
+              <g>
+                
+    
+                <path
+                  d="M5 10a5 5 0 1 0 5-5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                
+  
+              </g>
+              
+
+            </svg>
+            
+
+          </span>
+          <!---->
+        </div>
+        <div
+          class="k-search-actions"
+        >
+          <button
+            aria-pressed="false"
+            class="k-button small outline k-regexp-mode-button"
+            data-testid="k-code-block-regexp-mode-button"
+            title="Use regular expression (Alt+R)"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+            <span
+              class="visually-hidden"
+            >
+              RegExp mode enabled
+            </span>
+             .* 
+            
+            <!---->
+          </button>
+          <button
+            aria-pressed="false"
+            class="k-button small outline k-filter-mode-button"
+            data-testid="k-code-block-filter-mode-button"
+            title="Filter results (Alt+F)"
+            type="button"
+          >
+            
+            <span
+              class="k-button-icon kong-icon kong-icon-filter"
+            >
+              <svg
+                height="16px"
+                role="img"
+                viewBox="0 0 14 11"
+                width="16px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                
+  
+                <title>
+                  Filter results (Alt+F)
+                </title>
+                
+  
+                <path
+                  d="M8 9v2H6V9h2zm2-3v2H4V6h6zm2-3v2H2V3h10zm2-3v2H0V0h14z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                />
+                
+
+              </svg>
+              
+
+            </span>
+            
+            
+            <span
+              class="visually-hidden"
+            >
+              Filter mode enabled
+            </span>
+            
+            <!---->
+          </button>
+          <button
+            class="k-button small outline k-previous-match-button"
+            data-testid="k-code-block-previous-match-button"
+            disabled=""
+            title="Previous match (Shift+F3)"
+            type="button"
+          >
+            
+            <span
+              class="k-button-icon kong-icon kong-icon-chevronUp"
+            >
+              <svg
+                fill="currentColor"
+                height="16px"
+                role="img"
+                viewBox="0 0 20 20"
+                width="16px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                
+  
+                <title>
+                  Previous match (Shift+F3)
+                </title>
+                
+  
+                <path
+                  d="M15 12 9.8 7l-5.2 5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                
+
+              </svg>
+              
+
+            </span>
+            
+            
+            <span
+              class="visually-hidden"
+            >
+              Previous match
+            </span>
+            
+            <!---->
+          </button>
+          <button
+            class="k-button small outline k-next-match-button"
+            data-testid="k-code-block-next-match-button"
+            disabled=""
+            title="Next match (F3)"
+            type="button"
+          >
+            
+            <span
+              class="k-button-icon kong-icon kong-icon-chevronDown"
+            >
+              <svg
+                fill="currentColor"
+                height="16px"
+                role="img"
+                viewBox="0 0 20 20"
+                width="16px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                
+  
+                <title>
+                  Next match (F3)
+                </title>
+                
+  
+                <path
+                  d="m4.6 7 5.2 5L15 7"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                
+
+              </svg>
+              
+
+            </span>
+            
+            
+            <span
+              class="visually-hidden"
+            >
+              Next match
+            </span>
+            
+            <!---->
+          </button>
+        </div>
+      </div>
+      <div
+        class="k-code-block-content"
+      >
+        <pre
+          class="k-highlighted-code-block show-copy-button language-yaml"
+          data-testid="k-code-block-highlighted-code-block"
+          tabindex="0"
+        >
+                  
+          <span
+            class="k-line-number-rows"
+          >
+            
+          
+            
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L1"
+              >
+                1
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L2"
+              >
+                2
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L3"
+              >
+                3
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L4"
+              >
+                4
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L5"
+              >
+                5
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L6"
+              >
+                6
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L7"
+              >
+                7
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L8"
+              >
+                8
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L9"
+              >
+                9
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L10"
+              >
+                10
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L11"
+              >
+                11
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L12"
+              >
+                12
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L13"
+              >
+                13
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L14"
+              >
+                14
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L15"
+              >
+                15
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L16"
+              >
+                16
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L17"
+              >
+                17
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L18"
+              >
+                18
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L19"
+              >
+                19
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L20"
+              >
+                20
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L21"
+              >
+                21
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L22"
+              >
+                22
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L23"
+              >
+                23
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L24"
+              >
+                24
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L25"
+              >
+                25
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L26"
+              >
+                26
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L27"
+              >
+                27
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L28"
+              >
+                28
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L29"
+              >
+                29
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L30"
+              >
+                30
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L31"
+              >
+                31
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L32"
+              >
+                32
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L33"
+              >
+                33
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L34"
+              >
+                34
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L35"
+              >
+                35
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L36"
+              >
+                36
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L37"
+              >
+                37
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L38"
+              >
+                38
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L39"
+              >
+                39
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L40"
+              >
+                40
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L41"
+              >
+                41
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L42"
+              >
+                42
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L43"
+              >
+                43
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L44"
+              >
+                44
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L45"
+              >
+                45
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L46"
+              >
+                46
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L47"
+              >
+                47
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L48"
+              >
+                48
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L49"
+              >
+                49
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L50"
+              >
+                50
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L51"
+              >
+                51
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L52"
+              >
+                52
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L53"
+              >
+                53
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L54"
+              >
+                54
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L55"
+              >
+                55
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L56"
+              >
+                56
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L57"
+              >
+                57
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L58"
+              >
+                58
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L59"
+              >
+                59
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L60"
+              >
+                60
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L61"
+              >
+                61
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L62"
+              >
+                62
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L63"
+              >
+                63
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L64"
+              >
+                64
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L65"
+              >
+                65
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L66"
+              >
+                66
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L67"
+              >
+                67
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L68"
+              >
+                68
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L69"
+              >
+                69
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L70"
+              >
+                70
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L71"
+              >
+                71
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L72"
+              >
+                72
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L73"
+              >
+                73
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L74"
+              >
+                74
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L75"
+              >
+                75
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L76"
+              >
+                76
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L77"
+              >
+                77
+              </a>
+              
+          
+            </span>
+            <span
+              class="k-line"
+            >
+              
+            
+              <a
+                class="k-line-anchor"
+                id="code-block-data-plane-L78"
+              >
+                78
+              </a>
+              
+          
+            </span>
+            
+            
+        
+          </span>
+          
+        
+          <code
+            class="language-yaml"
+          >
+            <span
+              class="token key atrule"
+            >
+              type
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             DataplaneOverview
+
+            <span
+              class="token key atrule"
+            >
+              mesh
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             test
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+            mesh
+
+            <span
+              class="token key atrule"
+            >
+              name
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             backend
+
+            <span
+              class="token key atrule"
+            >
+              dataplane
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+  
+            <span
+              class="token key atrule"
+            >
+              networking
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+    
+            <span
+              class="token key atrule"
+            >
+              address
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             127.0.0.1
+    
+            <span
+              class="token key atrule"
+            >
+              inbound
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+      
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+             
+            <span
+              class="token key atrule"
+            >
+              port
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token number"
+            >
+              7776
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              servicePort
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token number"
+            >
+              7777
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              serviceAddress
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             127.0.0.1
+        
+            <span
+              class="token key atrule"
+            >
+              tags
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              kuma.io/protocol
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             http
+          
+            <span
+              class="token key atrule"
+            >
+              kuma.io/service
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             backend
+    
+            <span
+              class="token key atrule"
+            >
+              outbound
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+      
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+             
+            <span
+              class="token key atrule"
+            >
+              port
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token number"
+            >
+              10001
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              tags
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              kuma.io/service
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             frontend
+
+            <span
+              class="token key atrule"
+            >
+              dataplaneInsight
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+  
+            <span
+              class="token key atrule"
+            >
+              subscriptions
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+    
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+             
+            <span
+              class="token key atrule"
+            >
+              id
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             118b4d6f
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+            7a98
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+            4172
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+            96d9
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+            85ffb8b20b16
+      
+            <span
+              class="token key atrule"
+            >
+              controlPlaneInstanceId
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             foo
+      
+            <span
+              class="token key atrule"
+            >
+              connectTime
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2021-02-17T07:33:36.412683Z'
+            </span>
+            
+      
+            <span
+              class="token key atrule"
+            >
+              disconnectTime
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2021-02-17T07:33:36.412683Z'
+            </span>
+            
+      
+            <span
+              class="token key atrule"
+            >
+              status
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              lastUpdateTime
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2021-02-17T10:48:03.638434Z'
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              total
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesSent
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '5'
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesAcknowledged
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '5'
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              cds
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesSent
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '1'
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesAcknowledged
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '1'
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              eds
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesSent
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2'
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesAcknowledged
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2'
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              lds
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesSent
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2'
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesAcknowledged
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2'
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              rds
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token punctuation"
+            >
+              {
+            </span>
+            <span
+              class="token punctuation"
+            >
+              }
+            </span>
+            
+      
+            <span
+              class="token key atrule"
+            >
+              version
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              kumaDp
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              version
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             1.0.7
+          
+            <span
+              class="token key atrule"
+            >
+              gitTag
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             unknown
+          
+            <span
+              class="token key atrule"
+            >
+              gitCommit
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             unknown
+          
+            <span
+              class="token key atrule"
+            >
+              buildDate
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             unknown
+        
+            <span
+              class="token key atrule"
+            >
+              envoy
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              version
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             1.16.2
+          
+            <span
+              class="token key atrule"
+            >
+              build
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL
+        
+            <span
+              class="token key atrule"
+            >
+              dependencies
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              coredns
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             1.8.3
+    
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+             
+            <span
+              class="token key atrule"
+            >
+              id
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             118b4d6f
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+            7a98
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+            4172
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+            96d9
+            <span
+              class="token punctuation"
+            >
+              -
+            </span>
+            85ffb8b20b16
+      
+            <span
+              class="token key atrule"
+            >
+              controlPlaneInstanceId
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             foo
+      
+            <span
+              class="token key atrule"
+            >
+              connectTime
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2021-02-17T07:33:36.412683Z'
+            </span>
+            
+      
+            <span
+              class="token key atrule"
+            >
+              status
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              lastUpdateTime
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2021-02-17T10:48:03.638434Z'
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              total
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesSent
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '5'
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesAcknowledged
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '5'
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              cds
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesSent
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '1'
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesAcknowledged
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '1'
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              eds
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesSent
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2'
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesAcknowledged
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2'
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              lds
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesSent
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2'
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              responsesAcknowledged
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token string"
+            >
+              '2'
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              rds
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             
+            <span
+              class="token punctuation"
+            >
+              {
+            </span>
+            <span
+              class="token punctuation"
+            >
+              }
+            </span>
+            
+      
+            <span
+              class="token key atrule"
+            >
+              version
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+        
+            <span
+              class="token key atrule"
+            >
+              kumaDp
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              version
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             1.0.7
+          
+            <span
+              class="token key atrule"
+            >
+              gitTag
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             unknown
+          
+            <span
+              class="token key atrule"
+            >
+              gitCommit
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             unknown
+          
+            <span
+              class="token key atrule"
+            >
+              buildDate
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             unknown
+        
+            <span
+              class="token key atrule"
+            >
+              envoy
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              version
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             1.16.2
+          
+            <span
+              class="token key atrule"
+            >
+              build
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL
+        
+            <span
+              class="token key atrule"
+            >
+              dependencies
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+            
+          
+            <span
+              class="token key atrule"
+            >
+              coredns
+            </span>
+            <span
+              class="token punctuation"
+            >
+              :
+            </span>
+             1.8.3
+          </code>
+          
+      
+        </pre>
+        <div
+          class="k-code-block-secondary-actions"
+        >
+          <button
+            class="k-button small outline k-code-block-copy-button"
+            data-testid="k-code-block-copy-button"
+            title="Copy (Alt+C)"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+            <span
+              class="kong-icon kong-icon-copy"
+            >
+              <svg
+                height="16px"
+                role="img"
+                viewBox="0 0 32 32"
+                width="16px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                
+  
+                <title>
+                  Copy (Alt+C)
+                </title>
+                
+  
+                <path
+                  d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
+                  fill="currentColor"
+                />
+                
+
+              </svg>
+              
+
+            </span>
+            <span
+              class="visually-hidden"
+            >
+              Copy
+            </span>
+            
+            <!---->
+          </button>
+          
+          
+          
+          <button
+            class="k-button small outline copy-button non-visual-button"
+            data-testid="copy-button"
+            title="Copy as Kubernetes"
+            type="button"
+          >
+            
+            <!---->
+            
+            
+            <span
+              class="kong-icon kong-icon-copy"
+            >
+              <svg
+                height="18"
+                role="img"
+                viewBox="0 0 32 32"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                
+  
+                <title>
+                  Copy as Kubernetes
+                </title>
+                
+  
+                <path
+                  d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
+                  fill="currentColor"
+                />
+                
+
+              </svg>
+              
+
+            </span>
+            
+            as k8s
+            
+            
+            <!---->
+          </button>
+          
+          
+          
+        </div>
+      </div>
     </div>
+    
+    
+  </div>
+  <div
+    aria-labelledby="insights-tab"
+    class="tab-container"
+    id="panel-1"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <!---->
+  </div>
+  <div
+    aria-labelledby="dpp-policies-tab"
+    class="tab-container"
+    id="panel-2"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <!---->
+  </div>
+  <div
+    aria-labelledby="xds-configuration-tab"
+    class="tab-container"
+    id="panel-3"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <!---->
+  </div>
+  <div
+    aria-labelledby="envoy-stats-tab"
+    class="tab-container"
+    id="panel-4"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <!---->
+  </div>
+  <div
+    aria-labelledby="envoy-clusters-tab"
+    class="tab-container"
+    id="panel-5"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <!---->
+  </div>
+  <div
+    aria-labelledby="mtls-tab"
+    class="tab-container"
+    id="panel-6"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <!---->
   </div>
   
 </div>

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -29,21 +29,20 @@
         v-slot="{ data, isLoading, error }: DataplaneOverviewSource"
         :src="`/meshes/${route.params.mesh}/dataplane-overviews/${route.params.dataPlane}`"
       >
-        <div class="kcard-border">
-          <LoadingBlock v-if="isLoading" />
+        <LoadingBlock v-if="isLoading" />
 
-          <ErrorBlock
-            v-else-if="error"
-            :error="error"
-          />
+        <ErrorBlock
+          v-else-if="error"
+          :error="error"
+        />
 
-          <EmptyBlock v-else-if="data === undefined" />
+        <EmptyBlock v-else-if="data === undefined" />
 
-          <DataPlaneDetails
-            v-else
-            :dataplane-overview="data"
-          />
-        </div>
+        <DataPlaneDetails
+          v-else
+          :dataplane-overview="data"
+          data-testid="detail-view-details"
+        />
       </DataSource>
     </AppView>
   </RouteView>

--- a/src/app/policies/components/PolicyDetails.vue
+++ b/src/app/policies/components/PolicyDetails.vue
@@ -1,24 +1,22 @@
 <template>
-  <div class="policy-details kcard-border">
-    <TabsWidget :tabs="tabs">
-      <template #overview>
-        <ResourceCodeBlock
-          id="code-block-policy"
-          :resource="props.policy"
-          :resource-fetcher="fetchPolicy"
-          is-searchable
-        />
-      </template>
+  <TabsWidget :tabs="tabs">
+    <template #overview>
+      <ResourceCodeBlock
+        id="code-block-policy"
+        :resource="props.policy"
+        :resource-fetcher="fetchPolicy"
+        is-searchable
+      />
+    </template>
 
-      <template #affected-dpps>
-        <PolicyConnections
-          :mesh="props.policy.mesh"
-          :policy-name="props.policy.name"
-          :policy-path="props.path"
-        />
-      </template>
-    </TabsWidget>
-  </div>
+    <template #affected-dpps>
+      <PolicyConnections
+        :mesh="props.policy.mesh"
+        :policy-name="props.policy.name"
+        :policy-path="props.path"
+      />
+    </template>
+  </TabsWidget>
 </template>
 
 <script lang="ts" setup>

--- a/src/app/zones/components/ZoneDetails.vue
+++ b/src/app/zones/components/ZoneDetails.vue
@@ -1,39 +1,43 @@
 <template>
   <TabsWidget :tabs="filteredTabs">
     <template #overview>
-      <DefinitionList>
-        <DefinitionListItem
-          v-for="(value, property) in processedZoneOverview"
-          :key="property"
-          :term="t(`http.api.property.${property}`)"
-        >
-          <KBadge
-            v-if="property === 'status'"
-            :appearance="value === 'offline' ? 'danger' : 'success'"
-          >
-            {{ value }}
-          </KBadge>
-
-          <template v-else-if="property === 'name'">
-            <TextWithCopyButton :text="props.zoneOverview.name">
-              <RouterLink
-                :to="{
-                  name: 'zone-cp-detail-view',
-                  params: {
-                    zone: props.zoneOverview.name,
-                  },
-                }"
+      <KCard>
+        <template #body>
+          <DefinitionList>
+            <DefinitionListItem
+              v-for="(value, property) in processedZoneOverview"
+              :key="property"
+              :term="t(`http.api.property.${property}`)"
+            >
+              <KBadge
+                v-if="property === 'status'"
+                :appearance="value === 'offline' ? 'danger' : 'success'"
               >
-                {{ props.zoneOverview.name }}
-              </RouterLink>
-            </TextWithCopyButton>
-          </template>
+                {{ value }}
+              </KBadge>
 
-          <template v-else>
-            {{ value }}
-          </template>
-        </DefinitionListItem>
-      </DefinitionList>
+              <template v-else-if="property === 'name'">
+                <TextWithCopyButton :text="props.zoneOverview.name">
+                  <RouterLink
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: props.zoneOverview.name,
+                      },
+                    }"
+                  >
+                    {{ props.zoneOverview.name }}
+                  </RouterLink>
+                </TextWithCopyButton>
+              </template>
+
+              <template v-else>
+                {{ value }}
+              </template>
+            </DefinitionListItem>
+          </DefinitionList>
+        </template>
+      </KCard>
     </template>
 
     <template #insights>
@@ -80,7 +84,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KBadge, KAlert } from '@kong/kongponents'
+import { KAlert, KBadge, KCard } from '@kong/kongponents'
 import { computed, PropType } from 'vue'
 
 import AccordionItem from '@/app/common/AccordionItem.vue'

--- a/src/app/zones/components/ZoneEgressDetails.vue
+++ b/src/app/zones/components/ZoneEgressDetails.vue
@@ -1,32 +1,36 @@
 <template>
   <TabsWidget :tabs="TABS">
     <template #overview>
-      <DefinitionList>
-        <DefinitionListItem
-          v-for="(value, property) in processedZoneEgressOverview"
-          :key="property"
-          :term="t(`http.api.property.${property}`)"
-        >
-          <template v-if="property === 'name'">
-            <TextWithCopyButton :text="props.zoneEgressOverview.name">
-              <RouterLink
-                :to="{
-                  name: 'zone-egress-detail-view',
-                  params: {
-                    zoneEgress: props.zoneEgressOverview.name,
-                  },
-                }"
-              >
-                {{ props.zoneEgressOverview.name }}
-              </RouterLink>
-            </TextWithCopyButton>
-          </template>
+      <KCard>
+        <template #body>
+          <DefinitionList>
+            <DefinitionListItem
+              v-for="(value, property) in processedZoneEgressOverview"
+              :key="property"
+              :term="t(`http.api.property.${property}`)"
+            >
+              <template v-if="property === 'name'">
+                <TextWithCopyButton :text="props.zoneEgressOverview.name">
+                  <RouterLink
+                    :to="{
+                      name: 'zone-egress-detail-view',
+                      params: {
+                        zoneEgress: props.zoneEgressOverview.name,
+                      },
+                    }"
+                  >
+                    {{ props.zoneEgressOverview.name }}
+                  </RouterLink>
+                </TextWithCopyButton>
+              </template>
 
-          <template v-else>
-            {{ value }}
-          </template>
-        </DefinitionListItem>
-      </DefinitionList>
+              <template v-else>
+                {{ value }}
+              </template>
+            </DefinitionListItem>
+          </DefinitionList>
+        </template>
+      </KCard>
     </template>
 
     <template #insights>
@@ -76,6 +80,7 @@
 </template>
 
 <script lang="ts" setup>
+import { KCard } from '@kong/kongponents'
 import { computed, PropType } from 'vue'
 
 import AccordionItem from '@/app/common/AccordionItem.vue'

--- a/src/app/zones/components/ZoneIngressDetails.vue
+++ b/src/app/zones/components/ZoneIngressDetails.vue
@@ -1,32 +1,36 @@
 <template>
   <TabsWidget :tabs="TABS">
     <template #overview>
-      <DefinitionList>
-        <DefinitionListItem
-          v-for="(value, property) in processedZoneIngressOverview"
-          :key="property"
-          :term="t(`http.api.property.${property}`)"
-        >
-          <template v-if="property === 'name'">
-            <TextWithCopyButton :text="props.zoneIngressOverview.name">
-              <RouterLink
-                :to="{
-                  name: 'zone-ingress-detail-view',
-                  params: {
-                    zoneIngress: props.zoneIngressOverview.name,
-                  },
-                }"
-              >
-                {{ props.zoneIngressOverview.name }}
-              </RouterLink>
-            </TextWithCopyButton>
-          </template>
+      <KCard>
+        <template #body>
+          <DefinitionList>
+            <DefinitionListItem
+              v-for="(value, property) in processedZoneIngressOverview"
+              :key="property"
+              :term="t(`http.api.property.${property}`)"
+            >
+              <template v-if="property === 'name'">
+                <TextWithCopyButton :text="props.zoneIngressOverview.name">
+                  <RouterLink
+                    :to="{
+                      name: 'zone-ingress-detail-view',
+                      params: {
+                        zoneIngress: props.zoneIngressOverview.name,
+                      },
+                    }"
+                  >
+                    {{ props.zoneIngressOverview.name }}
+                  </RouterLink>
+                </TextWithCopyButton>
+              </template>
 
-          <template v-else>
-            {{ value }}
-          </template>
-        </DefinitionListItem>
-      </DefinitionList>
+              <template v-else>
+                {{ value }}
+              </template>
+            </DefinitionListItem>
+          </DefinitionList>
+        </template>
+      </KCard>
     </template>
 
     <template #insights>
@@ -76,6 +80,7 @@
 </template>
 
 <script lang="ts" setup>
+import { KCard } from '@kong/kongponents'
 import { computed, PropType } from 'vue'
 
 import AccordionItem from '@/app/common/AccordionItem.vue'

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -36,13 +36,11 @@
 
         <EmptyBlock v-else-if="data === undefined" />
 
-        <div
+        <ZoneDetails
           v-else
-          class="kcard-border"
+          :zone-overview="data"
           data-testid="detail-view-details"
-        >
-          <ZoneDetails :zone-overview="data" />
-        </div>
+        />
       </DataSource>
     </AppView>
   </RouteView>

--- a/src/app/zones/views/ZoneEgressDetailView.vue
+++ b/src/app/zones/views/ZoneEgressDetailView.vue
@@ -36,13 +36,11 @@
 
         <EmptyBlock v-else-if="data === undefined" />
 
-        <div
+        <ZoneEgressDetails
           v-else
-          class="kcard-border"
+          :zone-egress-overview="data"
           data-testid="detail-view-details"
-        >
-          <ZoneEgressDetails :zone-egress-overview="data" />
-        </div>
+        />
       </DataSource>
     </AppView>
   </RouteView>

--- a/src/app/zones/views/ZoneIngressDetailView.vue
+++ b/src/app/zones/views/ZoneIngressDetailView.vue
@@ -36,13 +36,11 @@
 
         <EmptyBlock v-else-if="data === undefined" />
 
-        <div
+        <ZoneIngressDetails
           v-else
-          class="kcard-border"
+          :zone-ingress-overview="data"
           data-testid="detail-view-details"
-        >
-          <ZoneIngressDetails :zone-ingress-overview="data" />
-        </div>
+        />
       </DataSource>
     </AppView>
   </RouteView>

--- a/src/assets/styles/_components.scss
+++ b/src/assets/styles/_components.scss
@@ -1,16 +1,4 @@
 /*
-.kcard-border
-
-To be used in places where we solely need KCard’s frame properties.
-*/
-
-.kcard-border {
-  border: var(--KCardBorder);
-  border-radius: var(--KCardBorderRadius);
-  background-color: var(--KCardBackground);
-}
-
-/*
 .stack
 
 For stacking elements with consistent space between.


### PR DESCRIPTION
## Changes

Standardizes the usage of the TabsWidget component to not include a KCard as the new detail view designs don’t have a card around all of their content (though sometimes parts of it).

Removes a bunch of code from the TabsWidget component that we were already not using anymore.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

- The biggest contributor to the number of lines changed is a regenerated snapshot for a snapshot test. When I’ll work on implementing a new design for Data Plane Proxies, I’ll add some tests and remove the snapshot test for that component.