### PR TITLE
chore(tests): Removes last in-application reference to VITE_ vars

### DIFF
--- a/src/services/env/CliEnv.ts
+++ b/src/services/env/CliEnv.ts
@@ -1,6 +1,6 @@
 import Env, { getPathConfigDefault } from './Env'
 export default class CliEnv extends Env {
   protected getConfig() {
-    return getPathConfigDefault(import.meta.env.VITE_KUMA_API_SERVER_URL)
+    return getPathConfigDefault()
   }
 }


### PR DESCRIPTION
Removes last runtime-code reference to VITE_ var (we only use this one in tests).

There's one more I found but thats in the vite build config, so not only is that fine because its in `VITE` but also we don't have our `env` etc available there, nor should we.

Closes https://github.com/kumahq/kuma-gui/issues/666 😬 