### PR TITLE
chore(zones): tweaks create UI content formatting

### DIFF
--- a/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
+++ b/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <h3>
-      <span class="step-number">1</span>
+    <h3 class="form-step-title">
+      <span class="form-step-number">1</span>
       {{ i18n.t('zones.form.kubernetes.prerequisites.title') }}
     </h3>
 
-    <ul>
+    <ul class="instruction-list">
       <li>
         <b>{{ i18n.t('zones.form.kubernetes.prerequisites.step1Label') }}{{ props.zoneIngressEnabled ? ' ' + i18n.t('zones.form.kubernetes.prerequisites.step1LabelAddendum') : '' }}</b>:
         {{ i18n.t('zones.form.kubernetes.prerequisites.step1Description', { productName: i18n.t('common.product.name') }) }}
@@ -21,50 +21,50 @@
       </li>
     </ul>
 
-    <h3>
-      <span class="step-number">2</span>
+    <h3 class="form-step-title">
+      <span class="form-step-number">2</span>
       {{ i18n.t('zones.form.kubernetes.helm.title') }}
     </h3>
 
     <p>On your local machine, create a namespace in your Kubernetes cluster and pull down the kong Helm repo.</p>
 
-    <ol>
+    <ol class="instruction-list">
       <li>
-        {{ i18n.t('zones.form.kubernetes.helm.step1Description') }}
+        <b>{{ i18n.t('zones.form.kubernetes.helm.step1Description') }}</b>
 
         <CodeBlock
           id="zone-kubernetes-create-namespace"
-          class="mt-4"
+          class="mt-2"
           :code="i18n.t('zones.form.kubernetes.helm.step1Command')"
           language="bash"
         />
       </li>
 
       <li>
-        {{ i18n.t('zones.form.kubernetes.helm.step2Description') }}
+        <b>{{ i18n.t('zones.form.kubernetes.helm.step2Description') }}</b>
 
         <CodeBlock
           id="zone-kubernetes-add-charts-repo"
-          class="mt-4"
+          class="mt-2"
           :code="i18n.t('zones.form.kubernetes.helm.step2Command')"
           language="bash"
         />
       </li>
 
       <li>
-        {{ i18n.t('zones.form.kubernetes.helm.step3Description') }}
+        <b>{{ i18n.t('zones.form.kubernetes.helm.step3Description') }}</b>
 
         <CodeBlock
           id="zone-kubernetes-repo-update"
-          class="mt-4"
+          class="mt-2"
           :code="i18n.t('zones.form.kubernetes.helm.step3Command')"
           language="bash"
         />
       </li>
     </ol>
 
-    <h3>
-      <span class="step-number">3</span>
+    <h3 class="form-step-title">
+      <span class="form-step-number">3</span>
       {{ i18n.t('zones.form.kubernetes.secret.title') }}
     </h3>
 
@@ -77,14 +77,14 @@
       language="bash"
     />
 
-    <h3>
-      <span class="step-number">4</span>
+    <h3 class="form-step-title">
+      <span class="form-step-number">4</span>
       {{ i18n.t('zones.form.kubernetes.connectZone.title') }}
     </h3>
 
     <p>{{ i18n.t('zones.form.kubernetes.connectZone.configDescription') }}</p>
 
-    <span class="k-input-label mt-4">
+    <span class="field-group-label mt-4">
       {{ i18n.t('zones.form.kubernetes.connectZone.configFileName') }}
     </span>
 
@@ -171,18 +171,3 @@ const kubernetesConfig = computed(() => {
 })
 
 </script>
-
-<style lang="scss" scoped>
-.step-number {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  width: 30px;
-  height: 30px;
-  margin-right: $kui-space-20;
-  color: $kui-color-text-inverse;
-  background-color: #169fcc;
-  border-radius: 50%;
-  font-size: $kui-font-size-40;
-}
-</style>

--- a/src/app/zones/components/ZoneCreateUniversalInstructions.vue
+++ b/src/app/zones/components/ZoneCreateUniversalInstructions.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <h3>
-      <span class="step-number">1</span>
+    <h3 class="form-step-title">
+      <span class="form-step-number">1</span>
       {{ i18n.t('zones.form.universal.saveToken.title') }}
     </h3>
 
