### PR TITLE
feature: Adds `can` utility for querying user access/ability.

### DIFF
--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -14,6 +14,7 @@
       name="default"
       :t="t"
       :env="env"
+      :can="can"
       :route="{
         update: (params: Record<string, string | undefined>) => {
           router.replace({
@@ -39,6 +40,7 @@ import { provide, inject, ref, watch, onBeforeUnmount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { ROUTE_VIEW_PARENT } from '.'
+import { useCan } from '../../index'
 import {
   urlParam,
   cleanQuery,
@@ -48,6 +50,7 @@ import {
 import { useI18n, useEnv } from '@/utilities'
 
 const env = useEnv()
+const can = useCan()
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()

--- a/src/app/application/index.ts
+++ b/src/app/application/index.ts
@@ -1,0 +1,26 @@
+import can from './services/can'
+import { token, createInjections } from '@/services/utils'
+import type { ServiceDefinition } from '@/services/utils'
+type Can = ReturnType<typeof can>
+type Token = ReturnType<typeof token>
+
+const $ = {
+  can: token<Can>('application.can'),
+  features: token('application.can.features'),
+}
+export const services = (_app: Record<string, Token>): ServiceDefinition[] => {
+  return [
+    [$.can, {
+      service: can,
+      arguments: [
+        $.features,
+      ],
+    }],
+  ]
+}
+export const TOKENS = $
+export const [
+  useCan,
+] = createInjections(
+  $.can,
+)

--- a/src/app/application/services/can/README.md
+++ b/src/app/application/services/can/README.md
@@ -1,0 +1,5 @@
+# can
+
+`can` provides a way to easily ask about whether a user can do something, this
+could be based upon user permissions or just general ability to do something
+maybe based on what features the user has enabled in their cluster.

--- a/src/app/application/services/can/index.ts
+++ b/src/app/application/services/can/index.ts
@@ -1,0 +1,11 @@
+export type Can = (str: string, obj?: any) => boolean
+export default (features: Record<string, (...args: any[]) => boolean>) => {
+  const can: Can = (str, obj) => {
+    const feature = features[str]
+    if (typeof feature !== 'undefined') {
+      return features[str](can, obj)
+    }
+    return false
+  }
+  return can
+}

--- a/src/app/application/services/can/index.ts
+++ b/src/app/application/services/can/index.ts
@@ -1,5 +1,6 @@
 export type Can = (str: string, obj?: any) => boolean
-export default (features: Record<string, (...args: any[]) => boolean>) => {
+export type Features = Record<string, (can: Can, obj?: any) => boolean>
+export default (features: Features) => {
   const can: Can = (str, obj) => {
     const feature = features[str]
     if (typeof feature !== 'undefined') {

--- a/src/app/gateways/views/GatewayListView.vue
+++ b/src/app/gateways/views/GatewayListView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    v-slot="{ route }"
+    v-slot="{ route, can }"
     name="gateways-list-view"
   >
     <DataSource
@@ -44,7 +44,9 @@
                     name: { description: 'filter by name or parts of a name' },
                     service: { description: 'filter by “kuma.io/service” value' },
                     tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                    zone: { description: 'filter by “kuma.io/zone” value' },
+                    ...( can('use zones') ? {
+                      zone: { description: 'filter by “kuma.io/zone” value' },
+                    } : {})
                   }"
                   @fields-change="(val) => route.update({
                     query: val.query,

--- a/src/app/zones/features.ts
+++ b/src/app/zones/features.ts
@@ -1,7 +1,7 @@
-import type { Can } from '@/app/application/services/can'
+import type { Can, Features } from '@/app/application/services/can'
 import type Env from '@/services/env/Env'
-export const features = (env: Env['var']) => {
-  const features = {
+export const features = (env: Env['var']): Features => {
+  return {
     'use zones': () => {
       return env('KUMA_MODE') === 'global'
     },
@@ -9,5 +9,4 @@ export const features = (env: Env['var']) => {
       return can('use zones') && env('KUMA_ZONE_CREATION_FLOW') === 'enabled'
     },
   }
-  return features
 }

--- a/src/app/zones/features.ts
+++ b/src/app/zones/features.ts
@@ -1,0 +1,13 @@
+import type { Can } from '@/app/application/services/can'
+import type Env from '@/services/env/Env'
+export const features = (env: Env['var']) => {
+  const features = {
+    'use zones': () => {
+      return env('KUMA_MODE') === 'global'
+    },
+    'create zones': (can: Can) => {
+      return can('use zones') && env('KUMA_ZONE_CREATION_FLOW') === 'enabled'
+    },
+  }
+  return features
+}

--- a/src/app/zones/index.ts
+++ b/src/app/zones/index.ts
@@ -1,3 +1,4 @@
+import { features } from './features'
 import { sources } from './sources'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
@@ -5,9 +6,11 @@ export * from './routes'
 
 type Token = ReturnType<typeof token>
 type Sources = ReturnType<typeof sources>
+type Features = ReturnType<typeof features>
 
 const $ = {
   sources: token<Sources>('zone.sources'),
+  features: token<Features>('zone.features'),
 }
 
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
@@ -19,6 +22,15 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
       labels: [
         app.sources,
+      ],
+    }],
+    [$.features, {
+      service: features,
+      arguments: [
+        app.env,
+      ],
+      labels: [
+        app.features,
       ],
     }],
   ]

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -3,6 +3,7 @@ import { createStore, StoreOptions, Store } from 'vuex'
 
 import createDisabledLogger from './logger/DisabledLogger'
 import { useApp, useBootstrap } from '../index'
+import { services as application, TOKENS as APPLICATION } from '@/app/application'
 import { DataSourcePool } from '@/app/application/services/data-source/DataSourcePool'
 import DataSourceLifeCycle from '@/app/application/services/data-source/index'
 import { routes as dataplaneRoutes, services as dataplanes } from '@/app/data-planes'
@@ -32,6 +33,7 @@ import type {
 } from 'vue-router'
 
 const $ = {
+  ...APPLICATION,
   EnvVars: token<EnvVars>('EnvVars'),
   Env: token<Env>('Env'),
   env: token<Alias<Env['var']>>('env'),
@@ -255,6 +257,7 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
     service: diagnosticsRoutes,
   }],
   // Modules
+  ...application($),
   ...mainOverviewModule($),
   ...zonesModule($),
   ...meshes($),


### PR DESCRIPTION
Adds a `can` utility for querying user access (potentially based on permissions) or user abilities, i.e. can a user `use zones`.

---

- `can` can only ever return a boolean (unlike `env` which should only ever return strings)
- `can` can centralize these sorts of decisions within the 'module' meaning we don't mistakenly have these sorts of decisions made differently in different places by accident.
- `can` can have "features" injected from The Outside and "features" are composable so we can switch things in and out if we need to.

We purposefully return `false` if a "feature" is not defined i.e. we don't throw an error. Therefore identifiers are purposefully arbitrary strings and human readable/declarative-like. We should stick to `use/create/read/write/update/delete moduleName` semantics i.e. `can('delete meshes')`. This means as we now have `t` for printing human strings (using centralized i18n files), `can` for making decisions (using centralized feature files) and DataSource for accessing external data (using centralized sources files). As a sidenote `env` can be used a lot less within the application and reserved for actual environment variable usecases (of which we have very few), I guess we will still use env quite a bit within the `can` features.

Important note: We general use service injection to do these sorts of forks and prefer that approach over using conditional forks deep in the codebase. We should continue to prefer this, but! There are places/times where we may want to use this approach either temporarily or based on data that we only know at run-time, therefore:

```html
<DataSource
  v-slot="{data}"
>
<div v-if="can('use thing', data)"></div>
</DataSource>
```
```javascript
'use thing' => (can, data) => {
  return env('KUMA_THINGS') && data.permissions.for.user && data.enabled.at.runtime
}

```

The above may depend on an env var plus something that is only known via an API request.

I've included one instance of usage within the application to give an example of the usecase plus usage. We don't currently use service injection for many zone related things.

`can` will mostly be used in Route components (and its decision passed down into other components), hence its added as an export of `RouteView`, but it can also be injected into places like routing config if required.

