### PR TITLE
chore: standardizes empty state usage

### DIFF
--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -20,11 +20,17 @@
     :cell-attrs="({ headerKey }: CellAttrParams) => ({
       class: `${headerKey}-column`
     })"
-    empty-state-icon-size="96"
     disable-sorting
     hide-pagination-when-optional
     @row:click="click"
   >
+    <template
+      v-if="$slots.emptyState || props.items?.length === 0"
+      #empty-state
+    >
+      <EmptyBlock />
+    </template>
+
     <template
       v-for="key in Object.keys(slots)"
       :key="key"
@@ -52,6 +58,8 @@
 <script lang="ts" setup>
 import { KTable, TableHeader } from '@kong/kongponents'
 import { useSlots, ref, watch, computed } from 'vue'
+
+import EmptyBlock from '@/app/common/EmptyBlock.vue'
 
 type CellAttrParams = {
   headerKey: string

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -42,7 +42,15 @@
           v-if="props.emptyStateCtaTo"
           #cta
         >
+          <DocumentationLink
+            v-if="typeof props.emptyStateCtaTo === 'string'"
+            :href="props.emptyStateCtaTo"
+          >
+            {{ props.emptyStateCtaText }}
+          </DocumentationLink>
+
           <KButton
+            v-else
             appearance="primary"
             icon="plus"
             :to="props.emptyStateCtaTo"
@@ -82,6 +90,7 @@ import { KButton, KTable, TableHeader } from '@kong/kongponents'
 import { useSlots, ref, watch, computed } from 'vue'
 import { RouteLocationRaw } from 'vue-router'
 
+import DocumentationLink from '@/app/common/DocumentationLink.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import { PAGE_SIZE_DEFAULT } from '@/constants'
 import { useI18n } from '@/utilities'

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -5,7 +5,7 @@
     :style="`--column-width: ${columnWidth}; --special-column-width: ${SPECIAL_COLUMN_WIDTH}%;`"
     :has-error="(typeof props.error !== 'undefined')"
     :pagination-total-items="props.total"
-    :initial-fetcher-params="{ page: props.pageNumber, pageSize: props.pageSize }"
+    :initial-fetcher-params="{ page: props.pageNumber, pageSize: props.pageSize ?? PAGE_SIZE_DEFAULT }"
     :headers="props.headers"
     :fetcher-cache-key="String(cacheKey)"
     :fetcher="({ page, pageSize, query }: FetcherParams) => {
@@ -25,10 +25,32 @@
     @row:click="click"
   >
     <template
-      v-if="$slots.emptyState || props.items?.length === 0"
+      v-if="props.items?.length === 0"
       #empty-state
     >
-      <EmptyBlock />
+      <EmptyBlock>
+        {{ props.emptyStateTitle ?? t('common.emptyState.title') }}
+
+        <template
+          v-if="props.emptyStateMessage"
+          #message
+        >
+          {{ props.emptyStateMessage }}
+        </template>
+
+        <template
+          v-if="props.emptyStateCtaTo"
+          #cta
+        >
+          <KButton
+            appearance="primary"
+            icon="plus"
+            :to="props.emptyStateCtaTo"
+          >
+            {{ props.emptyStateCtaText }}
+          </KButton>
+        </template>
+      </EmptyBlock>
     </template>
 
     <template
@@ -56,10 +78,13 @@
 </template>
 
 <script lang="ts" setup>
-import { KTable, TableHeader } from '@kong/kongponents'
+import { KButton, KTable, TableHeader } from '@kong/kongponents'
 import { useSlots, ref, watch, computed } from 'vue'
+import { RouteLocationRaw } from 'vue-router'
 
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
+import { PAGE_SIZE_DEFAULT } from '@/constants'
+import { useI18n } from '@/utilities'
 
 type CellAttrParams = {
   headerKey: string
@@ -78,17 +103,30 @@ type ChangeValue = {
   s: string
 }
 
+const { t } = useI18n()
+
 const SPECIAL_COLUMN_WIDTH = 5
 
 const props = withDefaults(defineProps<{
   total?: number,
-  pageNumber: number,
-  pageSize: number,
+  pageNumber?: number,
+  pageSize?: number,
   items: unknown[] | undefined,
   headers: TableHeader[],
-  error: Error | undefined,
+  error?: Error | undefined,
+  emptyStateTitle?: string
+  emptyStateMessage?: string
+  emptyStateCtaTo?: string | RouteLocationRaw
+  emptyStateCtaText?: string
 }>(), {
   total: 0,
+  pageNumber: 1,
+  pageSize: 30,
+  error: undefined,
+  emptyStateTitle: undefined,
+  emptyStateMessage: undefined,
+  emptyStateCtaTo: undefined,
+  emptyStateCtaText: undefined,
 })
 
 const emit = defineEmits<{

--- a/src/app/common/DocumentationLink.vue
+++ b/src/app/common/DocumentationLink.vue
@@ -11,7 +11,7 @@
       :title="t('common.documentation')"
     />
 
-    <span class="visually-hidden">{{ t('common.documentation') }}</span>
+    <span><slot>{{ t('common.documentation') }}</slot></span>
   </a>
 </template>
 
@@ -22,18 +22,16 @@ import { useI18n } from '@/utilities'
 
 const { t } = useI18n()
 
-const props = defineProps({
-  href: {
-    type: String,
-    required: true,
-  },
-})
+const props = defineProps<{
+  href: string
+}>()
 </script>
 
 <style lang="scss" scoped>
 .docs-link {
   display: inline-flex;
-  align-items: center;
+  align-items: flex-end;
+  gap: $kui-space-20;
   padding-right: $kui-space-40;
   padding-left: $kui-space-40;
 }

--- a/src/app/common/EmptyBlock.vue
+++ b/src/app/common/EmptyBlock.vue
@@ -2,7 +2,7 @@
   <KEmptyState
     data-testid="empty-state"
     cta-is-hidden
-    icon="stateGruceo"
+    :icon="t('common.emptyState.icon')"
     icon-size="96"
   >
     <template #title>

--- a/src/app/common/EmptyBlock.vue
+++ b/src/app/common/EmptyBlock.vue
@@ -7,7 +7,7 @@
   >
     <template #title>
       <slot name="title">
-        <p><slot>There is no data to display.</slot></p>
+        <p><slot>{{ t('common.emptyState.title') }}</slot></p>
       </slot>
     </template>
 
@@ -29,4 +29,8 @@
 
 <script lang="ts" setup>
 import { KEmptyState } from '@kong/kongponents'
+
+import { useI18n } from '@/utilities'
+
+const { t } = useI18n()
 </script>

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -1,6 +1,5 @@
 <template>
   <AppCollection
-    :empty-state-title="t('common.emptyState.title')"
     :empty-state-message="t('common.emptyState.message', { type: props.gateways ? 'Gateways' : 'Data Plane Proxies' })"
     :headers="[
       { label: 'Name', key: 'name' },

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -1,6 +1,8 @@
 <template>
   <AppCollection
     :empty-state-message="t('common.emptyState.message', { type: props.gateways ? 'Gateways' : 'Data Plane Proxies' })"
+    :empty-state-cta-to="t(`data-planes.href.docs.${props.gateways ? 'gateway' : 'data_plane_proxy'}`)"
+    :empty-state-cta-text="t('common.documentation')"
     :headers="[
       { label: 'Name', key: 'name' },
       props.gateways ? { label: 'Type', key: 'type' } : undefined,

--- a/src/app/data-planes/locales/en-us/index.yaml
+++ b/src/app/data-planes/locales/en-us/index.yaml
@@ -14,6 +14,8 @@ data-planes:
       title: Data Plane Proxies
   href:
     docs:
+      data_plane_proxy: '{KUMA_DOCS_URL}/production/dp-config/dpp?{KUMA_UTM_QUERY_PARAMS}'
+      gateway: '{KUMA_DOCS_URL}/explore/gateway?{KUMA_UTM_QUERY_PARAMS}'
       mutual-tls: '{KUMA_DOCS_URL}/policies/mutual-tls?{KUMA_UTM_QUERY_PARAMS}'
   list:
     version_mismatch: 'Version mismatch'

--- a/src/app/main-overview/components/ControlPlaneDetails.vue
+++ b/src/app/main-overview/components/ControlPlaneDetails.vue
@@ -81,6 +81,19 @@
                 {{ t('main-overview.detail.health.view_all') }}
               </RouterLink>
             </div>
+
+            <div
+              v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled' && props.zoneOverviews.length > 0"
+              class="card-actions"
+            >
+              <KButton
+                appearance="primary"
+                icon="plus"
+                :to="{ name: 'zone-create-view' }"
+              >
+                {{ t('zones.index.create') }}
+              </KButton>
+            </div>
           </div>
 
           <ZoneControlPlanesDetails
@@ -126,9 +139,10 @@ import ResourceStatus from '@/app/common/ResourceStatus.vue'
 import { mergeInsightsReducer } from '@/store/reducers/mesh-insights'
 import { useStore } from '@/store/store'
 import { MeshInsight, ZoneOverview } from '@/types/index.d'
-import { useI18n } from '@/utilities'
+import { useI18n, useEnv } from '@/utilities'
 
 const { t } = useI18n()
+const env = useEnv()
 const store = useStore()
 
 const props = defineProps({

--- a/src/app/main-overview/components/ControlPlaneDetails.vue
+++ b/src/app/main-overview/components/ControlPlaneDetails.vue
@@ -115,10 +115,7 @@
             </div>
           </div>
 
-          <EmptyBlock v-if="props.meshInsights.length === 0" />
-
           <MeshesDetails
-            v-else
             data-testid="meshes-details"
             :mesh-insights="props.meshInsights.slice(0, 10)"
           />
@@ -134,7 +131,6 @@ import { PropType, computed } from 'vue'
 
 import MeshesDetails from './MeshesDetails.vue'
 import ZoneControlPlanesDetails from './ZoneControlPlanesDetails.vue'
-import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ResourceStatus from '@/app/common/ResourceStatus.vue'
 import { mergeInsightsReducer } from '@/store/reducers/mesh-insights'
 import { useStore } from '@/store/store'

--- a/src/app/main-overview/components/ControlPlaneDetails.vue
+++ b/src/app/main-overview/components/ControlPlaneDetails.vue
@@ -83,32 +83,7 @@
             </div>
           </div>
 
-          <EmptyBlock v-if="props.zoneOverviews.length === 0">
-            {{ t('main-overview.detail.zone_control_planes.empty_state.title') }}
-
-            <template
-              v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
-              #message
-            >
-              {{ t('main-overview.detail.zone_control_planes.empty_state.message') }}
-            </template>
-
-            <template
-              v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
-              #cta
-            >
-              <KButton
-                appearance="creation"
-                icon="plus"
-                :to="{ name: 'zone-create-view' }"
-              >
-                {{ t('zones.index.create') }}
-              </KButton>
-            </template>
-          </EmptyBlock>
-
           <ZoneControlPlanesDetails
-            v-else
             data-testid="zone-control-planes-details"
             :zone-overviews="props.zoneOverviews.slice(0, 10)"
           />
@@ -151,9 +126,8 @@ import ResourceStatus from '@/app/common/ResourceStatus.vue'
 import { mergeInsightsReducer } from '@/store/reducers/mesh-insights'
 import { useStore } from '@/store/store'
 import { MeshInsight, ZoneOverview } from '@/types/index.d'
-import { useEnv, useI18n } from '@/utilities'
+import { useI18n } from '@/utilities'
 
-const env = useEnv()
 const { t } = useI18n()
 const store = useStore()
 

--- a/src/app/main-overview/components/MeshesDetails.vue
+++ b/src/app/main-overview/components/MeshesDetails.vue
@@ -1,13 +1,15 @@
 <template>
-  <KTable
+  <AppCollection
+    class="mesh-preview-collection"
+    data-testid="mesh-preview-collection"
     :headers="[
       { label: t('main-overview.detail.meshes.table.name'), key: 'name'},
       { label: t('main-overview.detail.meshes.table.services'), key: 'services'},
       { label: t('main-overview.detail.meshes.table.data_plane_proxies'), key: 'dataPlaneProxies'},
     ]"
-    :fetcher="() => ({ data: tableData })"
-    disable-sorting
-    hide-pagination-when-optional
+    :items="tableData"
+    :total="tableData.length"
+    :empty-state-message="t('common.emptyState.message', { type: 'Meshes' })"
   >
     <template #name="{ rowValue }">
       <RouterLink
@@ -21,13 +23,13 @@
         {{ rowValue }}
       </RouterLink>
     </template>
-  </KTable>
+  </AppCollection>
 </template>
 
 <script lang="ts" setup>
-import { KTable } from '@kong/kongponents'
 import { PropType, computed } from 'vue'
 
+import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import type { MeshInsight } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 

--- a/src/app/main-overview/components/MeshesDetails.vue
+++ b/src/app/main-overview/components/MeshesDetails.vue
@@ -10,6 +10,8 @@
     :items="tableData"
     :total="tableData.length"
     :empty-state-message="t('common.emptyState.message', { type: 'Meshes' })"
+    :empty-state-cta-to="t('meshes.href.docs')"
+    :empty-state-cta-text="t('common.documentation')"
   >
     <template #name="{ rowValue }">
       <RouterLink

--- a/src/app/main-overview/components/ZoneControlPlanesDetails.vue
+++ b/src/app/main-overview/components/ZoneControlPlanesDetails.vue
@@ -1,42 +1,18 @@
 <template>
-  <KTable
+  <AppCollection
+    class="zone-cp-preview-collection"
+    data-testid="zone-cp-preview-collection"
     :headers="[
       { label: t('main-overview.detail.zone_control_planes.table.name'), key: 'name'},
       { label: t('main-overview.detail.zone_control_planes.table.status'), key: 'status'},
     ]"
-    :fetcher="() => ({ data: tableData })"
-    disable-sorting
-    hide-pagination-when-optional
+    :items="tableData"
+    :total="tableData.length"
+    :empty-state-title="t('zone-cps.empty_state.title')"
+    :empty-state-message="env('KUMA_ZONE_CREATION_FLOW') === 'enabled' ? t('zone-cps.empty_state.message') : t('common.emptyState.message', { type: 'Zones' })"
+    :empty-state-cta-to="env('KUMA_ZONE_CREATION_FLOW') === 'enabled' ? { name: 'zone-create-view' } : undefined"
+    :empty-state-cta-text="t('zones.index.create')"
   >
-    <template
-      v-if="props.zoneOverviews.length === 0"
-      #empty-state
-    >
-      <EmptyBlock>
-        {{ t('main-overview.detail.zone_control_planes.empty_state.title') }}
-
-        <template
-          v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
-          #message
-        >
-          {{ t('main-overview.detail.zone_control_planes.empty_state.message') }}
-        </template>
-
-        <template
-          v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
-          #cta
-        >
-          <KButton
-            appearance="primary"
-            icon="plus"
-            :to="{ name: 'zone-create-view' }"
-          >
-            {{ t('zones.index.create') }}
-          </KButton>
-        </template>
-      </EmptyBlock>
-    </template>
-
     <template #name="{ rowValue }">
       <RouterLink
         :to="{
@@ -60,14 +36,13 @@
         {{ t('common.collection.none') }}
       </template>
     </template>
-  </KTable>
+  </AppCollection>
 </template>
 
 <script lang="ts" setup>
-import { KTable } from '@kong/kongponents'
 import { PropType, computed } from 'vue'
 
-import EmptyBlock from '@/app/common/EmptyBlock.vue'
+import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import { getZoneControlPlaneStatus } from '@/app/zones/getZoneControlPlaneStatus'
 import type { ZoneOverview } from '@/types/index.d'

--- a/src/app/main-overview/components/ZoneControlPlanesDetails.vue
+++ b/src/app/main-overview/components/ZoneControlPlanesDetails.vue
@@ -27,7 +27,7 @@
           #cta
         >
           <KButton
-            appearance="creation"
+            appearance="primary"
             icon="plus"
             :to="{ name: 'zone-create-view' }"
           >

--- a/src/app/main-overview/components/ZoneControlPlanesDetails.vue
+++ b/src/app/main-overview/components/ZoneControlPlanesDetails.vue
@@ -8,6 +8,35 @@
     disable-sorting
     hide-pagination-when-optional
   >
+    <template
+      v-if="props.zoneOverviews.length === 0"
+      #empty-state
+    >
+      <EmptyBlock>
+        {{ t('main-overview.detail.zone_control_planes.empty_state.title') }}
+
+        <template
+          v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
+          #message
+        >
+          {{ t('main-overview.detail.zone_control_planes.empty_state.message') }}
+        </template>
+
+        <template
+          v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled'"
+          #cta
+        >
+          <KButton
+            appearance="creation"
+            icon="plus"
+            :to="{ name: 'zone-create-view' }"
+          >
+            {{ t('zones.index.create') }}
+          </KButton>
+        </template>
+      </EmptyBlock>
+    </template>
+
     <template #name="{ rowValue }">
       <RouterLink
         :to="{
@@ -38,12 +67,14 @@
 import { KTable } from '@kong/kongponents'
 import { PropType, computed } from 'vue'
 
+import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import { getZoneControlPlaneStatus } from '@/app/zones/getZoneControlPlaneStatus'
 import type { ZoneOverview } from '@/types/index.d'
-import { useI18n } from '@/utilities'
+import { useEnv, useI18n } from '@/utilities'
 
 const { t } = useI18n()
+const env = useEnv()
 
 const props = defineProps({
   zoneOverviews: {

--- a/src/app/main-overview/locales/en-us/index.yaml
+++ b/src/app/main-overview/locales/en-us/index.yaml
@@ -12,9 +12,6 @@ main-overview:
       data_plane_proxies: 'Data Plane Proxies'
     zone_control_planes:
       title: 'Zones'
-      empty_state:
-        title: 'No Zones yet …'
-        message: 'Create your first Zone to start managing your Mesh'
       table:
         name: 'Name'
         status: 'Status'

--- a/src/app/meshes/locales/en-us/index.yaml
+++ b/src/app/meshes/locales/en-us/index.yaml
@@ -15,6 +15,8 @@ meshes:
       breadcrumbs: Meshes
     overview:
       title: Mesh overview
+  href:
+    docs: '{KUMA_DOCS_URL}/production/mesh?{KUMA_UTM_QUERY_PARAMS}'
   detail:
     services: 'Services'
     data_plane_proxies: 'Data Plane Proxies'

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -22,7 +22,6 @@
               <AppCollection
                 class="mesh-collection"
                 data-testid="mesh-collection"
-                :empty-state-title="t('common.emptyState.title')"
                 :empty-state-message="t('common.emptyState.message', { type: 'Meshes' })"
                 :headers="[
                   { label: 'Name', key: 'name' },

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -22,7 +22,6 @@
               <AppCollection
                 class="mesh-collection"
                 data-testid="mesh-collection"
-                :empty-state-message="t('common.emptyState.message', { type: 'Meshes' })"
                 :headers="[
                   { label: 'Name', key: 'name' },
                   { label: 'Actions', key: 'actions', hideLabel: true },
@@ -32,6 +31,9 @@
                 :total="data?.total"
                 :items="data?.items"
                 :error="error"
+                :empty-state-message="t('common.emptyState.message', { type: 'Meshes' })"
+                :empty-state-cta-to="t('meshes.href.docs')"
+                :empty-state-cta-text="t('common.documentation')"
                 @change="route.update"
               >
                 <template #name="{ row: item }">

--- a/src/app/policies/components/PolicyConnections.spec.ts
+++ b/src/app/policies/components/PolicyConnections.spec.ts
@@ -109,6 +109,6 @@ describe('PolicyConnections.vue', () => {
 
     await flushPromises()
 
-    expect(wrapper.html()).toContain('There is no data to display.')
+    expect(wrapper.html()).toContain('No data')
   })
 })

--- a/src/app/policies/components/PolicyList.vue
+++ b/src/app/policies/components/PolicyList.vue
@@ -85,7 +85,6 @@
             <AppCollection
               class="policy-collection"
               data-testid="policy-collection"
-              :empty-state-title="t('common.emptyState.title')"
               :empty-state-message="t('common.emptyState.message', { type: `${props.currentPolicyType.name} policies` })"
               :headers="[
                 { label: 'Name', key: 'name' },

--- a/src/app/policies/components/PolicyList.vue
+++ b/src/app/policies/components/PolicyList.vue
@@ -74,7 +74,9 @@
                 <DocumentationLink
                   :href="t('policies.href.docs', { name: props.currentPolicyType.name })"
                   data-testid="policy-documentation-link"
-                />
+                >
+                  <span class="visually-hidden">{{ t('common.documentation') }}</span>
+                </DocumentationLink>
               </div>
             </div>
           </template>
@@ -86,6 +88,8 @@
               class="policy-collection"
               data-testid="policy-collection"
               :empty-state-message="t('common.emptyState.message', { type: `${props.currentPolicyType.name} policies` })"
+              :empty-state-cta-to="t('policies.href.docs', { name: props.currentPolicyType.name })"
+              :empty-state-cta-text="t('common.documentation')"
               :headers="[
                 { label: 'Name', key: 'name' },
                 props.currentPolicyType.isTargetRefBased ? { label: 'Target ref', key: 'targetRef' } : undefined,

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -21,7 +21,6 @@
             <AppCollection
               class="service-collection"
               data-testid="service-collection"
-              :empty-state-title="t('common.emptyState.title')"
               :empty-state-message="t('common.emptyState.message', { type: 'Services' })"
               :headers="[
                 { label: 'Name', key: 'name' },

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -14,6 +14,9 @@ zone-cps:
   detail:
     configuration_title: 'Configuration'
     no_subscriptions: 'This zone has no subscriptions'
+  empty_state:
+    title: 'No Zones yet …'
+    message: 'Create your first Zone to start managing your Mesh'
 
 zone-ingresses:
   routes:

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -32,6 +32,8 @@ zone-ingresses:
     items:
       title: Ingresses
       breadcrumbs: Ingresses
+  href:
+    docs: '{KUMA_DOCS_URL}/production/cp-deployment/zone-ingress?{KUMA_UTM_QUERY_PARAMS}'
 
 zone-egresses:
   routes:
@@ -47,6 +49,8 @@ zone-egresses:
     items:
       title: Egresses
       breadcrumbs: Egresses
+  href:
+    docs: '{KUMA_DOCS_URL}/production/cp-deployment/zoneegress?{KUMA_UTM_QUERY_PARAMS}'
 
 zones:
   href:

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -54,7 +54,7 @@
           </div>
 
           <KButton
-            appearance="creation"
+            appearance="primary"
             :icon="isChangingZone ? 'spinner' : 'plus'"
             :disabled="isCreateButtonDisabled"
             data-testid="create-zone-button"

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -32,6 +32,9 @@
               :total="data?.total"
               :items="data ? transformToTableData(data.items) : undefined"
               :error="error"
+              :empty-state-message="t('common.emptyState.message', { type: 'Zone Egresses' })"
+              :empty-state-cta-to="t('zone-egresses.href.docs')"
+              :empty-state-cta-text="t('common.documentation')"
               @change="route.update"
             >
               <template #name="{ row, rowValue }">

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -35,6 +35,9 @@
                 :total="data?.total"
                 :items="data ? transformToTableData(data.items) : undefined"
                 :error="error"
+                :empty-state-message="t('common.emptyState.message', { type: 'Zone Ingresses' })"
+                :empty-state-cta-to="t('zone-ingresses.href.docs')"
+                :empty-state-cta-text="t('common.documentation')"
                 @change="route.update"
               >
                 <template #name="{ row, rowValue }">

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -18,7 +18,7 @@
         #actions
       >
         <KButton
-          appearance="creation"
+          appearance="primary"
           icon="plus"
           :to="{ name: 'zone-create-view' }"
           data-testid="create-zone-link"

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -14,7 +14,7 @@
       </template>
 
       <template
-        v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled' && store.getters['config/getMulticlusterStatus']"
+        v-if="env('KUMA_ZONE_CREATION_FLOW') === 'enabled' && store.getters['config/getMulticlusterStatus'] && isCreateZoneButtonVisible"
         #actions
       >
         <KButton
@@ -33,6 +33,7 @@
         <DataSource
           v-slot="{ data, error, refresh }: ZoneOverviewCollectionSource"
           :src="`/zone-cps?size=${props.size}&page=${props.page}`"
+          @change="setIsCreateZoneButtonVisible"
         >
           <KCard>
             <template #body>
@@ -52,6 +53,10 @@
                 :total="data?.total"
                 :items="data ? transformToTableData(data.items) : undefined"
                 :error="error"
+                :empty-state-title="env('KUMA_ZONE_CREATION_FLOW') === 'enabled' ? t('zone-cps.empty_state.title') : undefined"
+                :empty-state-message="env('KUMA_ZONE_CREATION_FLOW') === 'enabled' ? t('zone-cps.empty_state.message') : undefined"
+                :empty-state-cta-to="env('KUMA_ZONE_CREATION_FLOW') === 'enabled' ? { name: 'zone-create-view' } : undefined"
+                :empty-state-cta-text="env('KUMA_ZONE_CREATION_FLOW') === 'enabled' ? t('zones.index.create') : undefined"
                 @change="route.update"
               >
                 <template #name="{ row, rowValue }">
@@ -221,6 +226,7 @@ const props = defineProps({
 })
 
 const isDeleteModalVisible = ref(false)
+const isCreateZoneButtonVisible = ref(false)
 const deleteZoneName = ref('')
 
 function transformToTableData(zoneOverviews: ZoneOverview[]): ZoneOverviewTableRow[] {
@@ -276,6 +282,10 @@ function toggleDeleteModal() {
 function setDeleteZoneName(name: string) {
   toggleDeleteModal()
   deleteZoneName.value = name
+}
+
+function setIsCreateZoneButtonVisible(data: any) {
+  isCreateZoneButtonVisible.value = data?.items.length > 0
 }
 </script>
 

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -12,6 +12,7 @@ common:
   emptyState:
     title: 'No data'
     message: 'There are no {type} present'
+    icon: 'stateNoData'
   collection:
     none: ' '
     actions:

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -11,7 +11,7 @@ common:
   documentation: 'Documentation'
   emptyState:
     title: 'No data'
-    message: 'There are no {type} present.'
+    message: 'There are no {type} present'
   collection:
     none: ' '
     actions:


### PR DESCRIPTION
## Changes

**chore: standardizes empty state usage**

Makes AppCollection accept our standard empty state component and passes it on to KTable. This way, each list view can easily customize the empty state with enriched UI elements like a "Create Zone" button. By default, our own empty state component will also be used (again) in list views.

**chore: uses primary appearance for creation buttons**

**chore: adds Create Zone button to overview**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Screenshots

**Before**:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/33a72655-82ea-411c-8ef2-e75b45cd7a84)

**After**:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/eea45c7a-d5ef-4046-9705-2a43691473f2)

![image](https://github.com/kumahq/kuma-gui/assets/5774638/c3d55ce4-e618-4dff-8ef9-a0dbe5bbd0e2)
