### PR TITLE
feat(app-collection): systematically add linked name and "Go to details" cells

### DIFF
--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -61,8 +61,8 @@ Feature: mesh / policies / index
 
   Scenario: Clicking the link goes to the detail page and back again
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "fake-cb-1"
-    When I click the "$item:nth-child(1) td:first-of-type a" element
-    Then I click the "$item:nth-child(1) [data-testid='details-link']" element
+
+    When I click the "$item:nth-child(1) [data-testid='details-link']" element
     Then the URL contains "circuit-breakers/fake-cb-1"
 
     When I click the "$breadcrumbs > .k-breadcrumbs-item:nth-child(3) > a" element

--- a/features/mesh/services/Item.feature
+++ b/features/mesh/services/Item.feature
@@ -145,8 +145,9 @@ Feature: mesh / services / item
 
     Scenario: Clicking an items view menu takes you to the correct page
       When I click the "$data-plane-proxies-tab" element
-      Then the "$item:nth-child(1) td:nth-child(1) a" element contains "fake-dataplane"
-      And I click the "$item:nth-child(1) [data-testid='details-link']" element
+      Then the "$item:nth-child(1) td:nth-child(1)" element contains "fake-dataplane"
+
+      When I click the "$item:nth-child(1) [data-testid='details-link']" element
       Then the URL contains "/meshes/default/data-planes/fake-dataplane/overview"
 
     Scenario: Service with matching ExternalService doesn't show empty state

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -18,6 +18,24 @@
     :items="props.items ? transformToTableData(props.items) : undefined"
     :error="props.error"
     :is-selected-row="props.isSelectedRow"
+    :get-detail-route="(row) => ({
+      name: 'data-plane-detail-view',
+      params: {
+        mesh: row.mesh,
+        dataPlane: row.name,
+      },
+    })"
+    :get-summary-route="(row) => ({
+      name: props.summaryRouteName,
+      params: {
+        mesh: row.mesh,
+        dataPlane: row.name,
+      },
+      query: {
+        page: props.pageNumber,
+        size: props.pageSize,
+      },
+    })"
     @change="emit('change', $event)"
   >
     <template
@@ -105,33 +123,11 @@
         {{ t('common.collection.none') }}
       </template>
     </template>
-
-    <template #details="{ row }: { row: DataPlaneOverviewTableRow }">
-      <RouterLink
-        class="details-link"
-        data-testid="details-link"
-        :to="{
-          name: 'data-plane-detail-view',
-          params: {
-            dataPlane: row.name,
-          },
-        }"
-      >
-        {{ t('common.collection.details_link') }}
-
-        <ArrowRightIcon
-          display="inline-block"
-          decorative
-          :size="KUI_ICON_SIZE_30"
-        />
-      </RouterLink>
-    </template>
   </AppCollection>
 </template>
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
 
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
@@ -263,11 +259,3 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
   })
 }
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/meshes/components/MeshInsightsList.vue
+++ b/src/app/meshes/components/MeshInsightsList.vue
@@ -10,19 +10,13 @@
     :empty-state-message="t('common.emptyState.message', { type: t('meshes.common.type', {count: 2}) })"
     :empty-state-cta-to="t('meshes.href.docs')"
     :empty-state-cta-text="t('common.documentation')"
+    :get-detail-route="(row) => ({
+      name: 'mesh-detail-view',
+      params: {
+        mesh: row.name,
+      },
+    })"
   >
-    <template #name="{ row: item }">
-      <RouterLink
-        :to="{
-          name: 'mesh-detail-view',
-          params: {
-            mesh: item.name,
-          },
-        }"
-      >
-        {{ item.name }}
-      </RouterLink>
-    </template>
     <template #services="{ row: item }">
       {{ item.services.internal ?? '0' }}
     </template>

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -53,53 +53,20 @@
                   :empty-state-message="t('common.emptyState.message', { type: 'Meshes' })"
                   :empty-state-cta-to="t('meshes.href.docs')"
                   :empty-state-cta-text="t('common.documentation')"
