### PR TITLE
chore: Remove usages of KUMA_PRODUCT_NAME

### DIFF
--- a/src/app/common/KumaLogo.vue
+++ b/src/app/common/KumaLogo.vue
@@ -1,13 +1,13 @@
 <template>
   <img
     src="@/assets/images/product-logo.png"
-    :alt="`${env('KUMA_PRODUCT_NAME')} Logo`"
+    :alt="`${t('common.product.name')} Logo`"
   >
 </template>
 
 <script lang="ts" setup>
-import { useEnv } from '@/utilities'
-const env = useEnv()
+import { useI18n } from '@/utilities'
+const { t } = useI18n()
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/common/UpgradeCheck.vue
+++ b/src/app/common/UpgradeCheck.vue
@@ -9,7 +9,7 @@
       <template #alertMessage>
         <div class="alert-content">
           <div>
-            {{ env('KUMA_PRODUCT_NAME') }} update available
+            {{ t('common.product.name') }} update available
           </div>
 
           <div>
@@ -32,10 +32,11 @@
 import { KAlert, KButton } from '@kong/kongponents'
 import { ref } from 'vue'
 
-import { useEnv, useKumaApi } from '@/utilities'
+import { useEnv, useKumaApi, useI18n } from '@/utilities'
 
 const kumaApi = useKumaApi()
 const env = useEnv()
+const { t } = useI18n()
 
 const latestVersion = ref('')
 const showNotice = ref(false)

--- a/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
+++ b/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
@@ -5,7 +5,7 @@
     <ul>
       <li>
         <b>{{ i18n.t('zones.form.kubernetes.prerequisites.step1Label') }}{{ props.zoneIngressEnabled ? ' ' + i18n.t('zones.form.kubernetes.prerequisites.step1LabelAddendum') : '' }}</b>:
-        {{ i18n.t('zones.form.kubernetes.prerequisites.step1Description', { productName: env('KUMA_PRODUCT_NAME') }) }}
+        {{ i18n.t('zones.form.kubernetes.prerequisites.step1Description', { productName: i18n.t('common.product.name') }) }}
       </li>
 
       <li>
@@ -102,11 +102,9 @@ import { useRoute } from 'vue-router'
 import CodeBlock from '@/app/common/CodeBlock.vue'
 import { useStore } from '@/store/store'
 import {
-  useEnv,
   useI18n,
 } from '@/utilities'
 
-const env = useEnv()
 const i18n = useI18n()
 const route = useRoute()
 const store = useStore()


### PR DESCRIPTION
Once we got a `i18n` layer and `t` into the application we started to use this for most strings over using environment variables. I spotted `KUMA_PRODUCT_NAME` being used so decided to get rid of the last remaining ones in the project.

Note: This does not make this environment variable unavailable yet (you will see I didn't remove the code for this), but this should be removed in a future update.

Signed-off-by: John Cowen <john.cowen@konghq.com>
