### PR TITLE
chore: updates breadcrumbs and page titles

### DIFF
--- a/features/application/Titles.feature
+++ b/features/application/Titles.feature
@@ -20,23 +20,23 @@ Feature: The HTML title is correct on each page
 
       | /zones/create                           | Create & connect Zone |
       | /zones/zone-cps                         | Zone Control Planes   |
-      | /zones/zone-cps/zone-cp-name            | Zone Control Plane    |
+      | /zones/zone-cps/zone-cp-name            | zone-cp-name          |
       | /zones/zone-ingresses                   | Ingresses             |
-      | /zones/zone-ingresses/zone-ingress-name | Ingress               |
+      | /zones/zone-ingresses/zone-ingress-name | zone-ingress-name     |
       | /zones/zone-egresses                    | Egresses              |
-      | /zones/zone-egresses/zone-egress-name   | Egress                |
+      | /zones/zone-egresses/zone-egress-name   | zone-egress-name      |
 
       | /mesh         | Meshes        |
       | /mesh/default | Mesh overview |
 
-      | /mesh/default/services             | Services |
-      | /mesh/default/service/service-name | Service  |
+      | /mesh/default/services             | Services     |
+      | /mesh/default/service/service-name | service-name |
 
-      | /mesh/default/gateways             | Gateways |
-      | /mesh/default/gateway/gateway-name | Gateway  |
+      | /mesh/default/gateways             | Gateways     |
+      | /mesh/default/gateway/gateway-name | gateway-name |
 
       | /mesh/default/data-planes                | Data Plane Proxies |
-      | /mesh/default/data-plane/data-plane-name | Data Plane Proxy   |
+      | /mesh/default/data-plane/data-plane-name | data-plane-name    |
 
-      | /mesh/default/policies/circuit-breakers         | Policies                 |
-      | /mesh/default/policy/circuit-breakers/program-0 | program-0 CircuitBreaker |
+      | /mesh/default/policies/circuit-breakers         | Policies  |
+      | /mesh/default/policy/circuit-breakers/program-0 | program-0 |

--- a/features/mesh/dataplanes/DetailViewContent.feature
+++ b/features/mesh/dataplanes/DetailViewContent.feature
@@ -81,8 +81,8 @@ Feature: Data Plane Proxies: Detail view content
     When I visit the "/mesh/default/data-plane/dpp-1" URL
 
   Scenario: Data Plane Proxy detail view has expected content
-    Then the page title contains "dpp-1 Data Plane Proxy"
-    And the "$detail-view" element contains "dpp-1 Data Plane Proxy"
+    Then the page title contains "dpp-1"
+    And the "$detail-view" element contains "dpp-1"
 
     And the "$overview-content" element contains "online"
     And the "$overview-content" element contains "dpp-1"

--- a/features/mesh/services/Index.feature
+++ b/features/mesh/services/Index.feature
@@ -61,7 +61,7 @@ Feature: mesh / services / index
     Then the "$item:nth-child(2) td:nth-child(1)" element contains "service-2"
     When I click the "$item:nth-child(2) td:first-of-type a" element
     Then the URL contains "service/service-2"
-    Then the "[data-testid='service-detail-view']" element contains "service-2 Service"
+    Then the "[data-testid='service-detail-view']" element contains "service-2"
     Then the "#overview-tab" element exists
     # Service Insights with serviceType "internal" should have a Data Plane Proxy table
     And the "#dataPlaneProxies-tab" element exists

--- a/features/zones/DetailViewContent.feature
+++ b/features/zones/DetailViewContent.feature
@@ -27,8 +27,8 @@ Feature: Zones: Detail view content
       """
 
     When I visit the "/zones/zone-ingresses/zone-ingress-1" URL
-    Then the page title contains "Zone Ingress"
-    Then the "$ingress-detail-view" element contains "zone-ingress-1 Zone Ingress"
+    Then the page title contains "zone-ingress-1"
+    Then the "$ingress-detail-view" element contains "zone-ingress-1"
     Then the "$ingress-detail-view" element contains "ZoneIngressOverview"
 
     When I click the "#insights-tab" element
@@ -56,8 +56,8 @@ Feature: Zones: Detail view content
       """
 
     When I visit the "/zones/zone-egresses/zone-egress-1" URL
-    Then the page title contains "Zone Egress"
-    Then the "$egress-detail-view" element contains "zone-egress-1 Zone Egress"
+    Then the page title contains "zone-egress-1"
+    Then the "$egress-detail-view" element contains "zone-egress-1"
     Then the "$egress-detail-view" element contains "ZoneEgressOverview"
 
     When I click the "#insights-tab" element

