### PR TITLE
feat: expand get utility to square bracket notation

### DIFF
--- a/src/utilities/get.spec.ts
+++ b/src/utilities/get.spec.ts
@@ -7,7 +7,17 @@ describe('get', () => {
     [{ a: { b: { c: 3 } } }, ['a', 'b', 'c'], undefined, 3],
     [{ a: { b: { c: 3 } } }, ['a', 'b', 'd'], undefined, undefined],
     [{ a: { b: { c: 3 } } }, 'a.b.c', 'default', 3],
+    [{ a: { b: { c: null } } }, 'a.b.c', 'default', null],
+    [{ a: { b: { c: undefined } } }, 'a.b.c', 'default', undefined],
     [{ a: { b: { c: 3 } } }, 'a.b.d', 'default', 'default'],
+    [{ a: { b: ['c', 'd'] } }, 'a.b[1]', undefined, 'd'],
+    [{ a: { b: ['c', 'd'] } }, ['a', 'b', '1'], undefined, 'd'],
+    [{ a: { b: ['c', { nested: 'd' }] } }, ['a', 'b', '1', 'nested'], undefined, 'd'],
+    [['a', 'b', 'c'], '1', undefined, 'b'],
+    [['a', 'b', 'c'], '[1]', undefined, 'b'],
+    [{ labels: { key: 'value' } }, 'labels["key"]', undefined, 'value'],
+    [{ labels: { key: 'value' } }, "labels['key']", undefined, 'value'],
+    [{ labels: { key: { nestedKey: 'nestedValue' } } }, 'labels["key"]["nestedKey"]', undefined, 'nestedValue'],
   ])('works', (obj, pathOrProps, defaultValue, expectedValue) => {
     expect(get(obj, pathOrProps, defaultValue)).toEqual(expectedValue)
   })

--- a/src/utilities/get.ts
+++ b/src/utilities/get.ts
@@ -4,19 +4,19 @@
 export function get(obj: any, pathOrProps: string | string[], defaultValue: any = undefined): any {
   if (
     !(typeof obj === 'object') ||
-    Array.isArray(obj) ||
     (Array.isArray(pathOrProps) && pathOrProps.length === 0)
   ) {
     return defaultValue
   }
 
-  const props = Array.isArray(pathOrProps) ? pathOrProps : pathOrProps.split('.')
+  const props = Array.isArray(pathOrProps) ? pathOrProps : pathOrProps.split(/[.[\]]/).filter((prop) => prop !== '')
+  const prop = props[0]
+  // Strips a quoted value from its quotes (e.g. "key" → key).
+  const strippedProp = prop.match(/(['"]).+\1/) !== null ? prop.substring(1, prop.length - 1) : prop
 
   if (props.length === 1) {
-    const value = obj[props[0]]
-
-    return value === undefined ? defaultValue : value
+    return strippedProp in obj ? obj[strippedProp] : defaultValue
   }
 
-  return get(obj[props[0]], props.slice(1), defaultValue)
+  return get(obj[strippedProp], props.slice(1), defaultValue)
 }


### PR DESCRIPTION
Adds support for square bracket notation to our get utility. For example, `get({ labels: { key: 'value' } }, 'labels["key"]')` will return `'value'`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>