### PR TITLE
chore: updates zone details and subscriptions

### DIFF
--- a/features/mesh/dataplanes/DetailViewContent.feature
+++ b/features/mesh/dataplanes/DetailViewContent.feature
@@ -93,7 +93,7 @@ Feature: Data Plane Proxies: Detail view content
     And the "$warnings" element doesn't exist
 
     When I click the "$insights-tab" element
-    Then the "$insights-content" element contains "Connect time: Feb 17, 2021, 7:33 AM"
+    Then the "$insights-content" element contains "Connected: Feb 17, 2021, 7:33 AM"
     Then the "$insights-content" element contains "CP instance ID: dpp-1-cp-instance-id"
 
     And the "$status-cds" element contains "CDS"

--- a/features/zones/DetailViewContent.feature
+++ b/features/zones/DetailViewContent.feature
@@ -30,9 +30,7 @@ Feature: Zones: Detail view content
     Then the page title contains "zone-ingress-1"
     Then the "$ingress-detail-view" element contains "zone-ingress-1"
     Then the "$ingress-detail-view" element contains "ZoneIngressOverview"
-
-    When I click the "#insights-tab" element
-    Then the "$ingress-detail-view" element contains "Connect time: Jul 28, 2020, 4:18 PM"
+    Then the "$ingress-detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"
 
   Scenario Outline: Zone Egress detail view has expected content
     Given the URL "/config" responds with
@@ -59,6 +57,4 @@ Feature: Zones: Detail view content
     Then the page title contains "zone-egress-1"
     Then the "$egress-detail-view" element contains "zone-egress-1"
     Then the "$egress-detail-view" element contains "ZoneEgressOverview"
-
-    When I click the "#insights-tab" element
-    Then the "$egress-detail-view" element contains "Connect time: Jul 28, 2020, 4:18 PM"
+    Then the "$egress-detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"

--- a/features/zones/zone-cps/Item.feature
+++ b/features/zones/zone-cps/Item.feature
@@ -47,7 +47,7 @@ Feature: zones / zone-cps / item
       | dpToken   |
 
     When I click the "$nav-insights" element
-    Then the "$tab-insights" element contains "Connect time: Jul 28, 2020, 4:18 PM"
+    Then the "$tab-insights" element contains "Connected: Jul 28, 2020, 4:18 PM"
 
   Scenario: When subscriptions aren't set a warning is shown
     And the URL "/zones+insights/zone-cp-1" responds with

--- a/src/app/common/EnvoyData.vue
+++ b/src/app/common/EnvoyData.vue
@@ -1,6 +1,16 @@
 <template>
   <div>
+    <KAlert
+      v-if="props.status !== 'online'"
+      appearance="info"
+    >
+      <template #alertMessage>
+        <p>{{ t('common.detail.no_envoy_data', { resource: props.resource }) }}</p>
+      </template>
+    </KAlert>
+
     <DataSource
+      v-else
       v-slot="{ data, error, refresh }: EnvoyDataSource"
       :src="props.src"
     >
@@ -38,7 +48,8 @@
 </template>
 
 <script lang="ts" setup>
-import { KButton } from '@kong/kongponents'
+import { KAlert, KButton } from '@kong/kongponents'
+import { PropType } from 'vue'
 
 import CodeBlock from './CodeBlock.vue'
 import DataSource from '@/app/application/components/data-source/DataSource.vue'
