### PR TITLE
chore: Uses can for zone abilities/features in all *View.vue files

### DIFF
--- a/src/app/onboarding/views/WelcomeView.spec.ts
+++ b/src/app/onboarding/views/WelcomeView.spec.ts
@@ -17,7 +17,6 @@ describe('WelcomeView.vue', () => {
       return merge({
         body: {
           environment: 'universal',
-          mode: 'standalone',
         },
       })
     })

--- a/src/app/onboarding/views/WelcomeView.vue
+++ b/src/app/onboarding/views/WelcomeView.vue
@@ -1,5 +1,7 @@
 <template>
-  <RouteView>
+  <RouteView
+    v-slot="{ t, can }"
+  >
     <RouteTitle
       :title="t('onboarding.routes.welcome.title', {name: t('common.product.name')})"
     />
@@ -32,7 +34,33 @@
             <div class="item-status-list-wrapper">
               <ul class="item-status-list">
                 <li
-                  v-for="item in statuses"
+                  v-for="item in [
+                    {
+                      name: `Run ${t('common.product.name')} control plane`,
+                      status: true,
+                    },
+                    {
+                      name: 'Learn about deployments',
+                      status: false,
+                    },
+                    {
+                      name: 'Learn about configuration storage',
+                      status: false,
+                    },
+                    ...can('use zones') ? [{ name: 'Add zones', status: false }] : [],
+                    {
+                      name: 'Create the mesh',
+                      status: false,
+                    },
+                    {
+                      name: 'Add services',
+                      status: false,
+                    },
+                    {
+                      name: 'Go to the dashboard',
+                      status: false,
+                    },
+                  ]"
                   :key="item.name"
                 >
                   <span class="circle mr-2">
@@ -55,7 +83,7 @@
           </template>
         </OnboardingPage>
 
-        <WelcomeAnimationSvg :longer="isMulticluster" />
+        <WelcomeAnimationSvg :longer="can('use zones')" />
       </div>
     </AppView>
   </RouteView>
@@ -74,44 +102,14 @@ import AppView from '@/app/application/components/app-view/AppView.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import { useStore } from '@/store/store'
-import { useI18n } from '@/utilities'
 
 const store = useStore()
-const { t } = useI18n()
 
 const enviromentFormatted = computed(() => {
   const environment = store.getters['config/getEnvironment']
   return environment.charAt(0).toUpperCase() + environment.slice(1)
 })
 
-const isMulticluster = computed(() => store.getters['config/getMulticlusterStatus'])
-const statuses = computed(() => [
-  {
-    name: `Run ${t('common.product.name')} control plane`,
-    status: true,
-  },
-  {
-    name: 'Learn about deployments',
-    status: false,
-  },
-  {
-    name: 'Learn about configuration storage',
-    status: false,
-  },
-  ...isMulticluster.value ? [{ name: 'Add zones', status: false }] : [],
-  {
-    name: 'Create the mesh',
-    status: false,
-  },
-  {
-    name: 'Add services',
-    status: false,
-  },
-  {
-    name: 'Go to the dashboard',
-    status: false,
-  },
-])
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/onboarding/views/__snapshots__/WelcomeView.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/WelcomeView.spec.ts.snap
@@ -137,6 +137,14 @@ exports[`WelcomeView.vue renders snapshot 1`] = `
                       >
                         <!--v-if-->
                       </span>
+                       Add zones
+                    </li>
+                    <li>
+                      <span
+                        class="circle mr-2"
+                      >
+                        <!--v-if-->
+                      </span>
                        Create the mesh
                     </li>
                     <li>
@@ -211,7 +219,7 @@ exports[`WelcomeView.vue renders snapshot 1`] = `
         </div>
         <svg
           class="background svg"
-          longer="false"
+          longer="true"
           viewBox="0 0 1920 1080"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    v-slot="{ route }"
+    v-slot="{ route, can }"
     name="zone-ingress-list-view"
   >
     <AppView>
@@ -12,8 +12,7 @@
           />
         </h1>
       </template>
-
-      <MultizoneInfo v-if="store.getters['config/getMulticlusterStatus'] === false" />
+      <MultizoneInfo v-if="!can('use zones')" />
 
       <template v-else>
         <DataSource
