### PR TITLE
refactor: uses plural resource names in URL paths

### DIFF
--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -56,7 +56,7 @@ Feature: application / MainNavigation
     And the URL contains "page=2&size=50"
     And the "[data-testid='page-2-btn'].active" element exists
 
-    When I visit the "/mesh/default/data-planes" URL
+    When I visit the "/meshes/default/data-planes" URL
     And the URL contains "page=1&size=50"
     And the URL doesn't contain "mesh=default"
 

--- a/features/application/Titles.feature
+++ b/features/application/Titles.feature
@@ -18,25 +18,25 @@ Feature: application / titles
       | /onboarding/dataplanes-overview | Data plane overview |
       | /onboarding/completed           | Completed           |
 
-      | /zones/create                           | Create & connect Zone |
-      | /zones/zone-cps                         | Zone Control Planes   |
-      | /zones/zone-cps/zone-cp-name            | zone-cp-name          |
-      | /zones/zone-ingresses                   | Ingresses             |
-      | /zones/zone-ingresses/zone-ingress-name | zone-ingress-name     |
-      | /zones/zone-egresses                    | Egresses              |
-      | /zones/zone-egresses/zone-egress-name   | zone-egress-name      |
+      | /zones/-create                                   | Create & connect Zone |
+      | /zones/zone-cps                                  | Zone Control Planes   |
+      | /zones/zone-cps/zone-cp-name/overview            | zone-cp-name          |
+      | /zones/zone-ingresses                            | Ingresses             |
+      | /zones/zone-ingresses/zone-ingress-name/overview | zone-ingress-name     |
+      | /zones/zone-egresses                             | Egresses              |
+      | /zones/zone-egresses/zone-egress-name/overview   | zone-egress-name      |
 
-      | /mesh         | Meshes        |
-      | /mesh/default | Mesh overview |
+      | /meshes         | Meshes        |
+      | /meshes/default | Mesh overview |
 
-      | /mesh/default/services             | Services     |
-      | /mesh/default/service/service-name | service-name |
+      | /meshes/default/services                       | Services     |
+      | /meshes/default/services/service-name/overview | service-name |
 
-      | /mesh/default/gateways             | Gateways     |
-      | /mesh/default/gateway/gateway-name | gateway-name |
+      | /meshes/default/gateways                       | Gateways     |
+      | /meshes/default/gateways/gateway-name/overview | gateway-name |
 
-      | /mesh/default/data-planes                | Data Plane Proxies |
-      | /mesh/default/data-plane/data-plane-name | data-plane-name    |
+      | /meshes/default/data-planes                          | Data Plane Proxies |
+      | /meshes/default/data-planes/data-plane-name/overview | data-plane-name    |
 
-      | /mesh/default/policies/circuit-breakers         | Policies  |
-      | /mesh/default/policy/circuit-breakers/program-0 | program-0 |
+      | /meshes/default/policies/circuit-breakers                    | Policies  |
+      | /meshes/default/policies/circuit-breakers/program-0/overview | program-0 |

--- a/features/mesh/Index.feature
+++ b/features/mesh/Index.feature
@@ -24,7 +24,7 @@ Feature: mesh / index
   Scenario: Clicking a mesh and back again for <Mesh>
     Then the "$item" element exists 2 times
     Then I click the "<Selector>" element
-    Then the URL contains "/mesh/<Mesh>"
+    Then the URL contains "/meshes/<Mesh>"
     And the "$breadcrumbs" element contains "Meshes"
 
     Then I click the "$navigation li:nth-child(2) a" element

--- a/features/mesh/Item.feature
+++ b/features/mesh/Item.feature
@@ -12,7 +12,7 @@ Feature: mesh / item
         services:
           total: 11
       """
-    When I visit the "/mesh/default/overview" URL
+    When I visit the "/meshes/default/overview" URL
     And the "$service-count" element contains "11"
 
   Scenario: /mesh-insights/* is a 404
@@ -21,6 +21,6 @@ Feature: mesh / item
       headers:
         Status-Code: 404
       """
-    When I visit the "/mesh/default/overview" URL
+    When I visit the "/meshes/default/overview" URL
     Then the "$error" element doesn't exist
     And the "$service-count" element contains "0"

--- a/features/mesh/dataplanes/DetailViewContent.feature
+++ b/features/mesh/dataplanes/DetailViewContent.feature
@@ -72,7 +72,7 @@ Feature: Data Plane Proxies: Detail view content
                 envoy:
                   kumaDpCompatible: true
       """
-    When I visit the "/mesh/default/data-plane/dpp-1-name-of-dataplane" URL
+    When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/overview" URL
 
   Scenario: Data Plane Proxy detail view has expected content
     Then the page title contains "dpp-1-name-of-dataplane"

--- a/features/mesh/dataplanes/Index.feature
+++ b/features/mesh/dataplanes/Index.feature
@@ -37,7 +37,7 @@ Feature: mesh / dataplanes / index
       KUMA_MODE: global
       """
 
-    When I visit the "/mesh/default/data-planes" URL
+    When I visit the "/meshes/default/data-planes" URL
 
     Then the "$table-header" element exists 9 times
     And the "$table-header" elements contain
