### PR TITLE
fix(dataplanes): certificate not showing in list view

### DIFF
--- a/features/mesh/dataplanes/Index.feature
+++ b/features/mesh/dataplanes/Index.feature
@@ -22,6 +22,9 @@ Feature: mesh / dataplanes / index
               inbound:
               - tags:
                   kuma.io/protocol: http
+          dataplaneInsight:
+            mTLS:
+              certificateExpirationTime: 2023-11-03T09:10:17Z
         - name: fake-frontend
       """
 
@@ -67,6 +70,7 @@ Feature: mesh / dataplanes / index
 
     Then the "$table-row" element exists 9 times
     Then the "$table-row:nth-child(1)" element contains
-      | Value        |
-      | fake-backend |
-      | http         |
+      | Value                |
+      | fake-backend         |
+      | http                 |
+      | Nov 3, 2023, 9:10 AM |

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -108,13 +108,6 @@
         {{ t('common.collection.none') }}
       </template>
     </template>
-    <template #certificate="{ row: item }">
-      {{
-        item.dataplaneInsight?.mTLS?.certificateExpirationTime ?
-          formatIsoDate(new Date(item.dataplaneInsight.mTLS.certificateExpirationTime).toUTCString()) :
-          t('data-planes.components.data-plane-list.certificate.none')
-      }}
-    </template>
 
     <template #details="{ row }">
       <RouterLink
@@ -179,6 +172,7 @@ type DataPlaneOverviewTableRow = {
     cert_expired: boolean
   }
   isGateway: boolean
+  certificate: string
 }
 
 type ChangeValue = {
@@ -266,6 +260,13 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
       initialData,
     )
 
+    let certificate
+    if (dataPlaneOverview.dataplaneInsight?.mTLS?.certificateExpirationTime) {
+      certificate = formatIsoDate(dataPlaneOverview.dataplaneInsight.mTLS.certificateExpirationTime)
+    } else {
+      certificate = t('data-planes.components.data-plane-list.certificate.none')
+    }
+
     // assemble the table data
     const item: DataPlaneOverviewTableRow = {
       name,
@@ -279,6 +280,7 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
         cert_expired: false,
       },
       isGateway: dataPlaneOverview.dataplane?.networking?.gateway !== undefined,
+      certificate,
     }
 
     if (summary.version) {


### PR DESCRIPTION
I moved the relevant into the data transformation function because that has types that would prevent that sort of mistake.

This broke in https://github.com/kumahq/kuma-gui/pull/1670/files#diff-82dda41d4ed9d37e3744cb3d5df6be752b1f5eefaa6da07331be40f5ca83cea5L175. There wasn’t a test covering it so I added one.

Resolves #1713.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
