### PR TITLE
fix(zones): Catch zoneEgressInsight/zoneIngressInsight being undefined

### DIFF
--- a/src/app/zones/views/IndexView.vue
+++ b/src/app/zones/views/IndexView.vue
@@ -291,7 +291,7 @@ const getIngresses = (data: {items: ZoneIngressOverview[]}) => {
           offline: [],
         }
       }
-      const subscriptions = item[`${prop}Insight`].subscriptions || []
+      const subscriptions = item[`${prop}Insight`]?.subscriptions || []
       const state = getState(subscriptions)
       prev[name][state].push(item)
     }
@@ -309,7 +309,7 @@ const getEgresses = (data: {items: ZoneEgressOverview[]}) => {
           offline: [],
         }
       }
-      const subscriptions = item[`${prop}Insight`].subscriptions || []
+      const subscriptions = item[`${prop}Insight`]?.subscriptions || []
       const state = getState(subscriptions)
       prev[name][state].push(item)
     }


### PR DESCRIPTION
See title

Note: I would like to move this code elsewhere (to the `data` folder). I didn't put it there when I originally did it because it was crossing over with other PRs I think, and I didn't do it here, as it would probably appear like lots of change. So I'm PRing this fix, and I'll move the code later.