### PR TITLE
chore(e2e): split input and element value assertion commands

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -190,11 +190,10 @@ Then(/^the "(.*)" element(s)? contain[s]?$/, (selector: string, multiple = '', t
   }
 })
 Then(/^the "(.*)" element contains "(.*)"$/, (selector: string, value: string) => {
-  $(selector).contains(value)
-})
-
-Then(/^the "(.*)" element has value "(.*)"$/, (selector: string, value: string) => {
-  $(selector).should('have.value', value)
+  $(selector).then(($el) => {
+    const chainer = $el[0].tagName === 'INPUT' ? 'have.value' : 'contain'
+    $(selector).should(chainer, value)
+  })
 })
 
 Then(/^the "(.*)" element is empty$/, (selector: string) => {

--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -190,10 +190,11 @@ Then(/^the "(.*)" element(s)? contain[s]?$/, (selector: string, multiple = '', t
   }
 })
 Then(/^the "(.*)" element contains "(.*)"$/, (selector: string, value: string) => {
-  $(selector).then(($el) => {
-    const chainer = $el[0].tagName === 'INPUT' ? 'have.value' : 'contain'
-    cy.wrap($el).should(chainer, value)
-  })
+  $(selector).contains(value)
+})
+
+Then(/^the "(.*)" element has value "(.*)"$/, (selector: string, value: string) => {
+  $(selector).should('have.value', value)
 })
 
 Then(/^the "(.*)" element is empty$/, (selector: string) => {

--- a/features/diagnostics/DetailViewContent.feature
+++ b/features/diagnostics/DetailViewContent.feature
@@ -19,7 +19,7 @@ Feature: Diagnostics: Detail view content
   Scenario: Reads code search value from URL
     When I visit the "/diagnostics?codeSearch=(groups%257Cusers)" URL
 
-    Then the "$code-block-search-input" element has value "(groups|users)"
+    Then the "$code-block-search-input" element contains "(groups|users)"
 
   Scenario: Stores code search value in URL
     When I visit the "/diagnostics" URL

--- a/features/diagnostics/DetailViewContent.feature
+++ b/features/diagnostics/DetailViewContent.feature
@@ -19,7 +19,7 @@ Feature: Diagnostics: Detail view content
   Scenario: Reads code search value from URL
     When I visit the "/diagnostics?codeSearch=(groups%257Cusers)" URL
 
-    Then the "$code-block-search-input" element contains "(groups|users)"
+    Then the "$code-block-search-input" element has value "(groups|users)"
 
   Scenario: Stores code search value in URL
     When I visit the "/diagnostics" URL


### PR DESCRIPTION
It looks like it can happen that with the following structure:

```ts
  $(selector).then(($el) => {
    const chainer = $el[0].tagName === 'INPUT' ? 'have.value' : 'contain'
    cy.wrap($el).should(chainer, value)
  })
```

... interactions like browser navigation can happen between getting the element with `$(selector)` and asserting against it inside the `then` callback. This can break tests.

There probably are other solutions to this, but this is the simplest thing I could think of for now.