### PR TITLE
chore: removes resource code block for internal service insights

### DIFF
--- a/src/app/common/ResourceCodeBlock.vue
+++ b/src/app/common/ResourceCodeBlock.vue
@@ -7,10 +7,7 @@
     :query-key="props.id"
     :code-max-height="props.codeMaxHeight"
   >
-    <template
-      v-if="showCopyAsKubernetesButton"
-      #secondary-actions
-    >
+    <template #secondary-actions>
       <CopyButton
         :get-text="getYamlAsKubernetes"
         :copy-text="i18n.t('common.copyKubernetesText')"
@@ -62,12 +59,6 @@ const props = defineProps({
     type: Boolean,
     required: false,
     default: false,
-  },
-
-  showCopyAsKubernetesButton: {
-    type: Boolean,
-    required: false,
-    default: true,
   },
 })
 

--- a/src/app/services/components/ServiceSummary.vue
+++ b/src/app/services/components/ServiceSummary.vue
@@ -79,11 +79,11 @@
     </KCard>
 
     <ResourceCodeBlock
+      v-if="props.service.serviceType === 'external' && props.externalService !== null"
       id="code-block-service"
       :resource="props.service"
       :resource-fetcher="fetchService"
       is-searchable
-      :show-copy-as-kubernetes-button="props.service.serviceType === 'external' && props.externalService !== null"
       code-max-height="250px"
     />
   </div>
@@ -154,12 +154,8 @@ const tags = computed(() => {
 })
 
 async function fetchService(params?: SingleResourceParameters) {
-  if (props.service.serviceType === 'external' && props.externalService !== null) {
-    const { mesh, name } = props.externalService
-    return await kumaApi.getExternalService({ mesh, name }, params)
-  } else {
-    const { mesh, name } = props.service
-    return await kumaApi.getServiceInsight({ mesh, name }, params)
-  }
+  // Justification for type assertion: this function is only used in a context where an appropriate check is made.
+  const { mesh, name } = props.externalService as ExternalService
+  return await kumaApi.getExternalService({ mesh, name }, params)
 }
 </script>


### PR DESCRIPTION
Removes the resource code block for internal `ServiceInsight`s as they don’t actually represent a resource.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