--- a/features/zones/PageNavigation.feature
+++ b/features/zones/PageNavigation.feature
@@ -17,6 +17,24 @@ Feature: Zones: Page navigation
       body:
         mode: global
       """
+    And the URL "/zones+insights" responds with
+      """
+      body:
+        items:
+          - name: zone-cp-1
+      """
+    And the URL "/zoneingresses+insights" responds with
+      """
+      body:
+        items:
+          - name: zone-ingress-1
+      """
+    And the URL "/zoneegressoverviews" responds with
+      """
+      body:
+        items:
+          - name: zone-egress-1
+      """
 
     When I visit the "/zones" URL
     # This `cy.wait` stabilizes the test significantly. For some reason, it can happen that the subsequent navigation to via nav tab is never triggered.
@@ -34,7 +52,7 @@ Feature: Zones: Page navigation
     Then the "<TableSelector>" element exists
 
     Examples:
-      | RouteName              | TableSelector                           | DetailViewTitle    | ListViewTitle       |
-      | zone-cp-list-view      | [data-testid='zone-cp-collection']      | Zone Control Plane | Zone Control Planes |
-      | zone-ingress-list-view | [data-testid='zone-ingress-collection'] | Ingress            | Ingresses           |
-      | zone-egress-list-view  | [data-testid='zone-egress-collection']  | Egress             | Egresses            |
+      | RouteName              | TableSelector                           | DetailViewTitle | ListViewTitle       |
+      | zone-cp-list-view      | [data-testid='zone-cp-collection']      | zone-cp-1       | Zone Control Planes |
+      | zone-ingress-list-view | [data-testid='zone-ingress-collection'] | zone-ingress-1  | Ingresses           |
+      | zone-egress-list-view  | [data-testid='zone-egress-collection']  | zone-egress-1   | Egresses            |

--- a/features/zones/zone-cps/Item.feature
+++ b/features/zones/zone-cps/Item.feature
@@ -37,8 +37,8 @@ Feature: zones / zone-cps / item
       """
 
     When I visit the "/zones/zone-cps/zone-cp-1" URL
-    Then the page title contains "zone-cp-1 Zone Control Plane"
-    Then the "$zone-control-plane-detail-view" element contains "zone-cp-1 Zone Control Plane"
+    Then the page title contains "zone-cp-1"
+    Then the "$zone-control-plane-detail-view" element contains "zone-cp-1"
 
     Then the "$tab-overview" element contains
       | Value     |

--- a/src/app/data-planes/locales/en-us/index.yaml
+++ b/src/app/data-planes/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 data-planes:
   routes:
     item:
