### PR TITLE
feat(zones): improves handling of validation errors

### DIFF
--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -1,19 +1,19 @@
 Feature: Zones: Create Zone flow
   Background:
     Given the CSS selectors
-      | Alias                               | Selector                                            |
-      | zone-nav-item                       | .app-sidebar > .nav-item:nth-child(2) > a           |
-      | name-input                          | [data-testid='name-input']                          |
-      | name-input-group                    | [data-testid='name-input-group']                    |
-      | create-zone-button                  | [data-testid='create-zone-button']                  |
-      | create-zone-link                    | [data-testid='create-zone-link']                    |
-      | environment-universal-radio-button  | [data-testid='environment-universal-radio-button']  |
-      | environment-kubernetes-radio-button | [data-testid='environment-kubernetes-radio-button'] |
-      | ingress-input-switch                | [for='zone-ingress-enabled']                        |
-      | egress-input-switch                 | [for='zone-egress-enabled']                         |
-      | zone-connected-scanner              | [data-testid='zone-connected-scanner']              |
-      | error                               | [data-testid='create-zone-error']                   |
-      | instructions                        | [data-testid='connect-zone-instructions']           |
+      | Alias                               | Selector                                             |
+      | zone-nav-item                       | .app-sidebar > .nav-item:nth-child(2) > a            |
+      | name-input                          | [data-testid='name-input']                           |
+      | name-input-invalid-dns-name         | $name-input[data-test-error-type='invalid-dns-name'] |
+      | create-zone-button                  | [data-testid='create-zone-button']                   |
+      | create-zone-link                    | [data-testid='create-zone-link']                     |
+      | environment-universal-radio-button  | [data-testid='environment-universal-radio-button']   |
+      | environment-kubernetes-radio-button | [data-testid='environment-kubernetes-radio-button']  |
+      | ingress-input-switch                | [for='zone-ingress-enabled']                         |
+      | egress-input-switch                 | [for='zone-egress-enabled']                          |
+      | zone-connected-scanner              | [data-testid='zone-connected-scanner']               |
+      | error                               | [data-testid='create-zone-error']                    |
+      | instructions                        | [data-testid='connect-zone-instructions']            |
     And the environment
       """
       KUMA_MODE: global
@@ -87,7 +87,7 @@ Feature: Zones: Create Zone flow
     Then the "$environment-kubernetes-radio-button" element is checked
     Then the "$ingress-input-switch input" element is checked
     Then the "$egress-input-switch input" element is checked
-    Then the "$zone-connected-scanner" element contains "Waiting for Zone to be connected"
+    Then the "$zone-connected-scanner[data-test-state='waiting']" element exists
 
     When I click the "$ingress-input-switch" element
     Then the "$ingress-input-switch input" element isn't checked
@@ -114,7 +114,7 @@ Feature: Zones: Create Zone flow
               disconnectTime: ~
               status: {}
       """
-    Then the "$zone-connected-scanner" element contains "The Zone “test” is now connected"
+    Then the "$zone-connected-scanner[data-test-state='success']" element exists
 
   Scenario: The form shows expected error for 409 response
     Given the URL "/provision-zone" responds with
@@ -150,8 +150,7 @@ Feature: Zones: Create Zone flow
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
 
-    Then the "$error" element contains "Invalid zone name"
-    And the "$name-input-group" element contains "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols."
+    Then the "$name-input-invalid-dns-name" element exists
     And the "$instructions" element doesn't exist
 
   Scenario: The form shows expected error for client-side name validation
@@ -160,7 +159,7 @@ Feature: Zones: Create Zone flow
     And I click the "$create-zone-button" element
 
     Then the "$error" element doesn't exist
-    And the "$name-input-group" element contains "The name must be a valid RFC 1035 DNS name, which means it must start with a letter, be less than 64 characters long, and only contain lowercase letters, numbers, and '-'."
+    And the "$name-input-invalid-dns-name" element exists
     And the "$instructions" element doesn't exist
 
     When I clear the "$name-input" element

--- a/src/app/zones/components/EntityScanner.vue
+++ b/src/app/zones/components/EntityScanner.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="scanner">
+  <div
+    class="scanner"
+    :data-test-state="isRunning ? 'waiting' : hasError ? 'error' : 'success'"
+  >
     <div class="scanner-content">
       <KEmptyState cta-is-hidden>
         <template #title>

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -75,7 +75,7 @@ zones:
   form:
     exit: 'Exit'
     nameLabel: 'Name'