@@ -57,7 +57,7 @@ Feature: mesh / dataplanes / index
       KUMA_MODE: standalone
       """
 
-    When I visit the "/mesh/default/data-planes" URL
+    When I visit the "/meshes/default/data-planes" URL
 
     Then the "$table-header" element exists 8 times
     And the "$table-header" elements contain
@@ -71,7 +71,7 @@ Feature: mesh / dataplanes / index
       | Warnings         |
 
   Scenario: The Proxy listing has the expected content and UI elements
-    When I visit the "/mesh/default/data-planes" URL
+    When I visit the "/meshes/default/data-planes" URL
 
     Then the "$table-row" element exists 9 times
     Then the "$table-row:nth-child(1)" element contains

--- a/features/mesh/dataplanes/NoSubscriptions.feature
+++ b/features/mesh/dataplanes/NoSubscriptions.feature
@@ -8,6 +8,6 @@ Feature: dataplanes / no-subscriptions
       """
       KUMA_SUBSCRIPTION_COUNT: 0
       """
-    When I visit the "/mesh/default/data-plane/dpp-1" URL
+    When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     And the "$detail-view" element contains "dpp-1"
     And the "$overview-content" element contains "offline"

--- a/features/mesh/dataplanes/Warnings.feature
+++ b/features/mesh/dataplanes/Warnings.feature
@@ -15,7 +15,7 @@ Feature: mesh / dataplanes / warnings
           mTLS:
             certificateExpirationTime: 2022-10-03T12:40:13Z
       """
-    When I visit the "/mesh/default/data-plane/dpp-1" URL
+    When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$expired-cert-warning" element exists
 
   Scenario: With an expired CA a CA warning isn't shown
@@ -26,7 +26,7 @@ Feature: mesh / dataplanes / warnings
           mTLS:
             certificateExpirationTime: 3022-10-03T12:40:13Z
       """
-    When I visit the "/mesh/default/data-plane/dpp-1" URL
+    When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$expired-cert-warning" element doesn't exist
 
   Scenario: With no mTLS a certificate warning isn't shown
@@ -36,7 +36,7 @@ Feature: mesh / dataplanes / warnings
         dataplaneInsight:
           mTLS: !!js/undefined
       """
-    When I visit the "/mesh/default/data-plane/dpp-1" URL
+    When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$expired-cert-warning" element doesn't exist
 
   Scenario: Unsupported zone warning is shown
@@ -60,7 +60,7 @@ Feature: mesh / dataplanes / warnings
                   kuma.io/zone: zone
       """
 
-    When I visit the "/mesh/default/data-plane/dpp-1" URL
+    When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$unsupported-zone-warning" element exists
 
   Scenario: Unsupported kuma warning is shown
@@ -80,7 +80,7 @@ Feature: mesh / dataplanes / warnings
                   kumaDpCompatible: true
       """
 
-    When I visit the "/mesh/default/data-plane/dpp-1" URL
+    When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$unsupported-kuma-warning" element exists
 
   Scenario: Unsupported envoy warning is shown
@@ -100,6 +100,5 @@ Feature: mesh / dataplanes / warnings
                   kumaDpCompatible: false
       """
 
-    When I visit the "/mesh/default/data-plane/dpp-1" URL
+    When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$unsupported-envoy-warning" element exists
-

--- a/features/mesh/gateways/Index.feature
+++ b/features/mesh/gateways/Index.feature
@@ -29,7 +29,7 @@ Feature: mesh / gateways / index
               gateway:
                 type: 'BUILTIN'
       """
-    When I visit the "/mesh/default/gateways" URL
+    When I visit the "/meshes/default/gateways" URL
 
   Scenario: The Gateway listing table has the correct columns
     Then the "$item-header" elements contain

--- a/features/mesh/gateways/PageNavigation.feature
+++ b/features/mesh/gateways/PageNavigation.feature
@@ -1,7 +1,7 @@
 Feature: Gateways: Page navigation
   Scenario Outline: Tabs have expected URLs
 
-    When I visit the "/mesh/default/gateway/firewal-gateway-1" URL
+    When I visit the "/meshes/default/gateways/firewal-gateway-1/overview" URL
     # This `cy.wait` stabilizes the test significantly. For some reason, it can happen that the subsequent navigation to via nav tab is never triggered.
     Then I wait for 1000 milliseconds
 
@@ -10,9 +10,9 @@ Feature: Gateways: Page navigation
     Then the page title contains "<Title>"
 
     Examples:
-      | TabSelector                    | Path                                  | Title             |
-      | #gateway-detail-view-tab a     | /gateway/firewal-gateway-1            | firewal-gateway-1 |
-      | #gateway-policies-view-tab a   | /gateway/firewal-gateway-1/policies   | Policies          |
-      | #gateway-xds-config-view-tab a | /gateway/firewal-gateway-1/xds-config | XDS Configuration |
-      | #gateway-stats-view-tab a      | /gateway/firewal-gateway-1/stats      | Stats             |
-      | #gateway-clusters-view-tab a   | /gateway/firewal-gateway-1/clusters   | Clusters          |
+      | TabSelector                    | Path                                   | Title             |
+      | #gateway-detail-view-tab a     | /gateways/firewal-gateway-1/overview   | firewal-gateway-1 |
+      | #gateway-policies-view-tab a   | /gateways/firewal-gateway-1/policies   | Policies          |
+      | #gateway-xds-config-view-tab a | /gateways/firewal-gateway-1/xds-config | XDS Configuration |
+      | #gateway-stats-view-tab a      | /gateways/firewal-gateway-1/stats      | Stats             |
+      | #gateway-clusters-view-tab a   | /gateways/firewal-gateway-1/clusters   | Clusters          |

--- a/features/mesh/policies/Data.feature
+++ b/features/mesh/policies/Data.feature
@@ -27,7 +27,7 @@ Feature: mesh / policies / data
         - name: fake-cb-1
         - name: fake-cb-2
       """
-    When I visit the "/mesh/default/policies/circuit-breakers" URL
+    When I visit the "/meshes/default/policies/circuit-breakers" URL
     Then the "$state-loading" element exists
     Then the "$item" element exists 2 times
   Scenario: Zero items shows the empty state
@@ -35,7 +35,7 @@ Feature: mesh / policies / data
       """
       KUMA_CIRCUITBREAKER_COUNT: 0
       """
-    When I visit the "/mesh/default/policies/circuit-breakers" URL
+    When I visit the "/meshes/default/policies/circuit-breakers" URL
     Then the "$state-empty" element exists
 
   Scenario: Erroring shows an error state
@@ -44,5 +44,5 @@ Feature: mesh / policies / data
       headers:
         Status-Code: '503'
       """
