### PR TITLE
feat: preserve code block queries using url parameters

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -190,11 +190,10 @@ Then(/^the "(.*)" element(s)? contain[s]?$/, (selector: string, multiple = '', t
   }
 })
 Then(/^the "(.*)" element contains "(.*)"$/, (selector: string, value: string) => {
-  $(selector).contains(value)
-})
-
-Then(/^the "(.*)" element has value "(.*)"$/, (selector: string, value: string) => {
-  $(selector).should('have.value', value)
+  $(selector).then(($el) => {
+    const chainer = $el[0].tagName === 'INPUT' ? 'have.value' : 'contain'
+    cy.wrap($el).should(chainer, value)
+  })
 })
 
 Then(/^the "(.*)" element is empty$/, (selector: string) => {

--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -193,6 +193,10 @@ Then(/^the "(.*)" element contains "(.*)"$/, (selector: string, value: string) =
   $(selector).contains(value)
 })
 
+Then(/^the "(.*)" element has value "(.*)"$/, (selector: string, value: string) => {
+  $(selector).should('have.value', value)
+})
+
 Then(/^the "(.*)" element is empty$/, (selector: string) => {
   $(selector).should('be.empty')
 })

--- a/features/diagnostics/DetailViewContent.feature
+++ b/features/diagnostics/DetailViewContent.feature
@@ -19,7 +19,7 @@ Feature: Diagnostics: Detail view content
   Scenario: Reads code search value from URL
     When I visit the "/diagnostics?codeSearch=(groups%257Cusers)" URL
 
-    Then the "$code-block-search-input" element has value "(groups|users)"
+    Then the "$code-block-search-input" element contains "(groups|users)"
 
   Scenario: Stores code search value in URL
     When I visit the "/diagnostics" URL

--- a/features/diagnostics/DetailViewContent.feature
+++ b/features/diagnostics/DetailViewContent.feature
@@ -1,8 +1,9 @@
 Feature: Diagnostics: Detail view content
   Background:
     Given the CSS selectors
-      | Alias   | Selector                               |
-      | details | [data-testid='code-block-diagnostics'] |
+      | Alias                   | Selector                                  |
+      | details                 | [data-testid='code-block-diagnostics']    |
+      | code-block-search-input | [data-testid='k-code-block-search-input'] |
 
   Scenario: Diagnostics detail view has expected content
     Given the environment
@@ -14,3 +15,14 @@ Feature: Diagnostics: Detail view content
     Then the page title contains "Diagnostics"
     Then the "$details" element contains ""mode": "global""
     Then the "$details" element contains ""environment": "universal""
+
+  Scenario: Reads code search value from URL
+    When I visit the "/diagnostics?codeSearch=(groups%257Cusers)" URL
+
+    Then the "$code-block-search-input" element has value "(groups|users)"
+
+  Scenario: Stores code search value in URL
+    When I visit the "/diagnostics" URL
+    And I "input" "(groups|users)" into the "$code-block-search-input" element
+
+    Then the URL contains "/diagnostics?codeSearch=(groups%257Cusers)"

--- a/src/app/common/CodeBlock.vue
+++ b/src/app/common/CodeBlock.vue
@@ -13,7 +13,10 @@
     @code-block-render="handleCodeBlockRenderEvent"
     @query-change="updateStoredQuery"
   >
-    <template #secondary-actions>
+    <template
+      v-if="$slots['secondary-actions']"
+      #secondary-actions
+    >
       <slot name="secondary-actions" />
     </template>
   </KCodeBlock>

--- a/src/app/common/CodeBlock.vue
+++ b/src/app/common/CodeBlock.vue
@@ -20,51 +20,25 @@
 </template>
 
 <script lang="ts" setup>
-import { CodeBlockEventData, KCodeBlock } from '@kong/kongponents'
-import { ref, PropType } from 'vue'
+import { type CodeBlockEventData, KCodeBlock } from '@kong/kongponents'
+import { ref } from 'vue'
 
 import { ClientStorage } from '@/utilities/ClientStorage'
-import { highlightElement, AvailableLanguages } from '@/utilities/highlightElement'
+import { highlightElement, type AvailableLanguages } from '@/utilities/highlightElement'
 
-const props = defineProps({
-  id: {
-    type: String,
-    required: true,
-  },
-
-  code: {
-    type: String,
-    required: true,
-  },
-
-  language: {
-    type: String as PropType<AvailableLanguages>,
-    required: true,
-  },
-
-  isSearchable: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-
-  showCopyButton: {
-    type: Boolean,
-    required: false,
-    default: true,
-  },
-
-  queryKey: {
-    type: String,
-    required: false,
-    default: null,
-  },
-
-  codeMaxHeight: {
-    type: String,
-    required: false,
-    default: null,
-  },
+const props = withDefaults(defineProps<{
+  id: string
+  code: string
+  language: AvailableLanguages
+  isSearchable?: boolean
+  showCopyButton?: boolean
+  queryKey?: string | null
+  codeMaxHeight?: string | null
+}>(), {
+  isSearchable: false,
+  showCopyButton: true,
+  queryKey: null,
+  codeMaxHeight: null,
 })
 
 const query = getStoredQuery()

--- a/src/app/common/CodeBlock.vue
+++ b/src/app/common/CodeBlock.vue
@@ -35,12 +35,10 @@ const props = withDefaults(defineProps<{
   language: AvailableLanguages
   isSearchable?: boolean
   showCopyButton?: boolean
-  queryKey?: string | null
   codeMaxHeight?: string | null
 }>(), {
   isSearchable: false,
   showCopyButton: true,
-  queryKey: null,
   codeMaxHeight: null,
 })
 

--- a/src/app/common/CodeBlock.vue
+++ b/src/app/common/CodeBlock.vue
@@ -8,16 +8,10 @@
     :is-processing="isProcessing"
     :is-searchable="isSearchable"
     :show-copy-button="showCopyButton"
-    :query="(router.currentRoute.value.query.codeSearch as string | null) || ''"
+    :query="props.query"
     theme="dark"
     @code-block-render="handleCodeBlockRenderEvent"
-    @query-change="router.push({
-      query: {
-        ...router.currentRoute.value.query,
-        // Setting `undefined` for empty queries ensures the parameter is deleted from the URL.
-        codeSearch: $event || undefined,
-      },
-    })"
+    @query-change="emit('query-change', $event)"
   >
     <template
       v-if="$slots['secondary-actions']"
@@ -31,11 +25,8 @@
 <script lang="ts" setup>
 import { type CodeBlockEventData, KCodeBlock } from '@kong/kongponents'
 import { ref } from 'vue'
-import { useRouter } from 'vue-router'
 
 import { highlightElement, type AvailableLanguages } from '@/utilities/highlightElement'
-
-const router = useRouter()
 
 const props = withDefaults(defineProps<{
   id: string
@@ -44,11 +35,17 @@ const props = withDefaults(defineProps<{
   isSearchable?: boolean
   showCopyButton?: boolean
   codeMaxHeight?: string | null
+  query?: string
 }>(), {
   isSearchable: false,
   showCopyButton: true,
   codeMaxHeight: null,
+  query: '',
 })
+
+const emit = defineEmits<{
+  (event: 'query-change', query: string): void
+}>()
 
 const isProcessing = ref(false)
 

--- a/src/app/common/EnvoyData.vue
+++ b/src/app/common/EnvoyData.vue
@@ -41,7 +41,6 @@
           language="json"
           :code="typeof data === 'string' ? data : JSON.stringify(data, null, 2)"
           is-searchable
-          :query-key="props.queryKey"
         />
       </template>
     </DataSource>
@@ -77,11 +76,6 @@ const props = defineProps({
   },
 
   src: {
-    type: String,
-    required: true,
-  },
-
-  queryKey: {
     type: String,
     required: true,
   },

--- a/src/app/common/EnvoyData.vue
+++ b/src/app/common/EnvoyData.vue
@@ -41,6 +41,8 @@
           language="json"
           :code="typeof data === 'string' ? data : JSON.stringify(data, null, 2)"
           is-searchable
+          :query="props.query"
+          @query-change="emit('query-change', $event)"
         />
       </template>
     </DataSource>
@@ -50,8 +52,6 @@
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { RefreshIcon } from '@kong/icons'
-import { KAlert, KButton } from '@kong/kongponents'
-import { PropType } from 'vue'
 
 import CodeBlock from './CodeBlock.vue'
 import DataSource from '@/app/application/components/data-source/DataSource.vue'
@@ -64,22 +64,18 @@ import { useI18n } from '@/utilities'
 
 const { t } = useI18n()
 
-const props = defineProps({
-  status: {
-    type: String as PropType<StatusKeyword>,
-    required: true,
-  },
-
-  resource: {
-    type: String,
-    required: true,
-  },
-
-  src: {
-    type: String,
-    required: true,
-  },
+const props = withDefaults(defineProps<{
+  status: StatusKeyword
+  resource: string
+  src: string
+  query?: string
+}>(), {
+  query: '',
 })
+
+const emit = defineEmits<{
+  (event: 'query-change', query: string): void
+}>()
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/common/ResourceCodeBlock.vue
+++ b/src/app/common/ResourceCodeBlock.vue
@@ -5,6 +5,8 @@
     :code="yamlUniversal"
     :is-searchable="props.isSearchable"
     :code-max-height="props.codeMaxHeight"
+    :query="props.query"
+    @query-change="emit('query-change', $event)"
   >
     <template #secondary-actions>
       <KTooltip
@@ -49,10 +51,16 @@ const props = withDefaults(defineProps<{
   resourceFetcher: (params?: SingleResourceParameters) => Promise<Entity>
   codeMaxHeight?: string | null
   isSearchable?: boolean
+  query?: string
 }>(), {
   codeMaxHeight: null,
   isSearchable: false,
+  query: '',
 })
+
+const emit = defineEmits<{
+  (event: 'query-change', query: string): void
+}>()
 
 const yamlUniversal = computed(() => toYamlRepresentation(props.resource))
 

--- a/src/app/common/ResourceCodeBlock.vue
+++ b/src/app/common/ResourceCodeBlock.vue
@@ -4,7 +4,6 @@
     language="yaml"
     :code="yamlUniversal"
     :is-searchable="props.isSearchable"
-    :query-key="props.id"
     :code-max-height="props.codeMaxHeight"
   >
     <template #secondary-actions>

--- a/src/app/common/ResourceCodeBlock.vue
+++ b/src/app/common/ResourceCodeBlock.vue
@@ -29,8 +29,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KTooltip } from '@kong/kongponents'
-import { PropType, computed } from 'vue'
+import { computed } from 'vue'
 
 import CodeBlock from './CodeBlock.vue'
 import CopyButton from './CopyButton.vue'
@@ -41,36 +40,19 @@ import { toYaml } from '@/utilities/toYaml'
 
 const { t } = useI18n()
 
-const props = defineProps({
-  id: {
-    type: String,
-    required: true,
-  },
-
-  resource: {
-    type: Object as PropType<Entity>,
-    required: true,
-  },
+const props = withDefaults(defineProps<{
+  id: string
+  resource: Entity
 
   /**
    * Function returning the resource.
    */
-  resourceFetcher: {
-    type: Function as PropType<(params?: SingleResourceParameters) => Promise<Entity>>,
-    required: true,
-  },
-
-  codeMaxHeight: {
-    type: String,
-    required: false,
-    default: null,
-  },
-
-  isSearchable: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
+  resourceFetcher: (params?: SingleResourceParameters) => Promise<Entity>
+  codeMaxHeight?: string | null
+  isSearchable?: boolean
+}>(), {
+  codeMaxHeight: null,
+  isSearchable: false,
 })
 
 const yamlUniversal = computed(() => toYamlRepresentation(props.resource))

--- a/src/app/data-planes/views/DataPlaneClustersView.vue
+++ b/src/app/data-planes/views/DataPlaneClustersView.vue
@@ -5,6 +5,7 @@
     :params="{
       mesh: '',
       dataPlane: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -23,6 +24,8 @@
             :status="getStatusAndReason(props.data.dataplane, props.data.dataplaneInsight).status"
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/clusters`"
+            :query="route.params.codeSearch"
+            @query-change="route.update({ codeSearch: $event })"
           />
         </template>
       </KCard>

--- a/src/app/data-planes/views/DataPlaneClustersView.vue
+++ b/src/app/data-planes/views/DataPlaneClustersView.vue
@@ -23,7 +23,6 @@
             :status="getStatusAndReason(props.data.dataplane, props.data.dataplaneInsight).status"
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/clusters`"
-            query-key="envoy-data-clusters-data-plane"
           />
         </template>
       </KCard>

--- a/src/app/data-planes/views/DataPlaneConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneConfigView.vue
@@ -5,6 +5,7 @@
     :params="{
       mesh: '',
       dataPlane: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -36,6 +37,8 @@
               :resource="data"
               :resource-fetcher="(params) => kumaApi.getDataplaneFromMesh({ mesh: data.mesh, name: data.name }, params)"
               is-searchable
+              :query="route.params.codeSearch"
+              @query-change="route.update({ codeSearch: $event })"
             />
           </DataSource>
         </template>

--- a/src/app/data-planes/views/DataPlaneStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneStatsView.vue
@@ -23,7 +23,6 @@
             :status="getStatusAndReason(props.data.dataplane, props.data.dataplaneInsight).status"
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/stats`"
-            query-key="envoy-data-stats-data-plane"
           />
         </template>
       </KCard>

--- a/src/app/data-planes/views/DataPlaneStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneStatsView.vue
@@ -5,6 +5,7 @@
     :params="{
       mesh: '',
       dataPlane: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -23,6 +24,8 @@
             :status="getStatusAndReason(props.data.dataplane, props.data.dataplaneInsight).status"
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/stats`"
+            :query="route.params.codeSearch"
+            @query-change="route.update({ codeSearch: $event })"
           />
         </template>
       </KCard>

--- a/src/app/data-planes/views/DataPlaneXdsConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneXdsConfigView.vue
@@ -23,7 +23,6 @@
             :status="getStatusAndReason(props.data.dataplane, props.data.dataplaneInsight).status"
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/xds`"
-            query-key="envoy-data-xds-data-plane"
           />
         </template>
       </KCard>

--- a/src/app/data-planes/views/DataPlaneXdsConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneXdsConfigView.vue
@@ -5,6 +5,7 @@
     :params="{
       mesh: '',
       dataPlane: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -23,6 +24,8 @@
             :status="getStatusAndReason(props.data.dataplane, props.data.dataplaneInsight).status"
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/xds`"
+            :query="route.params.codeSearch"
+            @query-change="route.update({ codeSearch: $event })"
           />
         </template>
       </KCard>

--- a/src/app/diagnostics/views/DiagnosticsView.vue
+++ b/src/app/diagnostics/views/DiagnosticsView.vue
@@ -6,8 +6,11 @@ import LoadingBlock from '@/app/common/LoadingBlock.vue'
 </script>
 <template>
   <RouteView
-    v-slot="{ t }"
+    v-slot="{ route, t }"
     name="diagnostics"
+    :params="{
+      codeSearch: '',
+    }"
   >
     <DataSource
       v-slot="{ data, error }: ConfigSource"
@@ -48,6 +51,8 @@ import LoadingBlock from '@/app/common/LoadingBlock.vue'
               language="json"
               :code="JSON.stringify(data, null, 2)"
               is-searchable
+              :query="route.params.codeSearch"
+              @query-change="route.update({ codeSearch: $event })"
             />
           </template>
         </KCard>

--- a/src/app/diagnostics/views/DiagnosticsView.vue
+++ b/src/app/diagnostics/views/DiagnosticsView.vue
@@ -48,7 +48,6 @@ import LoadingBlock from '@/app/common/LoadingBlock.vue'
               language="json"
               :code="JSON.stringify(data, null, 2)"
               is-searchable
-              query-key="diagnostics"
             />
           </template>
         </KCard>

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -6,6 +6,7 @@
       mesh: '',
       policy: '',
       policyPath: '',
+      codeSearch: '',
     }"
   >
     <AppView
@@ -80,6 +81,8 @@
               path: route.params.policyPath,
             }, params)"
             is-searchable
+            :query="route.params.codeSearch"
+            @query-change="route.update({ codeSearch: $event })"
           />
         </div>
       </DataSource>

--- a/src/app/policies/views/PolicySummaryView.vue
+++ b/src/app/policies/views/PolicySummaryView.vue
@@ -6,6 +6,7 @@
       mesh: '',
       policyPath: '',
       policy: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -83,6 +84,8 @@
                 path: route.params.policyPath,
               }, params)"
               is-searchable
+              :query="route.params.codeSearch"
+              @query-change="route.update({ codeSearch: $event })"
             />
           </div>
         </div>

--- a/src/app/services/views/ServiceConfigView.vue
+++ b/src/app/services/views/ServiceConfigView.vue
@@ -5,6 +5,7 @@
     :params="{
       mesh: '',
       service: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -46,6 +47,8 @@
                 :resource="externalService"
                 :resource-fetcher="(params) => kumaApi.getExternalService({ mesh: externalService.mesh, name: externalService.name }, params)"
                 is-searchable
+                :query="route.params.codeSearch"
+                @query-change="route.update({ codeSearch: $event })"
               />
             </DataSource>
           </div>

--- a/src/app/services/views/ServiceSummaryView.vue
+++ b/src/app/services/views/ServiceSummaryView.vue
@@ -5,6 +5,7 @@
     :params="{
       mesh: '',
       service: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -170,6 +171,8 @@
                 :resource="externalService"
                 :resource-fetcher="(params) => kumaApi.getExternalService({ mesh: externalService.mesh, name: externalService.name }, params)"
                 is-searchable
+                :query="route.params.codeSearch"
+                @query-change="route.update({ codeSearch: $event })"
               />
             </DataSource>
           </div>

--- a/src/app/zone-egresses/views/item/ClustersView.vue
+++ b/src/app/zone-egresses/views/item/ClustersView.vue
@@ -4,6 +4,7 @@
     name="zone-egress-clusters-view"
     :params="{
       zoneEgress: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -22,6 +23,8 @@
             :status="getItemStatusFromInsight(props.data.zoneEgressInsight)"
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/clusters`"
+            :query="route.params.codeSearch"
+            @query-change="route.update({ codeSearch: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zone-egresses/views/item/ClustersView.vue
+++ b/src/app/zone-egresses/views/item/ClustersView.vue
@@ -22,7 +22,6 @@
             :status="getItemStatusFromInsight(props.data.zoneEgressInsight)"
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/clusters`"
-            query-key="envoy-data-clusters-zone-egress"
           />
         </template>
       </KCard>

--- a/src/app/zone-egresses/views/item/ConfigView.vue
+++ b/src/app/zone-egresses/views/item/ConfigView.vue
@@ -4,6 +4,7 @@
     name="zone-egress-config-view"
     :params="{
       zoneEgress: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -35,6 +36,8 @@
                 :resource="data"
                 :resource-fetcher="(params) => kumaApi.getZoneEgress({ name: route.params.zoneEgress }, params)"
                 is-searchable
+                :query="route.params.codeSearch"
+                @query-change="route.update({ codeSearch: $event })"
               />
             </template>
           </DataSource>

--- a/src/app/zone-egresses/views/item/StatsView.vue
+++ b/src/app/zone-egresses/views/item/StatsView.vue
@@ -22,7 +22,6 @@
             :status="getItemStatusFromInsight(props.data.zoneEgressInsight)"
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/stats`"
-            query-key="envoy-data-stats-zone-egress"
           />
         </template>
       </KCard>

--- a/src/app/zone-egresses/views/item/StatsView.vue
+++ b/src/app/zone-egresses/views/item/StatsView.vue
@@ -4,6 +4,7 @@
     name="zone-egress-stats-view"
     :params="{
       zoneEgress: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -22,6 +23,8 @@
             :status="getItemStatusFromInsight(props.data.zoneEgressInsight)"
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/stats`"
+            :query="route.params.codeSearch"
+            @query-change="route.update({ codeSearch: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zone-egresses/views/item/XdsConfigView.vue
+++ b/src/app/zone-egresses/views/item/XdsConfigView.vue
@@ -22,7 +22,6 @@
             :status="getItemStatusFromInsight(props.data.zoneEgressInsight)"
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/xds`"
-            query-key="envoy-data-xds-zone-egress"
           />
         </template>
       </KCard>

--- a/src/app/zone-egresses/views/item/XdsConfigView.vue
+++ b/src/app/zone-egresses/views/item/XdsConfigView.vue
@@ -4,6 +4,7 @@
     name="zone-egress-xds-config-view"
     :params="{
       zoneEgress: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -22,6 +23,8 @@
             :status="getItemStatusFromInsight(props.data.zoneEgressInsight)"
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/xds`"
+            :query="route.params.codeSearch"
+            @query-change="route.update({ codeSearch: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zone-ingresses/views/item/ClustersView.vue
+++ b/src/app/zone-ingresses/views/item/ClustersView.vue
@@ -22,7 +22,6 @@
             :status="getItemStatusFromInsight(props.data.zoneIngressInsight)"
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/clusters`"
-            query-key="envoy-data-clusters-zone-ingress"
           />
         </template>
       </KCard>

--- a/src/app/zone-ingresses/views/item/ClustersView.vue
+++ b/src/app/zone-ingresses/views/item/ClustersView.vue
@@ -4,6 +4,7 @@
     name="zone-ingress-clusters-view"
     :params="{
       zoneIngress: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -22,6 +23,8 @@
             :status="getItemStatusFromInsight(props.data.zoneIngressInsight)"
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/clusters`"
+            :query="route.params.codeSearch"
+            @query-change="route.update({ codeSearch: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zone-ingresses/views/item/ConfigView.vue
+++ b/src/app/zone-ingresses/views/item/ConfigView.vue
@@ -4,6 +4,7 @@
     name="zone-ingress-config-view"
     :params="{
       zoneIngress: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -35,6 +36,8 @@
                 :resource="data"
                 :resource-fetcher="(params) => kumaApi.getZoneIngress({ name: route.params.zoneIngress }, params)"
                 is-searchable
+                :query="route.params.codeSearch"
+                @query-change="route.update({ codeSearch: $event })"
               />
             </template>
           </DataSource>

--- a/src/app/zone-ingresses/views/item/StatsView.vue
+++ b/src/app/zone-ingresses/views/item/StatsView.vue
@@ -4,6 +4,7 @@
     name="zone-ingress-stats-view"
     :params="{
       zoneIngress: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -22,6 +23,8 @@
             :status="getItemStatusFromInsight(props.data.zoneIngressInsight)"
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/stats`"
+            :query="route.params.codeSearch"
+            @query-change="route.update({ codeSearch: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zone-ingresses/views/item/StatsView.vue
+++ b/src/app/zone-ingresses/views/item/StatsView.vue
@@ -22,7 +22,6 @@
             :status="getItemStatusFromInsight(props.data.zoneIngressInsight)"
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/stats`"
-            query-key="envoy-data-stats-zone-ingress"
           />
         </template>
       </KCard>

--- a/src/app/zone-ingresses/views/item/XdsConfigView.vue
+++ b/src/app/zone-ingresses/views/item/XdsConfigView.vue
@@ -22,7 +22,6 @@
             :status="getItemStatusFromInsight(props.data.zoneIngressInsight)"
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/xds`"
-            query-key="envoy-data-xds-zone-ingress"
           />
         </template>
       </KCard>

--- a/src/app/zone-ingresses/views/item/XdsConfigView.vue
+++ b/src/app/zone-ingresses/views/item/XdsConfigView.vue
@@ -4,6 +4,7 @@
     name="zone-ingress-xds-config-view"
     :params="{
       zoneIngress: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -22,6 +23,8 @@
             :status="getItemStatusFromInsight(props.data.zoneIngressInsight)"
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/xds`"
+            :query="route.params.codeSearch"
+            @query-change="route.update({ codeSearch: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zones/views/item/ConfigView.vue
+++ b/src/app/zones/views/item/ConfigView.vue
@@ -1,9 +1,10 @@
 <template>
   <RouteView
-    v-slot="{ t }"
+    v-slot="{ route, t }"
     name="zone-cp-config-view"
     :params="{
       zone: '',
+      codeSearch: '',
     }"
   >
     <AppView>
@@ -45,6 +46,8 @@
               language="json"
               :code="conf"
               is-searchable
+              :query="route.params.codeSearch"
+              @query-change="route.update({ codeSearch: $event })"
             />
 
             <KAlert

--- a/src/app/zones/views/item/ConfigView.vue
+++ b/src/app/zones/views/item/ConfigView.vue
@@ -45,7 +45,6 @@
               language="json"
               :code="conf"
               is-searchable
-              query-key="zone-config"
             />
 
             <KAlert


### PR DESCRIPTION
## Changes

chore: uses TS syntax for props

fix(codeblock): secondary-actions slot not being optional

chore: removes props.queryKey uses

feat(codeblock): preserves queries using URL parameter

refactor: moves code block query storing logic into views

Resolves #1441.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

* Still considering whether it’s worth it to do all the work of `refactor: moves code block query storing logic into views` just so we can feed the route parameters through from the view components.