### PR TITLE
chore(deps): ignore Kongponents in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    ignore:
+      # TODO: Remove this once Kongponents v9 is used from a mainline release again (i.e. neither alpha or beta).
+      # Ignores Kongponents updates while on the v9 alpha and beta branches. This is necessary because Kongponents publishes prerelease versions for each pull request. Dependabot then creates PRs updating to `-pr.X.Y` which we definitely need to prevent. There doesn’t seem to be a way to update only the alpha version.
+      - dependency-name: "@kong/kongponents"
+        versions: ["9.x"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Changes

Ignores the Kongponents updates in Dependabot for the time being. Dependabot currently tries to update Kongponents’ alpha prerelease to PR prerelease versions which we definitely need to prevent.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

## Notes

- See example PR we don’t want: https://github.com/kumahq/kuma-gui/pull/1831