### PR TITLE
feat: updates create zone appearance

### DIFF
--- a/src/app/zones/components/EntityScanner.vue
+++ b/src/app/zones/components/EntityScanner.vue
@@ -6,7 +6,7 @@
     <div class="scanner-content">
       <KEmptyState cta-is-hidden>
         <template #title>
-          <div class="mb-2">
+          <span class="mr-1">
             <KIcon
               v-if="isRunning"
               icon="spinner"
@@ -27,7 +27,7 @@
               :color="KUI_COLOR_TEXT_SUCCESS"
               :size="KUI_ICON_SIZE_50"
             />
-          </div>
+          </span>
 
           <slot
             v-if="isRunning"

--- a/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
+++ b/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <h3>1. {{ i18n.t('zones.form.kubernetes.prerequisites.title') }}</h3>
+    <h3>
+      <span class="step-number">1</span>
+      {{ i18n.t('zones.form.kubernetes.prerequisites.title') }}
+    </h3>
 
     <ul>
       <li>
@@ -18,7 +21,10 @@
       </li>
     </ul>
 
-    <h3>2. {{ i18n.t('zones.form.kubernetes.helm.title') }}</h3>
+    <h3>
+      <span class="step-number">2</span>
+      {{ i18n.t('zones.form.kubernetes.helm.title') }}
+    </h3>
 
     <p>On your local machine, create a namespace in your Kubernetes cluster and pull down the kong Helm repo.</p>
 
@@ -57,7 +63,10 @@
       </li>
     </ol>
 
-    <h3>3. {{ i18n.t('zones.form.kubernetes.secret.title') }}</h3>
+    <h3>
+      <span class="step-number">3</span>
+      {{ i18n.t('zones.form.kubernetes.secret.title') }}
+    </h3>
 
     <p>{{ i18n.t('zones.form.kubernetes.secret.createSecretDescription') }}</p>
 
@@ -68,7 +77,10 @@
       language="bash"
     />
 
-    <h3>4. {{ i18n.t('zones.form.kubernetes.connectZone.title') }}</h3>
+    <h3>
+      <span class="step-number">4</span>
+      {{ i18n.t('zones.form.kubernetes.connectZone.title') }}
+    </h3>
 
     <p>{{ i18n.t('zones.form.kubernetes.connectZone.configDescription') }}</p>
 
@@ -155,3 +167,18 @@ const kubernetesConfig = computed(() => {
 })
 
 </script>
+
+<style lang="scss" scoped>
+.step-number {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 30px;
+  height: 30px;
+  margin-right: $kui-space-20;
+  color: $kui-color-text-inverse;
+  background-color: #169fcc;
+  border-radius: 50%;
+  font-size: $kui-font-size-40;
+}
+</style>

--- a/src/app/zones/components/ZoneCreateUniversalInstructions.vue
+++ b/src/app/zones/components/ZoneCreateUniversalInstructions.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <h3>1. {{ i18n.t('zones.form.universal.saveToken.title') }}</h3>
+    <h3>
+      <span class="step-number">1</span>
+      {{ i18n.t('zones.form.universal.saveToken.title') }}
+    </h3>
 
     <p>{{ i18n.t('zones.form.universal.saveToken.saveTokenDescription') }}</p>
 
@@ -11,7 +14,10 @@
       language="bash"
     />
 
-    <h3>2. {{ i18n.t('zones.form.universal.connectZone.title') }}</h3>
+    <h3>
+      <span class="step-number">2</span>
+      {{ i18n.t('zones.form.universal.connectZone.title') }}
+    </h3>
 
     <p>{{ i18n.t('zones.form.universal.connectZone.configDescription') }}</p>
 
@@ -77,3 +83,18 @@ const universalConfig = computed(() => {
   return i18n.t('zones.form.universal.connectZone.config', placeholders).trim()
 })
 </script>
+
+<style lang="scss" scoped>
+.step-number {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 30px;
+  height: 30px;
+  margin-right: $kui-space-20;
+  color: $kui-color-text-inverse;
+  background-color: #169fcc;
+  border-radius: 50%;
+  font-size: $kui-font-size-40;
+}
+</style>

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -85,6 +85,10 @@ zones:
     zoneEgressLabel: 'Zone Egress'
     zoneEgressEnabledLabel: 'Enabled'
     connectZone: 'Connect Zone'
+    confirm_modal:
+      action_button: 'Yes, exit'
+      title: 'Are you sure you want to exit?'
+      body: 'You’ve already created a Zone with a token. You won’t have access to the Zone’s token once you exit.'
     scan:
       waitTitle: 'Waiting for Zone to be connected …'
       completeTitle: 'Done!'

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -74,6 +74,15 @@ zones:
     create: 'Create Zone'
   form:
     exit: 'Exit'
+    section:
+      name:
+        title: 'Zone name'
+      configuration:
+        title: 'Configuration'
+      connect_zone:
+        title: 'Connect Zone'
+      scanner:
+        title: 'Waiting for Zone to be connected …'
     nameLabel: 'Name'
     name_tooltip: "The name must be a valid RFC 1035 DNS name, which means it must start with a letter, be less than 64 characters long, and only contain lowercase letters, numbers, and '-'."
     createZoneButtonLabel: 'Create Zone & generate token'
@@ -84,7 +93,6 @@ zones:
     zoneIngressEnabledLabel: 'Enabled'
     zoneEgressLabel: 'Zone Egress'
     zoneEgressEnabledLabel: 'Enabled'
-    connectZone: 'Connect Zone'
     confirm_modal:
       action_button: 'Yes, exit'
       title: 'Are you sure you want to exit?'

--- a/src/assets/styles/_forms.scss
+++ b/src/assets/styles/_forms.scss
@@ -1,11 +1,41 @@
-.form-content {
-  max-width: 1000px;
-  margin-right: auto;
-  margin-left: auto;
+.form-wrapper {
+  margin-top: $kui-space-100;
+  margin-bottom: $kui-space-100;
+  padding-right: 5%;
+  padding-left: 5%;
+
+  @media (min-width: $kui-breakpoint-desktop) {
+    padding-left: 15%;
+    padding-right: 15%;
+  }
 }
 
-.form-wrapper>*+* {
-  margin-block-start: $kui-space-60;
+.form>*+* {
+  margin-top: $kui-space-100;
+  border-top: $kui-border-width-10 solid $kui-color-border;
+  padding-top: $kui-space-100;
+}
+
+.form-title {
+  font-size: $kui-font-size-70;
+}
+
+.form-section {
+  display: grid;
+  grid-template-columns: 1fr 3fr;
+  gap: $kui-space-100;
+}
+
+.form-section__header {
+  grid-column-start: 1;
+}
+
+.form-section__content {
+  grid-column-start: 2;
+}
+
+.form-section-title {
+  font-size: $kui-font-size-50;
 }
 
 .radio-button-group>* {


### PR DESCRIPTION
**feat(zones): shows confirm modal when exiting zone creation mid process**

Shows a confirmation modal when exiting the Zone creation process while (1) a Zone with a token was already create and (2) the Zone wasn’t connected, yet.

**feat: updates Create Zone wizard layout**

Updates the layout of the Create Zone wizard to split the form into sections for Zone name, configuration, connecting a Zone, and waiting for a Zone to be connected.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
