### PR TITLE
chore: Make some app components global

### DIFF
--- a/src/app/application/index.ts
+++ b/src/app/application/index.ts
@@ -1,15 +1,43 @@
+import AppView from './components/app-view/AppView.vue'
+import DataSource from './components/data-source/DataSource.vue'
+import RouteTitle from './components/route-view/RouteTitle.vue'
+import RouteView from './components/route-view/RouteView.vue'
 import can from './services/can'
 import { token, createInjections } from '@/services/utils'
 import type { ServiceDefinition } from '@/services/utils'
+
 type Can = ReturnType<typeof can>
 type Token = ReturnType<typeof token>
+
+declare module '@vue/runtime-core' {
+  export interface GlobalComponents {
+    AppView: typeof AppView
+    DataSource: typeof DataSource
+    RouteView: typeof RouteView
+    RouteTitle: typeof RouteTitle
+  }
+}
 
 const $ = {
   can: token<Can>('application.can'),
   features: token('application.can.features'),
+  applicationComponents: token('application.components'),
 }
-export const services = (_app: Record<string, Token>): ServiceDefinition[] => {
+export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
+    [$.applicationComponents, {
+      service: () => {
+        return [
+          ['AppView', AppView],
+          ['DataSource', DataSource],
+          ['RouteView', RouteView],
+          ['RouteTitle', RouteTitle],
+        ]
+      },
+      labels: [
+        app.components,
+      ],
+    }],
     [$.can, {
       service: can,
       arguments: [

--- a/src/app/diagnostics/views/DiagnosticsView.vue
+++ b/src/app/diagnostics/views/DiagnosticsView.vue
@@ -1,5 +1,8 @@
 <template>
-  <RouteView name="diagnostics">
+  <RouteView
+    v-slot="{ t }"
+    name="diagnostics"
+  >
     <DataSource
       v-slot="{ data, error }: ConfigSource"
       :src="`/config`"
@@ -49,17 +52,8 @@
 </template>
 
 <script lang="ts" setup>
-import { KCard } from '@kong/kongponents'
-
 import type { ConfigSource } from '../sources'
-import AppView from '@/app/application/components/app-view/AppView.vue'
-import DataSource from '@/app/application/components/data-source/DataSource.vue'
-import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
-import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import CodeBlock from '@/app/common/CodeBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { useI18n } from '@/utilities'
-
-const { t } = useI18n()
 </script>

--- a/src/app/diagnostics/views/DiagnosticsView.vue
+++ b/src/app/diagnostics/views/DiagnosticsView.vue
@@ -1,3 +1,9 @@
+<script lang="ts" setup>
+import type { ConfigSource } from '../sources'
+import CodeBlock from '@/app/common/CodeBlock.vue'
+import ErrorBlock from '@/app/common/ErrorBlock.vue'
+import LoadingBlock from '@/app/common/LoadingBlock.vue'
+</script>
 <template>
   <RouteView
     v-slot="{ t }"
@@ -50,10 +56,3 @@
     </DataSource>
   </RouteView>
 </template>
-
-<script lang="ts" setup>
-import type { ConfigSource } from '../sources'
-import CodeBlock from '@/app/common/CodeBlock.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
-</script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,16 @@ import type { Router } from 'vue-router'
 export function useApp(
   store: Store<State>,
   router: Router,
+  components: [string, Component][],
 ) {
   return async (App: Component) => {
     const app = createApp(App)
     app.use(store, storeKey)
     app.use(router)
     app.use(Kongponents)
+    components.forEach(([name, component]: [string, Component]) => {
+      app.component(name, component)
+    })
     return app
   }
 }

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -4,9 +4,10 @@ import {
   createRouter,
   createWebHistory,
 } from 'vue-router'
-import { createStore, Store } from 'vuex'
+import { createStore } from 'vuex'
 
 import createDisabledLogger from './logger/DisabledLogger'
+import { TOKENS as _TOKENS } from './tokens'
 import { useApp } from '../index'
 import { services as application, TOKENS as APPLICATION } from '@/app/application'
 import type { Can } from '@/app/application/services/can'
@@ -16,64 +17,23 @@ import { routes as dataplaneRoutes, services as dataplanes } from '@/app/data-pl
 import { routes as gatewayRoutes, services as gateways } from '@/app/gateways'
 import { getNavItems } from '@/app/getNavItems'
 import { services as mainOverviewModule } from '@/app/main-overview'
-import type { SplitRouteRecordRaw } from '@/app/meshes'
 import { routes as meshRoutes, services as meshes } from '@/app/meshes'
 import { routes as policyRoutes, services as policies } from '@/app/policies'
 import { routes as serviceRoutes, services as servicesModule } from '@/app/services'
 import { routes as zoneRoutes, actions as zoneActionRoutes, services as zonesModule } from '@/app/zones'
 import i18nEnUs from '@/locales/en-us'
 import routes from '@/router/routes'
-import Env, { EnvArgs, EnvVars } from '@/services/env/Env'
+import Env, { EnvArgs } from '@/services/env/Env'
 import I18n from '@/services/i18n/I18n'
 import KumaApi from '@/services/kuma-api/KumaApi'
 import { RestClient } from '@/services/kuma-api/RestClient'
-import Logger from '@/services/logger/Logger'
 import type { Alias, ServiceConfigurator } from '@/services/utils'
-import { token, get, constant } from '@/services/utils'
-import { storeConfig, State } from '@/store/storeConfig'
-import type {
-  Router,
-} from 'vue-router'
+import { get, constant } from '@/services/utils'
+import { storeConfig } from '@/store/storeConfig'
 
 const $ = {
   ...APPLICATION,
-  EnvVars: token<EnvVars>('EnvVars'),
-  Env: token<Env>('Env'),
-  env: token<Alias<Env['var']>>('env'),
-
-  i18n: token<ReturnType<typeof I18n>>('i18n'),
-  enUs: token('i18n.locale.enUs'),
-  kumaEnUs: token('kuma.locale.enUs'),
-
-  httpClient: token<RestClient>('httpClient'),
-  api: token<KumaApi>('KumaApi'),
-  getDataSourceCacheKeyPrefix: token<() => string>('getDataSourceCacheKeyPrefix'),
-  dataSourcePool: token<DataSourcePool>('DataSourcePool'),
-  dataSourceLifecycle: token<typeof DataSourceLifeCycle>('DataSourceLifecycle'),
-  sources: token('sources'),
-
-  store: token<Store<State>>('store'),
-
-  router: token<Router>('router'),
-  routes: token<RouteRecordRaw[]>('vue.routes'),
-  routesLabel: token<RouteRecordRaw[]>('vue.routes.label'),
-  navigationGuards: token<NavigationGuard[]>('vue.routes.navigation.guards'),
-  guards: token<NavigationGuard[]>('app.guards'),
-
-  meshRoutes: token<RouteRecordRaw[]>('kuma.mesh.routes'),
-
-  dataplaneRoutes: token<SplitRouteRecordRaw[]>('kuma.dataplane.routes'),
-  gatewayRoutes: token<SplitRouteRecordRaw[]>('kuma.gateway.routes'),
-  serviceRoutes: token<SplitRouteRecordRaw[]>('kuma.service.routes'),
-  policyRoutes: token<SplitRouteRecordRaw[]>('kuma.policy.routes'),
-
-  zoneRoutes: token<RouteRecordRaw[]>('kuma.zone.routes'),
-
-  nav: token<ReturnType<typeof getNavItems>>('nav'),
-
-  logger: token<Logger>('logger'),
-
-  app: token<ReturnType<typeof useApp>>('app'),
+  ..._TOKENS,
 }
 type SupportedTokens = typeof $
 export const services: ServiceConfigurator<SupportedTokens> = ($) => [
@@ -203,6 +163,7 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
     arguments: [
       $.store,
       $.router,
+      $.components,
     ],
   }],
   // Routes

--- a/src/services/tokens.ts
+++ b/src/services/tokens.ts
@@ -48,7 +48,7 @@ export const TOKENS = {
 
   zoneRoutes: token<RouteRecordRaw[]>('kuma.zone.routes'),
 
-  nav: token<typeof getNavItems>('nav'),
+  nav: token<ReturnType<typeof getNavItems>>('nav'),
 
   logger: token<Logger>('logger'),
 

--- a/src/services/tokens.ts
+++ b/src/services/tokens.ts
@@ -1,0 +1,56 @@
+import type { useApp } from '../index'
+import type { DataSourcePool } from '@/app/application/services/data-source/DataSourcePool'
+import type DataSourceLifeCycle from '@/app/application/services/data-source/index'
+import type { getNavItems } from '@/app/getNavItems'
+import type { SplitRouteRecordRaw } from '@/app/meshes'
+import Env, { EnvVars } from '@/services/env/Env'
+import type I18n from '@/services/i18n/I18n'
+import type KumaApi from '@/services/kuma-api/KumaApi'
+import type { RestClient } from '@/services/kuma-api/RestClient'
+import type Logger from '@/services/logger/Logger'
+import type { Alias } from '@/services/utils'
+import { token } from '@/services/utils'
+import type { State } from '@/store/storeConfig'
+import type { Router, RouteRecordRaw, NavigationGuard } from 'vue-router'
+import type { Store } from 'vuex'
+
+export const TOKENS = {
+  EnvVars: token<EnvVars>('EnvVars'),
+  Env: token<Env>('Env'),
+  env: token<Alias<Env['var']>>('env'),
+  components: token('vue.components'),
+
+  i18n: token<ReturnType<typeof I18n>>('i18n'),
+  enUs: token('i18n.locale.enUs'),
+  kumaEnUs: token('kuma.locale.enUs'),
+
+  httpClient: token<RestClient>('httpClient'),
+  api: token<KumaApi>('KumaApi'),
+  dataSourcePool: token<DataSourcePool>('DataSourcePool'),
+  dataSourceLifecycle: token<typeof DataSourceLifeCycle>('DataSourceLifecycle'),
+  getDataSourceCacheKeyPrefix: token<() => string>('getDataSourceCacheKeyPrefix'),
+  sources: token('sources'),
+
+  store: token<Store<State>>('store'),
+
+  router: token<Router>('router'),
+  routes: token<RouteRecordRaw[]>('vue.routes'),
+  routesLabel: token<RouteRecordRaw[]>('vue.routes.label'),
+  navigationGuards: token<NavigationGuard[]>('vue.routes.navigation.guards'),
+  guards: token<NavigationGuard[]>('app.guards'),
+
+  meshRoutes: token<RouteRecordRaw[]>('kuma.mesh.routes'),
+
+  dataplaneRoutes: token<SplitRouteRecordRaw[]>('kuma.dataplane.routes'),
+  gatewayRoutes: token<SplitRouteRecordRaw[]>('kuma.gateway.routes'),
+  serviceRoutes: token<SplitRouteRecordRaw[]>('kuma.service.routes'),
+  policyRoutes: token<SplitRouteRecordRaw[]>('kuma.policy.routes'),
+
+  zoneRoutes: token<RouteRecordRaw[]>('kuma.zone.routes'),
+
+  nav: token<typeof getNavItems>('nav'),
+
+  logger: token<Logger>('logger'),
+
+  app: token<ReturnType<typeof useApp>>('app'),
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,4 +1,4 @@
-import { TOKENS } from '@/services/production'
+import { TOKENS } from '@/services/tokens'
 import { createInjections } from '@/services/utils'
 
 export const [


### PR DESCRIPTION
Moves some of our very commonly used components to be global.

Not only does this ease using these components, but it should also make certain components a lot easier to inject when/if we need to (instead of them only being injectable if they are used via `useComponentName`)

I've moved the imports/headers to the top of the template file here as it kinda make sense for 'headers' to be at the top of the file.

Signed-off-by: John Cowen <john.cowen@konghq.com>