-      title: "{name} Data Plane Proxy"
+      title: "{name}"
       breadcrumbs: Data Plane Proxies
       tabs:
         overview: 'Overview'

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -8,6 +8,15 @@
       :breadcrumbs="[
         {
           to: {
+            name: 'mesh-detail-view',
+            params: {
+              mesh: route.params.mesh,
+            },
+          },
+          text: route.params.mesh,
+        },
+        {
+          to: {
             name: `${props.isGatewayView ? 'gateways' : 'data-planes'}-list-view`,
             params: {
               mesh: route.params.mesh,
@@ -18,12 +27,12 @@
       ]"
     >
       <template #title>
-        <h2>
+        <h1>
           <RouteTitle
             :title="t(`${props.isGatewayView ? 'gateways' : 'data-planes'}.routes.item.title`, { name: route.params.dataPlane })"
             :render="true"
           />
-        </h2>
+        </h1>
       </template>
 
       <DataSource

--- a/src/app/gateways/locales/en-us/index.yaml
+++ b/src/app/gateways/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 gateways:
   routes:
     item:
-      title: "{name} Gateway"
+      title: "{name}"
       breadcrumbs: Gateways
     items:
       title: Gateways

--- a/src/app/meshes/locales/en-us/index.yaml
+++ b/src/app/meshes/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 meshes:
   routes:
     item:
-      title: "{name} Mesh"
+      title: "{name}"
       breadcrumbs: Meshes
       navigation:
         mesh-detail-view: Overview

--- a/src/app/meshes/views/MeshDetailIndexView.vue
+++ b/src/app/meshes/views/MeshDetailIndexView.vue
@@ -2,12 +2,15 @@
   <RouteView>
     <AppView
       :breadcrumbs="[
-        {
+        ...(route.name !== 'mesh-detail-view' ? [{
           to: {
-            name: 'mesh-list-view'
+            name: 'mesh-detail-view',
+            params: {
+              mesh: route.params.mesh,
+            },
           },
-          text: t('meshes.routes.item.breadcrumbs'),
-        },
+          text: route.params.mesh as string,
+        }] : []),
       ]"
     >
       <RouterView v-slot="child">
@@ -21,9 +24,10 @@
 </template>
 
 <script lang="ts" setup>
+import { useRoute } from 'vue-router'
+
 import AppView from '@/app/application/components/app-view/AppView.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
-import { useI18n } from '@/utilities'
 
-const { t } = useI18n()
+const route = useRoute()
 </script>

--- a/src/app/meshes/views/MeshTabsView.vue
+++ b/src/app/meshes/views/MeshTabsView.vue
@@ -1,6 +1,15 @@
 <template>
-  <RouteView>
+  <RouteView v-slot="{ route }">
     <AppView>
+      <template #title>
+        <h1>
+          <RouteTitle
+            :title="t('meshes.routes.item.title', { name: route.params.mesh })"
+            :render="true"
+          />
+        </h1>
+      </template>
+
       <NavTabs
         class="route-mesh-view-tabs"
         :tabs="tabs"
@@ -20,11 +29,12 @@
 import { useRouter, RouteRecordRaw } from 'vue-router'
 
 import AppView from '@/app/application/components/app-view/AppView.vue'
+import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import NavTabs, { NavTab } from '@/app/common/NavTabs.vue'
 import { useI18n } from '@/utilities'
 
-const i18n = useI18n()
+const { t } = useI18n()
 const router = useRouter()
 
 const meshRoutes = router.getRoutes().find((route) => route.name === 'mesh-tabs-view')?.children ?? []
@@ -32,7 +42,7 @@ const tabs: NavTab[] = meshRoutes.map((route) => {
   const referenceRoute = typeof route.name === 'undefined' ? route.children?.[0] as RouteRecordRaw : route
   const routeName = referenceRoute.name as string
   const module = referenceRoute.meta?.module ?? ''
-  const title = i18n.t(`meshes.routes.item.navigation.${routeName}`)
+  const title = t(`meshes.routes.item.navigation.${routeName}`)
 
   return { title, routeName, module }
 })

--- a/src/app/policies/locales/en-us/index.yaml
+++ b/src/app/policies/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 policies:
   routes:
     item:
-      title: "{name} {type}"
+      title: "{name}"
       breadcrumbs: Policies
     items:
       title: "Policies"

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -26,6 +26,15 @@
             :breadcrumbs="[
               {
                 to: {
+                  name: 'mesh-detail-view',
+                  params: {
+                    mesh: route.params.mesh,
+                  },
+                },
+                text: route.params.mesh,
+              },
+              {
+                to: {
                   name: 'policies-list-view',
                   params: {
                     mesh: route.params.mesh,
@@ -37,12 +46,12 @@
             ]"
           >
             <template #title>
-              <h2>
+              <h1>
                 <RouteTitle
                   :title="t('policies.routes.item.title', { name: route.params.policy })"
                   :render="true"
                 />
-              </h2>
+              </h1>
             </template>
 
             <DataSource

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -39,10 +39,7 @@
             <template #title>
               <h2>
                 <RouteTitle
-                  :title="t('policies.routes.item.title', {
-                    name: route.params.policy,
-                    type: currentPolicyType.name,
-                  })"
+                  :title="t('policies.routes.item.title', { name: route.params.policy })"
                   :render="true"
                 />
               </h2>

--- a/src/app/services/locales/en-us/index.yaml
+++ b/src/app/services/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 services:
   routes:
     item:
-      title: "{name} Service"
+      title: "{name}"
       breadcrumbs: Services
       tabs:
         overview: 'Overview'

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -8,6 +8,15 @@
       :breadcrumbs="[
         {
           to: {
+            name: 'mesh-detail-view',
+            params: {
+              mesh: route.params.mesh,
+            },
+          },
+          text: route.params.mesh,
+        },
+        {
+          to: {
             name: 'services-list-view',
             params: {
               mesh: route.params.mesh,
@@ -18,12 +27,12 @@
       ]"
     >
       <template #title>
-        <h2>
+        <h1>
           <RouteTitle
             :title="t('services.routes.item.title', {name: route.params.service})"
             :render="true"
           />
-        </h2>
+        </h1>
       </template>
 
       <DataSource

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -1,7 +1,7 @@
 zone-cps:
   routes:
     item:
-      title: '{name} Zone Control Plane'
+      title: '{name}'
       breadcrumbs: Zone Control Planes
       tabs:
         overview: 'Overview'
@@ -18,7 +18,7 @@ zone-cps:
 zone-ingresses:
   routes:
     item:
-      title: '{name} Zone Ingress'
+      title: '{name}'
       breadcrumbs: Ingresses
       tabs:
         overview: 'Overview'
@@ -33,7 +33,7 @@ zone-ingresses:
 zone-egresses:
   routes:
     item:
-      title: '{name} Zone Egress'
+      title: '{name}'
       breadcrumbs: Egresses
       tabs:
         overview: 'Overview'

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -5,12 +5,12 @@
   >
     <AppView>
       <template #title>
-        <h2>
+        <h1>
           <RouteTitle
             :title="t('zone-egresses.routes.items.title')"
             :render="true"
           />
-        </h2>
+        </h1>
       </template>
 
       <DataSource

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -5,12 +5,12 @@
   >
     <AppView>
       <template #title>
-        <h2>
+        <h1>
           <RouteTitle
             :title="t('zone-ingresses.routes.items.title')"
             :render="true"
           />
-        </h2>
+        </h1>
       </template>
 
       <MultizoneInfo v-if="store.getters['config/getMulticlusterStatus'] === false" />


### PR DESCRIPTION
**chore: removes suffixes from page titles in detail views**

Removes the suffixes from page titles in detail views (e.g. the service detail view will now only include the service name and not "{name} Service").

**chore(meshes): updates breadcrumbs and heading levels**

Removes the Mesh name from the breadcrumbs for the list views Services, Gateways, Data Plane Proxies, and Policies.

Removes the Mesh name heading from the detail views Service, Gateway, Data Plane Proxy, and Policy. Instead, their respective resource name is now the level 1 heading (used to be level 2).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
