### PR TITLE
feat: implements new zone details designs

### DIFF
--- a/features/zones/zone-cps/Item.feature
+++ b/features/zones/zone-cps/Item.feature
@@ -4,10 +4,8 @@ Feature: zones / zone-cps / item
       | Alias                          | Selector                                 |
       | zone-control-plane-detail-view | [data-testid='zone-cp-detail-view']      |
       | nav-insights                   | #insights-tab                            |
-      | nav-config                     | #config-tab                              |
       | tab-overview                   | #panel-0                                 |
       | tab-insights                   | #panel-1                                 |
-      | tab-config                     | #panel-2                                 |
       | warning-no-subscriptions       | [data-testid='warning-no-subscriptions'] |
 
     And the URL "/config" responds with
@@ -26,6 +24,8 @@ Feature: zones / zone-cps / item
       """
       body:
         name: zone-cp-1
+        zone:
+          enabled: true
         zoneInsight:
           subscriptions:
             - connectTime: 2020-07-28T16:18:09.743141Z
@@ -33,24 +33,21 @@ Feature: zones / zone-cps / item
             - connectTime: 2020-07-28T16:18:09.743141Z
               disconnectTime: ~
               config: |
-                {"dpServer": {"auth": {"type": "dpToken"}}}
+                { "environment": "universal", "dpServer": { "auth": { "type": "dpToken" } } }
       """
 
     When I visit the "/zones/zone-cps/zone-cp-1" URL
-    Then the page title contains "Zone Control Plane"
+    Then the page title contains "zone-cp-1 Zone Control Plane"
     Then the "$zone-control-plane-detail-view" element contains "zone-cp-1 Zone Control Plane"
 
     Then the "$tab-overview" element contains
-      | Value        |
-      | ZoneOverview |
-      | online       |
-      | dpToken      |
+      | Value     |
+      | universal |
+      | online    |
+      | dpToken   |
 
     When I click the "$nav-insights" element
     Then the "$tab-insights" element contains "Connect time: Jul 28, 2020, 4:18 PM"
-
-    When I click the "$nav-config" element
-    Then the "$tab-config" element contains "dpToken"
 
   Scenario: When subscriptions aren't set a warning is shown
     And the URL "/zones+insights/zone-cp-1" responds with
