### PR TITLE
fix: make sure spinners in LoadingBlock are centered

### DIFF
--- a/src/app/common/LoadingBlock.vue
+++ b/src/app/common/LoadingBlock.vue
@@ -6,6 +6,7 @@
     <template #title>
       <ProgressIcon
         class="mb-3"
+        display="inline-block"
         :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
       />
 


### PR DESCRIPTION
...by adding an inline-block

Before:

![Screenshot 2023-10-16 at 13 41 30](https://github.com/kumahq/kuma-gui/assets/554604/b9a6cf92-6df8-414b-9f7f-b36ec27537d1)

After:

![Screenshot 2023-10-16 at 13 41 50](https://github.com/kumahq/kuma-gui/assets/554604/671d238c-71c7-457e-8209-d6faee450ab9)

