### PR TITLE
chore(onboarding): Makes onboarding route guards injectable/modular

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -94,6 +94,12 @@ When('I go {string}', (direction: number | Cypress.HistoryDirection) => {
 })
 
 // assert
+Then('the URL is {string}', (expected: string) => {
+  cy.url().then((url) => {
+    const actual = new URL(url).pathname.replace(/^\/gui/, '')
+    expect(expected).to.equal(actual)
+  })
+})
 Then('the URL contains {string}', (str: string) => {
   cy.url().should('include', str)
 })

--- a/features/onboarding/Index.feature
+++ b/features/onboarding/Index.feature
@@ -1,0 +1,16 @@
+Feature: onboarding / index
+  Background:
+    Given the CSS selectors
+      | Alias           | Selector                              |
+      | skip-button           | [data-testid='onboarding-skip-button'] |
+      | table-header    | $table th                             |
+      | table-row       | $table tbody tr                       |
+      | dataplane-title | [data-testid='data-plane-collection'] |
+  Scenario: Visiting onboarding redirects to either welcome or root
+    When I visit the "/onboarding" URL
+    Then the URL is "/onboarding/welcome"
+    Then I click the "$skip-button" element
+    And I wait for 300 milliseconds
+    Then the URL is "/"
+    Then I visit the "/onboarding" URL
+    Then the URL is "/"

--- a/src/app/onboarding/guards.ts
+++ b/src/app/onboarding/guards.ts
@@ -1,38 +1,10 @@
 import {
-  createRouter as createVueRouter,
-  createWebHistory,
   NavigationGuard,
-  Router,
-  RouteRecordRaw,
 } from 'vue-router'
 
 import type { State } from '@/store/storeConfig'
 import { ClientStorage } from '@/utilities/ClientStorage'
 import type { Store } from 'vuex'
-
-export function createRouter(routes: RouteRecordRaw[], store: Store<State>, baseGuiPath: string = '/'): Router {
-  const router = createVueRouter({
-    history: createWebHistory(baseGuiPath),
-    routes,
-  })
-
-  router.beforeEach(redirectOldHashHistoryUrlPaths())
-  router.beforeEach(onboardingRouteGuard(store))
-
-  return router
-}
-
-/**
- * Redirects navigations to old hash history-style URL paths.
- */
-const redirectOldHashHistoryUrlPaths = (): NavigationGuard => (to, _from, next) => {
-  if (to.fullPath.startsWith('/#/')) {
-    next(to.fullPath.substring(2))
-  } else {
-    next()
-  }
-}
-
 /**
  * Redirects the user to the appropriate onboarding view if they haven’t completed it, yet.
  *

--- a/src/app/onboarding/index.ts
+++ b/src/app/onboarding/index.ts
@@ -1,1 +1,36 @@
-export { routes } from './routes'
+import {
+  NavigationGuard,
+} from 'vue-router'
+import { Store } from 'vuex'
+
+import { onboardingRouteGuard } from './guards'
+import type { ServiceDefinition } from '@/services/utils'
+import { token } from '@/services/utils'
+import type { State } from '@/store/storeConfig'
+export * from './routes'
+
+type Token = ReturnType<typeof token>
+
+const $ = {
+  guards: token<NavigationGuard[]>('onboarding.guards'),
+}
+
+export const services = (app: Record<string, Token>): ServiceDefinition[] => {
+  return [
+    [$.guards, {
+      service: (store: Store<State>) => {
+        return [
+          onboardingRouteGuard(store),
+        ]
+      },
+      arguments: [
+        app.store,
+      ],
+      labels: [
+        app.navigationGuards,
+      ],
+    }],
+  ]
+}
+
+export const TOKENS = $

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -1,6 +1,7 @@
 import {
-  RouteRecordRaw, NavigationGuard,
-  createRouter as createVueRouter,
+  RouteRecordRaw,
+  NavigationGuard,
+  createRouter,
   createWebHistory,
 } from 'vue-router'
 import { createStore, StoreOptions, Store } from 'vuex'
@@ -172,7 +173,7 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   // Router
   [$.router, {
     service: (env: Alias<Env['var']>, routes: RouteRecordRaw[], guards: NavigationGuard[]) => {
-      const router = createVueRouter({
+      const router = createRouter({
         history: createWebHistory(env('KUMA_BASE_PATH')),
         routes,
       })


### PR DESCRIPTION
Continuation of https://github.com/kumahq/kuma-gui/pull/1236

Moves onboarding route guards into their own 'module'

Also:

- Adds exact URL asserting so we can test for `/` (`contains` isn't enough for `/`)
- Temporarily moves our custom `createRouter` into `production.ts`, so we can then delete `router.ts` (this will be moved elsewhere later). We no longer have our own distinct createRouter/router setup function.
- Permanently deletes the old `#/url` style route guard. I don't think nowadays this is needed anymore (happy to put back if need be)