### PR TITLE
fix: browser navigation through history

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -89,6 +89,10 @@ When('I clear the {string} element', (selector: string) => {
   $(selector).clear()
 })
 
+When('I go {string}', (direction: number | Cypress.HistoryDirection) => {
+  cy.go(direction)
+})
+
 // assert
 Then('the URL contains {string}', (str: string) => {
   cy.url().should('include', str)

--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -40,3 +40,33 @@ Feature: MainNavigation
       | $main-nav .nav-item-home a              | Overview            |
       | $main-nav .nav-item-zone-cp-list-view a | Zone Control Planes |
       | [data-testid='nav-item-diagnostics']    | Diagnostics         |
+
+  Scenario: History navigation
+    Given the environment
+      """
+      KUMA_MESH_COUNT: 60
+      """
+    # This hack is necessary for the "the environment" population above to have an effect.
+    And the URL "/meshes" responds with
+      """
+      """
+
+    When I visit the "/" URL
+    Then the page title contains "Overview"
+    And the "[data-testid='zone-control-planes-status']" element exists
+
+    When I click the "$main-nav .nav-item-mesh-list-view a" element
+    Then the page title contains "Meshes"
+    And the "[data-testid='page-1-btn'].active" element exists
+
+    When I click the "[data-testid='next-btn'] > a" element
+    Then the page title contains "Meshes"
+    And the "[data-testid='page-2-btn'].active" element exists
+
+    When I go "back"
+    Then the page title contains "Meshes"
+    And the "[data-testid='page-1-btn'].active" element exists
+
+    When I go "back"
+    Then the page title contains "Overview"
+    And the "[data-testid='zone-control-planes-status']" element exists

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -97,6 +97,8 @@ const cacheKey = ref<number>(0)
  * This is a hack around the fact that there is no other way to tell KTable if the current page of a paginated view has changed. KTable assumes it’s the *sole* owner/maintainer of pagination-related state, but that’s a design flaw that doesn’t account for browser history navigation (e.g. pressing back to go from page 2 to page 1).
  *
  * Is triggered via a watcher whenever `props.pageNumber` changes while the last page number that was emitted by KTable (via calls to its `fetcher` prop) is different (i.e. the page number has changed independently of a KTable mechanism).
+ *
+ * TODO: If https://github.com/Kong/kongponents/pull/1631 is accepted, this hack can be removed in favor of setting the new prop whenever the page number changes externally.
  */
 const kTableMountKey = ref(0)
 const lastPageNumber = ref(props.pageNumber)

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -1,5 +1,6 @@
 <template>
   <KTable
+    :key="kTableMountKey"
     class="app-collection"
     :style="`--column-width: ${columnWidth}; --special-column-width: ${SPECIAL_COLUMN_WIDTH}%;`"
     :has-error="(typeof props.error !== 'undefined')"
@@ -8,6 +9,7 @@
     :headers="props.headers"
     :fetcher-cache-key="String(cacheKey)"
     :fetcher="({ page, pageSize, query }: FetcherParams) => {
+      lastPageNumber = page
       emit('change', {
         page: page,
         size: pageSize,
@@ -89,6 +91,15 @@ const slots = useSlots()
 
 const items = ref<unknown[] | undefined>(props.items)
 const cacheKey = ref<number>(0)
+/**
+ * Used as a means to instruct KTable to re-mount.
+ *
+ * This is a hack around the fact that there is no other way to tell KTable if the current page of a paginated view has changed. KTable assumes it’s the *sole* owner/maintainer of pagination-related state, but that’s a design flaw that doesn’t account for browser history navigation (e.g. pressing back to go from page 2 to page 1).
+ *
+ * Is triggered via a watcher whenever `props.pageNumber` changes while the last page number that was emitted by KTable (via calls to its `fetcher` prop) is different (i.e. the page number has changed independently of a KTable mechanism).
+ */
+const kTableMountKey = ref(0)
+const lastPageNumber = ref(props.pageNumber)
 
 const columnWidth = computed(() => {
   const specialColumns = props.headers.filter((header) => ['warnings', 'actions'].includes(header.key))
@@ -102,10 +113,19 @@ const columnWidth = computed(() => {
   return `calc(${percentage}% / ${numberOfCommonColumns})`
 })
 
-watch(() => props.items, () => {
-  cacheKey.value++
-  items.value = props.items
+watch(() => props.items, (newItems, oldItems) => {
+  if (newItems !== oldItems) {
+    cacheKey.value++
+    items.value = props.items
+  }
 })
+
+watch(() => props.pageNumber, function () {
+  if (props.pageNumber !== lastPageNumber.value) {
+    kTableMountKey.value++
+  }
+})
+
 const click = (e: MouseEvent) => {
   const $tr = (e.target as HTMLElement).closest('tr')
   if ($tr) {

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -16,7 +16,9 @@
       :env="env"
       :route="{
         update: (params: Record<string, string | undefined>) => {
-          router.replace({
+          // Avoids `router.push` specifically in the case where we try to persist the `page` query parameter in the URL while there isn’t one already. This happens when navigating to a list view through the UI (i.e. without directly using the `page` query parameter). If we use `router.push`, this creates a second history entry after that navigation which makes it near impossible to navigate back through the history because the browser will be stuck in a loop.
+          const method = !Boolean(route.query.page) ? 'replace' : 'push'
+          router[method]({
             name: props.name,
             query: cleanQuery(params, route.query),
           })

--- a/src/test-support/fake.ts
+++ b/src/test-support/fake.ts
@@ -28,7 +28,7 @@ const pager: Pager = (_total: string | number, req: RestRequest, self) => {
 
   const remaining = total - offset
   const pageTotal = Math.min(size, remaining)
-  const next = remaining <= size ? null : `${baseUrl}${self}?offset=${offset + size}`
+  const next = remaining <= size ? null : `${baseUrl}${self}?size=${size}offset=${offset + size}`
   return {
     next,
     pageTotal,


### PR DESCRIPTION
## Changes

Fixes a few issues related to browser navigation through history. Specifically, it implements a hack around a shortcoming of KTable to observe external page number changes.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Steps to reproduce

In the UI, navigate to a page with a list view and use its pagination. Then use the browser’s back button to navigate back. This will behave incorrectly (i.e. it will skip a page and navigate back two steps)