### PR TITLE
chore: Use DataSource for KDS address

### DIFF
--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -12,6 +12,8 @@ Feature: Zones: Create Zone flow
       | create-zone-link                    | [data-testid='create-zone-link']                     |
       | environment-universal-radio-button  | [data-testid='environment-universal-radio-button']   |
       | environment-kubernetes-radio-button | [data-testid='environment-kubernetes-radio-button']  |
+      | environment-universal-config        | [data-testid='zone-universal-config']                |
+      | environment-kubernetes-config       | [data-testid='zone-kubernetes-config']               |
       | ingress-input-switch                | [for='zone-ingress-enabled']                         |
       | egress-input-switch                 | [for='zone-egress-enabled']                          |
       | zone-connected-scanner              | [data-testid='zone-connected-scanner']               |
@@ -90,6 +92,7 @@ Feature: Zones: Create Zone flow
     Then the "$environment-kubernetes-radio-button" element is checked
     Then the "$ingress-input-switch input" element is checked
     Then the "$egress-input-switch input" element is checked
+    Then the "$environment-kubernetes-config" element contains "kdsGlobalAddress: grpcs://<global-kds-address>:5685"
     Then the "$zone-connected-scanner[data-test-state='waiting']" element exists
 
     When I click the "$ingress-input-switch" element
@@ -103,6 +106,7 @@ Feature: Zones: Create Zone flow
     When I click the "$environment-universal-radio-button + label" element
     Then the "$ingress-input-switch input" element doesn't exist
     Then the "$egress-input-switch input" element doesn't exist