-                  :is-selected-row="(row) => row.name === route.params.mesh"
+                  :get-detail-route="(row) => ({
+                    name: 'mesh-detail-view',
+                    params: {
+                      mesh: row.name,
+                    },
+                  })"
                   @change="route.update"
                 >
-                  <template #name="{ row: item }">
-                    <RouterLink
-                      :to="{
-                        name: 'mesh-detail-view',
-                        params: {
-                          mesh: item.name,
-                        },
-                        query: {
-                          page: route.params.page,
-                          size: route.params.size,
-                        },
-                      }"
-                    >
-                      {{ item.name }}
-                    </RouterLink>
-                  </template>
-
                   <template #services="{ row: item }">
                     {{ item.services.internal ?? '0' }}
                   </template>
 
                   <template #dataplanes="{ row: item }">
                     {{ item.dataplanesByType.standard.online ?? '0' }} / {{ item.dataplanesByType.standard.total ?? '0' }}
-                  </template>
-
-                  <template #details="{ row }">
-                    <RouterLink
-                      class="details-link"
-                      data-testid="details-link"
-                      :to="{
-                        name: 'mesh-detail-view',
-                        params: {
-                          mesh: row.name,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.details_link') }}
-
-                      <ArrowRightIcon
-                        display="inline-block"
-                        decorative
-                        :size="KUI_ICON_SIZE_30"
-                      />
-                    </RouterLink>
                   </template>
                 </AppCollection>
               </template>
@@ -136,20 +103,9 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import type { MeshInsightCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/policies/components/PolicyList.vue
+++ b/src/app/policies/components/PolicyList.vue
@@ -107,27 +107,28 @@
               :items="props.policyCollection?.items"
               :error="props.policyError"
               :is-selected-row="props.isSelectedRow"
+              :get-detail-route="(row) => ({
+                name: 'policy-detail-view',
+                params: {
+                  mesh: row.mesh,
+                  policyPath: props.currentPolicyType.path,
+                  policy: row.name,
+                },
+              })"
+              :get-summary-route="(row) => ({
+                name: 'policy-summary-view',
+                params: {
+                  mesh: row.mesh,
+                  policyPath: props.currentPolicyType.path,
+                  policy: row.name,
+                },
+                query: {
+                  page: props.pageNumber,
+                  size: props.pageSize,
+                },
+              })"
               @change="emit('change', $event)"
             >
-              <template #name="{ rowValue }">
-                <RouterLink
-                  :to="{
-                    name: 'policy-summary-view',
-                    params: {
-                      mesh: route.params.mesh,
-                      policyPath: props.currentPolicyType.path,
-                      policy: rowValue,
-                    },
-                    query: {
-                      page: props.pageNumber,
-                      size: props.pageSize,
-                    },
-                  }"
-                >
-                  {{ rowValue }}
-                </RouterLink>
-              </template>
-
               <template #targetRef="{ row }">
                 <template v-if="props.currentPolicyType.isTargetRefBased">
                   <KBadge appearance="neutral">
@@ -139,29 +140,6 @@
                   {{ t('common.detail.none') }}
                 </template>
               </template>
-
-              <template #details="{ row }">
-                <RouterLink
-                  class="details-link"
-                  data-testid="details-link"
-                  :to="{
-                    name: 'policy-detail-view',
-                    params: {
-                      mesh: row.mesh,
-                      policyPath: props.currentPolicyType.path,
-                      policy: row.name,
-                    },
-                  }"
-                >
-                  {{ t('common.collection.details_link') }}
-
-                  <ArrowRightIcon
-                    display="inline-block"
-                    decorative
-                    :size="KUI_ICON_SIZE_30"
-                  />
-                </RouterLink>
-              </template>
             </AppCollection>
           </template>
         </KCard>
@@ -171,8 +149,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
 import { useRoute } from 'vue-router'
 
 import { PolicyCollection } from '../sources'
@@ -262,11 +238,5 @@ const emit = defineEmits<{
   display: flex;
   align-items: flex-start;
   gap: $kui-space-40;
-}
-
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
 }
 </style>

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -54,26 +54,14 @@
                 :items="data?.items"
                 :error="error"
                 :is-selected-row="(row) => row.name === route.params.service"