@@ -61,5 +58,4 @@ Feature: zones / zone-cps / item
           subscriptions: ~
       """
     When I visit the "/zones/zone-cps/zone-cp-1" URL
-    And I click the "$nav-config" element
     Then the "$warning-no-subscriptions" element exists

--- a/src/app/common/DefinitionCard.vue
+++ b/src/app/common/DefinitionCard.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="definition-card">
+    <div class="definition-card-title">
+      <slot name="icon" />
+
+      <slot name="title" />
+    </div>
+
+    <div class="definition-card-container">
+      <slot name="body" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.definition-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.definition-card-title {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-xs);
+}
+
+.definition-card-container {
+  flex-grow: 1;
+  display: flex;
+  align-items: center;
+  font-size: var(--type-xxl);
+  line-height: 1.5;
+  font-weight: var(--font-weight-bold);
+}
+</style>

--- a/src/app/common/ResourceStatus.vue
+++ b/src/app/common/ResourceStatus.vue
@@ -1,21 +1,28 @@
 <template>
-  <div class="resource-status">
-    <div class="resource-status-title">
+  <DefinitionCard>
+    <template
+      v-if="$slots.icon"
+      #icon
+    >
       <slot name="icon" />
+    </template>
 
+    <template #title>
       <slot name="title" />
-    </div>
+    </template>
 
-    <div class="resource-status-container">
+    <template #body>
       <span v-if="props.online !== null">{{ props.online }}</span><span
         v-if="props.online !== null"
         class="status-separator"
       >/</span><span class="status-total">{{ props.total }}</span>
-    </div>
-  </div>
+    </template>
+  </DefinitionCard>
 </template>
 
 <script lang="ts" setup>
+import DefinitionCard from './DefinitionCard.vue'
+
 const props = defineProps({
   total: {
     type: Number,
@@ -30,22 +37,6 @@ const props = defineProps({
 </script>
 
 <style lang="scss" scoped>
-.resource-status>*+* {
-  margin-top: var(--spacing-xs);
-}
-
-.resource-status-title {
-  display: flex;
-  align-items: flex-end;
-  gap: var(--spacing-xs);
-}
-
-.resource-status-container {
-  font-size: var(--type-xxxl);
-  line-height: 1.5;
-  font-weight: var(--font-weight-bold);
-}
-
 .status-separator,
 .status-separator + .status-total {
   color: var(--black-200);

--- a/src/app/common/subscriptions/SubscriptionHeader.vue
+++ b/src/app/common/subscriptions/SubscriptionHeader.vue
@@ -1,22 +1,18 @@
 <template>
-  <h4 class="text-lg font-medium">
-    <span class="color-green-500">
-      Connect time: {{ formatIsoDate(props.details.connectTime) }}
-    </span>
+  <header class="subscription-header">
+    <span class="status--is-connected">{{ t('zone-cps.detail.connect_time') }}: {{ formatIsoDate(props.details.connectTime) }}</span>
 
     <span
       v-if="props.details.disconnectTime"
-      class="ml-4 color-red-600"
-    >
-      Disconnect time: {{ formatIsoDate(props.details.disconnectTime) }}
-    </span>
-  </h4>
+      class="ml-4 status--is-disconnected"
+    >{{ t('zone-cps.detail.disconnect_time') }}: {{ formatIsoDate(props.details.disconnectTime) }}</span>
+  </header>
 </template>
 
 <script lang="ts" setup>
 import { useI18n } from '@/utilities'
 
-const { formatIsoDate } = useI18n()
+const { t, formatIsoDate } = useI18n()
 
 const props = defineProps({
   details: {
@@ -25,3 +21,20 @@ const props = defineProps({
   },
 })
 </script>
+
+<style lang="scss" scoped>
+.subscription-header {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  font-weight: var(--font-weight-medium);
+}
+
+.status--is-connected {
+  color: var(--green-500);
+}
+
+.status--is-disconnected {
+  color: var(--red-500);
+}
+
+</style>

--- a/src/app/main-overview/components/ControlPlaneDetails.vue
+++ b/src/app/main-overview/components/ControlPlaneDetails.vue
@@ -75,19 +75,6 @@
                 {{ t('main-overview.detail.health.view_all') }}
               </RouterLink>
             </div>
-
-            <div
-              v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
-              class="card-actions"
-            >
-              <KButton
-                appearance="creation"
-                icon="plus"
-                :to="{ name: 'zone-create-view' }"
-              >
-                {{ t('zones.index.create') }}
-              </KButton>
-            </div>
           </div>
 
           <EmptyBlock v-if="props.zoneOverviews.length === 0">
@@ -180,15 +167,6 @@ const meshInsight = computed(() => mergeInsightsReducer(props.meshInsights))
 </script>
 
 <style lang="scss" scoped>
-.variable-columns {
-  display: flex;
-  gap: var(--AppGap);
-}
-
-.variable-columns>* {
-  flex-grow: 1;
-}
-
 .card-header {
   display: flex;
   justify-content: space-between;

--- a/src/app/zones/components/ZoneEgressDetails.vue
+++ b/src/app/zones/components/ZoneEgressDetails.vue
@@ -3,13 +3,23 @@
     <template #overview>
       <KCard>
         <template #body>
-          <DefinitionList>
-            <DefinitionListItem
-              v-for="(value, property) in processedZoneEgressOverview"
-              :key="property"
-              :term="t(`http.api.property.${property}`)"
-            >
-              <template v-if="property === 'name'">
+          <div class="variable-columns">
+            <DefinitionCard>
+              <template #title>
+                {{ t('http.api.property.status') }}
+              </template>
+
+              <template #body>
+                <StatusBadge :status="status" />
+              </template>
+            </DefinitionCard>
+
+            <DefinitionCard>
+              <template #title>
+                {{ t('http.api.property.name') }}
+              </template>
+
+              <template #body>
                 <TextWithCopyButton :text="props.zoneEgressOverview.name">
                   <RouterLink
                     :to="{
@@ -23,12 +33,18 @@
                   </RouterLink>
                 </TextWithCopyButton>
               </template>
+            </DefinitionCard>
 
-              <template v-else>
-                {{ value }}
+            <DefinitionCard>
+              <template #title>
+                {{ t('http.api.property.type') }}
               </template>
-            </DefinitionListItem>
-          </DefinitionList>
+
+              <template #body>
+                {{ props.zoneEgressOverview.type }}
+              </template>
+            </DefinitionCard>
+          </div>
         </template>
       </KCard>
     </template>
@@ -56,7 +72,7 @@
     <template #xds-configuration>
       <EnvoyData
         data-path="xds"
-        :zone-egress-name="processedZoneEgressOverview.name"
+        :zone-egress-name="props.zoneEgressOverview.name"
         query-key="envoy-data-zone-egress"
       />
     </template>
@@ -64,7 +80,7 @@
     <template #envoy-stats>
       <EnvoyData
         data-path="stats"
-        :zone-egress-name="processedZoneEgressOverview.name"
+        :zone-egress-name="props.zoneEgressOverview.name"
         query-key="envoy-data-zone-egress"
       />
     </template>
@@ -72,7 +88,7 @@
     <template #envoy-clusters>
       <EnvoyData
         data-path="clusters"
-        :zone-egress-name="processedZoneEgressOverview.name"
+        :zone-egress-name="props.zoneEgressOverview.name"
         query-key="envoy-data-zone-egress"
       />
     </template>
@@ -85,38 +101,39 @@ import { computed, PropType } from 'vue'
 
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
-import DefinitionList from '@/app/common/DefinitionList.vue'
-import DefinitionListItem from '@/app/common/DefinitionListItem.vue'
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import EnvoyData from '@/app/common/EnvoyData.vue'
+import StatusBadge from '@/app/common/StatusBadge.vue'
 import SubscriptionDetails from '@/app/common/subscriptions/SubscriptionDetails.vue'
 import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { ZoneEgressOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
+import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 const { t } = useI18n()
 
 const TABS = [
   {
     hash: '#overview',
-    title: 'Overview',
+    title: t('zone-egresses.routes.item.tabs.overview'),
   },
   {
     hash: '#insights',
-    title: 'Zone Egress Insights',
+    title: t('zone-egresses.routes.item.tabs.insights'),
   },
   {
     hash: '#xds-configuration',
-    title: 'XDS Configuration',
+    title: t('zone-egresses.routes.item.tabs.xds_configuration'),
   },
   {
     hash: '#envoy-stats',
-    title: 'Stats',
+    title: t('zone-egresses.routes.item.tabs.stats'),
   },
   {
     hash: '#envoy-clusters',
-    title: 'Clusters',
+    title: t('zone-egresses.routes.item.tabs.clusters'),
   },
 ]
 
@@ -127,14 +144,7 @@ const props = defineProps({
   },
 })
 
-const processedZoneEgressOverview = computed(() => {
-  const { type, name } = props.zoneEgressOverview
-
-  return {
-    type,
-    name,
-  }
-})
+const status = computed(() => getItemStatusFromInsight(props.zoneEgressOverview.zoneEgressInsight))
 
 const subscriptionsReversed = computed<any[]>(() => {
   const subscriptions = props.zoneEgressOverview.zoneEgressInsight?.subscriptions ?? []

--- a/src/app/zones/components/ZoneIngressDetails.vue
+++ b/src/app/zones/components/ZoneIngressDetails.vue
@@ -3,13 +3,23 @@
     <template #overview>
       <KCard>
         <template #body>
-          <DefinitionList>
-            <DefinitionListItem
-              v-for="(value, property) in processedZoneIngressOverview"
-              :key="property"
-              :term="t(`http.api.property.${property}`)"
-            >
-              <template v-if="property === 'name'">
+          <div class="variable-columns">
+            <DefinitionCard>
+              <template #title>
+                {{ t('http.api.property.status') }}
+              </template>
+
+              <template #body>
+                <StatusBadge :status="status" />
+              </template>
+            </DefinitionCard>
+
+            <DefinitionCard>
+              <template #title>
+                {{ t('http.api.property.name') }}
+              </template>
+
+              <template #body>
                 <TextWithCopyButton :text="props.zoneIngressOverview.name">
                   <RouterLink
                     :to="{
@@ -23,12 +33,18 @@
                   </RouterLink>
                 </TextWithCopyButton>
               </template>
+            </DefinitionCard>
 
-              <template v-else>
-                {{ value }}
+            <DefinitionCard>
+              <template #title>
+                {{ t('http.api.property.type') }}
               </template>
-            </DefinitionListItem>
-          </DefinitionList>
+
+              <template #body>
+                {{ props.zoneIngressOverview.type }}
+              </template>
+            </DefinitionCard>
+          </div>
         </template>
       </KCard>
     </template>
@@ -56,7 +72,7 @@
     <template #xds-configuration>
       <EnvoyData
         data-path="xds"
-        :zone-ingress-name="processedZoneIngressOverview.name"
+        :zone-ingress-name="props.zoneIngressOverview.name"
         query-key="envoy-data-zone-ingress"
       />
     </template>
@@ -64,7 +80,7 @@
     <template #envoy-stats>
       <EnvoyData
         data-path="stats"
-        :zone-ingress-name="processedZoneIngressOverview.name"
+        :zone-ingress-name="props.zoneIngressOverview.name"
         query-key="envoy-data-zone-ingress"
       />
     </template>
@@ -72,7 +88,7 @@
     <template #envoy-clusters>
       <EnvoyData
         data-path="clusters"
-        :zone-ingress-name="processedZoneIngressOverview.name"
+        :zone-ingress-name="props.zoneIngressOverview.name"
         query-key="envoy-data-zone-ingress"
       />
     </template>
@@ -85,37 +101,38 @@ import { computed, PropType } from 'vue'
 
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
-import DefinitionList from '@/app/common/DefinitionList.vue'
-import DefinitionListItem from '@/app/common/DefinitionListItem.vue'
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import EnvoyData from '@/app/common/EnvoyData.vue'
+import StatusBadge from '@/app/common/StatusBadge.vue'
 import SubscriptionDetails from '@/app/common/subscriptions/SubscriptionDetails.vue'
 import SubscriptionHeader from '@/app/common/subscriptions/SubscriptionHeader.vue'
 import TabsWidget from '@/app/common/TabsWidget.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { ZoneIngressOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
+import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 const { t } = useI18n()
 const TABS = [
   {
     hash: '#overview',
-    title: 'Overview',
+    title: t('zone-ingresses.routes.item.tabs.overview'),
   },
   {
     hash: '#insights',
-    title: 'Zone Ingress Insights',
+    title: t('zone-ingresses.routes.item.tabs.insights'),
   },
   {
     hash: '#xds-configuration',
-    title: 'XDS Configuration',
+    title: t('zone-ingresses.routes.item.tabs.xds_configuration'),
   },
   {
     hash: '#envoy-stats',
-    title: 'Stats',
+    title: t('zone-ingresses.routes.item.tabs.stats'),
   },
   {
     hash: '#envoy-clusters',
-    title: 'Clusters',
+    title: t('zone-ingresses.routes.item.tabs.clusters'),
   },
 ]
 
@@ -126,14 +143,7 @@ const props = defineProps({
   },
 })
 
-const processedZoneIngressOverview = computed(() => {
-  const { type, name } = props.zoneIngressOverview
-
-  return {
-    type,
-    name,
-  }
-})
+const status = computed(() => getItemStatusFromInsight(props.zoneIngressOverview.zoneIngressInsight))
 
 const subscriptionsReversed = computed<any[]>(() => {
   const subscriptions = props.zoneIngressOverview.zoneIngressInsight?.subscriptions ?? []

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -1,21 +1,33 @@
 zone-cps:
   routes:
     item:
-      title: "{name} Zone Control Plane"
+      title: '{name} Zone Control Plane'
       breadcrumbs: Zone Control Planes
-      config:
-        no-subscriptions: This zone has no subscriptions
+      tabs:
+        overview: 'Overview'
+        insights: 'Zone insights'
     items:
       title: Zone Control Planes
       breadcrumbs: Zone Control Planes
   list:
     version_mismatch: 'Version mismatch'
+  detail:
+    configuration_title: 'Configuration'
+    no_subscriptions: 'This zone has no subscriptions'
+    connect_time: 'Connect time'
+    disconnect_time: 'Disconnect time'
 
 zone-ingresses:
   routes:
     item:
-      title: "{name} Zone Ingress"
+      title: '{name} Zone Ingress'
       breadcrumbs: Ingresses
+      tabs:
+        overview: 'Overview'
+        insights: 'Zone Ingress insights'
+        xds_configuration: 'XDS Configuration'
+        stats: 'Stats'
+        clusters: 'Clusters'
     items:
       title: Ingresses
       breadcrumbs: Ingresses
@@ -23,8 +35,14 @@ zone-ingresses:
 zone-egresses:
   routes:
     item:
-      title: "{name} Zone Egress"
+      title: '{name} Zone Egress'
       breadcrumbs: Egresses
+      tabs:
+        overview: 'Overview'
+        insights: 'Zone Egress insights'
+        xds_configuration: 'XDS Configuration'
+        stats: 'Stats'
+        clusters: 'Clusters'
     items:
       title: Egresses
       breadcrumbs: Egresses

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -17,86 +17,82 @@
         v-slot="{ data, error }: ZoneEgressOverviewCollectionSource"
         :src="`/zone-egresses?size=${props.size}&page=${props.page}`"
       >
-        <KCard>
-          <template #body>
-            <AppCollection
-              class="zone-egress-collection"
-              data-testid="zone-egress-collection"
-              :headers="[
-                { label: 'Name', key: 'name' },
-                { label: 'Status', key: 'status' },
-                { label: 'Actions', key: 'actions', hideLabel: true },
-              ]"
-              :page-number="props.page"
-              :page-size="props.size"
-              :total="data?.total"
-              :items="data ? transformToTableData(data.items) : undefined"
-              :error="error"
-              @change="route.update"
+        <AppCollection
+          class="zone-egress-collection"
+          data-testid="zone-egress-collection"
+          :headers="[
+            { label: 'Name', key: 'name' },
+            { label: 'Status', key: 'status' },
+            { label: 'Actions', key: 'actions', hideLabel: true },
+          ]"
+          :page-number="props.page"
+          :page-size="props.size"
+          :total="data?.total"
+          :items="data ? transformToTableData(data.items) : undefined"
+          :error="error"
+          @change="route.update"
+        >
+          <template #name="{ row, rowValue }">
+            <RouterLink
+              :to="row.detailViewRoute"
+              data-testid="detail-view-link"
             >
-              <template #name="{ row, rowValue }">
-                <RouterLink
-                  :to="row.detailViewRoute"
-                  data-testid="detail-view-link"
+              {{ rowValue }}
+            </RouterLink>
+          </template>
+
+          <template #status="{ rowValue }">
+            <StatusBadge
+              v-if="rowValue"
+              :status="rowValue"
+            />
+
+            <template v-else>
+              {{ t('common.collection.none') }}
+            </template>
+          </template>
+
+          <template #actions="{ row }">
+            <KDropdownMenu
+              class="actions-dropdown"
+              data-testid="actions-dropdown"
+              :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
+              width="150"
+            >
+              <template #default>
+                <KButton
+                  class="non-visual-button"
+                  appearance="secondary"
+                  size="small"
                 >
-                  {{ rowValue }}
-                </RouterLink>
-              </template>
-
-              <template #status="{ rowValue }">
-                <StatusBadge
-                  v-if="rowValue"
-                  :status="rowValue"
-                />
-
-                <template v-else>
-                  {{ t('common.collection.none') }}
-                </template>
-              </template>
-
-              <template #actions="{ row }">
-                <KDropdownMenu
-                  class="actions-dropdown"
-                  data-testid="actions-dropdown"
-                  :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
-                  width="150"
-                >
-                  <template #default>
-                    <KButton
-                      class="non-visual-button"
-                      appearance="secondary"
-                      size="small"
-                    >
-                      <template #icon>
-                        <KIcon
-                          color="var(--black-400)"
-                          icon="more"
-                          size="16"
-                        />
-                      </template>
-                    </KButton>
-                  </template>
-
-                  <template #items>
-                    <KDropdownItem
-                      :item="{
-                        to: row.detailViewRoute,
-                        label: t('common.collection.actions.view'),
-                      }"
+                  <template #icon>
+                    <KIcon
+                      color="var(--black-400)"
+                      icon="more"
+                      size="16"
                     />
                   </template>
-                </KDropdownMenu>
+                </KButton>
               </template>
-            </AppCollection>
+
+              <template #items>
+                <KDropdownItem
+                  :item="{
+                    to: row.detailViewRoute,
+                    label: t('common.collection.actions.view'),
+                  }"
+                />
+              </template>
+            </KDropdownMenu>
           </template>
-        </KCard>
+        </AppCollection>
       </DataSource>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
+import { KButton, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
 import { RouteLocationNamedRaw } from 'vue-router'
 
 import type { ZoneEgressOverviewCollectionSource } from '../sources'

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -20,79 +20,75 @@
           v-slot="{ data, error }: ZoneIngressOverviewCollectionSource"
           :src="`/zone-ingresses?size=${props.size}&page=${props.page}`"
         >
-          <KCard>
-            <template #body>
-              <AppCollection
-                class="zone-ingress-collection"
-                data-testid="zone-ingress-collection"
-                :headers="[
-                  { label: 'Name', key: 'name' },
-                  { label: 'Status', key: 'status' },
-                  { label: 'Actions', key: 'actions', hideLabel: true },
-                ]"
-                :page-number="props.page"
-                :page-size="props.size"
-                :total="data?.total"
-                :items="data ? transformToTableData(data.items) : undefined"
-                :error="error"
-                @change="route.update"
+          <AppCollection
+            class="zone-ingress-collection"
+            data-testid="zone-ingress-collection"
+            :headers="[
+              { label: 'Name', key: 'name' },
+              { label: 'Status', key: 'status' },
+              { label: 'Actions', key: 'actions', hideLabel: true },
+            ]"
+            :page-number="props.page"
+            :page-size="props.size"
+            :total="data?.total"
+            :items="data ? transformToTableData(data.items) : undefined"
+            :error="error"
+            @change="route.update"
+          >
+            <template #name="{ row, rowValue }">
+              <RouterLink
+                :to="row.detailViewRoute"
+                data-testid="detail-view-link"
               >
-                <template #name="{ row, rowValue }">
-                  <RouterLink
-                    :to="row.detailViewRoute"
-                    data-testid="detail-view-link"
+                {{ rowValue }}
+              </RouterLink>
+            </template>
+
+            <template #status="{ rowValue }">
+              <StatusBadge
+                v-if="rowValue"
+                :status="rowValue"
+              />
+
+              <template v-else>
+                {{ t('common.collection.none') }}
+              </template>
+            </template>
+
+            <template #actions="{ row }">
+              <KDropdownMenu
+                class="actions-dropdown"
+                data-testid="actions-dropdown"
+                :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
+                width="150"
+              >
+                <template #default>
+                  <KButton
+                    class="non-visual-button"
+                    appearance="secondary"
+                    size="small"
                   >
-                    {{ rowValue }}
-                  </RouterLink>
-                </template>
-
-                <template #status="{ rowValue }">
-                  <StatusBadge
-                    v-if="rowValue"
-                    :status="rowValue"
-                  />
-
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-
-                <template #actions="{ row }">
-                  <KDropdownMenu
-                    class="actions-dropdown"
-                    data-testid="actions-dropdown"
-                    :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
-                    width="150"
-                  >
-                    <template #default>
-                      <KButton
-                        class="non-visual-button"
-                        appearance="secondary"
-                        size="small"
-                      >
-                        <template #icon>
-                          <KIcon
-                            color="var(--black-400)"
-                            icon="more"
-                            size="16"
-                          />
-                        </template>
-                      </KButton>
-                    </template>
-
-                    <template #items>
-                      <KDropdownItem
-                        :item="{
-                          to: row.detailViewRoute,
-                          label: t('common.collection.actions.view'),
-                        }"
+                    <template #icon>
+                      <KIcon
+                        color="var(--black-400)"
+                        icon="more"
+                        size="16"
                       />
                     </template>
-                  </KDropdownMenu>
+                  </KButton>
                 </template>
-              </AppCollection>
+
+                <template #items>
+                  <KDropdownItem
+                    :item="{
+                      to: row.detailViewRoute,
+                      label: t('common.collection.actions.view'),
+                    }"
+                  />
+                </template>
+              </KDropdownMenu>
             </template>
-          </KCard>
+          </AppCollection>
         </DataSource>
       </template>
     </AppView>
@@ -100,7 +96,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
+import { KButton, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
 import { RouteLocationNamedRaw } from 'vue-router'
 
 import MultizoneInfo from '../components/MultizoneInfo.vue'

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -34,120 +34,116 @@
           v-slot="{ data, error, refresh }: ZoneOverviewCollectionSource"
           :src="`/zone-cps?size=${props.size}&page=${props.page}`"
         >
-          <KCard>
-            <template #body>
-              <AppCollection
-                class="zone-cp-collection"
-                data-testid="zone-cp-collection"
-                :headers="[
-                  { label: 'Name', key: 'name' },
-                  { label: 'Zone CP Version', key: 'zoneCpVersion' },
-                  { label: 'Type', key: 'type' },
-                  { label: 'Status', key: 'status' },
-                  { label: 'Warnings', key: 'warnings', hideLabel: true },
-                  { label: 'Actions', key: 'actions', hideLabel: true },
-                ]"
-                :page-number="props.page"
-                :page-size="props.size"
-                :total="data?.total"
-                :items="data ? transformToTableData(data.items) : undefined"
-                :error="error"
-                @change="route.update"
+          <AppCollection
+            class="zone-cp-collection"
+            data-testid="zone-cp-collection"
+            :headers="[
+              { label: 'Name', key: 'name' },
+              { label: 'Zone CP Version', key: 'zoneCpVersion' },
+              { label: 'Type', key: 'type' },
+              { label: 'Status', key: 'status' },
+              { label: 'Warnings', key: 'warnings', hideLabel: true },
+              { label: 'Actions', key: 'actions', hideLabel: true },
+            ]"
+            :page-number="props.page"
+            :page-size="props.size"
+            :total="data?.total"
+            :items="data ? transformToTableData(data.items) : undefined"
+            :error="error"
+            @change="route.update"
+          >
+            <template #name="{ row, rowValue }">
+              <RouterLink
+                :to="row.detailViewRoute"
+                data-testid="detail-view-link"
               >
-                <template #name="{ row, rowValue }">
-                  <RouterLink
-                    :to="row.detailViewRoute"
-                    data-testid="detail-view-link"
+                {{ rowValue }}
+              </RouterLink>
+            </template>
+
+            <template #zoneCpVersion="{ rowValue }">
+              {{ rowValue || t('common.collection.none') }}
+            </template>
+
+            <template #type="{ rowValue }">
+              {{ rowValue || t('common.collection.none') }}
+            </template>
+
+            <template #status="{ rowValue }">
+              <StatusBadge
+                v-if="rowValue"
+                :status="rowValue"
+              />
+
+              <template v-else>
+                {{ t('common.collection.none') }}
+              </template>
+            </template>
+
+            <template #warnings="{ rowValue }">
+              <KTooltip
+                v-if="rowValue"
+                :label="t('zone-cps.list.version_mismatch')"
+              >
+                <KIcon
+                  class="mr-1"
+                  icon="warning"
+                  color="var(--black-500)"
+                  secondary-color="var(--yellow-300)"
+                  size="20"
+                  hide-title
+                />
+              </KTooltip>
+
+              <template v-else>
+                {{ t('common.collection.none') }}
+              </template>
+            </template>
+
+            <template #actions="{ row }">
+              <KDropdownMenu
+                class="actions-dropdown"
+                data-testid="actions-dropdown"
+                :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
+                width="150"
+              >
+                <template #default>
+                  <KButton
+                    class="non-visual-button"
+                    appearance="secondary"
+                    size="small"
                   >
-                    {{ rowValue }}
-                  </RouterLink>
+                    <template #icon>
+                      <KIcon
+                        color="var(--black-400)"
+                        icon="more"
+                        size="16"
+                      />
+                    </template>
+                  </KButton>
                 </template>
 
-                <template #zoneCpVersion="{ rowValue }">
-                  {{ rowValue || t('common.collection.none') }}
-                </template>
-
-                <template #type="{ rowValue }">
-                  {{ rowValue || t('common.collection.none') }}
-                </template>
-
-                <template #status="{ rowValue }">
-                  <StatusBadge
-                    v-if="rowValue"
-                    :status="rowValue"
+                <template #items>
+                  <KDropdownItem
+                    :item="{
+                      to: row.detailViewRoute,
+                      label: t('common.collection.actions.view'),
+                    }"
                   />
 
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-
-                <template #warnings="{ rowValue }">
-                  <KTooltip
-                    v-if="rowValue"
-                    :label="t('zone-cps.list.version_mismatch')"
+                  <KDropdownItem
+                    v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
+                    has-divider
+                    is-dangerous
+                    data-testid="dropdown-delete-item"
+                    @click="setDeleteZoneName(row.name)"
                   >
-                    <KIcon
-                      class="mr-1"
-                      icon="warning"
-                      color="var(--black-500)"
-                      secondary-color="var(--yellow-300)"
-                      size="20"
-                      hide-title
-                    />
-                  </KTooltip>
-
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
+                    {{ t('common.collection.actions.delete') }}
+                  </KDropdownItem>
                 </template>
-
-                <template #actions="{ row }">
-                  <KDropdownMenu
-                    class="actions-dropdown"
-                    data-testid="actions-dropdown"
-                    :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
-                    width="150"
-                  >
-                    <template #default>
-                      <KButton
-                        class="non-visual-button"
-                        appearance="secondary"
-                        size="small"
-                      >
-                        <template #icon>
-                          <KIcon
-                            color="var(--black-400)"
-                            icon="more"
-                            size="16"
-                          />
-                        </template>
-                      </KButton>
-                    </template>
-
-                    <template #items>
-                      <KDropdownItem
-                        :item="{
-                          to: row.detailViewRoute,
-                          label: t('common.collection.actions.view'),
-                        }"
-                      />
-
-                      <KDropdownItem
-                        v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
-                        has-divider
-                        is-dangerous
-                        data-testid="dropdown-delete-item"
-                        @click="setDeleteZoneName(row.name)"
-                      >
-                        {{ t('common.collection.actions.delete') }}
-                      </KDropdownItem>
-                    </template>
-                  </KDropdownMenu>
-                </template>
-              </AppCollection>
+              </KDropdownMenu>
             </template>
-          </KCard>
+          </AppCollection>
 
           <DeleteResourceModal
             v-if="isDeleteModalVisible"
@@ -177,7 +173,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon, KTooltip } from '@kong/kongponents'
+import { KButton, KDropdownItem, KDropdownMenu, KIcon, KTooltip } from '@kong/kongponents'
 import { ref } from 'vue'
 import { type RouteLocationNamedRaw } from 'vue-router'
 

--- a/src/assets/styles/_components.scss
+++ b/src/assets/styles/_components.scss
@@ -32,3 +32,17 @@ Adapted from https://every-layout.dev/layouts/switcher/.
   // Accounts for the gaps.
   inline-size: calc((100% - ((var(--columns) - 1) * var(--AppGap))) / var(--columns));
 }
+
+
+/*
+.variable-columns
+*/
+
+.variable-columns {
+  display: flex;
+  gap: var(--AppGap);
+}
+
+.variable-columns>* {
+  flex-grow: 1;
+}

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -37,15 +37,14 @@
   // Sets a default border style for commonly used component frames/panels.
   --KCardPaddingX: var(--AppGap);
   --KCardPaddingY: var(--KCardPaddingX);
-  --KCardBorderRadius: 3px;
+  --KCardBorderRadius: 9px;
   --KCardBackground: var(--white);
   --KCardBorder: 1px solid var(--grey-300);
 }
+
 :root.is-fullscreen {
   --AppHeaderHeight: 0;
   --AppSidebarWidth: 0;
   --AppContentPadding: 0;
   --AppDisplay: block;
 }
-
-

--- a/src/locales/en-us/http/index.yaml
+++ b/src/locales/en-us/http/index.yaml
@@ -17,6 +17,7 @@ http:
       certificateExpirationTime: Expiration time
       lastCertificateRegeneration: Last generated
       certificateRegenerations: Regenerations
+      authenticationType: 'Authentication type'
     value:
       online: 'online'
       offline: 'offline'

--- a/src/test-support/mocks/src/zones+insights.ts
+++ b/src/test-support/mocks/src/zones+insights.ts
@@ -182,7 +182,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                       gitTag: '1.0.0-rc2-211-g823fe8ce',
                       gitCommit: '823fe8cef6430a8f75e72a7224eb5a8ab571ec42',
                       buildDate: '2021-02-18T13:22:30Z',
-                      kumaCpGlobalCompatible: false,
+                      kumaCpGlobalCompatible: fake.datatype.boolean(),
                     },
                   },
                 },

--- a/src/test-support/mocks/src/zones+insights/_.ts
+++ b/src/test-support/mocks/src/zones+insights/_.ts
@@ -10,7 +10,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
       creationTime: '2021-02-19T08:06:15.380674+01:00',
       modificationTime: '2021-02-19T08:06:15.380674+01:00',
       zone: {
-        enabled: true,
+        enabled: fake.datatype.boolean(),
       },
       zoneInsight: {
         subscriptions: Array.from({ length: subscriptions }).map((_) => {
@@ -91,6 +91,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
                 gitTag: '1.0.0-rc2-211-g823fe8ce',
                 gitCommit: fake.git.commitSha(),
                 buildDate: '2021-02-18T13:22:30Z',
+                kumaCpGlobalCompatible: fake.datatype.boolean(),
               },
             },
           }


### PR DESCRIPTION
## Changes

Moves the config and warnings tab content of the Zone Control Plane detail view into the overview tab.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Screenshots

**Before**:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/e0753c2b-6d55-454a-9461-a884775192ae)

**After**:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/b065d8ce-0d1f-48c0-a0dd-d9614e522f1d)
