### PR TITLE
chore(test): Asyncify MSW initializing

### DIFF
--- a/jest/jest-setup-after-env.ts
+++ b/jest/jest-setup-after-env.ts
@@ -4,13 +4,14 @@ import 'isomorphic-fetch'
 import { config } from '@vue/test-utils'
 
 import { TOKENS as COMPONENT_TOKENS } from '../src/components'
-import { TOKENS as TEST, services as testing } from '../src/services/testing'
+import { TOKENS as TEST, services as testing, useServer } from '../src/services/testing'
 import { services as onboarding } from '@/app/onboarding'
 import { TOKENS as DEV, services as development } from '@/services/development'
 import CliEnv from '@/services/env/CliEnv'
 import { TOKENS as PROD, services as production } from '@/services/production'
-import { get, container, build, createInjections, token } from '@/services/utils'
+import { get, container, build, token } from '@/services/utils'
 
+export { useMock } from '../src/services/testing'
 // jest can't import this module properly due to transpiling issues
 // mock this out with a blank element
 jest.mock('vue-github-button', () => ({ template: '<span />' }))
@@ -55,7 +56,7 @@ const $ = {
   beforeEach(() => container.capture?.())
   afterEach(() => container.restore?.())
 
-  const server = get($.msw)
+  const server = useServer()
   beforeAll(() => server.listen())
   afterEach(() => server.resetHandlers())
   afterAll(() => server.close())
@@ -93,8 +94,3 @@ export const withSources = (sources: any) => {
     ],
   )
 }
-
-export const [
-  useServer,
-  useMock,
-] = createInjections($.msw, $.mock)

--- a/src/services/e2e.ts
+++ b/src/services/e2e.ts
@@ -11,14 +11,13 @@ const env = (
   return env[key] || d
 }
 type AEnv = ReturnType<typeof env>
-type Server = typeof cy
 // temporary intercept returning Mocker
 type Mocker = (route: string, opts?: Options, cb?: Callback) => ReturnType<typeof cy['intercept']>
 const $ = {
   EnvVars: token<EnvVars>('EnvVars'),
   env: token<AEnv>('env'),
 
-  cy: token<Server>('cy'),
+  cy: token<typeof cy>('cy'),
   mockServer: token('mockServer'),
   mock: token<Mocker>('mocker'),
   Env: token('Env'),

--- a/src/services/testing.ts
+++ b/src/services/testing.ts
@@ -1,7 +1,7 @@
 import { setupServer } from 'msw/node'
 
 import createDisabledLogger from './logger/DisabledLogger'
-import { Alias, ServiceConfigurator, token } from './utils'
+import { Alias, ServiceConfigurator, token, createInjections } from './utils'
 import CliEnv from '@/services/env/CliEnv'
 import Logger from '@/services/logger/Logger'
 import { mocker, fakeApi, FS } from '@/test-support'
@@ -9,6 +9,7 @@ import type { Mocker } from '@/test-support'
 
 const $ = {
   mock: token<Mocker>('mocker'),
+  server: token<ReturnType<typeof setupServer>>('server'),
 }
 
 export const services: ServiceConfigurator = (app) => [
@@ -17,7 +18,7 @@ export const services: ServiceConfigurator = (app) => [
     decorates: app.logger,
   }],
 
-  [app.msw, {
+  [$.server, {
     service: (env: Alias<CliEnv['var']>, fs: FS) => {
       const mock = fakeApi(env, fs)
       return setupServer(...mock('*'))
@@ -31,7 +32,7 @@ export const services: ServiceConfigurator = (app) => [
     service: mocker,
     arguments: [
       app.env,
-      app.msw,
+      app.server,
       app.fakeFS,
     ],
   }],
@@ -43,3 +44,7 @@ export const services: ServiceConfigurator = (app) => [
   }],
 ]
 export const TOKENS = $
+export const [
+  useMock,
+  useServer,
+] = createInjections($.mock, $.server)


### PR DESCRIPTION
The fact that our MSW `worker.start` has never been awaited has made me double, triple think that many times now or led to a wild goose chase that I decided to push this up after _yet again_ realizing that we don't use MSW in our e2e tests 😆 

See https://github.com/kumahq/kuma-gui/issues/952

While it's "technically incorrect" it hasn't affected anything for years now. (I have noticed that very very occasionally if you have no other browser window open and only on your first visit to the application on a fresh start, MSW sometimes won't get installed in time leading to a stuck loader, this is only during development or I suppose possibly PR previews).

While I was here I tweaked a few names of things and moved a tiny bit of stuff now that our DI layer has taken way more shape since this bit of code was originally written, while I was doing this rename/moving I did think - "this is probably due a spring clean", just not right now.

