### PR TITLE
fix(gateways): treating delegated gateways as builtin gateways

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -208,7 +208,7 @@ export type DataPlaneNetworking = {
   }[]
   gateway?: {
     tags: Record<string, string>
-    type?: 'builtin' | 'delegated' | undefined
+    type?: 'BUILTIN'
   }
 }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -206,9 +206,17 @@ export type DataPlaneNetworking = {
     port: number
     tags: Record<string, string>
   }[]
+  /**
+   * The presence of the `gateway` field means one of two things:
+   *
+   * - The resource represents a builtin gateway (when `gateway.type === 'BUILTIN'`)
+   * - The resource represents a delegated gateway (when `gateway.type === 'DELEGATED'` or `gateway.type` is omitted)
+   *
+   * If the `gateway` field is absent, the resource represents a regular Data Plane Proxy.
+   */
   gateway?: {
     tags: Record<string, string>
-    type?: 'BUILTIN'
+    type?: 'BUILTIN' | 'DELEGATED'
   }
 }
 


### PR DESCRIPTION
Changes the gateway detail view’s policy tab to treat delegated gateways the same as regular Data Plane Proxies (i.e. the same as the DPP detail view’s policy tab).

Resolves #1720.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
