### PR TITLE
chore: removes unused transition

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -37,23 +37,13 @@
         </template>
 
         <AppView>
-          <RouterView v-slot="{ Component }">
-            <transition
-              mode="out-in"
-              name="fade"
-            >
-              <div class="transition-root">
-                <component
-                  :is="Component"
-                />
-              </div>
-            </transition>
-          </RouterView>
+          <RouterView />
         </AppView>
       </ApplicationShell>
     </RouteView>
   </DataSource>
 </template>
+
 <script lang="ts" setup>
 import ControlPlaneNavigator from '@/app/control-planes/components/ControlPlaneNavigator.vue'
 import { ControlPlaneAddressesSource } from '@/app/control-planes/sources'
@@ -62,6 +52,7 @@ import MeshNavigator from '@/app/meshes/components/MeshNavigator.vue'
 import ZoneEgressNavigator from '@/app/zone-egresses/components/ZoneEgressNavigator.vue'
 import ZoneNavigator from '@/app/zones/components/ZoneNavigator.vue'
 </script>
+
 <style lang="scss" scoped>
 .logo {
   max-height: 36px;


### PR DESCRIPTION
Removes the transition on App.vue’s router view. The linter for https://eslint.vuejs.org/rules/require-toggle-inside-transition.html started to go off and that made me wonder if we even really use this transition. I’m not sure what effect it actually has on our pages. Does it have any?

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
