### PR TITLE
chore(e2e): general e2e test improvements

### DIFF
--- a/features/application/Loading.feature
+++ b/features/application/Loading.feature
@@ -11,9 +11,6 @@ Feature: application / loading
       """
       KUMA_LATENCY: 1000
       """
-    And the URL "/meshes" responds with
-      """
-      """
     When I load the "/" URL
     Then the "$loading" element exists
     Then the "$loading" element doesn't exist

--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -45,11 +45,6 @@ Feature: application / MainNavigation
       """
       KUMA_MESH_COUNT: 60
       """
-    # This hack is necessary for the "the environment" population above to have an effect.
-    And the URL "/meshes" responds with
-      """
-      """
-
     When I visit the "/" URL
     Then the page title contains "Overview"
     And the "[data-testid='zone-control-planes-status']" element exists

--- a/features/mesh/dataplanes/DetailViewContent.feature
+++ b/features/mesh/dataplanes/DetailViewContent.feature
@@ -25,7 +25,6 @@ Feature: Data Plane Proxies: Detail view content
       KUMA_SUBSCRIPTION_COUNT: 2
       KUMA_MODE: global
       """
-    # TODO: Use exact mocking here. It’s almost impossible to control the test data without exact mocking. For example, I need to set `disconnectTime: ''` just so that I don’t risk a faker-random disconnect time appearing in the last subscription.
     And the URL "/meshes/default/dataplanes+insights/dpp-1-name-of-dataplane" responds with
       """
       body:

--- a/features/mesh/policies/Data.feature
+++ b/features/mesh/policies/Data.feature
@@ -35,9 +35,6 @@ Feature: mesh / policies / data
       """
       KUMA_CIRCUITBREAKER_COUNT: 0
       """
-    And the URL "/meshes/default/circuit-breakers" responds with
-      """
-      """
     When I visit the "/mesh/default/policies/circuit-breakers" URL
     Then the "$state-empty" element exists
 

--- a/features/onboarding/add-new-services-code/Index.feature
+++ b/features/onboarding/add-new-services-code/Index.feature
@@ -12,9 +12,6 @@ Feature: onboarding / dataplanes-overview / index
       """
       KUMA_DATAPLANE_COUNT: 0
       """
-    And the URL "/dataplanes" responds with
-      """
-      """
     When I visit the "/onboarding/add-services-code" URL
     Then the "$loading" element exists
     And the "$is-disconnected" element exists

--- a/features/onboarding/dataplanes-overview/Index.feature
+++ b/features/onboarding/dataplanes-overview/Index.feature
@@ -12,9 +12,6 @@ Feature: onboarding / dataplanes-overview / index
       """
       KUMA_DATAPLANE_COUNT: 0
       """
-    And the URL "/dataplanes" responds with
-      """
-      """
     When I visit the "/onboarding/dataplanes-overview" URL
     Then the "$loading" element exists
     And the "$state-waiting" element exists

--- a/features/onboarding/multi-zone/Index.feature
+++ b/features/onboarding/multi-zone/Index.feature
@@ -12,9 +12,6 @@ Feature: onboarding / multi-zone / index
       """
       KUMA_ZONE_COUNT: 0
       """
-    And the URL "/zones" responds with
-      """
-      """
     When I visit the "/onboarding/multi-zone" URL
     Then the "$loading" element exists
     And the "$zone-connected" element doesn't exist

--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -64,6 +64,10 @@ Feature: Zones: Create Zone flow
     Then the "$egress-input-switch" element doesn't exist
 
   Scenario: The form interactions behave correctly
+    Given the environment
+      """
+      KUMA_SUBSCRIPTION_COUNT: 0
+      """
     When I visit the "/zones/create" URL
     Then the "$create-zone-button" element is disabled
 
@@ -74,12 +78,6 @@ Feature: Zones: Create Zone flow
       """
       body:
         token: spat_595QOxTSreRmrtdh8ValuoeUAzXMfBmRwYU3V35NQvwgLAWIU
-      """
-    And the URL "/zones+insights/test" responds with
-      """
-      body:
-        zoneInsight:
-          subscriptions: []
       """
     And I click the "$create-zone-button" element
     Then the URL "/provision-zone" was requested with
@@ -118,8 +116,7 @@ Feature: Zones: Create Zone flow
         zoneInsight:
           subscriptions:
             - connectTime: '2020-07-28T16:18:09.743141Z'
-              disconnectTime: ~
-              status: {}
+              disconnectTime: !!js/undefined
       """
     Then the "$zone-connected-scanner[data-test-state='success']" element exists
 
@@ -192,8 +189,7 @@ Feature: Zones: Create Zone flow
         zoneInsight:
           subscriptions:
             - connectTime: '2020-07-28T16:18:09.743141Z'
-              disconnectTime: ~
-              status: {}
+              disconnectTime: !!js/undefined
       """
 
     When I visit the "/zones/create" URL
@@ -217,12 +213,6 @@ Feature: Zones: Create Zone flow
       """
       body:
         token: spat_595QOxTSreRmrtdh8ValuoeUAzXMfBmRwYU3V35NQvwgLAWIU
-      """
-    And the URL "/zones+insights/test" responds with
-      """
-      body:
-        zoneInsight:
-          subscriptions: []
       """
 
     When I visit the "/zones/create" URL

--- a/features/zones/Delete.feature
+++ b/features/zones/Delete.feature
@@ -30,9 +30,6 @@ Feature: zones / delete
     Then I click the "$actions-button" element
     And I click the "$delete-button" element
     Then I "type" "zone-1" into the "$confirm-input" element
-    And the URL "/zones/zone-1" responds with
-      """
-      """
     And I click the "$confirm-button" element
     Then the URL "/zones/zone-1" was requested with
       """

--- a/features/zones/DetailViewContent.feature
+++ b/features/zones/DetailViewContent.feature
@@ -14,7 +14,6 @@ Feature: Zones: Detail view content
       """
       KUMA_MODE: global
       """
-
   Scenario: Zone Ingress detail view has expected content
     And the URL "/zoneingresses+insights/zone-ingress-1" responds with
       """
