### PR TITLE
fix: order of loading and error blocks

### DIFF
--- a/src/app/application/components/data-source/DataSource.vue
+++ b/src/app/application/components/data-source/DataSource.vue
@@ -1,7 +1,6 @@
 <template>
   <slot
     :data="(message as any)"
-    :is-loading="isLoading"
     :error="error"
     :refresh="refresh"
   />
@@ -24,7 +23,6 @@ const props = defineProps({
 })
 
 const message = ref<unknown>(undefined)
-const isLoading = ref(false)
 const error = ref<Error | undefined>(undefined)
 
 const emit = defineEmits<{
@@ -45,7 +43,6 @@ const open = async (src: string) => {
   if (src === '') {
     return
   }
-  isLoading.value = true
   state.controller = new AbortController()
   // this should emit proper events
   const source = data.source(src, sym)
@@ -56,7 +53,6 @@ const open = async (src: string) => {
       message.value = (e as MessageEvent).data
       // if we got a message we are no longer erroneous
       error.value = undefined
-      isLoading.value = false
 
       emit('change', message.value)
     },
@@ -67,7 +63,6 @@ const open = async (src: string) => {
     'error',
     (e) => {
       error.value = (e as ErrorEvent).error as Error
-      isLoading.value = false
 
       emit('error', error.value)
     },

--- a/src/app/application/services/data-source/DataSourcePool.ts
+++ b/src/app/application/services/data-source/DataSourcePool.ts
@@ -8,7 +8,6 @@ export type Sources = Record<string, Source>
 // reusable Type Utility for easy to use Types within Vue templates
 export type DataSourceResponse<T> = {
   data: T | undefined
-  isLoading: boolean
   error: Error | undefined
   refresh: () => void
 }

--- a/src/app/diagnostics/views/DiagnosticsView.vue
+++ b/src/app/diagnostics/views/DiagnosticsView.vue
@@ -25,12 +25,12 @@
 
         <KCard>
           <template #body>
-            <LoadingBlock v-if="data === undefined" />
-
             <ErrorBlock
-              v-else-if="error"
+              v-if="error"
               :error="error"
             />
+
+            <LoadingBlock v-else-if="data === undefined" />
 
             <CodeBlock
               v-else

--- a/src/app/main-overview/components/MainOverview.vue
+++ b/src/app/main-overview/components/MainOverview.vue
@@ -1,16 +1,14 @@
 <template>
   <DataSource
-    v-slot="{ data: meshInsightsData, isLoading: meshInsightsIsLoading, error: meshInsightsError }: MeshInsightCollectionSource"
+    v-slot="{ data: meshInsightsData, error: meshInsightsError }: MeshInsightCollectionSource"
     src="/all-mesh-insights"
   >
     <DataSource
-      v-slot="{ data: zoneOverviewsData, isLoading: zoneOverviewsIsLoading, error: zoneOverviewsError }: ZoneOverviewCollectionSource"
+      v-slot="{ data: zoneOverviewsData, error: zoneOverviewsError }: ZoneOverviewCollectionSource"
       :src="can('use zones') ? '/all-zone-overviews' : ''"
     >
-      <LoadingBlock v-if="meshInsightsIsLoading || zoneOverviewsIsLoading" />
-
       <ErrorBlock
-        v-else-if="meshInsightsError"
+        v-if="meshInsightsError"
         :error="meshInsightsError"
       />
 
@@ -19,11 +17,13 @@
         :error="zoneOverviewsError"
       />
 
+      <LoadingBlock v-else-if="meshInsightsData === undefined || (can('use zones') && zoneOverviewsData === undefined)" />
+
       <ControlPlaneDetails
         v-else
         data-testid="detail-view-details"
-        :mesh-insights="meshInsightsData?.items"
-        :zone-overviews="zoneOverviewsData?.items"
+        :mesh-insights="meshInsightsData.items"
+        :zone-overviews="zoneOverviewsData?.items ?? []"
       />
     </DataSource>
   </DataSource>

--- a/src/app/meshes/views/MeshDetailView.vue
+++ b/src/app/meshes/views/MeshDetailView.vue
@@ -7,17 +7,15 @@
 
     <AppView>
       <DataSource
-        v-slot="{ data: mesh, isLoading: isLoadingMesh, error: meshError }: MeshSource"
+        v-slot="{ data: mesh, error: meshError }: MeshSource"
         :src="`/meshes/${route.params.mesh}`"
       >
         <DataSource
-          v-slot="{ data: meshInsight, isLoading: isLoadingMeshInsight, error: meshInsightError }: MeshInsightSource"
+          v-slot="{ data: meshInsight, error: meshInsightError }: MeshInsightSource"
           :src="`/mesh-insights/${route.params.mesh}`"
         >
-          <LoadingBlock v-if="isLoadingMesh || isLoadingMeshInsight" />
-
           <ErrorBlock
-            v-else-if="meshError"
+            v-if="meshError"
             :error="meshError"
           />
 
@@ -26,7 +24,7 @@
             :error="meshInsightError"
           />
 
-          <EmptyBlock v-else-if="mesh === undefined || meshInsight === undefined" />
+          <LoadingBlock v-else-if="mesh === undefined || meshInsight === undefined" />
 
           <div
             v-else
@@ -63,7 +61,6 @@ import AppView from '@/app/application/components/app-view/AppView.vue'
 import DataSource from '@/app/application/components/data-source/DataSource.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
-import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import ResourceCodeBlock from '@/app/common/ResourceCodeBlock.vue'

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -57,17 +57,15 @@
             </template>
 
             <DataSource
-              v-slot="{ data, isLoading, error }: PolicySource"
+              v-slot="{ data, error }: PolicySource"
               :src="`/meshes/${route.params.mesh}/policy-path/${currentPolicyType.path}/policy/${route.params.policy}`"
             >
-              <LoadingBlock v-if="isLoading" />
-
               <ErrorBlock
-                v-else-if="error"
+                v-if="error"
                 :error="error"
               />
 
-              <EmptyBlock v-else-if="data === undefined" />
+              <LoadingBlock v-else-if="data === undefined" />
 
               <PolicyDetails
                 v-else

--- a/src/app/services/views/ServiceDetailTabsView.vue
+++ b/src/app/services/views/ServiceDetailTabsView.vue
@@ -41,12 +41,12 @@
         v-slot="{ data, error }: ServiceInsightSource"
         :src="`/meshes/${route.params.mesh}/service-insights/${route.params.service}`"
       >
-        <LoadingBlock v-if="data === undefined" />
-
         <ErrorBlock
-          v-else-if="error"
+          v-if="error"
           :error="error"
         />
+
+        <LoadingBlock v-else-if="data === undefined" />
 
         <template v-else>
           <NavTabs

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -16,15 +16,15 @@
 
       <template v-if="props.data.serviceType === 'external'">
         <DataSource
-          v-slot="{ data: externalService, error: externalServiceError }: ExternalServiceSource"
+          v-slot="{ data: externalService, error }: ExternalServiceSource"
           :src="`/meshes/${route.params.mesh}/external-services/${route.params.service}`"
         >
-          <LoadingBlock v-if="externalService === undefined" />
-
           <ErrorBlock
-            v-else-if="externalServiceError"
-            :error="externalServiceError"
+            v-if="error"
+            :error="error"
           />
+
+          <LoadingBlock v-else-if="externalService === undefined" />
 
           <ExternalServiceDetails
             v-else


### PR DESCRIPTION
Fixes the order of loading and error blocks and makes them consistently check for `data` being `undefined`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
