### PR TITLE
chore: adds esbuild to satisfy peer dependency need of @bahmutov/cypress-esbuild-preprocessor

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "cypress": "^12.17.3",
     "cypress-fail-fast": "^7.0.1",
     "dotenv": "^16.3.1",
+    "esbuild": "^0.19.2",
     "eslint": "^8.46.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-friendly-formatter": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4381,7 +4381,7 @@ esbuild@^0.18.10:
     "@esbuild/win32-ia32" "0.18.13"
     "@esbuild/win32-x64" "0.18.13"
 
-esbuild@^0.19.0:
+esbuild@^0.19.0, esbuild@^0.19.2:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.19.2.tgz#b1541828a89dfb6f840d38538767c6130dca2aac"
   integrity sha512-G6hPax8UbFakEj3hWO0Vs52LQ8k3lnBhxZWomUJDxfz3rZTLqF5k/FCzuNdLx2RbpBiQQF9H9onlDDH1lZsnjg==


### PR DESCRIPTION
`@bahmutov/cypress-esbuild-preprocessor` has a peer dependency on esbuild. Us no longer having it installed sometimes leads to dependency updates like https://github.com/kumahq/kuma-gui/pull/1324 to fail.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
