### PR TITLE
refactor(services): moves summary content into view

### DIFF
--- a/src/app/services/views/ServiceSummaryView.vue
+++ b/src/app/services/views/ServiceSummaryView.vue
@@ -42,16 +42,94 @@
           <h3>{{ t('services.routes.item.overview') }}</h3>
 
           <div class="mt-4">
-            <ExternalServiceDetails
-              v-if="props.service.serviceType === 'external'"
-              :mesh="props.service.mesh"
-              :service="props.service.name"
-            />
+            <div v-if="props.service.serviceType === 'external'">
+              <DataSource
+                v-slot="{ data: externalService, error }: ExternalServiceSource"
+                :src="`/meshes/${props.service.mesh}/external-services/for/${props.service.name}`"
+              >
+                <ErrorBlock
+                  v-if="error"
+                  :error="error"
+                />
 
-            <ServiceInsightDetails
+                <LoadingBlock v-else-if="externalService === undefined" />
+
+                <EmptyBlock
+                  v-else-if="externalService === null"
+                  data-testid="no-matching-external-service"
+                >
+                  <template #title>
+                    <p>{{ t('services.detail.no_matching_external_service', { name: props.service.name }) }}</p>
+                  </template>
+                </EmptyBlock>
+
+                <div
+                  v-else
+                  class="stack"
+                >
+                  <DefinitionCard>
+                    <template #title>
+                      {{ t('http.api.property.address') }}
+                    </template>
+
+                    <template #body>
+                      <TextWithCopyButton :text="externalService.networking.address" />
+                    </template>
+                  </DefinitionCard>
+
+                  <DefinitionCard v-if="externalService.tags !== null">
+                    <template #title>
+                      {{ t('http.api.property.tags') }}
+                    </template>
+
+                    <template #body>
+                      <TagList :tags="externalService.tags" />
+                    </template>
+                  </DefinitionCard>
+                </div>
+              </DataSource>
+            </div>
+
+            <div
               v-else
-              :service-insight="props.service"
-            />
+              class="stack"
+            >
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.status') }}
+                </template>
+
+                <template #body>
+                  <StatusBadge :status="props.service.status ?? 'not_available'" />
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.address') }}
+                </template>
+
+                <template #body>
+                  <TextWithCopyButton
+                    v-if="props.service.addressPort"
+                    :text="props.service.addressPort"
+                  />
+
+                  <template v-else>
+                    {{ t('common.detail.none') }}
+                  </template>
+                </template>
+              </DefinitionCard>
+
+              <ResourceStatus
+                :online="props.service.dataplanes?.online ?? 0"
+                :total="props.service.dataplanes?.total ?? 0"
+              >
+                <template #title>
+                  {{ t('http.api.property.dataPlaneProxies') }}
+                </template>
+              </ResourceStatus>
+            </div>
           </div>
         </div>
 
@@ -71,9 +149,15 @@
 
 <script lang="ts" setup>
 import ExternalServiceConfig from '../components/ExternalServiceConfig.vue'
-import ExternalServiceDetails from '../components/ExternalServiceDetails.vue'
-import ServiceInsightDetails from '../components/ServiceInsightDetails.vue'
+import type { ExternalServiceSource } from '../sources'
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
+import ErrorBlock from '@/app/common/ErrorBlock.vue'
+import LoadingBlock from '@/app/common/LoadingBlock.vue'
+import ResourceStatus from '@/app/common/ResourceStatus.vue'
+import StatusBadge from '@/app/common/StatusBadge.vue'
+import TagList from '@/app/common/TagList.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import { ServiceInsight } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 


### PR DESCRIPTION
Moves the summary content into the view so we’re able to control the layouting mechanisms more precisely. Generally, summary views are different from detail views anyway.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
