### PR TITLE
chore(dataplanes): tweak mocks

### DIFF
--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -4,9 +4,6 @@ import deepmerge from 'deepmerge'
 import type {
   DataplaneNetworking,
   DataPlaneProxyStatus,
-  DataplaneGateway,
-  DataplaneInbound,
-  DataplaneOutbound,
   ServiceStatus,
 } from '@/types/index.d'
 
@@ -195,72 +192,59 @@ export class KumaModule {
   dataplaneNetworking({ type = 'proxy', inbounds = 0, isMultizone = false, service }: { type?: 'gateway_builtin' | 'gateway_delegated' | 'proxy', inbounds?: number, isMultizone?: boolean, service?: string } = {}): DataplaneNetworking {
     const address = this.faker.internet.ipv4()
     const advertisedAddress = this.faker.datatype.boolean({ probability: 0.25 }) ? this.faker.internet.ipv4() : undefined
+    const dataplaneType = type === 'gateway_builtin' ? 'BUILTIN' : type === 'gateway_delegated' ? 'DELEGATED' : undefined
 
     return {
       address,
       ...(advertisedAddress && { advertisedAddress }),
       ...(type !== 'proxy'
         ? {
-          gateway: this.dataplaneGateway({ type, service, isMultizone }),
+          gateway: {
+            tags: this.tags({
+              service: service ?? this.serviceName(type),
+              zone: isMultizone && this.faker.datatype.boolean() ? this.faker.hacker.noun() : undefined,
+            }),
+            ...(dataplaneType && { type: dataplaneType }),
+          },
         }
         : {}),
       ...(type === 'proxy'
         ? {
-          inbound: Array.from({ length: inbounds }).map(() => this.dataplaneInbound({ service, isMultizone })),
+          inbound: Array.from({ length: inbounds }).map(() => {
+            const address = this.faker.datatype.boolean({ probability: 0.25 }) ? this.faker.internet.ipv4() : undefined
+            const port = this.faker.internet.port()
+            const hasServiceAddress = this.faker.datatype.boolean({ probability: 0.25 })
+            const serviceAddress = hasServiceAddress ? this.faker.internet.ipv4() : undefined
+            const servicePort = hasServiceAddress ? this.faker.internet.port() : undefined
+            const tags = this.tags({
+              protocol: this.protocol(),
+              service: service ?? this.serviceName(),
+              zone: isMultizone && this.faker.datatype.boolean() ? this.faker.hacker.noun() : undefined,
+            })
+
+            return {
+              port,
+              tags,
+              ...(this.faker.datatype.boolean()
+                ? {
+                  health: {
+                    ready: this.faker.datatype.boolean(),
+                  },
+                }
+                : {}),
+              ...(address && { address }),
+              ...(serviceAddress && { serviceAddress }),
+              ...(servicePort && { servicePort }),
+            }
+          }),
         }
         : {}),
       outbound: [
-        this.dataplaneOutbound({ service }),
-      ],
-    }
-  }
-
-  dataplaneGateway({ type = 'gateway_delegated', service, isMultizone = false }: { type?: 'gateway_builtin' | 'gateway_delegated', service?: string, isMultizone?: boolean } = {}): DataplaneGateway {
-    const dataplaneType = type === 'gateway_builtin' ? 'BUILTIN' : type === 'gateway_delegated' ? 'DELEGATED' : undefined
-
-    return {
-      tags: this.tags({
-        service: service ?? this.serviceName(type),
-        zone: isMultizone && this.faker.datatype.boolean() ? this.faker.hacker.noun() : undefined,
-      }),
-      ...(dataplaneType && { type: dataplaneType }),
-    }
-  }
-
-  dataplaneInbound({ service, isMultizone = false }: { service?: string, isMultizone?: boolean } = {}): DataplaneInbound {
-    const healthObject = this.faker.datatype.boolean()
-      ? {
-        health: {
-          ready: this.faker.datatype.boolean(),
+        {
+          port: this.faker.internet.port(),
+          tags: this.tags({ service }),
         },
-      }
-      : {}
-    const address = this.faker.datatype.boolean({ probability: 0.25 }) ? this.faker.internet.ipv4() : undefined
-    const port = this.faker.internet.port()
-    const hasServiceAddress = this.faker.datatype.boolean({ probability: 0.25 })
-    const serviceAddress = hasServiceAddress ? this.faker.internet.ipv4() : undefined
-    const servicePort = hasServiceAddress ? this.faker.internet.port() : undefined
-
-    return {
-      ...healthObject,
-      ...(address && { address }),
-      port,
-      ...(serviceAddress && { serviceAddress }),
-      ...(servicePort && { servicePort }),
-      tags: this.tags({
-        protocol: this.protocol(),
-        service: service ?? this.serviceName(),
-        zone: isMultizone && this.faker.datatype.boolean() ? this.faker.hacker.noun() : undefined,
-      }),
-    }
-  }
-
-  dataplaneOutbound({ service }: { service?: string }): DataplaneOutbound {
-    return {
-      port: this.faker.internet.port(),
-      tags: this.tags({
-        service: service ?? this.serviceName(),
-      }),
+      ],
     }
   }
 

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -181,6 +181,17 @@ export class KumaModule {
     return Object.fromEntries(values)
   }
 
+  tags({ protocol, service, zone }: { protocol?: string, service?: string, zone?: string } = {}): Record<string, string> {
+    const additionalTags = Object.fromEntries(this.faker.helpers.multiple(() => [this.faker.hacker.noun(), this.faker.hacker.noun()], { count: this.faker.number.int({ min: 0, max: 3 }) }))
+
+    return {
+      ...(protocol && { 'kuma.io/protocol': protocol }),
+      ...(service && { 'kuma.io/service': service }),
+      ...(zone && { 'kuma.io/zone': zone }),
+      ...additionalTags,
+    }
+  }
+
   dataplaneNetworking({ type = 'proxy', inbounds = 0, isMultizone = false, service }: { type?: 'gateway_builtin' | 'gateway_delegated' | 'proxy', inbounds?: number, isMultizone?: boolean, service?: string } = {}): DataplaneNetworking {
     const address = this.faker.internet.ipv4()
     const advertisedAddress = this.faker.datatype.boolean({ probability: 0.25 }) ? this.faker.internet.ipv4() : undefined
@@ -206,15 +217,12 @@ export class KumaModule {
 
   dataplaneGateway({ type = 'gateway_delegated', service, isMultizone = false }: { type?: 'gateway_builtin' | 'gateway_delegated', service?: string, isMultizone?: boolean } = {}): DataplaneGateway {
     const dataplaneType = type === 'gateway_builtin' ? 'BUILTIN' : type === 'gateway_delegated' ? 'DELEGATED' : undefined
-    const zone = isMultizone && this.faker.datatype.boolean() ? this.faker.hacker.noun() : undefined
-    const additionalTags = Object.fromEntries(this.faker.helpers.multiple(() => [this.faker.hacker.noun(), this.faker.hacker.noun()], { count: this.faker.number.int({ min: 0, max: 3 }) }))
 
     return {
-      tags: {
-        'kuma.io/service': service ?? this.serviceName(type),
-        ...(zone && { 'kuma.io/zone': zone }),
-        ...additionalTags,
-      },
+      tags: this.tags({
+        service: service ?? this.serviceName(type),
+        zone: isMultizone && this.faker.datatype.boolean() ? this.faker.hacker.noun() : undefined,
+      }),
       ...(dataplaneType && { type: dataplaneType }),
     }
   }
@@ -232,8 +240,6 @@ export class KumaModule {
     const hasServiceAddress = this.faker.datatype.boolean({ probability: 0.25 })
     const serviceAddress = hasServiceAddress ? this.faker.internet.ipv4() : undefined
     const servicePort = hasServiceAddress ? this.faker.internet.port() : undefined
-    const zone = isMultizone && this.faker.datatype.boolean() ? this.faker.hacker.noun() : undefined
-    const additionalTags = Object.fromEntries(this.faker.helpers.multiple(() => [this.faker.hacker.noun(), this.faker.hacker.noun()], { count: this.faker.number.int({ min: 0, max: 3 }) }))
 
     return {
       ...healthObject,
@@ -241,24 +247,20 @@ export class KumaModule {
       port,
       ...(serviceAddress && { serviceAddress }),
       ...(servicePort && { servicePort }),
-      tags: {
-        'kuma.io/service': service ?? this.serviceName(),
-        'kuma.io/protocol': this.protocol(),
-        ...(zone && { 'kuma.io/zone': zone }),
-        ...additionalTags,
-      },
+      tags: this.tags({
+        protocol: this.protocol(),
+        service: service ?? this.serviceName(),
+        zone: isMultizone && this.faker.datatype.boolean() ? this.faker.hacker.noun() : undefined,
+      }),
     }
   }
 
   dataplaneOutbound({ service }: { service?: string }): DataplaneOutbound {
-    const additionalTags = Object.fromEntries(this.faker.helpers.multiple(() => [this.faker.hacker.noun(), this.faker.hacker.noun()], { count: this.faker.number.int({ min: 0, max: 3 }) }))
-
     return {
       port: this.faker.internet.port(),
-      tags: {
-        'kuma.io/service': service ?? this.serviceName(),
-        ...additionalTags,
-      },
+      tags: this.tags({
+        service: service ?? this.serviceName(),
+      }),
     }
   }
 


### PR DESCRIPTION
## Changes

chore: add tags mock utility

chore(dataplanes): inline mock utilities in networking utility

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

- Related conversation: https://github.com/kumahq/kuma-gui/pull/1803#discussion_r1404323972

  We currently use `dataplaneNetworking` in five mocks (of which one isn’t strictly necessary because we don’t use the associated endpoint). For the remaining four mocks, I don’t want to repeat the contents of `dataplaneNetworking`. Ideally we had a generator method for an entire Dataplane object and an entire DataplaneOverview object. That would cut it down to two mocks (i.e. tolerable repetition) and the effect to see the entire object structure in one place. For now, `dataplaneNetworking` is a relatively good compromise because of how far up it appears in the `Dataplane` (on `networking`) and `DataplaneOverview` (on `dataplane.networking`) it appears in those objects.