### PR TITLE
chore: add actions div always

### DIFF
--- a/src/app/application/components/app-view/AppView.vue
+++ b/src/app/application/components/app-view/AppView.vue
@@ -26,7 +26,6 @@
         <slot name="title" />
 
         <div
-          v-if="$slots.actions"
           class="actions"
         >
           <slot name="actions" />


### PR DESCRIPTION
Sometimes we will need the `<div class="actions">` in AppView to always be in the DOM for if we need to inject something into it via Vue's Teleport functionality.

Teleport uses a CSS selector to target where to teleport its DOM to, and from what I can see there is no way to know whether a Teleport has been added to the page to decide whether to include `<div class="actions">` or not.

We probably only want to make one `<div class="actions">` be available for injecting into using Teleport probably using something similar to the parent/ancestor lookup we do for breadcrumbs, but this probably needs thinking about some more. In the meantime for the single instance we currently would like to use this for, the contents of this PR are fine and can be improved at a later date.
