### PR TITLE
feat: persist code block modes in URL

### DIFF
--- a/features/diagnostics/DetailViewContent.feature
+++ b/features/diagnostics/DetailViewContent.feature
@@ -1,9 +1,11 @@
 Feature: Diagnostics: Detail view content
   Background:
     Given the CSS selectors
-      | Alias                   | Selector                                  |
-      | details                 | [data-testid='code-block-diagnostics']    |
-      | code-block-search-input | [data-testid='k-code-block-search-input'] |
+      | Alias                         | Selector                                        |
+      | details                       | [data-testid='code-block-diagnostics']          |
+      | code-block-search-input       | [data-testid='k-code-block-search-input']       |
+      | code-block-regexp-mode-button | [data-testid='k-code-block-regexp-mode-button'] |
+      | code-block-filter-mode-button | [data-testid='k-code-block-filter-mode-button'] |
 
   Scenario: Diagnostics detail view has expected content
     Given the environment
@@ -17,12 +19,26 @@ Feature: Diagnostics: Detail view content
     Then the "$details" element contains ""environment": "universal""
 
   Scenario: Reads code search value from URL
-    When I visit the "/diagnostics?codeSearch=(groups%257Cusers)" URL
+    When I visit the "/diagnostics?codeSearch=(groups%257Cusers)&codeRegExp=true&codeFilter=true" URL
 
     Then the "$code-block-search-input" element contains "(groups|users)"
+    And the "$code-block-regexp-mode-button[aria-pressed='true']" element exists
+    And the "$code-block-filter-mode-button[aria-pressed='true']" element exists
 
   Scenario: Stores code search value in URL
     When I visit the "/diagnostics" URL
-    And I "input" "(groups|users)" into the "$code-block-search-input" element
+
+    Then the "$code-block-regexp-mode-button[aria-pressed='true']" element doesn't exist
+    And the "$code-block-filter-mode-button[aria-pressed='true']" element doesn't exist
+
+    When I "input" "(groups|users)" into the "$code-block-search-input" element
 
     Then the URL contains "/diagnostics?codeSearch=(groups%257Cusers)"
+
+    When I click the "$code-block-regexp-mode-button" element
+
+    Then the URL contains "/diagnostics?codeSearch=(groups%257Cusers)&codeRegExp=true"
+
+    When I click the "$code-block-filter-mode-button" element
+
+    Then the URL contains "/diagnostics?codeSearch=(groups%257Cusers)&codeRegExp=true&codeFilter=true"

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -25,7 +25,7 @@
     />
   </div>
 </template>
-<script lang="ts" setup generic="T extends Record<string, string | number> = {}">
+<script lang="ts" setup generic="T extends Record<string, string | number | boolean> = {}">
 import { computed, provide, inject, ref, watch, onBeforeUnmount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -130,21 +130,27 @@ watch(() => {
     if (param.length === 0) {
       param = String(def)
     }
+
+    // Change `param` to the empty string for boolean parameters that are `false` so that it’s omitted in the URL.
+    if (typeof def === 'boolean' && String(param) === 'false') {
+      param = ''
+    }
+
     prev[prop] = decodeURIComponent(param)
     return prev
   }, {})
   routeParams.value = params as UnwrapRef<Params>
 }, { immediate: true })
 
