### PR TITLE
chore: Move kds URL to env

### DIFF
--- a/src/app/control-planes/sources.ts
+++ b/src/app/control-planes/sources.ts
@@ -16,7 +16,7 @@ export const sources = (env: Env['var'], api: KumaApi) => {
     '/control-plane/addresses': async (): Promise<ControlPlaneAddresses> => {
       return {
         http: env('KUMA_API_URL'),
-        kds: 'grpcs://<global-kds-address>:5685',
+        kds: env('KUMA_KDS_URL'),
       }
     },
     '/global-insight': () => {

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -14,6 +14,7 @@ type EnvProps = {
   KUMA_VERSION: string
   KUMA_BASE_PATH: string
   KUMA_API_URL: string
+  KUMA_KDS_URL: string
   KUMA_UTM_QUERY_PARAMS: string
   KUMA_MODE: string
   KUMA_ENVIRONMENT: string
@@ -47,6 +48,7 @@ export default class Env {
       KUMA_MODE: env('KUMA_MODE') || config.mode,
       KUMA_ENVIRONMENT: env('KUMA_ENVIRONMENT') || config.environment,
       KUMA_STORE_TYPE: env('KUMA_STORE_TYPE') || config.storeType,
+      KUMA_KDS_URL: 'grpcs://<global-kds-address>:5685',
     }
   }
 


### PR DESCRIPTION
For the moment at least I've just moved the hardcoded string into Env.

We only use this value (well, not even this value) in one place/environment anyway so I've not moved the string to `.env` or anything, partly because it probably we only use this value in the single environment anyway, and partly because I think I would like to get rid of all the `.env` stuff pretty soon anyway.

Lastly, we still expose this to the application via a `DataSource` so whilst this is currently an `env` we can change it do a runtime API driven value at a later date if we want to.
