### PR TITLE
fix(e2e): Uses `url.should` to assert URL exactness instead of `url.then`

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -119,10 +119,8 @@ When('I go {string}', (direction: number | Cypress.HistoryDirection) => {
 
 // assert
 Then('the URL is {string}', (expected: string) => {
-  cy.url().then((url) => {
-    const actual = new URL(url).pathname.replace(/^\/gui/, '')
-    expect(expected).to.equal(actual)
-  })
+  const base = Cypress.env().KUMA_BASE_URL || 'http://localhost:5681/gui'
+  cy.url().should('eq', `${base}${expected}`)
 })
 Then('the URL contains {string}', (str: string) => {
   cy.url().should('include', str)


### PR DESCRIPTION
I noticed that our exact URL assertions would wait on the URL being set but no on the value being equal, probably just due to how we initially did the plumbing for the base URL.

I've done this in a "lets just try improve the flake" for now. There is a larger "work on test" effort happening and I'll be working a lot in this area so I plan to do a better clean up then. Some initial things I noticed:

1. We have unfortunate naming happening we have `KUMA_BASE_URL` and `KUMA_BASE_PATH` depending on whether you are in the app or in the Cypress code (there might have been reasons for this I don't remember but I'll find out when I dive in here)
2. Using our `env` utility consistently in Cypress code was left as a TODO, this is also related to consistently getting env vars and having defaults, which would come in handy here.

To be clear those points ^ will be done in a later PR coming up in the next few days. For now, I'm hoping this helps with a flakey test.