+                :get-detail-route="(row) => ({
+                  name: 'service-detail-view',
+                  params: {
+                    service: row.name,
+                  },
+                })"
                 @change="route.update"
               >
-                <template #name="{ row: item }">
-                  <RouterLink
-                    :to="{
-                      name: 'service-detail-view',
-                      params: {
-                        mesh: item.mesh,
-                        service: item.name,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                      },
-                    }"
-                  >
-                    {{ item.name }}
-                  </RouterLink>
-                </template>
-
                 <template #serviceType="{ rowValue }">
                   {{ rowValue || 'internal' }}
                 </template>
@@ -104,28 +92,6 @@
 
                 <template #status="{ row: item }">
                   <StatusBadge :status="item.status || 'not_available'" />
-                </template>
-
-                <template #details="{ row }">
-                  <RouterLink
-                    class="details-link"
-                    data-testid="details-link"
-                    :to="{
-                      name: 'service-detail-view',
-                      params: {
-                        mesh: row.mesh,
-                        service: row.name,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.details_link') }}
-
-                    <ArrowRightIcon
-                      display="inline-block"
-                      decorative
-                      :size="KUI_ICON_SIZE_30"
-                    />
-                  </RouterLink>
                 </template>
               </AppCollection>
             </template>
@@ -161,9 +127,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import type { ServiceInsightCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
@@ -172,11 +135,3 @@ import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/zone-egresses/views/IndexView.vue
+++ b/src/app/zone-egresses/views/IndexView.vue
@@ -57,27 +57,26 @@
                 :empty-state-cta-to="t('zone-egresses.href.docs')"
                 :empty-state-cta-text="t('common.documentation')"
                 :is-selected-row="(row) => row.name === route.params.zoneEgress"
+                :get-detail-route="(row) => ({
+                  name: 'zone-egress-detail-view',
+                  params: {
+                    zoneEgress: row.name,
+                  },
+                })"
+                :get-summary-route="(row) => ({
+                  name: 'zone-egress-summary-view',
+                  params: {
+                    zone: route.params.zone,
+                    zoneEgress: row.name,
+                  },
+                  query: {
+                    // TODO: Update page & size once the list endpoint is being filtered by zone
+                    page: 1,
+                    size: 100,
+                  },
+                })"
                 @change="route.update"
               >
-                <template #name="{ row }">
-                  <RouterLink
-                    :to="{
-                      name: 'zone-egress-summary-view',
-                      params: {
-                        zone: route.params.zone,
-                        zoneEgress: row.name,
-                      },
-                      query: {
-                        // TODO: Update page & size once the list endpoint is being filtered by zone
-                        page: 1,
-                        size: 100,
-                      },
-                    }"
-                  >
-                    {{ row.name }}
-                  </RouterLink>
-                </template>
-
                 <template #addressPort="{ rowValue }">
                   <TextWithCopyButton
                     v-if="rowValue"
@@ -98,27 +97,6 @@
                   <template v-else>
                     {{ t('common.collection.none') }}
                   </template>
-                </template>
-
-                <template #details="{ row }">
-                  <RouterLink
-                    class="details-link"
-                    data-testid="details-link"
-                    :to="{
-                      name: 'zone-egress-detail-view',
-                      params: {
-                        zoneEgress: row.name,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.details_link') }}
-
-                    <ArrowRightIcon
-                      display="inline-block"
-                      decorative
-                      :size="KUI_ICON_SIZE_30"
-                    />
-                  </RouterLink>
                 </template>
               </AppCollection>
             </template>
@@ -155,8 +133,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
 import { type RouteLocationNamedRaw } from 'vue-router'
 
 import type { ZoneEgressOverviewCollectionSource } from '../sources'
@@ -204,11 +180,3 @@ function transformToTableData(zoneEgressOverviews: ZoneEgressOverview[]): ZoneEg
   })
 }
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/zone-ingresses/views/IndexView.vue
+++ b/src/app/zone-ingresses/views/IndexView.vue
@@ -58,27 +58,26 @@
                 :empty-state-cta-to="t('zone-ingresses.href.docs')"
                 :empty-state-cta-text="t('common.documentation')"
                 :is-selected-row="(row) => row.name === route.params.zoneIngress"