@@ -27,11 +26,9 @@ Feature: Zones: Detail view content
             port: 20555
         zoneIngressInsight:
           subscriptions:
+            - connectTime: 2019-07-28T16:18:09.743141Z
+              disconnectTime: 2019-07-28T16:18:09.743141Z
             - connectTime: 2020-07-28T16:18:09.743141Z
-              disconnectTime: 2020-07-28T16:18:09.743141Z
-              status: {}
-            - connectTime: 2020-07-28T16:18:09.743141Z
-              status: {}
       """
 
     When I visit the "/zones/zone-ingresses/zone-ingress-1" URL
@@ -55,11 +52,9 @@ Feature: Zones: Detail view content
             port: 20555
         zoneEgressInsight:
           subscriptions:
+            - connectTime: 2019-07-28T16:18:09.743141Z
+              disconnectTime: 2019-07-28T16:18:09.743141Z
             - connectTime: 2020-07-28T16:18:09.743141Z
-              disconnectTime: 2020-07-28T16:18:09.743141Z
-              status: {}
-            - connectTime: 2020-07-28T16:18:09.743141Z
-              status: {}
       """
 
     When I visit the "/zones/zone-egresses/zone-egress-1" URL

--- a/features/zones/ListViewContent.feature
+++ b/features/zones/ListViewContent.feature
@@ -10,6 +10,7 @@ Feature: Zones: List view content
     Given the environment
       """
       KUMA_ZONE_COUNT: 3
+      KUMA_SUBSCRIPTION_COUNT: 2
       KUMA_MODE: global
       """
     And the URL "/zones+insights" responds with
@@ -23,23 +24,16 @@ Feature: Zones: List view content
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  config: '{"environment":"universal"}'
-                  status: {}
+                  config: '{"environment":"kubernetes"}'
                   version:
                     kumaCp:
-                      version: 1.0.0-rc2-211-g823fe8ce
-                      gitTag: 1.0.0-rc2-211-g823fe8ce
-                      gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
-                      buildDate: 2021-02-18T13:22:30Z
+                      version: 1.0.0-rc2-211-not-the-version-i-want
                 - connectTime: 2020-07-28T16:18:09.743141Z
+                  disconnectTime: !!js/undefined
                   config: '{"environment":"universal"}'
-                  status: {}
                   version:
                     kumaCp:
                       version: 1.0.0-rc2-211-g823fe8ce
-                      gitTag: 1.0.0-rc2-211-g823fe8ce
-                      gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
-                      buildDate: 2021-02-18T13:22:30Z
           - name: zone-cp-2
             zone:
               enabled: true
@@ -47,24 +41,15 @@ Feature: Zones: List view content
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  config: '{"environment":"kubernetes"}'
-                  status: {}
                   version:
                     kumaCp:
-                      version: 1.0.0-rc2-211-g823fe8ce
-                      gitTag: 1.0.0-rc2-211-g823fe8ce
-                      gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
-                      buildDate: 2021-02-18T13:22:30Z
+                      version: 1.0.0-rc2-211-not-the-version-i-want
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
                   config: '{"environment":"kubernetes"}'
-                  status: {}
                   version:
                     kumaCp:
                       version: 1.0.0-rc2-211-g823fe8ce
-                      gitTag: 1.0.0-rc2-211-g823fe8ce
-                      gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
-                      buildDate: 2021-02-18T13:22:30Z
           - name: zone-cp-3
             zone:
               enabled: false
@@ -72,14 +57,6 @@ Feature: Zones: List view content
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  config: '{"environment":"kubernetes"}'
-                  status: {}
-                  version:
-                    kumaCp:
-                      version: 1.0.0-rc2-211-g823fe8ce
-                      gitTag: 1.0.0-rc2-211-g823fe8ce
-                      gitCommit: 823fe8cef6430a8f75e72a7224eb5a8ab571ec42
-                      buildDate: 2021-02-18T13:22:30Z
       """
 
     When I visit the "/zones/zone-cps" URL
@@ -102,6 +79,7 @@ Feature: Zones: List view content
     Given the environment
       """
       KUMA_ZONEINGRESS_COUNT: 1
+      KUMA_SUBSCRIPTION_COUNT: 2
       KUMA_MODE: global
       """
     And the URL "/zoneingresses+insights" responds with
@@ -115,9 +93,8 @@ Feature: Zones: List view content
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  status: {}
                 - connectTime: 2020-07-28T16:18:09.743141Z
-                  status: {}
+                  disconnectTime: !!js/undefined
           - name: zone-ingress-2
             zoneIngress:
               zone: zone-cp-2
@@ -125,10 +102,8 @@ Feature: Zones: List view content
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  status: {}
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  status: {}
       """
 
     When I visit the "/zones/zone-ingresses" URL
@@ -144,6 +119,7 @@ Feature: Zones: List view content
     Given the environment
       """
       KUMA_ZONEEGRESS_COUNT: 1
+      KUMA_SUBSCRIPTION_COUNT: 2
       KUMA_MODE: global
       """
     And the URL "/zoneegressoverviews" responds with
@@ -157,9 +133,7 @@ Feature: Zones: List view content
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  status: {}
-                - connectTime: 2020-07-28T16:18:09.743141Z
-                  status: {}
+                - disconnectTime: !!js/undefined
           - name: zone-egress-2
             zoneEgress:
               zone: zone-cp-1
