### PR TITLE
feat(data-planes): adds summary tray

### DIFF
--- a/features/mesh/dataplanes/DataplaneSummary.feature
+++ b/features/mesh/dataplanes/DataplaneSummary.feature
@@ -1,0 +1,59 @@
+Feature: Dataplane summary
+  Background:
+    Given the CSS selectors
+      | Alias                | Selector                                       |
+      | item                 | [data-testid='data-plane-collection'] tbody tr |
+      | summary              | [data-testid='summary']                        |
+      | close-summary-button | $summary [data-testid^='close-button-']        |
+    And the environment
+      """
+      KUMA_SUBSCRIPTION_COUNT: 2
+      """
+    And the URL "/meshes/default/dataplanes/_overview" responds with
+      """
+      body:
+        items:
+          - name: test-data-plane-1
+            dataplaneInsight:
+              subscriptions:
+                - status:
+                    lastUpdateTime: 2021-02-16T08:33:36.442044+01:00
+                - status:
+                    lastUpdateTime: 2021-02-18T08:33:36.442044+01:00
+      """
+
+  Scenario: Clicking a row opens the summary
+    Given the environment
+      """
+      KUMA_DATAPLANE_COUNT: 1
+      """
+
+    When I visit the "/meshes/default/data-planes" URL
+    And I click the "$item:nth-child(1) td:nth-child(2)" element
+    Then the "$summary" element exists
+    And the "$summary" element contains "test-data-plane-1"
+
+    When I click the "$close-summary-button" element
+    Then the "$summary" element doesn't exist
+
+    When I navigate "back"
+    Then the "$summary" element exists
+    And the "$summary" element contains "test-data-plane-1"
+
+    When I navigate "forward"
+    Then the "$summary" element doesn't exist
+
+  Scenario: Summary has expected content
+    When I visit the "/meshes/default/data-planes" URL
+    And I click the "$item:nth-child(1) td:nth-child(2)" element
+
+    Then the "$summary" element contains "Feb 18, 2021"
+
+  Scenario: Summary URL goes to page with open dataplane summary
+    Given the environment
+      """
+      KUMA_DATAPLANE_COUNT: 51
+      """
+
+    When I visit the "/meshes/default/data-planes/test-data-plane-1?page=2&size=50" URL
+    Then the "$summary" element exists

--- a/features/mesh/dataplanes/Index.feature
+++ b/features/mesh/dataplanes/Index.feature
@@ -22,12 +22,6 @@ Feature: mesh / dataplanes / index
               inbound:
               - tags:
                   kuma.io/protocol: http