-    name_tooltip: 'Zone names may contain lowercase alphanumerical characters, dashes (-), and underscores (_).'
+    name_tooltip: "The name must be a valid RFC 1035 DNS name, which means it must start with a letter, be less than 64 characters long, and only contain lowercase letters, numbers, and '-'."
     createZoneButtonLabel: 'Create Zone & generate token'
     environmentLabel: 'Environment'
     universalLabel: 'Universal'
@@ -174,6 +174,7 @@ zones:
   create:
     generalError:
       title: 'Could not create the Zone'
+    invalidNameError: "The name must be a valid RFC 1035 DNS name, which means it must start with a letter, be less than 64 characters long, and only contain lowercase letters, numbers, and '-'."
     statusError:
       409:
         title: 'A Zone with the name {zoneName} already exists'

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -30,7 +30,7 @@
         <h1>{{ t('zones.routes.create.title') }}</h1>
 
         <div class="form-wrapper mt-4">
-          <div data-testid="name-input-group">
+          <div>
             <KLabel
               for="zone-name"
               required
@@ -49,6 +49,7 @@
               type="text"
               name="zone-name"
               data-testid="name-input"
+              :data-test-error-type="nameError !== null ? 'invalid-dns-name' : undefined"
               :has-error="nameError !== null"
               :error-message="nameError ?? undefined"
               :disabled="zone !== null"

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -30,7 +30,7 @@
         <h1>{{ t('zones.routes.create.title') }}</h1>
 
         <div class="form-wrapper mt-4">
-          <div>
+          <div data-testid="name-input-group">
             <KLabel
               for="zone-name"
               required
@@ -49,7 +49,10 @@
               type="text"
               name="zone-name"
               data-testid="name-input"
+              :has-error="nameError !== null"
+              :error-message="nameError ?? undefined"
               :disabled="zone !== null"
+              @blur="validateName(name)"
             />
           </div>
 
@@ -246,15 +249,20 @@ type ErrorState = {
 const { t } = useI18n()
 const kumaApi = useKumaApi()
 
+/**
+ * https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names
+ */
+const NAME_REGEX = /^(?![-0-9])[a-z0-9-]{1,63}$/
+
 const zone = ref<{ token: string } | null>(null)
 const isChangingZone = ref(false)
-const changingError = ref<Error | null>(null)
 const errorState = ref<ErrorState>({
   error: null,
   title: null,
   icon: 'warning',
   badgeAppearance: 'warning',
 })
+const frontendNameError = ref<string | null>(null)
 
 const isScanComplete = ref(false)
 const scanError = ref<Error | null>(null)
@@ -273,14 +281,41 @@ const isCreateButtonDisabled = computed(() => {
     zone.value !== null
 })
 
+const nameError = computed(() => {
+  // Reads client-side error
+  if (frontendNameError.value !== null) {
+    return frontendNameError.value
+  }
+
+  // Reads server-side error
+  if (errorState.value.error instanceof ApiError) {
+    const nameError = errorState.value.error.invalidParameters.find((param) => param.field === 'name')
+    if (nameError !== undefined) {
+      return nameError.reason
+    }
+  }
+
+  return null
+})
+
 /**
  * Creates a Zone via request to the appropriate endpoint. Importantly, this returns a Zone object including a base64-encoded token which is needed for enabling the Zone in the subsequent steps of the Zone creation flow.
  */
 async function createZone() {
   isChangingZone.value = true
-  changingError.value = null
+  errorState.value = {
+    error: null,
+    title: null,
+    icon: 'warning',
+    badgeAppearance: 'warning',
+  }
 
   try {
+    const isValidName = validateName(name.value)
+    if (!isValidName) {
+      return
+    }
+
     zone.value = await kumaApi.createZone({ name: name.value })
   } catch (err) {
     if (err instanceof ApiError && [409, 500].includes(err.status)) {
@@ -295,6 +330,7 @@ async function createZone() {
       errorState.value = {
         error: err,
         title: err instanceof ApiError ? err.title : t('zones.create.generalError.title'),
+        description: err instanceof ApiError && err.detail ? err.detail : undefined,
         icon: 'errorFilled',
         badgeAppearance: 'danger',
       }
@@ -304,6 +340,18 @@ async function createZone() {
   } finally {
     isChangingZone.value = false
   }
+}
+
+function validateName(name: string): boolean {
+  const isValidName = NAME_REGEX.test(name)
+
+  if (isValidName) {
+    frontendNameError.value = null
+  } else {
+    frontendNameError.value = t('zones.create.invalidNameError')
+  }
+
+  return isValidName
 }
 
 /**


### PR DESCRIPTION
Validates the name field on the client-side in addition to processing the already handled service-side validation error.

Makes sure errors are cleared correctly when clicking "Create Zone" after showing a service-side error.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
