### PR TITLE
fix(onboarding): Fixes error with onboarding when detecting new install

### DIFF
--- a/features/onboarding/Index.feature
+++ b/features/onboarding/Index.feature
@@ -1,9 +1,37 @@
 Feature: onboarding / index
   Background:
     Given the CSS selectors
-      | Alias            | Selector                               |
-      | skip-button      | [data-testid='onboarding-skip-button'] |
-      | environment-text | [data-testid='kuma-environment']       |
+      | Alias                   | Selector                                |
+      | skip-button             | [data-testid='onboarding-skip-button']  |
+      | environment-text        | [data-testid='kuma-environment']        |
+      | onboarding-notification | [data-testid='onboarding-notification'] |
+
+  Scenario: Visiting the homepage with a fresh install shows the onboarding notification
+    Given the environment
+      """
+      KUMA_DATAPLANE_COUNT: 0
+      KUMA_MESH_COUNT: 1
+      """
+    When I visit the "/" URL
+    Then the "$onboarding-notification" element exists
+
+  Scenario: Visiting the homepage with a dataplane in the default mesh doesn't show the onboarding notification
+    Given the environment
+      """
+      KUMA_DATAPLANE_COUNT: 1
+      KUMA_MESH_COUNT: 1
+      """
+    When I visit the "/" URL
+    Then the "$onboarding-notification" element doesn't exist
+
+  Scenario: Visiting the a non-home route with a fresh install doesn't show the onboarding notification
+    Given the environment
+      """
+      KUMA_DATAPLANE_COUNT: 0
+      KUMA_MESH_COUNT: 1
+      """
+    When I visit the "/meshes" URL
+    Then the "$onboarding-notification" element doesn't exist
 
   Scenario: Visiting onboarding redirects to welcome
     When I visit the "/onboarding" URL

--- a/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -68,6 +68,8 @@
 
           <KCard>
             <template #body>
+              <!-- This DataSource URL is currently shared with the OnboardingNotification -->
+              <!-- component to ensure that we share the API request -->
               <DataSource
                 v-slot="{ data, error }: MeshInsightCollectionSource"
                 src="/meshes?page=1&size=10"

--- a/src/app/onboarding/components/OnboardingNotification.vue
+++ b/src/app/onboarding/components/OnboardingNotification.vue
@@ -1,50 +1,48 @@
 <template>
+  <!-- As well as only showing the notification on the homepage -->
+  <!-- We also share the same datasource URL as the mesh listing on the homepage -->
   <DataSource
-    v-if="!route.meta.onboardingProcess"
+    v-if="route.name === 'home'"
     v-slot="{ data }"
-    :src="`/meshes?page=1&size=50`"
+    :src="`/meshes?page=1&size=10`"
   >
     <template
       v-if="data?.items.length === 1 && data.items[0].name === 'default'"
     >
-      <DataSource
-        v-slot="{ data: dataplaneData }"
-        :src="`/meshes/${data.items[0].name}/dataplanes?page=1&size=50&search=`"
+      <template
+        v-if="data.items[0].dataplanes.total === 0"
       >
-        <template
-          v-if="dataplaneData?.total === 0"
+        <div
+          v-if="alertClosed === false"
+          class="onboarding-check"
+          data-testid="onboarding-notification"
         >
-          <div
-            v-if="alertClosed === false"
-            class="onboarding-check"
+          <KAlert
+            appearance="success"
+            dismiss-type="icon"
+            @closed="closeAlert"
           >
-            <KAlert
-              appearance="success"
-              dismiss-type="icon"
-              @closed="closeAlert"
-            >
-              <template #alertMessage>
-                <div class="alert-content">
-                  <div>
-                    <strong>Welcome to {{ t('common.product.name') }}!</strong> We've detected that you don't have any data plane proxies running yet. We've created an onboarding process to help you!
-                  </div>
-
-                  <div>
-                    <KButton
-                      appearance="primary"
-                      size="small"
-                      class="action-button"
-                      :to="{ name: 'onboarding-welcome' }"
-                    >
-                      Get started
-                    </KButton>
-                  </div>
+            <template #alertMessage>
+              <div class="alert-content">
+                <div>
+                  <strong>Welcome to {{ t('common.product.name') }}!</strong> We've detected that you don't have any data plane proxies running yet. We've created an onboarding process to help you!
                 </div>
-              </template>
-            </KAlert>
-          </div>
-        </template>
-      </DataSource>
+
+                <div>
+                  <KButton
+                    appearance="primary"
+                    size="small"
+                    class="action-button"
+                    :to="{ name: 'onboarding-welcome' }"
+                  >
+                    Get started
+                  </KButton>
+                </div>
+              </div>
+            </template>
+          </KAlert>
+        </div>
+      </template>
     </template>
   </DataSource>
 </template>


### PR DESCRIPTION
The long story:

During https://github.com/kumahq/kuma-gui/pull/1728 a DataSource source was removed (https://github.com/kumahq/kuma-gui/pull/1728/files#diff-8c51094d188779df11ec5a418503cf5a77c088bb12581335955952e7deef4c3dL50-L65), and replaced by https://github.com/kumahq/kuma-gui/pull/1728/files#diff-8c51094d188779df11ec5a418503cf5a77c088bb12581335955952e7deef4c3dR100-R122

Then, as well as this usage:

https://github.com/kumahq/kuma-gui/pull/1728/files#diff-9d4c2f48081cf9b206eb208a8f15ad06ede0411df7c550dbd938e1926d89b2d9L21

... there is another usage of this DataSource for onboarding which, if you only have 1 mesh called `default` would use this DataSource to figure out if you had added any dataplanes yet, if not we would show you the onboarding notification.

Since the source was removed, the DataSource would error with a DataSource not found error.

---

Firstly, I added the source back and then added a test to cover this eventuality, as well as another for the negative.

As we had discussed https://github.com/kumahq/kuma-gui/pull/1746, I also made some small changes here to:

1. Restrict the OnboardingNotification to the homepage by checking for `route.name === 'home'`
2. Use the information already available about dataplanes in the `/mesh-insights` API endpoint, meaning we no longer have to make the additional HTTP request to inspect the amount of dataplanes. This then meant I could re-remove the source whose removal caused the error in the first place.
3. Add a further test to cover the "only show this on the homepage" case
4. As mentioned in https://github.com/kumahq/kuma-gui/pull/1746#discussion_r1387763698 I also made sure that the `?size=`s used for the homepage and the onboarding notification where them same, and could therefore re-use the same request.
5. Note I am still using the `/mesh-insights` API request. I believe it gives us the same information we would get from `/global-insights` plus it also means we can inspect the name of the only mesh. This means if the only mesh is called `default`, then its a possibly a fresh install and we may show the onboarding, if its called `another-mesh` then it's not a fresh install and we shouldn't ever show the onboarding.

Potential further improvement work that is not necessary in this PR:

1. I left a TODO in the mocks to properly use `KUMA_DATAPLANE_COUNT`, which will then need 'partioning' to give us a spread of types from the total requested.
2. Now that onboarding is only on the homepage we should extract it from ApplicationShell, and embed it into ControlPlaneStatus (the 'status' being "is this control plane fresh or not"). Importantly we should try to do this "as a micro service" so that when our onboarding isn't installed at all then we don't include any code whatsover to do with onboarding.

I did not add the help menu item for onboarding here and we should do that as a separate PR aside from the bugfix PR.


