### PR TITLE
chore: Add automatic typing to source internals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -150,6 +150,7 @@ const INLINE_NON_VOID_ELEMENTS = [
         'no-unused-vars': 'off',
         '@typescript-eslint/no-unused-vars': [process.env.LINTER_MODE === 'strict' ? 'error' : 'warn', {
           argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
           ignoreRestSiblings: true,
         }],
 

--- a/src/app/application/services/data-source/DataSourcePool.ts
+++ b/src/app/application/services/data-source/DataSourcePool.ts
@@ -43,19 +43,19 @@ export class DataSourcePool {
 
   source(src: string, ref: symbol): CallableEventSource {
     const cacheKey = this.getCacheKeyPrefix() + src
-    const _source = this.pool.acquire(src, ref)
-    _source.addEventListener('message', (e: Event) => {
+    const source = this.pool.acquire(src, ref)
+    source.addEventListener('message', (e: Event) => {
       // always fill the cache on a successful response
       this.cache.set(cacheKey, (e as MessageEvent).data)
     })
     if (this.cache.has(cacheKey)) {
       Promise.resolve().then(() => {
-        _source?.dispatchEvent(
+        source?.dispatchEvent(
           new MessageEvent('message', { data: this.cache.get(cacheKey) }),
         )
       })
     }
-    return _source
+    return source
   }
 
   close(src: string, ref: symbol) {

--- a/src/app/application/services/data-source/index.ts
+++ b/src/app/application/services/data-source/index.ts
@@ -2,6 +2,29 @@ import CallableEventSource from './CallableEventSource'
 import type { Creator, Destroyer } from './DataSourcePool'
 export type { DataSourceResponse } from './DataSourcePool'
 
+type ExtractRouteParams<T extends string> =
+  string extends T
+    ? Record<string, string>
+    : T extends `${infer _Start}:${infer Param}/${infer Rest}`
+      ? {[k in Param | keyof ExtractRouteParams<Rest>]: string}
+      : T extends `${infer _Start}:${infer Param}`
+        ? {[k in Param]: string}
+        : {};
+
+type PaginationParams = {
+  size: number
+  page: number
+  search: string
+}
+
+type ExtractSources<T extends string, K> = {
+  [Route in T]: (params: ExtractRouteParams<Route> & K, source: { close: () => void }) => void
+}
+
+export const defineSources = <T extends string>(sources: ExtractSources<T, PaginationParams>) => {
+  return sources
+}
+
 type Configuration = {
   interval?: number
   retry?: (e: unknown) => Promise<void> | undefined

--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -88,7 +88,7 @@ export const sources = (api: KumaApi) => {
       filterParams.tag = filterParams.tag.filter((item) => !item.startsWith('kuma.io/service:'))
       filterParams.tag.push(`kuma.io/service:${params.service}`)
 
-      // we use `all` in code to mean "don't specify ?gateway=0 at all" i.e.
+      // we use `all` in code to mean "don't specify `?gateway` in the API URL" i.e.
       // both gateway and sidecars
       const type = params.type === 'standard' ? 'false' : params.type
       const gatewayParams = includes(['delegated', 'builtin', 'false'] as const, type)


### PR DESCRIPTION
~I've had various iterations of this sat around for a little while now, and I think this is one I could be happy merging, so whilst I'm still not 100% I want to I wanted to put it up for review to see what feedback there was. So, this is currently in draft but~ looking for feedback.

---

This PR adds automatic types to the `"/services/:name": (params) => { params.name }` sources. The one little tiny downside is that currently you have to use `defineSources`, but you do maintain the key names (or the URIs) in the result type, which is important and why a simpler type definition wouldn't have been good enough for me.

Notes:

- We maintain the keys in the resulting definition, I don't want to lose these by doing something simpler like `Record<string,...>`
- `params` are now automatically inferred to strings based on the URI
- We don't assume things like `'all' | 'delegated' | 'builtin'` for a string that could come from the browser URL. i.e. `params.*` are always just strings not unions. I add a little runtime validation here to use a default if somehow something else ends up in the URL.
- `PaginationParams` are still typed as before, I'll potentially also make these strings, just not thought past that yet.

The plan is to eventually have a similar approach on The Other Side (i.e. the view layer), but both of these approaches should maintain some sort of separation similar to what we currently have, and should be as automatic as possible.

~Anyway as mentioned, I'm only 90% sure I want to merge this,~ but would like to get some other thoughts on it to help me make my mind up (and if we go with it, before I roll it out everywhere)