-    When I visit the "/mesh/default/policies/circuit-breakers" URL
+    When I visit the "/meshes/default/policies/circuit-breakers" URL
     Then the "$state-error" element exists

--- a/features/mesh/policies/DetailViewContent.feature
+++ b/features/mesh/policies/DetailViewContent.feature
@@ -31,7 +31,7 @@ Feature: Policies: Detail view content
                 name: '192.168.0.1:80:81'
       """
 
-    When I visit the "/mesh/default/policy/circuit-breakers/cb-1" URL
+    When I visit the "/meshes/default/policies/circuit-breakers/cb-1/overview" URL
     Then the "$affected-dpps-item" element exists 3 times
     Then the "$affected-dpps" element contains "backend"
     Then the "$affected-dpps" element contains "db"

--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -41,7 +41,7 @@ Feature: mesh / policies / index
         - name: fake-cb-1
         - name: fake-cb-2
       """
-    When I visit the "/mesh/default/policies/circuit-breakers" URL
+    When I visit the "/meshes/default/policies/circuit-breakers" URL
 
   Scenario: We have a documentation link
     Then the "$button-docs" element exists
@@ -53,7 +53,7 @@ Feature: mesh / policies / index
       | Name  |
 
   Scenario: The items have the expected content and UI elements
-    Then the "#policies-abstract-view-tab.active" element exists
+    Then the "#policy-list-index-view-tab.active" element exists
     Then the "$item" element exists 2 times
     Then the "$item:nth-child(1)" element contains
       | Value     |
@@ -80,7 +80,7 @@ Feature: mesh / policies / index
           - name: mfi-2
       """
 
-    When I visit the "/mesh/default/policies/circuit-breakers" URL
+    When I visit the "/meshes/default/policies/circuit-breakers" URL
     Then the "$item:nth-child(1)" element contains "fake-cb-1"
 
     When I click the "[data-testid='policy-type-link-MeshFaultInjection']" element

--- a/features/mesh/services/Index.feature
+++ b/features/mesh/services/Index.feature
@@ -18,7 +18,7 @@ Feature: mesh / services / index
         - name: service-1
         - name: service-2
       """
-    When I visit the "/mesh/default/services" URL
+    When I visit the "/meshes/default/services" URL
 
   Scenario: The items have the correct columns
     Then the "$items-header" element exists 6 times
@@ -31,7 +31,7 @@ Feature: mesh / services / index
       | Status                      |
 
   Scenario: The items have the expected content and UI elements
-    Then the "#services-abstract-view-tab.active" element exists
+    Then the "#service-list-view-tab.active" element exists
     Then the "$item" element exists 2 times
     Then the "$item:nth-child(1)" element contains
       | Value     |
@@ -49,7 +49,7 @@ Feature: mesh / services / index
       """
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "service-1"
     When I click the "$item:nth-child(1) td:first-of-type a" element
-    Then the URL contains "service/service-1"
+    Then the URL contains "services/service-1/overview"
     Then the "#service-detail-view-tab a" element exists
     # Service Insights with serviceType "external" shouldn't have a Data Plane Proxy table
     And the "#service-data-plane-proxies-view-tab a" element doesn't exists
@@ -58,7 +58,7 @@ Feature: mesh / services / index
     Then the "$item" element exists 2 times
     Then the "$item:nth-child(2) td:nth-child(1)" element contains "service-2"
     When I click the "$item:nth-child(2) td:first-of-type a" element
-    Then the URL contains "service/service-2"
+    Then the URL contains "services/service-2/overview"
     Then the "[data-testid='service-detail-tabs-view']" element contains "service-2"
     Then the "#service-detail-view-tab a" element exists
     # Service Insights with serviceType "internal" should have a Data Plane Proxy table

--- a/features/mesh/services/Item.feature
+++ b/features/mesh/services/Item.feature
@@ -17,7 +17,7 @@ Feature: mesh / services / item
           serviceType: <ServiceType>
       """
 
-    When I visit the "/mesh/default/service/firewall-1" URL
+    When I visit the "/meshes/default/services/firewall-1/overview" URL
     Then the "$data-plane-proxies-tab" element <ExistsAssertion>
 
     Examples:
@@ -44,7 +44,7 @@ Feature: mesh / services / item
                   networking:
                     gateway: ~
         """
-      When I visit the "/mesh/default/service/system-1" URL
+      When I visit the "/meshes/default/services/system-1/overview" URL
 
     Scenario: Internal services request the dataplanes for the service
       When I click the "$data-plane-proxies-tab" element
@@ -133,14 +133,14 @@ Feature: mesh / services / item
       When I click the "$data-plane-proxies-tab" element
       Then the "$item:nth-child(1) td:nth-child(1) a" element contains "fake-dataplane"
       And I click the "$item:nth-child(1) td:nth-child(1) a" element
-      Then the URL contains "/mesh/default/data-plane/fake-dataplane"
+      Then the URL contains "/meshes/default/data-planes/fake-dataplane/overview"
 
     Scenario: Clicking an items view menu takes you to the correct page
       When I click the "$data-plane-proxies-tab" element
       Then the "$item:nth-child(1) td:nth-child(1) a" element contains "fake-dataplane"
       And I click the "$button-actions" element
       Then I click the "$button-view" element
-      Then the URL contains "/mesh/default/data-plane/fake-dataplane"
+      Then the URL contains "/meshes/default/data-planes/fake-dataplane/overview"
 
     Scenario: Service with matching ExternalService doesn't show empty state
       Given the environment
@@ -161,7 +161,7 @@ Feature: mesh / services / item
                   kuma.io/service: service-1
         """
 
-      When I visit the "/mesh/default/service/service-1" URL
+      When I visit the "/meshes/default/services/service-1/overview" URL
 
       Then the "[data-testid='no-matching-external-service']" element doesn't exist
 
