### PR TITLE
chore(tests): Remove wait from gateway test

### DIFF
--- a/features/mesh/gateways/PageNavigation.feature
+++ b/features/mesh/gateways/PageNavigation.feature
@@ -2,17 +2,15 @@ Feature: Gateways: Page navigation
   Scenario Outline: Tabs have expected URLs
 
     When I visit the "/meshes/default/gateways/firewal-gateway-1/overview" URL
-    # This `cy.wait` stabilizes the test significantly. For some reason, it can happen that the subsequent navigation to via nav tab is never triggered.
-    Then I wait for 1000 milliseconds
 
-    When I click the "<TabSelector>" element
+    When I click the "[data-testid='<RouteName>-tab']" element
     And the URL contains "<Path>"
     Then the page title contains "<Title>"
 
     Examples:
-      | TabSelector                    | Path                                   | Title             |
-      | #gateway-detail-view-tab a     | /gateways/firewal-gateway-1/overview   | firewal-gateway-1 |
-      | #gateway-policies-view-tab a   | /gateways/firewal-gateway-1/policies   | Policies          |
-      | #gateway-xds-config-view-tab a | /gateways/firewal-gateway-1/xds-config | XDS Configuration |
-      | #gateway-stats-view-tab a      | /gateways/firewal-gateway-1/stats      | Stats             |
-      | #gateway-clusters-view-tab a   | /gateways/firewal-gateway-1/clusters   | Clusters          |
+      | RouteName               | Path                                   | Title             |
+      | gateway-detail-view     | /gateways/firewal-gateway-1/overview   | firewal-gateway-1 |
+      | gateway-policies-view   | /gateways/firewal-gateway-1/policies   | Policies          |
+      | gateway-xds-config-view | /gateways/firewal-gateway-1/xds-config | XDS Configuration |
+      | gateway-stats-view      | /gateways/firewal-gateway-1/stats      | Stats             |
+      | gateway-clusters-view   | /gateways/firewal-gateway-1/clusters   | Clusters          |

--- a/src/app/common/NavTabs.vue
+++ b/src/app/common/NavTabs.vue
@@ -11,9 +11,12 @@
       :key="`${tab.routeName}-anchor`"
       #[`${tab.routeName}-anchor`]
     >
-      <router-link :to="{ name: tab.routeName }">
+      <RouterLink
+        :data-testid="`${tab.routeName}-tab`"
+        :to="{ name: tab.routeName }"
+      >
         {{ tab.title }}
-      </router-link>
+      </RouterLink>
     </template>
   </KTabs>
 </template>


### PR DESCRIPTION
I spotted one last now unnecessary `wait` (since https://github.com/kumahq/kuma-gui/pull/1493)  in a gateway test. While I was removing it I spotted I could also change the selectors to use `data-testid`s.

The only `wait`s we have left now are these ones in this single file:

https://github.com/kumahq/kuma-gui/blob/d4c6fdc3cfd13e63d298176509dc4285ddc58c83/features/mesh/services/Item.feature#L59-L64

These ones are due to Cypress thinking that `input` elements are disabled (even though when you check they aren't disabled, they are not) and not letting you type into them unless you wait a little bit first. No idea what the issue is on those ones, but that one is for another day.

