### PR TITLE
feat: add feature flagged dataplane traffic view

### DIFF
--- a/src/app/data-planes/features.ts
+++ b/src/app/data-planes/features.ts
@@ -1,0 +1,13 @@
+import type { Features } from '@/app/application/services/can'
+import type Env from '@/services/env/Env'
+export const features = (env: Env['var']): Features => {
+  return {
+    'read traffic': () => {
+      try {
+        return !!JSON.parse(env('KUMA_TRAFFIC_ENABLED', 'false'))
+      } catch (e) {
+        return false
+      }
+    },
+  }
+}

--- a/src/app/data-planes/index.ts
+++ b/src/app/data-planes/index.ts
@@ -1,3 +1,4 @@
+import { features } from './features'
 import { sources } from './sources'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
@@ -14,6 +15,15 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
       labels: [
         app.sources,
+      ],
+    }],
+    [token('data-planes.features'), {
+      service: features,
+      arguments: [
+        app.env,
+      ],
+      labels: [
+        app.features,
       ],
     }],
   ]

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -8,6 +8,7 @@ export type EnvArgs = {
   KUMA_VERSION_URL: string
   KUMA_DOCS_URL: string
   KUMA_MOCK_API_ENABLED: string
+  KUMA_TRAFFIC_ENABLED: string
   KUMA_ZONE_CREATION_FLOW: 'disabled' | 'enabled' | undefined
 }
 type EnvProps = {

--- a/src/services/env/env.spec.ts
+++ b/src/services/env/env.spec.ts
@@ -36,6 +36,7 @@ describe('env', () => {
         KUMA_VERSION_URL: 'http://version.fake',
         KUMA_DOCS_URL: 'http://docs.fake',
         KUMA_MOCK_API_ENABLED: 'false',
+        KUMA_TRAFFIC_ENABLED: 'false',
         KUMA_ZONE_CREATION_FLOW: 'enabled',
       },
     )


### PR DESCRIPTION
Enables dataplane traffic view behind a feature flag.

Pretty much a copy/paste of https://github.com/kumahq/kuma-gui/pull/1839 behind a feature flag but there are a couple of additional type casts.

Note: there is still placeholder code in here that is not rendered via corresponding the slot as the comment is commented out. 

Also, I hit the same CSS lint issue as in https://github.com/kumahq/kuma-gui/pull/1839 here. I'll bring the issue up at a later date.

Make sure you have a cookie set to `KUMA_TRAFFIC_ENABLED=1` to view. The view only shows on non-gateways.