### PR TITLE
fix: zone ingress single resource API endpoint being wrong

### DIFF
--- a/features/zones/DetailViewContent.feature
+++ b/features/zones/DetailViewContent.feature
@@ -3,15 +3,19 @@ Feature: Zones: Detail view content
     Given the CSS selectors
       | Alias                    | Selector                                      |
       | ingress-detail-view      | [data-testid='zone-ingress-detail-view']      |
+      | ingress-config-view      | [data-testid='zone-ingress-config-view']      |
       | ingress-detail-tabs-view | [data-testid='zone-ingress-detail-tabs-view'] |
+      | ingress-config-tab       | #zone-ingress-config-view-tab a               |
       | egress-detail-view       | [data-testid='zone-egress-detail-view']       |
+      | egress-config-view       | [data-testid='zone-egress-config-view']       |
       | egress-detail-tabs-view  | [data-testid='zone-egress-detail-tabs-view']  |
+      | egress-config-tab        | #zone-egress-config-view-tab a                |
     And the environment
       """
       KUMA_MODE: global
       """
 
-  Scenario Outline: Zone Ingress detail view has expected content
+  Scenario: Zone Ingress detail view has expected content
     And the URL "/zoneingresses+insights/zone-ingress-1" responds with
       """
       body:
@@ -36,7 +40,10 @@ Feature: Zones: Detail view content
     Then the "$ingress-detail-view" element contains "166.197.238.26:20555"
     Then the "$ingress-detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"
 
-  Scenario Outline: Zone Egress detail view has expected content
+    When I click the "$ingress-config-tab" element
+    Then the "$ingress-config-view" element contains "type: ZoneIngress"
+
+  Scenario: Zone Egress detail view has expected content
     And the URL "/zoneegressoverviews/zone-egress-1" responds with
       """
       body:
@@ -60,3 +67,6 @@ Feature: Zones: Detail view content
     Then the "$egress-detail-tabs-view" element contains "zone-egress-1"
     Then the "$egress-detail-view" element contains "166.197.238.26:20555"
     Then the "$egress-detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"
+
+    When I click the "$egress-config-tab" element
+    Then the "$egress-config-view" element contains "type: ZoneEgress"

--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -80,7 +80,7 @@ export default class KumaApi extends Api {
   }
 
   getZoneIngress({ name }: { name: string }, params?: any): Promise<ZoneIngress> {
-    return this.client.get(`/zoneingresses/${name}`, { params })
+    return this.client.get(`/zone-ingresses/${name}`, { params })
   }
 
   /**

--- a/src/test-support/mocks/fs.ts
+++ b/src/test-support/mocks/fs.ts
@@ -50,6 +50,8 @@ import _47 from './src/meshes/_/virtual-outbounds'
 import _2 from './src/policies'
 import _51 from './src/provision-zone'
 import _7 from './src/service-insights'
+import _126 from './src/zone-ingresses/_'
+import _127 from './src/zoneegresses/_'
 import _10 from './src/zoneegressoverviews'
 import _49 from './src/zoneegressoverviews/_'
 import _9 from './src/zoneingresses+insights'
@@ -73,8 +75,10 @@ export const fs: FS = {
   '/zones': _8,
   '/zones/:name': _50,
   '/provision-zone': _51,
+  '/zone-ingresses/:name': _126,
   '/zoneingresses+insights': _9,
   '/zoneingresses+insights/:name': _48,
+  '/zoneegresses/:name': _127,
   '/zoneegressoverviews': _10,
   '/zoneegressoverviews/:name': _49,
   '/zones+insights': _11,

--- a/src/test-support/mocks/src/zone-ingresses/_.ts
+++ b/src/test-support/mocks/src/zone-ingresses/_.ts
@@ -1,0 +1,47 @@
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+
+export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
+  const { name } = req.params
+  const zoneName = fake.hacker.noun()
+
+  return {
+    headers: {},
+    body: {
+      type: 'ZoneIngress',
+      name,
+      creationTime: '2021-07-13T08:40:59Z',
+      modificationTime: '2021-07-13T08:40:59Z',
+      zone: zoneName,
+      networking: {
+        address: fake.internet.ip(),
+        advertisedAddress: fake.internet.ip(),
+        port: fake.internet.port(),
+        advertisedPort: fake.internet.port(),
+      },
+      availableServices: [
+        {
+          tags: {
+            app: 'demo-app',
+            'kuma.io/protocol': fake.kuma.protocol(),
+            'kuma.io/service': 'demo-app_kuma-demo_svc_5000',
+            'kuma.io/zone': zoneName,
+            'pod-template-hash': '5845d6447b',
+          },
+          instances: 1,
+          mesh: 'default',
+        },
+        {
+          tags: {
+            app: 'redis',
+            'kuma.io/protocol': fake.kuma.protocol(),
+            'kuma.io/service': 'redis_kuma-demo_svc_6379',
+            'kuma.io/zone': zoneName,
+            'pod-template-hash': '59c9d56fc',
+          },
+          instances: 1,
+          mesh: 'default',
+        },
+      ],
+    },
+  }
+}

--- a/src/test-support/mocks/src/zoneegresses/_.ts
+++ b/src/test-support/mocks/src/zoneegresses/_.ts
@@ -1,0 +1,24 @@
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+
+export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
+  const { name } = req.params
+  const zoneName = fake.hacker.noun()
+
+  return {
+    headers: {},
+    body: {
+      type: 'ZoneEgress',
+      name,
+      creationTime: '2021-07-13T08:40:59Z',
+      modificationTime: '2021-07-13T08:40:59Z',
+      zone: zoneName,
+      networking: {
+        address: fake.internet.ip(),
+        port: fake.internet.port(),
+        admin: {
+          port: fake.internet.port(),
+        },
+      },
+    },
+  }
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -460,7 +460,11 @@ export interface AvailableService {
   externalService?: boolean
 }
 
-export interface ZoneIngress extends MeshEntity {}
+export interface ZoneIngress extends MeshEntity {
+  zone?: string
+  networking?: ZoneIngressNetworking
+  availableServices?: AvailableService[]
+}
 
 export interface ZoneIngressOverview extends MeshEntity {
   type: 'ZoneIngressOverview'
@@ -477,7 +481,10 @@ export interface ZoneEgressNetworking {
   port?: string
 }
 
-export interface ZoneEgress extends MeshEntity {}
+export interface ZoneEgress extends MeshEntity {
+  zone?: string
+  networking?: ZoneEgressNetworking
+}
 
 export interface ZoneEgressOverview extends MeshEntity {
   type: 'ZoneEgressOverview'


### PR DESCRIPTION
Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Note: Zone Egress looks correct according to https://kuma.io/docs/2.4.x/reference/http-api/#get-zone-egress (i.e. `/zoneegresses/:zoneEgress`)