### PR TITLE
fix: small summary view issues

### DIFF
--- a/src/app/common/ResourceCodeBlock.vue
+++ b/src/app/common/ResourceCodeBlock.vue
@@ -14,6 +14,7 @@
         :label="t('common.copyKubernetesText')"
         placement="bottomEnd"
         max-width="200"
+        position-fixed
       >
         <CopyButton
           class="kubernetes-copy-button"

--- a/src/app/common/SummaryView.vue
+++ b/src/app/common/SummaryView.vue
@@ -38,6 +38,12 @@ const emit = defineEmits<{
   padding-left: $kui-space-80;
 }
 
+.summary-slideout :deep(.panel) {
+  // TODO: Remove this once we switch to Kongponents v9 which will fix this issue (https://github.com/Kong/kongponents/pull/1822).
+  // Fixes the content being taller than the viewport when using `props.offsetHeight`.
+  height: calc(100vh - var(--app-slideout-offset-top)) !important;
+}
+
 // Aligns the position of the close button with the summary slideout card’s content box.
 .summary-slideout :deep(.close-button-start),
 .summary-slideout :deep(.close-button-end) {

--- a/src/app/common/SummaryView.vue
+++ b/src/app/common/SummaryView.vue
@@ -39,6 +39,8 @@ const emit = defineEmits<{
 }
 
 .summary-slideout :deep(.panel) {
+  // Increases width of the content area a little.
+  max-width: 560px;
   // TODO: Remove this once we switch to Kongponents v9 which will fix this issue (https://github.com/Kong/kongponents/pull/1822).
   // Fixes the content being taller than the viewport when using `props.offsetHeight`.
   height: calc(100vh - var(--app-slideout-offset-top)) !important;

--- a/src/app/data-planes/components/DataPlaneSummary.vue
+++ b/src/app/data-planes/components/DataPlaneSummary.vue
@@ -13,6 +13,7 @@
             v-if="statusWithReason.reason.length > 0"
             :label="statusWithReason.reason.join(', ')"
             class="reason-tooltip"
+            position-fixed
           >
             <InfoIcon
               :size="KUI_ICON_SIZE_30"


### PR DESCRIPTION
**fix(summary-view): content being taller than viewport**

Fixes the summary view being taller than the viewport.

Note: This will be removed again with Kongponents v9 where the underlying issue was fixed.

**fix: tooltips being cut-off**
