### PR TITLE
feat(zones): add intro message describing data in subscription lists

### DIFF
--- a/src/app/common/subscriptions/SubscriptionDetails.vue
+++ b/src/app/common/subscriptions/SubscriptionDetails.vue
@@ -15,6 +15,12 @@
 
     <template v-else>
       <div>
+        <div
+          v-if="$slots.default"
+          class="intro"
+        >
+          <slot name="default" />
+        </div>
         <div class="row">
           <div class="header">
             {{ t('common.detail.subscriptions.type') }}
@@ -101,10 +107,13 @@ const statuses = computed<StatusRow[]>(() => {
 </script>
 
 <style lang="scss" scoped>
+.intro,
+.row {
+  padding: $kui-space-40;
+}
 .row {
   display: grid;
   grid-template-columns: 30ch 1fr;
-  padding: $kui-space-40;
 }
 
 .header,

--- a/src/app/common/subscriptions/SubscriptionList.vue
+++ b/src/app/common/subscriptions/SubscriptionList.vue
@@ -9,7 +9,15 @@
       </template>
 
       <template #accordion-content>
-        <SubscriptionDetails :subscription="subscription" />
+        <SubscriptionDetails
+          :subscription="subscription"
+        >
+          <template
+            v-if="$slots.default"
+          >
+            <slot name="default" />
+          </template>
+        </SubscriptionDetails>
       </template>
     </AccordionItem>
   </AccordionList>

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -25,6 +25,8 @@ zone-cps:
         zone-egress-list-view: 'Egresses'
       authentication_type: Dataplane authentication type
       overview: 'Overview'
+      subscription_intro: |
+        Statistics indicate requests and responses between global and zone only
     items:
       title: Zone Control Planes
       breadcrumbs: Zone Control Planes

--- a/src/app/zones/views/item/DetailView.vue
+++ b/src/app/zones/views/item/DetailView.vue
@@ -73,7 +73,9 @@
               <template #body>
                 <SubscriptionList
                   :subscriptions="subscriptions"
-                />
+                >
+                  <p>{{ t('zone-cps.routes.item.subscription_intro') }}</p>
+                </SubscriptionList>
               </template>
             </KCard>
           </div>


### PR DESCRIPTION
Adds a short sentence to the top of the subscription stats on the zone cp detail page.

Note: I did this in 'feature' mode, I would imagine a follow up soon to reorg this UI widget to make it a little more flexible and move it into a `subscriptions` module, I can do that later as more of a refactor/follow up PR.

<img width="1371" alt="Screenshot 2023-11-01 at 14 59 08" src="https://github.com/kumahq/kuma-gui/assets/554604/bb96be9a-5809-4838-b6ac-a61bd1275651">
