### PR TITLE
feat: adds networking data to ingress/egress detail and list views

### DIFF
--- a/features/zones/DetailViewContent.feature
+++ b/features/zones/DetailViewContent.feature
@@ -17,6 +17,9 @@ Feature: Zones: Detail view content
         name: zone-ingress-1
         zoneIngress:
           zone: zone-cp-1
+          networking:
+            address: '166.197.238.26'
+            port: 20555
         zoneIngressInsight:
           subscriptions:
             - connectTime: 2020-07-28T16:18:09.743141Z
@@ -29,7 +32,7 @@ Feature: Zones: Detail view content
     When I visit the "/zones/zone-ingresses/zone-ingress-1" URL
     Then the page title contains "zone-ingress-1"
     Then the "$ingress-detail-view" element contains "zone-ingress-1"
-    Then the "$ingress-detail-view" element contains "ZoneIngressOverview"
+    Then the "$ingress-detail-view" element contains "166.197.238.26:20555"
     Then the "$ingress-detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"
 
   Scenario Outline: Zone Egress detail view has expected content
@@ -44,6 +47,9 @@ Feature: Zones: Detail view content
         name: zone-egress-1
         zoneEgress:
           zone: zone-cp-2
+          networking:
+            address: '166.197.238.26'
+            port: 20555
         zoneEgressInsight:
           subscriptions:
             - connectTime: 2020-07-28T16:18:09.743141Z
@@ -56,5 +62,5 @@ Feature: Zones: Detail view content
     When I visit the "/zones/zone-egresses/zone-egress-1" URL
     Then the page title contains "zone-egress-1"
     Then the "$egress-detail-view" element contains "zone-egress-1"
-    Then the "$egress-detail-view" element contains "ZoneEgressOverview"
+    Then the "$egress-detail-view" element contains "166.197.238.26:20555"
     Then the "$egress-detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"

--- a/src/app/common/DefinitionCard.vue
+++ b/src/app/common/DefinitionCard.vue
@@ -34,3 +34,9 @@
   font-weight: $kui-font-weight-bold;
 }
 </style>
+
+<style lang="scss">
+.definition-card-container > * {
+  min-width: 0;
+}
+</style>

--- a/src/app/common/TextWithCopyButton.vue
+++ b/src/app/common/TextWithCopyButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="copy-button-wrapper">
-    <slot>{{ props.text }}</slot>
+    <span class="text"><slot>{{ props.text }}</slot></span>
 
     <CopyButton
       :text="props.text"
