### PR TITLE
chore(services): remove external service filtering workaround

### DIFF
--- a/features/mesh/services/Item.feature
+++ b/features/mesh/services/Item.feature
@@ -142,7 +142,7 @@ Feature: mesh / services / item
       Then I click the "$button-view" element
       Then the URL contains "/mesh/default/data-plane/fake-dataplane"
 
-    Scenario Outline: Service without matching ExternalService shows empty state
+    Scenario: Service with matching ExternalService doesn't show empty state
       Given the environment
         """
         KUMA_EXTERNALSERVICE_COUNT: 1
@@ -158,14 +158,24 @@ Feature: mesh / services / item
             items:
               - name: external-service-1
                 tags:
-                  kuma.io/service: <Service>
+                  kuma.io/service: service-1
         """
 
       When I visit the "/mesh/default/service/service-1" URL
 
-      Then the "[data-testid='no-matching-external-service']" element <ExistsAssertion>
+      Then the "[data-testid='no-matching-external-service']" element doesn't exist
 
-      Examples:
-        | Service   | ExistsAssertion |
-        | service-2 | exists          |
-        | service-1 | doesn't exist   |
+    Scenario: Service without matching ExternalService shows empty state
+      Given the environment
+        """
+        KUMA_EXTERNALSERVICE_COUNT: 0
+        """
+      And the URL "/meshes/default/service-insights/service-1" responds with
+        """
+          body:
+            serviceType: external
+        """
+
+      When I visit the "/mesh/default/service/service-1" URL
+
+      Then the "[data-testid='no-matching-external-service']" element exists

--- a/src/app/services/sources.ts
+++ b/src/app/services/sources.ts
@@ -52,7 +52,9 @@ export const sources = (api: KumaApi) => {
 
       const { mesh, service } = params
 
-      const { items } = await api.getExternalServicesByServiceInsightName({ mesh, service })
+      const { items } = await api.getAllExternalServicesFromMesh({ mesh }, {
+        tag: [`kuma.io/service:${service}`],
+      })
 
       return items.length > 0 ? items[0] : null
     },

--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -196,18 +196,6 @@ export default class KumaApi extends Api {
     return this.client.get(`/meshes/${mesh}/external-services/${name}`, { params })
   }
 
-  // TODO: Replace this workaround once https://github.com/kumahq/kuma/issues/5908 was implemented with a standard API method.
-  async getExternalServicesByServiceInsightName({ mesh, service }: { mesh: string, service: string }): Promise<PaginatedApiListResponse<ExternalService>> {
-    const response = await this.getAllExternalServicesFromMesh({ mesh }, { name: service })
-    const items = response.items.filter((externalService) => externalService.tags['kuma.io/service'] === service)
-
-    return {
-      items,
-      total: items.length,
-      next: null,
-    }
-  }
-
   getPolicyConnections({ mesh, path, name }: { mesh: string; path: string; name: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<PolicyDataplane>> {
     return this.client.get(`/meshes/${mesh}/${path}/${name}/dataplanes`, { params })
   }

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -58,4 +58,9 @@ export interface DataPlaneOverviewParameters extends PaginationParameters {
 
 export interface ExternalServicesParameters extends PaginationParameters {
   name?: string
+
+  /**
+   * **Example**: `?tag=kuma.io/service:foo&tag=version:v1`
+   */
+  tag?: string | string[]
 }


### PR DESCRIPTION
Removes the workaround for `/meshes/:mesh/external-services` not being filterable by service names (i.e. the name of a `ServiceInsight` object, not necessarily the `ExternalService`).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Note: I’ll leave this open for a while and only merge once the necessary API changes have rolled out everywhere.