### PR TITLE
fix(meshes): premature access of meshInsight.policies

### DIFF
--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -174,7 +174,7 @@ export const storeConfig = (kumaApi: KumaApi): StoreOptions<State> => {
         try {
           const meshInsight = await kumaApi.getMeshInsights({ name })
 
-          commit('SET_POLICY_TYPE_TOTALS', meshInsight.policies)
+          commit('SET_POLICY_TYPE_TOTALS', meshInsight.policies ?? {})
         } catch {
           commit('SET_POLICY_TYPE_TOTALS', {})
         }


### PR DESCRIPTION
Fixes another instance of premature object access of `meshInsight.policies`. We missed this when fixing a very similar issue recently because Vuex mutations can’t be properly type-checked.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