-let newParams = {}
-const routerPush = beforePaint((params: Record<string, string | undefined>) => {
+let newParams: Record<string, string | boolean | undefined> = {}
+const routerPush = beforePaint((params: Record<string, string | boolean | undefined>) => {
   router.push({
     name: props.name,
     query: cleanQuery(params, route.query),
   })
   newParams = {}
 })
-const routeUpdate = (params: Record<string, string | undefined>) => {
+const routeUpdate = (params: Record<string, string | boolean | undefined>) => {
   newParams = {
     ...newParams,
     ...params,

--- a/src/app/application/utilities/index.ts
+++ b/src/app/application/utilities/index.ts
@@ -38,12 +38,13 @@ export const createAttrsSetter = ($el = document.documentElement) => {
   })
 }
 // when used with router.push, prevents things like `q=` (i.e. key= but with no value)
-export const cleanQuery = <T extends Record<string, unknown>>(params: Record<string, string | undefined>, originalQuery: T) => {
+export const cleanQuery = <T extends Record<string, unknown>>(params: Record<string, string | boolean | undefined>, originalQuery: T) => {
   const query = {
     ...originalQuery as Record<string, string | undefined>,
   }
   const processed = Object.entries(params).reduce((prev, [key, value]) => {
-    if (String(value).length > 0) {
+    // Only add parameters for non-empty strings or non-false boolean
+    if (String(value).length > 0 && value !== false) {
       prev[key] = encodeURIComponent(String(value))
     } else {
       prev[key] = undefined

--- a/src/app/common/CodeBlock.vue
+++ b/src/app/common/CodeBlock.vue
@@ -5,6 +5,8 @@
     :max-height="props.codeMaxHeight"
     :code="props.code"
     :language="language"
+    :initial-filter-mode="props.isFilterMode"
+    :initial-reg-exp-mode="props.isRegExpMode"
     :is-processing="isProcessing"
     :is-searchable="isSearchable"
     :show-copy-button="showCopyButton"
@@ -12,6 +14,8 @@
     theme="dark"
     @code-block-render="handleCodeBlockRenderEvent"
     @query-change="emit('query-change', $event)"
+    @filter-mode-change="emit('filter-mode-change', $event)"
+    @reg-exp-mode-change="emit('reg-exp-mode-change', $event)"
   >
     <template
       v-if="$slots['secondary-actions']"
@@ -36,15 +40,21 @@ const props = withDefaults(defineProps<{
   showCopyButton?: boolean
   codeMaxHeight?: string
   query?: string
+  isFilterMode?: boolean
+  isRegExpMode?: boolean
 }>(), {
   isSearchable: false,
   showCopyButton: true,
   codeMaxHeight: undefined,
   query: '',
+  isFilterMode: false,
+  isRegExpMode: false,
 })
 
 const emit = defineEmits<{
   (event: 'query-change', query: string): void
+  (event: 'filter-mode-change', isFilterMode: boolean): void
+  (event: 'reg-exp-mode-change', isRegExpMode: boolean): void
 }>()
 
 const isProcessing = ref(false)

--- a/src/app/common/EnvoyData.vue
+++ b/src/app/common/EnvoyData.vue
@@ -32,7 +32,11 @@
           :code="typeof data === 'string' ? data : JSON.stringify(data, null, 2)"
           is-searchable
           :query="props.query"
+          :is-filter-mode="props.isFilterMode"
+          :is-reg-exp-mode="props.isRegExpMode"
           @query-change="emit('query-change', $event)"
+          @filter-mode-change="emit('filter-mode-change', $event)"
+          @reg-exp-mode-change="emit('reg-exp-mode-change', $event)"
         />
       </template>
     </DataSource>
@@ -54,12 +58,18 @@ const props = withDefaults(defineProps<{
   resource: string
   src: string
   query?: string
+  isFilterMode?: boolean
+  isRegExpMode?: boolean
 }>(), {
   query: '',
+  isFilterMode: false,
+  isRegExpMode: false,
 })
 
 const emit = defineEmits<{
   (event: 'query-change', query: string): void
+  (event: 'filter-mode-change', isFilterMode: boolean): void
+  (event: 'reg-exp-mode-change', isRegExpMode: boolean): void
 }>()
 </script>
 

--- a/src/app/common/ResourceCodeBlock.vue
+++ b/src/app/common/ResourceCodeBlock.vue
@@ -6,7 +6,11 @@
     :is-searchable="props.isSearchable"
     :code-max-height="props.codeMaxHeight"
     :query="props.query"
+    :is-filter-mode="props.isFilterMode"
+    :is-reg-exp-mode="props.isRegExpMode"
     @query-change="emit('query-change', $event)"
+    @filter-mode-change="emit('filter-mode-change', $event)"
+    @reg-exp-mode-change="emit('reg-exp-mode-change', $event)"
   >
     <template #secondary-actions>
       <KTooltip
@@ -53,14 +57,20 @@ const props = withDefaults(defineProps<{
   codeMaxHeight?: string
   isSearchable?: boolean
   query?: string
+  isFilterMode?: boolean
+  isRegExpMode?: boolean
 }>(), {
   codeMaxHeight: undefined,
   isSearchable: false,
   query: '',
+  isFilterMode: false,
+  isRegExpMode: false,
 })
 
 const emit = defineEmits<{
   (event: 'query-change', query: string): void
+  (event: 'filter-mode-change', isFilterMode: boolean): void
+  (event: 'reg-exp-mode-change', isRegExpMode: boolean): void
 }>()
 
 const yamlUniversal = computed(() => toYamlRepresentation(props.resource))

--- a/src/app/data-planes/views/DataPlaneClustersView.vue
+++ b/src/app/data-planes/views/DataPlaneClustersView.vue
@@ -6,6 +6,8 @@
       mesh: '',
       dataPlane: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -23,7 +25,11 @@
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/clusters`"
             :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter === 'true'"
+            :is-reg-exp-mode="route.params.codeRegExp === 'true'"
             @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           />
         </template>
       </KCard>

--- a/src/app/data-planes/views/DataPlaneConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneConfigView.vue
@@ -6,6 +6,8 @@
       mesh: '',
       dataPlane: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -37,7 +39,11 @@
               :resource-fetcher="(params) => kumaApi.getDataplaneFromMesh({ mesh: data.mesh, name: data.name }, params)"
               is-searchable
               :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter === 'true'"
+              :is-reg-exp-mode="route.params.codeRegExp === 'true'"
               @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
             />
           </DataSource>
         </template>

--- a/src/app/data-planes/views/DataPlaneStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneStatsView.vue
@@ -6,6 +6,8 @@
       mesh: '',
       dataPlane: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -23,7 +25,11 @@
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/stats`"
             :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter === 'true'"
+            :is-reg-exp-mode="route.params.codeRegExp === 'true'"
             @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           />
         </template>
       </KCard>

--- a/src/app/data-planes/views/DataPlaneXdsConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneXdsConfigView.vue
@@ -6,6 +6,8 @@
       mesh: '',
       dataPlane: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -23,7 +25,11 @@
             resource="Data Plane Proxy"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/xds`"
             :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter === 'true'"
+            :is-reg-exp-mode="route.params.codeRegExp === 'true'"
             @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           />
         </template>
       </KCard>

--- a/src/app/diagnostics/views/DiagnosticsDetailView.vue
+++ b/src/app/diagnostics/views/DiagnosticsDetailView.vue
@@ -10,6 +10,8 @@ import LoadingBlock from '@/app/common/LoadingBlock.vue'
     name="diagnostics"
     :params="{
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <DataSource
@@ -51,7 +53,11 @@ import LoadingBlock from '@/app/common/LoadingBlock.vue'
               :code="JSON.stringify(data, null, 2)"
               is-searchable
               :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter === 'true'"
+              :is-reg-exp-mode="route.params.codeRegExp === 'true'"
               @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
             />
           </template>
         </KCard>

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -7,6 +7,8 @@
       policy: '',
       policyPath: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView
@@ -81,7 +83,11 @@
             }, params)"
             is-searchable
             :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter === 'true'"
+            :is-reg-exp-mode="route.params.codeRegExp === 'true'"
             @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           />
         </div>
       </DataSource>

--- a/src/app/policies/views/PolicySummaryView.vue
+++ b/src/app/policies/views/PolicySummaryView.vue
@@ -7,6 +7,8 @@
       policyPath: '',
       policy: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -84,7 +86,11 @@
               }, params)"
               is-searchable
               :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter === 'true'"
+              :is-reg-exp-mode="route.params.codeRegExp === 'true'"
               @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
             />
           </div>
         </div>

--- a/src/app/services/views/ServiceConfigView.vue
+++ b/src/app/services/views/ServiceConfigView.vue
@@ -6,6 +6,8 @@
       mesh: '',
       service: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -47,7 +49,11 @@
                 :resource-fetcher="(params) => kumaApi.getExternalService({ mesh: externalService.mesh, name: externalService.name }, params)"
                 is-searchable
                 :query="route.params.codeSearch"
+                :is-filter-mode="route.params.codeFilter === 'true'"
+                :is-reg-exp-mode="route.params.codeRegExp === 'true'"
                 @query-change="route.update({ codeSearch: $event })"
+                @filter-mode-change="route.update({ codeFilter: $event })"
+                @reg-exp-mode-change="route.update({ codeRegExp: $event })"
               />
             </DataSource>
           </div>

--- a/src/app/services/views/ServiceSummaryView.vue
+++ b/src/app/services/views/ServiceSummaryView.vue
@@ -6,6 +6,8 @@
       mesh: '',
       service: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -171,7 +173,11 @@
                 :resource-fetcher="(params) => kumaApi.getExternalService({ mesh: externalService.mesh, name: externalService.name }, params)"
                 is-searchable
                 :query="route.params.codeSearch"
+                :is-filter-mode="route.params.codeFilter === 'true'"
+                :is-reg-exp-mode="route.params.codeRegExp === 'true'"
                 @query-change="route.update({ codeSearch: $event })"
+                @filter-mode-change="route.update({ codeFilter: $event })"
+                @reg-exp-mode-change="route.update({ codeRegExp: $event })"
               />
             </DataSource>
           </div>

--- a/src/app/zone-egresses/views/ZoneEgressClustersView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressClustersView.vue
@@ -5,6 +5,8 @@
     :params="{
       zoneEgress: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -22,7 +24,11 @@
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/clusters`"
             :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter === 'true'"
+            :is-reg-exp-mode="route.params.codeRegExp === 'true'"
             @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zone-egresses/views/ZoneEgressConfigView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressConfigView.vue
@@ -5,6 +5,8 @@
     :params="{
       zoneEgress: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -36,7 +38,11 @@
                 :resource-fetcher="(params) => kumaApi.getZoneEgress({ name: route.params.zoneEgress }, params)"
                 is-searchable
                 :query="route.params.codeSearch"
+                :is-filter-mode="route.params.codeFilter === 'true'"
+                :is-reg-exp-mode="route.params.codeRegExp === 'true'"
                 @query-change="route.update({ codeSearch: $event })"
+                @filter-mode-change="route.update({ codeFilter: $event })"
+                @reg-exp-mode-change="route.update({ codeRegExp: $event })"
               />
             </template>
           </DataSource>

--- a/src/app/zone-egresses/views/ZoneEgressStatsView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressStatsView.vue
@@ -5,6 +5,8 @@
     :params="{
       zoneEgress: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -22,7 +24,11 @@
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/stats`"
             :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter === 'true'"
+            :is-reg-exp-mode="route.params.codeRegExp === 'true'"
             @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
@@ -5,6 +5,8 @@
     :params="{
       zoneEgress: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -22,7 +24,11 @@
             resource="Zone"
             :src="`/zone-egresses/${route.params.zoneEgress}/data-path/xds`"
             :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter === 'true'"
+            :is-reg-exp-mode="route.params.codeRegExp === 'true'"
             @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zone-ingresses/views/ZoneIngressClustersView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressClustersView.vue
@@ -5,6 +5,8 @@
     :params="{
       zoneIngress: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -22,7 +24,11 @@
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/clusters`"
             :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter === 'true'"
+            :is-reg-exp-mode="route.params.codeRegExp === 'true'"
             @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zone-ingresses/views/ZoneIngressConfigView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressConfigView.vue
@@ -5,6 +5,8 @@
     :params="{
       zoneIngress: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -36,7 +38,11 @@
                 :resource-fetcher="(params) => kumaApi.getZoneIngress({ name: route.params.zoneIngress }, params)"
                 is-searchable
                 :query="route.params.codeSearch"
+                :is-filter-mode="route.params.codeFilter === 'true'"
+                :is-reg-exp-mode="route.params.codeRegExp === 'true'"
                 @query-change="route.update({ codeSearch: $event })"
+                @filter-mode-change="route.update({ codeFilter: $event })"
+                @reg-exp-mode-change="route.update({ codeRegExp: $event })"
               />
             </template>
           </DataSource>

--- a/src/app/zone-ingresses/views/ZoneIngressStatsView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressStatsView.vue
@@ -5,6 +5,8 @@
     :params="{
       zoneIngress: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -22,7 +24,11 @@
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/stats`"
             :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter === 'true'"
+            :is-reg-exp-mode="route.params.codeRegExp === 'true'"
             @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
@@ -5,6 +5,8 @@
     :params="{
       zoneIngress: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -22,7 +24,11 @@
             resource="Zone"
             :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/xds`"
             :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter === 'true'"
+            :is-reg-exp-mode="route.params.codeRegExp === 'true'"
             @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           />
         </template>
       </KCard>

--- a/src/app/zones/views/ZoneConfigView.vue
+++ b/src/app/zones/views/ZoneConfigView.vue
@@ -5,6 +5,8 @@
     :params="{
       zone: '',
       codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
   >
     <AppView>
@@ -46,7 +48,11 @@
               :code="conf"
               is-searchable
               :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter === 'true'"
+              :is-reg-exp-mode="route.params.codeRegExp === 'true'"
               @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
             />
 
             <KAlert


### PR DESCRIPTION
## Changes

Persists both the filter and regexp mode state of the code block in the URL alongside the already persisted query.

Resolves #1752.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes:

- Noticed a bug (https://github.com/Kong/kongponents/issues/1868) while working on this