@@ -167,10 +141,8 @@ Feature: Zones: List view content
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  status: {}
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  status: {}
       """
 
     When I visit the "/zones/zone-egresses" URL

--- a/features/zones/zone-cps/Item.feature
+++ b/features/zones/zone-cps/Item.feature
@@ -28,7 +28,7 @@ Feature: zones / zone-cps / item
             - connectTime: 2020-07-28T16:18:09.743141Z
               disconnectTime: 2020-07-28T16:18:09.743141Z
             - connectTime: 2020-07-28T16:18:09.743141Z
-              disconnectTime: ~
+              disconnectTime: !!js/undefined
               config: |
                 { "environment": "universal", "dpServer": { "auth": { "type": "dpToken" } } }
       """

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -61,6 +61,25 @@ export class KumaModule {
     return `${this.faker.hacker.noun()}-${deploymentId}-${podId}.${namespace}`
   }
 
+  connection<T>(_: T, i: number, arr: T[]) {
+    const connected = this.faker.date.past()
+    const times: {
+      connectTime: string,
+      disconnectTime?: string
+    } = {
+      connectTime: `${connected.toISOString().slice(0, -1)}${this.faker.number.int({ min: 1000, max: 9999 })}Z`,
+      // connectTime: '2021-07-13T08:41:04.556796688Z',
+    }
+    if ((arr.length > 1 && i !== arr.length - 1) || this.faker.datatype.boolean({ probability: 0.3 })) {
+      times.disconnectTime = `${this.faker.date.between({
+        from: connected,
+        to: new Date(),
+      }).toISOString().slice(0, -1)}${this.faker.number.int({ min: 1000, max: 9999 })}Z`
+      // times.disconnectTime = '2021-02-17T07:33:36.412683Z'
+    }
+    return times
+  }
+
   status() {
     return this.faker.helpers.arrayElement(
       [

--- a/src/test-support/mocks/src/dataplanes+insights.ts
+++ b/src/test-support/mocks/src/dataplanes+insights.ts
@@ -36,12 +36,16 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             },
           },
           dataplaneInsight: {
-            subscriptions: Array.from({ length: subscriptionCount }).map((_, i) => {
+            subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
               return {
                 id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
                 controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
                 connectTime: '2021-02-17T07:33:36.412683Z',
-                disconnectTime: i < (subscriptionCount - 1) ? '2021-02-17T07:33:36.412683Z' : undefined,
+                ...(i === (arr.length - 1) || fake.datatype.boolean()
+                  ? {
+                    disconnectTime: '2021-02-17T07:33:36.412683Z',
+                  }
+                  : {}),
                 status: {
                   lastUpdateTime: '2021-02-17T10:48:03.638434Z',
                   total: {

--- a/src/test-support/mocks/src/dataplanes+insights.ts
+++ b/src/test-support/mocks/src/dataplanes+insights.ts
@@ -36,16 +36,11 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             },
           },
           dataplaneInsight: {
-            subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+            subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
               return {
                 id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
                 controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
-                connectTime: '2021-02-17T07:33:36.412683Z',
-                ...(i === (arr.length - 1) || fake.datatype.boolean()
-                  ? {
-                    disconnectTime: '2021-02-17T07:33:36.412683Z',
-                  }
-                  : {}),
+                ...fake.kuma.connection(item, i, arr),
                 status: {
                   lastUpdateTime: '2021-02-17T10:48:03.638434Z',
                   total: {

--- a/src/test-support/mocks/src/meshes/_/dataplanes+insights.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes+insights.ts
@@ -66,16 +66,11 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             },
           },
           dataplaneInsight: {
-            subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+            subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
               return {
                 id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
                 controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
-                connectTime: '2021-02-17T07:33:36.412683Z',
-                ...(i === (arr.length - 1) || fake.datatype.boolean()
-                  ? {
-                    disconnectTime: '2021-02-17T07:33:36.412683Z',
-                  }
-                  : {}),
+                ...fake.kuma.connection(item, i, arr),
                 status: {
                   lastUpdateTime: '2021-02-17T10:48:03.638434Z',
                   total: {

--- a/src/test-support/mocks/src/meshes/_/dataplanes+insights.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes+insights.ts
@@ -66,12 +66,16 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             },
           },
           dataplaneInsight: {
-            subscriptions: Array.from({ length: subscriptionCount }).map((_, i) => {
+            subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
               return {
                 id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
                 controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
                 connectTime: '2021-02-17T07:33:36.412683Z',
-                disconnectTime: i < (subscriptionCount - 1) ? '2021-02-17T07:33:36.412683Z' : undefined,
+                ...(i === (arr.length - 1) || fake.datatype.boolean()
+                  ? {
+                    disconnectTime: '2021-02-17T07:33:36.412683Z',
+                  }
+                  : {}),
                 status: {
                   lastUpdateTime: '2021-02-17T10:48:03.638434Z',
                   total: {

--- a/src/test-support/mocks/src/meshes/_/dataplanes+insights/_.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes+insights/_.ts
@@ -44,12 +44,16 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
         },
       },
       dataplaneInsight: {
-        subscriptions: Array.from({ length: subscriptionCount }).map((_, i) => {
+        subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
           return {
             id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
             controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
             connectTime: '2021-02-17T07:33:36.412683Z',
-            disconnectTime: i < (subscriptionCount - 1) ? '2021-02-17T07:33:36.412683Z' : undefined,
+            ...(i === (arr.length - 1) || fake.datatype.boolean()
+              ? {
+                disconnectTime: '2021-02-17T07:33:36.412683Z',
+              }
+              : {}),
             status: {
               lastUpdateTime: '2021-02-17T10:48:03.638434Z',
               total: {

--- a/src/test-support/mocks/src/meshes/_/dataplanes+insights/_.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes+insights/_.ts
@@ -44,16 +44,11 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
         },
       },
       dataplaneInsight: {
-        subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+        subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
           return {
             id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
             controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
-            connectTime: '2021-02-17T07:33:36.412683Z',
-            ...(i === (arr.length - 1) || fake.datatype.boolean()
-              ? {
-                disconnectTime: '2021-02-17T07:33:36.412683Z',
-              }
-              : {}),
+            ...fake.kuma.connection(item, i, arr),
             status: {
               lastUpdateTime: '2021-02-17T10:48:03.638434Z',
               total: {

--- a/src/test-support/mocks/src/zoneegressoverviews.ts
+++ b/src/test-support/mocks/src/zoneegressoverviews.ts
@@ -5,6 +5,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     req,
     '/zoneegressoverviews',
   )
+  const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
   return {
     headers: {},
     body: {
@@ -30,30 +31,34 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             },
           },
           zoneEgressInsight: {
-            subscriptions: [
-              {
-                id: 'cc2743b5-43e0-45b6-be88-956ea91a4aad',
-                controlPlaneInstanceId: 'kuma-control-plane-84f5589874-nmspq-0867',
+            subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+              return {
+                id: fake.string.uuid(),
+                controlPlaneInstanceId: fake.hacker.noun(),
                 connectTime: '2021-07-13T08:41:04.556796688Z',
-                disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
+                ...(i === (arr.length - 1) || fake.datatype.boolean()
+                  ? {
+                    disconnectTime: '2021-02-17T07:33:36.412683Z',
+                  }
+                  : {}),
                 generation: 409,
                 status: {
                   lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
                   total: {
-                    responsesSent: '8',
-                    responsesAcknowledged: '9',
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
                   },
                   cds: {
-                    responsesSent: '3',
-                    responsesAcknowledged: '3',
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
                   },
                   eds: {
-                    responsesSent: '2',
-                    responsesAcknowledged: '3',
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
                   },
                   lds: {
-                    responsesSent: '3',
-                    responsesAcknowledged: '3',
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
                   },
                   rds: {},
                 },
@@ -69,8 +74,9 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                     build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
                   },
                 },
-              },
-            ],
+
+              }
+            }),
           },
         }
       }),

--- a/src/test-support/mocks/src/zoneegressoverviews.ts
+++ b/src/test-support/mocks/src/zoneegressoverviews.ts
@@ -31,16 +31,11 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             },
           },
           zoneEgressInsight: {
-            subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+            subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
               return {
                 id: fake.string.uuid(),
                 controlPlaneInstanceId: fake.hacker.noun(),
-                connectTime: '2021-07-13T08:41:04.556796688Z',
-                ...(i === (arr.length - 1) || fake.datatype.boolean()
-                  ? {
-                    disconnectTime: '2021-02-17T07:33:36.412683Z',
-                  }
-                  : {}),
+                ...fake.kuma.connection(item, i, arr),
                 generation: 409,
                 status: {
                   lastUpdateTime: '2021-07-13T09:03:11.614941842Z',

--- a/src/test-support/mocks/src/zoneegressoverviews/_.ts
+++ b/src/test-support/mocks/src/zoneegressoverviews/_.ts
@@ -1,7 +1,8 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
-export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
+export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => {
   const zoneEgressName = req.params.name
   const zoneName = fake.hacker.noun()
+  const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
 
   return {
     headers: {},
@@ -21,30 +22,34 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
         },
       },
       zoneEgressInsight: {
-        subscriptions: [
-          {
-            id: 'cc2743b5-43e0-45b6-be88-956ea91a4aad',
-            controlPlaneInstanceId: 'kuma-control-plane-84f5589874-nmspq-0867',
+        subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+          return {
+            id: fake.string.uuid(),
+            controlPlaneInstanceId: fake.hacker.noun(),
             connectTime: '2021-07-13T08:41:04.556796688Z',
-            disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
+            ...(i === (arr.length - 1) || fake.datatype.boolean()
+              ? {
+                disconnectTime: '2021-02-17T07:33:36.412683Z',
+              }
+              : {}),
             generation: 409,
             status: {
               lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
               total: {
-                responsesSent: '8',
-                responsesAcknowledged: '9',
+                responsesSent: `${fake.number.int(30)}`,
+                responsesAcknowledged: `${fake.number.int(30)}`,
               },
               cds: {
-                responsesSent: '3',
-                responsesAcknowledged: '3',
+                responsesSent: `${fake.number.int(30)}`,
+                responsesAcknowledged: `${fake.number.int(30)}`,
               },
               eds: {
-                responsesSent: '2',
-                responsesAcknowledged: '3',
+                responsesSent: `${fake.number.int(30)}`,
+                responsesAcknowledged: `${fake.number.int(30)}`,
               },
               lds: {
-                responsesSent: '3',
-                responsesAcknowledged: '3',
+                responsesSent: `${fake.number.int(30)}`,
+                responsesAcknowledged: `${fake.number.int(30)}`,
               },
               rds: {},
             },
@@ -60,8 +65,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
                 build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
               },
             },
-          },
-        ],
+
+          }
+        }),
       },
     },
   }

--- a/src/test-support/mocks/src/zoneegressoverviews/_.ts
+++ b/src/test-support/mocks/src/zoneegressoverviews/_.ts
@@ -22,16 +22,11 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
         },
       },
       zoneEgressInsight: {
-        subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+        subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
           return {
             id: fake.string.uuid(),
             controlPlaneInstanceId: fake.hacker.noun(),
-            connectTime: '2021-07-13T08:41:04.556796688Z',
-            ...(i === (arr.length - 1) || fake.datatype.boolean()
-              ? {
-                disconnectTime: '2021-02-17T07:33:36.412683Z',
-              }
-              : {}),
+            ...fake.kuma.connection(item, i, arr),
             generation: 409,
             status: {
               lastUpdateTime: '2021-07-13T09:03:11.614941842Z',

--- a/src/test-support/mocks/src/zoneingresses+insights.ts
+++ b/src/test-support/mocks/src/zoneingresses+insights.ts
@@ -5,6 +5,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     req,
     '/zoneingresses+insights',
   )
+  const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
 
   return {
     headers: {},
@@ -54,30 +55,34 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             ],
           },
           zoneIngressInsight: {
-            subscriptions: [
-              {
-                id: 'cc2743b5-43e0-45b6-be88-956ea91a4aad',
-                controlPlaneInstanceId: 'kuma-control-plane-84f5589874-nmspq-0867',
+            subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+              return {
+                id: fake.string.uuid(),
+                controlPlaneInstanceId: fake.hacker.noun(),
                 connectTime: '2021-07-13T08:41:04.556796688Z',
-                disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
+                ...(i === (arr.length - 1) || fake.datatype.boolean()
+                  ? {
+                    disconnectTime: '2021-02-17T07:33:36.412683Z',
+                  }
+                  : {}),
                 generation: 409,
                 status: {
                   lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
                   total: {
-                    responsesSent: '8',
-                    responsesAcknowledged: '9',
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
                   },
                   cds: {
-                    responsesSent: '3',
-                    responsesAcknowledged: '3',
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
                   },
                   eds: {
-                    responsesSent: '2',
-                    responsesAcknowledged: '3',
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
                   },
                   lds: {
-                    responsesSent: '3',
-                    responsesAcknowledged: '3',
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
                   },
                   rds: {},
                 },
@@ -93,8 +98,9 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                     build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
                   },
                 },
-              },
-            ],
+
+              }
+            }),
           },
         }
       }),