+                :get-detail-route="(row) => ({
+                  name: 'zone-ingress-detail-view',
+                  params: {
+                    zoneIngress: row.name,
+                  },
+                })"
+                :get-summary-route="(row) => ({
+                  name: 'zone-ingress-summary-view',
+                  params: {
+                    zone: route.params.zone,
+                    zoneIngress: row.name,
+                  },
+                  query: {
+                    // TODO: Update page & size once the list endpoint is being filtered by zone
+                    page: 1,
+                    size: 100,
+                  },
+                })"
                 @change="route.update"
               >
-                <template #name="{ row }">
-                  <RouterLink
-                    :to="{
-                      name: 'zone-ingress-summary-view',
-                      params: {
-                        zone: route.params.zone,
-                        zoneIngress: row.name,
-                      },
-                      query: {
-                        // TODO: Update page & size once the list endpoint is being filtered by zone
-                        page: 1,
-                        size: 100,
-                      },
-                    }"
-                  >
-                    {{ row.name }}
-                  </RouterLink>
-                </template>
-
                 <template #addressPort="{ rowValue }">
                   <TextWithCopyButton
                     v-if="rowValue"
@@ -110,27 +109,6 @@
                   <template v-else>
                     {{ t('common.collection.none') }}
                   </template>
-                </template>
-
-                <template #details="{ row }">
-                  <RouterLink
-                    class="details-link"
-                    data-testid="details-link"
-                    :to="{
-                      name: 'zone-ingress-detail-view',
-                      params: {
-                        zoneIngress: row.name,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.details_link') }}
-
-                    <ArrowRightIcon
-                      display="inline-block"
-                      decorative
-                      :size="KUI_ICON_SIZE_30"
-                    />
-                  </RouterLink>
                 </template>
               </AppCollection>
             </template>
@@ -167,8 +145,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
 import { type RouteLocationNamedRaw } from 'vue-router'
 
 import type { ZoneIngressOverviewCollectionSource } from '../sources'
@@ -223,11 +199,3 @@ function transformToTableData(zoneIngressOverviews: ZoneIngressOverview[]): Zone
   })
 }
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/zone-ingresses/views/item/ServicesView.vue
+++ b/src/app/zone-ingresses/views/item/ServicesView.vue
@@ -25,22 +25,15 @@
               { label: 'No. Instances', key: 'instances' },
               { label: 'Actions', key: 'actions', hideLabel: true },
             ]"
-            :items="props.data.zoneIngress.availableServices"
+            :items="props.data.zoneIngress.availableServices.map((service) => ({ ...service, name: service.tags['kuma.io/service'] }))"
+            :get-detail-route="(row) => ({
+              name: 'service-detail-view',
+              params: {
+                mesh: row.mesh,
+                service: row.tags['kuma.io/service'],
+              },
+            })"
           >
-            <template #name="{ row: item }: {row: AvailableService}">
-              <RouterLink
-                :to="{
-                  name: 'service-detail-view',
-                  params: {
-                    mesh: item.mesh,
-                    service: item.tags['kuma.io/service'],
-                  },
-                }"
-              >
-                {{ item.tags['kuma.io/service'] }}
-              </RouterLink>
-            </template>
-
             <template #mesh="{ row: item }: {row: AvailableService}">
               <RouterLink
                 :to="{
@@ -110,3 +103,9 @@ const props = defineProps<{
   data: ZoneIngressOverview
 }>()
 </script>
+
+<style lang="scss" scoped>
+.actions-dropdown {
+  display: inline-block;
+}
+</style>

--- a/src/app/zones/components/ZoneControlPlanesList.vue
+++ b/src/app/zones/components/ZoneControlPlanesList.vue
@@ -10,20 +10,13 @@
     :empty-state-message="can('create zones') ? t('zone-cps.empty_state.message') : t('common.emptyState.message', { type: 'Zones' })"
     :empty-state-cta-to="can('create zones') ? { name: 'zone-create-view' } : undefined"
     :empty-state-cta-text="t('zones.index.create')"
