### PR TITLE
chore: moves certificate insights into dpp overview

### DIFF
--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -94,12 +94,80 @@
           </template>
         </KCard>
 
-        <ResourceCodeBlock
-          id="code-block-data-plane"
-          :resource="props.dataplaneOverview"
-          :resource-fetcher="fetchDataPlaneProxy"
-          is-searchable
-        />
+        <div>
+          <h3>{{ t('data-planes.detail.mtls') }}</h3>
+
+          <KAlert
+            v-if="mtlsData === null"
+            class="mt-4"
+            appearance="danger"
+          >
+            <template #alertMessage>
+              {{ t('data-planes.detail.no_mtls') }} —
+              <a
+                :href="t('data-planes.href.docs.mutual-tls')"
+                class="external-link"
+                target="_blank"
+              >
+                {{ t('data-planes.detail.no_mtls_learn_more', { product: t('common.product.name') }) }}
+              </a>
+            </template>
+          </KAlert>
+
+          <KCard
+            v-else
+            class="mt-4"
+          >
+            <template #body>
+              <div
+                class="columns"
+                style="--columns: 3;"
+              >
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('http.api.property.certificateExpirationTime') }}
+                  </template>
+
+                  <template #body>
+                    {{ mtlsData.certificateExpirationTime }}
+                  </template>
+                </DefinitionCard>
+
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('http.api.property.lastCertificateRegeneration') }}
+                  </template>
+
+                  <template #body>
+                    {{ mtlsData.lastCertificateRegeneration }}
+                  </template>
+                </DefinitionCard>
+
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('http.api.property.certificateRegenerations') }}
+                  </template>
+
+                  <template #body>
+                    {{ mtlsData.certificateRegenerations }}
+                  </template>
+                </DefinitionCard>
+              </div>
+            </template>
+          </KCard>
+        </div>
+
+        <div>
+          <h3>{{ t('data-planes.detail.configuration') }}</h3>
+
+          <ResourceCodeBlock
+            id="code-block-data-plane"
+            class="mt-4"
+            :resource="props.dataplaneOverview"
+            :resource-fetcher="fetchDataPlaneProxy"
+            is-searchable
+          />
+        </div>
       </div>
     </template>
 
@@ -193,38 +261,6 @@
         </template>
       </KCard>
     </template>
-
-    <template #mtls>
-      <KCard>
-        <template #body>
-          <KAlert
-            v-if="mtlsData === null"
-            appearance="danger"
-          >
-            <template #alertMessage>
-              This data plane proxy does not yet have mTLS configured —
-              <a
-                :href="t('data-planes.href.docs.mutual-tls')"
-                class="external-link"
-                target="_blank"
-              >
-                Learn About Certificates in {{ t('common.product.name') }}
-              </a>
-            </template>
-          </KAlert>
-
-          <DefinitionList v-else>
-            <DefinitionListItem
-              v-for="(value, property) in mtlsData"
-              :key="property"
-              :term="t(`http.api.property.${property}`)"
-            >
-              {{ value }}
-            </DefinitionListItem>
-          </DefinitionList>
-        </template>
-      </KCard>
-    </template>
   </TabsWidget>
 </template>
 
@@ -237,8 +273,6 @@ import DataSource from '@/app/application/components/data-source/DataSource.vue'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
-import DefinitionList from '@/app/common/DefinitionList.vue'
-import DefinitionListItem from '@/app/common/DefinitionListItem.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import EnvoyData from '@/app/common/EnvoyData.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
@@ -304,10 +338,6 @@ const TABS = [
   {
     hash: '#envoy-clusters',
     title: t('data-planes.routes.item.tabs.clusters'),
-  },
-  {
-    hash: '#mtls',
-    title: t('data-planes.routes.item.tabs.mtls'),
   },
 ]
 

--- a/src/app/data-planes/locales/en-us/index.yaml
+++ b/src/app/data-planes/locales/en-us/index.yaml
@@ -10,7 +10,6 @@ data-planes:
         xds_configuration: 'XDS Configuration'
         stats: 'Stats'
         clusters: 'Clusters'
-        mtls: 'Certificate Insights'
     items:
       title: Data Plane Proxies
   href:
@@ -18,3 +17,8 @@ data-planes:
       mutual-tls: '{KUMA_DOCS_URL}/policies/mutual-tls?{KUMA_UTM_QUERY_PARAMS}'
   list:
     version_mismatch: 'Version mismatch'
+  detail:
+    mtls: 'Certificate'
+    no_mtls: 'This Data Plane Proxy does not have mTLS configured, yet'
+    no_mtls_learn_more: 'Learn about certificates in {product}'
+    configuration: 'Configuration'

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -42,6 +42,23 @@ export class KumaModule {
     )
   }
 
