### PR TITLE
refactor(dataplanes): move getStatusAndReason into data transformation file

### DIFF
--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -122,6 +122,7 @@
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { ArrowRightIcon } from '@kong/icons'
 
+import { getStatusAndReason } from '../data'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TagList from '@/app/common/TagList.vue'
@@ -131,7 +132,6 @@ import { useI18n } from '@/utilities'
 import {
   compatibilityKind,
   dpTags,
-  getStatusAndReason,
   COMPATIBLE,
 } from '@/utilities/dataplane'
 
@@ -183,7 +183,7 @@ function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlan
     const tags = dpTags(dataPlaneOverview.dataplane)
     const services = tags.filter((tag) => tag.label === 'kuma.io/service')
 
-    const { status } = getStatusAndReason(dataPlaneOverview.dataplane, dataPlaneOverview.dataplaneInsight)
+    const { status } = getStatusAndReason(dataPlaneOverview)
     const subscriptions = dataPlaneOverview.dataplaneInsight?.subscriptions ?? []
 
     const initialData: {

--- a/src/app/data-planes/components/DataPlaneSummary.vue
+++ b/src/app/data-planes/components/DataPlaneSummary.vue
@@ -148,14 +148,13 @@ import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tok
 import { InfoIcon } from '@kong/icons'
 import { computed } from 'vue'
 
-import { getLastUpdateTime } from '../data'
+import { getLastUpdateTime, getStatusAndReason } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TagList from '@/app/common/TagList.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { DataPlaneOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
-import { getStatusAndReason } from '@/utilities/dataplane'
 
 const { t, formatIsoDate } = useI18n()
 
@@ -163,7 +162,7 @@ const props = defineProps<{
   dataplaneOverview: DataPlaneOverview
 }>()
 
-const statusWithReason = computed(() => getStatusAndReason(props.dataplaneOverview.dataplane, props.dataplaneOverview.dataplaneInsight))
+const statusWithReason = computed(() => getStatusAndReason(props.dataplaneOverview))
 const formattedLastUpdateTime = computed(() => {
   const lastUpdateTime = getLastUpdateTime(props.dataplaneOverview.dataplaneInsight?.subscriptions ?? [])
   return lastUpdateTime !== undefined ? formatIsoDate(lastUpdateTime) : t('common.detail.none')

--- a/src/app/data-planes/data/index.spec.ts
+++ b/src/app/data-planes/data/index.spec.ts
@@ -72,7 +72,7 @@ describe('dataplanes data transformations', () => {
   describe('getStatusAndReason', () => {
     test.each<TestCase<typeof getStatusAndReason>>([
       {
-        message: 'nothing defined is online',
+        message: 'Built-in gateway: status determination based on subscriptions (online)',
         parameters: [{
           mesh: 'default',
           name: 'dataplane',
@@ -82,7 +82,30 @@ describe('dataplanes data transformations', () => {
           dataplane: {
             networking: {
               address: '',
+              gateway: {
+                type: 'BUILTIN',
+                tags: {
+                  'kuma.io/service': '',
+                },
+              },
             },
+          },
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                connectTime: '1',
+                status: {
+                  lastUpdateTime: '',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+              },
+            ],
           },
         }],
         expected: {
@@ -91,7 +114,7 @@ describe('dataplanes data transformations', () => {
         },
       },
       {
-        message: 'empty inbounds is online',
+        message: 'Built-in gateway: status determination based on subscriptions (offline)',
         parameters: [{
           mesh: 'default',
           name: 'dataplane',
@@ -101,17 +124,40 @@ describe('dataplanes data transformations', () => {
           dataplane: {
             networking: {
               address: '',
-              inbound: [],
+              gateway: {
+                type: 'BUILTIN',
+                tags: {
+                  'kuma.io/service': '',
+                },
+              },
             },
+          },
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                connectTime: '1',
+                disconnectTime: '1',
+                status: {
+                  lastUpdateTime: '',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+              },
+            ],
           },
         }],
         expected: {
-          status: 'online',
+          status: 'offline',
           reason: [],
         },
       },
       {
-        message: 'single healthy inbound defers to getItemStatusFromInsight (online)',
+        message: 'Standard proxy: status determination based on subscriptions (online)',
         parameters: [{
           mesh: 'default',
           name: 'dataplane',
@@ -158,7 +204,55 @@ describe('dataplanes data transformations', () => {
         },
       },
       {
-        message: 'single unhealthy inbound is offline with a single reason',
+        message: 'Standard proxy: status determination based on subscriptions (offline)',
+        parameters: [{
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
+              inbound: [
+                {
+                  health: {
+                    ready: true,
+                  },
+                  tags: {
+                    'kuma.io/service': '',
+                  },
+                  port: 1,
+                },
+              ],
+            },
+          },
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                connectTime: '1',
+                disconnectTime: '1',
+                status: {
+                  lastUpdateTime: '',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+              },
+            ],
+          },
+        }],
+        expected: {
+          status: 'offline',
+          reason: [],
+        },
+      },
+      {
+        message: 'Standard proxy: one unhealthy inbound out of one inbound means offline',
         parameters: [{
           mesh: 'default',
           name: 'dataplane',
@@ -188,7 +282,7 @@ describe('dataplanes data transformations', () => {
         },
       },
       {
-        message: 'single unhealthy inbound out of multiple is partially_degraded',
+        message: 'Standard proxy: one unhealthy inbound out of two inbounds means partially_degraded',
         parameters: [{
           mesh: 'default',
           name: 'dataplane',

--- a/src/app/data-planes/data/index.spec.ts
+++ b/src/app/data-planes/data/index.spec.ts
@@ -1,25 +1,24 @@
 import { describe, expect, test } from 'vitest'
 
-import { getLastUpdateTime } from './index'
-import type { DiscoverySubscription } from '@/types/index.d'
+import { getLastUpdateTime, getStatusAndReason } from './index'
 
-type LastUpdateTimeTestCase = {
+type TestCase<T extends (...args: any) => any> = {
   message: string
-  subscriptions: DiscoverySubscription[]
-  expected: string | undefined
+  parameters: Parameters<T>
+  expected: ReturnType<T>
 }
 
 describe('dataplanes data transformations', () => {
   describe('getLastUpdateTime', () => {
-    test.each([
+    test.each<TestCase<typeof getLastUpdateTime>>([
       {
         message: 'empty subscriptions',
-        subscriptions: [],
+        parameters: [[]],
         expected: undefined,
       },
       {
         message: 'single subscription',
-        subscriptions: [
+        parameters: [[
           {
             id: '',
             controlPlaneInstanceId: '',
@@ -32,12 +31,12 @@ describe('dataplanes data transformations', () => {
               rds: {},
             },
           },
-        ],
+        ]],
         expected: '2021-07-13T09:03:11.614941842Z',
       },
       {
         message: 'multiple subscriptions',
-        subscriptions: [
+        parameters: [[
           {
             id: '',
             controlPlaneInstanceId: '',
@@ -62,11 +61,173 @@ describe('dataplanes data transformations', () => {
               rds: {},
             },
           },
-        ],
+        ]],
         expected: '2021-07-13T09:03:11.614941842Z',
       },
-    ])('$message', (item: LastUpdateTimeTestCase) => {
-      expect(getLastUpdateTime(item.subscriptions)).toStrictEqual(item.expected)
+    ])('$message', ({ parameters, expected }) => {
+      expect(getLastUpdateTime(...parameters)).toStrictEqual(expected)
+    })
+  })
+
+  describe('getStatusAndReason', () => {
+    test.each<TestCase<typeof getStatusAndReason>>([
+      {
+        message: 'nothing defined is online',
+        parameters: [{
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
+            },
+          },
+        }],
+        expected: {
+          status: 'online',
+          reason: [],
+        },
+      },
+      {
+        message: 'empty inbounds is online',
+        parameters: [{
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
+              inbound: [],
+            },
+          },
+        }],
+        expected: {
+          status: 'online',
+          reason: [],
+        },
+      },
+      {
+        message: 'single healthy inbound defers to getItemStatusFromInsight (online)',
+        parameters: [{
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
+              inbound: [
+                {
+                  health: {
+                    ready: true,
+                  },
+                  tags: {
+                    'kuma.io/service': '',
+                  },
+                  port: 1,
+                },
+              ],
+            },
+          },
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                connectTime: '1',
+                status: {
+                  lastUpdateTime: '',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+              },
+            ],
+          },
+        }],
+        expected: {
+          status: 'online',
+          reason: [],
+        },
+      },
+      {
+        message: 'single unhealthy inbound is offline with a single reason',
+        parameters: [{
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
+              inbound: [
+                {
+                  health: {
+                    ready: false,
+                  },
+                  port: 1,
+                  tags: {
+                    'kuma.io/service': 'service',
+                  },
+                },
+              ],
+            },
+          },
+        }],
+        expected: {
+          status: 'offline',
+          reason: ['Inbound on port 1 is not ready (kuma.io/service: service)'],
+        },
+      },
+      {
+        message: 'single unhealthy inbound out of multiple is partially_degraded',
+        parameters: [{
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
+              inbound: [
+                {
+                  health: {
+                    ready: false,
+                  },
+                  port: 1,
+                  tags: {
+                    'kuma.io/service': 'service',
+                  },
+                },
+                {
+                  health: {
+                    ready: true,
+                  },
+                  port: 1,
+                  tags: {
+                    'kuma.io/service': '',
+                  },
+                },
+              ],
+            },
+          },
+        }],
+        expected: {
+          status: 'partially_degraded',
+          reason: ['Inbound on port 1 is not ready (kuma.io/service: service)'],
+        },
+      },
+    ])('$message', ({ parameters, expected }) => {
+      expect(getStatusAndReason(...parameters)).toStrictEqual(expected)
     })
   })
 })

--- a/src/app/data-planes/data/index.ts
+++ b/src/app/data-planes/data/index.ts
@@ -1,4 +1,4 @@
-import { getStatus } from '@/app/subscriptions/data'
+import { getIsConnected } from '@/app/subscriptions/data'
 import type {
   DataPlaneOverview as DataplaneOverview,
   DiscoverySubscription,
@@ -15,8 +15,17 @@ export function getLastUpdateTime(subscriptions: DiscoverySubscription[]): strin
 }
 
 export function getStatusAndReason(dataplaneOverview: DataplaneOverview): { status: StatusKeyword, reason: string[] } {
+  const isConnected = getIsConnected(dataplaneOverview.dataplaneInsight?.subscriptions)
+  // For gateways, the only relevant status criteria are subscriptions.
+  if (dataplaneOverview.dataplane.networking.gateway) {
+    return {
+      status: isConnected ? 'online' : 'offline',
+      reason: [],
+    }
+  }
+
   const inbounds = dataplaneOverview.dataplane.networking.inbound ?? []
-  const errors = inbounds
+  const unhealthyInbounds = inbounds
     .filter((inbound) => inbound.health && !inbound.health.ready)
     .map((inbound) => `Inbound on port ${inbound.port} is not ready (kuma.io/service: ${inbound.tags['kuma.io/service']})`)
 
@@ -25,20 +34,21 @@ export function getStatusAndReason(dataplaneOverview: DataplaneOverview): { stat
     case inbounds.length === 0:
       status = 'online'
       break
-    // If errors and inbounds are equal (even if they are both 0) then we are offline
-    case errors.length === inbounds.length:
+    case unhealthyInbounds.length === inbounds.length:
+      // All inbounds being unhealthy means the Dataplane is offline.
       status = 'offline'
       break
-    // If there are any errors then we are degraded
-    case errors.length > 0:
+    case unhealthyInbounds.length > 0:
+      // Some inbounds being unhealthy means the Dataplane is partially degraded.
       status = 'partially_degraded'
       break
     default:
-      status = getStatus(dataplaneOverview.dataplaneInsight?.subscriptions)
+      // All inbounds being healthy means the Dataplane’s status is determined by whether it’s connected to a control plane.
+      status = isConnected ? 'online' : 'offline'
   }
 
   return {
     status,
-    reason: errors,
+    reason: unhealthyInbounds,
   }
 }

--- a/src/app/data-planes/data/index.ts
+++ b/src/app/data-planes/data/index.ts
@@ -1,3 +1,4 @@
+import { getStatus } from '@/app/subscriptions/data'
 import type {
   DataPlaneOverview as DataplaneOverview,
   DiscoverySubscription,
@@ -32,16 +33,8 @@ export function getStatusAndReason(dataplaneOverview: DataplaneOverview): { stat
     case errors.length > 0:
       status = 'partially_degraded'
       break
-    default: {
-      const subscriptions = dataplaneOverview.dataplaneInsight?.subscriptions ?? []
-
-      if (subscriptions.length === 0) {
-        status = 'offline'
-      } else {
-        const lastSubscription = subscriptions[subscriptions.length - 1]
-        status = lastSubscription.connectTime?.length && !lastSubscription.disconnectTime ? 'online' : 'offline'
-      }
-    }
+    default:
+      status = getStatus(dataplaneOverview.dataplaneInsight?.subscriptions)
   }
 
   return {

--- a/src/app/data-planes/data/index.ts
+++ b/src/app/data-planes/data/index.ts
@@ -1,4 +1,8 @@
-import type { DiscoverySubscription } from '@/types/index.d'
+import type {
+  DataPlaneOverview as DataplaneOverview,
+  DiscoverySubscription,
+  StatusKeyword,
+} from '@/types/index.d'
 
 export function getLastUpdateTime(subscriptions: DiscoverySubscription[]): string | undefined {
   if (subscriptions.length === 0) {
@@ -7,4 +11,41 @@ export function getLastUpdateTime(subscriptions: DiscoverySubscription[]): strin
 
   const lastSubscription = subscriptions[subscriptions.length - 1]
   return lastSubscription.status.lastUpdateTime
+}
+
+export function getStatusAndReason(dataplaneOverview: DataplaneOverview): { status: StatusKeyword, reason: string[] } {
+  const inbounds = dataplaneOverview.dataplane.networking.inbound ?? []
+  const errors = inbounds
+    .filter((inbound) => inbound.health && !inbound.health.ready)
+    .map((inbound) => `Inbound on port ${inbound.port} is not ready (kuma.io/service: ${inbound.tags['kuma.io/service']})`)
+
+  let status: StatusKeyword
+  switch (true) {
+    case inbounds.length === 0:
+      status = 'online'
+      break
+    // If errors and inbounds are equal (even if they are both 0) then we are offline
+    case errors.length === inbounds.length:
+      status = 'offline'
+      break
+    // If there are any errors then we are degraded
+    case errors.length > 0:
+      status = 'partially_degraded'
+      break
+    default: {
+      const subscriptions = dataplaneOverview.dataplaneInsight?.subscriptions ?? []
+
+      if (subscriptions.length === 0) {
+        status = 'offline'
+      } else {
+        const lastSubscription = subscriptions[subscriptions.length - 1]
+        status = lastSubscription.connectTime?.length && !lastSubscription.disconnectTime ? 'online' : 'offline'
+      }
+    }
+  }
+
+  return {
+    status,
+    reason: errors,
+  }
 }

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -285,7 +285,7 @@ import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tok
 import { InfoIcon } from '@kong/icons'
 import { computed } from 'vue'
 
-import { getLastUpdateTime } from '../data'
+import { getLastUpdateTime, getStatusAndReason } from '../data'
 import { useCan } from '@/app/application'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
@@ -298,7 +298,6 @@ import {
   compatibilityKind,
   COMPATIBLE,
   dpTags,
-  getStatusAndReason,
   INCOMPATIBLE_WRONG_FORMAT,
 } from '@/utilities/dataplane'
 
@@ -309,7 +308,7 @@ const props = defineProps<{
   data: DataPlaneOverview
 }>()
 
-const statusWithReason = computed(() => getStatusAndReason(props.data.dataplane, props.data.dataplaneInsight))
+const statusWithReason = computed(() => getStatusAndReason(props.data))
 
 const formattedLastUpdateTime = computed(() => {
   const lastUpdateTime = getLastUpdateTime(props.data.dataplaneInsight?.subscriptions ?? [])

--- a/src/app/onboarding/views/OnboardingDataplanesView.vue
+++ b/src/app/onboarding/views/OnboardingDataplanesView.vue
@@ -83,8 +83,8 @@ import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
+import { getStatusAndReason } from '@/app/data-planes/data'
 import { useKumaApi } from '@/utilities'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 const kumaApi = useKumaApi()
 
@@ -124,7 +124,7 @@ async function getAllDataplanes() {
         const { name, mesh } = dataPlane
 
         const dataPlaneOverview = await kumaApi.getDataplaneOverviewFromMesh({ mesh, name })
-        const status = getItemStatusFromInsight(dataPlaneOverview.dataplaneInsight)
+        const { status } = getStatusAndReason(dataPlaneOverview)
 
         if (status === 'offline') {
           shouldRefetch = true

--- a/src/app/subscriptions/data/index.spec.ts
+++ b/src/app/subscriptions/data/index.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest'
+
+import { getStatus } from './index'
+
+type TestCase<T extends (...args: any) => any> = {
+  message: string
+  parameters: Parameters<T>
+  expected: ReturnType<T>
+}
+
+describe('subscriptions data transformations', () => {
+  describe('getStatus', () => {
+    test.each<TestCase<typeof getStatus>>([
+      {
+        message: 'no subscriptions means not connected, yet, i.e. offline (omitted array)',
+        parameters: [undefined],
+        expected: 'offline',
+      },
+      {
+        message: 'no subscriptions means not connected, yet, i.e. offline (empty array)',
+        parameters: [[]],
+        expected: 'offline',
+      },
+      {
+        message: 'last subscription without disconnect time means offline',
+        parameters: [[
+          {
+            connectTime: '2021-07-13T09:03:11.614941842Z',
+            disconnectTime: '2021-07-13T09:03:11.614941842Z',
+          },
+          {
+            connectTime: '2021-07-13T09:03:11.614941842Z',
+          },
+        ]],
+        expected: 'online',
+      },
+      {
+        message: 'last subscription with disconnect time means offline',
+        parameters: [[
+          {
+            connectTime: '2021-07-13T09:03:11.614941842Z',
+            disconnectTime: '2021-07-13T09:03:11.614941842Z',
+          },
+          {
+            connectTime: '2021-07-13T09:03:11.614941842Z',
+            disconnectTime: '2021-07-13T09:03:11.614941842Z',
+          },
+        ]],
+        expected: 'offline',
+      },
+    ])('$message', ({ parameters, expected }) => {
+      expect(getStatus(...parameters)).toStrictEqual(expected)
+    })
+  })
+})

--- a/src/app/subscriptions/data/index.spec.ts
+++ b/src/app/subscriptions/data/index.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { getStatus } from './index'
+import { getIsConnected } from './index'
 
 type TestCase<T extends (...args: any) => any> = {
   message: string
@@ -9,20 +9,20 @@ type TestCase<T extends (...args: any) => any> = {
 }
 
 describe('subscriptions data transformations', () => {
-  describe('getStatus', () => {
-    test.each<TestCase<typeof getStatus>>([
+  describe('getIsConnected', () => {
+    test.each<TestCase<typeof getIsConnected>>([
       {
-        message: 'no subscriptions means not connected, yet, i.e. offline (omitted array)',
+        message: 'no subscriptions means not connected (omitted array)',
         parameters: [undefined],
-        expected: 'offline',
+        expected: false,
       },
       {
-        message: 'no subscriptions means not connected, yet, i.e. offline (empty array)',
+        message: 'no subscriptions means not connected (empty array)',
         parameters: [[]],
-        expected: 'offline',
+        expected: false,
       },
       {
-        message: 'last subscription without disconnect time means offline',
+        message: 'last subscription without disconnect time means connected',
         parameters: [[
           {
             connectTime: '2021-07-13T09:03:11.614941842Z',
@@ -32,10 +32,10 @@ describe('subscriptions data transformations', () => {
             connectTime: '2021-07-13T09:03:11.614941842Z',
           },
         ]],
-        expected: 'online',
+        expected: true,
       },
       {
-        message: 'last subscription with disconnect time means offline',
+        message: 'last subscription with disconnect time means not connected',
         parameters: [[
           {
             connectTime: '2021-07-13T09:03:11.614941842Z',
@@ -46,10 +46,10 @@ describe('subscriptions data transformations', () => {
             disconnectTime: '2021-07-13T09:03:11.614941842Z',
           },
         ]],
-        expected: 'offline',
+        expected: false,
       },
     ])('$message', ({ parameters, expected }) => {
-      expect(getStatus(...parameters)).toStrictEqual(expected)
+      expect(getIsConnected(...parameters)).toStrictEqual(expected)
     })
   })
 })

--- a/src/app/subscriptions/data/index.ts
+++ b/src/app/subscriptions/data/index.ts
@@ -1,4 +1,3 @@
-export function getStatus(subscriptions: { connectTime?: string, disconnectTime?: string }[] | undefined = []): 'online' | 'offline' {
-  const proxyOnline = subscriptions.length > 0 && [subscriptions[subscriptions.length - 1]].every((item) => item.connectTime?.length && !item.disconnectTime)
-  return proxyOnline ? 'online' : 'offline'
+export function getIsConnected(subscriptions: { connectTime?: string, disconnectTime?: string }[] | undefined = []): boolean {
+  return subscriptions.length > 0 && [subscriptions[subscriptions.length - 1]].every((item) => item.connectTime?.length && !item.disconnectTime)
 }

--- a/src/app/subscriptions/data/index.ts
+++ b/src/app/subscriptions/data/index.ts
@@ -1,0 +1,4 @@
+export function getStatus(subscriptions: { connectTime?: string, disconnectTime?: string }[] | undefined = []): 'online' | 'offline' {
+  const proxyOnline = subscriptions.length > 0 && [subscriptions[subscriptions.length - 1]].every((item) => item.connectTime?.length && !item.disconnectTime)
+  return proxyOnline ? 'online' : 'offline'
+}

--- a/src/app/zones/data/index.ts
+++ b/src/app/zones/data/index.ts
@@ -1,3 +1,4 @@
+import { getStatus } from '@/app/subscriptions/data'
 import type { ZoneOverview } from '@/types/index.d'
 import { get } from '@/utilities/get'
 
@@ -32,8 +33,4 @@ export function getZoneControlPlaneStatus(zoneOverview: ZoneOverview): 'online' 
     return 'disabled'
   }
   return getStatus(zoneOverview.zoneInsight?.subscriptions)
-}
-export function getStatus(subscriptions: {connectTime?: string, disconnectTime?: string}[] | undefined = []): 'online' | 'offline' {
-  const proxyOnline = subscriptions.length > 0 && [subscriptions[subscriptions.length - 1]].every((item) => item.connectTime?.length && !item.disconnectTime)
-  return proxyOnline ? 'online' : 'offline'
 }

--- a/src/app/zones/data/index.ts
+++ b/src/app/zones/data/index.ts
@@ -1,4 +1,4 @@
-import { getStatus } from '@/app/subscriptions/data'
+import { getIsConnected } from '@/app/subscriptions/data'
 import type { ZoneOverview } from '@/types/index.d'
 import { get } from '@/utilities/get'
 
@@ -32,5 +32,5 @@ export function getZoneControlPlaneStatus(zoneOverview: ZoneOverview): 'online' 
   if (zoneOverview.zone.enabled === false) {
     return 'disabled'
   }
-  return getStatus(zoneOverview.zoneInsight?.subscriptions)
+  return getIsConnected(zoneOverview.zoneInsight?.subscriptions) ? 'online' : 'offline'
 }

--- a/src/utilities/dataplane.spec.ts
+++ b/src/utilities/dataplane.spec.ts
@@ -1,10 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
-import { getStatusAndReason, getItemStatusFromInsight } from './dataplane'
-import {
-  DiscoverySubscription,
-  DataplaneNetworking,
-} from '@/types/index.d'
+import { getItemStatusFromInsight } from './dataplane'
+import type { DiscoverySubscription } from '@/types/index.d'
 
 describe('utilities/dataplane', () => {
   describe('getItemStatusFromInsight', () => {
@@ -60,110 +57,6 @@ describe('utilities/dataplane', () => {
       },
     ] as TestCases))('$message', (item) => {
       expect(getItemStatusFromInsight(...item.args)).toBe(item.expected)
-    })
-  })
-
-  describe('getStatusAndReason', () => {
-    type TestCases = {message: string, args: [{ networking: DataplaneNetworking }, { subscriptions?: DiscoverySubscription[] }], expected: any}[]
-    test.each(([
-      {
-        message: 'nothing defined is online',
-        args: [{
-          networking: {
-            address: '',
-          },
-        }],
-        expected: {
-          status: 'online',
-          reason: [],
-        },
-      },
-      {
-        message: 'empty inbounds is online',
-        args: [{
-          networking: {
-            address: '',
-            inbound: [],
-          },
-        }],
-        expected: {
-          status: 'online',
-          reason: [],
-        },
-      },
-      {
-        message: 'single healthy inbound defers to getItemStatusFromInsight (online)',
-        args: [{
-          networking: {
-            address: '',
-            inbound: [{
-              health: {
-                ready: true,
-              },
-            }],
-          },
-        }, {
-          subscriptions: [
-            {
-              connectTime: '1',
-            },
-          ],
-        }],
-        expected: {
-          status: 'online',
-          reason: [],
-        },
-      },
-      {
-        message: 'single unhealthy inbound is offline with a single reason',
-        args: [{
-          networking: {
-            address: '',
-            inbound: [{
-              health: {
-                ready: false,
-              },
-              port: 1,
-              tags: {
-                'kuma.io/service': 'service',
-              },
-            }],
-          },
-        }],
-        expected: {
-          status: 'offline',
-          reason: [`Inbound on port ${1} is not ready (kuma.io/service: ${'service'})`],
-        },
-      },
-      {
-        message: 'single unhealthy inbound out of multiple is partially_degraded',
-        args: [{
-          networking: {
-            address: '',
-            inbound: [{
-              health: {
-                ready: false,
-              },
-              port: 1,
-              tags: {
-                'kuma.io/service': 'service',
-              },
-            },
-            {
-              health: {
-                ready: true,
-              },
-            }],
-          },
-        }],
-        expected: {
-          status: 'partially_degraded',
-          reason: [`Inbound on port ${1} is not ready (kuma.io/service: ${'service'})`],
-        },
-      },
-    ] as TestCases))('$message', (item) => {
-      const actual = getStatusAndReason(...item.args)
-      expect(actual).toStrictEqual(item.expected)
     })
   })
 })

--- a/src/utilities/dataplane.ts
+++ b/src/utilities/dataplane.ts
@@ -73,38 +73,6 @@ export function getItemStatusFromInsight(insight: { subscriptions?: DiscoverySub
   return proxyOnline ? 'online' : 'offline'
 }
 
-// getStatusAndReason takes Dataplane and DataplaneInsight and returns a
-// {status: 'online' | 'offline' | 'partially_degraded', reason: errors[]}
-export function getStatusAndReason(dataplane: { networking: DataplaneNetworking }, insight: { subscriptions?: DiscoverySubscription[] } | undefined = { subscriptions: [] }): { status: StatusKeyword, reason: string[] } {
-  const inbound = dataplane.networking.inbound ?? []
-  const errors = inbound
-    .filter(item => item.health && !item.health.ready)
-    .map(item => `Inbound on port ${item.port} is not ready (kuma.io/service: ${item.tags['kuma.io/service']})`)
-
-  let status: StatusKeyword
-  switch (true) {
-    case inbound.length === 0:
-      status = 'online'
-      break
-    // if errors and inbounds are equal, even if they are both 0
-    // then we are offline
-    case errors.length === inbound.length:
-      status = 'offline'
-      break
-    // otherwise any errors at all, we are degraded
-    case errors.length > 0:
-      status = 'partially_degraded'
-      break
-    default:
-      // otherwise run the normal getter
-      status = getItemStatusFromInsight(insight)
-  }
-  return {
-    status,
-    reason: errors,
-  }
-}
-
 /*
 getStatus takes DataplaneInsight and returns map of versions
  */


### PR DESCRIPTION
Follow up to https://github.com/kumahq/kuma-gui/pull/1800. Follow up PRs to this one: https://github.com/kumahq/kuma-gui/pull/1834 and https://github.com/kumahq/kuma-gui/pull/1835.

Moves the `getStatusAndReason` dataplane utility into its data transformation file.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