@@ -29,5 +29,10 @@ const props = defineProps({
   display: inline-flex;
   align-items: center;
   gap: $kui-space-40;
+}
+
+.text {
+  min-width: 0;
+  word-wrap: break-word;
 }
 </style>

--- a/src/app/common/subscriptions/SubscriptionHeader.vue
+++ b/src/app/common/subscriptions/SubscriptionHeader.vue
@@ -18,12 +18,10 @@
       <b>{{ t('common.detail.subscriptions.connect_time') }}</b>: {{ connectTime }}
     </span>
 
-    <span>
-      <template v-if="disconnectTime">
-        <img src="@/assets/images/icon-disconnected.svg?url">
+    <span v-if="disconnectTime">
+      <img src="@/assets/images/icon-disconnected.svg?url">
 
-        <b>{{ t('common.detail.subscriptions.disconnect_time') }}</b>: {{ disconnectTime }}
-      </template>
+      <b>{{ t('common.detail.subscriptions.disconnect_time') }}</b>: {{ disconnectTime }}
     </span>
 
     <span class="responses-sent-acknowledged">
@@ -66,8 +64,7 @@ const total = computed(() => {
 
 <style lang="scss" scoped>
 .subscription-header {
-  display: grid;
-  grid-template-columns: 30ch repeat(3, 1fr);
+  display: flex;
   gap: $kui-space-80;
   padding-right: $kui-space-40;
   padding-left: $kui-space-40;
@@ -75,7 +72,7 @@ const total = computed(() => {
 }
 
 .instance-id {
-  flex-basis: 30ch;
+  flex-basis: 50ch;
 }
 
 .responses-sent-acknowledged {

--- a/src/app/zones/components/ZoneEgressDetails.vue
+++ b/src/app/zones/components/ZoneEgressDetails.vue
@@ -30,11 +30,17 @@
 
               <DefinitionCard>
                 <template #title>
-                  {{ t('http.api.property.type') }}
+                  {{ t('http.api.property.address') }}
                 </template>
 
                 <template #body>
-                  {{ props.zoneEgressOverview.type }}
+                  <template v-if="props.zoneEgressOverview.zoneEgress.networking?.address && props.zoneEgressOverview.zoneEgress.networking?.port">
+                    <TextWithCopyButton :text="`${props.zoneEgressOverview.zoneEgress.networking.address}:${props.zoneEgressOverview.zoneEgress.networking.port}`" />
+                  </template>
+
+                  <template v-else>
+                    {{ t('common.detail.none') }}
+                  </template>
                 </template>
               </DefinitionCard>
             </div>

--- a/src/app/zones/components/ZoneIngressDetails.vue
+++ b/src/app/zones/components/ZoneIngressDetails.vue
@@ -6,7 +6,7 @@
           <template #body>
             <div
               class="columns"
-              style="--columns: 3;"
+              style="--columns: 4;"
             >
               <DefinitionCard>
                 <template #title>
@@ -30,11 +30,33 @@
 
               <DefinitionCard>
                 <template #title>
-                  {{ t('http.api.property.type') }}
+                  {{ t('http.api.property.address') }}
                 </template>
 
                 <template #body>
-                  {{ props.zoneIngressOverview.type }}
+                  <template v-if="props.zoneIngressOverview.zoneIngress.networking?.address && props.zoneIngressOverview.zoneIngress.networking?.port">
+                    <TextWithCopyButton :text="`${props.zoneIngressOverview.zoneIngress.networking.address}:${props.zoneIngressOverview.zoneIngress.networking.port}`" />
+                  </template>
+
+                  <template v-else>
+                    {{ t('common.detail.none') }}
+                  </template>
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.advertisedAddress') }}
+                </template>
+
+                <template #body>
+                  <template v-if="props.zoneIngressOverview.zoneIngress.networking?.advertisedAddress && props.zoneIngressOverview.zoneIngress.networking?.advertisedPort">
+                    <TextWithCopyButton :text="`${props.zoneIngressOverview.zoneIngress.networking.advertisedAddress}:${props.zoneIngressOverview.zoneIngress.networking.advertisedPort}`" />
+                  </template>
+
+                  <template v-else>
+                    {{ t('common.detail.none') }}
+                  </template>
                 </template>
               </DefinitionCard>
             </div>

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -24,6 +24,7 @@
               data-testid="zone-egress-collection"
               :headers="[
                 { label: 'Name', key: 'name' },
+                { label: 'Address', key: 'addressPort' },
                 { label: 'Status', key: 'status' },
                 { label: 'Actions', key: 'actions', hideLabel: true },
               ]"
@@ -44,6 +45,17 @@
                 >
                   {{ rowValue }}
                 </RouterLink>
+              </template>
+
+              <template #addressPort="{ rowValue }">
+                <TextWithCopyButton
+                  v-if="rowValue"
+                  :text="rowValue"
+                />
+
+                <template v-else>
+                  {{ t('common.collection.none') }}
+                </template>
               </template>
 
               <template #status="{ rowValue }">
@@ -110,6 +122,7 @@ import DataSource from '@/app/application/components/data-source/DataSource.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import { StatusKeyword, ZoneEgressOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
@@ -117,6 +130,7 @@ import { getItemStatusFromInsight } from '@/utilities/dataplane'
 type ZoneEgressOverviewTableRow = {
   detailViewRoute: RouteLocationNamedRaw
   name: string
+  addressPort: string | undefined
   status: StatusKeyword
 }
 
@@ -143,11 +157,20 @@ function transformToTableData(zoneEgressOverviews: ZoneEgressOverview[]): ZoneEg
         zoneEgress: name,
       },
     }
+
+    const { networking } = entity.zoneEgress
+
+    let addressPort
+    if (networking?.address && networking?.port) {
+      addressPort = `${networking.address}:${networking.port}`
+    }
+
     const status = getItemStatusFromInsight(entity.zoneEgressInsight ?? {})
 
     return {
       detailViewRoute,
       name,
+      addressPort,
       status,
     }
   })

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -26,6 +26,8 @@
                 data-testid="zone-ingress-collection"
                 :headers="[
                   { label: 'Name', key: 'name' },
+                  { label: 'Address', key: 'addressPort' },
+                  { label: 'Advertised address', key: 'advertisedAddressPort' },
                   { label: 'Status', key: 'status' },
                   { label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
@@ -46,6 +48,28 @@
                   >
                     {{ rowValue }}
                   </RouterLink>
+                </template>
+
+                <template #addressPort="{ rowValue }">
+                  <TextWithCopyButton
+                    v-if="rowValue"
+                    :text="rowValue"
+                  />
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #advertisedAddressPort="{ rowValue }">
+                  <TextWithCopyButton
+                    v-if="rowValue"
+                    :text="rowValue"
+                  />
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
                 </template>
 
                 <template #status="{ rowValue }">
@@ -114,6 +138,7 @@ import DataSource from '@/app/application/components/data-source/DataSource.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import { StatusKeyword, ZoneIngressOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'
@@ -121,6 +146,8 @@ import { getItemStatusFromInsight } from '@/utilities/dataplane'
 type ZoneIngressOverviewTableRow = {
   detailViewRoute: RouteLocationNamedRaw
   name: string
+  addressPort: string | undefined
+  advertisedAddressPort: string | undefined
   status: StatusKeyword
 }
 
@@ -147,11 +174,26 @@ function transformToTableData(zoneIngressOverviews: ZoneIngressOverview[]): Zone
         zoneIngress: name,
       },
     }
