### PR TITLE
chore: Adds YAML undefined type to aid testing

### DIFF
--- a/features/mesh/dataplanes/DetailViewContent.feature
+++ b/features/mesh/dataplanes/DetailViewContent.feature
@@ -52,7 +52,7 @@ Feature: Data Plane Proxies: Detail view content
                   kumaDpCompatible: false
             - controlPlaneInstanceId: 'dpp-1-cp-instance-id'
               connectTime: 2021-02-17T07:33:36.412683Z
-              disconnectTime: ''
+              disconnectTime: !!js/undefined
               status:
                 total:
                   responsesSent: '12'


### PR DESCRIPTION
See https://github.com/kumahq/kuma-gui/pull/1316#discussion_r1293326627

We had a bit of discussion a while back on the inability to omit a property from a merge (i.e. mark it as undefined). This adds a `!!js/undefined` YAML tag to let you do that.

I don't think we'll ever need the ability to specify between omitted vs set to `undefined` but if we do we can just add a new tag to cope for that.
