### PR TITLE
chore(e2e): Extends the visit timeout

### DIFF
--- a/cypress/support/step_definitions/visit.ts
+++ b/cypress/support/step_definitions/visit.ts
@@ -32,7 +32,7 @@ When('I visit the {string} URL', function (path: string) {
     })
   })
   // currently use this to denote "the page has initially rendered"
-  cy.get('.app-main-content').should('be.visible')
+  cy.get('.app-main-content', { timeout: 10000 }).should('be.visible')
 })
 When('I load the {string} URL', function (path: string) {
   cy.viewport(1366, 768)


### PR DESCRIPTION
Extends the timeout for the `.app-main-content` assertion.
