### PR TITLE
fix: Ignores mesh-insights errors

### DIFF
--- a/features/mesh/Item.feature
+++ b/features/mesh/Item.feature
@@ -1,0 +1,26 @@
+Feature: mesh / item
+  Background:
+    Given the CSS selectors
+      | Alias         | Selector                        |
+      | error         | [data-testid="error-state"]     |
+      | service-count | [data-testid="services-status"] |
+
+  Scenario: /mesh-insights/* isn't a 404
+    Given the URL "/mesh-insights/default" responds with
+      """
+      body:
+        services:
+          total: 11
+      """
+    When I visit the "/mesh/default/overview" URL
+    And the "$service-count" element contains "11"
+
+  Scenario: /mesh-insights/* is a 404
+    Given the URL "/mesh-insights/default" responds with
+      """
+      headers:
+        Status-Code: 404
+      """
+    When I visit the "/mesh/default/overview" URL
+    Then the "$error" element doesn't exist
+    And the "$service-count" element contains "0"

--- a/src/app/meshes/components/MeshDetails.vue
+++ b/src/app/meshes/components/MeshDetails.vue
@@ -7,7 +7,7 @@
           style="--columns: 3;"
         >
           <ResourceStatus
-            :total="props.meshInsight.services.total ?? 0"
+            :total="props.meshInsight?.services.total ?? 0"
             data-testid="services-status"
           >
             <template #title>
@@ -16,7 +16,7 @@
           </ResourceStatus>
 
           <ResourceStatus
-            :total="props.meshInsight.dataplanesByType.standard.total ?? 0"
+            :total="props.meshInsight?.dataplanesByType.standard.total ?? 0"
             data-testid="data-plane-proxies-status"
           >
             <template #title>
@@ -111,7 +111,7 @@ const props = defineProps({
   },
 
   meshInsight: {
-    type: Object as PropType<MeshInsight>,
+    type: Object as PropType<MeshInsight | undefined>,
     required: true,
   },
 })
@@ -120,7 +120,7 @@ const mtls = computed(() => getBackendTypeAndName(props.mesh.mtls))
 const metrics = computed(() => getBackendTypeAndName(props.mesh.metrics))
 
 const totalPolicyCount = computed(() => {
-  return Object.values(props.meshInsight.policies ?? {}).reduce((total, stat) => total + stat.total, 0)
+  return Object.values(props.meshInsight?.policies ?? {}).reduce((total, stat) => total + stat.total, 0)
 })
 
 function getBackendTypeAndName(meshBackend?: MeshBackend): string {

--- a/src/app/meshes/views/MeshDetailView.vue
+++ b/src/app/meshes/views/MeshDetailView.vue
@@ -11,7 +11,7 @@
         :src="`/meshes/${route.params.mesh}`"
       >
         <DataSource
-          v-slot="{ data: meshInsight, error: meshInsightError }: MeshInsightSource"
+          v-slot="{ data: meshInsight }: MeshInsightSource"
           :src="`/mesh-insights/${route.params.mesh}`"
         >
           <ErrorBlock
@@ -19,12 +19,7 @@
             :error="meshError"
           />
 
-          <ErrorBlock
-            v-else-if="meshInsightError"
-            :error="meshInsightError"
-          />
-
-          <LoadingBlock v-else-if="mesh === undefined || meshInsight === undefined" />
+          <LoadingBlock v-else-if="mesh === undefined" />
 
           <div
             v-else
@@ -35,7 +30,6 @@
               :mesh="mesh"
               :mesh-insight="meshInsight"
             />
-
             <div class="date-status-wrapper">
               <ResourceDateStatus
                 :creation-time="mesh.creationTime"


### PR DESCRIPTION
When viewing a mesh detail page, this PR ignores any errors coming from the `/mesh-insights/:name` endpoint. Instead we'd just show zeros if we get an error from that endpoint for the relevant stats.

There's probably more we could do here, and I almost made a lot more change to alter this slightly (for instance I didn't really want to use a zero when mesh-insights is loading/erroring), but I didn't want to get too involved at the moment.

Let me know if its worth making an issue to improve this so its clearer that loading/erroring is happening to prevent any confusion over the `0`.



