### PR TITLE
chore(dataplanes): truncate name column

### DIFF
--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -1,5 +1,6 @@
 <template>
   <AppCollection
+    class="data-plane-collection"
     :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
     :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
     :empty-state-cta-text="t('common.documentation')"
@@ -29,6 +30,8 @@
 
     <template #name="{ row: item }: { row: DataPlaneOverviewTableRow }">
       <RouterLink
+        class="name-link"
+        :title="item.name"
         :to="{
           name: props.summaryRouteName,
           params: {
@@ -252,9 +255,21 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
 </script>
 
 <style lang="scss" scoped>
+.name-link {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .details-link {
   display: inline-flex;
   align-items: center;
   gap: $kui-space-20;
+}
+
+.data-plane-collection :deep(.name-column) {
+  max-width: 400px;
 }
 </style>

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -40,7 +40,6 @@
               <DataPlaneList
                 v-else
                 data-testid="data-plane-collection"
-                class="data-plane-collection"
                 :page-number="parseInt(route.params.page)"
                 :page-size="parseInt(route.params.size)"
                 :total="data?.total"

--- a/src/app/services/views/ServiceDataPlaneProxiesView.vue
+++ b/src/app/services/views/ServiceDataPlaneProxiesView.vue
@@ -41,7 +41,6 @@
               <DataPlaneList
                 v-else
                 data-testid="data-plane-collection"
-                class="data-plane-collection"
                 :page-number="parseInt(route.params.page)"
                 :page-size="parseInt(route.params.size)"
                 :total="dataplanesData?.total"

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -59,11 +59,14 @@ export class KumaModule {
     }
   }
 
-  dataPlaneProxyName() {
-    const namespace = this.faker.hacker.noun()
+  dataPlaneProxyName({ zone }: { zone?: string } = {}) {
+    const shortServiceName = this.faker.helpers.arrayElement(['redis', 'frontend', 'backend', 'demo-app', 'gateway', 'postgres', 'api'])
     const deploymentId = this.faker.string.hexadecimal({ length: 10, casing: 'lower', prefix: '' })
-    const podId = this.faker.string.hexadecimal({ length: 5, casing: 'lower', prefix: '' })
-    return `${this.faker.hacker.noun()}-${deploymentId}-${podId}.${namespace}`
+    const podId = this.faker.string.alpha({ length: 5, casing: 'lower' })
+    const zoneControlPlaneNamespace = this.faker.hacker.noun()
+    const systemNamespace = this.faker.helpers.arrayElement(['kuma-system'])
+
+    return (zone ? `${zone}.` : '') + `${shortServiceName}-${deploymentId}-${podId}.${zoneControlPlaneNamespace}.${systemNamespace}`
   }
 
   connection<T>(_: T, i: number, arr: T[]) {


### PR DESCRIPTION
## Changes

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

- I’ve made this change specific to the DPP list for now. We could consider generalizing this to all list views, but I think this should be a good first step.
- I’ve updated the logic for DPP name generation in our mocks to be a bit more realistic. This isn’t quite complete, yet. Ideally, the DPP mocks would have the same zone prefix in the name as they have a zone tag in somewhere in `networking`. Another day.