-          dataplaneInsight:
-            subscriptions:
-            - status:
-                lastUpdateTime: 2021-02-16T08:33:36.442044+01:00
-            - status:
-                lastUpdateTime: 2021-02-18T08:33:36.442044+01:00
         - name: fake-frontend
       """
 
@@ -39,14 +33,13 @@ Feature: mesh / dataplanes / index
 
     When I visit the "/meshes/default/data-planes" URL
 
-    Then the "$table-header" element exists 9 times
+    Then the "$table-header" element exists 8 times
     And the "$table-header" elements contain
       | Value            |
       | Name             |
       | Service          |
       | Protocol         |
       | Zone             |
-      | Last Updated     |
       | Certificate Info |
       | Status           |
       | Warnings         |
@@ -59,13 +52,12 @@ Feature: mesh / dataplanes / index
 
     When I visit the "/meshes/default/data-planes" URL
 
-    Then the "$table-header" element exists 8 times
+    Then the "$table-header" element exists 7 times
     And the "$table-header" elements contain
       | Value            |
       | Name             |
       | Service          |
       | Protocol         |
-      | Last Updated     |
       | Certificate Info |
       | Status           |
       | Warnings         |
@@ -78,4 +70,3 @@ Feature: mesh / dataplanes / index
       | Value        |
       | fake-backend |
       | http         |
-      | Feb 18, 2021 |

--- a/features/mesh/gateways/GatewaySummary.feature
+++ b/features/mesh/gateways/GatewaySummary.feature
@@ -1,0 +1,59 @@
+Feature: Gateway summary
+  Background:
+    Given the CSS selectors
+      | Alias                | Selector                                    |
+      | item                 | [data-testid='gateway-collection'] tbody tr |
+      | summary              | [data-testid='summary']                     |
+      | close-summary-button | $summary [data-testid^='close-button-']     |
+    And the environment
+      """
+      KUMA_SUBSCRIPTION_COUNT: 2
+      """
+    And the URL "/meshes/default/dataplanes/_overview" responds with
+      """
+      body:
+        items:
+          - name: test-gateway-1
+            dataplaneInsight:
+              subscriptions:
+                - status:
+                    lastUpdateTime: 2021-02-16T08:33:36.442044+01:00
+                - status:
+                    lastUpdateTime: 2021-02-18T08:33:36.442044+01:00
+      """
+
+  Scenario: Clicking a row opens the summary
+    Given the environment
+      """
+      KUMA_DATAPLANE_COUNT: 1
+      """
+
+    When I visit the "/meshes/default/gateways" URL
+    And I click the "$item:nth-child(1) td:nth-child(2)" element
+    Then the "$summary" element exists
+    And the "$summary" element contains "test-gateway-1"
+
+    When I click the "$close-summary-button" element
+    Then the "$summary" element doesn't exist
+
+    When I navigate "back"
+    Then the "$summary" element exists
+    And the "$summary" element contains "test-gateway-1"
+
+    When I navigate "forward"
+    Then the "$summary" element doesn't exist
+
+  Scenario: Summary has expected content
+    When I visit the "/meshes/default/gateways" URL
+    And I click the "$item:nth-child(1) td:nth-child(2)" element
+
+    Then the "$summary" element contains "Feb 18, 2021"
+
+  Scenario: Summary URL goes to page with open dataplane summary
+    Given the environment
+      """
+      KUMA_DATAPLANE_COUNT: 51
+      """
+
+    When I visit the "/meshes/default/gateways/test-gateway-1?page=2&size=50" URL
+    Then the "$summary" element exists

--- a/features/mesh/gateways/Index.feature
+++ b/features/mesh/gateways/Index.feature
@@ -38,7 +38,6 @@ Feature: mesh / gateways / index
       | Type             |
       | Service          |
       | Zone             |
-      | Last Updated     |
       | Certificate Info |
       | Status           |
       | Warnings         |

--- a/features/mesh/services/Item.feature
+++ b/features/mesh/services/Item.feature
@@ -1,14 +1,12 @@
 Feature: mesh / services / item
   Background:
     Given the CSS selectors
-      | Alias                  | Selector                                                                          |
-      | data-plane-proxies-tab | #service-data-plane-proxies-view-tab a                                            |
-      | item                   | [data-testid='data-plane-collection'] tbody tr                                    |
-      | input-search           | [data-testid='k-filter-bar-filter-input']                                         |
-      | button-search          | [data-testid='k-filter-bar-submit-query-button']                                  |
-      | button-clear-search    | [data-testid="k-filter-bar-clear-query-button"]                                   |
-      | button-actions         | $item:nth-child(1) .actions-column .dropdown-trigger button                       |
-      | button-view            | $item:nth-child(1) .actions-column [data-testid="k-dropdown-item-View-details"] a |
+      | Alias                  | Selector                                         |
+      | data-plane-proxies-tab | #service-data-plane-proxies-view-tab a           |
+      | item                   | [data-testid='data-plane-collection'] tbody tr   |
+      | input-search           | [data-testid='k-filter-bar-filter-input']        |
+      | button-search          | [data-testid='k-filter-bar-submit-query-button'] |
+      | button-clear-search    | [data-testid="k-filter-bar-clear-query-button"]  |
 
   Scenario Outline: Shows Data Plane Proxies for service type <ServiceType>
     Given the URL "/meshes/default/service-insights/firewall-1" responds with
@@ -129,17 +127,10 @@ Feature: mesh / services / item
             - "kuma.io/service:system-1"
         """
 
