### PR TITLE
chore: expands standalone test coverage

### DIFF
--- a/features/diagnostics/DetailViewContent.feature
+++ b/features/diagnostics/DetailViewContent.feature
@@ -5,10 +5,9 @@ Feature: Diagnostics: Detail view content
       | details | [data-testid='code-block-diagnostics'] |
 
   Scenario: Diagnostics detail view has expected content
-    Given the URL "/config" responds with
+    Given the environment
       """
-      body:
-        mode: global
+      KUMA_MODE: global
       """
 
     When I visit the "/diagnostics" URL

--- a/features/main-overview/DetailViewContent.feature
+++ b/features/main-overview/DetailViewContent.feature
@@ -12,11 +12,6 @@ Feature: Overview: Detail view content
       KUMA_MESH_COUNT: 3
       KUMA_MODE: standalone
       """
-    And the URL "/config" responds with
-      """
-      body:
-        mode: 'standalone'
-      """
     And the URL "/mesh-insights" responds with
       """
       body:
@@ -58,11 +53,7 @@ Feature: Overview: Detail view content
       """
       KUMA_ZONE_COUNT: 2
       KUMA_MESH_COUNT: 3
-      """
-    And the URL "/config" responds with
-      """
-      body:
-        mode: 'global'
+      KUMA_MODE: global
       """
     And the URL "/zones+insights" responds with
       """

--- a/features/mesh/dataplanes/DetailViewContent.feature
+++ b/features/mesh/dataplanes/DetailViewContent.feature
@@ -23,11 +23,7 @@ Feature: Data Plane Proxies: Detail view content
     And the environment
       """
       KUMA_SUBSCRIPTION_COUNT: 2
-      """
-    And the URL "/config" responds with
-      """
-      body:
-        mode: global
+      KUMA_MODE: global
       """
     # TODO: Use exact mocking here. It’s almost impossible to control the test data without exact mocking. For example, I need to set `disconnectTime: ''` just so that I don’t risk a faker-random disconnect time appearing in the last subscription.
     And the URL "/meshes/default/dataplanes+insights/dpp-1" responds with

--- a/features/mesh/dataplanes/Index.feature
+++ b/features/mesh/dataplanes/Index.feature
@@ -30,11 +30,17 @@ Feature: mesh / dataplanes / index
                 lastUpdateTime: 2021-02-18T08:33:36.442044+01:00
         - name: fake-frontend
       """
+
+  Scenario: The Proxy listing table has the correct columns (mode: global)
+    Given the environment
+      """
+      KUMA_MODE: global
+      """
+
     When I visit the "/mesh/default/data-planes" URL
 
-  Scenario: The Proxy listing table has the correct columns
     Then the "$table-header" element exists 8 times
-    Then the "$table-header" elements contain
+    And the "$table-header" elements contain
       | Value        |
       | Name         |
       | Service      |
@@ -44,7 +50,27 @@ Feature: mesh / dataplanes / index
       | Status       |
       | Warnings     |
 
+  Scenario: The Proxy listing table has the correct columns (mode: standalone)
+    Given the environment
+      """
+      KUMA_MODE: standalone
+      """
+
+    When I visit the "/mesh/default/data-planes" URL
+
+    Then the "$table-header" element exists 7 times
+    And the "$table-header" elements contain
+      | Value        |
+      | Name         |
+      | Service      |
+      | Protocol     |
+      | Last Updated |
+      | Status       |
+      | Warnings     |
+
   Scenario: The Proxy listing has the expected content and UI elements
+    When I visit the "/mesh/default/data-planes" URL
+
     Then the "$table-row" element exists 9 times
     Then the "$table-row:nth-child(1)" element contains
       | Value        |

--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -1,7 +1,8 @@
-Feature: Zones: Zone create flow
+Feature: Zones: Create Zone flow
   Background:
     Given the CSS selectors
       | Alias                               | Selector                                            |
+      | zone-nav-item                       | .app-sidebar > .nav-item:nth-child(2) > a           |
       | name-input                          | [data-testid='name-input']                          |
       | create-zone-button                  | [data-testid='create-zone-button']                  |
       | create-zone-link                    | [data-testid='create-zone-link']                    |
@@ -12,12 +13,42 @@ Feature: Zones: Zone create flow
       | zone-connected-scanner              | [data-testid='zone-connected-scanner']              |
       | error                               | [data-testid='create-zone-error']                   |
       | instructions                        | [data-testid='connect-zone-instructions']           |
-    When I visit the "/zones" URL
+    And the environment
+      """
+      KUMA_MODE: global
+      """
+
+  Scenario: Create Zone link doesn't exist in standalone mode
+    Given the environment
+      """
+      KUMA_MODE: standalone
+      """
+
+    When I visit the "/" URL
+    Then the "[data-testid='loading-block']" element doesn't exist
+    And I click the "$zone-nav-item" element
+
+    Then the page title contains "Egresses"
+    And the "$create-zone-link" element doesn't exist
+
+  Scenario: Create Zone link exists in global mode
+    Given the environment
+      """
+      KUMA_MODE: global
+      """
+
+    When I visit the "/" URL
+    Then the "[data-testid='loading-block']" element doesn't exist
+    And I click the "$zone-nav-item" element
+
     Then the page title contains "Zone Control Planes"
