### PR TITLE
fix(e2e): Removes hardcoded timeout from visit

### DIFF
--- a/cypress/support/step_definitions/visit.ts
+++ b/cypress/support/step_definitions/visit.ts
@@ -27,7 +27,7 @@ When('I visit the {string} URL', function (path: string) {
     })
   })
   // currently use this to denote "the page has initially rendered"
-  cy.get('.app-main-content', { timeout: 10000 }).should('be.visible')
+  cy.get('.app-main-content').should('be.visible')
 })
 When('I load the {string} URL', function (path: string) {
   cy.visit(`${path}`)


### PR DESCRIPTION
All "positive" assertions should use the default timeout for the project