-    Scenario: Clicking an item takes you to the correct page
-      When I click the "$data-plane-proxies-tab" element
-      Then the "$item:nth-child(1) td:nth-child(1) a" element contains "fake-dataplane"
-      And I click the "$item:nth-child(1) td:nth-child(1) a" element
-      Then the URL contains "/meshes/default/data-planes/fake-dataplane/overview"
-
     Scenario: Clicking an items view menu takes you to the correct page
       When I click the "$data-plane-proxies-tab" element
       Then the "$item:nth-child(1) td:nth-child(1) a" element contains "fake-dataplane"
-      And I click the "$button-actions" element
-      Then I click the "$button-view" element
+      And I click the "$item:nth-child(1) [data-testid='details-link']" element
       Then the URL contains "/meshes/default/data-planes/fake-dataplane/overview"
 
     Scenario: Service with matching ExternalService doesn't show empty state

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -9,35 +9,41 @@
       { label: 'Service', key: 'service' },
       ...(!props.gateways ? [{ label: 'Protocol', key: 'protocol' }] : []),
       ...(isMultiZoneMode ? [{ label: 'Zone', key: 'zone' }] : []),
-      { label: 'Last Updated', key: 'lastUpdated' },
       { label: 'Certificate Info', key: 'certificate' },
       { label: 'Status', key: 'status' },
       { label: 'Warnings', key: 'warnings', hideLabel: true },
-      { label: 'Actions', key: 'actions', hideLabel: true },
+      { label: 'Details', key: 'details', hideLabel: true },
     ]"
     :page-number="props.pageNumber"
     :page-size="props.pageSize"
     :total="props.total"
     :items="props.items ? transformToTableData(props.items) : undefined"
     :error="props.error"
+    :is-selected-row="props.isSelectedRow"
     @change="emit('change', $event)"
   >
     <template #toolbar>
       <slot name="toolbar" />
     </template>
+
     <template #name="{ row: item }">
       <RouterLink
         :to="{
-          name: item.isGateway ? 'gateway-detail-view' : 'data-plane-detail-view',
+          name: props.summaryRouteName,
           params: {
+            mesh: item.mesh,
             dataPlane: item.name,
           },
+          query: {
+            page: props.pageNumber,
+            size: props.pageSize,
+          },
         }"
-        data-testid="detail-view-link"
       >
         {{ item.name }}
       </RouterLink>
     </template>
+
     <template #service="{ rowValue }">
       <RouterLink
         v-if="rowValue.route"
@@ -102,56 +108,33 @@
         {{ t('common.collection.none') }}
       </template>
     </template>
-    <template #certificate="{ row: item }">
-      {{
-        item.dataplaneInsight?.mTLS?.certificateExpirationTime ?
-          formatIsoDate(new Date(item.dataplaneInsight.mTLS.certificateExpirationTime).toUTCString()) :
-          t('data-planes.components.data-plane-list.certificate.none')
-      }}
-    </template>
 
-    <template #actions="{ row: item }">
-      <KDropdownMenu
-        class="actions-dropdown"
-        :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
-        width="150"
+    <template #details="{ row }">
+      <RouterLink
+        class="details-link"
+        data-testid="details-link"
+        :to="{
+          name: row.isGateway ? 'gateway-detail-view' : 'data-plane-detail-view',
+          params: {
+            dataPlane: row.name,
+          },
+        }"
       >
-        <template #default>
-          <KButton
-            class="non-visual-button"
-            appearance="secondary"
-            size="small"
-          >
-            <MoreIcon :size="KUI_ICON_SIZE_30" />
-          </KButton>
-        </template>
-        <template #items>
-          <KDropdownItem
-            :item="{
-              to: {
-                name: item.isGateway ? 'gateway-detail-view' : 'data-plane-detail-view',
-                params: {
-                  dataPlane: item.name,
-                },
-              },
-              label: t('common.collection.actions.view'),
-            }"
-          />
-        </template>
-      </KDropdownMenu>
+        {{ t('common.collection.details_link') }}
+
+        <ArrowRightIcon
+          display="inline-block"
+          decorative
+          :size="KUI_ICON_SIZE_30"
+        />
+      </RouterLink>
     </template>
   </AppCollection>
 </template>
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { MoreIcon } from '@kong/icons'
-import {
-  KDropdownItem,
-  KDropdownMenu,
-  KButton,
-  KTooltip,
-} from '@kong/kongponents'
+import { ArrowRightIcon } from '@kong/icons'
 import { type RouteLocationNamedRaw } from 'vue-router'
 
 import { useCan } from '@/app/application'