@@ -14,14 +14,14 @@
       language="bash"
     />
 
-    <h3>
-      <span class="step-number">2</span>
+    <h3 class="form-step-title">
+      <span class="form-step-number">2</span>
       {{ i18n.t('zones.form.universal.connectZone.title') }}
     </h3>
 
     <p>{{ i18n.t('zones.form.universal.connectZone.configDescription') }}</p>
 
-    <span class="k-input-label mt-4">
+    <span class="field-group-label mt-4">
       {{ i18n.t('zones.form.universal.connectZone.configFileName') }}
     </span>
 
@@ -87,18 +87,3 @@ const universalConfig = computed(() => {
   return i18n.t('zones.form.universal.connectZone.config', placeholders).trim()
 })
 </script>
-
-<style lang="scss" scoped>
-.step-number {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  width: 30px;
-  height: 30px;
-  margin-right: $kui-space-20;
-  color: $kui-color-text-inverse;
-  background-color: #169fcc;
-  border-radius: 50%;
-  font-size: $kui-font-size-40;
-}
-</style>

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -38,7 +38,7 @@
       </template>
 
       <div class="form-wrapper">
-        <KCard>
+        <KCard class="form-card">
           <template #body>
             <div class="form">
               <div class="form-header">
@@ -156,71 +156,73 @@
                   </div>
 
                   <div class="form-section__content">
-                    <div>
-                      <span class="k-input-label">
-                        {{ t('zones.form.environmentLabel') }} *
-                      </span>
+                    <div class="field-group-list">
+                      <div class="field-group">
+                        <span class="field-group-label">
+                          {{ t('zones.form.environmentLabel') }} *
+                        </span>
 
-                      <div class="radio-button-group">
-                        <KRadio
-                          id="zone-environment-universal"
-                          v-model="environment"
-                          selected-value="universal"
-                          name="zone-environment"
-                          data-testid="environment-universal-radio-button"
-                        >
-                          {{ t('zones.form.universalLabel') }}
-                        </KRadio>
+                        <div class="radio-button-group">
+                          <KRadio
+                            id="zone-environment-universal"
+                            v-model="environment"
+                            selected-value="universal"
+                            name="zone-environment"
+                            data-testid="environment-universal-radio-button"
+                          >
+                            {{ t('zones.form.universalLabel') }}
+                          </KRadio>
 
-                        <KRadio
-                          id="zone-environment-kubernetes"
-                          v-model="environment"
-                          selected-value="kubernetes"
-                          name="zone-environment"
-                          data-testid="environment-kubernetes-radio-button"
-                        >
-                          {{ t('zones.form.kubernetesLabel') }}
-                        </KRadio>
+                          <KRadio
+                            id="zone-environment-kubernetes"
+                            v-model="environment"
+                            selected-value="kubernetes"
+                            name="zone-environment"
+                            data-testid="environment-kubernetes-radio-button"
+                          >
+                            {{ t('zones.form.kubernetesLabel') }}
+                          </KRadio>
+                        </div>
                       </div>
+
+                      <template v-if="environment === 'kubernetes'">
+                        <div class="field-group">
+                          <span class="field-group-label">
+                            {{ t('zones.form.zoneIngressLabel') }} *
+                          </span>
+
+                          <div class="radio-button-group">
+                            <KInputSwitch
+                              id="zone-ingress-enabled"
+                              v-model="zoneIngressEnabled"
+                              data-testid="ingress-input-switch"
+                            >
+                              <template #label>
+                                {{ t('zones.form.zoneIngressEnabledLabel') }}
+                              </template>
+                            </KInputSwitch>
+                          </div>
+                        </div>
+
+                        <div class="field-group">
+                          <span class="field-group-label">
+                            {{ t('zones.form.zoneEgressLabel') }} *
+                          </span>
+
+                          <div class="radio-button-group">
+                            <KInputSwitch
+                              id="zone-egress-enabled"
+                              v-model="zoneEgressEnabled"
+                              data-testid="egress-input-switch"
+                            >
+                              <template #label>
+                                {{ t('zones.form.zoneEgressEnabledLabel') }}
+                              </template>
+                            </KInputSwitch>
+                          </div>
+                        </div>
+                      </template>
                     </div>
