### PR TITLE
fix: too large font sizes on definition cards

### DIFF
--- a/src/app/common/DefinitionCard.vue
+++ b/src/app/common/DefinitionCard.vue
@@ -16,21 +16,21 @@
 .definition-card {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-xs);
+  gap: $kui-space-40;
 }
 
 .definition-card-title {
   display: flex;
   align-items: flex-end;
-  gap: var(--spacing-xs);
+  gap: $kui-space-40;
 }
 
 .definition-card-container {
   flex-grow: 1;
   display: flex;
-  align-items: center;
-  font-size: var(--type-xxl);
+  align-items: flex-start;
+  font-size: $kui-font-size-60;
   line-height: 1.5;
-  font-weight: var(--font-weight-bold);
+  font-weight: $kui-font-weight-bold;
 }
 </style>

--- a/src/app/common/ResourceStatus.vue
+++ b/src/app/common/ResourceStatus.vue
@@ -39,6 +39,6 @@ const props = defineProps({
 <style lang="scss" scoped>
 .status-separator,
 .status-separator + .status-total {
-  color: var(--black-200);
+  color: $kui-color-text-neutral;
 }
 </style>

--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -41,19 +41,7 @@
                 </template>
 
                 <template #body>
-                  <TextWithCopyButton :text="props.dataplaneOverview.name">
-                    <RouterLink
-                      :to="{
-                        name: 'data-plane-detail-view',
-                        params: {
-                          mesh: props.dataplaneOverview.mesh,
-                          dataPlane: props.dataplaneOverview.name,
-                        },
-                      }"
-                    >
-                      {{ props.dataplaneOverview.name }}
-                    </RouterLink>
-                  </TextWithCopyButton>
+                  <TextWithCopyButton :text="props.dataplaneOverview.name" />
                 </template>
               </DefinitionCard>
 

--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -10,7 +10,10 @@
 
         <KCard>
           <template #body>
-            <div class="variable-columns">
+            <div
+              class="columns"
+              style="--columns: 4;"
+            >
               <DefinitionCard>
                 <template #title>
                   {{ t('http.api.property.status') }}

--- a/src/app/main-overview/components/ControlPlaneDetails.vue
+++ b/src/app/main-overview/components/ControlPlaneDetails.vue
@@ -8,7 +8,10 @@
           </div>
         </div>
 
-        <div class="variable-columns">
+        <div
+          class="columns"
+          style="--columns: 4;"
+        >
           <ResourceStatus
             :total="store.getters['config/getMulticlusterStatus'] ? props.zoneOverviews.length : 1"
             data-testid="zone-control-planes-status"
@@ -64,7 +67,10 @@
       </template>
     </KCard>
 
-    <div class="variable-columns">
+    <div
+      class="columns"
+      style="--columns: 2;"
+    >
       <KCard v-if="store.getters['config/getMulticlusterStatus']">
         <template #body>
           <div class="card-header">

--- a/src/app/meshes/components/MeshDetails.vue
+++ b/src/app/meshes/components/MeshDetails.vue
@@ -13,18 +13,7 @@
               </template>
 
               <template #body>
-                <TextWithCopyButton :text="props.mesh.name">
-                  <RouterLink
-                    :to="{
-                      name: 'mesh-detail-view',
-                      params: {
-                        mesh: props.mesh.name,
-                      },
-                    }"
-                  >
-                    {{ props.mesh.name }}
-                  </RouterLink>
-                </TextWithCopyButton>
+                <TextWithCopyButton :text="props.mesh.name" />
               </template>
             </DefinitionCard>
 

--- a/src/app/services/components/ExternalServiceDetails.vue
+++ b/src/app/services/components/ExternalServiceDetails.vue
@@ -12,19 +12,7 @@
             </template>
 
             <template #body>
-              <TextWithCopyButton :text="props.serviceInsight.name">
-                <RouterLink
-                  :to="{
-                    name: 'service-detail-view',
-                    params: {
-                      service: props.serviceInsight.name,
-                      mesh: props.serviceInsight.mesh,
-                    },
-                  }"
-                >
-                  {{ props.serviceInsight.name }}
-                </RouterLink>
-              </TextWithCopyButton>
+              <TextWithCopyButton :text="props.serviceInsight.name" />
             </template>
           </DefinitionCard>
 

--- a/src/app/services/components/ServiceInsightDetails.vue
+++ b/src/app/services/components/ServiceInsightDetails.vue
@@ -22,19 +22,7 @@
             </template>
 
             <template #body>
