### PR TITLE
chore(deps-dev): pins vue-tsc to 1.8.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "vite-plugin-rewrite-all": "^1.0.1",
     "vite-svg-loader": "^4.0.0",
     "vitepress": "^1.0.0-rc.14",
-    "vue-tsc": "^1.8.11",
+    "vue-tsc": "1.8.11",
     "yaml-jest": "^1.2.0"
   },
   "browserslist": [

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.2.3).
+ * Mock Service Worker (1.3.1).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/yarn.lock
+++ b/yarn.lock
@@ -9474,7 +9474,7 @@ vue-template-compiler@^2.7.14:
     de-indent "^1.0.2"
     he "^1.2.0"
 
-vue-tsc@^1.8.11:
+vue-tsc@1.8.11:
   version "1.8.11"
   resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-1.8.11.tgz#4a972e58a9eaae72d73e63e0bedacb56391b7cb4"
   integrity sha512-BzfiMdPqDHBlysx4g26NkfVHSQwGD/lTRausmxN9sFyjXz34OWfsbkh0YsVkX84Hu65In1fFlxHiG39Tr4Vojg==


### PR DESCRIPTION
Pins vue-tsc to 1.8.11 because 1.8.12 has a regression that prevents it from inferring custom event types.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