--- a/src/test-support/mocks/src/zoneingresses+insights.ts
+++ b/src/test-support/mocks/src/zoneingresses+insights.ts
@@ -55,16 +55,11 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             ],
           },
           zoneIngressInsight: {
-            subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+            subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
               return {
                 id: fake.string.uuid(),
                 controlPlaneInstanceId: fake.hacker.noun(),
-                connectTime: '2021-07-13T08:41:04.556796688Z',
-                ...(i === (arr.length - 1) || fake.datatype.boolean()
-                  ? {
-                    disconnectTime: '2021-02-17T07:33:36.412683Z',
-                  }
-                  : {}),
+                ...fake.kuma.connection(item, i, arr),
                 generation: 409,
                 status: {
                   lastUpdateTime: '2021-07-13T09:03:11.614941842Z',

--- a/src/test-support/mocks/src/zoneingresses+insights/_.ts
+++ b/src/test-support/mocks/src/zoneingresses+insights/_.ts
@@ -45,16 +45,11 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
         ],
       },
       zoneIngressInsight: {
-        subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+        subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
           return {
             id: fake.string.uuid(),
             controlPlaneInstanceId: fake.hacker.noun(),
-            connectTime: '2021-07-13T08:41:04.556796688Z',
-            ...(i === (arr.length - 1) || fake.datatype.boolean()
-              ? {
-                disconnectTime: '2021-02-17T07:33:36.412683Z',
-              }
-              : {}),
+            ...fake.kuma.connection(item, i, arr),
             generation: 409,
             status: {
               lastUpdateTime: '2021-07-13T09:03:11.614941842Z',

--- a/src/test-support/mocks/src/zoneingresses+insights/_.ts
+++ b/src/test-support/mocks/src/zoneingresses+insights/_.ts
@@ -1,8 +1,9 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
-export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
+export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => {
   const zoneIngressName = req.params.name
   const zoneName = fake.hacker.noun()
 
+  const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
   return {
     headers: {},
     body: {
@@ -44,30 +45,34 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
         ],
       },
       zoneIngressInsight: {
-        subscriptions: [
-          {
-            id: 'cc2743b5-43e0-45b6-be88-956ea91a4aad',
-            controlPlaneInstanceId: 'kuma-control-plane-84f5589874-nmspq-0867',
+        subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+          return {
+            id: fake.string.uuid(),
+            controlPlaneInstanceId: fake.hacker.noun(),
             connectTime: '2021-07-13T08:41:04.556796688Z',
-            disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
+            ...(i === (arr.length - 1) || fake.datatype.boolean()
+              ? {
+                disconnectTime: '2021-02-17T07:33:36.412683Z',
+              }
+              : {}),
             generation: 409,
             status: {
               lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
               total: {
-                responsesSent: '8',
-                responsesAcknowledged: '9',
+                responsesSent: `${fake.number.int(30)}`,
+                responsesAcknowledged: `${fake.number.int(30)}`,
               },
               cds: {
-                responsesSent: '3',
-                responsesAcknowledged: '3',
+                responsesSent: `${fake.number.int(30)}`,
+                responsesAcknowledged: `${fake.number.int(30)}`,
               },
               eds: {
-                responsesSent: '2',
-                responsesAcknowledged: '3',
+                responsesSent: `${fake.number.int(30)}`,
+                responsesAcknowledged: `${fake.number.int(30)}`,
               },
               lds: {
-                responsesSent: '3',
-                responsesAcknowledged: '3',
+                responsesSent: `${fake.number.int(30)}`,
+                responsesAcknowledged: `${fake.number.int(30)}`,
               },
               rds: {},
             },
@@ -83,8 +88,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
                 build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
               },
             },
-          },
-        ],
+
+          }
+        }),
       },
     },
   }

