### PR TITLE
chore(e2e): Directly throw i18n errors with onError vs console.error

### DIFF
--- a/src/services/i18n/I18n.ts
+++ b/src/services/i18n/I18n.ts
@@ -21,7 +21,14 @@ class I18nError extends Error {
 }
 
 export default <T extends I18nRecord>(strs: T, env: Env['var']) => {
-  const i18n = createI18n<typeof strs>('en-us', strs, true)
+  const i18n = createI18n<typeof strs>('en-us', strs, {
+    isGlobal: true,
+    onError: (e) => {
+      // TODO: change the below code that we used before we had onError to be
+      // here instead of just rethrowing
+      throw e
+    },
+  })
   return {
     ...i18n,
     t: function (...rest: Parameters<typeof i18n['t']>) {


### PR DESCRIPTION
Uses the new `onError` configuration option of `core/i18n` to throw errors rather than `console.error` them. This means these errors will fail tests.

Note: For the minute I've just done a simple approach as I have some tests that require this elsewhere that use this.

We can come back and refactor soon, plus there is an issue already to do this https://github.com/kumahq/kuma-gui/issues/1478