@@ -188,8 +171,8 @@ type DataPlaneOverviewTableRow = {
     version_mismatch: boolean
     cert_expired: boolean
   }
-  lastUpdated: string
   isGateway: boolean
+  certificate: string
 }
 
 type ChangeValue = {
@@ -204,9 +187,12 @@ const props = withDefaults(defineProps<{
   items: DataPlaneOverview[] | undefined
   error: Error | undefined
   gateways?: boolean
+  isSelectedRow: ((row: any) => boolean) | null
+  summaryRouteName: string
 }>(), {
   total: 0,
   gateways: false,
+  isSelectedRow: null,
 })
 
 const emit = defineEmits<{
@@ -258,31 +244,28 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
 
     const initialData: {
       dpVersion: string | null
-      selectedUpdateTime: number
       version: Version | null
     } = {
       dpVersion: null,
-      selectedUpdateTime: NaN,
       version: null,
     }
 
     const summary = subscriptions.reduce(
       (acc, subscription) => {
-        const lastUpdateDate = Date.parse(subscription.status.lastUpdateTime)
-        if (lastUpdateDate) {
-          if (!acc.selectedUpdateTime || lastUpdateDate > acc.selectedUpdateTime) {
-            acc.selectedUpdateTime = lastUpdateDate
-          }
-        }
-
         return {
           dpVersion: subscription.version?.kumaDp.version || acc.dpVersion,
-          selectedUpdateTime: acc.selectedUpdateTime,
           version: subscription.version || acc.version,
         }
       },
       initialData,
     )
+
+    let certificate
+    if (dataPlaneOverview.dataplaneInsight?.mTLS?.certificateExpirationTime) {
+      certificate = formatIsoDate(dataPlaneOverview.dataplaneInsight.mTLS.certificateExpirationTime)
+    } else {
+      certificate = t('data-planes.components.data-plane-list.certificate.none')
+    }
 
     // assemble the table data
     const item: DataPlaneOverviewTableRow = {
@@ -296,8 +279,8 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
         version_mismatch: false,
         cert_expired: false,
       },
-      lastUpdated: summary.selectedUpdateTime ? formatIsoDate(new Date(summary.selectedUpdateTime).toUTCString()) : t('common.collection.none'),
       isGateway: dataPlaneOverview.dataplane?.networking?.gateway !== undefined,
+      certificate,
     }
 
     if (summary.version) {
@@ -330,7 +313,9 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
 </script>
 
 <style lang="scss" scoped>
-.actions-dropdown {
-  display: inline-block;
+.details-link {
+  display: inline-flex;
+  align-items: center;
+  gap: $kui-space-20;
 }
 </style>

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -108,6 +108,13 @@
         {{ t('common.collection.none') }}
       </template>
     </template>
+    <template #certificate="{ row: item }">
+      {{
+        item.dataplaneInsight?.mTLS?.certificateExpirationTime ?
+          formatIsoDate(new Date(item.dataplaneInsight.mTLS.certificateExpirationTime).toUTCString()) :
+          t('data-planes.components.data-plane-list.certificate.none')
+      }}
+    </template>
 
     <template #details="{ row }">
       <RouterLink
@@ -172,7 +179,6 @@ type DataPlaneOverviewTableRow = {
     cert_expired: boolean
   }
   isGateway: boolean
-  certificate: string
 }
 
 type ChangeValue = {
@@ -260,13 +266,6 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
       initialData,
     )
 
-    let certificate
-    if (dataPlaneOverview.dataplaneInsight?.mTLS?.certificateExpirationTime) {
-      certificate = formatIsoDate(dataPlaneOverview.dataplaneInsight.mTLS.certificateExpirationTime)
-    } else {
-      certificate = t('data-planes.components.data-plane-list.certificate.none')
-    }
-
     // assemble the table data
     const item: DataPlaneOverviewTableRow = {
       name,
@@ -280,7 +279,6 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
         cert_expired: false,
       },
       isGateway: dataPlaneOverview.dataplane?.networking?.gateway !== undefined,
-      certificate,
     }
 
     if (summary.version) {

--- a/src/app/data-planes/components/DataPlaneSummary.vue
+++ b/src/app/data-planes/components/DataPlaneSummary.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="stack">
+    <DefinitionCard>
+      <template #title>
+        {{ t('http.api.property.status') }}
+      </template>
+
+      <template #body>
+        <div class="status-with-reason">
+          <StatusBadge :status="statusWithReason.status" />
+
+          <KTooltip
+            v-if="statusWithReason.reason.length > 0"
+            :label="statusWithReason.reason.join(', ')"
+            class="reason-tooltip"
+          >
+            <InfoIcon
+              :size="KUI_ICON_SIZE_30"
+              hide-title
+            />
+          </KTooltip>
+        </div>
+      </template>
+    </DefinitionCard>
+
+    <DefinitionCard>
+      <template #title>
+        {{ t('http.api.property.tags') }}
+      </template>
+
+      <template #body>
+        <TagList
+          v-if="dataPlaneTags.length > 0"
+          :tags="dataPlaneTags"
+        />
+
+        <template v-else>
+          {{ t('common.detail.none') }}
+        </template>
+      </template>
+    </DefinitionCard>
+
+    <DefinitionCard>
+      <template #title>
+        {{ t('http.api.property.dependencies') }}
+      </template>
+
+      <template #body>
+        <TagList
+          v-if="dataPlaneVersions !== null"
+          :tags="dataPlaneVersions"
+        />
+
+        <template v-else>
+          {{ t('common.detail.none') }}
+        </template>
+      </template>
+    </DefinitionCard>
+
+    <DefinitionCard>
+      <template #title>
+        {{ t('data-planes.routes.item.last_updated') }}
+      </template>
+
+      <template #body>
+        <template v-if="lastUpdatedTime">
+          {{ lastUpdatedTime }}
+        </template>
+
+        <template v-else>
+          {{ t('common.detail.none') }}
+        </template>
+      </template>
+    </DefinitionCard>
+
+    <DefinitionCard>
+      <template #title>
+        {{ t('data-planes.routes.item.certificate_info') }}
+      </template>
+
+      <template #body>
+        <template v-if="props.dataplaneOverview.dataplaneInsight?.mTLS?.certificateExpirationTime">
+          {{ formatIsoDate(props.dataplaneOverview.dataplaneInsight?.mTLS.certificateExpirationTime) }}
+        </template>
+
+        <template v-else>
+          {{ t('data-planes.routes.item.no_certificate') }}
+        </template>
+      </template>
+    </DefinitionCard>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { InfoIcon } from '@kong/icons'
+import { computed } from 'vue'
+
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
+import StatusBadge from '@/app/common/StatusBadge.vue'
+import TagList from '@/app/common/TagList.vue'
+import type { DataPlaneOverview } from '@/types/index.d'
+import { useI18n } from '@/utilities'
+import { dpTags, getStatusAndReason, getVersions } from '@/utilities/dataplane'
+
+const { t, formatIsoDate } = useI18n()
+
+const props = defineProps<{
+  dataplaneOverview: DataPlaneOverview
+}>()
+
+const statusWithReason = computed(() => getStatusAndReason(props.dataplaneOverview.dataplane, props.dataplaneOverview.dataplaneInsight))
+const dataPlaneTags = computed(() => dpTags(props.dataplaneOverview.dataplane))
+const dataPlaneVersions = computed(() => getVersions(props.dataplaneOverview.dataplaneInsight))
+const lastUpdatedTime = computed(() => {
+  const subscriptions = props.dataplaneOverview.dataplaneInsight?.subscriptions ?? []
+
+  if (subscriptions.length === 0) {
+    return null
+  }
+
+  const lastSubscription = subscriptions[subscriptions.length - 1]
+
+  return formatIsoDate(lastSubscription.status.lastUpdateTime)
+})
+</script>
+
+<style lang="scss" scoped>
+.status-with-reason {
+  display: flex;
+  align-items: center;
+  gap: $kui-space-50;
+}
+
+.reason-tooltip :deep(.kong-icon) {
+  display: flex;
+  align-items: center;
+}
+</style>

--- a/src/app/data-planes/locales/en-us/index.yaml
+++ b/src/app/data-planes/locales/en-us/index.yaml
@@ -16,6 +16,10 @@ data-planes:
         data-plane-stats-view: 'Stats'
         data-plane-clusters-view: 'Clusters'
         data-plane-config-view: 'YAML'
+      overview: 'Overview'
+      last_updated: 'Last updated'
+      certificate_info: 'Certificate info'
+      no_certificate: 'No certificate'
       mtls:
         title: 'TLS'
         expiration_time:

--- a/src/app/data-planes/routes.ts
+++ b/src/app/data-planes/routes.ts
@@ -52,6 +52,13 @@ export const routes = () => {
             module: 'data-planes',
           },
           component: () => import('@/app/data-planes/views/DataPlaneListView.vue'),
+          children: [
+            {
+              path: ':dataPlane',
+              name: 'data-plane-summary-view',
+              component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
+            },
+          ],
         },
       ]
     },

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -208,7 +208,6 @@
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { InfoIcon } from '@kong/icons'
-import { KAlert, KCard, KTooltip } from '@kong/kongponents'
 import { computed } from 'vue'
 
 import { useCan } from '@/app/application'
