### PR TITLE
refactor: adds @kong/design-tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
     "@faker-js/faker": "^8.0.2",
     "@jest/globals": "^29.6.2",
+    "@kong/design-tokens": "^1.9.0",
     "@modyfi/vite-plugin-yaml": "^1.0.4",
     "@types/js-yaml": "^4.0.5",
     "@types/marked": "^5.0.1",

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -1,3 +1,4 @@
+@import '@kong/design-tokens/tokens/css/custom-properties.css';
 @import '@kong/kongponents/dist/style.css';
 @import '@kong/kongponents/dist/_variables.scss';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1937,6 +1937,11 @@
     flat "^5.0.2"
     intl-messageformat "^10.5.0"
 
+"@kong/design-tokens@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@kong/design-tokens/-/design-tokens-1.9.0.tgz#ebdce87c460e6095428ca37792d90e9540527f7d"
+  integrity sha512-y68F8uUxLQZDRqN8365TPVsYPNPS9jGTlsap8A6N2MkYHYZ75Qnewl7cK6M+YUbG9AUx1YE64vt1yQe5+/Ydzg==
+
 "@kong/kongponents@^8.122.2":
   version "8.122.2"
   resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.122.2.tgz#c1812ca4d3ffdb1385dab7520a2eb89475279152"


### PR DESCRIPTION
Adding this now so we can start using variables from the design-tokens package.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