@@ -176,6 +176,6 @@ Feature: mesh / services / item
             serviceType: external
         """
 
-      When I visit the "/mesh/default/service/service-1" URL
+      When I visit the "/meshes/default/services/service-1/overview" URL
 
       Then the "[data-testid='no-matching-external-service']" element exists

--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -54,7 +54,7 @@ Feature: Zones: Create Zone flow
     Then the page title contains "Create & connect Zone"
 
   Scenario: The form shows only the initial elements
-    When I visit the "/zones/create" URL
+    When I visit the "/zones/-create" URL
     Then the "$name-input" element exists
     Then the "$create-zone-button" element is disabled
 
@@ -68,7 +68,7 @@ Feature: Zones: Create Zone flow
       """
       KUMA_SUBSCRIPTION_COUNT: 0
       """
-    When I visit the "/zones/create" URL
+    When I visit the "/zones/-create" URL
     Then the "$create-zone-button" element is disabled
 
     When I "type" "test" into the "$name-input" element
@@ -127,7 +127,7 @@ Feature: Zones: Create Zone flow
         Status-Code: '409'
       """
 
-    When I visit the "/zones/create" URL
+    When I visit the "/zones/-create" URL
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
 
@@ -149,7 +149,7 @@ Feature: Zones: Create Zone flow
             reason: "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols."
       """
 
-    When I visit the "/zones/create" URL
+    When I visit the "/zones/-create" URL
     # Note: We're deliberately using a valid name here in order to not trigger client-side validation.
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
@@ -158,7 +158,7 @@ Feature: Zones: Create Zone flow
     And the "$instructions" element doesn't exist
 
   Scenario: The form shows expected error for client-side name validation
-    When I visit the "/zones/create" URL
+    When I visit the "/zones/-create" URL
     And I "type" "zone.eu" into the "$name-input" element
     And I click the "$create-zone-button" element
 
@@ -192,7 +192,7 @@ Feature: Zones: Create Zone flow
               disconnectTime: !!js/undefined
       """
 
-    When I visit the "/zones/create" URL
+    When I visit the "/zones/-create" URL
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
 
@@ -215,7 +215,7 @@ Feature: Zones: Create Zone flow
         token: spat_595QOxTSreRmrtdh8ValuoeUAzXMfBmRwYU3V35NQvwgLAWIU
       """
 
-    When I visit the "/zones/create" URL
+    When I visit the "/zones/-create" URL
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
 

--- a/features/zones/DetailViewContent.feature
+++ b/features/zones/DetailViewContent.feature
@@ -31,7 +31,7 @@ Feature: Zones: Detail view content
             - connectTime: 2020-07-28T16:18:09.743141Z
       """
 
-    When I visit the "/zones/zone-ingresses/zone-ingress-1" URL
+    When I visit the "/zones/zone-ingresses/zone-ingress-1/overview" URL
     Then the page title contains "zone-ingress-1"
     Then the "$ingress-detail-tabs-view" element contains "zone-ingress-1"
     Then the "$ingress-detail-view" element contains "166.197.238.26:20555"
@@ -57,7 +57,7 @@ Feature: Zones: Detail view content
             - connectTime: 2020-07-28T16:18:09.743141Z
       """
 
-    When I visit the "/zones/zone-egresses/zone-egress-1" URL
+    When I visit the "/zones/zone-egresses/zone-egress-1/overview" URL
     Then the page title contains "zone-egress-1"
     Then the "$egress-detail-tabs-view" element contains "zone-egress-1"
     Then the "$egress-detail-view" element contains "166.197.238.26:20555"

--- a/features/zones/zone-cps/Item.feature
+++ b/features/zones/zone-cps/Item.feature
@@ -1,9 +1,9 @@
 Feature: zones / zone-cps / item
   Background:
     Given the CSS selectors
-      | Alias                    | Selector                                  |
-      | zone-detail-tabs-view    | [data-testid='zone-cp-detail-tabs-view']  |
-      | tab-overview             | [data-testid='zone-cp-detail-view']       |
+      | Alias                 | Selector                                 |
+      | zone-detail-tabs-view | [data-testid='zone-cp-detail-tabs-view'] |
+      | tab-overview          | [data-testid='zone-cp-detail-view']      |
     And the environment
       """
       KUMA_MODE: global
@@ -32,7 +32,7 @@ Feature: zones / zone-cps / item
                 { "environment": "universal", "store": {"type": "memory"}, "dpServer": { "auth": { "type": "dpToken" } } }
       """
 
-    When I visit the "/zones/zone-cps/zone-cp-1" URL
+    When I visit the "/zones/zone-cps/zone-cp-1/overview" URL
     Then the page title contains "zone-cp-1"
     Then the "$zone-detail-tabs-view" element contains "zone-cp-1"
 

--- a/features/zones/zone-cps/Warnings.feature
+++ b/features/zones/zone-cps/Warnings.feature
@@ -1,12 +1,12 @@
 Feature: zones / zone-cps / warnings
   Background:
     Given the CSS selectors
-      | Alias                    | Selector                                  |
-      | warning-no-subscriptions | [data-testid='warning-no-subscriptions']  |
-      | warning-zone-memory           | [data-testid='warning-ZONE_STORE_TYPE_MEMORY'] |
-      | zone-cp-table-row      | [data-testid='zone-cp-collection'] tbody tr      |
-      | warning-trigger      | $zone-cp-table-row:nth-child(1) span[data-testid="warning"]    |
-      | warning-memory      | $zone-cp-table-row:nth-child(1) [data-testid="warning-store_memory"]    |
+      | Alias                    | Selector                                                             |
+      | warning-no-subscriptions | [data-testid='warning-no-subscriptions']                             |
+      | warning-zone-memory      | [data-testid='warning-ZONE_STORE_TYPE_MEMORY']                       |
+      | zone-cp-table-row        | [data-testid='zone-cp-collection'] tbody tr                          |
+      | warning-trigger          | $zone-cp-table-row:nth-child(1) span[data-testid="warning"]          |
+      | warning-memory           | $zone-cp-table-row:nth-child(1) [data-testid="warning-store_memory"] |
     And the environment
       """
       KUMA_ZONE_COUNT: 1