@@ -288,16 +287,15 @@ const warnings = computed(() => {
 })
 
 </script>
+
 <style lang="scss" scoped>
 .status-with-reason {
   display: flex;
   align-items: center;
   gap: $kui-space-50;
 }
-</style>
 
-<style lang="scss">
-.reason-tooltip .kong-icon {
+.reason-tooltip :deep(.kong-icon) {
   display: flex;
   align-items: center;
 }

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -13,6 +13,7 @@
         query: '',
         s: '',
         mesh: '',
+        dataPlane: '',
       }"
     >
       <DataSource
@@ -28,6 +29,7 @@
               />
             </h2>
           </template>
+
           <KCard>
             <template #body>
               <ErrorBlock
@@ -44,6 +46,8 @@
                 :total="data?.total"
                 :items="data?.items"
                 :error="error"
+                :is-selected-row="(row) => row.name === route.params.dataPlane"
+                summary-route-name="data-plane-summary-view"
                 @change="route.update"
               >
                 <template #toolbar>
@@ -66,6 +70,30 @@
               </DataPlaneList>
             </template>
           </KCard>
+
+          <RouterView
+            v-if="route.params.dataPlane"
+            v-slot="child"
+          >
+            <SummaryView
+              @close="route.replace({
+                name: 'data-plane-list-view',
+                params: {
+                  mesh: route.params.mesh,
+                },
+                query: {
+                  page: route.params.page,
+                  size: route.params.size,
+                },
+              })"
+            >
+              <component
+                :is="child.Component"
+                :name="route.params.dataPlane"
+                :dataplane-overview="data?.items.find((item) => item.name === route.params.dataPlane)"
+              />
+            </SummaryView>
+          </RouterView>
         </AppView>
       </DataSource>
     </RouteView>
