### PR TITLE
chore(deps): Bump @kong/kongponents from 9.0.0-alpha.55 to 9.0.0-alpha.63

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@kong-ui-public/i18n": "2.0.0",
     "@kong/icons": "1.8.0",
-    "@kong/kongponents": "9.0.0-alpha.55",
+    "@kong/kongponents": "9.0.0-alpha.63",
     "brandi": "5.0.0",
     "deepmerge": "4.3.1",
     "js-yaml": "4.1.0",

--- a/src/app/common/SummaryView.vue
+++ b/src/app/common/SummaryView.vue
@@ -4,6 +4,7 @@
     close-button-alignment="end"
     :has-overlay="false"
     is-visible
+    max-width="560px"
     offset-top="var(--app-slideout-offset-top, 0)"
     data-testid="summary"
     @close="emit('close')"
@@ -28,11 +29,6 @@ const emit = defineEmits<{
 .summary-slideout :deep(.k-slideout-header-content) {
   padding-right: $kui-space-80;
   padding-left: $kui-space-80;
-}
-
-.summary-slideout :deep(.panel) {
-  // Increases width of the content area a little.
-  max-width: 560px;
 }
 
 .summary-slideout :deep(.border-styles) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1832,10 +1832,10 @@
   resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.8.0.tgz#3fb6423fec31be4cc27af94f2912f52aee4f9077"
   integrity sha512-ynO3GXaJTh4yoJMZ7XeTbA+ZHvlrteleI+rWNGUbEr726Tw/jgHLdT6wZ1YWR65cA38FN0Q96vEX/7+6ExwaHA==
 
-"@kong/kongponents@9.0.0-alpha.55":
-  version "9.0.0-alpha.55"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.55.tgz#34eb59f2d26bdd002bc965493c5b8094f6418ad3"
-  integrity sha512-I20eS4x+gBaPG5x4gjHE3W24VMsRuQpQdiOe1uZGAZV6DJcpJZ1WYZCB7cmSgGU7swQmMt/+Co1WSE76NL5baQ==
+"@kong/kongponents@9.0.0-alpha.63":
+  version "9.0.0-alpha.63"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.63.tgz#98e54c6377e471a73caf03c43b373fbc5eb50913"
+  integrity sha512-7HIkjWkaw63YgfGy/BZGFuk7X0Tq5VYAJXN8xNO0yy5xNIZUAALZn7sfcXUp1mrGNX2p95IjhqOi+ioFyZGDow==
   dependencies:
     "@kong/icons" "^1.8.0"
     "@popperjs/core" "^2.11.8"


### PR DESCRIPTION
See https://github.com/Kong/kongponents/blob/alpha/CHANGELOG.md.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>