### PR TITLE
refactor: switches to kongponents v9 alpha

### DIFF
--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -86,7 +86,7 @@ Feature: zones / create
     Then the "$ingress-input-switch input" element isn't checked
     And the "$egress-input-switch input" element isn't checked
 
-    When I click the "$environment-universal-radio-button + label" element
+    When I click the "$environment-universal-radio-button" element
     Then the "$ingress-input-switch input" element doesn't exist
     And the "$egress-input-switch input" element doesn't exist
     And the "$environment-universal-config" element contains "globalAddress: grpcs://<global-kds-address>:5685"

--- a/features/zones/Delete.feature
+++ b/features/zones/Delete.feature
@@ -4,8 +4,8 @@ Feature: zones / delete
       | Alias          | Selector                                                       |
       | items          | [data-testid="zone-cp-collection"]                             |
       | item           | $items tbody tr                                                |
-      | actions-button | $item:nth-child(1) [data-testid="k-dropdown-trigger"] button   |
-      | delete-button  | $item:nth-child(1) [data-testid="dropdown-delete-item"] button |
+      | actions-button | $item:nth-child(1) [data-testid='dropdown-trigger'] button     |
+      | delete-button  | $item:nth-child(1) [data-testid='dropdown-delete-item'] button |
       | delete-prompt  | [data-testid="delete-zone-modal"]                              |
       | confirm-button | $delete-prompt .k-prompt-proceed                               |
       | confirm-input  | $delete-prompt .k-prompt-confirm-text .k-input                 |

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test:unit": "cross-env FORCE_COLOR=1 vitest -c vite.config.production.ts run",
     "test:unit:coverage": "cross-env FORCE_COLOR=1 vitest -c vite.config.production.ts run --coverage",
     "test:watch": "vitest -c vite.config.production.ts --watch",
-
     "docs:dev": "vitepress dev",
     "docs:generate": "rm -rf docs/components && vue-docgen src/**/*.vue",
     "docs:build": "vitepress build",
@@ -40,7 +39,7 @@
   "dependencies": {
     "@kong-ui-public/i18n": "0.8.6",
     "@kong/icons": "1.8.0",
-    "@kong/kongponents": "8.126.2",
+    "@kong/kongponents": "9.0.0-alpha.54",
     "brandi": "5.0.0",
     "deepmerge": "4.3.1",
     "js-yaml": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "yarn": "^1.22.0"
   },
   "dependencies": {
-    "@kong-ui-public/i18n": "0.8.6",
+    "@kong-ui-public/i18n": "2.0.0",
     "@kong/icons": "1.8.0",
-    "@kong/kongponents": "9.0.0-alpha.54",
+    "@kong/kongponents": "9.0.0-alpha.55",
     "brandi": "5.0.0",
     "deepmerge": "4.3.1",
     "js-yaml": "4.1.0",

--- a/src/app/common/CodeBlock.vue
+++ b/src/app/common/CodeBlock.vue
@@ -2,7 +2,7 @@
   <KCodeBlock
     :id="id"
     class="code-block"
-    :style="props.codeMaxHeight ? `--KCodeBlockMaxHeight: ${props.codeMaxHeight}` : undefined"
+    :max-height="props.codeMaxHeight"
     :code="props.code"
     :language="language"
     :is-processing="isProcessing"
@@ -34,12 +34,12 @@ const props = withDefaults(defineProps<{
   language: AvailableLanguages
   isSearchable?: boolean
   showCopyButton?: boolean
-  codeMaxHeight?: string | null
+  codeMaxHeight?: string
   query?: string
 }>(), {
   isSearchable: false,
   showCopyButton: true,
-  codeMaxHeight: null,
+  codeMaxHeight: undefined,
   query: '',
 })
 

--- a/src/app/common/CopyButton.vue
+++ b/src/app/common/CopyButton.vue
@@ -14,9 +14,7 @@
       type="button"
       @click="copy($event, copyToClipboard)"
     >
-      <KIcon
-        color="currentColor"
-        icon="copy"
+      <CopyIcon
         :size="KUI_ICON_SIZE_30"
         :title="!props.hideTitle ? props.copyText : undefined"
         :hide-title="props.hideTitle"
@@ -31,7 +29,8 @@
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { KButton, KClipboardProvider, KIcon } from '@kong/kongponents'
+import { CopyIcon } from '@kong/icons'
+import { KButton, KClipboardProvider } from '@kong/kongponents'
 
 import type { PropType } from 'vue'
 

--- a/src/app/common/CopyButton.vue
+++ b/src/app/common/CopyButton.vue
@@ -2,14 +2,12 @@
   <KClipboardProvider v-slot="{ copyToClipboard }">
     <KButton
       v-bind="$attrs"
-      appearance="outline"
+      appearance="tertiary"
       class="copy-button"
       :class="{
         'non-visual-button': !props.hasBorder,
       }"
       data-testid="copy-button"