@@ -77,8 +105,10 @@ import DataPlaneList from '../components/DataPlaneList.vue'
 import type { DataPlaneCollectionSource } from '../sources'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import KFilterBar from '@/app/common/KFilterBar.vue'
+import SummaryView from '@/app/common/SummaryView.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
+
 <style lang="scss" scoped>
 .data-plane-proxy-filter {
   flex-basis: 350px;

--- a/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -1,0 +1,88 @@
+<template>
+  <RouteView :name="(route.name as string)">
+    <AppView>
+      <template #title>
+        <div class="summary-title-wrapper">
+          <img
+            aria-hidden="true"
+            src="@/assets/images/icon-wifi-tethering.svg?url"
+          >
+
+          <h2 class="summary-title">
+            <RouterLink
+              :to="{
+                name: isGateway ? 'gateway-detail-view' : 'data-plane-detail-view',
+                params: {
+                  dataPlane: props.name,
+                },
+              }"
+            >
+              <RouteTitle
+                :title="t('data-planes.routes.item.title', { name: props.name })"
+                :render="true"
+              />
+            </RouterLink>
+          </h2>
+        </div>
+      </template>
+
+      <EmptyBlock v-if="props.dataplaneOverview === undefined">
+        {{ t('common.collection.summary.empty_title', { type: isGateway ? 'Gateway' : 'Dataplane' }) }}
+
+        <template #message>
+          <p>{{ t('common.collection.summary.empty_message', { type: isGateway ? 'Gateway' : 'Dataplane' }) }}</p>
+        </template>
+      </EmptyBlock>
+
+      <div
+        v-else
+        class="stack"
+      >
+        <div>
+          <h3>{{ t('data-planes.routes.item.overview') }}</h3>
+
+          <DataPlaneSummary
+            class="mt-4"
+            :dataplane-overview="props.dataplaneOverview"
+          />
+        </div>
+      </div>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+import EmptyBlock from '@/app/common/EmptyBlock.vue'
+import DataPlaneSummary from '@/app/data-planes/components/DataPlaneSummary.vue'
+import type { DataPlaneOverview } from '@/types/index.d'
+import { useI18n } from '@/utilities'
+
+const { t } = useI18n()
+const route = useRoute()
+
+const props = withDefaults(defineProps<{
+  name: string
+  dataplaneOverview?: DataPlaneOverview
+}>(), {
+  dataplaneOverview: undefined,
+})
+
+const isGateway = computed(() => props.dataplaneOverview?.dataplane?.networking?.gateway !== undefined)
+</script>
+
+<style lang="scss" scoped>
+.summary-title-wrapper {
+  display: flex;
+  align-items: baseline;
+  gap: $kui-space-30;
+  // Accounts for the absolutely-positioned close button
+  margin-right: calc($kui-space-30 + 24px);
+}
+
+.summary-title {
+  margin-top: 0;
+}
+</style>

