### PR TITLE
refactor(dataplanes): move warnings and cert expired utilities into data transformation file

### DIFF
--- a/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
@@ -31,6 +31,7 @@ Feature: Dataplane details for built-in gateway
                 kuma.io/zone: zone-1
             inbound: !!js/undefined
         dataplaneInsight:
+          mTLS: !!js/undefined
           subscriptions:
             - controlPlaneInstanceId: 'dpp-1-cp-instance-id'
               connectTime: 2021-02-17T07:33:36.412683Z
@@ -51,13 +52,13 @@ Feature: Dataplane details for built-in gateway
   Scenario: Overview tab has expected content
     Then the page title contains "dataplane-gateway_builtin-1"
     And the "$detail-view" element contains "dataplane-gateway_builtin-1"
-    And the "$warnings" element doesn't exist
     And the "$details" element contains
       | Value                 |
       | online                |
       | 193.107.134.106       |
       | kuma.io/protocol:http |
       | kuma.io/zone:zone-1   |
+    And the "$warnings" element doesn't exist
     And the "$inbounds" element doesn't exist
 
   Scenario: Policies tab has expected content

--- a/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
@@ -33,6 +33,7 @@ Feature: Dataplane details for delegated gateway
                 kuma.io/zone: zone-1
             inbound: !!js/undefined
         dataplaneInsight:
+          mTLS: !!js/undefined
           subscriptions:
             - controlPlaneInstanceId: 'dpp-1-cp-instance-id'
               connectTime: 2021-02-17T07:33:36.412683Z
@@ -53,13 +54,13 @@ Feature: Dataplane details for delegated gateway
   Scenario: Overview tab has expected content
     Then the page title contains "dataplane-gateway_delegated-1"
     And the "$detail-view" element contains "dataplane-gateway_delegated-1"
-    And the "$warnings" element doesn't exist
     And the "$details" element contains
       | Value                 |
       | online                |
       | 193.107.134.106       |
       | kuma.io/protocol:http |
       | kuma.io/zone:zone-1   |
+    And the "$warnings" element doesn't exist
     And the "$inbounds" element doesn't exist
 
   Scenario: Policies tab has expected content

--- a/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
@@ -46,6 +46,7 @@ Feature: Dataplane details for standard Data Plane Proxy
                   kuma.io/protocol: http
                   kuma.io/zone: zone-1
         dataplaneInsight:
+          mTLS: !!js/undefined
           subscriptions:
             - controlPlaneInstanceId: 'dpp-1-cp-instance-id'
               connectTime: 2021-02-17T07:33:36.412683Z
@@ -86,7 +87,6 @@ Feature: Dataplane details for standard Data Plane Proxy
   Scenario: Overview tab has expected content
     Then the page title contains "dpp-1-name-of-dataplane"
     And the "$detail-view" element contains "dpp-1-name-of-dataplane"
-    And the "$warnings" element doesn't exist
     And the "$details" element contains "online"
     And the "$inbounds" element contains
       | Value                 |
@@ -95,6 +95,7 @@ Feature: Dataplane details for standard Data Plane Proxy
       | 44.167.201.218:62098  |
       | kuma.io/protocol:http |
       | kuma.io/zone:zone-1   |
+    And the "$warnings" element doesn't exist
     And the "$subscriptions" element contains "Connected: Feb 17, 2021, 7:33 AM"
     And the "$subscriptions" element contains "CP instance ID: dpp-1-cp-instance-id"
 

