### PR TITLE
chore(linters): applies consistent TS delimiter rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -136,6 +136,15 @@ const INLINE_NON_VOID_ELEMENTS = [
             },
           },
         }],
+
+        '@typescript-eslint/member-delimiter-style': ['error', {
+          singleline: {
+            delimiter: 'comma',
+          },
+          multiline: {
+            delimiter: 'none',
+          },
+        }],
       },
     },
   ],

--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -74,7 +74,7 @@ Given('the URL {string} responds with', (url: string, yaml: string) => {
   mock(url, env, (respond) => {
     const response = respond(
       (YAML.parse(yaml) || {}) as {
-        headers?: Record<string, string>,
+        headers?: Record<string, string>
         body?: Record<string, unknown>
       },
     )
@@ -138,8 +138,8 @@ Then(/^the URL "(.*)" was?(n't | not | )requested with$/, (url: string, not: str
   cy.wrap({
     url,
     ...YAML.parse(yaml) as {
-      method: string,
-      searchParams: Record<string, string>,
+      method: string
+      searchParams: Record<string, string>
       body: Record<string, unknown>
     },
   }).then(async (request) => {

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -53,7 +53,7 @@ const router = useRouter()
 const sym = Symbol('route-view')
 
 const props = withDefaults(defineProps<{
-  name: string,
+  name: string
   attrs?: Record<string, string>
   params?: T
 }>(), {

--- a/src/app/application/services/data-source/SharedPool.ts
+++ b/src/app/application/services/data-source/SharedPool.ts
@@ -2,7 +2,7 @@ type Creator<K, T> = (key: K) => T
 type Destroyer<K, T> = (key: K, item: T) => void
 
 type Entry<T> = {
-  value: T,
+  value: T
   references: Set<symbol>
 }
 export default class SharedPool<K, T> {

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -198,11 +198,11 @@ type ChangeValue = {
 }
 
 const props = withDefaults(defineProps<{
-  total?: number,
-  pageNumber: number,
-  pageSize: number,
-  items: DataPlaneOverview[] | undefined,
-  error: Error | undefined,
+  total?: number
+  pageNumber: number
+  pageSize: number
+  items: DataPlaneOverview[] | undefined
+  error: Error | undefined
   gateways?: boolean
 }>(), {
   total: 0,

--- a/src/app/onboarding/components/ServiceBox.vue
+++ b/src/app/onboarding/components/ServiceBox.vue
@@ -19,7 +19,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits<{
-  (event: 'clicked'): void,
+  (event: 'clicked'): void
 }>()
 </script>
 

--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -153,15 +153,15 @@ export default class KumaApi extends Api {
     return this.client.get(`/meshes/${mesh}/dataplanes+insights/${name}`, { params })
   }
 
-  getSidecarDataplanePolicies({ mesh, name }: { mesh: string; name: string }, params?: any): Promise<ApiKindListResponse<SidecarDataplane>> {
+  getSidecarDataplanePolicies({ mesh, name }: { mesh: string, name: string }, params?: any): Promise<ApiKindListResponse<SidecarDataplane>> {
     return this.client.get(`/meshes/${mesh}/dataplanes/${name}/policies`, { params })
   }
 
-  getMeshGatewayDataplane({ mesh, name }: { mesh: string; name: string }, params?: any): Promise<MeshGatewayDataplane> {
+  getMeshGatewayDataplane({ mesh, name }: { mesh: string, name: string }, params?: any): Promise<MeshGatewayDataplane> {
     return this.client.get(`/meshes/${mesh}/dataplanes/${name}/policies`, { params })
   }
 
-  getDataplaneRules({ mesh, name }: { mesh: string; name: string }, params?: any): Promise<ApiListResponse<DataplaneRule>> {
+  getDataplaneRules({ mesh, name }: { mesh: string, name: string }, params?: any): Promise<ApiListResponse<DataplaneRule>> {
     return this.client.get(`/meshes/${mesh}/dataplanes/${name}/rules`, { params })
   }
 
@@ -196,7 +196,7 @@ export default class KumaApi extends Api {
     return this.client.get(`/meshes/${mesh}/external-services/${name}`, { params })
   }
 
-  getPolicyConnections({ mesh, path, name }: { mesh: string; path: string; name: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<PolicyDataplane>> {
+  getPolicyConnections({ mesh, path, name }: { mesh: string, path: string, name: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<PolicyDataplane>> {
     return this.client.get(`/meshes/${mesh}/${path}/${name}/dataplanes`, { params })
   }
 

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -65,7 +65,7 @@ export class KumaModule {
   connection<T>(_: T, i: number, arr: T[]) {
     const connected = this.faker.date.past()
     const times: {
-      connectTime: string,
+      connectTime: string
       disconnectTime?: string
     } = {
       connectTime: `${connected.toISOString().slice(0, -1)}${this.faker.number.int({ min: 1000, max: 9999 })}Z`,

--- a/src/test-support/client.ts
+++ b/src/test-support/client.ts
@@ -6,9 +6,9 @@ type HistoryEntry = {
   }
 }
 type Request = {
-  url: string,
-  method: string,
-  searchParams: Record<string, string>,
+  url: string
+  method: string
+  searchParams: Record<string, string>
   body: Record<string, unknown>
 }
 type Listener = {

--- a/src/test-support/fake.ts
+++ b/src/test-support/fake.ts
@@ -13,10 +13,10 @@ export type RestRequest = {
 }
 
 type Pager = (total: string | number, req: RestRequest, self: string) => {
-  next: string | null,
-  pageTotal: number,
-  total: number,
-  offset: number,
+  next: string | null
+  pageTotal: number
+  total: number
+  offset: number
   size: number
 }
 const pager: Pager = (_total: string | number, req: RestRequest, self) => {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -209,7 +209,7 @@ export type DataPlaneNetworking = {
   gateway?: {
     tags: Record<string, string>
     type?: 'builtin' | 'delegated' | undefined
-  },
+  }
 }
 
 /**
@@ -295,7 +295,7 @@ export interface DataPlaneOverview extends MeshEntity {
 }
 
 export interface DataplaneRule {
-  type: 'ClientSubset' | 'DestinationSubset' | 'SingleItem',
+  type: 'ClientSubset' | 'DestinationSubset' | 'SingleItem'
   name: string
   service?: string
   addresses?: string[]


### PR DESCRIPTION
Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
