### PR TITLE
chore(policies): allows policy type-specific descriptions

### DIFF
--- a/src/app/meshes/components/MeshDetails.vue
+++ b/src/app/meshes/components/MeshDetails.vue
@@ -111,8 +111,9 @@ const props = defineProps({
   },
 
   meshInsight: {
-    type: Object as PropType<MeshInsight | undefined>,
-    required: true,
+    type: [Object] as PropType<MeshInsight | undefined>,
+    required: false,
+    default: undefined,
   },
 })
 

--- a/src/app/policies/components/PolicyList.vue
+++ b/src/app/policies/components/PolicyList.vue
@@ -46,7 +46,7 @@
                   </PolicyTypeTag>
                 </h3>
 
-                <p>{{ t('policies.collection.description') }}</p>
+                <p>{{ t(`policies.type.${props.currentPolicyType.name}.description`, undefined, { fallback: t('policies.collection.description') }) }}</p>
               </div>
 
               <div class="description-actions">

--- a/src/app/policies/locales/en-us/index.yaml
+++ b/src/app/policies/locales/en-us/index.yaml
@@ -15,3 +15,6 @@ policies:
     outbound: 'Outbound'
   detail:
     affected_dpps: 'Affected Data Plane Proxies'
+  type:
+    # CircuitBreaker:
+    #   description: 'About CircuitBreaker ...'

--- a/src/services/i18n/I18n.ts
+++ b/src/services/i18n/I18n.ts
@@ -4,6 +4,12 @@ import type Env from '@/services/env/Env'
 import { camelCaseToWords } from '@/utilities/camelCaseToWords'
 import { get } from '@/utilities/get'
 
+declare module 'intl-messageformat' {
+  interface Options {
+    fallback: string
+  }
+}
+
 interface I18nRecord {
   [key: string]: I18nRecord | string
 }
@@ -30,12 +36,16 @@ export default <T extends I18nRecord>(strs: T, env: Env['var']) => {
         }
         rest[1] = { KUMA_DOCS_URL: env('KUMA_DOCS_URL'), KUMA_UTM_QUERY_PARAMS: env('KUMA_UTM_QUERY_PARAMS'), ...rest[1] }
         return i18n.t(...rest)
-      } catch (e: unknown) {
+      } catch (e) {
         switch (true) {
           case e instanceof I18nError:
             // temporarily change any http.api terms to camelCase at runtime
             return camelCaseToWords((e as I18nError).key.split('.').pop()!)
           default:
+            if (rest[2]?.fallback) {
+              return rest[2].fallback
+            }
+
             throw e
         }
       }


### PR DESCRIPTION
chore: fix incorrect prop definition

chore(policies): allows policy type-specific descriptions

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>