@@ -21,7 +21,7 @@ Feature: zones / zone-cps / warnings
         zoneInsight:
           subscriptions: ~
       """
-    When I visit the "/zones/zone-cps/zone-cp-1" URL
+    When I visit the "/zones/zone-cps/zone-cp-1/overview" URL
     And I click the "#zone-cp-config-view-tab a" element
     Then the "$warning-no-subscriptions" element exists
 
@@ -58,9 +58,9 @@ Feature: zones / zone-cps / warnings
     When I visit the "<URL>" URL
     Then the "$warning-zone-memory" element exists
     Examples:
-      | URL                              |
-      | /zones/zone-cps/zone-cp-1        |
-      | /zones/zone-cps/zone-cp-1/config |
+      | URL                                |
+      | /zones/zone-cps/zone-cp-1/overview |
+      | /zones/zone-cps/zone-cp-1/config   |
 
   Scenario Outline: When store type is kubernetes a warning isn't shown at "<URL>"
     And the URL "/config" responds with
@@ -72,7 +72,6 @@ Feature: zones / zone-cps / warnings
     When I visit the "<URL>" URL
     Then the "$warning-zone-memory" element doesn't exist
     Examples:
-      | URL                              |
-      | /zones/zone-cps/zone-cp-1        |
-      | /zones/zone-cps/zone-cp-1/config |
-
+      | URL                                |
+      | /zones/zone-cps/zone-cp-1/overview |
+      | /zones/zone-cps/zone-cp-1/config   |

--- a/src/app/data-planes/routes.ts
+++ b/src/app/data-planes/routes.ts
@@ -1,51 +1,41 @@
 import type { RouteRecordRaw } from 'vue-router'
 export const routes = () => {
-  const item = (prefix: string = 'data-plane'): RouteRecordRaw[] => {
+  const item = (): RouteRecordRaw[] => {
     return [
       {
-        path: `${prefix}`,
-        name: `${prefix}-abstract-view`,
-        meta: {
-          module: 'data-planes',
-        },
-        redirect: () => ({ name: 'data-planes-list-view' }),
+        path: 'data-planes/:dataPlane',
+        name: 'data-plane-detail-tabs-view',
+        component: () => import('@/app/data-planes/views/DataPlaneDetailTabsView.vue'),
         children: [
           {
-            path: ':dataPlane',
-            name: `${prefix}-detail-tabs-view`,
-            component: () => import('@/app/data-planes/views/DataPlaneDetailTabsView.vue'),
-            children: [
-              {
-                path: '',
-                name: `${prefix}-detail-view`,
-                component: () => import('@/app/data-planes/views/DataPlaneDetailView.vue'),
-              },
-              {
-                path: 'policies',
-                name: `${prefix}-policies-view`,
-                component: () => import('@/app/data-planes/views/DataPlanePoliciesView.vue'),
-              },
-              {
-                path: 'xds-config',
-                name: `${prefix}-xds-config-view`,
-                component: () => import('@/app/data-planes/views/DataPlaneXdsConfigView.vue'),
-              },
-              {
-                path: 'stats',
-                name: `${prefix}-stats-view`,
-                component: () => import('@/app/data-planes/views/DataPlaneStatsView.vue'),
-              },
-              {
-                path: 'clusters',
-                name: `${prefix}-clusters-view`,
-                component: () => import('@/app/data-planes/views/DataPlaneClustersView.vue'),
-              },
-              {
-                path: 'config',
-                name: `${prefix}-config-view`,
-                component: () => import('@/app/data-planes/views/DataPlaneConfigView.vue'),
-              },
-            ],
+            path: 'overview',
+            name: 'data-plane-detail-view',
+            component: () => import('@/app/data-planes/views/DataPlaneDetailView.vue'),
+          },
+          {
+            path: 'policies',
+            name: 'data-plane-policies-view',
+            component: () => import('@/app/data-planes/views/DataPlanePoliciesView.vue'),
+          },
+          {
+            path: 'xds-config',
+            name: 'data-plane-xds-config-view',
+            component: () => import('@/app/data-planes/views/DataPlaneXdsConfigView.vue'),
+          },
+          {
+            path: 'stats',
+            name: 'data-plane-stats-view',
+            component: () => import('@/app/data-planes/views/DataPlaneStatsView.vue'),
+          },
+          {
+            path: 'clusters',
+            name: 'data-plane-clusters-view',
+            component: () => import('@/app/data-planes/views/DataPlaneClustersView.vue'),
+          },
+          {
+            path: 'config',
+            name: 'data-plane-config-view',
+            component: () => import('@/app/data-planes/views/DataPlaneConfigView.vue'),
           },
         ],
       },
@@ -53,25 +43,15 @@ export const routes = () => {
   }
 
   return {
-    items: (prefix: string = 'data-planes'): RouteRecordRaw[] => {
+    items: (): RouteRecordRaw[] => {
       return [
         {
-          path: `${prefix}`,
-          name: `${prefix}-abstract-view`,
+          path: 'data-planes',
+          name: 'data-plane-list-view',
           meta: {
             module: 'data-planes',
           },
-          redirect: () => ({ name: 'data-planes-list-view' }),
-          children: [
-            {
-              path: '',
-              name: `${prefix}-list-view`,
-              component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
-              // children: [
-              //   ...(item(prefix)[0]).children ?? [],
-              // ],
-            },
-          ],
+          component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
         },
       ]
     },

--- a/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -20,7 +20,7 @@
         },
         {
           to: {
-            name: `${props.isGatewayView ? 'gateways' : 'data-planes'}-list-view`,
+            name: `${props.isGatewayView ? 'gateway' : 'data-plane'}-list-view`,
             params: {
               mesh: route.params.mesh,
             },

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -6,7 +6,7 @@
     <RouteView
       v-if="me"
       v-slot="{ route, t }"
-      name="data-planes-list-view"
+      name="data-plane-list-view"
       :params="{
         page: 1,
         size: 50,

--- a/src/app/gateways/routes.ts
+++ b/src/app/gateways/routes.ts
@@ -1,49 +1,39 @@
 import type { RouteRecordRaw } from 'vue-router'
 export const routes = () => {
-  const item = (prefix: string = 'gateway'): RouteRecordRaw[] => {
+  const item = (): RouteRecordRaw[] => {
     return [
       {
-        path: `${prefix}`,
-        name: `${prefix}-abstract-view`,
-        meta: {
-          module: 'gateways',
+        path: 'gateways/:dataPlane',
+        name: 'gateway-detail-tabs-view',
+        component: () => import('@/app/data-planes/views/DataPlaneDetailTabsView.vue'),
+        props: {
+          isGatewayView: true,
         },
-        redirect: () => ({ name: 'gateways-list-view' }),
         children: [
           {
-            path: ':dataPlane',
-            name: `${prefix}-detail-tabs-view`,
-            component: () => import('@/app/data-planes/views/DataPlaneDetailTabsView.vue'),
-            props: {
-              isGatewayView: true,
-            },
-            children: [
-              {
-                path: '',
-                name: `${prefix}-detail-view`,
-                component: () => import('@/app/data-planes/views/DataPlaneDetailView.vue'),
-              },
-              {
-                path: 'policies',
-                name: `${prefix}-policies-view`,
-                component: () => import('@/app/gateways/views/GatewayPoliciesView.vue'),
-              },
-              {
-                path: 'xds-config',
-                name: `${prefix}-xds-config-view`,
-                component: () => import('@/app/data-planes/views/DataPlaneXdsConfigView.vue'),
-              },
-              {
-                path: 'stats',
-                name: `${prefix}-stats-view`,
-                component: () => import('@/app/data-planes/views/DataPlaneStatsView.vue'),
-              },
-              {
-                path: 'clusters',
-                name: `${prefix}-clusters-view`,
-                component: () => import('@/app/data-planes/views/DataPlaneClustersView.vue'),
-              },
-            ],
+            path: 'overview',
+            name: 'gateway-detail-view',
+            component: () => import('@/app/data-planes/views/DataPlaneDetailView.vue'),
+          },
+          {
+            path: 'policies',
+            name: 'gateway-policies-view',
+            component: () => import('@/app/gateways/views/GatewayPoliciesView.vue'),
+          },
+          {
+            path: 'xds-config',
+            name: 'gateway-xds-config-view',
+            component: () => import('@/app/data-planes/views/DataPlaneXdsConfigView.vue'),
+          },
+          {
+            path: 'stats',
+            name: 'gateway-stats-view',
+            component: () => import('@/app/data-planes/views/DataPlaneStatsView.vue'),
+          },
+          {
+            path: 'clusters',
+            name: 'gateway-clusters-view',
+            component: () => import('@/app/data-planes/views/DataPlaneClustersView.vue'),
           },
         ],
       },
@@ -51,25 +41,15 @@ export const routes = () => {
   }
 
   return {
-    items: (prefix: string = 'gateways'): RouteRecordRaw[] => {
+    items: (): RouteRecordRaw[] => {
       return [
         {
-          path: `${prefix}`,
-          name: `${prefix}-abstract-view`,
+          path: 'gateways',
+          name: 'gateway-list-view',
           meta: {
             module: 'gateways',
           },
-          redirect: () => ({ name: 'gateways-list-view' }),
-          children: [
-            {
-              path: '',
-              name: `${prefix}-list-view`,
-              component: () => import('@/app/gateways/views/GatewayListView.vue'),
-              // children: [
-              //   ...(item(prefix)[0]).children ?? [],
-              // ],
-            },
-          ],
+          component: () => import('@/app/gateways/views/GatewayListView.vue'),
         },
       ]
     },

--- a/src/app/gateways/views/GatewayListView.vue
+++ b/src/app/gateways/views/GatewayListView.vue
@@ -6,7 +6,7 @@
     <RouteView
       v-if="me"
       v-slot="{ route, can, t }"
-      name="gateways-list-view"
+      name="gateway-list-view"
       :params="{
         page: 1,
         size: me.pageSize,

--- a/src/app/meshes/locales/en-us/index.yaml
+++ b/src/app/meshes/locales/en-us/index.yaml
@@ -6,10 +6,10 @@ meshes:
       navigation:
         mesh-detail-view: Overview
         mesh-config-view: YAML
-        services-abstract-view: Services
-        data-planes-abstract-view: Data Plane Proxies
-        gateways-abstract-view: Gateways
-        policies-abstract-view: Policies
+        service-list-view: Services
+        data-plane-list-view: Data Plane Proxies
+        gateway-list-view: Gateways
+        policy-list-index-view: Policies
 
     items:
       title: Meshes

--- a/src/app/meshes/routes.ts
+++ b/src/app/meshes/routes.ts
@@ -1,8 +1,8 @@
 import type { RouteRecordRaw } from 'vue-router'
 
 export type SplitRouteRecordRaw = {
-  items: (prefix: string) => RouteRecordRaw[]
-  item: (prefix: string) => RouteRecordRaw[]
+  items: () => RouteRecordRaw[]
+  item: () => RouteRecordRaw[]
 }
 
 export const routes = (
@@ -14,16 +14,15 @@ export const routes = (
   return [
     {
       path: '/meshes',
-      name: 'mesh-list-view',
-      component: () => import('@/app/meshes/views/MeshListView.vue'),
-    },
-    {
-      path: '/mesh',
       name: 'mesh-index-view',
-      // if no mesh is specified redirect to /meshes
       redirect: { name: 'mesh-list-view' },
       component: () => import('@/app/meshes/views/MeshIndexView.vue'),
       children: [
+        {
+          path: '',
+          name: 'mesh-list-view',
+          component: () => import('@/app/meshes/views/MeshListView.vue'),
+        },
         {
           path: ':mesh',
           name: 'mesh',
@@ -48,16 +47,16 @@ export const routes = (
                   name: 'mesh-config-view',
                   component: () => import('@/app/meshes/views/MeshConfigView.vue'),
                 },
-                ...services.items('services'),
-                ...gateways.items('gateways'),
-                ...dataplanes.items('data-planes'),
-                ...policies.items('policies'),
+                ...services.items(),
+                ...gateways.items(),
+                ...dataplanes.items(),
+                ...policies.items(),
               ],
             },
-            ...services.item('service'),
-            ...gateways.item('gateway'),
-            ...dataplanes.item('data-plane'),
-            ...policies.item('policy'),
+            ...services.item(),
+            ...gateways.item(),
+            ...dataplanes.item(),
+            ...policies.item(),
           ],
         },
       ],

--- a/src/app/policies/components/PolicyList.vue
+++ b/src/app/policies/components/PolicyList.vue
@@ -16,7 +16,7 @@
           <RouterLink
             class="policy-type-link"
             :to="{
-              name: 'policies-list-view',
+              name: 'policy-list-view',
               params: {
                 mesh: route.params.mesh,
                 policyPath: policyType.path,

--- a/src/app/policies/routes.ts
+++ b/src/app/policies/routes.ts
@@ -1,60 +1,40 @@
 import type { RouteRecordRaw } from 'vue-router'
 
 export const routes = () => {
-  const item = (prefix: string = 'policy'): RouteRecordRaw[] => {
+  const item = (): RouteRecordRaw[] => {
     return [
       {
-        path: `${prefix}`,
-        name: `${prefix}-abstract-view`,
-        meta: {
-          module: 'policies',
-        },
-        redirect: () => ({ name: 'policies' }),
-        children: [
-          {
-            path: `${prefix === 'policy' ? ':policyPath/' : ''}:policy`,
-            name: `${prefix}-detail-view`,
-            component: () => import('@/app/policies/views/PolicyDetailView.vue'),
-          },
-        ],
+        path: 'policies/:policyPath/:policy/overview',
+        name: 'policy-detail-view',
+        component: () => import('@/app/policies/views/PolicyDetailView.vue'),
       },
     ]
   }
 
   return {
-    items: (prefix: string = 'policies'): RouteRecordRaw[] => {
+    items: (): RouteRecordRaw[] => {
       return [
         {
-          path: `${prefix}`,
-          name: `${prefix}-abstract-view`,
+          path: 'policies',
+          name: 'policy-list-index-view',
           meta: {
             module: 'policies',
           },
-          redirect: () => ({ name: 'policies' }),
+          redirect: (to) => {
+            return {
+              ...to,
+              params: {
+                ...to.params,
+                policyPath: 'circuit-breakers',
+              },
+              name: 'policy-list-view',
+            }
+          },
           children: [
             {
-              path: '',
-              name: `${prefix}`,
-              redirect: (to) => {
-                return {
-                  ...to,
-                  params: {
-                    ...to.params,
-                    policyPath: 'circuit-breakers',
-                  },
-                  name: 'policies-list-view',
-                }
-              },
-              children: [
-                {
-                  path: ':policyPath',
-                  name: `${prefix}-list-view`,
-                  component: () => import('@/app/policies/views/PolicyListView.vue'),
-                  // children: [
-                  //   ...(item(prefix)[0]).children ?? [],
-                  // ],
-                },
-              ],
+              path: ':policyPath',
+              name: 'policy-list-view',
+              component: () => import('@/app/policies/views/PolicyListView.vue'),
             },
           ],
         },

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -39,7 +39,7 @@
               },
               {
                 to: {
-                  name: 'policies-list-view',
+                  name: 'policy-list-view',
                   params: {
                     mesh: route.params.mesh,
                     policyPath: route.params.policyPath,

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -6,7 +6,7 @@
     <RouteView
       v-if="me"
       v-slot="{ route, t }"
-      name="policies-list-view"
+      name="policy-list-view"
       :params="{
         page: 1,
         size: me.pageSize,

--- a/src/app/services/routes.ts
+++ b/src/app/services/routes.ts
@@ -1,37 +1,27 @@
 import type { RouteRecordRaw } from 'vue-router'
 
 export const routes = () => {
-  const item = (prefix: string = ''): RouteRecordRaw[] => {
+  const item = (): RouteRecordRaw[] => {
     return [
       {
-        path: `${prefix}`,
-        name: `${prefix}-abstract-view`,
-        meta: {
-          module: 'services',
-        },
-        redirect: () => ({ name: 'services-list-view' }),
+        path: 'services/:service',
+        name: 'service-detail-tabs-view',
+        component: () => import('@/app/services/views/ServiceDetailTabsView.vue'),
         children: [
           {
-            path: ':service',
-            name: `${prefix}-detail-tabs-view`,
-            component: () => import('@/app/services/views/ServiceDetailTabsView.vue'),
-            children: [
-              {
-                path: '',
-                name: `${prefix}-detail-view`,
-                component: () => import('@/app/services/views/ServiceDetailView.vue'),
-              },
-              {
-                path: 'config',
-                name: `${prefix}-config-view`,
-                component: () => import('@/app/services/views/ServiceConfigView.vue'),
-              },
-              {
-                path: 'data-plane-proxies',
-                name: `${prefix}-data-plane-proxies-view`,
-                component: () => import('@/app/services/views/ServiceDataPlaneProxiesView.vue'),
-              },
-            ],
+            path: 'overview',
+            name: 'service-detail-view',
+            component: () => import('@/app/services/views/ServiceDetailView.vue'),
+          },
+          {
+            path: 'config',
+            name: 'service-config-view',
+            component: () => import('@/app/services/views/ServiceConfigView.vue'),
+          },
+          {
+            path: 'data-plane-proxies',
+            name: 'service-data-plane-proxies-view',
+            component: () => import('@/app/services/views/ServiceDataPlaneProxiesView.vue'),
           },
         ],
       },
@@ -39,25 +29,15 @@ export const routes = () => {
   }
 
   return {
-    items: (prefix: string = 'services'): RouteRecordRaw[] => {
+    items: (): RouteRecordRaw[] => {
       return [
         {
-          path: `${prefix}`,
-          name: `${prefix}-abstract-view`,
+          path: 'services',
+          name: 'service-list-view',
           meta: {
             module: 'services',
           },
-          redirect: () => ({ name: 'services-list-view' }),
-          children: [
-            {
-              path: '',
-              name: `${prefix}-list-view`,
-              component: () => import('@/app/services/views/ServiceListView.vue'),
-              // children: [
-              //   ...(item(prefix)[0]).children ?? [],
-              // ],
-            },
-          ],
+          component: () => import('@/app/services/views/ServiceListView.vue'),
         },
       ]
     },

--- a/src/app/services/views/ServiceDetailTabsView.vue
+++ b/src/app/services/views/ServiceDetailTabsView.vue
@@ -20,7 +20,7 @@
         },
         {
           to: {
-            name: 'services-list-view',
+            name: 'service-list-view',
             params: {
               mesh: route.params.mesh,
             },

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -6,7 +6,7 @@
     <RouteView
       v-if="me"
       v-slot="{ route, t }"
-      name="services-list-view"
+      name="service-list-view"
       :params="{
         page: 1,
         size: me.pageSize,

--- a/src/app/zones/routes.ts
+++ b/src/app/zones/routes.ts
@@ -2,7 +2,7 @@ import type { RouteRecordRaw } from 'vue-router'
 
 export const actions = (): RouteRecordRaw[] => {
   return [{
-    path: '/zones/create',
+    path: '/zones/-create',
     name: 'zone-create-view',
     meta: {
       isWizard: true,
@@ -46,7 +46,7 @@ export const routes = (
               component: () => import('@/app/zones/views/ZoneDetailTabsView.vue'),
               children: [
                 {
-                  path: '',
+                  path: 'overview',
                   name: 'zone-cp-detail-view',
                   component: () => import('@/app/zones/views/ZoneDetailView.vue'),
                 },
@@ -84,7 +84,7 @@ export const routes = (
               component: () => import('@/app/zones/views/ZoneIngressDetailTabsView.vue'),
               children: [
                 {
-                  path: '',
+                  path: 'overview',
                   name: 'zone-ingress-detail-view',
                   component: () => import('@/app/zones/views/ZoneIngressDetailView.vue'),
                 },
@@ -137,7 +137,7 @@ export const routes = (
               component: () => import('@/app/zones/views/ZoneEgressDetailTabsView.vue'),
               children: [
                 {
-                  path: '',
+                  path: 'overview',
                   name: 'zone-egress-detail-view',
                   component: () => import('@/app/zones/views/ZoneEgressDetailView.vue'),
                 },

--- a/src/test-support/mocks/README.md
+++ b/src/test-support/mocks/README.md
@@ -159,7 +159,7 @@ you can easily view empty states.
 At the time of writing the `req:Request` variables consist of:
 
 - `req.params`: an object containing the parameters from any dynamic URL
-    segments i.e. `/mesh/:mesh/dataplanes/:name` > `{mesh: 'default', name:
+    segments i.e. `/meshes/:mesh/dataplanes/:name` > `{mesh: 'default', name:
     'dp-name'}`
 - `req.url.searchParams`: A [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/get)
     object for access to anything from the requests query parameters.


### PR DESCRIPTION
## Introduction

In order to verify the approach of using plural resource names in URL paths together with the idea for using summary drawers in list views that are hooked up to their own route, I did the following:

- Added a change that changes all routes to use plural resource names in the URL paths. The changed paths are listen below. I also wanted to change `/data-planes` to `/dataplanes` because its more consistent with established names, but I left this out for now.
- Added a _temporary_ change that changes the behavior for clicking a table row to no longer navigate to the detail view but emit a `row:click` event. This will be used to demonstrate that selecting a row to navigate to the summary drawer route is viable.
- Added a _temporary_ change that adds a prototypical implementation of a summary drawer component for the service list view. This isn’t feature-complete. For example, using a table’s pagination won’t currently clear the selected item.

If we’re happy with how this works, the commits labeled as _temporary_ above will be removed again as they relate to implementing the summary drawer and not the plural resource names in route paths.

Resolves #1355.

## Changes

**refactor: uses plural resource names in URL paths**

Uses plural resource names in URL paths and uses `/overview` as the final path segment for detail views. The following URL paths were changed:

| Before                                  | Now                                                  |
| --- | --- |
| `mesh`                                  | `meshes`                                             |
| `mesh/:mesh/data-plane/:dataplane`      | `meshes/:mesh/data-planes/:dataplane/overview`       |
| `mesh/:mesh/gateway/:dataplane`         | `meshes/:mesh/gateways/:dataplane/overview`          |
| `mesh/:mesh/policy/:policyPath/:policy` | `meshes/:mesh/policies/:policyPath/:policy/overview` |
| `mesh/:mesh/service/:service`           | `meshes/:mesh/services/:service/overview`            |
| `zones/zone-cps/:zone`                  | `zones/zone-cps/:zone/overview`                      |

**feat: adds support for marking a selected row** (**REMOVED**, was only present during verification of approach)

Adds support for marking a selected row with `AppCollection` based on a row’s `id` field.

Adds a new event `row:selected` to `AppCollection` that is triggered both on row clicks and when a default selected row is determined.

**chore(services): adds prototype for summary route** (**REMOVED**, was only present during verification of approach)

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