@@ -115,7 +114,6 @@ import DataSource from '@/app/application/components/data-source/DataSource.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
-import { useStore } from '@/store/store'
 import { StatusKeyword, ZoneIngressOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
@@ -127,7 +125,6 @@ type ZoneIngressOverviewTableRow = {
 }
 
 const { t } = useI18n()
-const store = useStore()
 
 const props = defineProps({
   page: {

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    v-slot="{ route }"
+    v-slot="{ route, t, can, env }"
     name="zone-cp-list-view"
   >
     <AppView>
@@ -14,7 +14,7 @@
       </template>
 
       <template
-        v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled' && store.getters['config/getMulticlusterStatus'] && isCreateZoneButtonVisible"
+        v-if="can('create zones') && isCreateZoneButtonVisible"
         #actions
       >
         <KButton
@@ -27,7 +27,7 @@
         </KButton>
       </template>
 
-      <MultizoneInfo v-if="store.getters['config/getMulticlusterStatus'] === false" />
+      <MultizoneInfo v-if="!can('use zones')" />
 
       <template v-else>
         <DataSource
@@ -136,7 +136,7 @@
                       />
 
                       <KDropdownItem
-                        v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
+                        v-if="can('create zones')"
                         has-divider
                         is-dangerous
                         data-testid="dropdown-delete-item"
@@ -195,9 +195,8 @@ import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import DeleteResourceModal from '@/app/common/DeleteResourceModal.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import WarningIcon from '@/app/common/WarningIcon.vue'
-import { useStore } from '@/store/store'
 import { StatusKeyword, ZoneOverview } from '@/types/index.d'
-import { useEnv, useI18n, useKumaApi } from '@/utilities'
+import { useKumaApi } from '@/utilities'
 
 type ZoneOverviewTableRow = {
   detailViewRoute: RouteLocationNamedRaw
@@ -208,10 +207,7 @@ type ZoneOverviewTableRow = {
   warnings: boolean
 }
 
-const env = useEnv()
-const { t } = useI18n()
 const kumaApi = useKumaApi()
-const store = useStore()
 
 const props = defineProps({
   page: {

--- a/src/app/zones/views/ZoneTabsView.vue
+++ b/src/app/zones/views/ZoneTabsView.vue
@@ -1,11 +1,33 @@
+<script lang="ts" setup>
+import AppView from '@/app/application/components/app-view/AppView.vue'
+import RouteView from '@/app/application/components/route-view/RouteView.vue'
+import NavTabs from '@/app/common/NavTabs.vue'
+</script>
 <template>
-  <RouteView>
+  <RouteView
+    v-slot="{ t, can }"
+  >
     <AppView>
       <NavTabs
-        v-if="store.getters['config/getMulticlusterStatus']"
-        :tabs="tabs"
+        v-if="can('use zones')"
+        :tabs="[
+          {
+            title: t('zones.routes.items.navigation.zone-cp-list-view'),
+            routeName: 'zone-cp-list-view',
+            module: 'zone-cps',
+          },
+          {
+            title: t('zones.routes.items.navigation.zone-ingress-list-view'),
+            routeName: 'zone-ingress-list-view',
+            module: 'zone-ingresses',
+          },
+          {
+            title: t('zones.routes.items.navigation.zone-egress-list-view'),
+            routeName: 'zone-egress-list-view',
+            module: 'zone-egresses',
+          },
+        ]"
       />
-
       <RouterView v-slot="{ Component, route }">
         <component
           :is="Component"
@@ -15,32 +37,3 @@
     </AppView>
   </RouteView>
 </template>
-
-<script lang="ts" setup>
-import AppView from '@/app/application/components/app-view/AppView.vue'
-import RouteView from '@/app/application/components/route-view/RouteView.vue'
-import NavTabs, { NavTab } from '@/app/common/NavTabs.vue'
-import { useStore } from '@/store/store'
-import { useI18n } from '@/utilities'
-
-const { t } = useI18n()
-const store = useStore()
-
-const tabs: NavTab[] = [
-  {
-    title: t('zones.routes.items.navigation.zone-cp-list-view'),
-    routeName: 'zone-cp-list-view',
-    module: 'zone-cps',
-  },
-  {
-    title: t('zones.routes.items.navigation.zone-ingress-list-view'),
-    routeName: 'zone-ingress-list-view',
-    module: 'zone-ingresses',
-  },
-  {
-    title: t('zones.routes.items.navigation.zone-egress-list-view'),
-    routeName: 'zone-egress-list-view',
-    module: 'zone-egresses',
-  },
-]
-</script>

--- a/vite.config.preview.ts
+++ b/vite.config.preview.ts
@@ -46,6 +46,10 @@ export const config: (context: PreviewConfigContext) => UserConfigFn = ({
                 baseGuiPath: base,
                 apiUrl: api,
                 version,
+                product: 'Kuma',
+                mode: 'global',
+                environment: 'universal',
+                apiReadOnly: false,
               },
             ))
           server.middlewares.use('/', async (req, res, next) => {


### PR DESCRIPTION
Uses `can` for checking whether we can do zone type things in all `*View.vue` files (where we export `can` from RouteView).

There will be a follow up for the components. I've split this into separate PRs as I would rather look to see how straightforwards it is to pass down whether we can do zone type things into the components rather than using can in the component directly.

Signed-off-by: John Cowen <john.cowen@konghq.com>