### PR TITLE
fix: service dpp list linking to wrong views

### DIFF
--- a/features/mesh/services/Item.feature
+++ b/features/mesh/services/Item.feature
@@ -42,7 +42,7 @@ Feature: mesh / services / item
               - name: fake-dataplane
                 dataplane:
                   networking:
-                    gateway: ~
+                    gateway: !!js/undefined
         """
       When I visit the "/meshes/default/services/system-1/overview" URL
 

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -28,7 +28,7 @@
     <template #name="{ row: item }">
       <RouterLink
         :to="{
-          name: props.gateways ? 'gateway-detail-view' : 'data-plane-detail-view',
+          name: item.isGateway ? 'gateway-detail-view' : 'data-plane-detail-view',
           params: {
             dataPlane: item.name
           }
@@ -129,7 +129,7 @@
           <KDropdownItem
             :item="{
               to: {
-                name: props.gateways ? 'gateway-detail-view' : 'data-plane-detail-view',
+                name: item.isGateway ? 'gateway-detail-view' : 'data-plane-detail-view',
                 params: {
                   dataPlane: item.name,
                 },
@@ -196,6 +196,7 @@ type DataPlaneOverviewTableRow = {
   lastUpdated: string
   lastConnected: string
   overview: DataPlaneOverview
+  isGateway: boolean
 }
 
 type ChangeValue = {
@@ -337,6 +338,7 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
       lastUpdated: summary.selectedUpdateTime ? formatIsoDate(new Date(summary.selectedUpdateTime).toUTCString()) : t('common.collection.none'),
       lastConnected: summary.selectedTime ? formatIsoDate(new Date(summary.selectedTime).toUTCString()) : t('common.collection.none'),
       overview: dataPlaneOverview,
+      isGateway: dataPlaneOverview.dataplane?.networking?.gateway !== undefined,
     }
 
     if (summary.version) {

--- a/src/app/services/views/ServiceDataPlaneProxiesView.vue
+++ b/src/app/services/views/ServiceDataPlaneProxiesView.vue
@@ -32,7 +32,7 @@
           :src="`/meshes/${route.params.mesh}/dataplanes/for/${route.params.service}/of/${'all'}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
         >
           <template
-            v-for="gateways in [typeof dataplanesData?.items?.[0]?.dataplane?.networking?.gateway === 'undefined']"
+            v-for="gateways in [dataplanesData?.items?.[0]?.dataplane?.networking?.gateway !== undefined]"
             :key="gateways"
           >
             <KCard>


### PR DESCRIPTION
**fix(services): check for gateway being inverted**

Fixes the service detail view’s DPP list passing `props.gateways` as `true` when the first item **isn’t** a gateway and as `false` when the first item **is** a gateway. This view is still flawed, but it’s less broken now.

**fix(services): dpp list linking to wrong views**

Fixes the service detail view’s DPP list linking to the wrong views depending. This change makes it so that the links in this list are always correct and independent from `props.gateways`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Addresses some of the issues related to #1443.