### PR TITLE
fix: background color leaking through to content

### DIFF
--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -1,166 +1,204 @@
 <template>
   <TabsWidget :tabs="filteredTabs">
     <template #overview>
-      <DefinitionList>
-        <DefinitionListItem :term="t('http.api.property.name')">
-          <TextWithCopyButton :text="props.dataplaneOverview.name">
-            <RouterLink
-              :to="{
-                name: 'data-plane-detail-view',
-                params: {
-                  mesh: props.dataplaneOverview.mesh,
-                  dataPlane: props.dataplaneOverview.name,
-                },
-              }"
-            >
-              {{ props.dataplaneOverview.name }}
-            </RouterLink>
-          </TextWithCopyButton>
-        </DefinitionListItem>
+      <div class="stack">
+        <KCard>
+          <template #body>
+            <DefinitionList>
+              <DefinitionListItem :term="t('http.api.property.name')">
+                <TextWithCopyButton :text="props.dataplaneOverview.name">
+                  <RouterLink
+                    :to="{
+                      name: 'data-plane-detail-view',
+                      params: {
+                        mesh: props.dataplaneOverview.mesh,
+                        dataPlane: props.dataplaneOverview.name,
+                      },
+                    }"
+                  >
+                    {{ props.dataplaneOverview.name }}
+                  </RouterLink>
+                </TextWithCopyButton>
+              </DefinitionListItem>
 
-        <DefinitionListItem
-          v-if="dataPlaneTags.length > 0"
-          term="Tags"
-        >
-          <TagList :tags="dataPlaneTags" />
-        </DefinitionListItem>
+              <DefinitionListItem
+                v-if="dataPlaneTags.length > 0"
+                term="Tags"
+              >
+                <TagList :tags="dataPlaneTags" />
+              </DefinitionListItem>
 
-        <DefinitionListItem
-          v-if="statusWithReason.status"
-          term="Status"
-        >
-          <StatusBadge :status="statusWithReason.status" />
-        </DefinitionListItem>
+              <DefinitionListItem
+                v-if="statusWithReason.status"
+                term="Status"
+              >
+                <StatusBadge :status="statusWithReason.status" />
+              </DefinitionListItem>
 
-        <DefinitionListItem
-          v-if="statusWithReason.reason.length > 0"
-          term="Reason"
-        >
-          <div
-            v-for="(reason, index) in statusWithReason.reason"
-            :key="index"
-            class="reason"
-          >
-            {{ reason }}
-          </div>
-        </DefinitionListItem>
+              <DefinitionListItem
+                v-if="statusWithReason.reason.length > 0"
+                term="Reason"
+              >
+                <div
+                  v-for="(reason, index) in statusWithReason.reason"
+                  :key="index"
+                  class="reason"
+                >
+                  {{ reason }}
+                </div>
+              </DefinitionListItem>
 
-        <DefinitionListItem
-          v-if="dataPlaneVersions !== null"
-          term="Dependencies"
-        >
-          <ul>
-            <li
-              v-for="(version, dependency) in dataPlaneVersions"
-              :key="dependency"
-              class="tag-cols"
-            >
-              {{ dependency }}: {{ version }}
-            </li>
-          </ul>
-        </DefinitionListItem>
-      </DefinitionList>
+              <DefinitionListItem
+                v-if="dataPlaneVersions !== null"
+                term="Dependencies"
+              >
+                <ul>
+                  <li
+                    v-for="(version, dependency) in dataPlaneVersions"
+                    :key="dependency"
+                    class="tag-cols"
+                  >
+                    {{ dependency }}: {{ version }}
+                  </li>
+                </ul>
+              </DefinitionListItem>
+            </DefinitionList>
+          </template>
+        </KCard>
 
-      <ResourceCodeBlock
-        id="code-block-data-plane"
-        class="mt-4"
-        :resource="props.dataplaneOverview"
-        :resource-fetcher="fetchDataPlaneProxy"
-        is-searchable
-      />
+        <KCard>
+          <template #body>
+            <ResourceCodeBlock
+              id="code-block-data-plane"
+              :resource="props.dataplaneOverview"
+              :resource-fetcher="fetchDataPlaneProxy"
+              is-searchable
+            />
+          </template>
+        </KCard>
+      </div>
     </template>
 
     <template #insights>
-      <StatusInfo :is-empty="insightSubscriptions.length === 0">
-        <AccordionList :initially-open="0">
-          <AccordionItem
-            v-for="(insight, key) in insightSubscriptions"
-            :key="key"
-          >
-            <template #accordion-header>
-              <SubscriptionHeader :details="insight" />
-            </template>
+      <KCard>
+        <template #body>
+          <StatusInfo :is-empty="insightSubscriptions.length === 0">
+            <AccordionList :initially-open="0">
+              <AccordionItem
+                v-for="(insight, key) in insightSubscriptions"
+                :key="key"
+              >
+                <template #accordion-header>
+                  <SubscriptionHeader :details="insight" />
+                </template>
 
-            <template #accordion-content>
-              <SubscriptionDetails
-                :details="insight"
-                is-discovery-subscription
-              />
-            </template>
-          </AccordionItem>
-        </AccordionList>
-      </StatusInfo>
+                <template #accordion-content>
+                  <SubscriptionDetails
+                    :details="insight"
+                    is-discovery-subscription
+                  />
+                </template>
+              </AccordionItem>
+            </AccordionList>
+          </StatusInfo>
+        </template>
+      </KCard>
     </template>
 
     <template #dpp-policies>
-      <DataplanePolicies :dataplane-overview="dataplaneOverview" />
+      <KCard>
+        <template #body>
+          <DataplanePolicies :dataplane-overview="dataplaneOverview" />
+        </template>
+      </KCard>
     </template>
 
     <template #xds-configuration>
-      <EnvoyData
-        data-path="xds"
-        :mesh="dataplaneOverview.mesh"
-        :dpp-name="dataplaneOverview.name"
-        query-key="envoy-data-data-plane"
-      />
+      <KCard>
+        <template #body>
+          <EnvoyData
+            data-path="xds"
+            :mesh="dataplaneOverview.mesh"
+            :dpp-name="dataplaneOverview.name"
+            query-key="envoy-data-data-plane"
+          />
+        </template>
+      </KCard>
     </template>
 
     <template #envoy-stats>
-      <EnvoyData
-        data-path="stats"
-        :mesh="dataplaneOverview.mesh"
-        :dpp-name="dataplaneOverview.name"
-        query-key="envoy-data-data-plane"
-      />
+      <KCard>
+        <template #body>
+          <EnvoyData
+            data-path="stats"
+            :mesh="dataplaneOverview.mesh"
+            :dpp-name="dataplaneOverview.name"
+            query-key="envoy-data-data-plane"
+          />
+        </template>
+      </KCard>
     </template>
 
     <template #envoy-clusters>
-      <EnvoyData
-        data-path="clusters"
-        :mesh="dataplaneOverview.mesh"
-        :dpp-name="dataplaneOverview.name"
-        query-key="envoy-data-data-plane"
-      />
+      <KCard>
+        <template #body>
+          <EnvoyData
+            data-path="clusters"
+            :mesh="dataplaneOverview.mesh"
+            :dpp-name="dataplaneOverview.name"
+            query-key="envoy-data-data-plane"
+          />
+        </template>
+      </KCard>
     </template>
 
     <template #mtls>
-      <KAlert
-        v-if="mtlsData === null"
-        appearance="danger"
-      >
-        <template #alertMessage>
-          This data plane proxy does not yet have mTLS configured —
-          <a
-            :href="t('data-planes.href.docs.mutual-tls')"
-            class="external-link"
-            target="_blank"
+      <KCard>
+        <template #body>
+          <KAlert
+            v-if="mtlsData === null"
+            appearance="danger"
           >
-            Learn About Certificates in {{ t('common.product.name') }}
-          </a>
+            <template #alertMessage>
+              This data plane proxy does not yet have mTLS configured —
+              <a
+                :href="t('data-planes.href.docs.mutual-tls')"
+                class="external-link"
+                target="_blank"
+              >
+                Learn About Certificates in {{ t('common.product.name') }}
+              </a>
+            </template>
+          </KAlert>
+
+          <DefinitionList v-else>
+            <DefinitionListItem
+              v-for="(value, property) in mtlsData"
+              :key="property"
+              :term="t(`http.api.property.${property}`)"
+            >
+              {{ value }}
+            </DefinitionListItem>
+          </DefinitionList>
         </template>
-      </KAlert>
-      <DefinitionList v-else>
-        <DefinitionListItem
-          v-for="(value, property) in mtlsData"
-          :key="property"
-          :term="t(`http.api.property.${property}`)"
-        >
-          {{ value }}
-        </DefinitionListItem>
-      </DefinitionList>
+      </KCard>
     </template>
 
     <template #warnings>
