### PR TITLE
chore: remove online check for envoy data

### DIFF
--- a/src/app/common/EnvoyData.vue
+++ b/src/app/common/EnvoyData.vue
@@ -1,16 +1,6 @@
 <template>
   <div>
-    <KAlert
-      v-if="props.status !== 'online'"
-      appearance="info"
-    >
-      <template #alertMessage>
-        <p>{{ t('common.detail.no_envoy_data', { resource: props.resource }) }}</p>
-      </template>
-    </KAlert>
-
     <DataSource
-      v-else
       v-slot="{ data, error, refresh }: EnvoyDataSource"
       :src="props.src"
     >
@@ -59,13 +49,8 @@ import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import { EnvoyDataSource } from '@/app/zones/sources'
-import { StatusKeyword } from '@/types'
-import { useI18n } from '@/utilities'
-
-const { t } = useI18n()
 
 const props = withDefaults(defineProps<{
-  status: StatusKeyword
   resource: string
   src: string
   query?: string

--- a/src/app/data-planes/views/DataPlaneClustersView.vue
+++ b/src/app/data-planes/views/DataPlaneClustersView.vue
@@ -20,7 +20,6 @@
       <KCard>
         <template #body>
           <EnvoyData
-            :status="getStatusAndReason(props.data.dataplane, props.data.dataplaneInsight).status"
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/clusters`"
             :query="route.params.codeSearch"
@@ -34,10 +33,4 @@
 
 <script lang="ts" setup>
 import EnvoyData from '@/app/common/EnvoyData.vue'
-import type { DataPlaneOverview } from '@/types/index.d'
-import { getStatusAndReason } from '@/utilities/dataplane'
-
-const props = defineProps<{
-  data: DataPlaneOverview
-}>()
 </script>

--- a/src/app/data-planes/views/DataPlaneStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneStatsView.vue
@@ -20,7 +20,6 @@
       <KCard>
         <template #body>
           <EnvoyData
-            :status="getStatusAndReason(props.data.dataplane, props.data.dataplaneInsight).status"
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/stats`"
             :query="route.params.codeSearch"
@@ -34,10 +33,4 @@
 
 <script lang="ts" setup>
 import EnvoyData from '@/app/common/EnvoyData.vue'
-import type { DataPlaneOverview } from '@/types/index.d'
-import { getStatusAndReason } from '@/utilities/dataplane'
-
-const props = defineProps<{
-  data: DataPlaneOverview
-}>()
 </script>

--- a/src/app/data-planes/views/DataPlaneXdsConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneXdsConfigView.vue
@@ -20,7 +20,6 @@
       <KCard>
         <template #body>
           <EnvoyData
-            :status="getStatusAndReason(props.data.dataplane, props.data.dataplaneInsight).status"
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/xds`"
             :query="route.params.codeSearch"
@@ -34,10 +33,4 @@
 
 <script lang="ts" setup>
 import EnvoyData from '@/app/common/EnvoyData.vue'
-import type { DataPlaneOverview } from '@/types/index.d'
-import { getStatusAndReason } from '@/utilities/dataplane'
-
-const props = defineProps<{
-  data: DataPlaneOverview
-}>()
 </script>

--- a/src/app/zone-egresses/views/ZoneEgressClustersView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressClustersView.vue
@@ -19,7 +19,6 @@
       <KCard>
         <template #body>
           <EnvoyData
-            :status="getItemStatusFromInsight(props.data.zoneEgressInsight)"
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/clusters`"
             :query="route.params.codeSearch"
@@ -33,10 +32,4 @@
 
 <script lang="ts" setup>
 import EnvoyData from '@/app/common/EnvoyData.vue'
-import type { ZoneEgressOverview } from '@/types/index.d'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
-
-const props = defineProps<{
-  data: ZoneEgressOverview
-}>()
 </script>

--- a/src/app/zone-egresses/views/ZoneEgressStatsView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressStatsView.vue
@@ -19,7 +19,6 @@
       <KCard>
         <template #body>
           <EnvoyData
-            :status="getItemStatusFromInsight(props.data.zoneEgressInsight)"
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/stats`"
             :query="route.params.codeSearch"
@@ -33,10 +32,4 @@
 
 <script lang="ts" setup>
 import EnvoyData from '@/app/common/EnvoyData.vue'
-import type { ZoneEgressOverview } from '@/types/index.d'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
-
-const props = defineProps<{
-  data: ZoneEgressOverview
-}>()
 </script>

--- a/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
@@ -19,7 +19,6 @@
       <KCard>
         <template #body>
           <EnvoyData
-            :status="getItemStatusFromInsight(props.data.zoneEgressInsight)"
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/xds`"
             :query="route.params.codeSearch"
@@ -33,10 +32,4 @@
 
 <script lang="ts" setup>
 import EnvoyData from '@/app/common/EnvoyData.vue'
-import type { ZoneEgressOverview } from '@/types/index.d'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
-
-const props = defineProps<{
-  data: ZoneEgressOverview
-}>()
 </script>

--- a/src/app/zone-ingresses/views/ZoneIngressClustersView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressClustersView.vue
@@ -19,7 +19,6 @@
       <KCard>
         <template #body>
           <EnvoyData
-            :status="getItemStatusFromInsight(props.data.zoneIngressInsight)"
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/clusters`"
             :query="route.params.codeSearch"
@@ -33,10 +32,4 @@
 
 <script lang="ts" setup>
 import EnvoyData from '@/app/common/EnvoyData.vue'
-import type { ZoneIngressOverview } from '@/types/index.d'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
-
-const props = defineProps<{
-  data: ZoneIngressOverview
-}>()
 </script>

--- a/src/app/zone-ingresses/views/ZoneIngressStatsView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressStatsView.vue
@@ -19,7 +19,6 @@
       <KCard>
         <template #body>
           <EnvoyData
-            :status="getItemStatusFromInsight(props.data.zoneIngressInsight)"
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/stats`"
             :query="route.params.codeSearch"
@@ -33,10 +32,4 @@
 
 <script lang="ts" setup>
 import EnvoyData from '@/app/common/EnvoyData.vue'
-import type { ZoneIngressOverview } from '@/types/index.d'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
-
-const props = defineProps<{
-  data: ZoneIngressOverview
-}>()
 </script>

--- a/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
@@ -19,7 +19,6 @@
       <KCard>
         <template #body>
           <EnvoyData
-            :status="getItemStatusFromInsight(props.data.zoneIngressInsight)"
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/xds`"
             :query="route.params.codeSearch"
@@ -33,10 +32,4 @@
 
 <script lang="ts" setup>
 import EnvoyData from '@/app/common/EnvoyData.vue'
-import type { ZoneIngressOverview } from '@/types/index.d'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
-
-const props = defineProps<{
-  data: ZoneIngressOverview
-}>()
 </script>

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -69,4 +69,3 @@ common:
     none: '—'
     created: 'Created'
     modified: 'Modified'
-    no_envoy_data: 'No Envoy data is available because the {resource} is not online'


### PR DESCRIPTION
## Changes

Removes the online check from the EnvoyData component. It wasn’t correctly implemented for ZoneIngress and ZoneEgress where we would need to check for the status of the Zone not the ZoneIngress/ZoneEgress.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

- This is one half of #1565. The other half will be ensuring that we correctly surface information from the error responses added in https://github.com/kumahq/kuma/issues/5216.