### PR TITLE
chore: switches code blocks to dark theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@kong-ui-public/i18n": "^0.8.1",
     "@kong/icons": "^1.4.3",
-    "@kong/kongponents": "^8.123.5",
+    "@kong/kongponents": "^8.123.7",
     "brandi": "^5.0.0",
     "chart.js": "^4.4.0",
     "deepmerge": "^4.3.1",

--- a/src/app/common/CodeBlock.vue
+++ b/src/app/common/CodeBlock.vue
@@ -9,6 +9,7 @@
     :is-searchable="isSearchable"
     :show-copy-button="showCopyButton"
     :query="query"
+    theme="dark"
     @code-block-render="handleCodeBlockRenderEvent"
     @query-change="updateStoredQuery"
   >
@@ -116,5 +117,9 @@ function updateStoredQuery(queryValue: string): void {
   position: sticky;
   z-index: 4;
   top: var(--AppHeaderHeight);
+}
+
+.code-block .k-highlighted-code-block {
+  border: none;
 }
 </style>

--- a/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
+++ b/src/app/onboarding/views/__snapshots__/AddNewServicesCode.spec.ts.snap
@@ -71,7 +71,7 @@ exports[`AddNewServicesCode.vue renders snapshot 1`] = `
                    for the demo application: 
                 </p>
                 <div
-                  class="k-code-block theme-light code-block"
+                  class="k-code-block theme-dark code-block"
                   data-testid="k-code-block"
                   id="code-block-clone-command"
                   style="--maxLineNumberWidth: 1ch;"

--- a/src/utilities/highlightElement.ts
+++ b/src/utilities/highlightElement.ts
@@ -3,7 +3,7 @@ import 'prismjs/components/prism-bash.min.js'
 import 'prismjs/components/prism-json.min.js'
 import 'prismjs/components/prism-yaml.min.js'
 
-import 'prismjs/themes/prism.min.css'
+import 'prismjs/themes/prism-dark.min.css'
 
 Prism.manual = true
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2186,10 +2186,10 @@
   resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.4.3.tgz#1686da86dd13b6cb6995933067dfcc2675a6e023"
   integrity sha512-MymjAY044yG633C/tsxtdITk92g+EiRFhloTNBkrg+d5LFaBjz6Zw7YGStAAy+4Spy8jGmrGlJPmWiavOU1+Bg==
 
-"@kong/kongponents@^8.123.5":
-  version "8.123.5"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.123.5.tgz#eb4aca334adc1a21597fe1e81518d951691eacb7"
-  integrity sha512-CvTphs/EMuztAadmP1QhE56Eo5yj9s/K6XiCv3yrnTEEli/LbNkj6wpdpv7GnWdMxpQd7laainc3hilGKwEsag==
+"@kong/kongponents@^8.123.7":
+  version "8.123.7"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.123.7.tgz#1229f1fc906fa355e96b0bba7e50c16e66fe5a2d"
+  integrity sha512-QYKAFzpxvK7zFt/t9YaEiic87+q/IEFdyFZzC4LwuzKFeFjatg3NSoQJXTj9C87LEWpxhvlI1qyruwAY1DxRMw==
   dependencies:
     axios "^0.27.2"
     date-fns "^2.30.0"


### PR DESCRIPTION
Changes the CodeBlock component to use the KCodeBlock component’s dark theme.

Changes the syntax highlighting theme we use to its dark variant.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

![image](https://github.com/kumahq/kuma-gui/assets/5774638/3fa3fb8a-ed5f-4b08-a846-01f183a9e707)
