### PR TITLE
chore(zones): switches to alert for error in create view

### DIFF
--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -197,12 +197,12 @@ zones:
     generalError:
       title: 'Could not create the Zone'
     invalidNameError: "The name must be a valid RFC 1035 DNS name, which means it must start with a letter, be less than 64 characters long, and only contain lowercase letters, numbers, and '-'."
-    statusError:
+    status_error:
       409:
-        title: 'A Zone with the name {zoneName} already exists'
+        title: 'Error 409: A Zone with the name {name} already exists'
         description: 'If you want to connect a Zone with this name, you can delete the existing one and create a new one.'
       500:
-        title: 'An error occurred while creating the Zone {zoneName}'
+        title: 'Error 500: An error occurred while creating the Zone {name}'
         description: 'You may retry this operation.'
   delete:
     confirmModal:

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -16,6 +16,8 @@ common:
   copyKubernetesShortText: 'as k8s'
   documentation: 'Documentation'
   error_state:
+    api_error: 'Error {status}: {title}'
+    default_error: 'An unexpected error occurred'
     title: 'An error has occurred while trying to load this data.'
     details: 'Details'
     field: 'Field'


### PR DESCRIPTION
## Changes

Switches to using a KAlert at the top of the page in the Zone Create View instead of ErrorBlock.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Screenshots

**Before**:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/57245dcf-1441-48a5-92a4-78f72455783f)

![image](https://github.com/kumahq/kuma-gui/assets/5774638/3c8c9398-0a2a-40b5-9d8f-cfc6138573ee)

**After**:

![image](https://github.com/kumahq/kuma-gui/assets/5774638/8d2c9162-a8ff-4647-b620-ec17dccd595c)

![image](https://github.com/kumahq/kuma-gui/assets/5774638/d21bab62-86f7-4395-bacb-7e0569773984)
