### PR TITLE
refactor: switches to @kong/icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@kong-ui-public/i18n": "0.8.4",
-    "@kong/icons": "1.7.2",
+    "@kong/icons": "1.7.3",
     "@kong/kongponents": "8.123.8",
     "brandi": "5.0.0",
     "chart.js": "4.4.0",

--- a/src/app/AppHeader.vue
+++ b/src/app/AppHeader.vue
@@ -41,11 +41,13 @@
         {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
       </p>
 
-      <KDropdownMenu
-        icon="help"
-        button-appearance="outline"
-        :kpop-attributes="{ placement: 'bottomEnd' }"
-      >
+      <KDropdownMenu :kpop-attributes="{ placement: 'bottomEnd' }">
+        <KButton appearance="outline">
+          <HelpIcon :size="KUI_ICON_SIZE_30" />
+
+          <span class="visually-hidden">Help</span>
+        </KButton>
+
         <template #items>
           <KDropdownItem>
             <a
@@ -67,20 +69,17 @@
           </KDropdownItem>
         </template>
       </KDropdownMenu>
+
       <KButton
         :to="{ name: 'diagnostics' }"
-        icon="gearFilled"
         button-appearance="btn-link"
         data-testid="nav-item-diagnostics"
       >
-        <template #icon>
-          <KIcon
-            icon="gearFilled"
-            :size="KUI_ICON_SIZE_30"
-            color="currentColor"
-            hide-title
-          />
-        </template>
+        <CogIcon
+          :size="KUI_ICON_SIZE_30"
+          hide-title
+        />
+
         <span class="visually-hidden">Diagnostics</span>
       </KButton>
     </div>
@@ -89,11 +88,11 @@
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { CogIcon, HelpIcon } from '@kong/icons'
 import {
   KButton,
   KDropdownMenu,
   KDropdownItem,
-  KIcon,
   KPop,
 } from '@kong/kongponents'
 

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -58,9 +58,10 @@
           <KButton
             v-else
             appearance="primary"
-            icon="plus"
             :to="props.emptyStateCtaTo"
           >
+            <AddIcon :size="KUI_ICON_SIZE_30" />
+
             {{ props.emptyStateCtaText }}
           </KButton>
         </template>
@@ -92,6 +93,8 @@
 </template>
 
 <script lang="ts" setup>
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { AddIcon } from '@kong/icons'
 import { KButton, KTable, TableHeader } from '@kong/kongponents'
 import { useSlots, ref, watch, computed } from 'vue'
 import { RouteLocationRaw } from 'vue-router'

--- a/src/app/application/components/app-view/AppView.vue
+++ b/src/app/application/components/app-view/AppView.vue
@@ -20,10 +20,8 @@
         v-if="slots.title"
         class="app-view-title-bar"
       >
-        <KIcon
-          v-if="props.fullscreen"
-          icon="kong"
-        />
+        <KongIcon v-if="props.fullscreen" />
+
         <slot
           name="title"
         />
@@ -49,10 +47,8 @@
         v-if="slots.title"
         class="app-view-title-bar"
       >
-        <KIcon
-          v-if="props.fullscreen"
-          icon="kong"
-        />
+        <KongIcon v-if="props.fullscreen" />
+
         <slot
           name="title"
         />
@@ -84,11 +80,8 @@
   </template>
 </template>
 <script lang="ts" setup>
-import {
-  KBreadcrumbs,
-  BreadcrumbItem,
-  KIcon,
-} from '@kong/kongponents'
+import { KongIcon } from '@kong/icons'
+import { KBreadcrumbs, BreadcrumbItem } from '@kong/kongponents'
 import { provide, inject, PropType, watch, ref, onBeforeUnmount, useSlots } from 'vue'
 
 import { useMainView } from '@/components'

--- a/src/app/common/DocumentationLink.vue
+++ b/src/app/common/DocumentationLink.vue
@@ -4,9 +4,7 @@
     :href="props.href"
     target="_blank"
   >
-    <KIcon
-      icon="book"
-      color="currentColor"
+    <BookIcon
       :size="KUI_ICON_SIZE_30"
       :title="t('common.documentation')"
     />
@@ -17,6 +15,7 @@
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { BookIcon } from '@kong/icons'
 
 import { useI18n } from '@/utilities'
 

--- a/src/app/common/EnvoyData.vue
+++ b/src/app/common/EnvoyData.vue
@@ -27,10 +27,11 @@
         <div class="envoy-data-actions">
           <KButton
             appearance="primary"
-            icon="redo"
             data-testid="envoy-data-refresh-button"
             @click="refresh"
           >
+            <RefreshIcon :size="KUI_ICON_SIZE_30" />
+
             Refresh
           </KButton>
         </div>
@@ -48,6 +49,8 @@
 </template>
 
 <script lang="ts" setup>
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { RefreshIcon } from '@kong/icons'
 import { KAlert, KButton } from '@kong/kongponents'
 import { PropType } from 'vue'
 

--- a/src/app/common/ErrorBlock.vue
+++ b/src/app/common/ErrorBlock.vue
@@ -8,13 +8,7 @@
         <div class="error-block-header">
           <div class="error-block-title">
             <WarningIcon
-              v-if="props.icon === 'warning'"
-              :size="KUI_ICON_SIZE_50"
-            />
-
-            <KIcon
-              v-else
-              :icon="props.icon"
+              display="inline-block"
               :size="KUI_ICON_SIZE_50"
             />
 
@@ -83,7 +77,7 @@
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
-import { type BadgeAppearance, KBadge, KEmptyState, KIcon } from '@kong/kongponents'
+import { type BadgeAppearance, KBadge, KEmptyState } from '@kong/kongponents'
 import { computed, PropType } from 'vue'
 
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
@@ -97,12 +91,6 @@ const props = defineProps({
   error: {
     type: Error,
     required: true,
-  },
-
-  icon: {
-    type: String,
-    required: false,
-    default: 'warning',
   },
 
   badgeAppearance: {

--- a/src/app/common/KFilterBar.vue
+++ b/src/app/common/KFilterBar.vue
@@ -13,15 +13,14 @@
     >
       <span class="visually-hidden">Focus filter</span>
 
-      <KIcon
-        aria-hidden="true"
-        class="k-filter-icon"
-        :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
-        data-testid="k-filter-bar-filter-icon"
-        hide-title
-        icon="filter"
-        :size="KUI_ICON_SIZE_30"
-      />
+      <span class="k-filter-icon">
+        <FilterIcon
+          decorative
+          data-testid="k-filter-bar-filter-icon"
+          hide-title
+          :size="KUI_ICON_SIZE_30"
+        />
+      </span>
     </button>
 
     <label
@@ -89,11 +88,9 @@
           >
             <span class="visually-hidden">Add {{ fieldEntry.fieldName }}:</span>
 
-            <KIcon
-              aria-hidden="true"
-              color="currentColor"
+            <ChevronRightIcon
+              decorative
               hide-title
-              icon="chevronRight"
               :size="KUI_ICON_SIZE_30"
             />
           </button>
@@ -111,10 +108,8 @@
     >
       <span class="visually-hidden">Clear query</span>
 
-      <KIcon
-        aria-hidden="true"
-        color="currentColor"
-        icon="clear"
+      <ClearIcon
+        decorative
         hide-title
         :size="KUI_ICON_SIZE_30"
       />
@@ -123,8 +118,8 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_NEUTRAL_WEAK, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { KIcon } from '@kong/kongponents'
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { ChevronRightIcon, ClearIcon, FilterIcon } from '@kong/icons'
 import { computed, onBeforeUnmount, onMounted, PropType, ref, watch } from 'vue'
 
 import { clamp } from '@/utilities/clamp'

--- a/src/app/common/LoadingBlock.vue
+++ b/src/app/common/LoadingBlock.vue
@@ -4,11 +4,10 @@
     data-testid="loading-block"
   >
     <template #title>
-      <KIcon
+      <ProgressIcon
         class="mb-3"
-        icon="spinner"
-        color="rgba(0, 0, 0, 0.1)"
-        :size="KUI_ICON_SIZE_50"
+        :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
+        display="inline-block"
       />
 
       <slot>
@@ -19,6 +18,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
-import { KEmptyState, KIcon } from '@kong/kongponents'
+import { KUI_COLOR_TEXT_NEUTRAL_WEAK } from '@kong/design-tokens'
+import { ProgressIcon } from '@kong/icons'
+import { KEmptyState } from '@kong/kongponents'
 </script>

--- a/src/app/common/PolicyTypeTag.vue
+++ b/src/app/common/PolicyTypeTag.vue
@@ -7,11 +7,7 @@
       alt=""
     >
 
-    <KIcon
-      v-else
-      icon="brain"
-      :size="KUI_ICON_SIZE_50"
-    />
+    <BrainIcon v-else />
 
     <slot>
       {{ props.policyType }}
@@ -20,8 +16,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
-import { KIcon } from '@kong/kongponents'
+import { BrainIcon } from '@kong/icons'
 
 import CircuitBreakerIconUrl from '@/assets/images/policies/CircuitBreaker.png'
 import FaultInjectionIconUrl from '@/assets/images/policies/FaultInjection.png'

--- a/src/app/common/ResourceDateStatus.vue
+++ b/src/app/common/ResourceDateStatus.vue
@@ -2,14 +2,14 @@
   <span class="date-status">
     {{ t('common.detail.created') }}: {{ createdDate }}
 
-    <KIcon icon="arrowRight" />
+    <ArrowRightIcon />
 
     {{ t('common.detail.modified') }}: {{ modifiedDate }}
   </span>
 </template>
 
 <script lang="ts" setup>
-import { KIcon } from '@kong/kongponents'
+import { ArrowRightIcon } from '@kong/icons'
 import { computed } from 'vue'
 
 import { useI18n } from '@/utilities'

--- a/src/app/common/WarningIcon.vue
+++ b/src/app/common/WarningIcon.vue
@@ -1,21 +1,21 @@
 <template>
-  <KIcon
-    icon="warning"
-    color="#0b172d"
-    secondary-color="#ffd68c"
-    :size="props.size"
+  <WarningIcon
+    color="var(--WarningIconBackground, currentColor)"
+    display="inline-block"
+    :size="props.size || KUI_ICON_SIZE_60"
     :hide-title="props.hideTitle"
   />
 </template>
 
 <script lang="ts" setup>
-import { KIcon } from '@kong/kongponents'
+import { KUI_ICON_SIZE_60 } from '@kong/design-tokens'
+import { WarningIcon } from '@kong/icons'
 
 const props = withDefaults(defineProps<{
   size?: string
   hideTitle?: boolean
 }>(), {
-  size: '64',
+  size: '',
   hideTitle: false,
 })
 </script>

--- a/src/app/common/subscriptions/SubscriptionDetails.vue
+++ b/src/app/common/subscriptions/SubscriptionDetails.vue
@@ -5,7 +5,7 @@
       appearance="info"
     >
       <template #alertIcon>
-        <KIcon icon="portal" />
+        <PortalIcon />
       </template>
 
       <template #alertMessage>
@@ -45,7 +45,8 @@
 </template>
 
 <script lang="ts" setup>
-import { KAlert, KIcon } from '@kong/kongponents'
+import { PortalIcon } from '@kong/icons'
+import { KAlert } from '@kong/kongponents'
 import { PropType, computed } from 'vue'
 
 import type { DiscoveryServiceStats, DiscoverySubscription, KDSSubscription } from '@/types/index.d'

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -122,13 +122,7 @@
             appearance="secondary"
             size="small"
           >
-            <template #icon>
-              <KIcon
-                :color="KUI_COLOR_TEXT_NEUTRAL_STRONGER"
-                icon="more"
-                :size="KUI_ICON_SIZE_30"
-              />
-            </template>
+            <MoreIcon :size="KUI_ICON_SIZE_30" />
           </KButton>
         </template>
         <template #items>
@@ -150,12 +144,12 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_NEUTRAL_STRONGER, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { MoreIcon } from '@kong/icons'
 import {
   KDropdownItem,
   KDropdownMenu,
   KButton,
-  KIcon,
   KTooltip,
 } from '@kong/kongponents'
 import { RouteLocationNamedRaw } from 'vue-router'

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -45,8 +45,7 @@
                       :label="statusWithReason.reason.join(', ')"
                       class="reason-tooltip"
                     >
-                      <KIcon
-                        icon="info"
+                      <InfoIcon
                         :size="KUI_ICON_SIZE_30"
                         hide-title
                       />
@@ -214,7 +213,8 @@
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { KAlert, KCard, KIcon, KTooltip } from '@kong/kongponents'
+import { InfoIcon } from '@kong/icons'
+import { KAlert, KCard, KTooltip } from '@kong/kongponents'
 import { computed } from 'vue'
 
 import { useCan } from '@/app/application'

--- a/src/app/main-overview/components/MainOverview.vue
+++ b/src/app/main-overview/components/MainOverview.vue
@@ -118,9 +118,10 @@
                 >
                   <KButton
                     appearance="primary"
-                    icon="plus"
                     :to="{ name: 'zone-create-view' }"
                   >
+                    <AddIcon :size="KUI_ICON_SIZE_30" />
+
                     {{ t('zones.index.create') }}
                   </KButton>
                 </div>
@@ -172,6 +173,8 @@
 </template>
 
 <script lang="ts" setup>
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { AddIcon } from '@kong/icons'
 import { KCard } from '@kong/kongponents'
 
 import MeshesDetails from './MeshesDetails.vue'

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -75,13 +75,7 @@
                           appearance="secondary"
                           size="small"
                         >
-                          <template #icon>
-                            <KIcon
-                              :color="KUI_COLOR_TEXT_NEUTRAL_STRONGER"
-                              icon="more"
-                              :size="KUI_ICON_SIZE_30"
-                            />
-                          </template>
+                          <MoreIcon :size="KUI_ICON_SIZE_30" />
                         </KButton>
                       </template>
 
@@ -111,7 +105,9 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_NEUTRAL_STRONGER, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { MoreIcon } from '@kong/icons'
+import { KCard, KDropdownMenu, KDropdownItem, KButton } from '@kong/kongponents'
 
 import type { MeshCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'

--- a/src/app/onboarding/views/WelcomeView.vue
+++ b/src/app/onboarding/views/WelcomeView.vue
@@ -65,11 +65,9 @@
                   :key="item.name"
                 >
                   <span class="circle mr-2">
-                    <KIcon
+                    <CheckIcon
                       v-if="item.status"
-                      icon="check"
                       :size="KUI_ICON_SIZE_30"
-                      color="currentColor"
                     />
                   </span>
 
@@ -92,6 +90,7 @@
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { CheckIcon } from '@kong/icons'
 
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'

--- a/src/app/policies/components/PolicyList.vue
+++ b/src/app/policies/components/PolicyList.vue
@@ -148,13 +148,7 @@
                       appearance="secondary"
                       size="small"
                     >
-                      <template #icon>
-                        <KIcon
-                          :color="KUI_COLOR_TEXT_NEUTRAL_STRONGER"
-                          icon="more"
-                          :size="KUI_ICON_SIZE_30"
-                        />
-                      </template>
+                      <MoreIcon :size="KUI_ICON_SIZE_30" />
                     </KButton>
                   </template>
 
@@ -184,14 +178,14 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_NEUTRAL_STRONGER, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { MoreIcon } from '@kong/icons'
 import {
   KBadge,
   KButton,
   KCard,
   KDropdownItem,
   KDropdownMenu,
-  KIcon,
 } from '@kong/kongponents'
 import { useRoute } from 'vue-router'
 

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -110,13 +110,10 @@
                         appearance="secondary"
                         size="small"
                       >
-                        <template #icon>
-                          <KIcon
-                            :color="KUI_COLOR_TEXT_NEUTRAL_STRONGER"
-                            icon="more"
-                            :size="KUI_ICON_SIZE_30"
-                          />
-                        </template>
+                        <MoreIcon
+                          :color="KUI_COLOR_TEXT_NEUTRAL_STRONGER"
+                          :size="KUI_ICON_SIZE_30"
+                        />
                       </KButton>
                     </template>
                     <template #items>
@@ -145,6 +142,7 @@
 
 <script lang="ts" setup>
 import { KUI_COLOR_TEXT_NEUTRAL_STRONGER, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { MoreIcon } from '@kong/icons'
 
 import type { ServiceInsightCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'

--- a/src/app/zones/components/EntityScanner.vue
+++ b/src/app/zones/components/EntityScanner.vue
@@ -7,25 +7,20 @@
       <KEmptyState cta-is-hidden>
         <template #title>
           <span class="mr-1">
-            <KIcon
+            <ProgressIcon
               v-if="isRunning"
-              icon="spinner"
               :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
-              :size="KUI_ICON_SIZE_50"
+              display="inline-block"
             />
 
-            <KIcon
+            <DangerIcon
               v-else-if="hasError"
-              icon="errorFilled"
               :color="KUI_COLOR_TEXT_DANGER"
-              :size="KUI_ICON_SIZE_50"
             />
 
-            <KIcon
+            <CheckCircleIcon
               v-else
-              icon="circleCheck"
               :color="KUI_COLOR_TEXT_SUCCESS"
-              :size="KUI_ICON_SIZE_50"
             />
           </span>
 
@@ -67,8 +62,8 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_NEUTRAL_WEAK, KUI_COLOR_TEXT_DANGER, KUI_COLOR_TEXT_SUCCESS, KUI_ICON_SIZE_50 } from '@kong/design-tokens'
-import { KEmptyState, KIcon } from '@kong/kongponents'
+import { KUI_COLOR_TEXT_NEUTRAL_WEAK, KUI_COLOR_TEXT_DANGER, KUI_COLOR_TEXT_SUCCESS } from '@kong/design-tokens'
+import { ProgressIcon, CheckCircleIcon, DangerIcon } from '@kong/icons'
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 
 const props = defineProps({

--- a/src/app/zones/components/MultizoneInfo.vue
+++ b/src/app/zones/components/MultizoneInfo.vue
@@ -1,11 +1,7 @@
 <template>
   <KEmptyState>
     <template #title>
-      <KIcon
-        class="mb-3"
-        icon="dangerCircleOutline"
-        :size="KUI_ICON_SIZE_50"
-      />
+      <DangerIcon class="mb-3" />
 
       <p>{{ t('common.product.name') }} is running in Standalone mode.</p>
     </template>
@@ -29,8 +25,8 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
-import { KButton, KEmptyState, KIcon } from '@kong/kongponents'
+import { DangerIcon } from '@kong/icons'
+import { KButton, KEmptyState } from '@kong/kongponents'
 
 import { useI18n } from '@/utilities'
 

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -86,10 +86,7 @@
                       :key="index"
                       class="fact-list__item"
                     >
-                      <KIcon
-                        icon="check"
-                        :color="KUI_COLOR_TEXT_SUCCESS"
-                      />
+                      <CheckIcon :color="KUI_COLOR_TEXT_SUCCESS" />
 
                       {{ fact }}
                     </li>
@@ -139,11 +136,22 @@
                   <KButton
                     appearance="primary"
                     class="mt-4"
-                    :icon="isChangingZone ? 'spinner' : 'plus'"
                     :disabled="isCreateButtonDisabled"
                     data-testid="create-zone-button"
                     @click="createZone"
                   >
+                    <ProgressIcon
+                      v-if="isChangingZone"
+                      :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
+                      display="inline-block"
+                      :size="KUI_ICON_SIZE_30"
+                    />
+
+                    <AddIcon
+                      v-else
+                      :size="KUI_ICON_SIZE_30"
+                    />
+
                     {{ t('zones.form.createZoneButtonLabel') }}
                   </KButton>
                 </div>
@@ -367,7 +375,8 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_SUCCESS } from '@kong/design-tokens'
+import { KUI_COLOR_TEXT_SUCCESS, KUI_ICON_SIZE_30, KUI_COLOR_TEXT_NEUTRAL_WEAK } from '@kong/design-tokens'
+import { AddIcon, CheckIcon, ProgressIcon } from '@kong/icons'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 

--- a/src/app/zones/views/ZoneEgressListView.vue
+++ b/src/app/zones/views/ZoneEgressListView.vue
@@ -97,13 +97,7 @@
                         appearance="secondary"
                         size="small"
                       >
-                        <template #icon>
-                          <KIcon
-                            :color="KUI_COLOR_TEXT_NEUTRAL_STRONGER"
-                            icon="more"
-                            :size="KUI_ICON_SIZE_30"
-                          />
-                        </template>
+                        <MoreIcon :size="KUI_ICON_SIZE_30" />
                       </KButton>
                     </template>
 
@@ -127,7 +121,8 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_NEUTRAL_STRONGER, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { MoreIcon } from '@kong/icons'
 import { RouteLocationNamedRaw } from 'vue-router'
 
 import type { ZoneEgressOverviewCollectionSource } from '../sources'

--- a/src/app/zones/views/ZoneIngressListView.vue
+++ b/src/app/zones/views/ZoneIngressListView.vue
@@ -111,13 +111,7 @@
                           appearance="secondary"
                           size="small"
                         >
-                          <template #icon>
-                            <KIcon
-                              :color="KUI_COLOR_TEXT_NEUTRAL_STRONGER"
-                              icon="more"
-                              :size="KUI_ICON_SIZE_30"
-                            />
-                          </template>
+                          <MoreIcon :size="KUI_ICON_SIZE_30" />
                         </KButton>
                       </template>
 
@@ -142,7 +136,8 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_NEUTRAL_STRONGER, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { MoreIcon } from '@kong/icons'
 import { RouteLocationNamedRaw } from 'vue-router'
 
 import MultizoneInfo from '../components/MultizoneInfo.vue'

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -28,10 +28,11 @@
         >
           <KButton
             appearance="primary"
-            icon="plus"
             :to="{ name: 'zone-create-view' }"
             data-testid="create-zone-link"
           >
+            <AddIcon :size="KUI_ICON_SIZE_30" />
+
             {{ t('zones.index.create') }}
           </KButton>
         </template>
@@ -150,11 +151,7 @@
                           size="small"
                         >
                           <template #icon>
-                            <KIcon
-                              :color="KUI_COLOR_TEXT_NEUTRAL_STRONGER"
-                              icon="more"
-                              :size="KUI_ICON_SIZE_30"
-                            />
+                            <MoreIcon :size="KUI_ICON_SIZE_30" />
                           </template>
                         </KButton>
                       </template>
@@ -208,8 +205,9 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_NEUTRAL_STRONGER, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { KButton, KCard, KDropdownItem, KDropdownMenu, KIcon, KTooltip } from '@kong/kongponents'
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { MoreIcon, AddIcon } from '@kong/icons'
+import { KButton, KCard, KDropdownItem, KDropdownMenu, KTooltip } from '@kong/kongponents'
 import { ref } from 'vue'
 import { type RouteLocationNamedRaw } from 'vue-router'
 

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -32,6 +32,7 @@
   // MISC
   --TextGradientBackground: linear-gradient(90deg, #473cfb 0%, #a300bd 33.17%);
   --StepBackground: #169fcc;
+  --WarningIconBackground: #ffa600;
 }
 
 :root.is-fullscreen {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,10 +2012,10 @@
   resolved "https://registry.yarnpkg.com/@kong/design-tokens/-/design-tokens-1.11.2.tgz#9f2f297dc947ba1097e9fcd08e2ba5c1d11db8ac"
   integrity sha512-0x1lLa1htkpGDVTIuf7nTL1z2XiiGGcW5tM5HdAVJktXGkaJqD7oJsGfhhI9SvCbt5O1z9lCfSCHINybL8Da9w==
 
-"@kong/icons@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.7.2.tgz#3ee7c07f8913f96a459744ebf820c303a1f43c06"
-  integrity sha512-BZfc9xpBwcgPQWyr2AGmJuh5xwN5EBwqkdUEt3R5YPygnouYy3CjFa/5iTfuGc8MIRp8awJ2n9DxgpzuCkLB5A==
+"@kong/icons@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.7.3.tgz#9ebbacce5288004bc786681f02ad9db331aebf5b"
+  integrity sha512-VI/7fpbH4WoNShy095JzOqAQs1SAMvWSFnKfD1MreQyR6b3Usn00ugkgF2j5PVP/CvflZ63U9Ay7RlUtW/Ih/w==
 
 "@kong/kongponents@8.123.8":
   version "8.123.8"


### PR DESCRIPTION
## Changes

Replaces most Kongponents icons with @kong/icons. This includes cases where we used a component’s `icon` prop as that functionality will be removed from Kongponents. There is one instance of KIcon left in CopyButton that we can’t replace, yet because we’d otherwise have two slightly different copy icons in resource code blocks.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

This PR is a preparation for https://github.com/kumahq/kuma-gui/pull/1532. I decided to pull it out of that PR because it’s a change we can make before switching to Kongponents’ alpha branch.