### PR TITLE
fix(zones): Make sure the exit the modal doesn't take you elsewhere

### DIFF
--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -20,6 +20,7 @@
         update: routeUpdate,
         replace: routeReplace,
         params: routeParams,
+        back: routerBack,
       }"
     />
   </div>
@@ -46,14 +47,16 @@ export type RouteView = {
   removeAttrs: (sym: Symbol) => void
 }
 
-type Params = { [K in keyof T]: string }
-
+const win = window
 const env = useEnv()
 const can = useCan()
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const sym = Symbol('route-view')
+
+type Params = { [K in keyof T]: string }
+type RouteReplaceParams = Parameters<typeof router['push']>
 
 const props = withDefaults(defineProps<{
   name: string
@@ -148,9 +151,21 @@ const routeUpdate = (params: Record<string, string | undefined>) => {
   }
   routerPush(newParams)
 }
-const routeReplace = (...args: Parameters<typeof router['push']>) => {
+const routeReplace = (...args: RouteReplaceParams) => {
   router.push(...args)
 }
+const routerBack = (...args: RouteReplaceParams) => {
+  try {
+    if (win.history.state.back !== null) {
+      router.back()
+      return
+    }
+  } catch (_) {
+    // passthrough
+  }
+  routeReplace(...args)
+}
+
 watch(() => props.name, () => {
   // we only want query params here
   const params = Object.entries(routeParams.value || {}).reduce<Record<string, string>>((prev, [key, value]) => {

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -20,19 +20,17 @@
 
       <template #actions>
         <KButton
-          v-if="token === '' || isZoneConnected"
           appearance="tertiary"
           data-testid="exit-button"
-          :to="{ name: 'zone-cp-list-view' }"
-        >
-          {{ t('zones.form.exit') }}
-        </KButton>
-
-        <KButton
-          v-else
-          appearance="tertiary"
-          data-testid="exit-button"
-          @click="toggleConfirmModal"
+          @click="() => {
+            if(token === '' || isZoneConnected) {
+              route.back({
+                name: 'zone-cp-list-view',
+              })
+            } else {
+              toggleConfirmModal()
+            }
+          }"
         >
           {{ t('zones.form.exit') }}
         </KButton>


### PR DESCRIPTION
This is pretty much the code I originally added https://github.com/kumahq/kuma-gui/pull/1634/commits/230027097451b272a162889e87f918d5723339f9 and then removed during review, apart from: I found that vue-router also has a `.back()`, so I preferred to use that, although I still need to access window to check to see if we came straight to the URL of the modal.

Closes https://github.com/kumahq/kuma-gui/issues/1706