### PR TITLE
chore: tweaks copy as k8s button appearance

### DIFF
--- a/src/app/common/CopyButton.vue
+++ b/src/app/common/CopyButton.vue
@@ -1,12 +1,16 @@
 <template>
   <KClipboardProvider v-slot="{ copyToClipboard }">
     <KButton
+      v-bind="$attrs"
       appearance="outline"
-      class="copy-button non-visual-button"
+      class="copy-button"
+      :class="{
+        'non-visual-button': !props.hasBorder,
+      }"
       data-testid="copy-button"
       :is-rounded="false"
       size="small"
-      :title="props.copyText"
+      :title="!props.hideTitle ? props.copyText : undefined"
       type="button"
       @click="copy($event, copyToClipboard)"
     >
@@ -14,7 +18,8 @@
         color="currentColor"
         icon="copy"
         :size="KUI_ICON_SIZE_30"
-        :title="props.copyText"
+        :title="!props.hideTitle ? props.copyText : undefined"
+        :hide-title="props.hideTitle"
       />
 
       <slot>
@@ -60,6 +65,16 @@ const props = defineProps({
     required: false,
     default: 'Failed to copy!',
   },
+
+  hasBorder: {
+    type: Boolean,
+    default: false,
+  },
+
+  hideTitle: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 async function copy(event: Event, copyToClipboard: (text: string) => Promise<boolean>) {
@@ -88,6 +103,12 @@ async function copy(event: Event, copyToClipboard: (text: string) => Promise<boo
 }
 </script>
 
+<script lang="ts">
+export default {
+  inheritAttrs: false,
+}
+</script>
+
 <style lang="scss" scoped>
 // Overrides KButton’s default padding.
 .copy-button.copy-button {
@@ -104,7 +125,7 @@ async function copy(event: Event, copyToClipboard: (text: string) => Promise<boo
 
 .copy-button[data-tooltip-text]::after {
   background-color: var(--tooltip-background-color);
-  border-radius: 3px;
+  border-radius: $kui-border-radius-20;
   color: $kui-color-text-inverse;
   content: attr(data-tooltip-text);
   font-weight: $kui-font-weight-regular;

--- a/src/app/common/ResourceCodeBlock.vue
+++ b/src/app/common/ResourceCodeBlock.vue
@@ -8,17 +8,28 @@
     :code-max-height="props.codeMaxHeight"
   >
     <template #secondary-actions>
-      <CopyButton
-        :get-text="getYamlAsKubernetes"
-        :copy-text="i18n.t('common.copyKubernetesText')"
+      <KTooltip
+        class="kubernetes-copy-button-tooltip"
+        :label="t('common.copyKubernetesText')"
+        placement="bottomEnd"
+        max-width="200"
       >
-        {{ i18n.t('common.copyKubernetesShortText') }}
-      </CopyButton>
+        <CopyButton
+          class="kubernetes-copy-button"
+          :get-text="getYamlAsKubernetes"
+          :copy-text="t('common.copyKubernetesText')"
+          has-border
+          hide-title
+        >
+          {{ t('common.copyKubernetesShortText') }}
+        </CopyButton>
+      </KTooltip>
     </template>
   </CodeBlock>
 </template>
 
 <script lang="ts" setup>
+import { KTooltip } from '@kong/kongponents'
 import { PropType, computed } from 'vue'
 
 import CodeBlock from './CodeBlock.vue'
@@ -28,7 +39,7 @@ import type { Entity } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 import { toYaml } from '@/utilities/toYaml'
 
-const i18n = useI18n()
+const { t } = useI18n()
 
 const props = defineProps({
   id: {
@@ -76,3 +87,15 @@ function toYamlRepresentation(resource: Entity): string {
   return toYaml(resourceWithoutTimes)
 }
 </script>
+
+<style lang="scss">
+.kubernetes-copy-button-tooltip {
+  display: flex;
+}
+
+.kubernetes-copy-button:not(.increase-specificity.increase-specificity) {
+  padding: $kui-space-20 $kui-space-40;
+  border: $kui-border-width-10 solid $kui-color-border-neutral-weak;
+  border-radius: $kui-border-radius-20;
+}
+</style>


### PR DESCRIPTION
Adds a bordered style to the "Copy as Kubernetes" button to visually separate it from the default copy button a bit better.

Adds a tooltip to the "Copy as Kubernetes" button to explain its purpose.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
