### PR TITLE
fix: dataplane policies api url containing undefined

### DIFF
--- a/features/mesh/gateways/PageNavigation.feature
+++ b/features/mesh/gateways/PageNavigation.feature
@@ -1,0 +1,18 @@
+Feature: Gateways: Page navigation
+  Scenario Outline: Tabs have expected URLs
+
+    When I visit the "/mesh/default/gateway/firewal-gateway-1" URL
+    # This `cy.wait` stabilizes the test significantly. For some reason, it can happen that the subsequent navigation to via nav tab is never triggered.
+    Then I wait for 1000 milliseconds
+
+    When I click the "<TabSelector>" element
+    And the URL contains "<Path>"
+    Then the page title contains "<Title>"
+
+    Examples:
+      | TabSelector                    | Path                                  | Title             |
+      | #gateway-detail-view-tab a     | /gateway/firewal-gateway-1            | firewal-gateway-1 |
+      | #gateway-policies-view-tab a   | /gateway/firewal-gateway-1/policies   | Policies          |
+      | #gateway-xds-config-view-tab a | /gateway/firewal-gateway-1/xds-config | XDS Configuration |
+      | #gateway-stats-view-tab a      | /gateway/firewal-gateway-1/stats      | Stats             |
+      | #gateway-clusters-view-tab a   | /gateway/firewal-gateway-1/clusters   | Clusters          |

--- a/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -91,12 +91,12 @@ const props = defineProps({
   },
 })
 
-const routes = router.getRoutes().find((route) => route.name === 'data-plane-detail-tabs-view')?.children ?? []
+const routes = router.getRoutes().find((route) => route.name === `${props.isGatewayView ? 'gateway' : 'data-plane'}-detail-tabs-view`)?.children ?? []
 const tabs: NavTab[] = routes.map((route) => {
   const referenceRoute = typeof route.name === 'undefined' ? route.children?.[0] as RouteRecordRaw : route
   const routeName = referenceRoute.name as string
   const module = referenceRoute.meta?.module ?? ''
-  const title = t(`data-planes.routes.item.navigation.${routeName}`)
+  const title = t(`${props.isGatewayView ? 'gateways' : 'data-planes'}.routes.item.navigation.${routeName}`)
 
   return { title, routeName, module }
 })

--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -22,11 +22,11 @@
           >
             <DataSource
               v-slot="{ data, error }: SidecarDataplaneCollectionSource"
-              :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.name}/sidecar-dataplanes-policies`"
+              :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/sidecar-dataplanes-policies`"
             >
               <DataSource
                 v-slot="{ data: rulesData, error: rulesError }: DataplaneRulesCollectionSource"
-                :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.name}/rules`"
+                :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/rules`"
               >
                 <ErrorBlock
                   v-if="policyTypesError"

--- a/src/app/gateways/locales/en-us/index.yaml
+++ b/src/app/gateways/locales/en-us/index.yaml
@@ -4,6 +4,11 @@ gateways:
       title: "{name}"
       breadcrumbs: Gateways
       navigation:
+        gateway-detail-view: 'Overview'
         gateway-policies-view: 'Policies'
+        gateway-xds-config-view: 'XDS Configuration'
+        gateway-stats-view: 'Stats'
+        gateway-clusters-view: 'Clusters'
+        gateway-config-view: 'YAML'
     items:
       title: Gateways

--- a/src/app/gateways/views/GatewayPoliciesView.vue
+++ b/src/app/gateways/views/GatewayPoliciesView.vue
@@ -22,7 +22,7 @@
           >
             <DataSource
               v-slot="{ data, error }: MeshGatewayDataplaneSource"
-              :src="`/meshes/${route.params.mesh}/gateways/${route.params.name}/policies`"
+              :src="`/meshes/${route.params.mesh}/gateways/${route.params.dataPlane}/policies`"
             >
               <ErrorBlock
                 v-if="policyTypesError"


### PR DESCRIPTION
fix: using incorrect route parameter for DPP/gateway policies

fix(gateways): detail view tabs linking to data plane routes

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Note: I’ll be adding a test for the second issue later, but I’m busy with other things right now.