+    :get-detail-route="(row) => ({
+      name: 'zone-cp-detail-view',
+      params: {
+        zone: row.name,
+      },
+    })"
   >
-    <template #name="{ row: item }">
-      <RouterLink
-        :to="{
-          name: 'zone-cp-detail-view',
-          params: {
-            zone: item.name,
-          },
-        }"
-      >
-        {{ item.name }}
-      </RouterLink>
-    </template>
-
     <template #status="{ row: item }">
       <template
         v-for="status in [getZoneControlPlaneStatus(item)]"

--- a/src/app/zones/views/IndexView.vue
+++ b/src/app/zones/views/IndexView.vue
@@ -82,25 +82,14 @@
                 :empty-state-cta-to="can('create zones') ? { name: 'zone-create-view' } : undefined"
                 :empty-state-cta-text="can('create zones') ? t('zones.index.create') : undefined"
                 :is-selected-row="(row) => row.name === route.params.zone"
+                :get-detail-route="(row) => ({
+                  name: 'zone-cp-detail-view',
+                  params: {
+                    zone: row.name,
+                  },
+                })"
                 @change="route.update"
               >
-                <template #name="{ row }">
-                  <RouterLink
-                    :to="{
-                      name: 'zone-cp-detail-view',
-                      params: {
-                        zone: row.name,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                      },
-                    }"
-                  >
-                    {{ row.name }}
-                  </RouterLink>
-                </template>
-
                 <template #zoneCpVersion="{ rowValue }">
                   {{ rowValue || t('common.collection.none') }}
                 </template>
@@ -170,34 +159,12 @@
                   </template>
                 </template>
 
-                <template #details="{ row }">
-                  <RouterLink
-                    class="details-link"
-                    data-testid="details-link"
-                    :to="{
-                      name: 'zone-cp-detail-view',
-                      params: {
-                        zone: row.name,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.details_link') }}
-
-                    <ArrowRightIcon
-                      display="inline-block"
-                      decorative
-                      :size="KUI_ICON_SIZE_30"
-                    />
-                  </RouterLink>
-                </template>
-
                 <template
                   v-if="can('create zones')"
                   #actions="{ row }"
                 >
                   <KDropdownMenu
                     class="actions-dropdown"
-                    data-testid="actions-dropdown"
                     :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
                     width="150"
                   >
@@ -273,7 +240,7 @@
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon, MoreIcon } from '@kong/icons'
+import { MoreIcon } from '@kong/icons'
 import { ref } from 'vue'
 import { type RouteLocationNamedRaw } from 'vue-router'
 
@@ -427,18 +394,7 @@ function setIsCreateZoneButtonVisible(data: any) {
 </script>
 
 <style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-
 .actions-dropdown {
   display: inline-block;
-}
-
-.warning-type-memory {
-  margin-top: $kui-space-60;
-  margin-bottom: $kui-space-60;
 }
 </style>


### PR DESCRIPTION
## Changes

Systematically adds a “name” cell to AppCollections. The name cell will always be linked as long as either a summary or detail route is provided.

Systematically adds a “Go to details” link to AppCollections that have a summary route. This is intended as the primary quick interaction to go from list to detail view when a summary view exists for that list view. This becomes relevant because the default row click interaction for list views with a summary view is to open the summary view (and no longer the detail view).

Relates to #1681.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes & motivation

This PR provides AppCollection with access to both the detail and summary route (if applicable). This is intended to move the responsibility for some pretty important interactions from users of AppCollection into AppCollection itself:

- **Row-click interactions**. They are now conditional depending on the type of AppCollection: a row-click can go to either a summary route (if provided) or a detail route.
- **Linked name cells**. Each use of AppCollection should have a linked name cell (unless there is neither a detail or summary view associated with it).
- **"Go to details" cell**. On uses of AppCollection that have a summary, we want to add a "Go to details" cell that makes the navigation to the detail view available in one click and obvious.

I think these items should be handled more systematically than they currently do. It’s easy to forget adding one of these things on the user side of AppCollection.

As an additional bonus, it allow us to move the three-dot "More" dropdown menu code into AppCollection (in #1680) to avoid repeating it in the list view code.