### PR TITLE
fix(zones): Zone creation should error normally on 404 responses

### DIFF
--- a/cypress/support/step_definitions/index.ts
+++ b/cypress/support/step_definitions/index.ts
@@ -134,6 +134,9 @@ Then(/^the URL( doesn't | )contain[s]? "(.*)"$/, (assertion: string, str: string
   cy.url().should(`${prefix}include`, str)
 })
 
+// whilst the response is sent after waitForRequest resolves the response itself
+// has been rendered on the server therefore any mocking done after this step
+// will apply to the following request
 Then(/^the URL "(.*)" was?(n't | not | )requested with$/, (url: string, not: string = '', yaml: string) => {
   cy.wrap({
     url,

--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -133,6 +133,11 @@ Feature: zones / create
     When I visit the "/zones/-create" URL
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
+    And the URL "/zones/test/_overview" was requested with
+      """
+      method: GET
+      """
+    And the "$waiting" element exists
     And the URL "/zones/test/_overview" responds with
       """
       headers:

--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -16,10 +16,12 @@ Feature: zones / create
       | environment-kubernetes-config       | [data-testid='zone-kubernetes-config']               |
       | ingress-input-switch                | [for='zone-ingress-enabled']                         |
       | egress-input-switch                 | [for='zone-egress-enabled']                          |
+      | create-error                        | [data-testid='create-zone-error']                    |
       | waiting                             | [data-testid='waiting']                              |
       | connected                           | [data-testid='connected']                            |
-      | error                               | [data-testid='create-zone-error']                    |
+      | error                               | [data-testid='error']                                |
       | instructions                        | [data-testid='connect-zone-instructions']            |
+
     And the environment
       """
       KUMA_MODE: global
@@ -89,6 +91,19 @@ Feature: zones / create
     And the "$egress-input-switch input" element doesn't exist
     And the "$environment-universal-config" element contains "globalAddress: grpcs://<global-kds-address>:5685"
 
+  Scenario: The zone get connected successfully and shows the success
+    Given the environment
+      """
+      KUMA_SUBSCRIPTION_COUNT: 0
+      """
+    And the URL "/provision-zone" responds with
+      """
+      body:
+        token: spat_595QOxTSreRmrtdh8ValuoeUAzXMfBmRwYU3V35NQvwgLAWIU
+      """
+    When I visit the "/zones/-create" URL
+    And I "type" "test" into the "$name-input" element
+    And I click the "$create-zone-button" element
     Given the environment
       """
       KUMA_SUBSCRIPTION_COUNT: 1
@@ -97,13 +112,33 @@ Feature: zones / create
       """
       body:
         zone:
-          enabled: true
+          enabled: !!js/undefined
         zoneInsight:
           subscriptions:
             - connectTime: '2020-07-28T16:18:09.743141Z'
               disconnectTime: !!js/undefined
       """
     Then the "$connected" element exists
+
+  Scenario: The zone is deleted whilst waiting to be connected and shows an error
+    Given the environment
+      """
+      KUMA_SUBSCRIPTION_COUNT: 0
+      """
+    And the URL "/provision-zone" responds with
+      """
+      body:
+        token: spat_595QOxTSreRmrtdh8ValuoeUAzXMfBmRwYU3V35NQvwgLAWIU
+      """
+    When I visit the "/zones/-create" URL
+    And I "type" "test" into the "$name-input" element
+    And I click the "$create-zone-button" element
+    And the URL "/zones/test/_overview" responds with
+      """
+      headers:
+        Status-Code: 404
+      """
+    Then the "$error" element exists
 
   Scenario: The form shows expected error for 409 response
     Given the URL "/provision-zone" responds with
@@ -116,7 +151,7 @@ Feature: zones / create
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
 
-    Then the "$error" element exists
+    Then the "$create-error" element exists
     Then the "$instructions" element doesn't exist
 
   Scenario: The form shows expected error for 400 response
@@ -147,7 +182,7 @@ Feature: zones / create
     And I "type" "zone.eu" into the "$name-input" element
     And I click the "$create-zone-button" element
 
-    Then the "$error" element doesn't exist
+    Then the "$create-error" element doesn't exist
     And the "$name-input-invalid-dns-name" element exists
     And the "$instructions" element doesn't exist
 
@@ -155,7 +190,7 @@ Feature: zones / create
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
 
-    Then the "$error" element doesn't exist
+    Then the "$create-error" element doesn't exist
     And the "$instructions" element exists
 
   Scenario: Exiting the form in a safe state without confirm dialog

--- a/src/app/application/services/data-source/CallableEventSource.ts
+++ b/src/app/application/services/data-source/CallableEventSource.ts
@@ -25,11 +25,12 @@ export default class CallableEventSource<T = {}> extends EventTarget {
     this._open()
   }
 
-  _open() {
+  protected _open() {
     (async function (self) {
       try {
-        self.readyState = 0
+        self.readyState = CONNECTING
         const source = self.source()
+        self.readyState = OPEN
         for await (const res of source) {
           self.dispatchEvent(new MessageEvent('message', {
             data: res,

--- a/src/app/zones/data/index.ts
+++ b/src/app/zones/data/index.ts
@@ -24,6 +24,9 @@ export function getZoneDpServerAuthType(zone: ZoneOverview): string {
 }
 // TODO(jc): end
 
+// The presence of a `ZoneOverview.zoneInsight` object's subscriptions
+// with a connect time and without a disconnect time indicate a Zone to
+// be connected and online.
 export function getZoneControlPlaneStatus(zoneOverview: ZoneOverview): 'online' | 'offline' | 'disabled' {
   if (zoneOverview.zone.enabled === false) {
     return 'disabled'

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -76,7 +76,7 @@ zones:
         description: 'Establish a connection to your remote zone by following the instructions to setup dependencies and install the remote zone control plane.'
       scanner:
         title: 'Waiting for Zone to be connected …'
-        description: ' '
+        description: ''
     nameLabel: 'Name'
     name_tooltip: "The name must be a valid RFC 1035 DNS name, which means it must start with a letter, be less than 64 characters long, and only contain lowercase letters, numbers, and '-'."
     createZoneButtonLabel: 'Create Zone & generate token'

--- a/src/app/zones/views/CreateView.vue
+++ b/src/app/zones/views/CreateView.vue
@@ -284,28 +284,29 @@
                 </div>
 
                 <div class="form-section">
-                  <div class="form-section__header">
-                    <h2 class="form-section-title">
-                      {{ t('zones.form.section.scanner.title') }}
-                    </h2>
-
-                    <p v-if="t('zones.form.section.scanner.description') !== ' '">
-                      {{ t('zones.form.section.scanner.description') }}
-                    </p>
-                  </div>
-
-                  <div class="form-section__content">
-                    <DataSource
-                      v-slot="{ data, error: scanError }: ZoneOverviewSource"
-                      :src="`/zone-cps/online/${name}?no-cache=${Date.now()}`"
-                      @change="success"
+                  <DataSource
+                    v-slot="{ data, error: scanError }: ZoneOverviewSource"
+                    :src="`/zone-cps/online/${name}?no-cache=${now}`"
+                    @change="success"
+                  >
+                    <div
+                      v-if="!scanError"
+                      class="form-section__header"
                     >
+                      <h2 class="form-section-title">
+                        {{ t('zones.form.section.scanner.title') }}
+                      </h2>
+                      <p>{{ t('zones.form.section.scanner.description') }}</p>
+                    </div>
+
+                    <div class="form-section__content">
                       <KEmptyState cta-is-hidden>
                         <template #title>
                           <template
                             v-if="scanError"
                           >
                             <DangerIcon
+                              data-testid="error"
                               display="inline-block"
                               :color="KUI_COLOR_TEXT_DANGER"
                             />
@@ -360,8 +361,8 @@
                           </template>
                         </template>
                       </KEmptyState>
-                    </DataSource>
-                  </div>
+                    </div>
+                  </DataSource>
                 </div>
               </template>
             </div>
@@ -425,6 +426,7 @@ const error = ref<Error | null>(null)
 const frontendNameError = ref<string | null>(null)
 
 const isZoneConnected = ref(false)
+const now = ref(new Date())
 
 const name = ref('')
 const environment = ref<'universal' | 'kubernetes'>('kubernetes')

--- a/src/test-support/intercept.ts
+++ b/src/test-support/intercept.ts
@@ -79,6 +79,10 @@ export const mocker = (env: (key: AppEnvKeys, d?: string) => string, cy: Server,
           }
           const _response = fetch(request)
           const response = cb(createMerge(_response), request, _response)
+          // once the response has been rendered but not sent resolve any
+          // waiting request assertions this means that any mocking done after
+          // awaiting the request will happen on the subsequent request not this
+          // one
           client.request({
             url,
             request,

--- a/src/test-support/mocks/src/zones/_/_overview.ts
+++ b/src/test-support/mocks/src/zones/_/_overview.ts
@@ -12,91 +12,99 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
       creationTime: '2021-02-19T08:06:15.380674+01:00',
       modificationTime: '2021-02-19T08:06:15.380674+01:00',
       zone: {
-        enabled: fake.datatype.boolean(),
+        ...(fake.datatype.boolean()
+          ? {
+            enabled: true,
+          }
+          : {}),
       },
       zoneInsight: {
-        subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
-          return {
-            config: fake.kuma.subscriptionConfig(),
-            id: fake.string.uuid(),
-            globalInstanceId: fake.hacker.noun(),
-            ...fake.kuma.connection(item, i, arr),
-            status: {
-              lastUpdateTime: '2021-02-19T07:06:16.384057Z',
-              total: {
-                responsesSent: `${fake.number.int(30)}`,
-                responsesAcknowledged: `${fake.number.int(30)}`,
-              },
-              stat: {
-                CircuitBreaker: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
+        ...(subscriptionCount !== 0
+          ? {
+            subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
+              return {
+                config: fake.kuma.subscriptionConfig(),
+                id: fake.string.uuid(),
+                globalInstanceId: fake.hacker.noun(),
+                ...fake.kuma.connection(item, i, arr),
+                status: {
+                  lastUpdateTime: '2021-02-19T07:06:16.384057Z',
+                  total: {
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
+                  },
+                  stat: {
+                    CircuitBreaker: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    Config: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    Dataplane: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    ExternalService: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    FaultInjection: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    HealthCheck: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    Mesh: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    ProxyTemplate: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    Retry: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    Secret: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    TrafficLog: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    TrafficPermission: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    TrafficRoute: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                    TrafficTrace: {
+                      responsesSent: `${fake.number.int(30)}`,
+                      responsesAcknowledged: `${fake.number.int(30)}`,
+                    },
+                  },
                 },
-                Config: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
+                version: {
+                  kumaCp: {
+                    version: '1.0.0-rc2-211-g823fe8ce',
+                    gitTag: '1.0.0-rc2-211-g823fe8ce',
+                    gitCommit: fake.git.commitSha(),
+                    buildDate: '2021-02-18T13:22:30Z',
+                    kumaCpGlobalCompatible: fake.datatype.boolean(),
+                  },
                 },
-                Dataplane: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-                ExternalService: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-                FaultInjection: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-                HealthCheck: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-                Mesh: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-                ProxyTemplate: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-                Retry: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-                Secret: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-                TrafficLog: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-                TrafficPermission: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-                TrafficRoute: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-                TrafficTrace: {
-                  responsesSent: `${fake.number.int(30)}`,
-                  responsesAcknowledged: `${fake.number.int(30)}`,
-                },
-              },
-            },
-            version: {
-              kumaCp: {
-                version: '1.0.0-rc2-211-g823fe8ce',
-                gitTag: '1.0.0-rc2-211-g823fe8ce',
-                gitCommit: fake.git.commitSha(),
-                buildDate: '2021-02-18T13:22:30Z',
-                kumaCpGlobalCompatible: fake.datatype.boolean(),
-              },
-            },
+              }
+            }),
           }
-        }),
+          : {}),
       },
     },
   }


### PR DESCRIPTION
Back in https://github.com/kumahq/kuma-gui/pull/1634 we changed the functionality of checking for a connected zone by additionally catching a 404 error and retrying the request, which I'd wrongly assumed how this functioned.

The endpoint only ever returns a 404 if the zone is deleted (i.e. doesn't exist). It doesn't 404 if the zone exists but is not connected.

Due to the change, it was possible to create a zone, without connecting it, and then in say another tab, delete the zone, and the scanner would continue to spin due to the 404s.

I've removed the 404 retries, and also added further testing for making sure a 404 shows the error page when the scanner is waiting to connect, and I also updated the mocks so that they are closer to the real responses.

We decided that we should check for a `zone.enabled` (https://github.com/kumahq/kuma-gui/pull/1634#discussion_r1376119606) but I don't think we ever need to check for `zone.enabled` for the purposes of this PR (or #1634) when checking for whether the zone is connected. I haven't altered anything there as yet as it doesn't have any effect, but I have updated the mocks here so that we don't get `enabled: true`, only a non-existant `enabled` (i.e. defaults to `true`) or `false`, which I 'think' is more correct.

I re-added some comments explaining this a little better in a couple of places, and I almost renamed and moved around functions to help the code self-comment, but I'm a little way into a longer piece of work of collecting up zone data related functions de-duping them and refactoring them, which I'd rather continue to do separately rather than in this PR. The comments here will help when I continue with that.

There are a couple of other things here that I'll note inline.

Closes https://github.com/kumahq/kuma-gui/issues/1749

