### PR TITLE
chore: Reduce line-height overwrites, add base font-size

### DIFF
--- a/src/app/application/components/app-view/AppView.vue
+++ b/src/app/application/components/app-view/AppView.vue
@@ -127,13 +127,11 @@ onBeforeUnmount(() => {
   margin-bottom: 20px; /* 2rem */
 
   h1, h2, h3, h4, h5, h6  {
-    line-height: 36px;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 }
 .app-view-title-bar h1 {
-  line-height: 1.3;
   font-weight: $kui-font-weight-semibold;
   font-size: $kui-font-size-80;
 }

--- a/src/app/common/DefinitionCard.vue
+++ b/src/app/common/DefinitionCard.vue
@@ -55,7 +55,6 @@ const props = withDefaults(defineProps<{
 .definition-card--vertical .definition-card-container {
   flex-grow: 1;
   font-size: $kui-font-size-60;
-  line-height: 1.5;
 }
 </style>
 

--- a/src/app/common/data-card/DataCard.vue
+++ b/src/app/common/data-card/DataCard.vue
@@ -39,8 +39,6 @@
   flex-direction: column;
 }
 .title {
-  line-height: $kui-line-height-20;
-
   font-weight: $kui-font-weight-semibold;
   font-size: $kui-font-size-60;
 }

--- a/src/app/onboarding/components/OnboardingHeading.vue
+++ b/src/app/onboarding/components/OnboardingHeading.vue
@@ -31,8 +31,6 @@ const slots = useSlots()
   padding-top: $kui-space-20;
   padding-bottom: $kui-space-20;
   text-align: center;
-  font-size: 2.25rem;
-  line-height: 2.5rem;
   font-weight: $kui-font-weight-semibold;
   color: transparent;
   background-image: linear-gradient(to right, var(--onboarding-heading-1), var(--onboarding-heading-2));
@@ -43,7 +41,6 @@ const slots = useSlots()
 .onboarding-description {
   margin-top: $kui-space-50;
   text-align: center;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
+  font-size: $kui-font-size-60;
 }
 </style>

--- a/src/app/onboarding/components/OnboardingPage.vue
+++ b/src/app/onboarding/components/OnboardingPage.vue
@@ -66,8 +66,6 @@ const props = defineProps({
   align-items: center;
   justify-content: center;
   min-height: 500px;
-  font-size: 1.125rem;
-  line-height: 1.75rem;
 }
 
 .onboarding-container__content--with-image {

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -4,6 +4,26 @@
   box-sizing: border-box;
 }
 
+:root.kuma-ready {
+  // TODO(jc) ideally --kui-line-height would be set to $kui-line-height-20;
+  // $kui-line-height is currently 16px, but 1.3 gives the same relative height
+  // across font-sizing, which resolves all our line-height issues
+  --kui-line-height-20: 1.3;
+  // we set the base font-size for our rems here incase it ever gets set to
+  // something other than 16px
+  font-size: $kui-font-size-40;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  line-height: var(--kui-line-height-20);
+}
+
 body {
   margin: 0;
   tab-size: 2;
@@ -11,7 +31,6 @@ body {
   font-family: $kui-font-family-text;
   font-weight: $kui-font-weight-regular;
   font-size: $kui-font-size-40;
-  line-height: 1.5;
 }
 
 blockquote,
@@ -38,7 +57,6 @@ h3,
 h4,
 h5,
 h6 {
-  line-height: 1.3;
   font-weight: $kui-font-weight-semibold;
 }
 
@@ -174,7 +192,6 @@ select {
   border: $kui-border-width-10 solid $kui-color-border;
   border-radius: 3px;
   font-size: $kui-font-size-40;
-  line-height: $kui-line-height-30;
   padding: 10px 30px 10px 13px;
   background-color: $kui-color-background;
   background-image: url('@/assets/images/chevron-down.svg?url');

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -4,7 +4,7 @@
   box-sizing: border-box;
 }
 
-:root.kuma-ready {
+:root {
   font-size: $kui-font-size-40;
 }
 
@@ -95,6 +95,7 @@ ol {
     margin-top: $kui-space-50;
   }
 }
+
 p:empty {
   display: none;
 }

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -5,12 +5,6 @@
 }
 
 :root.kuma-ready {
-  // TODO(jc) ideally --kui-line-height would be set to $kui-line-height-20;
-  // $kui-line-height is currently 16px, but 1.3 gives the same relative height
-  // across font-sizing, which resolves all our line-height issues
-  --kui-line-height-20: 1.3;
-  // we set the base font-size for our rems here incase it ever gets set to
-  // something other than 16px
   font-size: $kui-font-size-40;
 }
 
@@ -21,7 +15,7 @@ h3,
 h4,
 h5,
 h6 {
-  line-height: var(--kui-line-height-20);
+  line-height: 1.3;
 }
 
 body {

--- a/src/assets/styles/_forms.scss
+++ b/src/assets/styles/_forms.scss
@@ -12,7 +12,6 @@
 
 .form-card .card-content:not(.increase-specificity) {
   font-size: $kui-font-size-40;
-  line-height: 1.5;
 }
 
 .form>*+* {
@@ -72,7 +71,6 @@
   display: inline-flex;
   margin-bottom: $kui-space-40;
   font-size: $kui-font-size-30;
-  line-height: $kui-line-height-30;
   font-weight: $kui-font-weight-semibold;
 }
 


### PR DESCRIPTION
I keep noticing several bits of weirdness to do with line-heights and font-sizes. This PR deals mainly with line-heights and centralizes them using relative units in our base stylesheet. I also noticed setting `--kui-line-height` also solves some issues mainly with k-cards.

The font-size addition was a late amend when I noticed some weirdness there also. At least for the moment, this amend means we can control our base font size, which is important for us seeing as we use `rems` quite a bit. I guess there are other places where we might change our `rem` usage to use `--kui-font-size` more, but still I guess there will be places where we might use `rem`.

This PR originally grew out of https://github.com/kumahq/kuma-gui/pull/1807#pullrequestreview-1748060631

I'm still a little unsure about setting `--kui-line-height-20` ourselves but given everything I'd rather do that now and have all our line-heights make sense, we can always undo this at a later date. All in all there are more things that make me want to do this than not want to do this.