+    Then the "$environment-universal-config" element contains "globalAddress: grpcs://<global-kds-address>:5685"
 
     Given the environment
       """

--- a/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
+++ b/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
@@ -90,6 +90,7 @@
 
     <CodeBlock
       id="zone-kubernetes-config-code-block"
+      data-testid="zone-kubernetes-config"
       :code="kubernetesConfig"
       language="yaml"
     />
@@ -112,17 +113,20 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 import CodeBlock from '@/app/common/CodeBlock.vue'
-import { useStore } from '@/store/store'
 import {
   useI18n,
 } from '@/utilities'
 
 const i18n = useI18n()
 const route = useRoute()
-const store = useStore()
 
 const props = defineProps({
   zoneName: {
+    type: String,
+    required: true,
+  },
+
+  globalKdsAddress: {
     type: String,
     required: true,
   },
@@ -154,7 +158,7 @@ const kubernetesCreateSecretCommand = computed(() => i18n.t('zones.form.kubernet
 const kubernetesConfig = computed(() => {
   const placeholders: Record<string, string> = {
     zoneName: props.zoneName,
-    globalKdsAddress: store.state.globalKdsAddress,
+    globalKdsAddress: props.globalKdsAddress,
     zoneIngressEnabled: String(props.zoneIngressEnabled),
     zoneEgressEnabled: String(props.zoneEgressEnabled),
   }

--- a/src/app/zones/components/ZoneCreateUniversalInstructions.vue
+++ b/src/app/zones/components/ZoneCreateUniversalInstructions.vue
@@ -27,6 +27,7 @@
 
     <CodeBlock
       id="zone-universal-config-code-block"
+      data-testid="zone-universal-config"
       class="mt-4"
       :code="universalConfig"
       language="yaml"
@@ -50,15 +51,18 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 import CodeBlock from '@/app/common/CodeBlock.vue'
-import { useStore } from '@/store/store'
 import { useI18n } from '@/utilities'
 
 const i18n = useI18n()
 const route = useRoute()
-const store = useStore()
 
 const props = defineProps({
   zoneName: {
+    type: String,
+    required: true,
+  },
+
+  globalKdsAddress: {
     type: String,
     required: true,
   },
@@ -73,7 +77,7 @@ const saveTokenCommand = computed(() => i18n.t('zones.form.universal.saveToken.s
 const universalConfig = computed(() => {
   const placeholders: Record<string, string> = {
     zoneName: props.zoneName,
-    globalKdsAddress: store.state.globalKdsAddress,
+    globalKdsAddress: props.globalKdsAddress,
   }
 
   if (typeof route.params.virtualControlPlaneId === 'string') {

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -201,20 +201,31 @@
                   </div>
 
                   <div class="form-section__content">
-                    <ZoneCreateUniversalInstructions
-                      v-if="environment === 'universal'"
-                      :zone-name="name"
-                      :token="token"
-                    />
+                    <DataSource
+                      v-slot="{ data }: ControlPlaneAddressesSource"
+                      src="/control-plane/addresses"
+                    >
+                      <template
+                        v-if="(typeof data !== 'undefined')"
+                      >
+                        <ZoneCreateUniversalInstructions
+                          v-if="environment === 'universal'"
+                          :zone-name="name"
+                          :token="token"
+                          :global-kds-address="data.kds"
+                        />
 
-                    <ZoneCreateKubernetesInstructions
-                      v-else
-                      :zone-name="name"
-                      :zone-ingress-enabled="zoneIngressEnabled"
-                      :zone-egress-enabled="zoneEgressEnabled"
-                      :token="token"
-                      :base64-encoded-token="base64EncodedToken"
-                    />
+                        <ZoneCreateKubernetesInstructions
+                          v-else
+                          :zone-name="name"
+                          :zone-ingress-enabled="zoneIngressEnabled"
+                          :zone-egress-enabled="zoneEgressEnabled"
+                          :token="token"
+                          :base64-encoded-token="base64EncodedToken"
+                          :global-kds-address="data.kds"
+                        />
+                      </template>
+                    </DataSource>
                   </div>
                 </div>
 
@@ -317,6 +328,7 @@ import AppView from '@/app/application/components/app-view/AppView.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
+import { ControlPlaneAddressesSource } from '@/app/control-planes/sources'
 import { ApiError } from '@/services/kuma-api/ApiError'
 import { useI18n, useKumaApi } from '@/utilities'
 import { getItemStatusFromInsight } from '@/utilities/dataplane'

--- a/src/store/storeConfig.ts
+++ b/src/store/storeConfig.ts
@@ -3,23 +3,7 @@ import { StoreOptions } from 'vuex'
 import { OnboardingInterface } from './modules/onboarding/onboarding.types'
 import onboarding from '@/store/modules/onboarding/onboarding'
 
-/**
- * The root state of the application’s Vuex store minus all module state.
- */
-interface BareRootState {
-  globalKdsAddress: string
-}
-
-const initialState: BareRootState = {
-  globalKdsAddress: 'grpcs://<global-kds-address>:5685',
-}
-
-/**
- * The root state of the application’s Vuex store including all module state.
- *
- * Module state is explicitly added because creating a store using modules needs it. By default, Vuex’s types for stores with namespaced modules will be incorrect.
- */
-export interface State extends BareRootState {
+export interface State {
   onboarding: OnboardingInterface
 }
 
@@ -27,19 +11,6 @@ export const storeConfig = (): StoreOptions<State> => {
   return {
     modules: {
       onboarding,
-    },
-
-    // Explicitly asserts `initialState` to be of type `State` (which includes module state) even though `initialSate` doesn’t include module state. This is necessary because otherwise the result of creating a store from `storeConfig` and `State` will be a store (i.e. `Store<State>`) that, according to its type, is missing all module state which it actually doesn’t. Vuex’s types aren’t complete and don’t account for this scenario. Without this workaround, accessing module state without a type guard would always produce a TypeScript error.
-    state: () => initialState as State,
-
-    mutations: {
-      SET_GLOBAL_KDS_ADDRESS: (state, globalKdsAddress: typeof state.globalKdsAddress) => (state.globalKdsAddress = globalKdsAddress),
-    },
-
-    actions: {
-      updateGlobalKdsAddress({ commit }, globalKdsAddress: string) {
-        commit('SET_GLOBAL_KDS_ADDRESS', globalKdsAddress)
-      },
     },
   }
 }


### PR DESCRIPTION
Moves globalAddress to use DataSource instead of the store.

---

Notes:

1. At this point **we should make a point of not adding anything else to the Vuex store**. Only onboarding is using the store, which whilst not a huge priority, would be good to remove also so we can then remove Vuex entirely. If there is a need for some sort of more in-depth frontend context/infinite state store then we should consider other alternatives via either provide/inject or Pinia. TLDR; If you need to add something to the Vuex store, please reach out to discuss first.
2. I noticed a number of things whilst doing this, and even started on a slightly bigger refactor. Some of the things I noticed shouldn't really be in here so whilst I pulled back for the moment to make this more isolated, a slightly larger refactor of this area is likely to happen relatively soon (probably a few weeks off yet)