### PR TITLE
chore: adds data source cache key prefix service

### DIFF
--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -44,6 +44,7 @@ const $ = {
 
   httpClient: token<RestClient>('httpClient'),
   api: token<KumaApi>('KumaApi'),
+  getDataSourceCacheKeyPrefix: token<() => string>('getDataSourceCacheKeyPrefix'),
   dataSourcePool: token<DataSourcePool>('DataSourcePool'),
   dataSourceLifecycle: token<typeof DataSourceLifeCycle>('DataSourceLifecycle'),
   sources: token('sources'),
@@ -124,11 +125,18 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   [$.dataSourceLifecycle, {
     constant: DataSourceLifeCycle,
   }],
+  [$.getDataSourceCacheKeyPrefix, {
+    service: () => () => '',
+    arguments: [
+      $.router,
+    ],
+  }],
   [$.dataSourcePool, {
     service: DataSourcePool,
     arguments: [
       $.sources,
       $.dataSourceLifecycle,
+      $.getDataSourceCacheKeyPrefix,
     ],
   }],
   [$.api, {


### PR DESCRIPTION
Adds a small DI service for retrieving a cache key prefix for DataSource.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