-      :is-rounded="false"
-      size="small"
       :title="!props.hideTitle ? props.copyText : undefined"
       type="button"
       @click="copy($event, copyToClipboard)"

--- a/src/app/common/NavTabs.vue
+++ b/src/app/common/NavTabs.vue
@@ -72,6 +72,12 @@ const currentTabHash = computed(() => {
 .nav-tabs {
   margin-bottom: var(--AppGap);
 }
+
+.nav-tabs :deep(ul) {
+  // TODO: Remove this override once KTabs was updated in Kongponents v9’s alpha version.
+  // Overrides the bottom border color to the same value KCard uses for its borders.
+  border-bottom-color: rgba(0, 0, 0, 0.1);
+}
 </style>
 
 <style lang="scss">

--- a/src/app/common/ResourceCodeBlock.vue
+++ b/src/app/common/ResourceCodeBlock.vue
@@ -50,11 +50,11 @@ const props = withDefaults(defineProps<{
    * Function returning the resource.
    */
   resourceFetcher: (params?: SingleResourceParameters) => Promise<Entity>
-  codeMaxHeight?: string | null
+  codeMaxHeight?: string
   isSearchable?: boolean
   query?: string
 }>(), {
-  codeMaxHeight: null,
+  codeMaxHeight: undefined,
   isSearchable: false,
   query: '',
 })

--- a/src/app/common/StatusBadge.vue
+++ b/src/app/common/StatusBadge.vue
@@ -3,6 +3,7 @@
     <KBadge
       class="status-badge"
       :appearance="BADGE_APPEARANCE[props.status]"
+      max-width="auto"
       data-testid="status-badge"
     >
       {{ t(`http.api.value.${props.status}`) }}

--- a/src/app/common/SummaryView.vue
+++ b/src/app/common/SummaryView.vue
@@ -19,10 +19,11 @@ const emit = defineEmits<{
 
 <style lang="scss" scoped>
 .summary-slideout {
-  // TODO: Remove or replace these once we switch to Kongponents v9 which will deprecate these variables.
-  // Overrides KSlideout’s override.
-  --KCardPaddingX: #{$kui-space-80} !important;
-  --KCardPaddingY: #{$kui-space-80} !important;
+  :deep(.kong-card) {
+    // TODO: Remove these once those styles have been removed/fixed in Kongponents v9.
+    // Overrides KSlideout’s override.
+    padding: #{$kui-space-80} !important;
+  }
 
   :deep(.panel),
   :deep(.panel-background),

--- a/src/app/common/SummaryView.vue
+++ b/src/app/common/SummaryView.vue
@@ -4,6 +4,7 @@
     close-button-alignment="end"
     :has-overlay="false"
     is-visible
+    offset-top="var(--app-slideout-offset-top, 0)"
     data-testid="summary"
     @close="emit('close')"
   >
@@ -18,20 +19,10 @@ const emit = defineEmits<{
 </script>
 
 <style lang="scss" scoped>
-.summary-slideout {
-  :deep(.kong-card) {
-    // TODO: Remove these once those styles have been removed/fixed in Kongponents v9.
-    // Overrides KSlideout’s override.
-    padding: #{$kui-space-80} !important;
-  }
-
-  :deep(.panel),
-  :deep(.panel-background),
-  :deep(.panel-background-transparent) {
-    // TODO: Remove this in favor of setting KSlideout’s `props.offsetTop` to `var(--AppHeaderHeight)` once Kongponents v9 is available (which has https://github.com/Kong/kongponents/pull/1769).
-    // Overrides KSlideout’s top offset. `props.offsetTop` doesn’t accept plain CSS values.
-    top: var(--app-slideout-offset-top) !important;
-  }
+.summary-slideout :deep(.kong-card) {
+  // TODO: Remove these once those styles have been removed/fixed in Kongponents v9.
+  // Overrides KSlideout’s override.
+  padding: #{$kui-space-80} !important;
 }
 
 .summary-slideout :deep(.k-slideout-header-content) {
@@ -42,9 +33,12 @@ const emit = defineEmits<{
 .summary-slideout :deep(.panel) {
   // Increases width of the content area a little.
   max-width: 560px;
-  // TODO: Remove this once we switch to Kongponents v9 which will fix this issue (https://github.com/Kong/kongponents/pull/1822).
-  // Fixes the content being taller than the viewport when using `props.offsetHeight`.
-  height: calc(100vh - var(--app-slideout-offset-top)) !important;
+}
+
+.summary-slideout :deep(.border-styles) {
+  // TODO: Remove this override once KSlideout was updated in Kongponents v9’s alpha version.
+  // Overrides the left border color to the same value KCard uses for its borders.
+  border-left-color: rgba(0, 0, 0, 0.1);
 }
 
 // Aligns the position of the close button with the summary slideout card’s content box.

--- a/src/app/common/TagList.vue
+++ b/src/app/common/TagList.vue
@@ -4,6 +4,7 @@
       v-for="(tag, index) in tagList"
       :key="index"
       class="tag-badge"
+      max-width="auto"
     >
       <component
         :is="tag.route ? 'RouterLink' : 'span'"

--- a/src/app/common/UpgradeCheck.vue
+++ b/src/app/common/UpgradeCheck.vue
@@ -6,7 +6,7 @@
       v-if="showNotice"
       data-testid="upgrade-check"
       class="upgrade-check-alert"
-      appearance="warning"
+      appearance="info"
       size="small"
     >
       <template #alertMessage>
@@ -17,7 +17,6 @@
 
           <div>
             <KButton
-              class="warning-button"
               appearance="primary"
               :to="env('KUMA_INSTALL_URL')"
             >
@@ -100,11 +99,5 @@ async function checkVersion(currentVersion: string): Promise<void> {
   > *:first-of-type {
     margin-right: $kui-space-50;
   }
-}
-
-.warning-button {
-  --KButtonPrimaryBase: #f2a230;
-  --KButtonPrimaryHover: #f2a230;
-  --KButtonPrimaryActive: #f2a230;
 }
 </style>

--- a/src/app/common/UpgradeCheck.vue
+++ b/src/app/common/UpgradeCheck.vue
@@ -19,7 +19,6 @@
             <KButton
               class="warning-button"
               appearance="primary"
-              size="small"
               :to="env('KUMA_INSTALL_URL')"
             >
               Update

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -70,8 +70,8 @@
                   />
 
                   <KSelect
+                    class="filter-select"
                     label="Type"
-                    :overlay-label="true"
                     :items="['all', 'standard', 'builtin', 'delegated'].map((value) => ({
                       value,
                       label: t(`data-planes.type.${value}`),
@@ -131,5 +131,16 @@ import type { MeSource } from '@/app/me/sources'
 .data-plane-proxy-filter {
   flex-basis: 350px;
   flex-grow: 1;
+}
+
+.filter-select {
+  display: flex;
+  align-items: center;
+  gap: $kui-space-40;
+}
+
+.filter-select :deep(.k-label) {
+  // Removes the bottom margin as we’re aligning the label with the select in a horizontal layout.
+  margin-bottom: 0 !important;
 }
 </style>

--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -37,7 +37,7 @@
               width="280"
             >
               <KButton
-                appearance="outline"
+                appearance="tertiary"
               >
                 Info
               </KButton>
@@ -55,7 +55,10 @@
           </p>
 
           <KDropdownMenu :kpop-attributes="{ placement: 'bottomEnd' }">
-            <KButton appearance="outline">
+            <KButton
+              appearance="tertiary"
+              icon-only
+            >
               <HelpIcon :size="KUI_ICON_SIZE_30" />
 
               <span class="visually-hidden">Help</span>
@@ -92,7 +95,8 @@
 
           <KButton
             :to="{ name: 'diagnostics' }"
-            button-appearance="btn-link"
+            appearance="tertiary"
+            icon-only
             data-testid="nav-item-diagnostics"
           >
             <CogIcon

--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -54,7 +54,7 @@
             {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
           </p>
 
-          <KDropdownMenu :kpop-attributes="{ placement: 'bottomEnd' }">
+          <KDropdown :kpop-attributes="{ placement: 'bottomEnd' }">
             <KButton
               appearance="tertiary"
               icon-only
@@ -91,7 +91,7 @@
                 }"
               />
             </template>
-          </KDropdownMenu>
+          </KDropdown>
 
           <KButton
             :to="{ name: 'diagnostics' }"

--- a/src/app/onboarding/components/OnboardingNavigation.vue
+++ b/src/app/onboarding/components/OnboardingNavigation.vue
@@ -12,7 +12,7 @@
     <div class="button-list">
       <KButton
         v-if="props.showSkip"
-        appearance="outline"
+        appearance="tertiary"
         data-testid="onboarding-skip-button"
         :to="{ name: 'home' }"
       >
@@ -21,7 +21,7 @@
 
       <KButton
         :disabled="!props.shouldAllowNext"
-        :appearance="props.lastStep ? 'creation' : 'primary'"
+        appearance="primary"
         :to="{ name: props.lastStep ? 'home' : props.nextStep }"
         data-testid="onboarding-next-button"
       >

--- a/src/app/services/views/ServiceDataPlaneProxiesView.vue
+++ b/src/app/services/views/ServiceDataPlaneProxiesView.vue
@@ -70,8 +70,8 @@
                   />
 
                   <KSelect
+                    class="filter-select"
                     label="Type"
-                    :overlay-label="true"
                     :items="['all', 'standard', 'builtin', 'delegated'].map((value) => ({
                       value,
                       label: t(`data-planes.type.${value}`),
@@ -131,5 +131,16 @@ import type { MeSource } from '@/app/me/sources'
 .data-plane-proxy-filter {
   flex-basis: 350px;
   flex-grow: 1;
+}
+
+.filter-select {
+  display: flex;
+  align-items: center;
+  gap: $kui-space-40;
+}
+
+.filter-select :deep(.k-label) {
+  // Removes the bottom margin as we’re aligning the label with the select in a horizontal layout.
+  margin-bottom: 0 !important;
 }
 </style>

--- a/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
@@ -71,9 +71,9 @@
                   <KButton
                     class="non-visual-button"
                     appearance="secondary"
-                    size="small"
+                    icon-only
                   >
-                    <MoreIcon :size="KUI_ICON_SIZE_30" />
+                    <MoreIcon />
                   </KButton>
                 </template>
                 <template #items>
@@ -100,7 +100,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { MoreIcon } from '@kong/icons'
 
 import type { AvailableService, ZoneIngressOverview } from '../data'

--- a/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
@@ -62,7 +62,7 @@
             </template>
 
             <template #actions="{ row: item }: {row: AvailableService}">
-              <KDropdownMenu
+              <KDropdown
                 class="actions-dropdown"
                 :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
                 width="150"
@@ -90,7 +90,7 @@
                     }"
                   />
                 </template>
-              </KDropdownMenu>
+              </KDropdown>
             </template>
           </AppCollection>
         </template>

--- a/src/app/zones/components/ZoneActionMenu.vue
+++ b/src/app/zones/components/ZoneActionMenu.vue
@@ -1,22 +1,21 @@
 <template>
   <div>
-    <KDropdownMenu
-      button-appearance="primary"
+    <KDropdown
       :kpop-attributes="props.kpopAttributes"
-      :label="t('zones.action_menu.toggle_button')"
+      :trigger-text="t('zones.action_menu.toggle_button')"
       show-caret
       width="280"
     >
       <template #items>
         <KDropdownItem
-          is-dangerous
+          danger
           data-testid="delete-button"
           @click.prevent="toggleDeleteModal"
         >
           {{ t('zones.action_menu.delete_button') }}
         </KDropdownItem>
       </template>
-    </KDropdownMenu>
+    </KDropdown>
 
     <DeleteResourceModal
       v-if="isDeleteModalOpen"
@@ -39,7 +38,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KDropdownItem, KDropdownMenu } from '@kong/kongponents'
 import { PropType, ref } from 'vue'
 import { useRouter } from 'vue-router'
 

--- a/src/app/zones/components/ZoneActionMenu.vue
+++ b/src/app/zones/components/ZoneActionMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <KDropdownMenu
-      button-appearance="creation"
+      button-appearance="primary"
       :kpop-attributes="props.kpopAttributes"
       :label="t('zones.action_menu.toggle_button')"
       show-caret

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -126,7 +126,7 @@
                       name="zone-name"
                       data-testid="name-input"
                       :data-test-error-type="nameError !== null ? 'invalid-dns-name' : undefined"
-                      :has-error="nameError !== null"
+                      :error="nameError !== null"
                       :error-message="nameError ?? undefined"
                       :disabled="zone !== null"
                       @blur="validateName(name)"

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -502,8 +502,11 @@ function success() {
   isZoneConnected.value = true
 }
 </script>
+
 <style lang="scss" scoped>
-.radio-button-group > * + * {
-  margin-block-start: $kui-space-40;
+.radio-button-group {
+  display: flex;
+  flex-direction: column;
+  gap: $kui-space-40;
 }
 </style>

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -21,7 +21,7 @@
       <template #actions>
         <KButton
           v-if="token === '' || isZoneConnected"
-          appearance="outline"
+          appearance="tertiary"
           data-testid="exit-button"
           :to="{ name: 'zone-cp-list-view' }"
         >
@@ -30,7 +30,7 @@
 
         <KButton
           v-else
-          appearance="outline"
+          appearance="tertiary"
           data-testid="exit-button"
           @click="toggleConfirmModal"
         >

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -28,10 +28,11 @@
         >
           <KButton
             appearance="primary"
-            icon="plus"
             :to="{ name: 'zone-create-view' }"
             data-testid="create-zone-link"
           >
+            <AddIcon :size="KUI_ICON_SIZE_30" />
+
             {{ t('zones.index.create') }}
           </KButton>
         </template>
@@ -204,7 +205,7 @@
                       <KButton
                         class="non-visual-button"
                         appearance="secondary"
-                        size="small"
+                        icon-only
                       >
                         <MoreIcon />
                       </KButton>
@@ -272,7 +273,7 @@
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon, MoreIcon } from '@kong/icons'
+import { AddIcon, ArrowRightIcon, MoreIcon } from '@kong/icons'
 import { ref } from 'vue'
 import { type RouteLocationNamedRaw } from 'vue-router'
 

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -195,9 +195,8 @@
                   v-if="can('create zones')"
                   #actions="{ row }"
                 >
-                  <KDropdownMenu
+                  <KDropdown
                     class="actions-dropdown"
-                    data-testid="actions-dropdown"
                     :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
                     width="150"
                   >
@@ -214,14 +213,14 @@
                     <template #items>
                       <KDropdownItem
                         has-divider
-                        is-dangerous
+                        danger
                         data-testid="dropdown-delete-item"
                         @click="setDeleteZoneName(row.name)"
                       >
                         {{ t('common.collection.actions.delete') }}
                       </KDropdownItem>
                     </template>
-                  </KDropdownMenu>
+                  </KDropdown>
                 </template>
               </AppCollection>
             </template>

--- a/src/assets/styles/_utilities.scss
+++ b/src/assets/styles/_utilities.scss
@@ -41,8 +41,8 @@
 
 // remove button default styles for elements that act like buttons, but don't look like them
 .non-visual-button {
-  font-weight: $kui-font-weight-regular;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
+  background-color: transparent !important;
+  border: none !important;
+  color: currentColor !important;
+  cursor: pointer !important;
 }

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -23,10 +23,6 @@
   --graph-color-8: #fff182;
   --graph-color-9: #fff9ca;
 
-  // KONGPONENTS
-  // Reduces the excessive vertical padding.
-  --KPopPaddingY: #{$kui-space-40};
-
   // MISC
   --TextGradientBackground: linear-gradient(90deg, #473cfb 0%, #a300bd 33.17%);
   --StepBackground: #169fcc;

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -26,7 +26,6 @@
   // KONGPONENTS
   // Reduces the excessive vertical padding.
   --KPopPaddingY: #{$kui-space-40};
-  --KCardBorderRadius: 9px;
 
   // MISC
   --TextGradientBackground: linear-gradient(90deg, #473cfb 0%, #a300bd 33.17%);

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -26,8 +26,6 @@
   // KONGPONENTS
   // Reduces the excessive vertical padding.
   --KPopPaddingY: #{$kui-space-40};
-  // Removes the default max width of 200 pixels because badges should never be cut-off.
-  --KBadgeMaxWidth: auto;
   --KCardBorderRadius: 9px;
 
   // MISC

--- a/yarn.lock
+++ b/yarn.lock
@@ -1827,25 +1827,27 @@
   resolved "https://registry.yarnpkg.com/@kong/design-tokens/-/design-tokens-1.11.10.tgz#e53bc7fd4e241473c5aa909f009469286e4a3d7b"
   integrity sha512-0ovN/48VgduW/FHQJ2ygHdrjW0mBrUu1GJptFYIzwL0MTRavBBfBQ5uq7NvYlsZWODgSnNh3N7RBwDO+LALvew==
 
-"@kong/icons@1.8.0":
+"@kong/icons@1.8.0", "@kong/icons@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.8.0.tgz#3fb6423fec31be4cc27af94f2912f52aee4f9077"
   integrity sha512-ynO3GXaJTh4yoJMZ7XeTbA+ZHvlrteleI+rWNGUbEr726Tw/jgHLdT6wZ1YWR65cA38FN0Q96vEX/7+6ExwaHA==
 
-"@kong/kongponents@8.126.2":
-  version "8.126.2"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-8.126.2.tgz#dcf337aeb8a7d623b03b0af8f4936d7a030e09a5"
-  integrity sha512-isTzDHB/21O+hMq+tMRH5A3WyOVC5FZqLs1YrfW8zb6VX9Xm1tmtVHO0Qtfo2DpMs2c9rNdl/yBa1vijkOSkHA==
+"@kong/kongponents@9.0.0-alpha.54":
+  version "9.0.0-alpha.54"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.54.tgz#c96721495c718719b3d7e3925e80b053cd21e479"
+  integrity sha512-mZ3qlsywpDskIoGvcPX+bxFD3F8guy3T57SOhdtL6v2XOPClvVgHVSwVY7/mxP2nB1ygrWoqnDc7GtvSq5EpmA==
   dependencies:
+    "@kong/icons" "^1.8.0"
+    "@popperjs/core" "^2.11.8"
     date-fns "^2.30.0"
     date-fns-tz "^2.0.0"
-    focus-trap "^7.5.2"
-    focus-trap-vue "^4.0.2"
+    focus-trap "^7.5.4"
+    focus-trap-vue "^4.0.3"
     popper.js "^1.16.1"
     sortablejs "^1.15.0"
     swrv "^1.0.4"
-    uuid "^9.0.0"
-    v-calendar "3.0.0-alpha.8"
+    uuid "^9.0.1"
+    v-calendar "^3.0.3"
     vue-draggable-next "^2.2.1"
 
 "@modyfi/vite-plugin-yaml@1.0.4":
@@ -1915,10 +1917,10 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@popperjs/core@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.0.tgz#0e1bdf8d021e7ea58affade33d9d607e11365915"
-  integrity sha512-NMrDy6EWh9TPdSRiHmHH2ye1v5U0gBD7pRYwSwJvomx7Bm4GG04vu63dYiVzebLOx2obPpJugew06xVP0Nk7hA==
+"@popperjs/core@^2.11.8":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
 "@rollup/pluginutils@5.0.2":
   version "5.0.2"
@@ -2172,10 +2174,20 @@
   resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.26.3.tgz#47fe8e784c2dee24fe636cab82e090d3da9b7dec"
   integrity sha512-A0D0aTXvjlqJ5ZILMz3rNfDBOx9hHxLZYv2by47Sm/pqW35zzjusrZTryatjN/Rf8Us2gZrJD+KeHbUSTux1Cw==
 
-"@types/semver@7.5.5", "@types/semver@^7.5.0":
+"@types/resize-observer-browser@^0.1.7":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.8.tgz#db41a93f9f37dad8e6f0c7bd2f5bbc042bf714d1"
+  integrity sha512-OpjAd26fD1G2OWlYzkrapJ12n+kyi0znYgE2AHfNccHY/am3kG+lfJ5brfcZ7+1CIybkPWGKrW+Wm97kbcOQaQ==
+
+"@types/semver@7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.5.tgz#deed5ab7019756c9c90ea86139106b0346223f35"
   integrity sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==
+
+"@types/semver@^7.5.0":
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.3.tgz#9a726e116beb26c24f1ccd6850201e1246122e04"
+  integrity sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==
 
 "@types/set-cookie-parser@^2.4.0":
   version "2.4.4"
@@ -4765,12 +4777,12 @@ flatted@^3.2.7, flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-focus-trap-vue@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/focus-trap-vue/-/focus-trap-vue-4.0.2.tgz#c9cc4976b2625d5290a8263b4edea542559fdb1a"
-  integrity sha512-2iQN2xKCSCzyhcD90VpueQcTIAhaCRxxo67fkz7RSqLmEd16QKjfGslCr3KxvBx0LfpVN9j0IAyKKuJKw3Intg==
+focus-trap-vue@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/focus-trap-vue/-/focus-trap-vue-4.0.3.tgz#c13f19d94e666c5144498793e93e51e0c46c2660"
+  integrity sha512-cIX5rybkCAlNZ4IHYJ3nCFIsipDDljJHHjtTO2IgYWkVYg7X9ipUVdab3HzYp88kmHgMwjcB71LYnXRRsF6ZqQ==
 
-focus-trap@^7.5.2, focus-trap@^7.5.4:
+focus-trap@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.5.4.tgz#6c4e342fe1dae6add9c2aa332a6e7a0bbd495ba2"
   integrity sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==
@@ -8443,21 +8455,22 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^9.0.0, uuid@^9.0.1:
+uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
-v-calendar@3.0.0-alpha.8:
-  version "3.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/v-calendar/-/v-calendar-3.0.0-alpha.8.tgz#3bc8c69f4788fb527c39706f41fd2a502a17c827"
-  integrity sha512-T23H5UbK0EomrwArlF/jrT2LFbV/lu+Bp9JroZ1paN6rPoaMyvE+HrLxvAmUgi+pODrdTURDMzM3+WPgeFKEBQ==
+v-calendar@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/v-calendar/-/v-calendar-3.1.1.tgz#0fbda63f21463e939a87b00c205dfbaf77fc03b3"
+  integrity sha512-9ZgHOcbg97TGyokcFE8yVNwjzu8pUxSMnUMHh/1flSTM8Uof2GLqiu5f00+nl30hooK149ScdIb74VZebUfmvA==
   dependencies:
-    "@popperjs/core" "2.4.0"
     "@types/lodash" "^4.14.165"
+    "@types/resize-observer-browser" "^0.1.7"
     date-fns "^2.16.1"
     date-fns-tz "^1.0.12"
     lodash "^4.17.20"
+    vue-screen-utils "^1.0.0-beta.13"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
@@ -8698,6 +8711,11 @@ vue-router@4.2.5:
   integrity sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==
   dependencies:
     "@vue/devtools-api" "^6.5.0"
+
+vue-screen-utils@^1.0.0-beta.13:
+  version "1.0.0-beta.13"
+  resolved "https://registry.yarnpkg.com/vue-screen-utils/-/vue-screen-utils-1.0.0-beta.13.tgz#0c739e19f6ffbffab63184aba7b6d710b6a63681"
+  integrity sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==
 
 vue-template-compiler@^2.7.14:
   version "2.7.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1813,10 +1813,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@kong-ui-public/i18n@0.8.6":
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/@kong-ui-public/i18n/-/i18n-0.8.6.tgz#6774fe21626bcd014ef9b9d8a87bc950e28e0288"
-  integrity sha512-FPf5nfpJzjwvx5CQGXh7tjZqcy7IeRZyquoM6dsM+/O9wIlmr/PGfqVCiJwwdONgrkg/DCVuzm+qQBAjdaQlXQ==
+"@kong-ui-public/i18n@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@kong-ui-public/i18n/-/i18n-2.0.0.tgz#d36b5df36074ac0d55f7ed719e122ea0e76da144"
+  integrity sha512-n/fkoGmY9CG9tgMrBwxGCiI8M8x4KoUwwSL361gIs8E8ehbtfn0Tw3O9Tpwzq3JRqnzyYuTf/S4Z4ZaI5/SC9g==
   dependencies:
     "@formatjs/intl" "^2.9.3"
     flat "^6.0.1"
@@ -1832,10 +1832,10 @@
   resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.8.0.tgz#3fb6423fec31be4cc27af94f2912f52aee4f9077"
   integrity sha512-ynO3GXaJTh4yoJMZ7XeTbA+ZHvlrteleI+rWNGUbEr726Tw/jgHLdT6wZ1YWR65cA38FN0Q96vEX/7+6ExwaHA==
 
-"@kong/kongponents@9.0.0-alpha.54":
-  version "9.0.0-alpha.54"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.54.tgz#c96721495c718719b3d7e3925e80b053cd21e479"
-  integrity sha512-mZ3qlsywpDskIoGvcPX+bxFD3F8guy3T57SOhdtL6v2XOPClvVgHVSwVY7/mxP2nB1ygrWoqnDc7GtvSq5EpmA==
+"@kong/kongponents@9.0.0-alpha.55":
+  version "9.0.0-alpha.55"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.55.tgz#34eb59f2d26bdd002bc965493c5b8094f6418ad3"
+  integrity sha512-I20eS4x+gBaPG5x4gjHE3W24VMsRuQpQdiOe1uZGAZV6DJcpJZ1WYZCB7cmSgGU7swQmMt/+Co1WSE76NL5baQ==
   dependencies:
     "@kong/icons" "^1.8.0"
     "@popperjs/core" "^2.11.8"


### PR DESCRIPTION
Kongponents v9 migration guide: https://alpha--kongponents.netlify.app/guide/migrating-to-version-9.html

## Changes

- **chore(deps): updates @kong/kongponents to v9.0.0-alpha.N**

- **refactor(codeblock): switches to @kong/icons**

  Replaces all the copy KIcon.

- **chore: addresses KBadge changes**

- **chore: addresses KButton changes**

  Appearance: renames outline to tertiary.

  Size: removes some instances of `size="small"` as we don’t need it anymore in most cases.

  Adds `icon-only` to icon-only buttons.

- **chore: addresses KCard changes**

- **chore: addresses KCodeBlock changes**

- **chore: addresses KDropdownMenu changes**

  Removes unnecessary `props.buttonAppearance`.

  Renames `props.label` to `props.triggerText`.

  Updates related test selector usage.

- **chore: addresses KInput changes**

- **chore: addresses KPop changes**

- **chore: addresses KRadio changes**

  Makes sure radio button groups in Zone create view are stacked vertically.

  Adjusts test selector to account for breaking change in KRadio markup (label is no longer a sibling of the input).

- **chore: addresses KSelect changes**

  Removes `props.overlayLabel`. The removal of the floating label breaks the layout of the gateway list view toolbar. To account for this, I’ve added a few styles to position the label before the select element instead of above it.

- **chore: addresses KSlideout changes**

  Uses `props.offsetTop` instead of overriding `top` using CSS.

- **chore: addresses KTabs changes**

  Adds a Kongponents override to NavTabs to make the component’s border bottom have the same color as KCard.

- **chore: makes non-visual-button use !important**

- **chore: changes upgrade check appearance to info**

## Notes

**Known/outstanding issues**:

- **Icons**: No Kong/icons replacement for the "stateNoData" KIcon
- **KSlideout**: has a too dark left border color (an override was added in this PR)
- **KTabs**: has a too dark bottom border color (an override was added in this PR)
- **KTabs**: inactive tabs have the same text color as active tabs

**Related**:

- https://github.com/kumahq/kuma-gui/pull/1527
- https://github.com/kumahq/kuma-gui/pull/1563