### PR TITLE
chore(deps): adds @kong/icons package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@kong-ui-public/i18n": "^0.8.1",
+    "@kong/icons": "^1.4.3",
     "@kong/kongponents": "^8.123.5",
     "brandi": "^5.0.0",
     "chart.js": "^4.4.0",
@@ -110,8 +111,8 @@
     "vite-plugin-html": "^3.2.0",
     "vite-plugin-rewrite-all": "^1.0.1",
     "vite-svg-loader": "^4.0.0",
-    "vue-tsc": "^1.8.10",
     "vitepress": "^1.0.0-rc.12",
+    "vue-tsc": "^1.8.10",
     "yaml-jest": "^1.2.0"
   },
   "browserslist": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2181,6 +2181,11 @@
   resolved "https://registry.yarnpkg.com/@kong/design-tokens/-/design-tokens-1.10.2.tgz#2b9dc88bba73c2968ea1d06ba7b348910444cf10"
   integrity sha512-14LZsxQmhbpAxqDRREkHcQEiYg/I1mRMcI1p1aHRK5bY9rcEQkWmiuNXPRHhEpG+8/n099g1HwAaKFmJBwYwRg==
 
+"@kong/icons@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.4.3.tgz#1686da86dd13b6cb6995933067dfcc2675a6e023"
+  integrity sha512-MymjAY044yG633C/tsxtdITk92g+EiRFhloTNBkrg+d5LFaBjz6Zw7YGStAAy+4Spy8jGmrGlJPmWiavOU1+Bg==
+
 "@kong/kongponents@^8.123.5":
   version "8.123.5"
   resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.123.5.tgz#eb4aca334adc1a21597fe1e81518d951691eacb7"


### PR DESCRIPTION
Adds `@kong/icons` package so we can start using the new icons.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>