### PR TITLE
chore(e2e): Adds a negative timeout defaulting to 4000

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -9,8 +9,18 @@ import fs from 'node:fs'
 
 const env = dotenv.config().parsed as {[key: string]: string}
 
+Object.entries({
+  // default base URL for testing against
+  KUMA_BASE_URL: 'http://localhost:5681/gui',
+}).forEach(([key, d]: [string, string]) => {
+  env[key] = process.env[key] ?? d
+})
+
 export default defineConfig({
+  viewportWidth: 1366,
+  viewportHeight: 768,
   e2e: {
+    baseUrl: env.KUMA_BASE_URL,
     specPattern: '**/*.feature',
     experimentalRunAllSpecs: true,
     // Can be turned on via CLI using `CYPRESS_video=true yarn test:browser`
@@ -19,14 +29,7 @@ export default defineConfig({
       // propagate env to Cypress.env
       Object.entries(env).forEach(([prop, value]) => {
         config.env[prop] = value
-      });
-      // additional non-dotenv environment vars
-      [
-        'KUMA_BASE_URL',
-      ].forEach(item => {
-        config.env[item] = process.env[item]
       })
-
       // This is required for the preprocessor to be able to generate JSON reports after each run, and more,
       await addCucumberPreprocessorPlugin(on, config)
 

--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -32,26 +32,24 @@ Before(() => {
   useServer()
 })
 
-const $ = (selector: string) => {
-  const resolvedSelector = resolveCustomAlias(selector)
+const negativeTimeout = parseInt(Cypress.env().KUMA_NEGATIVE_TIMEOUT) || 4000
+const timeout = (negative: boolean) => negative ? { timeout: negativeTimeout } : {}
 
-  return cy.get(resolvedSelector)
+const $ = (...args: Parameters<typeof cy.get>) => {
+  return cy.get(...resolveCustomAlias(...args))
 }
 
-function resolveCustomAlias(selector: string): string {
+function resolveCustomAlias(...args: Parameters<typeof cy.get>): Parameters<typeof cy.get> {
+  let selector = args[0]
   if (selector.startsWith('$')) {
     const alias = selector.split(/[: .[#]/).shift()!.substring(1)
-
     if (typeof selectors[alias] === 'undefined') {
       throw new Error(`Could not find alias $${alias}. Make sure you have defined the alias in a CSS selectors step`)
     }
-
     selector = selector.replace(`$${alias}`, selectors[alias])
-
-    return resolveCustomAlias(selector)
+    return resolveCustomAlias(selector, args[1])
   }
-
-  return selector
+  return args
 }
 
 // arrange
@@ -113,15 +111,17 @@ When('I clear the {string} element', (selector: string) => {
   $(selector).clear()
 })
 
-When('I go {string}', (direction: number | Cypress.HistoryDirection) => {
+When('I navigate {string}', (direction: Cypress.HistoryDirection) => {
   cy.go(direction)
 })
 
 // assert
+
 Then('the URL is {string}', (expected: string) => {
-  const base = Cypress.env().KUMA_BASE_URL || 'http://localhost:5681/gui'
+  const base = Cypress.config('baseUrl') || Cypress.env().KUMA_BASE_URL
   cy.url().should('eq', `${base}${expected}`)
 })
+
 Then('the URL contains {string}', (str: string) => {
   cy.url().should('include', str)
 })
@@ -207,22 +207,26 @@ Then(/^the URL "(.*)" was requested with only$/, (url: string, exact: string, ya
   })
 })
 
-Then(/^the "(.*)" element[s]?( don't | doesn't | )exist[s]?$/, function (selector: string, assertion: string) {
-  const prefix = assertion === ' ' ? '' : 'not.'
-  const chainer = `${prefix}exist`
-
-  $(selector).should(chainer)
-})
-
 Then(/^the "(.*)" element[s]? exist[s]? ([0-9]*) time[s]?$/, (selector: string, count: string) => {
   $(selector).should('have.length', count)
 })
 
-Then(/^the "(.*)" element[s]?( isn't | aren't | is | are )(.*)$/, (selector: string, assertion: string, booleanAttribute: string) => {
-  const prefix = ['is', 'are'].includes(assertion.trim()) ? '' : 'not.'
-  const chainer = `${prefix}be.${booleanAttribute}`
+Then(/^the "(.*)" element[s]?( don't | doesn't | )exist[s]?$/, function (selector: string, assertion: string) {
+  const negative = assertion !== ' '
+  const prefix = negative ? 'not.' : ''
 
-  $(selector).should(chainer)
+  $(selector, {
+    ...timeout(negative),
+  }).should(`${prefix}exist`)
+})
+
+Then(/^the "(.*)" element[s]?( isn't | aren't | is | are )(.*)$/, (selector: string, assertion: string, booleanAttribute: string) => {
+  const negative = !['is', 'are'].includes(assertion.trim())
+  const prefix = negative ? 'not.' : ''
+
+  $(selector, {
+    ...timeout(negative),
+  }).should(`${prefix}be.${booleanAttribute}`)
 })
 
 Then(/^the "(.*)" element(s)? contain[s]?$/, (selector: string, multiple = '', table: DataTable) => {

--- a/cypress/support/step_definitions/visit.ts
+++ b/cypress/support/step_definitions/visit.ts
@@ -1,17 +1,12 @@
 import { When } from '@badeball/cypress-cucumber-preprocessor'
 
-const config = {
-  BASE_URL: Cypress.env('KUMA_BASE_URL') || 'http://localhost:5681/gui',
-}
-
 When('I visit the {string} URL', function (path: string) {
-  cy.viewport(1366, 768)
   // turn off MSW in dev environments so we can use cy.intercept
   cy.setCookie('KUMA_MOCK_API_ENABLED', 'false')
   //
 
   cy.getAllCookies().then((cookies) => {
-    cy.visit(`${config.BASE_URL}${path}`)
+    cy.visit(`${path}`)
     cy.get('#kuma-config').then((obj) => {
       const node = obj.get(0)
       if (node === null || node.textContent === null) {
@@ -35,6 +30,5 @@ When('I visit the {string} URL', function (path: string) {
   cy.get('.app-main-content', { timeout: 10000 }).should('be.visible')
 })
 When('I load the {string} URL', function (path: string) {
-  cy.viewport(1366, 768)
-  cy.visit(`${config.BASE_URL}${path}`)
+  cy.visit(`${path}`)
 })

--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -62,10 +62,10 @@ Feature: application / MainNavigation
     Then the page title contains "Meshes"
     And the "[data-testid='page-2-btn'].active" element exists
 
-    When I go "back"
+    When I navigate "back"
     Then the page title contains "Meshes"
     And the "[data-testid='page-1-btn'].active" element exists
 
-    When I go "back"
+    When I navigate "back"
     Then the page title contains "Overview"
     And the "[data-testid='zone-control-planes-status']" element exists


### PR DESCRIPTION
Mostly makes any "negative" assertions use `4000` for a timeout, for if we extend "positive" assertions to a `10000` timeout. This will mean "positive" will pass as soon as possible, but "negative" ones won't wait a full `10000` until they fail.

(plus a few tiny amends detailed in the inlines)