### PR TITLE
feat: adds tray view

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -110,8 +110,4 @@ const isWizard = computed(() => route.meta.isWizard === true)
   // Note: `minmax(0, 1fr)` is used because `1fr` implies `minmax(auto, 1fr)` which will allow grid items to grow beyond their container's size.
   grid-template-columns: var(--AppSidebarWidth) minmax(0, 1fr);
 }
-
-.app-main-content {
-  padding: var(--AppContentPadding);
-}
 </style>

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -225,7 +225,8 @@ const click = (e: MouseEvent) => {
 </script>
 
 <style lang="scss" scoped>
-.app-collection :deep(td:first-of-type > a) {
+.app-collection :deep(td:first-child),
+.app-collection :deep(td:first-child > *) {
   color: inherit;
   font-weight: $kui-font-weight-semibold;
   text-decoration: none;

--- a/src/app/application/components/app-view/AppView.vue
+++ b/src/app/application/components/app-view/AppView.vue
@@ -52,7 +52,7 @@
 <script lang="ts" setup>
 import { KongIcon } from '@kong/icons'
 import { KBreadcrumbs, BreadcrumbItem } from '@kong/kongponents'
-import { provide, inject, PropType, watch, ref, onBeforeUnmount } from 'vue'
+import { provide, inject, watch, ref, onBeforeUnmount } from 'vue'
 
 import { useMainView } from '@/components'
 
@@ -61,19 +61,15 @@ type AppView = {
   removeBreadcrumbs: (sym: Symbol) => void
 }
 type Breadcrumbs = Map<Symbol, BreadcrumbItem[]>
+
 const MainView = useMainView()
 
-const props = defineProps({
-  breadcrumbs: {
-    type: Array as PropType<BreadcrumbItem[]>,
-    required: false,
-    default: null,
-  },
-  fullscreen: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
+const props = withDefaults(defineProps<{
+  breadcrumbs?: BreadcrumbItem[] | null
+  fullscreen?: boolean
+}>(), {
+  breadcrumbs: null,
+  fullscreen: false,
 })
 
 const map: Breadcrumbs = new Map()
@@ -153,6 +149,10 @@ onBeforeUnmount(() => {
 </style>
 
 <style lang="scss" scoped>
+.app-main-content {
+  padding: var(--AppContentPadding);
+}
+
 .actions {
   flex-grow: 1;
   display: flex;

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -19,7 +19,7 @@
       :route="{
         update: routeUpdate,
         replace: routeReplace,
-        params: routeParams
+        params: routeParams,
       }"
     />
   </div>
@@ -143,7 +143,7 @@ const routeUpdate = (params: Record<string, string | undefined>) => {
 const routeReplace = (...args: Parameters<typeof router['push']>) => {
   router.push(...args)
 }
-watch(() => props.name, (name) => {
+watch(() => props.name, () => {
   // we only want query params here
   const params = Object.entries(routeParams.value || {}).reduce<Record<string, string>>((prev, [key, value]) => {
     if (typeof route.params[key] === 'undefined') {
@@ -154,7 +154,6 @@ watch(() => props.name, (name) => {
 
   if (Object.keys(params).length > 0) {
     router.replace({
-      name,
       query: cleanQuery(params, route.query),
     })
   }

--- a/src/app/common/TrayView.vue
+++ b/src/app/common/TrayView.vue
@@ -8,19 +8,6 @@
     data-testid="tray"
     @close="emit('close')"
   >
-    <template #before-title>
-      <div class="tray-title-wrapper">
-        <slot
-          v-if="$slots.icon"
-          name="icon"
-        />
-
-        <h2 class="tray-title">
-          <slot name="title" />
-        </h2>
-      </div>
-    </template>
-
     <slot />
   </KSlideout>
 </template>
@@ -32,17 +19,6 @@ const emit = defineEmits<{
 </script>
 
 <style lang="scss" scoped>
-
-.tray-title-wrapper {
-  display: flex;
-  align-items: center;
-  gap: $kui-space-30;
-}
-
-.tray-title {
-  margin-top: 0;
-}
-
 .tray {
   // TODO: Remove or replace these once we switch to Kongponents v9 which will deprecate these variables.
   // Overrides KSlideout’s override.

--- a/src/app/common/TrayView.vue
+++ b/src/app/common/TrayView.vue
@@ -7,12 +7,12 @@
     data-testid="tray"
     @close="emit('close')"
   >
-    <template
-      v-if="$slots.icon"
-      #before-title
-    >
+    <template #before-title>
       <div class="tray-title-wrapper">
-        <slot name="icon" />
+        <slot
+          v-if="$slots.icon"
+          name="icon"
+        />
 
         <h2 class="tray-title">
           <slot name="title" />

--- a/src/app/common/TrayView.vue
+++ b/src/app/common/TrayView.vue
@@ -4,7 +4,6 @@
     close-button-alignment="end"
     :has-overlay="false"
     is-visible
-    prevent-close-on-blur
     data-testid="tray"
     @close="emit('close')"
   >

--- a/src/app/common/TrayView.vue
+++ b/src/app/common/TrayView.vue
@@ -38,4 +38,18 @@ const emit = defineEmits<{
   padding-right: $kui-space-80;
   padding-left: $kui-space-80;
 }
+
+// Aligns the position of the close button with the tray card’s content box.
+.tray :deep(.close-button-start),
+.tray :deep(.close-button-end) {
+  margin-top: $kui-space-80 !important;
+}
+
+.tray :deep(.close-button-start) {
+  margin-left: $kui-space-80 !important;
+}
+
+.tray :deep(.close-button-end) {
+  margin-right: $kui-space-80 !important;
+}
 </style>

--- a/src/app/common/TrayView.vue
+++ b/src/app/common/TrayView.vue
@@ -1,72 +1,36 @@
 <template>
-  <div
-    class="tray"
+  <KSlideout
+    close-button-alignment="end"
+    :has-overlay="false"
+    is-visible
+    prevent-close-on-blur
     data-testid="tray"
+    @close="emit('close')"
   >
-    <header class="tray-header">
+    <template
+      v-if="$slots.icon"
+      #before-title
+    >
       <div class="tray-title-wrapper">
-        <span
-          v-if="$slots.icon"
-          class="tray-icon"
-        >
-          <slot name="icon" />
-        </span>
+        <slot name="icon" />
 
         <h2 class="tray-title">
           <slot name="title" />
         </h2>
       </div>
-
-      <KButton
-        appearance="btn-link"
-        class="non-visual-button"
-        data-testid="close-tray-button"
-        @click="emit('close')"
-      >
-        <CloseIcon aria-hidden="true" />
-
-        <span class="visually-hidden">{{ t('common.tray.close') }}</span>
-      </KButton>
-    </header>
+    </template>
 
     <slot />
-  </div>
+  </KSlideout>
 </template>
 
 <script lang="ts" setup>
-import { CloseIcon } from '@kong/icons'
-
-import { useI18n } from '@/utilities'
-
-const { t } = useI18n()
-
 const emit = defineEmits<{
   (event: 'close'): void
 }>()
 </script>
 
 <style lang="scss" scoped>
-.tray {
-  position: fixed;
-  z-index: 100;
-  top: var(--AppHeaderHeight);
-  bottom: 0;
-  right: 0;
-  width: 600px;
-  max-width: calc(100% - var(--AppSidebarWidth));
-  padding: $kui-space-70;
-  border-left: $kui-border-width-10 solid $kui-color-border;
-  background-color: $kui-color-background;
-  box-shadow: -6px 0px 15px 0px rgba(0, 0, 0, 0.04);
-}
-
-.tray-header {
-  display: flex;
-  align-items: center;
-  gap: $kui-space-50;
-  justify-content: space-between;
-  margin-bottom: $kui-space-50;
-}
 
 .tray-title-wrapper {
   display: flex;
@@ -76,5 +40,25 @@ const emit = defineEmits<{
 
 .tray-title {
   margin-top: 0;
+}
+</style>
+
+<style lang="scss">
+.k-slideout {
+  // Overrides KSlideout’s override.
+  --KCardPaddingX: #{$kui-space-80} !important;
+  --KCardPaddingY: #{$kui-space-80} !important;
+}
+
+.k-slideout .panel,
+.k-slideout .panel-background,
+.k-slideout .panel-background-transparent {
+  // Overrides KSlideout’s top offset. `props.offsetTop` doesn’t accept plain CSS values.
+  top: var(--AppHeaderHeight) !important;
+}
+
+.k-slideout-header-content {
+  padding-right: $kui-space-80;
+  padding-left: $kui-space-80;
 }
 </style>

--- a/src/app/common/TrayView.vue
+++ b/src/app/common/TrayView.vue
@@ -1,5 +1,6 @@
 <template>
   <KSlideout
+    class="tray"
     close-button-alignment="end"
     :has-overlay="false"
     is-visible
@@ -41,23 +42,23 @@ const emit = defineEmits<{
 .tray-title {
   margin-top: 0;
 }
-</style>
 
-<style lang="scss">
-.k-slideout {
+.tray {
+  // TODO: Remove or replace these once we switch to Kongponents v9 which will deprecate these variables.
   // Overrides KSlideout’s override.
   --KCardPaddingX: #{$kui-space-80} !important;
   --KCardPaddingY: #{$kui-space-80} !important;
+
+  :deep(.panel),
+  :deep(.panel-background),
+  :deep(.panel-background-transparent) {
+    // TODO: Remove this in favor of setting KSlideout’s `props.offsetTop` to `var(--AppHeaderHeight)` once Kongponents v9 is available (which has https://github.com/Kong/kongponents/pull/1769).
+    // Overrides KSlideout’s top offset. `props.offsetTop` doesn’t accept plain CSS values.
+    top: var(--AppHeaderHeight) !important;
+  }
 }
 
-.k-slideout .panel,
-.k-slideout .panel-background,
-.k-slideout .panel-background-transparent {
-  // Overrides KSlideout’s top offset. `props.offsetTop` doesn’t accept plain CSS values.
-  top: var(--AppHeaderHeight) !important;
-}
-
-.k-slideout-header-content {
+.tray :deep(.k-slideout-header-content) {
   padding-right: $kui-space-80;
   padding-left: $kui-space-80;
 }

--- a/src/app/common/TrayView.vue
+++ b/src/app/common/TrayView.vue
@@ -1,0 +1,80 @@
+<template>
+  <div
+    class="tray"
+    data-testid="tray"
+  >
+    <header class="tray-header">
+      <div class="tray-title-wrapper">
+        <span
+          v-if="$slots.icon"
+          class="tray-icon"
+        >
+          <slot name="icon" />
+        </span>
+
+        <h2 class="tray-title">
+          <slot name="title" />
+        </h2>
+      </div>
+
+      <KButton
+        appearance="btn-link"
+        class="non-visual-button"
+        data-testid="close-tray-button"
+        @click="emit('close')"
+      >
+        <CloseIcon aria-hidden="true" />
+
+        <span class="visually-hidden">{{ t('common.tray.close') }}</span>
+      </KButton>
+    </header>
+
+    <slot />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { CloseIcon } from '@kong/icons'
+
+import { useI18n } from '@/utilities'
+
+const { t } = useI18n()
+
+const emit = defineEmits<{
+  (event: 'close'): void
+}>()
+</script>
+
+<style lang="scss" scoped>
+.tray {
+  position: fixed;
+  z-index: 100;
+  top: var(--AppHeaderHeight);
+  bottom: 0;
+  right: 0;
+  width: 600px;
+  max-width: calc(100% - var(--AppSidebarWidth));
+  padding: $kui-space-70;
+  border-left: $kui-border-width-10 solid $kui-color-border;
+  background-color: $kui-color-background;
+  box-shadow: -6px 0px 15px 0px rgba(0, 0, 0, 0.04);
+}
+
+.tray-header {
+  display: flex;
+  align-items: center;
+  gap: $kui-space-50;
+  justify-content: space-between;
+  margin-bottom: $kui-space-50;
+}
+
+.tray-title-wrapper {
+  display: flex;
+  align-items: center;
+  gap: $kui-space-30;
+}
+
+.tray-title {
+  margin-top: 0;
+}
+</style>

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -45,6 +45,8 @@ common:
     text1: 'Are you sure you want to delete the {type} {name}?'
     text2: 'This action cannot be reversed.'
     title: 'Delete {type}'
+  tray:
+    close: 'Close'
   emptyState:
     title: 'No data'
     message: 'There are no {type} present'


### PR DESCRIPTION
Contains all the non-module specific changes needed for adding service trays (like for services https://github.com/kumahq/kuma-gui/pull/1611).

## Changes

**chore: cleans up AppView**

Moves the `.app-main-content` styles into AppView (where the `.app-main-content` element is).

**feat: adds TrayView component**

**chore: always styles first AppCollection row item**

**chore: removes explicit name parameters from RouteView method**

Removes the `name` parameter from the `router.push` call in RouteView. They’re currently not necessary and cause issues when using tray routes for list views (specifically, they prevent a cold navigation to a summary route).

**refactor: switches to KSlideout**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

- Follow up to #1601 and #1604.