--- a/src/test-support/mocks/src/zones+insights.ts
+++ b/src/test-support/mocks/src/zones+insights.ts
@@ -5,6 +5,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     req,
     '/zones+insights',
   )
+  const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 0, max: 10 })}`))
 
   return {
     headers: {},
@@ -13,7 +14,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
         const name = `${fake.hacker.noun()}-${id}`
-        const shouldHaveZoneInsight = fake.datatype.boolean()
+        const shouldHaveZoneInsight = subscriptionCount === 0 || fake.datatype.boolean()
 
         return {
           type: 'ZoneOverview',
@@ -25,75 +26,79 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
           },
           ...(shouldHaveZoneInsight && {
             zoneInsight: {
-              subscriptions: [
-                {
-                  config: '{"apiServer":{"auth":{"allowFromLocalhost":true,"clientCertsDir":""},"corsAllowedDomains":[".*"],"http":{"enabled":true,"interface":"0.0.0.0","port":6681},"https":{"enabled":true,"interface":"0.0.0.0","port":6682,"tlsCertFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.crt","tlsKeyFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.key"},"readOnly":false},"bootstrapServer":{"apiVersion":"v3","params":{"adminAccessLogPath":"/dev/null","adminAddress":"127.0.0.1","adminPort":0,"xdsConnectTimeout":"1s","xdsHost":"","xdsPort":5678}},"defaults":{"skipMeshCreation":false},"diagnostics":{"debugEndpoints":false,"serverPort":6680},"dnsServer":{"CIDR":"240.0.0.0/4","domain":"mesh","port":5653},"dpServer":{"auth":{"type":"dpToken"},"hds":{"checkDefaults":{"healthyThreshold":1,"interval":"1s","noTrafficInterval":"1s","timeout":"2s","unhealthyThreshold":1},"enabled":true,"interval":"5s","refreshInterval":"10s"},"port":5678,"tlsCertFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.crt","tlsKeyFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.key"},"environment":"universal","general":{"dnsCacheTTL":"10s","tlsCertFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.crt","tlsKeyFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.key","workDir":"/Users/tomasz.wylezek/.kuma"},"guiServer":{"apiServerUrl":""},"metrics":{"dataplane":{"enabled":true,"idleTimeout":"5m0s","subscriptionLimit":2},"mesh":{"maxResyncTimeout":"20s","minResyncTimeout":"1s"},"zone":{"enabled":true,"idleTimeout":"5m0s","subscriptionLimit":10}},"mode":"zone","monitoringAssignmentServer":{"apiVersions":["v1"],"assignmentRefreshInterval":"1s","defaultFetchTimeout":"30s","grpcPort":0,"port":5676},"multizone":{"global":{"kds":{"grpcPort":5685,"maxMsgSize":10485760,"refreshInterval":"1s","tlsCertFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.crt","tlsKeyFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.key","zoneInsightFlushInterval":"10s"}},"zone":{"globalAddress":"grpcs://localhost:5685","kds":{"maxMsgSize":10485760,"refreshInterval":"1s","rootCaFile":""},"name":"cluster-1"}},"reports":{"enabled":true},"runtime":{"kubernetes":{"admissionServer":{"address":"","certDir":"","port":5443},"controlPlaneServiceName":"kuma-control-plane","injector":{"builtinDNS":{"enabled":true,"port":15053},"caCertFile":"","cniEnabled":false,"exceptions":{"labels":{"openshift.io/build.name":"*","openshift.io/deployer-pod-for.name":"*"}},"initContainer":{"image":"kuma/kuma-init:latest"},"sidecarContainer":{"adminPort":9901,"drainTime":"30s","envVars":{},"gid":5678,"image":"kuma/kuma-dp:latest","livenessProbe":{"failureThreshold":12,"initialDelaySeconds":60,"periodSeconds":5,"timeoutSeconds":3},"readinessProbe":{"failureThreshold":12,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3},"redirectPortInbound":15006,"redirectPortInboundV6":15010,"redirectPortOutbound":15001,"resources":{"limits":{"cpu":"1000m","memory":"512Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"uid":5678},"sidecarTraffic":{"excludeInboundPorts":[],"excludeOutboundPorts":[]},"virtualProbesEnabled":true,"virtualProbesPort":9000},"marshalingCacheExpirationTime":"5m0s"},"universal":{"dataplaneCleanupAge":"72h0m0s"}},"store":{"cache":{"enabled":true,"expirationTime":"1s"},"kubernetes":{"systemNamespace":"kuma-system"},"postgres":{"connectionTimeout":5,"dbName":"kuma","host":"127.0.0.1","maxIdleConnections":0,"maxOpenConnections":0,"maxReconnectInterval":"1m0s","minReconnectInterval":"10s","password":"*****","port":15432,"tls":{"caPath":"","certPath":"","keyPath":"","mode":"disable"},"user":"kuma"},"type":"memory","upsert":{"conflictRetryBaseBackoff":"100ms","conflictRetryMaxTimes":5}},"xdsServer":{"dataplaneConfigurationRefreshInterval":"1s","dataplaneStatusFlushInterval":"10s","nackBackoff":"5s"}}',
-                  id: 'b21265cf-f856-4214-ad1b-42539c4b20a9',
-                  globalInstanceId: 'foobar',
-                  connectTime: '2020-07-28T16:08:09.743141Z',
-                  disconnectTime: fake.datatype.boolean() ? '2021-02-17T07:33:36.412683Z' : undefined,
+              subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+                return {
+                  config: fake.kuma.subscriptionConfig(),
+                  id: fake.string.uuid(),
+                  globalInstanceId: fake.hacker.noun(),
+                  connectTime: '2020-07-28T16:18:09.743141Z',
+                  ...(i === (arr.length - 1) || fake.datatype.boolean()
+                    ? {
+                      disconnectTime: '2021-02-17T07:33:36.412683Z',
+                    }
+                    : {}),
                   status: {
                     lastUpdateTime: '2021-02-19T07:06:16.384057Z',
                     total: {
-                      responsesSent: '14',
-                      responsesAcknowledged: '14',
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
                     },
                     stat: {
                       CircuitBreaker: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       Config: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       Dataplane: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       ExternalService: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       FaultInjection: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       HealthCheck: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       Mesh: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       ProxyTemplate: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       Retry: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       Secret: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       TrafficLog: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       TrafficPermission: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       TrafficRoute: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                       TrafficTrace: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
                       },
                     },
                   },
@@ -101,92 +106,13 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                     kumaCp: {
                       version: '1.0.0-rc2-211-g823fe8ce',
                       gitTag: '1.0.0-rc2-211-g823fe8ce',
-                      gitCommit: '823fe8cef6430a8f75e72a7224eb5a8ab571ec42',
-                      buildDate: '2021-02-18T13:22:30Z',
-                    },
-                  },
-                },
-                {
-                  config: '{"apiServer":{"auth":{"allowFromLocalhost":true,"clientCertsDir":""},"corsAllowedDomains":[".*"],"http":{"enabled":true,"interface":"0.0.0.0","port":6681},"https":{"enabled":true,"interface":"0.0.0.0","port":6682,"tlsCertFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.crt","tlsKeyFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.key"},"readOnly":false},"bootstrapServer":{"apiVersion":"v3","params":{"adminAccessLogPath":"/dev/null","adminAddress":"127.0.0.1","adminPort":0,"xdsConnectTimeout":"1s","xdsHost":"","xdsPort":5678}},"defaults":{"skipMeshCreation":false},"diagnostics":{"debugEndpoints":false,"serverPort":6680},"dnsServer":{"CIDR":"240.0.0.0/4","domain":"mesh","port":5653},"dpServer":{"auth":{"type":"dpToken"},"hds":{"checkDefaults":{"healthyThreshold":1,"interval":"1s","noTrafficInterval":"1s","timeout":"2s","unhealthyThreshold":1},"enabled":true,"interval":"5s","refreshInterval":"10s"},"port":5678,"tlsCertFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.crt","tlsKeyFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.key"},"environment":"universal","general":{"dnsCacheTTL":"10s","tlsCertFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.crt","tlsKeyFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.key","workDir":"/Users/tomasz.wylezek/.kuma"},"guiServer":{"apiServerUrl":""},"metrics":{"dataplane":{"enabled":true,"idleTimeout":"5m0s","subscriptionLimit":2},"mesh":{"maxResyncTimeout":"20s","minResyncTimeout":"1s"},"zone":{"enabled":true,"idleTimeout":"5m0s","subscriptionLimit":10}},"mode":"zone","monitoringAssignmentServer":{"apiVersions":["v1"],"assignmentRefreshInterval":"1s","defaultFetchTimeout":"30s","grpcPort":0,"port":5676},"multizone":{"global":{"kds":{"grpcPort":5685,"maxMsgSize":10485760,"refreshInterval":"1s","tlsCertFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.crt","tlsKeyFile":"/Users/tomasz.wylezek/.kuma/kuma-cp.key","zoneInsightFlushInterval":"10s"}},"zone":{"globalAddress":"grpcs://localhost:5685","kds":{"maxMsgSize":10485760,"refreshInterval":"1s","rootCaFile":""},"name":"cluster-1"}},"reports":{"enabled":true},"runtime":{"kubernetes":{"admissionServer":{"address":"","certDir":"","port":5443},"controlPlaneServiceName":"kuma-control-plane","injector":{"builtinDNS":{"enabled":true,"port":15053},"caCertFile":"","cniEnabled":false,"exceptions":{"labels":{"openshift.io/build.name":"*","openshift.io/deployer-pod-for.name":"*"}},"initContainer":{"image":"kuma/kuma-init:latest"},"sidecarContainer":{"adminPort":9901,"drainTime":"30s","envVars":{},"gid":5678,"image":"kuma/kuma-dp:latest","livenessProbe":{"failureThreshold":12,"initialDelaySeconds":60,"periodSeconds":5,"timeoutSeconds":3},"readinessProbe":{"failureThreshold":12,"initialDelaySeconds":1,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":3},"redirectPortInbound":15006,"redirectPortInboundV6":15010,"redirectPortOutbound":15001,"resources":{"limits":{"cpu":"1000m","memory":"512Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"uid":5678},"sidecarTraffic":{"excludeInboundPorts":[],"excludeOutboundPorts":[]},"virtualProbesEnabled":true,"virtualProbesPort":9000},"marshalingCacheExpirationTime":"5m0s"},"universal":{"dataplaneCleanupAge":"72h0m0s"}},"store":{"cache":{"enabled":true,"expirationTime":"1s"},"kubernetes":{"systemNamespace":"kuma-system"},"postgres":{"connectionTimeout":5,"dbName":"kuma","host":"127.0.0.1","maxIdleConnections":0,"maxOpenConnections":0,"maxReconnectInterval":"1m0s","minReconnectInterval":"10s","password":"*****","port":15432,"tls":{"caPath":"","certPath":"","keyPath":"","mode":"disable"},"user":"kuma"},"type":"memory","upsert":{"conflictRetryBaseBackoff":"100ms","conflictRetryMaxTimes":5}},"xdsServer":{"dataplaneConfigurationRefreshInterval":"1s","dataplaneStatusFlushInterval":"10s","nackBackoff":"5s"}}',
-                  id: '3d3b7a11-e0f9-4f70-8cc9-2594318488d3',
-                  globalInstanceId: 'MacBook-Pro-Bartlomiej.local-9e52',
-                  connectTime: '2021-02-19T07:07:15.535286Z',
-                  status: {
-                    lastUpdateTime: '2021-02-19T07:07:15.537654Z',
-                    total: {
-                      responsesSent: '14',
-                      responsesAcknowledged: '14',
-                    },
-                    stat: {
-                      CircuitBreaker: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      Config: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      Dataplane: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      ExternalService: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      FaultInjection: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      HealthCheck: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      Mesh: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      ProxyTemplate: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      Retry: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      Secret: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      TrafficLog: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      TrafficPermission: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      TrafficRoute: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                      TrafficTrace: {
-                        responsesSent: '1',
-                        responsesAcknowledged: '1',
-                      },
-                    },
-                  },
-                  version: {
-                    kumaCp: {
-                      version: '1.0.0-rc2-211-g823fe8ce',
-                      gitTag: '1.0.0-rc2-211-g823fe8ce',
-                      gitCommit: '823fe8cef6430a8f75e72a7224eb5a8ab571ec42',
+                      gitCommit: fake.git.commitSha(),
                       buildDate: '2021-02-18T13:22:30Z',
                       kumaCpGlobalCompatible: fake.datatype.boolean(),
                     },
                   },
-                },
-              ],
+                }
+              }),
             },
           }),
         }

--- a/src/test-support/mocks/src/zones+insights.ts
+++ b/src/test-support/mocks/src/zones+insights.ts
@@ -26,17 +26,12 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
           },
           ...(shouldHaveZoneInsight && {
             zoneInsight: {
-              subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+              subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
                 return {
                   config: fake.kuma.subscriptionConfig(),
                   id: fake.string.uuid(),
                   globalInstanceId: fake.hacker.noun(),
-                  connectTime: '2020-07-28T16:18:09.743141Z',
-                  ...(i === (arr.length - 1) || fake.datatype.boolean()
-                    ? {
-                      disconnectTime: '2021-02-17T07:33:36.412683Z',
-                    }
-                    : {}),
+                  ...fake.kuma.connection(item, i, arr),
                   status: {
                     lastUpdateTime: '2021-02-19T07:06:16.384057Z',
                     total: {

--- a/src/test-support/mocks/src/zones+insights/_.ts
+++ b/src/test-support/mocks/src/zones+insights/_.ts
@@ -13,13 +13,17 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
         enabled: fake.datatype.boolean(),
       },
       zoneInsight: {
-        subscriptions: Array.from({ length: subscriptionCount }).map((_, i) => {
+        subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
           return {
             config: fake.kuma.subscriptionConfig(),
             id: fake.string.uuid(),
             globalInstanceId: fake.hacker.noun(),
             connectTime: '2020-07-28T16:18:09.743141Z',
-            disconnectTime: i < (subscriptionCount - 1) ? '2021-02-17T07:33:36.412683Z' : undefined,
+            ...(i === (arr.length - 1) || fake.datatype.boolean()
+              ? {
+                disconnectTime: '2021-02-17T07:33:36.412683Z',
+              }
+              : {}),
             status: {
               lastUpdateTime: '2021-02-19T07:06:16.384057Z',
               total: {

--- a/src/test-support/mocks/src/zones+insights/_.ts
+++ b/src/test-support/mocks/src/zones+insights/_.ts
@@ -13,17 +13,12 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
         enabled: fake.datatype.boolean(),
       },
       zoneInsight: {
-        subscriptions: Array.from({ length: subscriptionCount }).map((_, i, arr) => {
+        subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
           return {
             config: fake.kuma.subscriptionConfig(),
             id: fake.string.uuid(),
             globalInstanceId: fake.hacker.noun(),
-            connectTime: '2020-07-28T16:18:09.743141Z',
-            ...(i === (arr.length - 1) || fake.datatype.boolean()
-              ? {
-                disconnectTime: '2021-02-17T07:33:36.412683Z',
-              }
-              : {}),
+            ...fake.kuma.connection(item, i, arr),
             status: {
               lastUpdateTime: '2021-02-19T07:06:16.384057Z',
               total: {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -545,7 +545,7 @@ export interface ZoneEgress extends MeshEntity {
 
 export interface ZoneEgressOverview extends MeshEntity {
   type: 'ZoneEgressOverview'
-  zoneEgress?: {
+  zoneEgress: {
     zone?: string
     networking?: ZoneEgressNetworking
   }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -549,9 +549,7 @@ export interface ZoneEgressOverview extends MeshEntity {
     zone?: string
     networking?: ZoneEgressNetworking
   }
-  zoneEgressInsight?: {
-    subscriptions: DiscoverySubscription[]
-  }
+  zoneEgressInsight: any
 }
 
 export interface Backend {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -545,11 +545,13 @@ export interface ZoneEgress extends MeshEntity {
 
 export interface ZoneEgressOverview extends MeshEntity {
   type: 'ZoneEgressOverview'
-  zoneEgress: {
+  zoneEgress?: {
     zone?: string
     networking?: ZoneEgressNetworking
   }
-  zoneEgressInsight: any
+  zoneEgressInsight?: {
+    subscriptions: DiscoverySubscription[]
+  }
 }
 
 export interface Backend {


### PR DESCRIPTION
This began as a clean up of e2e test code following improvements in:

- https://github.com/kumahq/kuma-gui/pull/1482
- https://github.com/kumahq/kuma-gui/pull/1417
- https://github.com/kumahq/kuma-gui/pull/1452

I also noticed some areas mainly around subscription counts that felt a little strange, and began to tweak those a little, and then as I delved deeper I started to go down a bit of a rabbit hole:

- I started to make all mock instances of subscriptions used the `KUMA_SUBSCRIPTION_COUNT` variable.
- Started making all mock instances of subscriptions as consistent as possible, and decided to make a `fake.kuma.connection` for providing `connectTime`/`disconnectTime`, which I _think_ is more realistic, would be good for a second pair of eyes on that. The intention is that only the last subscription possibly won't have a disconnectTime and it will always be after the connectTime. I just padded out the difference in golang date formats with a random number.
- The above led me to looking at our types around subscriptions and then zone overview type things, and this is where I felt like I was going too far into a rabbit hole for this PR. For example, one of the type corrections I made (`zoneEgress` here https://github.com/kumahq/kuma-gui/pull/1558/commits/14dd7105ecc328ae0c0a9635074f5e8c845854c2 seems to be possibly `undefined`) started breaking things deeper in the app, so if this type is incorrect there are more potential undefined access bugs to be had. Instead of fixing things here I undid that change (https://github.com/kumahq/kuma-gui/pull/1558/commits/db2cb1f7a3def1359ab2bf15f5697fb9c78f9abc) for a future piece of work.