--- a/src/app/gateways/routes.ts
+++ b/src/app/gateways/routes.ts
@@ -50,6 +50,13 @@ export const routes = () => {
             module: 'gateways',
           },
           component: () => import('@/app/gateways/views/GatewayListView.vue'),
+          children: [
+            {
+              path: ':dataPlane',
+              name: 'gateway-summary-view',
+              component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
+            },
+          ],
         },
       ]
     },

--- a/src/app/gateways/views/GatewayListView.vue
+++ b/src/app/gateways/views/GatewayListView.vue
@@ -14,6 +14,7 @@
         query: '',
         s: '',
         mesh: '',
+        dataPlane: '',
       }"
     >
       <DataSource
@@ -29,6 +30,7 @@
               />
             </h2>
           </template>
+
           <KCard>
             <template #body>
               <ErrorBlock
@@ -46,6 +48,8 @@
                 :items="data?.items"
                 :error="error"
                 :gateways="true"
+                :is-selected-row="(row) => row.name === route.params.dataPlane"
+                summary-route-name="gateway-summary-view"
                 @change="({page, size}) => {
                   route.update({
                     page: String(page),
@@ -104,6 +108,30 @@
               </DataPlaneList>
             </template>
           </KCard>
+
+          <RouterView
+            v-if="route.params.dataPlane"
+            v-slot="child"
+          >
+            <SummaryView
+              @close="route.replace({
+                name: 'gateway-list-view',
+                params: {
+                  mesh: route.params.mesh,
+                },
+                query: {
+                  page: route.params.page,
+                  size: route.params.size,
+                },
+              })"
+            >
+              <component
+                :is="child.Component"
+                :name="route.params.dataPlane"
+                :dataplane-overview="data?.items.find((item) => item.name === route.params.dataPlane)"
+              />
+            </SummaryView>
+          </RouterView>
         </AppView>
       </DataSource>
     </RouteView>
