### PR TITLE
fix: premature access of empty dataplane list

### DIFF
--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -80,7 +80,7 @@
                 :src="`/meshes/${route.params.mesh}/dataplanes/for/${route.params.service}/of/${props.gatewayType}?page=${props.page}&size=${props.size}&search=${props.search}`"
               >
                 <template
-                  v-for="gateways in [typeof dataplanesData?.items?.[0].dataplane.networking.gateway === 'undefined']"
+                  v-for="gateways in [typeof dataplanesData?.items?.[0]?.dataplane?.networking?.gateway === 'undefined']"
                   :key="gateways"
                 >
                   <KCard>


### PR DESCRIPTION
Causes a rendering error in the service detail view’s DPP list if the DPP list is empty.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