-              <TextWithCopyButton :text="props.serviceInsight.name">
-                <RouterLink
-                  :to="{
-                    name: 'service-detail-view',
-                    params: {
-                      service: props.serviceInsight.name,
-                      mesh: props.serviceInsight.mesh,
-                    },
-                  }"
-                >
-                  {{ props.serviceInsight.name }}
-                </RouterLink>
-              </TextWithCopyButton>
+              <TextWithCopyButton :text="props.serviceInsight.name" />
             </template>
           </DefinitionCard>
 
@@ -44,7 +32,14 @@
             </template>
 
             <template #body>
-              {{ props.serviceInsight.addressPort ?? t('common.detail.none') }}
+              <TextWithCopyButton
+                v-if="props.serviceInsight.addressPort"
+                :text="props.serviceInsight.addressPort"
+              />
+
+              <template v-else>
+                {{ t('common.detail.none') }}
+              </template>
             </template>
           </DefinitionCard>
 

--- a/src/app/zones/components/ZoneDetails.vue
+++ b/src/app/zones/components/ZoneDetails.vue
@@ -9,7 +9,10 @@
 
         <KCard>
           <template #body>
-            <div class="variable-columns">
+            <div
+              class="columns"
+              style="--columns: 4;"
+            >
               <DefinitionCard>
                 <template #title>
                   {{ t('http.api.property.status') }}
@@ -26,18 +29,7 @@
                 </template>
 
                 <template #body>
-                  <TextWithCopyButton :text="props.zoneOverview.name">
-                    <RouterLink
-                      :to="{
-                        name: 'zone-cp-detail-view',
-                        params: {
-                          zone: props.zoneOverview.name,
-                        },
-                      }"
-                    >
-                      {{ props.zoneOverview.name }}
-                    </RouterLink>
-                  </TextWithCopyButton>
+                  <TextWithCopyButton :text="props.zoneOverview.name" />
                 </template>
               </DefinitionCard>
 

--- a/src/app/zones/components/ZoneEgressDetails.vue
+++ b/src/app/zones/components/ZoneEgressDetails.vue
@@ -20,18 +20,7 @@
               </template>
 
               <template #body>
-                <TextWithCopyButton :text="props.zoneEgressOverview.name">
-                  <RouterLink
-                    :to="{
-                      name: 'zone-egress-detail-view',
-                      params: {
-                        zoneEgress: props.zoneEgressOverview.name,
-                      },
-                    }"
-                  >
-                    {{ props.zoneEgressOverview.name }}
-                  </RouterLink>
-                </TextWithCopyButton>
+                <TextWithCopyButton :text="props.zoneEgressOverview.name" />
               </template>
             </DefinitionCard>
 

--- a/src/app/zones/components/ZoneEgressDetails.vue
+++ b/src/app/zones/components/ZoneEgressDetails.vue
@@ -3,7 +3,10 @@
     <template #overview>
       <KCard>
         <template #body>
-          <div class="variable-columns">
+          <div
+            class="columns"
+            style="--columns: 3;"
+          >
             <DefinitionCard>
               <template #title>
                 {{ t('http.api.property.status') }}

--- a/src/app/zones/components/ZoneIngressDetails.vue
+++ b/src/app/zones/components/ZoneIngressDetails.vue
@@ -3,7 +3,10 @@
     <template #overview>
       <KCard>
         <template #body>
-          <div class="variable-columns">
+          <div
+            class="columns"
+            style="--columns: 3;"
+          >
             <DefinitionCard>
               <template #title>
                 {{ t('http.api.property.status') }}

--- a/src/app/zones/components/ZoneIngressDetails.vue
+++ b/src/app/zones/components/ZoneIngressDetails.vue
@@ -20,18 +20,7 @@
               </template>
 
               <template #body>
-                <TextWithCopyButton :text="props.zoneIngressOverview.name">
-                  <RouterLink
-                    :to="{
-                      name: 'zone-ingress-detail-view',
-                      params: {
-                        zoneIngress: props.zoneIngressOverview.name,
-                      },
-                    }"
-                  >
-                    {{ props.zoneIngressOverview.name }}
-                  </RouterLink>
-                </TextWithCopyButton>
+                <TextWithCopyButton :text="props.zoneIngressOverview.name" />
               </template>
             </DefinitionCard>
 


### PR DESCRIPTION
**chore: makes definition card font size smaller**

Makes the font size used for definition cards smaller overall as we often get long resource names, etc. and it starts to look jarring.

**chore: removes self-referencing links from detail views**

Removes the links for the resource name cards as they’re not useful.

**chore: uses equal width columns for definition card lists**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