-      <WarningsWidget
-        v-if="warnings.length > 0"
-        :warnings="warnings"
-      />
+      <KCard>
+        <template #body>
+          <WarningsWidget
+            v-if="warnings.length > 0"
+            :warnings="warnings"
+          />
+        </template>
+      </KCard>
     </template>
   </TabsWidget>
 </template>
 
 <script lang="ts" setup>
-import { KAlert } from '@kong/kongponents'
+import { KAlert, KCard } from '@kong/kongponents'
 import { computed, ref, PropType } from 'vue'
 
 import DataplanePolicies from './DataplanePolicies.vue'

--- a/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
+++ b/src/app/data-planes/components/__snapshots__/DataPlaneDetails.spec.ts.snap
@@ -147,2904 +147,2946 @@ exports[`DataPlaneDetails matches snapshot 1`] = `
   >
     
     
-    <dl
-      class="definition-list"
+    <div
+      class="stack"
     >
-      
-      <div
-        class="definition-list-item"
+      <section
+        aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+        class="kong-card border"
       >
-        <dt
-          class="definition-list-item__term"
+        <!---->
+        <!---->
+        <div
+          class="k-card-content"
         >
-          Name
-        </dt>
-        <dd
-          class="definition-list-item__details"
-        >
-          
           <div
-            class="copy-button-wrapper"
+            class="k-card-body"
+            id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
           >
             
-            <a
-              class=""
-              href="/gui/mesh/test-mesh/data-plane/backend"
-            >
-              backend
-            </a>
-            
-            
-            <button
-              class="k-button small outline copy-button non-visual-button"
-              data-testid="copy-button"
-              title="Copy"
-              type="button"
+            <dl
+              class="definition-list"
             >
               
-              <!---->
-              
-              
-              <span
-                class="kong-icon kong-icon-copy"
-              >
-                <svg
-                  height="18"
-                  role="img"
-                  viewBox="0 0 32 32"
-                  width="18"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  
-  
-                  <title>
-                    Copy
-                  </title>
-                  
-  
-                  <path
-                    d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
-                    fill="currentColor"
-                  />
-                  
-
-                </svg>
-                
-
-              </span>
-              
-              <span
-                class="visually-hidden"
-              >
-                Copy
-              </span>
-              
-              
-              <!---->
-            </button>
-            
-          </div>
-          
-        </dd>
-      </div>
-      <div
-        class="definition-list-item"
-      >
-        <dt
-          class="definition-list-item__term"
-        >
-          Tags
-        </dt>
-        <dd
-          class="definition-list-item__details"
-        >
-          
-          <span
-            class="tag-list"
-          >
-            
-            <div
-              class="k-badge k-badge-default k-badge-rounded tag-badge"
-              tabindex="0"
-            >
               <div
-                class="k-badge-text"
+                class="definition-list-item"
               >
-                <div
-                  class="k-badge-text"
+                <dt
+                  class="definition-list-item__term"
+                >
+                  Name
+                </dt>
+                <dd
+                  class="definition-list-item__details"
                 >
                   
-                  <span>
-                    kuma.io/protocol:
-                    <b>
-                      http
-                    </b>
+                  <div
+                    class="copy-button-wrapper"
+                  >
+                    
+                    <a
+                      class=""
+                      href="/gui/mesh/test-mesh/data-plane/backend"
+                    >
+                      backend
+                    </a>
+                    
+                    
+                    <button
+                      class="k-button small outline copy-button non-visual-button"
+                      data-testid="copy-button"
+                      title="Copy"
+                      type="button"
+                    >
+                      
+                      <!---->
+                      
+                      
+                      <span
+                        class="kong-icon kong-icon-copy"
+                      >
+                        <svg
+                          height="18"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width="18"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          
+  
+                          <title>
+                            Copy
+                          </title>
+                          
+  
+                          <path
+                            d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
+                            fill="currentColor"
+                          />
+                          
+
+                        </svg>
+                        
+
+                      </span>
+                      
+                      <span
+                        class="visually-hidden"
+                      >
+                        Copy
+                      </span>
+                      
+                      
+                      <!---->
+                    </button>
+                    
+                  </div>
+                  
+                </dd>
+              </div>
+              <div
+                class="definition-list-item"
+              >
+                <dt
+                  class="definition-list-item__term"
+                >
+                  Tags
+                </dt>
+                <dd
+                  class="definition-list-item__details"
+                >
+                  
+                  <span
+                    class="tag-list"
+                  >
+                    
+                    <div
+                      class="k-badge k-badge-default k-badge-rounded tag-badge"
+                      tabindex="0"
+                    >
+                      <div
+                        class="k-badge-text"
+                      >
+                        <div
+                          class="k-badge-text"
+                        >
+                          
+                          <span>
+                            kuma.io/protocol:
+                            <b>
+                              http
+                            </b>
+                          </span>
+                          
+                        </div>
+                      </div>
+                      <!---->
+                    </div>
+                    <div
+                      class="k-badge k-badge-default k-badge-rounded tag-badge"
+                      tabindex="0"
+                    >
+                      <div
+                        class="k-badge-text"
+                      >
+                        <div
+                          class="k-badge-text"
+                        >
+                          
+                          <a
+                            class=""
+                            href="/gui/mesh/default/service/backend"
+                          >
+                            kuma.io/service:
+                            <b>
+                              backend
+                            </b>
+                          </a>
+                          
+                        </div>
+                      </div>
+                      <!---->
+                    </div>
+                    
                   </span>
                   
-                </div>
+                </dd>
               </div>
-              <!---->
-            </div>
+              <div
+                class="definition-list-item"
+              >
+                <dt
+                  class="definition-list-item__term"
+                >
+                  Status
+                </dt>
+                <dd
+                  class="definition-list-item__details"
+                >
+                  
+                  <div
+                    class="k-badge k-badge-success k-badge-rounded status"
+                    data-testid="status-badge"
+                    tabindex="0"
+                  >
+                    <div
+                      class="k-badge-text"
+                    >
+                      <div
+                        class="k-badge-text"
+                      >
+                        
+                        online
+                        
+                      </div>
+                    </div>
+                    <!---->
+                  </div>
+                  
+                </dd>
+              </div>
+              <!--v-if-->
+              <div
+                class="definition-list-item"
+              >
+                <dt
+                  class="definition-list-item__term"
+                >
+                  Dependencies
+                </dt>
+                <dd
+                  class="definition-list-item__details"
+                >
+                  
+                  <ul>
+                    
+                    <li
+                      class="tag-cols"
+                    >
+                      envoy: 1.16.2
+                    </li>
+                    <li
+                      class="tag-cols"
+                    >
+                      kumaDp: 1.0.7
+                    </li>
+                    <li
+                      class="tag-cols"
+                    >
+                      coredns: 1.8.3
+                    </li>
+                    
+                  </ul>
+                  
+                </dd>
+              </div>
+              
+            </dl>
+            
+          </div>
+          <!---->
+        </div>
+      </section>
+      <section
+        aria-describedby="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+        class="kong-card border"
+      >
+        <!---->
+        <!---->
+        <div
+          class="k-card-content"
+        >
+          <div
+            class="k-card-body"
+            id="aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+          >
+            
             <div
-              class="k-badge k-badge-default k-badge-rounded tag-badge"
+              class="k-code-block theme-light code-block"
+              data-testid="k-code-block"
+              id="code-block-data-plane"
+              style="--maxLineNumberWidth: 2ch;"
               tabindex="0"
             >
               <div
-                class="k-badge-text"
+                class="k-code-block-actions"
               >
-                <div
-                  class="k-badge-text"
+                <p
+                  class="k-code-block-search-results"
                 >
                   
-                  <a
-                    class=""
-                    href="/gui/mesh/default/service/backend"
+                     
+                  
+                </p>
+                <div
+                  class="k-search-container"
+                >
+                  <span
+                    class="k-search-icon theme-light kong-icon kong-icon-search"
+                    data-testid="k-code-block-search-icon"
                   >
-                    kuma.io/service:
-                    <b>
-                      backend
-                    </b>
-                  </a>
+                    <svg
+                      data-testid="k-code-block-search-icon"
+                      fill="currentColor"
+                      height="20px"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width="20px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      
+  
+                      <title>
+                        Search
+                      </title>
+                      
+  
+                      <path
+                        d="M10.88 18.75a7.88 7.88 0 1 0 0-15.75 7.88 7.88 0 0 0 0 15.75ZM16.44 16.44 21 21"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="3"
+                      />
+                      
+
+                    </svg>
+                    
+
+                  </span>
+                  <label
+                    class="k-code-block-search-label"
+                    for="code-block-data-plane-search-input"
+                  >
+                    <span
+                      class="visually-hidden"
+                    >
+                      Search
+                    </span>
+                  </label>
+                  <input
+                    class="k-code-block-search-input"
+                    data-testid="k-code-block-search-input"
+                    id="code-block-data-plane-search-input"
+                    type="text"
+                  />
+                  <!---->
+                  <span
+                    class="k-is-processing-icon theme-light kong-icon kong-icon-spinner"
+                    data-testid="k-code-block-is-processing-icon"
+                  >
+                    <svg
+                      data-testid="k-code-block-is-processing-icon"
+                      fill="currentColor"
+                      height="24px"
+                      role="img"
+                      viewBox="0 0 20 20"
+                      width="24px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      
+  
+                      <title>
+                        Loading
+                      </title>
+                      
+  
+                      <g>
+                        
+    
+                        <path
+                          d="M5 10a5 5 0 1 0 5-5"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        />
+                        
+  
+                      </g>
+                      
+
+                    </svg>
+                    
+
+                  </span>
+                  <!---->
+                </div>
+                <div
+                  class="k-search-actions"
+                >
+                  <button
+                    aria-pressed="false"
+                    class="k-button small outline k-regexp-mode-button"
+                    data-testid="k-code-block-regexp-mode-button"
+                    title="Use regular expression (Alt+R)"
+                    type="button"
+                  >
+                    
+                    <!---->
+                    
+                    
+                    <span
+                      class="visually-hidden"
+                    >
+                      RegExp mode enabled
+                    </span>
+                     .* 
+                    
+                    <!---->
+                  </button>
+                  <button
+                    aria-pressed="false"
+                    class="k-button small outline k-filter-mode-button"
+                    data-testid="k-code-block-filter-mode-button"
+                    title="Filter results (Alt+F)"
+                    type="button"
+                  >
+                    
+                    <span
+                      class="k-button-icon kong-icon kong-icon-filter"
+                    >
+                      <svg
+                        height="16px"
+                        role="img"
+                        viewBox="0 0 14 11"
+                        width="16px"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        
+  
+                        <title>
+                          Filter results (Alt+F)
+                        </title>
+                        
+  
+                        <path
+                          d="M8 9v2H6V9h2zm2-3v2H4V6h6zm2-3v2H2V3h10zm2-3v2H0V0h14z"
+                          fill="currentColor"
+                          fill-rule="evenodd"
+                        />
+                        
+
+                      </svg>
+                      
+
+                    </span>
+                    
+                    
+                    <span
+                      class="visually-hidden"
+                    >
+                      Filter mode enabled
+                    </span>
+                    
+                    <!---->
+                  </button>
+                  <button
+                    class="k-button small outline k-previous-match-button"
+                    data-testid="k-code-block-previous-match-button"
+                    disabled=""
+                    title="Previous match (Shift+F3)"
+                    type="button"
+                  >
+                    
+                    <span
+                      class="k-button-icon kong-icon kong-icon-chevronUp"
+                    >
+                      <svg
+                        fill="currentColor"
+                        height="16px"
+                        role="img"
+                        viewBox="0 0 20 20"
+                        width="16px"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        
+  
+                        <title>
+                          Previous match (Shift+F3)
+                        </title>
+                        
+  
+                        <path
+                          d="M15 12 9.8 7l-5.2 5"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        />
+                        
+
+                      </svg>
+                      
+
+                    </span>
+                    
+                    
+                    <span
+                      class="visually-hidden"
+                    >
+                      Previous match
+                    </span>
+                    
+                    <!---->
+                  </button>
+                  <button
+                    class="k-button small outline k-next-match-button"
+                    data-testid="k-code-block-next-match-button"
+                    disabled=""
+                    title="Next match (F3)"
+                    type="button"
+                  >
+                    
+                    <span
+                      class="k-button-icon kong-icon kong-icon-chevronDown"
+                    >
+                      <svg
+                        fill="currentColor"
+                        height="16px"
+                        role="img"
+                        viewBox="0 0 20 20"
+                        width="16px"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        
+  
+                        <title>
+                          Next match (F3)
+                        </title>
+                        
+  
+                        <path
+                          d="m4.6 7 5.2 5L15 7"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        />
+                        
+
+                      </svg>
+                      
+
+                    </span>
+                    
+                    
+                    <span
+                      class="visually-hidden"
+                    >
+                      Next match
+                    </span>
+                    
+                    <!---->
+                  </button>
+                </div>
+              </div>
+              <div
+                class="k-code-block-content"
+              >
+                <pre
+                  class="k-highlighted-code-block show-copy-button language-yaml"
+                  data-testid="k-code-block-highlighted-code-block"
+                  tabindex="0"
+                >
+                          
+                  <span
+                    class="k-line-number-rows"
+                  >
+                    
+          
+                    
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L1"
+                      >
+                        1
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L2"
+                      >
+                        2
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L3"
+                      >
+                        3
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L4"
+                      >
+                        4
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L5"
+                      >
+                        5
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L6"
+                      >
+                        6
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L7"
+                      >
+                        7
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L8"
+                      >
+                        8
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L9"
+                      >
+                        9
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L10"
+                      >
+                        10
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L11"
+                      >
+                        11
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L12"
+                      >
+                        12
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L13"
+                      >
+                        13
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L14"
+                      >
+                        14
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L15"
+                      >
+                        15
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L16"
+                      >
+                        16
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L17"
+                      >
+                        17
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L18"
+                      >
+                        18
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L19"
+                      >
+                        19
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L20"
+                      >
+                        20
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L21"
+                      >
+                        21
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L22"
+                      >
+                        22
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L23"
+                      >
+                        23
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L24"
+                      >
+                        24
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L25"
+                      >
+                        25
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L26"
+                      >
+                        26
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L27"
+                      >
+                        27
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L28"
+                      >
+                        28
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L29"
+                      >
+                        29
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L30"
+                      >
+                        30
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L31"
+                      >
+                        31
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L32"
+                      >
+                        32
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L33"
+                      >
+                        33
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L34"
+                      >
+                        34
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L35"
+                      >
+                        35
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L36"
+                      >
+                        36
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L37"
+                      >
+                        37
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L38"
+                      >
+                        38
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L39"
+                      >
+                        39
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L40"
+                      >
+                        40
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L41"
+                      >
+                        41
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L42"
+                      >
+                        42
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L43"
+                      >
+                        43
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L44"
+                      >
+                        44
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L45"
+                      >
+                        45
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L46"
+                      >
+                        46
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L47"
+                      >
+                        47
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L48"
+                      >
+                        48
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L49"
+                      >
+                        49
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L50"
+                      >
+                        50
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L51"
+                      >
+                        51
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L52"
+                      >
+                        52
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L53"
+                      >
+                        53
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L54"
+                      >
+                        54
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L55"
+                      >
+                        55
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L56"
+                      >
+                        56
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L57"
+                      >
+                        57
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L58"
+                      >
+                        58
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L59"
+                      >
+                        59
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L60"
+                      >
+                        60
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L61"
+                      >
+                        61
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L62"
+                      >
+                        62
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L63"
+                      >
+                        63
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L64"
+                      >
+                        64
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L65"
+                      >
+                        65
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L66"
+                      >
+                        66
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L67"
+                      >
+                        67
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L68"
+                      >
+                        68
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L69"
+                      >
+                        69
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L70"
+                      >
+                        70
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L71"
+                      >
+                        71
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L72"
+                      >
+                        72
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L73"
+                      >
+                        73
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L74"
+                      >
+                        74
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L75"
+                      >
+                        75
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L76"
+                      >
+                        76
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L77"
+                      >
+                        77
+                      </a>
+                      
+          
+                    </span>
+                    <span
+                      class="k-line"
+                    >
+                      
+            
+                      <a
+                        class="k-line-anchor"
+                        id="code-block-data-plane-L78"
+                      >
+                        78
+                      </a>
+                      
+          
+                    </span>
+                    
+                    
+        
+                  </span>
+                  
+        
+                  <code
+                    class="language-yaml"
+                  >
+                    <span
+                      class="token key atrule"
+                    >
+                      type
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     DataplaneOverview
+
+                    <span
+                      class="token key atrule"
+                    >
+                      mesh
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     test
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                    mesh
+
+                    <span
+                      class="token key atrule"
+                    >
+                      name
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     backend
+
+                    <span
+                      class="token key atrule"
+                    >
+                      dataplane
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+  
+                    <span
+                      class="token key atrule"
+                    >
+                      networking
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+    
+                    <span
+                      class="token key atrule"
+                    >
+                      address
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     127.0.0.1
+    
+                    <span
+                      class="token key atrule"
+                    >
+                      inbound
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+      
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                     
+                    <span
+                      class="token key atrule"
+                    >
+                      port
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token number"
+                    >
+                      7776
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      servicePort
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token number"
+                    >
+                      7777
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      serviceAddress
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     127.0.0.1
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      tags
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      kuma.io/protocol
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     http
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      kuma.io/service
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     backend
+    
+                    <span
+                      class="token key atrule"
+                    >
+                      outbound
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+      
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                     
+                    <span
+                      class="token key atrule"
+                    >
+                      port
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token number"
+                    >
+                      10001
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      tags
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      kuma.io/service
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     frontend
+
+                    <span
+                      class="token key atrule"
+                    >
+                      dataplaneInsight
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+  
+                    <span
+                      class="token key atrule"
+                    >
+                      subscriptions
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+    
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                     
+                    <span
+                      class="token key atrule"
+                    >
+                      id
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     118b4d6f
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                    7a98
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                    4172
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                    96d9
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                    85ffb8b20b16
+      
+                    <span
+                      class="token key atrule"
+                    >
+                      controlPlaneInstanceId
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     foo
+      
+                    <span
+                      class="token key atrule"
+                    >
+                      connectTime
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2021-02-17T07:33:36.412683Z'
+                    </span>
+                    
+      
+                    <span
+                      class="token key atrule"
+                    >
+                      disconnectTime
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2021-02-17T07:33:36.412683Z'
+                    </span>
+                    
+      
+                    <span
+                      class="token key atrule"
+                    >
+                      status
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      lastUpdateTime
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2021-02-17T10:48:03.638434Z'
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      total
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesSent
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '5'
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesAcknowledged
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '5'
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      cds
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesSent
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '1'
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesAcknowledged
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '1'
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      eds
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesSent
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2'
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesAcknowledged
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2'
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      lds
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesSent
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2'
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesAcknowledged
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2'
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      rds
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token punctuation"
+                    >
+                      {
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      }
+                    </span>
+                    
+      
+                    <span
+                      class="token key atrule"
+                    >
+                      version
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      kumaDp
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      version
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     1.0.7
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      gitTag
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     unknown
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      gitCommit
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     unknown
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      buildDate
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     unknown
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      envoy
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      version
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     1.16.2
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      build
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      dependencies
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      coredns
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     1.8.3
+    
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                     
+                    <span
+                      class="token key atrule"
+                    >
+                      id
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     118b4d6f
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                    7a98
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                    4172
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                    96d9
+                    <span
+                      class="token punctuation"
+                    >
+                      -
+                    </span>
+                    85ffb8b20b16
+      
+                    <span
+                      class="token key atrule"
+                    >
+                      controlPlaneInstanceId
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     foo
+      
+                    <span
+                      class="token key atrule"
+                    >
+                      connectTime
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2021-02-17T07:33:36.412683Z'
+                    </span>
+                    
+      
+                    <span
+                      class="token key atrule"
+                    >
+                      status
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      lastUpdateTime
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2021-02-17T10:48:03.638434Z'
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      total
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesSent
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '5'
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesAcknowledged
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '5'
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      cds
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesSent
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '1'
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesAcknowledged
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '1'
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      eds
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesSent
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2'
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesAcknowledged
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2'
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      lds
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesSent
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2'
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      responsesAcknowledged
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token string"
+                    >
+                      '2'
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      rds
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     
+                    <span
+                      class="token punctuation"
+                    >
+                      {
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      }
+                    </span>
+                    
+      
+                    <span
+                      class="token key atrule"
+                    >
+                      version
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      kumaDp
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      version
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     1.0.7
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      gitTag
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     unknown
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      gitCommit
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     unknown
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      buildDate
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     unknown
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      envoy
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      version
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     1.16.2
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      build
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL
+        
+                    <span
+                      class="token key atrule"
+                    >
+                      dependencies
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                    
+          
+                    <span
+                      class="token key atrule"
+                    >
+                      coredns
+                    </span>
+                    <span
+                      class="token punctuation"
+                    >
+                      :
+                    </span>
+                     1.8.3
+                  </code>
+                  
+      
+                </pre>
+                <div
+                  class="k-code-block-secondary-actions"
+                >
+                  <button
+                    class="k-button small outline k-code-block-copy-button"
+                    data-testid="k-code-block-copy-button"
+                    title="Copy (Alt+C)"
+                    type="button"
+                  >
+                    
+                    <!---->
+                    
+                    
+                    <span
+                      class="kong-icon kong-icon-copy"
+                    >
+                      <svg
+                        height="16px"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width="16px"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        
+  
+                        <title>
+                          Copy (Alt+C)
+                        </title>
+                        
+  
+                        <path
+                          d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
+                          fill="currentColor"
+                        />
+                        
+
+                      </svg>
+                      
+
+                    </span>
+                    <span
+                      class="visually-hidden"
+                    >
+                      Copy
+                    </span>
+                    
+                    <!---->
+                  </button>
+                  
+                  
+                  
+                  <button
+                    class="k-button small outline copy-button non-visual-button"
+                    data-testid="copy-button"
+                    title="Copy as Kubernetes"
+                    type="button"
+                  >
+                    
+                    <!---->
+                    
+                    
+                    <span
+                      class="kong-icon kong-icon-copy"
+                    >
+                      <svg
+                        height="18"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width="18"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        
+  
+                        <title>
+                          Copy as Kubernetes
+                        </title>
+                        
+  
+                        <path
+                          d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
+                          fill="currentColor"
+                        />
+                        
+
+                      </svg>
+                      
+
+                    </span>
+                    
+                    as k8s
+                    
+                    
+                    <!---->
+                  </button>
+                  
+                  
                   
                 </div>
               </div>
-              <!---->
             </div>
             
-          </span>
-          
-        </dd>
-      </div>
-      <div
-        class="definition-list-item"
-      >
-        <dt
-          class="definition-list-item__term"
-        >
-          Status
-        </dt>
-        <dd
-          class="definition-list-item__details"
-        >
-          
-          <div
-            class="k-badge k-badge-success k-badge-rounded status"
-            data-testid="status-badge"
-            tabindex="0"
-          >
-            <div
-              class="k-badge-text"
-            >
-              <div
-                class="k-badge-text"
-              >
-                
-                online
-                
-              </div>
-            </div>
-            <!---->
           </div>
-          
-        </dd>
-      </div>
-      <!--v-if-->
-      <div
-        class="definition-list-item"
-      >
-        <dt
-          class="definition-list-item__term"
-        >
-          Dependencies
-        </dt>
-        <dd
-          class="definition-list-item__details"
-        >
-          
-          <ul>
-            
-            <li
-              class="tag-cols"
-            >
-              envoy: 1.16.2
-            </li>
-            <li
-              class="tag-cols"
-            >
-              kumaDp: 1.0.7
-            </li>
-            <li
-              class="tag-cols"
-            >
-              coredns: 1.8.3
-            </li>
-            
-          </ul>
-          
-        </dd>
-      </div>
-      
-    </dl>
-    <div
-      class="k-code-block theme-light code-block mt-4"
-      data-testid="k-code-block"
-      id="code-block-data-plane"
-      style="--maxLineNumberWidth: 2ch;"
-      tabindex="0"
-    >
-      <div
-        class="k-code-block-actions"
-      >
-        <p
-          class="k-code-block-search-results"
-        >
-          
-             
-          
-        </p>
-        <div
-          class="k-search-container"
-        >
-          <span
-            class="k-search-icon theme-light kong-icon kong-icon-search"
-            data-testid="k-code-block-search-icon"
-          >
-            <svg
-              data-testid="k-code-block-search-icon"
-              fill="currentColor"
-              height="20px"
-              role="img"
-              viewBox="0 0 24 24"
-              width="20px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              
-  
-              <title>
-                Search
-              </title>
-              
-  
-              <path
-                d="M10.88 18.75a7.88 7.88 0 1 0 0-15.75 7.88 7.88 0 0 0 0 15.75ZM16.44 16.44 21 21"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="3"
-              />
-              
-
-            </svg>
-            
-
-          </span>
-          <label
-            class="k-code-block-search-label"
-            for="code-block-data-plane-search-input"
-          >
-            <span
-              class="visually-hidden"
-            >
-              Search
-            </span>
-          </label>
-          <input
-            class="k-code-block-search-input"
-            data-testid="k-code-block-search-input"
-            id="code-block-data-plane-search-input"
-            type="text"
-          />
-          <!---->
-          <span
-            class="k-is-processing-icon theme-light kong-icon kong-icon-spinner"
-            data-testid="k-code-block-is-processing-icon"
-          >
-            <svg
-              data-testid="k-code-block-is-processing-icon"
-              fill="currentColor"
-              height="24px"
-              role="img"
-              viewBox="0 0 20 20"
-              width="24px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              
-  
-              <title>
-                Loading
-              </title>
-              
-  
-              <g>
-                
-    
-                <path
-                  d="M5 10a5 5 0 1 0 5-5"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                
-  
-              </g>
-              
-
-            </svg>
-            
-
-          </span>
           <!---->
         </div>
-        <div
-          class="k-search-actions"
-        >
-          <button
-            aria-pressed="false"
-            class="k-button small outline k-regexp-mode-button"
-            data-testid="k-code-block-regexp-mode-button"
-            title="Use regular expression (Alt+R)"
-            type="button"
-          >
-            
-            <!---->
-            
-            
-            <span
-              class="visually-hidden"
-            >
-              RegExp mode enabled
-            </span>
-             .* 
-            
-            <!---->
-          </button>
-          <button
-            aria-pressed="false"
-            class="k-button small outline k-filter-mode-button"
-            data-testid="k-code-block-filter-mode-button"
-            title="Filter results (Alt+F)"
-            type="button"
-          >
-            
-            <span
-              class="k-button-icon kong-icon kong-icon-filter"
-            >
-              <svg
-                height="16px"
-                role="img"
-                viewBox="0 0 14 11"
-                width="16px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                
-  
-                <title>
-                  Filter results (Alt+F)
-                </title>
-                
-  
-                <path
-                  d="M8 9v2H6V9h2zm2-3v2H4V6h6zm2-3v2H2V3h10zm2-3v2H0V0h14z"
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                />
-                
-
-              </svg>
-              
-
-            </span>
-            
-            
-            <span
-              class="visually-hidden"
-            >
-              Filter mode enabled
-            </span>
-            
-            <!---->
-          </button>
-          <button
-            class="k-button small outline k-previous-match-button"
-            data-testid="k-code-block-previous-match-button"
-            disabled=""
-            title="Previous match (Shift+F3)"
-            type="button"
-          >
-            
-            <span
-              class="k-button-icon kong-icon kong-icon-chevronUp"
-            >
-              <svg
-                fill="currentColor"
-                height="16px"
-                role="img"
-                viewBox="0 0 20 20"
-                width="16px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                
-  
-                <title>
-                  Previous match (Shift+F3)
-                </title>
-                
-  
-                <path
-                  d="M15 12 9.8 7l-5.2 5"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                
-
-              </svg>
-              
-
-            </span>
-            
-            
-            <span
-              class="visually-hidden"
-            >
-              Previous match
-            </span>
-            
-            <!---->
-          </button>
-          <button
-            class="k-button small outline k-next-match-button"
-            data-testid="k-code-block-next-match-button"
-            disabled=""
-            title="Next match (F3)"
-            type="button"
-          >
-            
-            <span
-              class="k-button-icon kong-icon kong-icon-chevronDown"
-            >
-              <svg
-                fill="currentColor"
-                height="16px"
-                role="img"
-                viewBox="0 0 20 20"
-                width="16px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                
-  
-                <title>
-                  Next match (F3)
-                </title>
-                
-  
-                <path
-                  d="m4.6 7 5.2 5L15 7"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                
-
-              </svg>
-              
-
-            </span>
-            
-            
-            <span
-              class="visually-hidden"
-            >
-              Next match
-            </span>
-            
-            <!---->
-          </button>
-        </div>
-      </div>
-      <div
-        class="k-code-block-content"
-      >
-        <pre
-          class="k-highlighted-code-block show-copy-button language-yaml"
-          data-testid="k-code-block-highlighted-code-block"
-          tabindex="0"
-        >
-                  
-          <span
-            class="k-line-number-rows"
-          >
-            
-          
-            
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L1"
-              >
-                1
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L2"
-              >
-                2
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L3"
-              >
-                3
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L4"
-              >
-                4
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L5"
-              >
-                5
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L6"
-              >
-                6
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L7"
-              >
-                7
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L8"
-              >
-                8
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L9"
-              >
-                9
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L10"
-              >
-                10
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L11"
-              >
-                11
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L12"
-              >
-                12
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L13"
-              >
-                13
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L14"
-              >
-                14
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L15"
-              >
-                15
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L16"
-              >
-                16
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L17"
-              >
-                17
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L18"
-              >
-                18
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L19"
-              >
-                19
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L20"
-              >
-                20
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L21"
-              >
-                21
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L22"
-              >
-                22
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L23"
-              >
-                23
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L24"
-              >
-                24
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L25"
-              >
-                25
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L26"
-              >
-                26
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L27"
-              >
-                27
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L28"
-              >
-                28
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L29"
-              >
-                29
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L30"
-              >
-                30
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L31"
-              >
-                31
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L32"
-              >
-                32
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L33"
-              >
-                33
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L34"
-              >
-                34
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L35"
-              >
-                35
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L36"
-              >
-                36
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L37"
-              >
-                37
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L38"
-              >
-                38
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L39"
-              >
-                39
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L40"
-              >
-                40
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L41"
-              >
-                41
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L42"
-              >
-                42
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L43"
-              >
-                43
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L44"
-              >
-                44
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L45"
-              >
-                45
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L46"
-              >
-                46
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L47"
-              >
-                47
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L48"
-              >
-                48
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L49"
-              >
-                49
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L50"
-              >
-                50
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L51"
-              >
-                51
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L52"
-              >
-                52
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L53"
-              >
-                53
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L54"
-              >
-                54
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L55"
-              >
-                55
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L56"
-              >
-                56
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L57"
-              >
-                57
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L58"
-              >
-                58
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L59"
-              >
-                59
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L60"
-              >
-                60
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L61"
-              >
-                61
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L62"
-              >
-                62
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L63"
-              >
-                63
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L64"
-              >
-                64
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L65"
-              >
-                65
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L66"
-              >
-                66
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L67"
-              >
-                67
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L68"
-              >
-                68
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L69"
-              >
-                69
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L70"
-              >
-                70
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L71"
-              >
-                71
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L72"
-              >
-                72
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L73"
-              >
-                73
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L74"
-              >
-                74
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L75"
-              >
-                75
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L76"
-              >
-                76
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L77"
-              >
-                77
-              </a>
-              
-          
-            </span>
-            <span
-              class="k-line"
-            >
-              
-            
-              <a
-                class="k-line-anchor"
-                id="code-block-data-plane-L78"
-              >
-                78
-              </a>
-              
-          
-            </span>
-            
-            
-        
-          </span>
-          
-        
-          <code
-            class="language-yaml"
-          >
-            <span
-              class="token key atrule"
-            >
-              type
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             DataplaneOverview
-
-            <span
-              class="token key atrule"
-            >
-              mesh
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             test
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-            mesh
-
-            <span
-              class="token key atrule"
-            >
-              name
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             backend
-
-            <span
-              class="token key atrule"
-            >
-              dataplane
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-  
-            <span
-              class="token key atrule"
-            >
-              networking
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-    
-            <span
-              class="token key atrule"
-            >
-              address
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             127.0.0.1
-    
-            <span
-              class="token key atrule"
-            >
-              inbound
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-      
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-             
-            <span
-              class="token key atrule"
-            >
-              port
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token number"
-            >
-              7776
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              servicePort
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token number"
-            >
-              7777
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              serviceAddress
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             127.0.0.1
-        
-            <span
-              class="token key atrule"
-            >
-              tags
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              kuma.io/protocol
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             http
-          
-            <span
-              class="token key atrule"
-            >
-              kuma.io/service
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             backend
-    
-            <span
-              class="token key atrule"
-            >
-              outbound
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-      
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-             
-            <span
-              class="token key atrule"
-            >
-              port
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token number"
-            >
-              10001
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              tags
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              kuma.io/service
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             frontend
-
-            <span
-              class="token key atrule"
-            >
-              dataplaneInsight
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-  
-            <span
-              class="token key atrule"
-            >
-              subscriptions
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-    
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-             
-            <span
-              class="token key atrule"
-            >
-              id
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             118b4d6f
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-            7a98
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-            4172
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-            96d9
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-            85ffb8b20b16
-      
-            <span
-              class="token key atrule"
-            >
-              controlPlaneInstanceId
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             foo
-      
-            <span
-              class="token key atrule"
-            >
-              connectTime
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2021-02-17T07:33:36.412683Z'
-            </span>
-            
-      
-            <span
-              class="token key atrule"
-            >
-              disconnectTime
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2021-02-17T07:33:36.412683Z'
-            </span>
-            
-      
-            <span
-              class="token key atrule"
-            >
-              status
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              lastUpdateTime
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2021-02-17T10:48:03.638434Z'
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              total
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesSent
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '5'
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesAcknowledged
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '5'
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              cds
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesSent
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '1'
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesAcknowledged
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '1'
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              eds
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesSent
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2'
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesAcknowledged
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2'
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              lds
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesSent
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2'
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesAcknowledged
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2'
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              rds
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token punctuation"
-            >
-              {
-            </span>
-            <span
-              class="token punctuation"
-            >
-              }
-            </span>
-            
-      
-            <span
-              class="token key atrule"
-            >
-              version
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              kumaDp
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              version
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             1.0.7
-          
-            <span
-              class="token key atrule"
-            >
-              gitTag
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             unknown
-          
-            <span
-              class="token key atrule"
-            >
-              gitCommit
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             unknown
-          
-            <span
-              class="token key atrule"
-            >
-              buildDate
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             unknown
-        
-            <span
-              class="token key atrule"
-            >
-              envoy
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              version
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             1.16.2
-          
-            <span
-              class="token key atrule"
-            >
-              build
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL
-        
-            <span
-              class="token key atrule"
-            >
-              dependencies
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              coredns
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             1.8.3
-    
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-             
-            <span
-              class="token key atrule"
-            >
-              id
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             118b4d6f
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-            7a98
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-            4172
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-            96d9
-            <span
-              class="token punctuation"
-            >
-              -
-            </span>
-            85ffb8b20b16
-      
-            <span
-              class="token key atrule"
-            >
-              controlPlaneInstanceId
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             foo
-      
-            <span
-              class="token key atrule"
-            >
-              connectTime
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2021-02-17T07:33:36.412683Z'
-            </span>
-            
-      
-            <span
-              class="token key atrule"
-            >
-              status
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              lastUpdateTime
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2021-02-17T10:48:03.638434Z'
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              total
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesSent
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '5'
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesAcknowledged
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '5'
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              cds
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesSent
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '1'
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesAcknowledged
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '1'
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              eds
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesSent
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2'
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesAcknowledged
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2'
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              lds
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesSent
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2'
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              responsesAcknowledged
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token string"
-            >
-              '2'
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              rds
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             
-            <span
-              class="token punctuation"
-            >
-              {
-            </span>
-            <span
-              class="token punctuation"
-            >
-              }
-            </span>
-            
-      
-            <span
-              class="token key atrule"
-            >
-              version
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-        
-            <span
-              class="token key atrule"
-            >
-              kumaDp
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              version
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             1.0.7
-          
-            <span
-              class="token key atrule"
-            >
-              gitTag
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             unknown
-          
-            <span
-              class="token key atrule"
-            >
-              gitCommit
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             unknown
-          
-            <span
-              class="token key atrule"
-            >
-              buildDate
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             unknown
-        
-            <span
-              class="token key atrule"
-            >
-              envoy
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              version
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             1.16.2
-          
-            <span
-              class="token key atrule"
-            >
-              build
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL
-        
-            <span
-              class="token key atrule"
-            >
-              dependencies
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-            
-          
-            <span
-              class="token key atrule"
-            >
-              coredns
-            </span>
-            <span
-              class="token punctuation"
-            >
-              :
-            </span>
-             1.8.3
-          </code>
-          
-      
-        </pre>
-        <div
-          class="k-code-block-secondary-actions"
-        >
-          <button
-            class="k-button small outline k-code-block-copy-button"
-            data-testid="k-code-block-copy-button"
-            title="Copy (Alt+C)"
-            type="button"
-          >
-            
-            <!---->
-            
-            
-            <span
-              class="kong-icon kong-icon-copy"
-            >
-              <svg
-                height="16px"
-                role="img"
-                viewBox="0 0 32 32"
-                width="16px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                
-  
-                <title>
-                  Copy (Alt+C)
-                </title>
-                
-  
-                <path
-                  d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
-                  fill="currentColor"
-                />
-                
-
-              </svg>
-              
-
-            </span>
-            <span
-              class="visually-hidden"
-            >
-              Copy
-            </span>
-            
-            <!---->
-          </button>
-          
-          
-          
-          <button
-            class="k-button small outline copy-button non-visual-button"
-            data-testid="copy-button"
-            title="Copy as Kubernetes"
-            type="button"
-          >
-            
-            <!---->
-            
-            
-            <span
-              class="kong-icon kong-icon-copy"
-            >
-              <svg
-                height="18"
-                role="img"
-                viewBox="0 0 32 32"
-                width="18"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                
-  
-                <title>
-                  Copy as Kubernetes
-                </title>
-                
-  
-                <path
-                  d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"
-                  fill="currentColor"
-                />
-                
-
-              </svg>
-              
-
-            </span>
-            
-            as k8s
-            
-            
-            <!---->
-          </button>
-          
-          
-          
-        </div>
-      </div>
+      </section>
     </div>
     
     

--- a/src/app/policies/components/PolicyDetails.vue
+++ b/src/app/policies/components/PolicyDetails.vue
@@ -1,25 +1,34 @@
 <template>
   <TabsWidget :tabs="tabs">
     <template #overview>
-      <ResourceCodeBlock
-        id="code-block-policy"
-        :resource="props.policy"
-        :resource-fetcher="fetchPolicy"
-        is-searchable
-      />
+      <KCard>
+        <template #body>
+          <ResourceCodeBlock
+            id="code-block-policy"
+            :resource="props.policy"
+            :resource-fetcher="fetchPolicy"
+            is-searchable
+          />
+        </template>
+      </KCard>
     </template>
 
     <template #affected-dpps>
-      <PolicyConnections
-        :mesh="props.policy.mesh"
-        :policy-name="props.policy.name"
-        :policy-path="props.path"
-      />
+      <KCard>
+        <template #body>
+          <PolicyConnections
+            :mesh="props.policy.mesh"
+            :policy-name="props.policy.name"
+            :policy-path="props.path"
+          />
+        </template>
+      </KCard>
     </template>
   </TabsWidget>
 </template>
 
 <script lang="ts" setup>
+import { KCard } from '@kong/kongponents'
 import { PropType } from 'vue'
 
 import PolicyConnections from '../components/PolicyConnections.vue'

--- a/src/app/zones/components/ZoneDetails.vue
+++ b/src/app/zones/components/ZoneDetails.vue
@@ -67,45 +67,52 @@
         <div>
           <h2>{{ t('zone-cps.detail.configuration_title') }}</h2>
 
-          <CodeBlock
-            v-if="codeOutput !== null"
-            id="code-block-zone-config"
-            class="mt-4"
-            language="json"
-            :code="codeOutput"
-            is-searchable
-            query-key="zone-config"
-          />
+          <KCard class="mt-4">
+            <template #body>
+              <CodeBlock
+                v-if="codeOutput !== null"
+                id="code-block-zone-config"
+                language="json"
+                :code="codeOutput"
+                is-searchable
+                query-key="zone-config"
+              />
 
-          <KAlert
-            v-else
-            class="mt-4"
-            data-testid="warning-no-subscriptions"
-            appearance="warning"
-          >
-            <template #alertMessage>
-              {{ t('zone-cps.detail.no_subscriptions') }}
+              <KAlert
+                v-else
+                class="mt-4"
+                data-testid="warning-no-subscriptions"
+                appearance="warning"
+              >
+                <template #alertMessage>
+                  {{ t('zone-cps.detail.no_subscriptions') }}
+                </template>
+              </KAlert>
             </template>
-          </KAlert>
+          </KCard>
         </div>
       </div>
     </template>
 
     <template #insights>
-      <AccordionList :initially-open="0">
-        <AccordionItem
-          v-for="(value, key) in subscriptionsReversed"
-          :key="key"
-        >
-          <template #accordion-header>
-            <SubscriptionHeader :details="value" />
-          </template>
+      <KCard>
+        <template #body>
+          <AccordionList :initially-open="0">
+            <AccordionItem
+              v-for="(value, key) in subscriptionsReversed"
+              :key="key"
+            >
+              <template #accordion-header>
+                <SubscriptionHeader :details="value" />
+              </template>
 
-          <template #accordion-content>
-            <SubscriptionDetails :details="value" />
-          </template>
-        </AccordionItem>
-      </AccordionList>
+              <template #accordion-content>
+                <SubscriptionDetails :details="value" />
+              </template>
+            </AccordionItem>
+          </AccordionList>
+        </template>
+      </KCard>
     </template>
   </TabsWidget>
 </template>

--- a/src/app/zones/components/ZoneEgressDetails.vue
+++ b/src/app/zones/components/ZoneEgressDetails.vue
@@ -50,47 +50,63 @@
     </template>
 
     <template #insights>
-      <AccordionList :initially-open="0">
-        <AccordionItem
-          v-for="(value, key) in subscriptionsReversed"
-          :key="key"
-        >
-          <template #accordion-header>
-            <SubscriptionHeader :details="value" />
-          </template>
+      <KCard>
+        <template #body>
+          <AccordionList :initially-open="0">
+            <AccordionItem
+              v-for="(value, key) in subscriptionsReversed"
+              :key="key"
+            >
+              <template #accordion-header>
+                <SubscriptionHeader :details="value" />
+              </template>
 
-          <template #accordion-content>
-            <SubscriptionDetails
-              :details="value"
-              is-discovery-subscription
-            />
-          </template>
-        </AccordionItem>
-      </AccordionList>
+              <template #accordion-content>
+                <SubscriptionDetails
+                  :details="value"
+                  is-discovery-subscription
+                />
+              </template>
+            </AccordionItem>
+          </AccordionList>
+        </template>
+      </KCard>
     </template>
 
     <template #xds-configuration>
-      <EnvoyData
-        data-path="xds"
-        :zone-egress-name="props.zoneEgressOverview.name"
-        query-key="envoy-data-zone-egress"
-      />
+      <KCard>
+        <template #body>
+          <EnvoyData
+            data-path="xds"
+            :zone-egress-name="props.zoneEgressOverview.name"
+            query-key="envoy-data-zone-egress"
+          />
+        </template>
+      </KCard>
     </template>
 
     <template #envoy-stats>
-      <EnvoyData
-        data-path="stats"
-        :zone-egress-name="props.zoneEgressOverview.name"
-        query-key="envoy-data-zone-egress"
-      />
+      <KCard>
+        <template #body>
+          <EnvoyData
+            data-path="stats"
+            :zone-egress-name="props.zoneEgressOverview.name"
+            query-key="envoy-data-zone-egress"
+          />
+        </template>
+      </KCard>
     </template>
 
     <template #envoy-clusters>
-      <EnvoyData
-        data-path="clusters"
-        :zone-egress-name="props.zoneEgressOverview.name"
-        query-key="envoy-data-zone-egress"
-      />
+      <KCard>
+        <template #body>
+          <EnvoyData
+            data-path="clusters"
+            :zone-egress-name="props.zoneEgressOverview.name"
+            query-key="envoy-data-zone-egress"
+          />
+        </template>
+      </KCard>
     </template>
   </TabsWidget>
 </template>

--- a/src/app/zones/components/ZoneIngressDetails.vue
+++ b/src/app/zones/components/ZoneIngressDetails.vue
@@ -50,47 +50,63 @@
     </template>
 
     <template #insights>
-      <AccordionList :initially-open="0">
-        <AccordionItem
-          v-for="(value, key) in subscriptionsReversed"
-          :key="key"
-        >
-          <template #accordion-header>
-            <SubscriptionHeader :details="value" />
-          </template>
+      <KCard>
+        <template #body>
+          <AccordionList :initially-open="0">
+            <AccordionItem
+              v-for="(value, key) in subscriptionsReversed"
+              :key="key"
+            >
+              <template #accordion-header>
+                <SubscriptionHeader :details="value" />
+              </template>
 
-          <template #accordion-content>
-            <SubscriptionDetails
-              :details="value"
-              is-discovery-subscription
-            />
-          </template>
-        </AccordionItem>
-      </AccordionList>
+              <template #accordion-content>
+                <SubscriptionDetails
+                  :details="value"
+                  is-discovery-subscription
+                />
+              </template>
+            </AccordionItem>
+          </AccordionList>
+        </template>
+      </KCard>
     </template>
 
     <template #xds-configuration>
-      <EnvoyData
-        data-path="xds"
-        :zone-ingress-name="props.zoneIngressOverview.name"
-        query-key="envoy-data-zone-ingress"
-      />
+      <KCard>
+        <template #body>
+          <EnvoyData
+            data-path="xds"
+            :zone-ingress-name="props.zoneIngressOverview.name"
+            query-key="envoy-data-zone-ingress"
+          />
+        </template>
+      </KCard>
     </template>
 
     <template #envoy-stats>
-      <EnvoyData
-        data-path="stats"
-        :zone-ingress-name="props.zoneIngressOverview.name"
-        query-key="envoy-data-zone-ingress"
-      />
+      <KCard>
+        <template #body>
+          <EnvoyData
+            data-path="stats"
+            :zone-ingress-name="props.zoneIngressOverview.name"
+            query-key="envoy-data-zone-ingress"
+          />
+        </template>
+      </KCard>
     </template>
 
     <template #envoy-clusters>
-      <EnvoyData
-        data-path="clusters"
-        :zone-ingress-name="props.zoneIngressOverview.name"
-        query-key="envoy-data-zone-ingress"
-      />
+      <KCard>
+        <template #body>
+          <EnvoyData
+            data-path="clusters"
+            :zone-ingress-name="props.zoneIngressOverview.name"
+            query-key="envoy-data-zone-ingress"
+          />
+        </template>
+      </KCard>
     </template>
   </TabsWidget>
 </template>

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -17,82 +17,86 @@
         v-slot="{ data, error }: ZoneEgressOverviewCollectionSource"
         :src="`/zone-egresses?size=${props.size}&page=${props.page}`"
       >
-        <AppCollection
-          class="zone-egress-collection"
-          data-testid="zone-egress-collection"
-          :headers="[
-            { label: 'Name', key: 'name' },
-            { label: 'Status', key: 'status' },
-            { label: 'Actions', key: 'actions', hideLabel: true },
-          ]"
-          :page-number="props.page"
-          :page-size="props.size"
-          :total="data?.total"
-          :items="data ? transformToTableData(data.items) : undefined"
-          :error="error"
-          @change="route.update"
-        >
-          <template #name="{ row, rowValue }">
-            <RouterLink
-              :to="row.detailViewRoute"
-              data-testid="detail-view-link"
+        <KCard>
+          <template #body>
+            <AppCollection
+              class="zone-egress-collection"
+              data-testid="zone-egress-collection"
+              :headers="[
+                { label: 'Name', key: 'name' },
+                { label: 'Status', key: 'status' },
+                { label: 'Actions', key: 'actions', hideLabel: true },
+              ]"
+              :page-number="props.page"
+              :page-size="props.size"
+              :total="data?.total"
+              :items="data ? transformToTableData(data.items) : undefined"
+              :error="error"
+              @change="route.update"
             >
-              {{ rowValue }}
-            </RouterLink>
-          </template>
-
-          <template #status="{ rowValue }">
-            <StatusBadge
-              v-if="rowValue"
-              :status="rowValue"
-            />
-
-            <template v-else>
-              {{ t('common.collection.none') }}
-            </template>
-          </template>
-
-          <template #actions="{ row }">
-            <KDropdownMenu
-              class="actions-dropdown"
-              data-testid="actions-dropdown"
-              :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
-              width="150"
-            >
-              <template #default>
-                <KButton
-                  class="non-visual-button"
-                  appearance="secondary"
-                  size="small"
+              <template #name="{ row, rowValue }">
+                <RouterLink
+                  :to="row.detailViewRoute"
+                  data-testid="detail-view-link"
                 >
-                  <template #icon>
-                    <KIcon
-                      color="var(--black-400)"
-                      icon="more"
-                      size="16"
+                  {{ rowValue }}
+                </RouterLink>
+              </template>
+
+              <template #status="{ rowValue }">
+                <StatusBadge
+                  v-if="rowValue"
+                  :status="rowValue"
+                />
+
+                <template v-else>
+                  {{ t('common.collection.none') }}
+                </template>
+              </template>
+
+              <template #actions="{ row }">
+                <KDropdownMenu
+                  class="actions-dropdown"
+                  data-testid="actions-dropdown"
+                  :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
+                  width="150"
+                >
+                  <template #default>
+                    <KButton
+                      class="non-visual-button"
+                      appearance="secondary"
+                      size="small"
+                    >
+                      <template #icon>
+                        <KIcon
+                          color="var(--black-400)"
+                          icon="more"
+                          size="16"
+                        />
+                      </template>
+                    </KButton>
+                  </template>
+
+                  <template #items>
+                    <KDropdownItem
+                      :item="{
+                        to: row.detailViewRoute,
+                        label: t('common.collection.actions.view'),
+                      }"
                     />
                   </template>
-                </KButton>
+                </KDropdownMenu>
               </template>
-
-              <template #items>
-                <KDropdownItem
-                  :item="{
-                    to: row.detailViewRoute,
-                    label: t('common.collection.actions.view'),
-                  }"
-                />
-              </template>
-            </KDropdownMenu>
+            </AppCollection>
           </template>
-        </AppCollection>
+        </KCard>
       </DataSource>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import { KButton, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
+import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
 import { RouteLocationNamedRaw } from 'vue-router'
 
 import type { ZoneEgressOverviewCollectionSource } from '../sources'

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -20,75 +20,79 @@
           v-slot="{ data, error }: ZoneIngressOverviewCollectionSource"
           :src="`/zone-ingresses?size=${props.size}&page=${props.page}`"
         >
-          <AppCollection
-            class="zone-ingress-collection"
-            data-testid="zone-ingress-collection"
-            :headers="[
-              { label: 'Name', key: 'name' },
-              { label: 'Status', key: 'status' },
-              { label: 'Actions', key: 'actions', hideLabel: true },
-            ]"
-            :page-number="props.page"
-            :page-size="props.size"
-            :total="data?.total"
-            :items="data ? transformToTableData(data.items) : undefined"
-            :error="error"
-            @change="route.update"
-          >
-            <template #name="{ row, rowValue }">
-              <RouterLink
-                :to="row.detailViewRoute"
-                data-testid="detail-view-link"
+          <KCard>
+            <template #body>
+              <AppCollection
+                class="zone-ingress-collection"
+                data-testid="zone-ingress-collection"
+                :headers="[
+                  { label: 'Name', key: 'name' },
+                  { label: 'Status', key: 'status' },
+                  { label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :page-number="props.page"
+                :page-size="props.size"
+                :total="data?.total"
+                :items="data ? transformToTableData(data.items) : undefined"
+                :error="error"
+                @change="route.update"
               >
-                {{ rowValue }}
-              </RouterLink>
-            </template>
-
-            <template #status="{ rowValue }">
-              <StatusBadge
-                v-if="rowValue"
-                :status="rowValue"
-              />
-
-              <template v-else>
-                {{ t('common.collection.none') }}
-              </template>
-            </template>
-
-            <template #actions="{ row }">
-              <KDropdownMenu
-                class="actions-dropdown"
-                data-testid="actions-dropdown"
-                :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
-                width="150"
-              >
-                <template #default>
-                  <KButton
-                    class="non-visual-button"
-                    appearance="secondary"
-                    size="small"
+                <template #name="{ row, rowValue }">
+                  <RouterLink
+                    :to="row.detailViewRoute"
+                    data-testid="detail-view-link"
                   >
-                    <template #icon>
-                      <KIcon
-                        color="var(--black-400)"
-                        icon="more"
-                        size="16"
+                    {{ rowValue }}
+                  </RouterLink>
+                </template>
+
+                <template #status="{ rowValue }">
+                  <StatusBadge
+                    v-if="rowValue"
+                    :status="rowValue"
+                  />
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #actions="{ row }">
+                  <KDropdownMenu
+                    class="actions-dropdown"
+                    data-testid="actions-dropdown"
+                    :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
+                    width="150"
+                  >
+                    <template #default>
+                      <KButton
+                        class="non-visual-button"
+                        appearance="secondary"
+                        size="small"
+                      >
+                        <template #icon>
+                          <KIcon
+                            color="var(--black-400)"
+                            icon="more"
+                            size="16"
+                          />
+                        </template>
+                      </KButton>
+                    </template>
+
+                    <template #items>
+                      <KDropdownItem
+                        :item="{
+                          to: row.detailViewRoute,
+                          label: t('common.collection.actions.view'),
+                        }"
                       />
                     </template>
-                  </KButton>
+                  </KDropdownMenu>
                 </template>
-
-                <template #items>
-                  <KDropdownItem
-                    :item="{
-                      to: row.detailViewRoute,
-                      label: t('common.collection.actions.view'),
-                    }"
-                  />
-                </template>
-              </KDropdownMenu>
+              </AppCollection>
             </template>
-          </AppCollection>
+          </KCard>
         </DataSource>
       </template>
     </AppView>
@@ -96,7 +100,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KButton, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
+import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon } from '@kong/kongponents'
 import { RouteLocationNamedRaw } from 'vue-router'
 
 import MultizoneInfo from '../components/MultizoneInfo.vue'

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -34,116 +34,120 @@
           v-slot="{ data, error, refresh }: ZoneOverviewCollectionSource"
           :src="`/zone-cps?size=${props.size}&page=${props.page}`"
         >
-          <AppCollection
-            class="zone-cp-collection"
-            data-testid="zone-cp-collection"
-            :headers="[
-              { label: 'Name', key: 'name' },
-              { label: 'Zone CP Version', key: 'zoneCpVersion' },
-              { label: 'Type', key: 'type' },
-              { label: 'Status', key: 'status' },
-              { label: 'Warnings', key: 'warnings', hideLabel: true },
-              { label: 'Actions', key: 'actions', hideLabel: true },
-            ]"
-            :page-number="props.page"
-            :page-size="props.size"
-            :total="data?.total"
-            :items="data ? transformToTableData(data.items) : undefined"
-            :error="error"
-            @change="route.update"
-          >
-            <template #name="{ row, rowValue }">
-              <RouterLink
-                :to="row.detailViewRoute"
-                data-testid="detail-view-link"
+          <KCard>
+            <template #body>
+              <AppCollection
+                class="zone-cp-collection"
+                data-testid="zone-cp-collection"
+                :headers="[
+                  { label: 'Name', key: 'name' },
+                  { label: 'Zone CP Version', key: 'zoneCpVersion' },
+                  { label: 'Type', key: 'type' },
+                  { label: 'Status', key: 'status' },
+                  { label: 'Warnings', key: 'warnings', hideLabel: true },
+                  { label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :page-number="props.page"
+                :page-size="props.size"
+                :total="data?.total"
+                :items="data ? transformToTableData(data.items) : undefined"
+                :error="error"
+                @change="route.update"
               >
-                {{ rowValue }}
-              </RouterLink>
-            </template>
-
-            <template #zoneCpVersion="{ rowValue }">
-              {{ rowValue || t('common.collection.none') }}
-            </template>
-
-            <template #type="{ rowValue }">
-              {{ rowValue || t('common.collection.none') }}
-            </template>
-
-            <template #status="{ rowValue }">
-              <StatusBadge
-                v-if="rowValue"
-                :status="rowValue"
-              />
-
-              <template v-else>
-                {{ t('common.collection.none') }}
-              </template>
-            </template>
-
-            <template #warnings="{ rowValue }">
-              <KTooltip
-                v-if="rowValue"
-                :label="t('zone-cps.list.version_mismatch')"
-              >
-                <KIcon
-                  class="mr-1"
-                  icon="warning"
-                  color="var(--black-500)"
-                  secondary-color="var(--yellow-300)"
-                  size="20"
-                  hide-title
-                />
-              </KTooltip>
-
-              <template v-else>
-                {{ t('common.collection.none') }}
-              </template>
-            </template>
-
-            <template #actions="{ row }">
-              <KDropdownMenu
-                class="actions-dropdown"
-                data-testid="actions-dropdown"
-                :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
-                width="150"
-              >
-                <template #default>
-                  <KButton
-                    class="non-visual-button"
-                    appearance="secondary"
-                    size="small"
+                <template #name="{ row, rowValue }">
+                  <RouterLink
+                    :to="row.detailViewRoute"
+                    data-testid="detail-view-link"
                   >
-                    <template #icon>
-                      <KIcon
-                        color="var(--black-400)"
-                        icon="more"
-                        size="16"
-                      />
-                    </template>
-                  </KButton>
+                    {{ rowValue }}
+                  </RouterLink>
                 </template>
 
-                <template #items>
-                  <KDropdownItem
-                    :item="{
-                      to: row.detailViewRoute,
-                      label: t('common.collection.actions.view'),
-                    }"
+                <template #zoneCpVersion="{ rowValue }">
+                  {{ rowValue || t('common.collection.none') }}
+                </template>
+
+                <template #type="{ rowValue }">
+                  {{ rowValue || t('common.collection.none') }}
+                </template>
+
+                <template #status="{ rowValue }">
+                  <StatusBadge
+                    v-if="rowValue"
+                    :status="rowValue"
                   />
 
-                  <KDropdownItem
-                    v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
-                    has-divider
-                    is-dangerous
-                    data-testid="dropdown-delete-item"
-                    @click="setDeleteZoneName(row.name)"
-                  >
-                    {{ t('common.collection.actions.delete') }}
-                  </KDropdownItem>
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
                 </template>
-              </KDropdownMenu>
+
+                <template #warnings="{ rowValue }">
+                  <KTooltip
+                    v-if="rowValue"
+                    :label="t('zone-cps.list.version_mismatch')"
+                  >
+                    <KIcon
+                      class="mr-1"
+                      icon="warning"
+                      color="var(--black-500)"
+                      secondary-color="var(--yellow-300)"
+                      size="20"
+                      hide-title
+                    />
+                  </KTooltip>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #actions="{ row }">
+                  <KDropdownMenu
+                    class="actions-dropdown"
+                    data-testid="actions-dropdown"
+                    :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
+                    width="150"
+                  >
+                    <template #default>
+                      <KButton
+                        class="non-visual-button"
+                        appearance="secondary"
+                        size="small"
+                      >
+                        <template #icon>
+                          <KIcon
+                            color="var(--black-400)"
+                            icon="more"
+                            size="16"
+                          />
+                        </template>
+                      </KButton>
+                    </template>
+
+                    <template #items>
+                      <KDropdownItem
+                        :item="{
+                          to: row.detailViewRoute,
+                          label: t('common.collection.actions.view'),
+                        }"
+                      />
+
+                      <KDropdownItem
+                        v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
+                        has-divider
+                        is-dangerous
+                        data-testid="dropdown-delete-item"
+                        @click="setDeleteZoneName(row.name)"
+                      >
+                        {{ t('common.collection.actions.delete') }}
+                      </KDropdownItem>
+                    </template>
+                  </KDropdownMenu>
+                </template>
+              </AppCollection>
             </template>
-          </AppCollection>
+          </KCard>
 
           <DeleteResourceModal
             v-if="isDeleteModalVisible"
@@ -173,7 +177,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KButton, KDropdownItem, KDropdownMenu, KIcon, KTooltip } from '@kong/kongponents'
+import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon, KTooltip } from '@kong/kongponents'
 import { ref } from 'vue'
 import { type RouteLocationNamedRaw } from 'vue-router'
 


### PR DESCRIPTION
Fixes an issue with the background color of the page leaking through to content if it’s not wrapped in a `KCard` (which has a background color).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Note: the number of lines changed is blown out of proportion mainly through the regeneration of one snapshot and because wrapping markup in another element inadvertently causes indentation changes in otherwise unchanged lines.
