### PR TITLE
refactor: simplifies columns component

### DIFF
--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -27,10 +27,7 @@
       >
         <KCard>
           <template #body>
-            <div
-              class="columns"
-              style="--columns: 3;"
-            >
+            <div class="columns">
               <DefinitionCard>
                 <template #title>
                   {{ t('http.api.property.status') }}
@@ -107,10 +104,7 @@
                 class="mt-4"
               >
                 <template #body>
-                  <div
-                    class="columns"
-                    style="--columns: 5;"
-                  >
+                  <div class="columns">
                     <DefinitionCard>
                       <template #title>
                         {{ t('data-planes.routes.item.mtls.expiration_time.title') }}

--- a/src/app/main-overview/components/MainOverview.vue
+++ b/src/app/main-overview/components/MainOverview.vue
@@ -23,10 +23,7 @@
               </div>
             </div>
 
-            <div
-              class="columns"
-              :style="`--columns: ${can('use zones') ? 4 : 3};`"
-            >
+            <div class="columns">
               <ResourceStatus
                 v-if="can('use zones')"
                 :total="data.zones.controlPlanes.total"

--- a/src/app/main-overview/components/MainOverview.vue
+++ b/src/app/main-overview/components/MainOverview.vue
@@ -85,7 +85,7 @@
       </template>
     </KCard>
 
-    <div class="variable-columns">
+    <div class="columns">
       <KCard v-if="can('use zones')">
         <template #body>
           <DataSource

--- a/src/app/meshes/components/MeshDetails.vue
+++ b/src/app/meshes/components/MeshDetails.vue
@@ -2,10 +2,7 @@
   <KCard>
     <template #body>
       <div class="stack">
-        <div
-          class="columns"
-          style="--columns: 3;"
-        >
+        <div class="columns">
           <ResourceStatus
             :total="props.meshInsight?.services.total ?? 0"
             data-testid="services-status"
@@ -34,10 +31,7 @@
           </ResourceStatus>
         </div>
 
-        <div
-          class="columns"
-          style="--columns: 3;"
-        >
+        <div class="columns">
           <DefinitionCard>
             <template #title>
               {{ t('http.api.property.mtls') }}

--- a/src/app/services/components/ExternalServiceDetails.vue
+++ b/src/app/services/components/ExternalServiceDetails.vue
@@ -2,10 +2,7 @@
   <div class="stack">
     <KCard>
       <template #body>
-        <div
-          class="columns"
-          style="--columns: 2;"
-        >
+        <div class="columns">
           <DefinitionCard>
             <template #title>
               {{ t('http.api.property.address') }}

--- a/src/app/services/components/ServiceInsightDetails.vue
+++ b/src/app/services/components/ServiceInsightDetails.vue
@@ -2,10 +2,7 @@
   <div class="stack">
     <KCard>
       <template #body>
-        <div
-          class="columns"
-          style="--columns: 3;"
-        >
+        <div class="columns">
           <DefinitionCard>
             <template #title>
               {{ t('http.api.property.status') }}

--- a/src/app/zone-egresses/views/item/DetailView.vue
+++ b/src/app/zone-egresses/views/item/DetailView.vue
@@ -10,10 +10,7 @@
       >
         <KCard>
           <template #body>
-            <div
-              class="columns"
-              style="--columns: 2;"
-            >
+            <div class="columns">
               <DefinitionCard>
                 <template #title>
                   {{ t('http.api.property.status') }}

--- a/src/app/zone-ingresses/views/item/DetailView.vue
+++ b/src/app/zone-ingresses/views/item/DetailView.vue
@@ -10,10 +10,7 @@
       >
         <KCard>
           <template #body>
-            <div
-              class="columns"
-              style="--columns: 3;"
-            >
+            <div class="columns">
               <DefinitionCard>
                 <template #title>
                   {{ t('http.api.property.status') }}

--- a/src/app/zones/views/item/DetailView.vue
+++ b/src/app/zones/views/item/DetailView.vue
@@ -26,10 +26,7 @@
       >
         <KCard>
           <template #body>
-            <div
-              class="columns"
-              style="--columns: 3;"
-            >
+            <div class="columns">
               <DefinitionCard>
                 <template #title>
                   {{ t('http.api.property.status') }}

--- a/src/assets/styles/_components.scss
+++ b/src/assets/styles/_components.scss
@@ -31,18 +31,3 @@ Adapted from https://every-layout.dev/layouts/switcher/.
   flex-basis: calc((var(--threshold) - 100%) * 999);
   min-inline-size: 0;
 }
-
-
-/*
-.variable-columns
-*/
-
-.variable-columns {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--AppGap);
-}
-
-.variable-columns>* {
-  flex-grow: 1;
-}

--- a/src/assets/styles/_components.scss
+++ b/src/assets/styles/_components.scss
@@ -19,8 +19,7 @@ Adapted from https://every-layout.dev/layouts/switcher/.
 */
 
 .columns {
-  --threshold: 20rem;
-  --columns: 3;
+  --threshold: 40rem;
 
   display: flex;
   flex-wrap: wrap;
@@ -28,9 +27,9 @@ Adapted from https://every-layout.dev/layouts/switcher/.
 }
 
 .columns>* {
-  min-inline-size: min(var(--threshold), 100%);
-  // Accounts for the gaps.
-  inline-size: calc((100% - ((var(--columns) - 1) * var(--AppGap))) / var(--columns));
+  flex-grow: 1;
+  flex-basis: calc((var(--threshold) - 100%) * 999);
+  min-inline-size: 0;
 }
 
 


### PR DESCRIPTION
**refactor: simplifies columns component**

Simplifies the CSS columns component to not require setting `--columns` anymore.

**chore: removes unused variable-columns component**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>