### PR TITLE
chore: Changes RouteTitle to render by default

### DIFF
--- a/src/app/application/components/route-view/RouteTitle.vue
+++ b/src/app/application/components/route-view/RouteTitle.vue
@@ -20,7 +20,7 @@ const props = defineProps({
   render: {
     type: Boolean,
     required: false,
-    default: false,
+    default: true,
   },
 })
 

--- a/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -8,7 +8,6 @@
         <h1>
           <RouteTitle
             :title="t('main-overview.routes.item.title')"
-            :render="true"
           />
         </h1>
       </template>

--- a/src/app/data-planes/views/DataPlaneClustersView.vue
+++ b/src/app/data-planes/views/DataPlaneClustersView.vue
@@ -13,7 +13,6 @@
         <h2>
           <RouteTitle
             :title="t('data-planes.routes.item.navigation.data-plane-clusters-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/data-planes/views/DataPlaneConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneConfigView.vue
@@ -13,7 +13,6 @@
         <h2>
           <RouteTitle
             :title="t('data-planes.routes.item.navigation.data-plane-config-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -34,7 +34,6 @@
           <TextWithCopyButton :text="route.params.dataPlane">
             <RouteTitle
               :title="t(`${props.isGatewayView ? 'gateways' : 'data-planes'}.routes.item.title`, { name: route.params.dataPlane })"
-              :render="true"
             />
           </TextWithCopyButton>
         </h1>

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -26,7 +26,6 @@
             <h2>
               <RouteTitle
                 :title="t('data-planes.routes.items.title')"
-                :render="true"
               />
             </h2>
           </template>

--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -12,7 +12,6 @@
         <h2>
           <RouteTitle
             :title="t('data-planes.routes.item.navigation.data-plane-policies-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/data-planes/views/DataPlaneStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneStatsView.vue
@@ -13,7 +13,6 @@
         <h2>
           <RouteTitle
             :title="t('data-planes.routes.item.navigation.data-plane-stats-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -19,7 +19,6 @@
             >
               <RouteTitle
                 :title="t('data-planes.routes.item.title', { name: props.name })"
-                :render="true"
               />
             </RouterLink>
           </h2>

--- a/src/app/data-planes/views/DataPlaneXdsConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneXdsConfigView.vue
@@ -13,7 +13,6 @@
         <h2>
           <RouteTitle
             :title="t('data-planes.routes.item.navigation.data-plane-xds-config-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/diagnostics/views/DiagnosticsView.vue
+++ b/src/app/diagnostics/views/DiagnosticsView.vue
@@ -30,7 +30,6 @@ import LoadingBlock from '@/app/common/LoadingBlock.vue'
           <h1>
             <RouteTitle
               :title="t('diagnostics.routes.item.title')"
-              :render="true"
             />
           </h1>
         </template>

--- a/src/app/kuma/views/NotFoundView.vue
+++ b/src/app/kuma/views/NotFoundView.vue
@@ -10,7 +10,6 @@
             <h1>
               <RouteTitle
                 title="Page Not Found"
-                :render="true"
               />
             </h1>
           </template>

--- a/src/app/meshes/views/MeshConfigView.vue
+++ b/src/app/meshes/views/MeshConfigView.vue
@@ -12,7 +12,6 @@
         <h2>
           <RouteTitle
             :title="t('meshes.routes.item.navigation.mesh-config-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/meshes/views/MeshDetailView.vue
+++ b/src/app/meshes/views/MeshDetailView.vue
@@ -6,7 +6,10 @@
       mesh: '',
     }"
   >
-    <RouteTitle :title="t('meshes.routes.overview.title')" />
+    <RouteTitle
+      :title="t('meshes.routes.overview.title')"
+      :render="false"
+    />
 
     <AppView>
       <DataSource

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -22,7 +22,6 @@
             <h1>
               <RouteTitle
                 :title="t('meshes.routes.items.title')"
-                :render="true"
               />
             </h1>
           </template>

--- a/src/app/meshes/views/MeshSummaryView.vue
+++ b/src/app/meshes/views/MeshSummaryView.vue
@@ -19,7 +19,6 @@
             >
               <RouteTitle
                 :title="t('meshes.routes.item.title', { name: props.name })"