+  serviceName(serviceType: string = 'internal') {
+    const prefix = `${this.faker.hacker.noun()}_`
+
+    if (serviceType === 'gateway_delegated' || serviceType === 'gateway_builtin') {
+      return prefix + 'gateway'
+    } else {
+      return prefix + `${this.faker.hacker.noun()}_svc.mesh:80_${serviceType}`
+    }
+  }
+
+  dataPlaneProxyName() {
+    const namespace = this.faker.hacker.noun()
+    const deploymentId = this.faker.string.hexadecimal({ length: 10, casing: 'lower', prefix: '' })
+    const podId = this.faker.string.hexadecimal({ length: 5, casing: 'lower', prefix: '' })
+    return `${this.faker.hacker.noun()}-${deploymentId}-${podId}.${namespace}`
+  }
+
   status() {
     return this.faker.helpers.arrayElement(
       [

--- a/src/test-support/mocks/src/dataplanes+insights.ts
+++ b/src/test-support/mocks/src/dataplanes+insights.ts
@@ -16,14 +16,14 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         return {
           type: 'DataplaneOverview',
           mesh: `${fake.hacker.noun()}-${id}`,
-          name: `${fake.hacker.noun()}-${id}`,
+          name: `${fake.kuma.dataPlaneProxyName()}-${id}`,
           creationTime: '2021-02-17T08:33:36.442044+01:00',
           modificationTime: '2021-02-17T08:33:36.442044+01:00',
           dataplane: {
             networking: {
               address: '127.0.0.1',
               inbound: [
-                fake.kuma.inbound(fake.hacker.noun()),
+                fake.kuma.inbound(fake.kuma.serviceName()),
               ],
               outbound: [
                 {

--- a/src/test-support/mocks/src/dataplanes.ts
+++ b/src/test-support/mocks/src/dataplanes.ts
@@ -17,7 +17,7 @@ export default ({ env, fake, pager }: EndpointDependencies): MockResponder => (r
         return {
           type: 'Dataplane',
           mesh: `${fake.hacker.noun()}-${id}`,
-          name: `${fake.hacker.noun()}-${id}`,
+          name: `${fake.kuma.dataPlaneProxyName()}-${id}`,
           networking: {},
         }
       }),

--- a/src/test-support/mocks/src/meshes/_/dataplanes+insights.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes+insights.ts
@@ -27,9 +27,9 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const isGateway = (!hasSidecars || (hasGateways && fake.datatype.boolean()))
 
         const isMultizone = true && fake.datatype.boolean()
-        const service = tags['kuma.io/service'] ?? `${fake.hacker.noun()}`
+        const service = tags['kuma.io/service'] ?? fake.kuma.serviceName()
 
-        const name = `${_name || fake.hacker.noun()}${isGateway ? '-gateway' : '-proxy'}-${id}`
+        const name = `${_name || fake.kuma.dataPlaneProxyName()}${isGateway ? '-gateway' : '-proxy'}-${id}`
         const zone = isMultizone ? `${fake.hacker.noun()}-${id}` : undefined
 
         return {
@@ -44,7 +44,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               ...(isGateway && {
                 gateway: {
                   tags: {
-                    'kuma.io/service': name,
+                    'kuma.io/service': service,
                     ...(zone && {
                       'kuma.io/zone': zone,
                     }),
@@ -59,7 +59,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 {
                   port: fake.internet.port(),
                   tags: {
-                    'kuma.io/service': `${fake.hacker.noun()}-${i}`,
+                    'kuma.io/service': fake.kuma.serviceName(),
                   },
                 },
               ],

--- a/src/test-support/mocks/src/meshes/_/dataplanes+insights/_.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes+insights/_.ts
@@ -3,7 +3,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
   const params = req.params
   const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
 
-  const service = (params.name as string) ?? fake.hacker.noun()
+  const service = fake.kuma.serviceName()
   const isMultizone = true && fake.datatype.boolean()
   const zone = fake.hacker.noun()
 
@@ -26,7 +26,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
             {
               port: fake.internet.port(),
               tags: {
-                'kuma.io/service': fake.hacker.noun(),
+                'kuma.io/service': fake.kuma.serviceName(),
               },
             },
           ],

--- a/src/test-support/mocks/src/meshes/_/dataplanes/_.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes/_.ts
@@ -1,9 +1,8 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
 export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
-  const params = req.params
-
-  const isGateway = params.name.includes('gateway')
-  const service = (params.name as string) ?? fake.hacker.noun()
+  const { mesh, name } = req.params
+  const isGateway = name.includes('gateway')
+  const service = fake.kuma.serviceName(isGateway ? 'gateway_builtin' : 'internal')
   const isMultizone = true && fake.datatype.boolean()
   const zone = fake.hacker.noun()
 
@@ -12,8 +11,8 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
     },
     body: {
       type: 'Dataplane',
-      mesh: params.mesh,
-      name: params.name,
+      mesh,
+      name,
       creationTime: '2021-02-17T08:33:36.442044+01:00',
       modificationTime: '2021-02-17T08:33:36.442044+01:00',
       networking: {
@@ -21,7 +20,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
         ...(isGateway && {
           gateway: {
             tags: {
-              'kuma.io/service': `${service}`,
+              'kuma.io/service': service,
               ...(isMultizone && {
                 'kuma.io/zone': zone,
               }),
@@ -36,7 +35,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
           {
             port: fake.internet.port(),
             tags: {
-              'kuma.io/service': fake.hacker.noun(),
+              'kuma.io/service': fake.kuma.serviceName(),
             },
           },
         ],


### PR DESCRIPTION
Moves the content of the mTLS certificate insights tab into the DPP overview tab.

Updates DPP mocks to have more realistic (read: long) DPP and service names.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