@@ -46,8 +57,22 @@ import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import { EnvoyDataSource } from '@/app/zones/sources'
+import { StatusKeyword } from '@/types'
+import { useI18n } from '@/utilities'
+
+const { t } = useI18n()
 
 const props = defineProps({
+  status: {
+    type: String as PropType<StatusKeyword>,
+    required: true,
+  },
+
+  resource: {
+    type: String,
+    required: true,
+  },
+
   src: {
     type: String,
     required: true,

--- a/src/app/common/subscriptions/SubscriptionDetails.vue
+++ b/src/app/common/subscriptions/SubscriptionDetails.vue
@@ -21,11 +21,7 @@
           </div>
 
           <div class="header">
-            {{ t('http.api.property.responsesSent') }}
-          </div>
-
-          <div class="header">
-            {{ t('http.api.property.responsesAcknowledged') }}
+            {{ t('common.detail.subscriptions.responses_sent_acknowledged') }}
           </div>
         </div>
 
@@ -40,11 +36,7 @@
           </div>
 
           <div>
-            {{ row.responsesSent }}
-          </div>
-
-          <div>
-            {{ row.responsesAcknowledged }}
+            {{ row.responsesSent }}/{{ row.responsesAcknowledged }}
           </div>
         </div>
       </div>
@@ -108,16 +100,9 @@ const statuses = computed<StatusRow[]>(() => {
 </script>
 
 <style lang="scss" scoped>
-.overview-tertiary-title {
-  font-size: $kui-font-size-30;
-  font-weight: $kui-font-weight-semibold;
-  color: $kui-color-text-neutral;
-  margin: $kui-space-40 0;
-}
-
 .row {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 30ch 1fr;
   padding: $kui-space-40;
 }
 

--- a/src/app/common/subscriptions/SubscriptionHeader.vue
+++ b/src/app/common/subscriptions/SubscriptionHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <header class="subscription-header">
-    <span>
+    <span class="instance-id">
       <img src="@/assets/images/icon-deployed-code.svg?url">
 
       <template v-if="globalInstanceId">
@@ -25,6 +25,12 @@
         <b>{{ t('common.detail.subscriptions.disconnect_time') }}</b>: {{ disconnectTime }}
       </template>
     </span>
+
+    <span class="responses-sent-acknowledged">
+      {{ t('common.detail.subscriptions.responses_sent_acknowledged') }}:
+
+      {{ total.responsesSent }}/{{ total.responsesAcknowledged }}
+    </span>
   </header>
 </template>
 
@@ -47,16 +53,34 @@ const globalInstanceId = computed(() => 'globalInstanceId' in props.subscription
 const controlPlaneInstanceId = computed(() => 'controlPlaneInstanceId' in props.subscription ? props.subscription.controlPlaneInstanceId : null)
 const connectTime = computed(() => props.subscription.connectTime ? formatIsoDate(props.subscription.connectTime) : null)
 const disconnectTime = computed(() => props.subscription.disconnectTime ? formatIsoDate(props.subscription.disconnectTime) : null)
+const total = computed(() => {
+  const { responsesSent = 0, responsesAcknowledged = 0, responsesRejected = 0 } = props.subscription.status?.total ?? {}
+
+  return {
+    responsesSent,
+    responsesAcknowledged,
+    responsesRejected,
+  }
+})
 </script>
 
 <style lang="scss" scoped>
 .subscription-header {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 30ch repeat(3, 1fr);
+  gap: $kui-space-80;
   padding-right: $kui-space-40;
   padding-left: $kui-space-40;
   font-size: 1.125rem;
   line-height: 1.75rem;
   font-weight: $kui-font-weight-medium;
+}
+
+.instance-id {
+  flex-basis: 30ch;
+}
+
+.responses-sent-acknowledged {
+  color: $kui-color-text-neutral;
 }
 </style>

--- a/src/app/common/subscriptions/SubscriptionHeader.vue
+++ b/src/app/common/subscriptions/SubscriptionHeader.vue
@@ -71,8 +71,6 @@ const total = computed(() => {
   gap: $kui-space-80;
   padding-right: $kui-space-40;
   padding-left: $kui-space-40;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
   font-weight: $kui-font-weight-medium;
 }
 

--- a/src/app/data-planes/components/DataPlaneDetails.vue
+++ b/src/app/data-planes/components/DataPlaneDetails.vue
@@ -232,6 +232,8 @@
       <KCard>
         <template #body>
           <EnvoyData
+            :status="statusWithReason.status"
+            resource="Data Plane Proxy"
             :src="`/meshes/${props.dataplaneOverview.mesh}/dataplanes/${props.dataplaneOverview.name}/data-path/xds`"
             query-key="envoy-data-xds-data-plane"
           />
@@ -243,6 +245,8 @@
       <KCard>
         <template #body>
           <EnvoyData
+            :status="statusWithReason.status"
+            resource="Data Plane Proxy"
             :src="`/meshes/${props.dataplaneOverview.mesh}/dataplanes/${props.dataplaneOverview.name}/data-path/stats`"
             query-key="envoy-data-stats-data-plane"
           />
@@ -254,6 +258,8 @@
       <KCard>
         <template #body>
           <EnvoyData
+            :status="statusWithReason.status"
+            resource="Data Plane Proxy"
             :src="`/meshes/${props.dataplaneOverview.mesh}/dataplanes/${props.dataplaneOverview.name}/data-path/clusters`"
             query-key="envoy-data-clusters-data-plane"
           />

--- a/src/app/data-planes/locales/en-us/index.yaml
+++ b/src/app/data-planes/locales/en-us/index.yaml
@@ -5,7 +5,7 @@ data-planes:
       breadcrumbs: Data Plane Proxies
       tabs:
         overview: 'Overview'
-        insights: 'Insights'
+        insights: 'Subscriptions'
         policies: 'Policies'
         xds_configuration: 'XDS Configuration'
         stats: 'Stats'

--- a/src/app/zones/components/ZoneEgressDetails.vue
+++ b/src/app/zones/components/ZoneEgressDetails.vue
@@ -1,68 +1,68 @@
 <template>
   <TabsWidget :tabs="TABS">
     <template #overview>
-      <KCard>
-        <template #body>
-          <div
-            class="columns"
-            style="--columns: 3;"
-          >
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.status') }}
-              </template>
-
-              <template #body>
-                <StatusBadge :status="status" />
-              </template>
-            </DefinitionCard>
-
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.name') }}
-              </template>
-
-              <template #body>
-                <TextWithCopyButton :text="props.zoneEgressOverview.name" />
-              </template>
-            </DefinitionCard>
-
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.type') }}
-              </template>
-
-              <template #body>
-                {{ props.zoneEgressOverview.type }}
-              </template>
-            </DefinitionCard>
-          </div>
-        </template>
-      </KCard>
-    </template>
-
-    <template #insights>
-      <KCard>
-        <template #body>
-          <AccordionList :initially-open="0">
-            <AccordionItem
-              v-for="(subscription, index) in subscriptionsReversed"
-              :key="index"
+      <div class="stack">
+        <KCard>
+          <template #body>
+            <div
+              class="columns"
+              style="--columns: 3;"
             >
-              <template #accordion-header>
-                <SubscriptionHeader :subscription="subscription" />
-              </template>
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.status') }}
+                </template>
 
-              <template #accordion-content>
-                <SubscriptionDetails
-                  :subscription="subscription"
-                  is-discovery-subscription
-                />
-              </template>
-            </AccordionItem>
-          </AccordionList>
-        </template>
-      </KCard>
+                <template #body>
+                  <StatusBadge :status="status" />
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.name') }}
+                </template>
+
+                <template #body>
+                  <TextWithCopyButton :text="props.zoneEgressOverview.name" />
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.type') }}
+                </template>
+
+                <template #body>
+                  {{ props.zoneEgressOverview.type }}
+                </template>
+              </DefinitionCard>
+            </div>
+          </template>
+        </KCard>
+
+        <KCard>
+          <template #body>
+            <AccordionList :initially-open="0">
+              <AccordionItem
+                v-for="(subscription, index) in subscriptionsReversed"
+                :key="index"
+              >
+                <template #accordion-header>
+                  <SubscriptionHeader :subscription="subscription" />
+                </template>
+
+                <template #accordion-content>
+                  <SubscriptionDetails
+                    :subscription="subscription"
+                    is-discovery-subscription
+                  />
+                </template>
+              </AccordionItem>
+            </AccordionList>
+          </template>
+        </KCard>
+      </div>
     </template>
 
     <template #xds-configuration>
@@ -129,10 +129,6 @@ const TABS = [
   {
     hash: '#overview',
     title: t('zone-egresses.routes.item.tabs.overview'),
-  },
-  {
-    hash: '#insights',
-    title: t('zone-egresses.routes.item.tabs.insights'),
   },
   {
     hash: '#xds-configuration',

--- a/src/app/zones/components/ZoneEgressDetails.vue
+++ b/src/app/zones/components/ZoneEgressDetails.vue
@@ -69,6 +69,8 @@
       <KCard>
         <template #body>
           <EnvoyData
+            :status="status"
+            resource="Zone"
             :src="`/zone-egresses/${props.zoneEgressOverview.name}/data-path/xds`"
             query-key="envoy-data-xds-zone-egress"
           />
@@ -80,6 +82,8 @@
       <KCard>
         <template #body>
           <EnvoyData
+            :status="status"
+            resource="Zone"
             :src="`/zone-egresses/${props.zoneEgressOverview.name}/data-path/stats`"
             query-key="envoy-data-stats-zone-egress"
           />
@@ -91,6 +95,8 @@
       <KCard>
         <template #body>
           <EnvoyData
+            :status="status"
+            resource="Zone"
             :src="`/zone-egresses/${props.zoneEgressOverview.name}/data-path/clusters`"
             query-key="envoy-data-clusters-zone-egress"
           />

--- a/src/app/zones/components/ZoneIngressDetails.vue
+++ b/src/app/zones/components/ZoneIngressDetails.vue
@@ -1,68 +1,68 @@
 <template>
   <TabsWidget :tabs="TABS">
     <template #overview>
-      <KCard>
-        <template #body>
-          <div
-            class="columns"
-            style="--columns: 3;"
-          >
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.status') }}
-              </template>
-
-              <template #body>
-                <StatusBadge :status="status" />
-              </template>
-            </DefinitionCard>
-
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.name') }}
-              </template>
-
-              <template #body>
-                <TextWithCopyButton :text="props.zoneIngressOverview.name" />
-              </template>
-            </DefinitionCard>
-
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.type') }}
-              </template>
-
-              <template #body>
-                {{ props.zoneIngressOverview.type }}
-              </template>
-            </DefinitionCard>
-          </div>
-        </template>
-      </KCard>
-    </template>
-
-    <template #insights>
-      <KCard>
-        <template #body>
-          <AccordionList :initially-open="0">
-            <AccordionItem
-              v-for="(subscription, index) in subscriptionsReversed"
-              :key="index"
+      <div class="stack">
+        <KCard>
+          <template #body>
+            <div
+              class="columns"
+              style="--columns: 3;"
             >
-              <template #accordion-header>
-                <SubscriptionHeader :subscription="subscription" />
-              </template>
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.status') }}
+                </template>
 
-              <template #accordion-content>
-                <SubscriptionDetails
-                  :subscription="subscription"
-                  is-discovery-subscription
-                />
-              </template>
-            </AccordionItem>
-          </AccordionList>
-        </template>
-      </KCard>
+                <template #body>
+                  <StatusBadge :status="status" />
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.name') }}
+                </template>
+
+                <template #body>
+                  <TextWithCopyButton :text="props.zoneIngressOverview.name" />
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.type') }}
+                </template>
+
+                <template #body>
+                  {{ props.zoneIngressOverview.type }}
+                </template>
+              </DefinitionCard>
+            </div>
+          </template>
+        </KCard>
+
+        <KCard>
+          <template #body>
+            <AccordionList :initially-open="0">
+              <AccordionItem
+                v-for="(subscription, index) in subscriptionsReversed"
+                :key="index"
+              >
+                <template #accordion-header>
+                  <SubscriptionHeader :subscription="subscription" />
+                </template>
+
+                <template #accordion-content>
+                  <SubscriptionDetails
+                    :subscription="subscription"
+                    is-discovery-subscription
+                  />
+                </template>
+              </AccordionItem>
+            </AccordionList>
+          </template>
+        </KCard>
+      </div>
     </template>
 
     <template #xds-configuration>
@@ -128,10 +128,6 @@ const TABS = [
   {
     hash: '#overview',
     title: t('zone-ingresses.routes.item.tabs.overview'),
-  },
-  {
-    hash: '#insights',
-    title: t('zone-ingresses.routes.item.tabs.insights'),
   },
   {
     hash: '#xds-configuration',

--- a/src/app/zones/components/ZoneIngressDetails.vue
+++ b/src/app/zones/components/ZoneIngressDetails.vue
@@ -69,6 +69,8 @@
       <KCard>
         <template #body>
           <EnvoyData
+            :status="status"
+            resource="Zone"
             :src="`/zone-ingresses/${props.zoneIngressOverview.name}/data-path/xds`"
             query-key="envoy-data-xds-zone-ingress"
           />
@@ -80,6 +82,8 @@
       <KCard>
         <template #body>
           <EnvoyData
+            :status="status"
+            resource="Zone"
             :src="`/zone-ingresses/${props.zoneIngressOverview.name}/data-path/stats`"
             query-key="envoy-data-stats-zone-ingress"
           />
@@ -91,6 +95,8 @@
       <KCard>
         <template #body>
           <EnvoyData
+            :status="status"
+            resource="Zone"
             :src="`/zone-ingresses/${props.zoneIngressOverview.name}/data-path/clusters`"
             query-key="envoy-data-clusters-zone-ingress"
           />

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -5,7 +5,7 @@ zone-cps:
       breadcrumbs: Zone Control Planes
       tabs:
         overview: 'Overview'
-        insights: 'Insights'
+        insights: 'Subscriptions'
     items:
       title: Zone Control Planes
       breadcrumbs: Zone Control Planes
@@ -25,7 +25,7 @@ zone-ingresses:
       breadcrumbs: Ingresses
       tabs:
         overview: 'Overview'
-        insights: 'Zone Ingress insights'
+        insights: 'Zone Ingress subscriptions'
         xds_configuration: 'XDS Configuration'
         stats: 'Stats'
         clusters: 'Clusters'
@@ -42,7 +42,7 @@ zone-egresses:
       breadcrumbs: Egresses
       tabs:
         overview: 'Overview'
-        insights: 'Zone Egress insights'
+        insights: 'Zone Egress subscriptions'
         xds_configuration: 'XDS Configuration'
         stats: 'Stats'
         clusters: 'Clusters'

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -28,3 +28,4 @@ common:
     none: '—'
     created: 'Created'
     modified: 'Modified'
+    no_envoy_data: 'No Envoy data is available because the {resource} is not online'

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -22,9 +22,10 @@ common:
   detail:
     subscriptions:
       no_stats: 'There are no statistics for subscription “{id}”'
-      connect_time: 'Connect time'
-      disconnect_time: 'Disconnect time'
+      connect_time: 'Connected'
+      disconnect_time: 'Disconnected'
       type: 'Type'
+      responses_sent_acknowledged: 'Responses sent/ack’ed'
     none: '—'
     created: 'Created'
     modified: 'Modified'

--- a/src/locales/en-us/http/index.yaml
+++ b/src/locales/en-us/http/index.yaml
@@ -6,8 +6,8 @@ http:
       mTLS: mTLS
       globalInstanceId: Global instance ID
       controlPlaneInstanceId: CP instance ID
-      connectTime: Last connected
-      disconnectTime: Disconnect time
+      connectTime: Connected
+      disconnectTime: Disconnected
       cds: CDS
       eds: EDS
       lds: LDS

--- a/src/test-support/mocks/src/dataplanes+insights.ts
+++ b/src/test-support/mocks/src/dataplanes+insights.ts
@@ -41,7 +41,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
                 controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
                 connectTime: '2021-02-17T07:33:36.412683Z',
-                disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
+                disconnectTime: i < (subscriptionCount - 1) ? '2021-02-17T07:33:36.412683Z' : undefined,
                 status: {
                   lastUpdateTime: '2021-02-17T10:48:03.638434Z',
                   total: {

--- a/src/test-support/mocks/src/meshes/_/dataplanes+insights.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes+insights.ts
@@ -71,7 +71,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
                 controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
                 connectTime: '2021-02-17T07:33:36.412683Z',
-                disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
+                disconnectTime: i < (subscriptionCount - 1) ? '2021-02-17T07:33:36.412683Z' : undefined,
                 status: {
                   lastUpdateTime: '2021-02-17T10:48:03.638434Z',
                   total: {

--- a/src/test-support/mocks/src/meshes/_/dataplanes+insights/_.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes+insights/_.ts
@@ -38,7 +38,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
             id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
             controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
             connectTime: '2021-02-17T07:33:36.412683Z',
-            disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
+            disconnectTime: i < (subscriptionCount - 1) ? '2021-02-17T07:33:36.412683Z' : undefined,
             status: {
               lastUpdateTime: '2021-02-17T10:48:03.638434Z',
               total: {

--- a/src/test-support/mocks/src/zoneegressoverviews.ts
+++ b/src/test-support/mocks/src/zoneegressoverviews.ts
@@ -35,6 +35,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 id: 'cc2743b5-43e0-45b6-be88-956ea91a4aad',
                 controlPlaneInstanceId: 'kuma-control-plane-84f5589874-nmspq-0867',
                 connectTime: '2021-07-13T08:41:04.556796688Z',
+                disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
                 generation: 409,
                 status: {
                   lastUpdateTime: '2021-07-13T09:03:11.614941842Z',

--- a/src/test-support/mocks/src/zoneegressoverviews/_.ts
+++ b/src/test-support/mocks/src/zoneegressoverviews/_.ts
@@ -26,6 +26,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
             id: 'cc2743b5-43e0-45b6-be88-956ea91a4aad',
             controlPlaneInstanceId: 'kuma-control-plane-84f5589874-nmspq-0867',
             connectTime: '2021-07-13T08:41:04.556796688Z',
+            disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
             generation: 409,
             status: {
               lastUpdateTime: '2021-07-13T09:03:11.614941842Z',

--- a/src/test-support/mocks/src/zoneingresses+insights.ts
+++ b/src/test-support/mocks/src/zoneingresses+insights.ts
@@ -59,6 +59,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 id: 'cc2743b5-43e0-45b6-be88-956ea91a4aad',
                 controlPlaneInstanceId: 'kuma-control-plane-84f5589874-nmspq-0867',
                 connectTime: '2021-07-13T08:41:04.556796688Z',
+                disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
                 generation: 409,
                 status: {
                   lastUpdateTime: '2021-07-13T09:03:11.614941842Z',

--- a/src/test-support/mocks/src/zoneingresses+insights/_.ts
+++ b/src/test-support/mocks/src/zoneingresses+insights/_.ts
@@ -49,6 +49,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
             id: 'cc2743b5-43e0-45b6-be88-956ea91a4aad',
             controlPlaneInstanceId: 'kuma-control-plane-84f5589874-nmspq-0867',
             connectTime: '2021-07-13T08:41:04.556796688Z',
+            disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
             generation: 409,
             status: {
               lastUpdateTime: '2021-07-13T09:03:11.614941842Z',

--- a/src/test-support/mocks/src/zones+insights/_.ts
+++ b/src/test-support/mocks/src/zones+insights/_.ts
@@ -1,7 +1,7 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
 export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
-  const subscriptions = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
+  const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
   return {
     headers: {},
     body: {
@@ -13,13 +13,13 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
         enabled: fake.datatype.boolean(),
       },
       zoneInsight: {
-        subscriptions: Array.from({ length: subscriptions }).map((_) => {
+        subscriptions: Array.from({ length: subscriptionCount }).map((_, i) => {
           return {
             config: fake.kuma.subscriptionConfig(),
             id: fake.string.uuid(),
             globalInstanceId: fake.hacker.noun(),
             connectTime: '2020-07-28T16:18:09.743141Z',
-            disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
+            disconnectTime: i < (subscriptionCount - 1) ? '2021-02-17T07:33:36.412683Z' : undefined,
             status: {
               lastUpdateTime: '2021-02-19T07:06:16.384057Z',
               total: {


### PR DESCRIPTION
**feat: only queries envoy data if resource is online**

Changes EnvoyData to only query envoy data if the corresponding resource is online.

**chore(zones): moves subscriptions into overview tab for ingress/egress details**

**chore(subscriptions): collapses responses sent and acknowledged, adds total**

Collapses the responses sent and acknowledged entries.

Adds the total number of responses sent and acknowledged.

Renames the "Insights" tab to "Subscriptions".

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