--- a/src/app/data-planes/components/DataPlaneSummary.vue
+++ b/src/app/data-planes/components/DataPlaneSummary.vue
@@ -164,7 +164,7 @@ const props = defineProps<{
 
 const statusWithReason = computed(() => getStatusAndReason(props.dataplaneOverview))
 const formattedLastUpdateTime = computed(() => {
-  const lastUpdateTime = getLastUpdateTime(props.dataplaneOverview.dataplaneInsight?.subscriptions ?? [])
+  const lastUpdateTime = getLastUpdateTime(props.dataplaneOverview)
   return lastUpdateTime !== undefined ? formatIsoDate(lastUpdateTime) : t('common.detail.none')
 })
 </script>

--- a/src/app/data-planes/data/index.spec.ts
+++ b/src/app/data-planes/data/index.spec.ts
@@ -13,55 +13,94 @@ describe('dataplanes data transformations', () => {
     test.each<TestCase<typeof getLastUpdateTime>>([
       {
         message: 'empty subscriptions',
-        parameters: [[]],
+        parameters: [{
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
+            },
+          },
+        }],
         expected: undefined,
       },
       {
         message: 'single subscription',
-        parameters: [[
-          {
-            id: '',
-            controlPlaneInstanceId: '',
-            status: {
-              lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-              total: {},
-              cds: {},
-              eds: {},
-              lds: {},
-              rds: {},
+        parameters: [{
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
             },
           },
-        ]],
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                status: {
+                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+              },
+            ],
+          },
+        }],
         expected: '2021-07-13T09:03:11.614941842Z',
       },
       {
         message: 'multiple subscriptions',
-        parameters: [[
-          {
-            id: '',
-            controlPlaneInstanceId: '',
-            status: {
-              lastUpdateTime: '2020-07-13T09:03:11.614941842Z',
-              total: {},
-              cds: {},
-              eds: {},
-              lds: {},
-              rds: {},
+        parameters: [{
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
             },
           },
-          {
-            id: '',
-            controlPlaneInstanceId: '',
-            status: {
-              lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-              total: {},
-              cds: {},
-              eds: {},
-              lds: {},
-              rds: {},
-            },
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                status: {
+                  lastUpdateTime: '2020-07-13T09:03:11.614941842Z',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+              },
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                status: {
+                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+              },
+            ],
           },
-        ]],
+        }],
         expected: '2021-07-13T09:03:11.614941842Z',
       },
     ])('$message', ({ parameters, expected }) => {

--- a/src/app/data-planes/data/index.ts
+++ b/src/app/data-planes/data/index.ts
@@ -40,9 +40,6 @@ export function getStatusAndReason(dataplaneOverview: DataplaneOverview): { stat
 
   let status: StatusKeyword
   switch (true) {
-    case inbounds.length === 0:
-      status = 'online'
-      break
     case unhealthyInbounds.length === inbounds.length:
       // All inbounds being unhealthy means the Dataplane is offline.
       status = 'offline'

--- a/src/app/data-planes/data/index.ts
+++ b/src/app/data-planes/data/index.ts
@@ -1,7 +1,6 @@
 import { getIsConnected } from '@/app/subscriptions/data'
 import type {
   DataPlaneOverview as DataplaneOverview,
-  DiscoverySubscription,
   LabelValue,
   StatusKeyword,
 } from '@/types/index.d'
@@ -14,7 +13,8 @@ export type DataplaneWarning = {
   }
 }
 
-export function getLastUpdateTime(subscriptions: DiscoverySubscription[]): string | undefined {
+export function getLastUpdateTime(dataplaneOverview: DataplaneOverview): string | undefined {
+  const subscriptions = dataplaneOverview.dataplaneInsight?.subscriptions ?? []
   if (subscriptions.length === 0) {
     return undefined
   }

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -304,7 +304,7 @@ const props = defineProps<{
 
 const statusWithReason = computed(() => getStatusAndReason(props.data))
 const formattedLastUpdateTime = computed(() => {
-  const lastUpdateTime = getLastUpdateTime(props.data.dataplaneInsight?.subscriptions ?? [])
+  const lastUpdateTime = getLastUpdateTime(props.data)
   return lastUpdateTime !== undefined ? formatIsoDate(lastUpdateTime) : t('common.detail.none')
 })
 const warnings = computed(() => {

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -285,7 +285,7 @@ import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tok
 import { InfoIcon } from '@kong/icons'
 import { computed } from 'vue'
 
-import { getLastUpdateTime, getStatusAndReason, getTags } from '../data'
+import { getLastUpdateTime, getIsCertExpired, getStatusAndReason, getWarnings } from '../data'
 import { useCan } from '@/app/application'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
@@ -294,11 +294,6 @@ import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
 import type { DataPlaneOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
-import {
-  compatibilityKind,
-  COMPATIBLE,
-  INCOMPATIBLE_WRONG_FORMAT,
-} from '@/utilities/dataplane'
 
 const { t, formatIsoDate } = useI18n()
 const can = useCan()
@@ -308,61 +303,19 @@ const props = defineProps<{
 }>()
 
 const statusWithReason = computed(() => getStatusAndReason(props.data))
-
 const formattedLastUpdateTime = computed(() => {
   const lastUpdateTime = getLastUpdateTime(props.data.dataplaneInsight?.subscriptions ?? [])
   return lastUpdateTime !== undefined ? formatIsoDate(lastUpdateTime) : t('common.detail.none')
 })
-
 const warnings = computed(() => {
-  const subscriptions = props.data.dataplaneInsight?.subscriptions ?? []
-  if (subscriptions.length === 0) {
-    return []
-  }
+  const warnings = getWarnings(props.data, can('use zones'))
 
-  const lastSubscription = subscriptions[subscriptions.length - 1]
-  if (!('version' in lastSubscription) || !lastSubscription.version) {
-    return []
-  }
-
-  const version = lastSubscription.version
-
-  const warnings: { kind: string, payload?: any }[] = []
-  if (version.kumaDp && version.envoy) {
-    const compatibility = compatibilityKind(version)
-
-    if (compatibility.kind !== COMPATIBLE && compatibility.kind !== INCOMPATIBLE_WRONG_FORMAT) {
-      warnings.push(compatibility)
-    }
-  }
-  const mTLS = props.data.dataplaneInsight?.mTLS
-  if (
-    mTLS &&
-    (Date.now() > new Date(mTLS?.certificateExpirationTime).getTime())
-  ) {
-    warnings.push({
-      kind: 'CERT_EXPIRED',
-      payload: {},
-    })
-  }
-
-  if (can('use zones')) {
-    const tags = getTags(props.data)
-    const zoneTag = tags.find((tag) => tag.label === 'kuma.io/zone')
-
-    if (zoneTag && typeof version.kumaDp.kumaCpCompatible === 'boolean' && !version.kumaDp.kumaCpCompatible) {
-      warnings.push({
-        kind: 'INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS',
-        payload: {
-          kumaDp: version.kumaDp.version,
-        },
-      })
-    }
+  if (getIsCertExpired(props.data)) {
+    warnings.push({ kind: 'CERT_EXPIRED' })
   }
 
   return warnings
 })
-
 </script>
 
 <style lang="scss" scoped>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -259,16 +259,8 @@ export type PolicyType = {
 
 export type DataPlaneStatus = 'Online' | 'Offline' | 'Partially degraded'
 
-export type Compatibility = {
-  kind: 'COMPATIBLE' | 'INCOMPATIBLE_UNSUPPORTED_KUMA_DP' | 'INCOMPATIBLE_UNSUPPORTED_ENVOY' | 'INCOMPATIBLE_WRONG_FORMAT' | 'INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS'
-  payload?: {
-    kumaDp: string
-    envoy?: string
-  }
-}
-
 export type ZoneCompatibility = {
-  kind: INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS
+  kind: 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS'
   payload?: {
     zoneCpVersion: string
     globalCpVersion: string

--- a/src/utilities/dataplane.spec.ts
+++ b/src/utilities/dataplane.spec.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'vitest'
 
 import { getItemStatusFromInsight } from './dataplane'
-import type { DiscoverySubscription } from '@/types/index.d'
+import type { KDSSubscription } from '@/types/index.d'
 
 describe('utilities/dataplane', () => {
   describe('getItemStatusFromInsight', () => {
-    type TestCases = {message: string, args: [{ subscriptions?: DiscoverySubscription[] }], expected: string}[]
+    type TestCases = {message: string, args: [{ subscriptions?: KDSSubscription[] }], expected: string}[]
     test.each(([
       {
         message: 'undefined insight is offline',

--- a/src/utilities/dataplane.ts
+++ b/src/utilities/dataplane.ts
@@ -1,86 +1,8 @@
-import {
-  Compatibility,
-  DataPlaneInsight,
-  DiscoverySubscription,
-  KDSSubscription,
-  StatusKeyword,
-  Version,
-} from '@/types/index.d'
+import type { KDSSubscription, StatusKeyword } from '@/types/index.d'
 
 // getItemStatusFromInsight takes object with subscriptions and returns a
 // status 'online' | 'offline'
-export function getItemStatusFromInsight(insight: { subscriptions?: DiscoverySubscription[] | KDSSubscription[] } | undefined = { subscriptions: [] }): StatusKeyword {
+export function getItemStatusFromInsight(insight: { subscriptions?: KDSSubscription[] } | undefined = { subscriptions: [] }): StatusKeyword {
   const proxyOnline = (insight.subscriptions ?? []).some((subscription) => subscription.connectTime?.length && !subscription.disconnectTime)
   return proxyOnline ? 'online' : 'offline'
 }
-
-/*
-getStatus takes DataplaneInsight and returns map of versions
- */
-
-export function getVersions(dataPlaneInsight: DataPlaneInsight | undefined): Record<string, string> | null {
-  const subscriptions = dataPlaneInsight?.subscriptions || []
-  if (subscriptions.length === 0) {
-    return null
-  }
-
-  const versions: Record<string, string> = {}
-
-  const lastSubscription = subscriptions[subscriptions.length - 1]
-
-  if (lastSubscription.version === undefined) {
-    return null
-  }
-
-  if (lastSubscription.version.envoy) {
-    versions.envoy = lastSubscription.version.envoy.version
-  }
-
-  if (lastSubscription.version.kumaDp) {
-    versions.kumaDp = lastSubscription.version.kumaDp.version
-  }
-
-  if (lastSubscription.version.dependencies) {
-    Object.entries(lastSubscription.version.dependencies).forEach(([key, value]) => {
-      versions[key] = value
-    })
-  }
-
-  return versions
-}
-
-export function compatibilityKind(version: Version): Compatibility {
-  const isKumaCpCompatible = version.kumaDp?.kumaCpCompatible ?? true
-
-  if (!isKumaCpCompatible) {
-    return {
-      kind: INCOMPATIBLE_UNSUPPORTED_KUMA_DP,
-      payload: {
-        kumaDp: version.kumaDp.version,
-      },
-    }
-  }
-
-  const isKumaDpCompatible = version.envoy?.kumaDpCompatible ?? true
-
-  if (!isKumaDpCompatible) {
-    return {
-      kind: INCOMPATIBLE_UNSUPPORTED_ENVOY,
-      payload: {
-        envoy: version.envoy.version,
-        kumaDp: version.kumaDp.version,
-      },
-    }
-  }
-
-  return {
-    kind: COMPATIBLE,
-  }
-}
-
-export const COMPATIBLE = 'COMPATIBLE'
-export const INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS = 'INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS'
-export const INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS = 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS'
-export const INCOMPATIBLE_UNSUPPORTED_KUMA_DP = 'INCOMPATIBLE_UNSUPPORTED_KUMA_DP'
-export const INCOMPATIBLE_UNSUPPORTED_ENVOY = 'INCOMPATIBLE_UNSUPPORTED_ENVOY'
-export const INCOMPATIBLE_WRONG_FORMAT = 'INCOMPATIBLE_WRONG_FORMAT'


### PR DESCRIPTION
Follow up to https://github.com/kumahq/kuma-gui/pull/1834.

---

chore(dataplanes): fix rare flake

Fixes a rare flake that is caused by the mocked API endpoint for Dataplane details not removing the mTLS object. There was a negative assertion trying make sure that’s not the case, but it was executed before any content even rendered most of the times. When it didn’t _and_ the mock data rolled the dice for an expired cert, the flake happened.

**refactor(dataplanes): move warnings and cert expired utilities into data transformation file**

Moves the warnings and cert expired functionality into the dataplanes data transformation file in the form of the new `getIsCertExpired` and `getWarnings` utilities.

Adds new `getDataplaneType` utility.

**refactor(dataplanes): make all data transformers take a DataplaneOverview parameter**

**refactor(dataplanes): status utility edge case for gateways**

Removes the `inbounds.length === 0` check for the Dataplanes status utility. It’s not needed because non-gateway Dataplanes always have an inbound.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