-                :render="true"
               />
             </RouterLink>
           </h2>

--- a/src/app/meshes/views/MeshTabsView.vue
+++ b/src/app/meshes/views/MeshTabsView.vue
@@ -12,7 +12,6 @@
           <TextWithCopyButton :text="route.params.mesh">
             <RouteTitle
               :title="t('meshes.routes.item.title', { name: route.params.mesh })"
-              :render="true"
             />
           </TextWithCopyButton>
         </h1>

--- a/src/app/onboarding/views/AddNewServices.vue
+++ b/src/app/onboarding/views/AddNewServices.vue
@@ -5,6 +5,7 @@
   >
     <RouteTitle
       :title="t('onboarding.routes.add-services.title')"
+      :render="false"
     />
     <AppView>
       <OnboardingPage>

--- a/src/app/onboarding/views/AddNewServicesCode.vue
+++ b/src/app/onboarding/views/AddNewServicesCode.vue
@@ -5,6 +5,7 @@
   >
     <RouteTitle
       :title="t('onboarding.routes.add-services-code.title')"
+      :render="false"
     />
     <AppView>
       <OnboardingPage>

--- a/src/app/onboarding/views/CompletedView.vue
+++ b/src/app/onboarding/views/CompletedView.vue
@@ -5,6 +5,7 @@
   >
     <RouteTitle
       :title="t('onboarding.routes.completed.title')"
+      :render="false"
     />
     <AppView>
       <OnboardingPage>

--- a/src/app/onboarding/views/ConfigurationTypes.vue
+++ b/src/app/onboarding/views/ConfigurationTypes.vue
@@ -5,6 +5,7 @@
   >
     <RouteTitle
       :title="t('onboarding.routes.configuration-types.title')"
+      :render="false"
     />
     <AppView>
       <OnboardingPage with-image>

--- a/src/app/onboarding/views/CreateMesh.vue
+++ b/src/app/onboarding/views/CreateMesh.vue
@@ -5,6 +5,7 @@
   >
     <RouteTitle
       :title="t('onboarding.routes.create-mesh.title')"
+      :render="false"
     />
     <AppView>
       <OnboardingPage>

--- a/src/app/onboarding/views/DataplanesOverview.vue
+++ b/src/app/onboarding/views/DataplanesOverview.vue
@@ -5,6 +5,7 @@
   >
     <RouteTitle
       :title="t('onboarding.routes.dataplanes-overview.title')"
+      :render="false"
     />
     <AppView>
       <OnboardingPage>

--- a/src/app/onboarding/views/DeploymentTypes.vue
+++ b/src/app/onboarding/views/DeploymentTypes.vue
@@ -5,6 +5,7 @@
   >
     <RouteTitle
       :title="t('onboarding.routes.deployment-types.title')"
+      :render="false"
     />
     <AppView>
       <OnboardingPage with-image>

--- a/src/app/onboarding/views/MultiZoneView.vue
+++ b/src/app/onboarding/views/MultiZoneView.vue
@@ -5,6 +5,7 @@
   >
     <RouteTitle
       :title="t('onboarding.routes.multizone.title')"
+      :render="false"
     />
     <AppView>
       <OnboardingPage>

--- a/src/app/onboarding/views/WelcomeView.vue
+++ b/src/app/onboarding/views/WelcomeView.vue
@@ -5,6 +5,7 @@
   >
     <RouteTitle
       :title="t('onboarding.routes.welcome.title', {name: t('common.product.name')})"
+      :render="false"
     />
     <AppView>
       <div>

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -37,7 +37,6 @@
           <TextWithCopyButton :text="route.params.policy">
             <RouteTitle
               :title="t('policies.routes.item.title', { name: route.params.policy })"
-              :render="true"
             />
           </TextWithCopyButton>
         </h1>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -20,7 +20,6 @@
           <h2>
             <RouteTitle
               :title="t('policies.routes.items.title')"
-              :render="true"
             />
           </h2>
         </template>

