### PR TITLE
fix(zones): not always marking Zone CP as disabled

### DIFF
--- a/src/app/main-overview/components/ZoneControlPlanesDetails.vue
+++ b/src/app/main-overview/components/ZoneControlPlanesDetails.vue
@@ -39,9 +39,9 @@ import { KTable } from '@kong/kongponents'
 import { PropType, computed } from 'vue'
 
 import StatusBadge from '@/app/common/StatusBadge.vue'
-import type { StatusKeyword, ZoneOverview } from '@/types/index.d'
+import { getZoneControlPlaneStatus } from '@/app/zones/getZoneControlPlaneStatus'
+import type { ZoneOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 const { t } = useI18n()
 
@@ -55,11 +55,7 @@ const props = defineProps({
 const tableData = computed(() => props.zoneOverviews.map((zoneOverview) => {
   const { name } = zoneOverview
 
-  let status: StatusKeyword | 'disabled' = 'disabled'
-
-  if (zoneOverview.zone.enabled === true) {
-    status = getItemStatusFromInsight(zoneOverview.zoneInsight)
-  }
+  const status = getZoneControlPlaneStatus(zoneOverview)
 
   return {
     name,

--- a/src/app/zones/components/ZoneDetails.vue
+++ b/src/app/zones/components/ZoneDetails.vue
@@ -114,6 +114,7 @@
 import { KAlert, KCard } from '@kong/kongponents'
 import { computed, PropType } from 'vue'
 
+import { getZoneControlPlaneStatus } from '../getZoneControlPlaneStatus'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
 import CodeBlock from '@/app/common/CodeBlock.vue'
@@ -126,7 +127,7 @@ import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import WarningsWidget from '@/app/common/warnings/WarningsWidget.vue'
 import type { ZoneCompatibility, ZoneOverview } from '@/types/index.d'
 import { useI18n, useEnv } from '@/utilities'
-import { getItemStatusFromInsight, INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS } from '@/utilities/dataplane'
+import { INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS } from '@/utilities/dataplane'
 import { getZoneDpServerAuthType } from '@/utilities/helpers'
 
 const { t } = useI18n()
@@ -159,13 +160,7 @@ const type = computed(() => {
 
   return 'kubernetes'
 })
-const status = computed(() => {
-  if (props.zoneOverview.zone.enabled === false) {
-    return 'disabled'
-  } else {
-    return getItemStatusFromInsight(props.zoneOverview.zoneInsight)
-  }
-})
+const status = computed(() => getZoneControlPlaneStatus(props.zoneOverview))
 const authenticationType = computed(() => getZoneDpServerAuthType(props.zoneOverview))
 
 const warnings = computed<ZoneCompatibility[]>(() => {

--- a/src/app/zones/getZoneControlPlaneStatus.ts
+++ b/src/app/zones/getZoneControlPlaneStatus.ts
@@ -1,0 +1,15 @@
+import { StatusKeyword, ZoneOverview } from '@/types/index.d'
+
+export function getZoneControlPlaneStatus(zoneOverview: ZoneOverview): StatusKeyword | 'disabled' {
+  if (zoneOverview.zone.enabled === false) {
+    return 'disabled'
+  }
+
+  const subscriptions = zoneOverview.zoneInsight?.subscriptions ?? []
+  if (subscriptions.length === 0) {
+    return 'offline'
+  }
+
+  const lastSubscription = subscriptions[subscriptions.length - 1]
+  return lastSubscription.connectTime?.length && !lastSubscription.disconnectTime ? 'online' : 'offline'
+}

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -178,6 +178,7 @@ import { ref } from 'vue'
 import { type RouteLocationNamedRaw } from 'vue-router'
 
 import MultizoneInfo from '../components/MultizoneInfo.vue'
+import { getZoneControlPlaneStatus } from '../getZoneControlPlaneStatus'
 import type { ZoneOverviewCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import AppView from '@/app/application/components/app-view/AppView.vue'
@@ -189,7 +190,6 @@ import StatusBadge from '@/app/common/StatusBadge.vue'
 import { useStore } from '@/store/store'
 import { StatusKeyword, ZoneOverview } from '@/types/index.d'
 import { useEnv, useI18n, useKumaApi } from '@/utilities'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 type ZoneOverviewTableRow = {
   detailViewRoute: RouteLocationNamedRaw
@@ -248,11 +248,7 @@ function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableR
       }
     })
 
-    let status: StatusKeyword | 'disabled' = 'disabled'
-
-    if (zoneOverview.zone.enabled === true) {
-      status = getItemStatusFromInsight(zoneOverview.zoneInsight)
-    }
+    const status = getZoneControlPlaneStatus(zoneOverview)
 
     return {
       detailViewRoute,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -421,7 +421,7 @@ export interface ExternalService extends MeshEntity {
 
 export interface Zone {
   name: string
-  enabled: boolean
+  enabled?: boolean
 }
 
 /**


### PR DESCRIPTION
Extracts the logic for determining the status of a Zone Control Plane to avoid duplicating its logic.

Fixes an issue with a Zone being shown as `offline` when it should be `disabled`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