-
-                    <template v-if="environment === 'kubernetes'">
-                      <div class="mt-4">
-                        <span class="k-input-label">
-                          {{ t('zones.form.zoneIngressLabel') }} *
-                        </span>
-
-                        <div class="radio-button-group">
-                          <KInputSwitch
-                            id="zone-ingress-enabled"
-                            v-model="zoneIngressEnabled"
-                            data-testid="ingress-input-switch"
-                          >
-                            <template #label>
-                              {{ t('zones.form.zoneIngressEnabledLabel') }}
-                            </template>
-                          </KInputSwitch>
-                        </div>
-                      </div>
-
-                      <div class="mt-4">
-                        <span class="k-input-label">
-                          {{ t('zones.form.zoneEgressLabel') }} *
-                        </span>
-
-                        <div class="radio-button-group">
-                          <KInputSwitch
-                            id="zone-egress-enabled"
-                            v-model="zoneEgressEnabled"
-                            data-testid="egress-input-switch"
-                          >
-                            <template #label>
-                              {{ t('zones.form.zoneEgressEnabledLabel') }}
-                            </template>
-                          </KInputSwitch>
-                        </div>
-                      </div>
-                    </template>
                   </div>
                 </div>
 

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -68,7 +68,7 @@ h6 {
 
 ul,
 ol {
-  padding-left: $kui-space-60;
+  padding-left: $kui-space-80;
 }
 
 h2,

--- a/src/assets/styles/_forms.scss
+++ b/src/assets/styles/_forms.scss
@@ -10,6 +10,11 @@
   }
 }
 
+.form-card .k-card-body:not(.increase-specificity) {
+  font-size: $kui-font-size-40;
+  line-height: 1.5;
+}
+
 .form>*+* {
   margin-top: $kui-space-100;
   border-top: $kui-border-width-10 solid $kui-color-border;
@@ -58,10 +63,47 @@
   font-size: $kui-font-size-50;
 }
 
+.field-group-list > *+* {
+  margin-top: $kui-space-80;
+}
+
+.field-group-label {
+  display: inline-flex;
+  margin-bottom: $kui-space-40;
+  font-size: $kui-font-size-30;
+  line-height: $kui-line-height-30;
+  font-weight: $kui-font-weight-semibold;
+}
+
 .radio-button-group>* {
   display: flex;
 }
 
 .radio-button-group>*+* {
   margin-block-start: $kui-space-40;
+}
+
+.instruction-list >*+* {
+  margin-top: $kui-space-50;
+}
+
+.form-step-title {
+  font-size: $kui-font-size-60;
+}
+
+.form-step-title:not(:first-child) {
+  margin-top: $kui-space-90;
+}
+
+.form-step-number {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 30px;
+  height: 30px;
+  margin-right: $kui-space-20;
+  color: $kui-color-text-inverse;
+  background-color: var(--StepBackground);
+  border-radius: 50%;
+  font-size: $kui-font-size-40;
 }

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -31,6 +31,7 @@
 
   // MISC
   --TextGradientBackground: linear-gradient(90deg, #473cfb 0%, #a300bd 33.17%);
+  --StepBackground: #169fcc;
 }
 
 :root.is-fullscreen {


### PR DESCRIPTION
## Changes

Changes the base ul and ol padding so that it doesn’t overflow its content container narrowly.

Overrides the KCard body font size specifically for forms where we expect general body text to have the same font size (`$kui-font-size-40`).

Tweaks the gaps between various form elements and groups to make it more clear which elements belong together in some way or another.

Stops using `k-input-label` as a styling utility as it will be removed in a future version of Kongponents.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Screenshots

**Before**:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/b13d86c7-3d16-4723-9f04-e99ea31063f6)


**After**:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/766d1984-32d3-4314-9b74-9acfec8ebb12)