+
+    const { networking } = entity.zoneIngress
+
+    let addressPort
+    if (networking?.address && networking?.port) {
+      addressPort = `${networking.address}:${networking.port}`
+    }
+
+    let advertisedAddressPort
+    if (networking?.advertisedAddress && networking?.advertisedPort) {
+      advertisedAddressPort = `${networking.advertisedAddress}:${networking.advertisedPort}`
+    }
+
     const status = getItemStatusFromInsight(entity.zoneIngressInsight ?? {})
 
     return {
       detailViewRoute,
       name,
+      addressPort,
+      advertisedAddressPort,
       status,
     }
   })

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -446,15 +446,41 @@ export interface ZoneOverview extends MeshEntity {
   zoneInsight?: ZoneInsight
 }
 
+export interface ZoneIngressNetworking {
+  address?: string
+  advertisedAddress?: string
+  port?: string
+  advertisedPort?: string
+}
+
+export interface AvailableService {
+  tags?: Record<string, string>
+  instances?: number
+  mesh?: string
+  externalService?: boolean
+}
+
 export interface ZoneIngressOverview extends MeshEntity {
   type: 'ZoneIngressOverview'
-  zoneIngress: any
+  zoneIngress: {
+    zone?: string
+    networking?: ZoneIngressNetworking
+    availableServices?: AvailableService[]
+  }
   zoneIngressInsight: any
+}
+
+export interface ZoneEgressNetworking {
+  address?: string
+  port?: string
 }
 
 export interface ZoneEgressOverview extends MeshEntity {
   type: 'ZoneEgressOverview'
-  zoneEgress: any
+  zoneEgress: {
+    zone?: string
+    networking?: ZoneEgressNetworking
+  }
   zoneEgressInsight: any
 }
 


### PR DESCRIPTION
Adds networking data (Ingress: address and port, advertised address and port; Egress: address and port) to the Ingress/Egress detail and list views.

Implements one part of https://github.com/kumahq/kuma-gui/issues/1388.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