--- a/src/app/policies/views/PolicySummaryView.vue
+++ b/src/app/policies/views/PolicySummaryView.vue
@@ -28,7 +28,6 @@
             >
               <RouteTitle
                 :title="t('policies.routes.item.title', { name: props.name })"
-                :render="true"
               />
             </RouterLink>
           </h2>

--- a/src/app/services/views/ServiceConfigView.vue
+++ b/src/app/services/views/ServiceConfigView.vue
@@ -13,7 +13,6 @@
         <h2>
           <RouteTitle
             :title="t('services.routes.item.navigation.service-config-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/services/views/ServiceDataPlaneProxiesView.vue
+++ b/src/app/services/views/ServiceDataPlaneProxiesView.vue
@@ -23,7 +23,6 @@
           <h2>
             <RouteTitle
               :title="t('services.routes.item.navigation.service-data-plane-proxies-view')"
-              :render="true"
             />
           </h2>
         </template>

--- a/src/app/services/views/ServiceDetailTabsView.vue
+++ b/src/app/services/views/ServiceDetailTabsView.vue
@@ -34,7 +34,6 @@
           <TextWithCopyButton :text="route.params.service">
             <RouteTitle
               :title="t('services.routes.item.title', { name: route.params.service })"
-              :render="true"
             />
           </TextWithCopyButton>
         </h1>

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -23,7 +23,6 @@
             <h2>
               <RouteTitle
                 :title="t('services.routes.items.title')"
-                :render="true"
               />
             </h2>
           </template>

--- a/src/app/services/views/ServiceSummaryView.vue
+++ b/src/app/services/views/ServiceSummaryView.vue
@@ -27,7 +27,6 @@
             >
               <RouteTitle
                 :title="t('services.routes.item.title', { name: route.params.service })"
-                :render="true"
               />
             </RouterLink>
           </h2>

--- a/src/app/zone-egresses/views/IndexView.vue
+++ b/src/app/zone-egresses/views/IndexView.vue
@@ -20,7 +20,6 @@
           <h2>
             <RouteTitle
               :title="t('zone-egresses.routes.items.title')"
-              :render="true"
             />
           </h2>
         </template>

--- a/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
@@ -19,7 +19,6 @@
             >
               <RouteTitle
                 :title="t('zone-egresses.routes.item.title', { name: props.name })"
-                :render="true"
               />
             </RouterLink>
           </h2>

--- a/src/app/zone-egresses/views/item/ClustersView.vue
+++ b/src/app/zone-egresses/views/item/ClustersView.vue
@@ -12,7 +12,6 @@
         <h2>
           <RouteTitle
             :title="t('zone-egresses.routes.item.navigation.zone-egress-clusters-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/zone-egresses/views/item/ConfigView.vue
+++ b/src/app/zone-egresses/views/item/ConfigView.vue
@@ -12,7 +12,6 @@
         <h2>
           <RouteTitle
             :title="t('zone-egresses.routes.item.navigation.zone-egress-config-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/zone-egresses/views/item/IndexView.vue
+++ b/src/app/zone-egresses/views/item/IndexView.vue
@@ -27,7 +27,6 @@
           <TextWithCopyButton :text="route.params.zoneEgress">
             <RouteTitle
               :title="t('zone-egresses.routes.item.title', { name: route.params.zoneEgress })"
-              :render="true"
             />
           </TextWithCopyButton>
         </h1>

--- a/src/app/zone-egresses/views/item/StatsView.vue
+++ b/src/app/zone-egresses/views/item/StatsView.vue
@@ -12,7 +12,6 @@
         <h2>
           <RouteTitle
             :title="t('zone-egresses.routes.item.navigation.zone-egress-stats-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/zone-egresses/views/item/XdsConfigView.vue
+++ b/src/app/zone-egresses/views/item/XdsConfigView.vue
@@ -12,7 +12,6 @@
         <h2>
           <RouteTitle
             :title="t('zone-egresses.routes.item.navigation.zone-egress-xds-config-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/zone-ingresses/views/IndexView.vue
+++ b/src/app/zone-ingresses/views/IndexView.vue
@@ -20,7 +20,6 @@
           <h2>
             <RouteTitle
               :title="t('zone-ingresses.routes.items.title')"
