### PR TITLE
chore: Creates an onboarding microservice

### DIFF
--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -6,6 +6,7 @@ import { config } from '@vue/test-utils'
 import { replaceAttributesSnapshotSerializer } from './jest-replace-attribute-snapshot-serializer'
 import { TOKENS as COMPONENT_TOKENS } from '../src/components'
 import { TOKENS as TEST, services as testing } from '../src/services/testing'
+import { services as onboarding } from '@/app/onboarding'
 import { TOKENS as DEV, services as development } from '@/services/development'
 import CliEnv from '@/services/env/CliEnv'
 import { TOKENS as PROD, services as production } from '@/services/production'
@@ -25,6 +26,11 @@ const $ = {
 (async () => {
   build(
     production($),
+    onboarding({
+      ...$,
+      routes: $.routesLabel,
+    }),
+
     development($),
     testing($),
   )

--- a/src/app/diagnostics/index.ts
+++ b/src/app/diagnostics/index.ts
@@ -1,13 +1,13 @@
+import { routes } from './routes'
 import { sources } from './sources'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
-export * from './routes'
 
 type Token = ReturnType<typeof token>
-type Sources = ReturnType<typeof sources>
 
 const $ = {
-  sources: token<Sources>('diagnostics.sources'),
+  sources: token<ReturnType<typeof sources>>('diagnostics.sources'),
+  routes: token<ReturnType<typeof routes>>('diagnostics.routes'),
 }
 
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
@@ -19,6 +19,12 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
       labels: [
         app.sources,
+      ],
+    }],
+    [$.routes, {
+      service: routes,
+      labels: [
+        app.routes,
       ],
     }],
   ]

--- a/src/app/onboarding/index.ts
+++ b/src/app/onboarding/index.ts
@@ -4,19 +4,26 @@ import {
 import { Store } from 'vuex'
 
 import { onboardingRouteGuard } from './guards'
+import { routes } from './routes'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
 import type { State } from '@/store/storeConfig'
-export * from './routes'
 
 type Token = ReturnType<typeof token>
 
 const $ = {
+  routes: token<ReturnType<typeof routes>>('diagnostics.routes'),
   guards: token<NavigationGuard[]>('onboarding.guards'),
 }
 
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
+    [$.routes, {
+      service: routes,
+      labels: [
+        app.routes,
+      ],
+    }],
     [$.guards, {
       service: (store: Store<State>) => {
         return [
@@ -30,6 +37,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         app.navigationGuards,
       ],
     }],
+
   ]
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import { services as diagnostics } from '@/app/diagnostics'
+import { services as onboarding } from '@/app/onboarding'
 import { TOKENS as $, services as production } from '@/services/production'
 import { build } from '@/services/utils'
 
@@ -5,6 +7,14 @@ async function mountVueApplication() {
   const get = build(
     // production service container configuration
     production($),
+    onboarding({
+      ...$,
+      routes: $.routesLabel,
+    }),
+    diagnostics({
+      ...$,
+      routes: $.routesLabel,
+    }),
     // any DEV-time only service container configuration
     import.meta.env.MODE !== 'production'
       ? await (async () => {

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -1,9 +1,6 @@
 import { RouteRecordRaw } from 'vue-router'
 export default (
-  zones: RouteRecordRaw[],
-  meshes: RouteRecordRaw[],
-  onboarding: RouteRecordRaw[],
-  diagnostics: RouteRecordRaw[],
+  routes: RouteRecordRaw[],
 ): RouteRecordRaw[] => {
   return [
     {
@@ -20,9 +17,6 @@ export default (
       name: 'home',
       component: () => import('@/app/main-overview/views/MainOverviewView.vue'),
     },
-    ...zones,
-    ...meshes,
-    ...onboarding,
-    ...diagnostics,
+    ...routes,
   ]
 }


### PR DESCRIPTION
This is the first step towards the end of our "Monolith to Microservice Journey".

This PR splits off our `onboarding` and `diagnostics` "modules" (a.k.a "microservices") into externally loadable "things" that our loaded in via our `main.ts` entrypoint/wiring root files. If you don't add these things into your `main.ts` then **nothing** gets loaded into the application. No in-application conditionals required.

Adding these into `main.ts` is an `import` plus a one-liner, making it super easy to configure the application as a whole from the single `main.ts` file meaning we can have multiple `main.ts` files in multiple projects with entirely different setups all controlled from the `main.ts` "wiring root".

There are a few things I would do differently here given different circumstances (hence the "first step towards the end"):

1. `routeLabel`: I would prefer this to be `routes` but we use that name already along with decorators, and we don't currently support decorating labels. It was easier to alias these from `$.routeLabel` in `main.ts` to `$.route` so its as I would prefer in the "plugin/module/microservice". i.e. I avoid messing around and moving lots of stuff around now and punt that one to later on.
2. Labels right now require at least one thing to be labelled if you are passing it through as an argument. Therefore there is an empty "application level" empty set of navigation routes that do absolutely nothing. Again this is to avoid messing with our current labelling implementation now and punting it until later (I have a "rebuild labels" plan already but I don't want to do that now)

Lastly "why is diagnostics done here as well as onboarding?". Well, I used diagnostics as a "test bed" for this a while back as it was the most simple "microservice" to do. `onboarding` was slightly more involved and I need to do a little more work before trying it out with that. As `diagnostics` needed to be a microservice anyway, and I had the work from testing this approach out, I've PRed both `onboarding` and `diagnostics` at the same time.
