### PR TITLE
chore(zones): Alter text for authentication types

### DIFF
--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -8,6 +8,7 @@ zone-cps:
         zone-cp-config-view: 'Config'
         zone-ingress-list-view: 'Ingresses'
         zone-egress-list-view: 'Egresses'
+      authentication_type: Dataplane authentication type
     items:
       title: Zone Control Planes
       breadcrumbs: Zone Control Planes

--- a/src/app/zones/views/item/DetailView.vue
+++ b/src/app/zones/views/item/DetailView.vue
@@ -49,7 +49,7 @@
 
               <DefinitionCard>
                 <template #title>
-                  {{ t('http.api.property.authenticationType') }}
+                  {{ t('zone-cps.routes.item.authentication_type') }}
                 </template>
 
                 <template #body>


### PR DESCRIPTION
Changes text from `Authentication Type` to `Dataplane authentication type` only in Zones, which I think is the only change required here.

Please see below issue though incase I've misunderstood.

Closes https://github.com/kumahq/kuma-gui/issues/424