@@ -114,11 +142,13 @@
 import type { GatewayCollectionSource } from '../sources'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import KFilterBar from '@/app/common/KFilterBar.vue'
+import SummaryView from '@/app/common/SummaryView.vue'
 import DataPlaneList from '@/app/data-planes/components/DataPlaneList.vue'
 import type { MeSource } from '@/app/me/sources'
 import type { SelectItem } from '@kong/kongponents'
 
 </script>
+
 <style lang="scss" scoped>
 .data-plane-proxy-filter {
   flex-basis: 350px;

--- a/src/app/services/routes.ts
+++ b/src/app/services/routes.ts
@@ -21,7 +21,17 @@ export const routes = () => {
           {
             path: 'data-plane-proxies',
             name: 'service-data-plane-proxies-view',
+            meta: {
+              module: 'service-data-planes',
+            },
             component: () => import('@/app/services/views/ServiceDataPlaneProxiesView.vue'),
+            children: [
+              {
+                path: ':dataPlane',
+                name: 'service-data-plane-summary-view',
+                component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
+              },
+            ],
           },
         ],
       },

--- a/src/app/services/views/ServiceDataPlaneProxiesView.vue
+++ b/src/app/services/views/ServiceDataPlaneProxiesView.vue
@@ -15,6 +15,7 @@
         mesh: '',
         service: '',
         gatewayType: '',
+        dataPlane: '',
       }"
     >
       <AppView>
@@ -46,6 +47,8 @@
                   :items="dataplanesData?.items"
                   :error="dataplanesError"
                   :gateways="gateways"
+                  :is-selected-row="(row) => row.name === route.params.dataPlane"
+                  summary-route-name="service-data-plane-summary-view"
                   @change="route.update"
                 >
                   <template #toolbar>
@@ -99,6 +102,30 @@
                 </DataPlaneList>
               </template>
             </KCard>
+
+            <RouterView
+              v-if="route.params.dataPlane"
+              v-slot="child"
+            >
+              <SummaryView
+                @close="route.replace({
+                  name: 'service-data-plane-proxies-view',
+                  params: {
+                    mesh: route.params.mesh,
+                  },
+                  query: {
+                    page: route.params.page,
+                    size: route.params.size,
+                  },
+                })"
+              >
+                <component
+                  :is="child.Component"
+                  :name="route.params.dataPlane"
+                  :dataplane-overview="dataplanesData?.items.find((item) => item.name === route.params.dataPlane)"
+                />
+              </SummaryView>
+            </RouterView>
           </template>
         </DataSource>
       </AppView>
@@ -108,6 +135,7 @@
 
 <script lang="ts" setup>
 import KFilterBar from '@/app/common/KFilterBar.vue'
+import SummaryView from '@/app/common/SummaryView.vue'
 import DataPlaneList from '@/app/data-planes/components/DataPlaneList.vue'
 import { DataPlaneCollectionSource } from '@/app/data-planes/sources'
 import type { MeSource } from '@/app/me/sources'


### PR DESCRIPTION
## Changes

Adds a summary tray to the DPP and Gateway list views and the DPP table in the service detail view.

Resolves #1637.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

- I decided to move the "Last updated" column into the summary trays (and out of the tables). Let’s discuss this.
- There is an issue with KSlideout: content that overflows the tray area is clipped off because the content area has `overflow-y: auto` which implies that `overflow-x` _also_ computes to `auto` (and cannot be changed to `visible`). This can be observed in service trays that have a StatusBadge with a tooltip: the tooltip content will be only partially visible.
- The arrangement of the summary trays in the DPP listing of a service detail view is a little awkward right now. In order to link to the correct summary tray route name withing DataPlaneList, I needed to add `props.trayRouteName`. I’d like to address this as part of https://github.com/kumahq/kuma-gui/issues/1443 and make sure we have dedicated listings for Gateways and DPPs that aren’t mixed in one component (i.e. how we do it today with DataPlaneList), but I think that would really blow up the scope of this PR, too much.

## Screenshots

![image](https://github.com/kumahq/kuma-gui/assets/5774638/e879a4f5-5cc0-4a19-b950-dfaed418a54d)
