### PR TITLE
chore: fixes vitepress build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,7 @@ yarn-error.log*
 
 # Yarn
 .yarn/*
+
+# Vitepress
 .vitepress/cache
+.vitepress/dist

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -18,6 +18,10 @@ export default defineConfig({
   title: 'kuma-gui',
   description: '',
   cleanUrls: true,
+  ignoreDeadLinks: [
+    // ignore all localhost links
+    /^https?:\/\/localhost/,
+  ],
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -11,7 +11,11 @@ const files = globSync('./src/**/README.md').map(item => {
     text: name,
     link: item
   }
-}).filter(Boolean)
+}).filter(notEmpty)
+
+function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
+  return value !== null && value !== undefined
+}
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({


### PR DESCRIPTION
**chore: fixes vitepress build**

Renames config.ts to config.mts to address `"vitepress" resolved to an ESM file.` error.

Adds `ignoreDeadLinks` config for the dead link checker matching on localhost references.

**chore: address vitepress config type issues**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>