+    And the "$create-zone-link" element exists
+
     When I click the "$create-zone-link" element
     Then the page title contains "Create & connect Zone"
 
   Scenario: The form shows only the initial elements
+    When I visit the "/zones/create" URL
     Then the "$name-input" element exists
     Then the "$create-zone-button" element is disabled
 
@@ -27,6 +58,7 @@ Feature: Zones: Zone create flow
     Then the "$egress-input-switch" element doesn't exist
 
   Scenario: The form interactions behave correctly
+    When I visit the "/zones/create" URL
     Then the "$create-zone-button" element is disabled
 
     When I "type" "test" into the "$name-input" element
@@ -84,6 +116,7 @@ Feature: Zones: Zone create flow
     Then the "$zone-connected-scanner" element contains "The Zone “test” is now connected"
 
   Scenario: The form shows an error
+    When I visit the "/zones/create" URL
     Given the URL "/provision-zone" responds with
       """
       headers:
@@ -95,6 +128,7 @@ Feature: Zones: Zone create flow
     Then the "$instructions" element doesn't exist
 
   Scenario: The form shows expected error for 400 response
+    When I visit the "/zones/create" URL
     Given the URL "/provision-zone" responds with
       """
       headers:

--- a/features/zones/DetailViewContent.feature
+++ b/features/zones/DetailViewContent.feature
@@ -6,13 +6,12 @@ Feature: Zones: Detail view content
       | ingress-detail-tabs-view | [data-testid='zone-ingress-detail-tabs-view'] |
       | egress-detail-view       | [data-testid='zone-egress-detail-view']       |
       | egress-detail-tabs-view  | [data-testid='zone-egress-detail-tabs-view']  |
+    And the environment
+      """
+      KUMA_MODE: global
+      """
 
   Scenario Outline: Zone Ingress detail view has expected content
-    Given the URL "/config" responds with
-      """
-      body:
-        mode: global
-      """
     And the URL "/zoneingresses+insights/zone-ingress-1" responds with
       """
       body:
@@ -38,11 +37,6 @@ Feature: Zones: Detail view content
     Then the "$ingress-detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"
 
   Scenario Outline: Zone Egress detail view has expected content
-    Given the URL "/config" responds with
-      """
-      body:
-        mode: global
-      """
     And the URL "/zoneegressoverviews/zone-egress-1" responds with
       """
       body:

--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -10,11 +10,7 @@ Feature: Zones: List view content
     Given the environment
       """
       KUMA_ZONE_COUNT: 3
-      """
-    And the URL "/config" responds with
-      """
-      body:
-        mode: global
+      KUMA_MODE: global
       """
     And the URL "/zones+insights" responds with
       """
@@ -106,11 +102,7 @@ Feature: Zones: List view content
     Given the environment
       """
       KUMA_ZONEINGRESS_COUNT: 1
-      """
-    And the URL "/config" responds with
-      """
-      body:
-        mode: global
+      KUMA_MODE: global
       """
     And the URL "/zoneingresses+insights" responds with
       """
@@ -152,11 +144,7 @@ Feature: Zones: List view content
     Given the environment
       """
       KUMA_ZONEEGRESS_COUNT: 1
-      """
-    And the URL "/config" responds with
-      """
-      body:
-        mode: global
+      KUMA_MODE: global
       """
     And the URL "/zoneegressoverviews" responds with
       """

--- a/features/zones/PageNavigation.feature
+++ b/features/zones/PageNavigation.feature
@@ -11,11 +11,7 @@ Feature: Zones: Page navigation
       KUMA_ZONE_COUNT: 2
       KUMA_ZONEINGRESS_COUNT: 1
       KUMA_ZONEEGRESS_COUNT: 1
-      """
-    And the URL "/config" responds with
-      """
-      body:
-        mode: global
+      KUMA_MODE: global
       """
     And the URL "/zones+insights" responds with
       """

--- a/features/zones/zone-cps/Item.feature
+++ b/features/zones/zone-cps/Item.feature
@@ -5,12 +5,11 @@ Feature: zones / zone-cps / item
       | zone-detail-tabs-view    | [data-testid='zone-cp-detail-tabs-view'] |
       | tab-overview             | [data-testid='zone-cp-detail-view']      |
       | warning-no-subscriptions | [data-testid='warning-no-subscriptions'] |
+    And the environment
+      """
+      KUMA_MODE: global
+      """
 
-    And the URL "/config" responds with
-      """
-      body:
-        mode: global
-      """
   Scenario: Zone CP detail view has expected content
     # We always use the final subscription
     # If the disconnectTime is empty then we are online


### PR DESCRIPTION
chore(zones): adds test for lack of create zone button

chore(dataplanes): adds test for Zone column

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
