### PR TITLE
chore: disable summary trays for some views

### DIFF
--- a/features/mesh/MeshSummary.feature
+++ b/features/mesh/MeshSummary.feature
@@ -18,8 +18,10 @@ Feature: Mesh summary
       KUMA_MESH_COUNT: 1
       """
 
-    When I visit the "/meshes" URL
-    And I click the "$item:nth-child(1) td:nth-child(2)" element
+    # TODO: Remove the following line and enable the next two lines again to turn summary trays back on.
+    When I visit the "/meshes/mesh-1" URL
+    # When I visit the "/meshes" URL
+    # And I click the "$item:nth-child(1) td:nth-child(2)" element
     Then the "$summary" element exists
     And the "$summary" element contains "mesh-1"
 

--- a/features/mesh/services/ServiceSummary.feature
+++ b/features/mesh/services/ServiceSummary.feature
@@ -18,8 +18,10 @@ Feature: Service summary
       KUMA_SERVICEINSIGHT_COUNT: 1
       """
 
-    When I visit the "/meshes/default/services" URL
-    And I click the "$item:nth-child(1) td:nth-child(2)" element
+    # TODO: Remove the following line and enable the next two lines again to turn summary trays back on.
+    When I visit the "/meshes/default/services/service-1" URL
+    # When I visit the "/meshes/default/services" URL
+    # And I click the "$item:nth-child(1) td:nth-child(2)" element
     Then the "$summary" element exists
     And the "$summary" element contains "service-1"
 

--- a/features/zones/zone-cps/ZoneSummary.feature
+++ b/features/zones/zone-cps/ZoneSummary.feature
@@ -18,8 +18,10 @@ Feature: Zone summary
       KUMA_ZONE_COUNT: 1
       """
 
-    When I visit the "/zones" URL
-    And I click the "$item:nth-child(1) td:nth-child(2)" element
+    # TODO: Remove the following line and enable the next two lines again to turn summary trays back on.
+    When I visit the "/zones/zone-1" URL
+    # When I visit the "/zones" URL
+    # And I click the "$item:nth-child(1) td:nth-child(2)" element
     Then the "$summary" element exists
     And the "$summary" element contains "zone-1"
 

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -59,7 +59,7 @@
                   <template #name="{ row: item }">
                     <RouterLink
                       :to="{
-                        name: 'mesh-summary-view',
+                        name: 'mesh-detail-view',
                         params: {
                           mesh: item.name,
                         },

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -59,7 +59,7 @@
                 <template #name="{ row: item }">
                   <RouterLink
                     :to="{
-                      name: 'service-summary-view',
+                      name: 'service-detail-view',
                       params: {
                         mesh: item.mesh,
                         service: item.name,

--- a/src/app/zones/views/IndexView.vue
+++ b/src/app/zones/views/IndexView.vue
@@ -87,7 +87,7 @@
                 <template #name="{ row }">
                   <RouterLink
                     :to="{
-                      name: 'zone-cp-summary-view',
+                      name: 'zone-cp-detail-view',
                       params: {
                         zone: row.name,
                       },


### PR DESCRIPTION
Disables the summary trays for Zone CPs, Meshes, and Services.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