-              :render="true"
             />
           </h2>
         </template>

--- a/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -19,7 +19,6 @@
             >
               <RouteTitle
                 :title="t('zone-ingresses.routes.item.title', { name: props.name })"
-                :render="true"
               />
             </RouterLink>
           </h2>

--- a/src/app/zone-ingresses/views/item/ClustersView.vue
+++ b/src/app/zone-ingresses/views/item/ClustersView.vue
@@ -12,7 +12,6 @@
         <h2>
           <RouteTitle
             :title="t('zone-ingresses.routes.item.navigation.zone-ingress-clusters-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/zone-ingresses/views/item/ConfigView.vue
+++ b/src/app/zone-ingresses/views/item/ConfigView.vue
@@ -12,7 +12,6 @@
         <h2>
           <RouteTitle
             :title="t('zone-ingresses.routes.item.navigation.zone-ingress-config-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/zone-ingresses/views/item/IndexView.vue
+++ b/src/app/zone-ingresses/views/item/IndexView.vue
@@ -27,7 +27,6 @@
           <TextWithCopyButton :text="route.params.zoneIngress">
             <RouteTitle
               :title="t('zone-ingresses.routes.item.title', { name: route.params.zoneIngress })"
-              :render="true"
             />
           </TextWithCopyButton>
         </h1>

--- a/src/app/zone-ingresses/views/item/ServicesView.vue
+++ b/src/app/zone-ingresses/views/item/ServicesView.vue
@@ -8,7 +8,6 @@
         <h2>
           <RouteTitle
             :title="t('zone-ingresses.routes.item.navigation.zone-ingress-services-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/zone-ingresses/views/item/StatsView.vue
+++ b/src/app/zone-ingresses/views/item/StatsView.vue
@@ -12,7 +12,6 @@
         <h2>
           <RouteTitle
             :title="t('zone-ingresses.routes.item.navigation.zone-ingress-stats-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/zone-ingresses/views/item/XdsConfigView.vue
+++ b/src/app/zone-ingresses/views/item/XdsConfigView.vue
@@ -12,7 +12,6 @@
         <h2>
           <RouteTitle
             :title="t('zone-ingresses.routes.item.navigation.zone-ingress-xds-config-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/zones/views/CreateView.vue
+++ b/src/app/zones/views/CreateView.vue
@@ -14,7 +14,6 @@
         <h1>
           <RouteTitle
             :title="t('zones.routes.create.title')"
-            :render="true"
           />
         </h1>
       </template>

--- a/src/app/zones/views/IndexView.vue
+++ b/src/app/zones/views/IndexView.vue
@@ -18,7 +18,6 @@
           <h1>
             <RouteTitle
               :title="t('zone-cps.routes.items.title')"
-              :render="true"
             />
           </h1>
         </template>

--- a/src/app/zones/views/ZoneSummaryView.vue
+++ b/src/app/zones/views/ZoneSummaryView.vue
@@ -19,7 +19,6 @@
             >
               <RouteTitle
                 :title="t('zone-cps.routes.item.title', { name: props.name })"
-                :render="true"
               />
             </RouterLink>
           </h2>

--- a/src/app/zones/views/item/ConfigView.vue
+++ b/src/app/zones/views/item/ConfigView.vue
@@ -29,7 +29,6 @@
         <h2>
           <RouteTitle
             :title="t('zone-cps.routes.item.navigation.zone-cp-config-view')"
-            :render="true"
           />
         </h2>
       </template>

--- a/src/app/zones/views/item/IndexView.vue
+++ b/src/app/zones/views/item/IndexView.vue
@@ -34,7 +34,6 @@
               <TextWithCopyButton :text="route.params.zone">
                 <RouteTitle
                   :title="t('zone-cps.routes.item.title', { name: route.params.zone })"
-                  :render="true"
                 />
               </TextWithCopyButton>
             </h1>


### PR DESCRIPTION
Changes `RouteTitle::render` to default to `true`.

This means we can remove all the many places where we use `render=true`, and use `render=false` in the few places where we don't want to render the document title in the HTML page (mainly in onboarding it seems)

Closes https://github.com/kumahq/kuma-gui/issues/1418