### PR TITLE
chore(linter): error on undefined Vue components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -116,6 +116,23 @@ const INLINE_NON_VOID_ELEMENTS = [
             message: 'Using "data-test-id" is not allowed. Use "data-testid" instead.',
           },
         ],
+        'vue/no-undef-components': ['error', {
+          // Globally-registered components must be ignored here (https://eslint.vuejs.org/rules/no-undef-components.html)
+          ignorePatterns: [
+            // vue-router
+            'RouterLink',
+            'RouterView',
+            // @kong/kongponents
+            'K[A-Z].*',
+            // @kong-ui-public/i18n
+            'I18nT',
+            // Application
+            'AppView',
+            'DataSource',
+            'RouteView',
+            'RouteTitle',
+          ],
+        }],
       },
     },
     {

--- a/src/app/main-overview/views/MainOverviewView.vue
+++ b/src/app/main-overview/views/MainOverviewView.vue
@@ -106,6 +106,7 @@
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { AddIcon } from '@kong/icons'
 
+import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import MeshInsightsList from '@/app/meshes/components/MeshInsightsList.vue'
 import { MeshInsightCollectionSource } from '@/app/meshes/sources'
 import ZoneControlPlanesList from '@/app/zones/components/ZoneControlPlanesList.vue'

--- a/src/app/zone-ingresses/views/item/ServicesView.vue
+++ b/src/app/zone-ingresses/views/item/ServicesView.vue
@@ -102,6 +102,7 @@
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { MoreIcon } from '@kong/icons'
 
 import type { AvailableService, ZoneIngressOverview } from '../../data'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'


### PR DESCRIPTION
Adds a linter rule for erroring on undefined Vue components which is an easy mistake to make.

Fixes three instances of undefined components this rule caught.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
