### PR TITLE
chore(zones): ZoneIngress data layer pt1 

### DIFF
--- a/src/app/zone-ingresses/components/ZoneIngressSummary.vue
+++ b/src/app/zone-ingresses/components/ZoneIngressSummary.vue
@@ -6,7 +6,7 @@
       </template>
 
       <template #body>
-        <StatusBadge :status="status" />
+        <StatusBadge :status="props.zoneIngressOverview.state" />
       </template>
     </DefinitionCard>
 
@@ -16,8 +16,8 @@
       </template>
 
       <template #body>
-        <template v-if="address">
-          <TextWithCopyButton :text="address" />
+        <template v-if="props.zoneIngressOverview.zoneIngress.socketAddress.length > 0">
+          <TextWithCopyButton :text="props.zoneIngressOverview.zoneIngress.socketAddress" />
         </template>
 
         <template v-else>
@@ -32,8 +32,8 @@
       </template>
 
       <template #body>
-        <template v-if="advertisedAddress">
-          <TextWithCopyButton :text="advertisedAddress" />
+        <template v-if="props.zoneIngressOverview.zoneIngress.advertisedSocketAddress.length > 0">
+          <TextWithCopyButton :text="props.zoneIngressOverview.zoneIngress.advertisedSocketAddress" />
         </template>
 
         <template v-else>
@@ -45,38 +45,15 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
-
+import type { ZoneIngressOverview } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import type { ZoneIngressOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 const { t } = useI18n()
 
 const props = defineProps<{
   zoneIngressOverview: ZoneIngressOverview
 }>()
-
-const status = computed(() => getItemStatusFromInsight(props.zoneIngressOverview.zoneIngressInsight))
-const address = computed(() => {
-  const { networking } = props.zoneIngressOverview.zoneIngress
-
-  if (networking?.address && networking?.port) {
-    return `${networking.address}:${networking.port}`
-  }
-
-  return null
-})
-const advertisedAddress = computed(() => {
-  const { networking } = props.zoneIngressOverview.zoneIngress
-
-  if (networking?.advertisedAddress && networking?.advertisedPort) {
-    return `${networking.advertisedAddress}:${networking.advertisedPort}`
-  }
-
-  return null
-})
 </script>

--- a/src/app/zone-ingresses/data/index.ts
+++ b/src/app/zone-ingresses/data/index.ts
@@ -1,24 +1,100 @@
-import type { ZoneIngressOverview as PartialZoneIngressOverview } from '@/types/index.d'
+import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
+import type {
+  ZoneIngressOverview as PartialZoneIngressOverview,
+  ZoneIngress as PartialZoneIngress,
+  KDSSubscription,
+} from '@/types/index.d'
 export type { AvailableService } from '@/types/index.d'
-type PartialZoneIngress = PartialZoneIngressOverview['zoneIngress']
 
-type RequiredZoneIngress =
-  Required<Pick<PartialZoneIngress,
-  'availableServices'
-  >>
-  & PartialZoneIngressOverview['zoneIngress']
+type PartialZoneIngressInsight = any
+type PartialInternalZoneIngress = PartialZoneIngressOverview['zoneIngress']
 
+// TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
+type InternalZoneIngress = {
+  socketAddress: string
+  advertisedSocketAddress: string
+} & Required<Pick<PartialInternalZoneIngress, 'availableServices'>> & PartialInternalZoneIngress
+
+export type ZoneIngress = {
+  config: PartialZoneIngress
+  socketAddress: string
+  advertisedSocketAddress: string
+} & Required<Pick<PartialZoneIngress, 'availableServices'>> & PartialZoneIngress
+// end TODO
+
+// TODO(jc) currently in our manually written types ZoneIngressInsight is any therefore
+// we have no Partial*
+export type ZoneIngressInsight = {
+  connectedSubscription?: KDSSubscription
+  subscriptions: KDSSubscription[]
+}
 export type ZoneIngressOverview = PartialZoneIngressOverview & {
-  zoneIngress: RequiredZoneIngress
+  zoneIngress: InternalZoneIngress
+  zoneIngressInsight?: ZoneIngressInsight
+  state: 'online' | 'offline'
+}
+// TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
+const InternalZoneIngress = {
+  fromObject: (item: PartialInternalZoneIngress): InternalZoneIngress => {
+    return {
+      ...item,
+      availableServices: Array.isArray(item.availableServices) ? item.availableServices : [],
+      socketAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
+      advertisedSocketAddress: item.networking?.advertisedAddress && item.networking?.advertisedPort ? `${item.networking.advertisedAddress}:${item.networking.advertisedPort}` : '',
+    }
+  },
+}
+
+export const ZoneIngress = {
+  fromObject: (item: PartialZoneIngress): ZoneIngress => {
+    return {
+      ...item,
+      config: item,
+      availableServices: Array.isArray(item.availableServices) ? item.availableServices : [],
+      socketAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
+      advertisedSocketAddress: item.networking?.advertisedAddress && item.networking?.advertisedPort ? `${item.networking.advertisedAddress}:${item.networking.advertisedPort}` : '',
+    }
+  },
+}
+// end TODO
+export const ZoneIngressInsight = {
+  fromObject: (item?: PartialZoneIngressInsight): ZoneIngressInsight | undefined => {
+    // if item isn't set don't even try augmenting things
+    return isSet<PartialZoneIngressInsight>(item)
+      ? ((item) => {
+        const subscriptions: KDSSubscription[] = Array.isArray(item.subscriptions) ? item.subscriptions : []
+        // figure out the connectedSubscription by looking at the connectTime
+        // and disconnectTime of the last subscription
+        const connectedSubscription = subscriptions.slice(-1).find((item) => item.connectTime?.length && !item.disconnectTime)
+        return {
+          ...item,
+          subscriptions,
+          connectedSubscription,
+        }
+      })(item)
+      : undefined
+  },
 }
 export const ZoneIngressOverview = {
   fromObject: (item: PartialZoneIngressOverview): ZoneIngressOverview => {
+    const insight = ZoneIngressInsight.fromObject(item.zoneIngressInsight)
+    const zoneIngress = InternalZoneIngress.fromObject(item.zoneIngress)
     return {
       ...item,
-      zoneIngress: {
-        ...item.zoneIngress,
-        availableServices: !Array.isArray(item.zoneIngress.availableServices) ? [] : item.zoneIngress.availableServices,
-      },
+      zoneIngressInsight: insight,
+      zoneIngress,
+      // it is possible to have zoneIngresses on a 'disabled' zone but we don't
+      // want to do anything special about that just now at least
+      state: typeof insight?.connectedSubscription !== 'undefined' ? 'online' : 'offline',
     }
   },
+  fromCollection: (collection: CollectionResponse<PartialZoneIngressOverview>): CollectionResponse<ZoneIngressOverview> => {
+    return {
+      ...collection,
+      items: Array.isArray(collection.items) ? collection.items.map(ZoneIngressOverview.fromObject) : [],
+    }
+  },
+}
+function isSet<T>(value: T | null | undefined): value is T {
+  return value !== null && typeof value !== 'undefined'
 }

--- a/src/app/zone-ingresses/views/ZoneIngressConfigView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressConfigView.vue
@@ -33,7 +33,7 @@
           <template v-else>
             <ResourceCodeBlock
               id="code-block-zone-ingress"
-              :resource="data"
+              :resource="data.config"
               :resource-fetcher="(params) => kumaApi.getZoneIngress({ name: route.params.zoneIngress }, params)"
               is-searchable
               :query="route.params.codeSearch"

--- a/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -16,7 +16,7 @@
               </template>
 
               <template #body>
-                <StatusBadge :status="getItemStatusFromInsight(props.data.zoneIngressInsight)" />
+                <StatusBadge :status="props.data.state" />
               </template>
             </DefinitionCard>
 
@@ -26,8 +26,8 @@
               </template>
 
               <template #body>
-                <template v-if="props.data.zoneIngress.networking?.address && props.data.zoneIngress.networking?.port">
-                  <TextWithCopyButton :text="`${props.data.zoneIngress.networking.address}:${props.data.zoneIngress.networking.port}`" />
+                <template v-if="props.data.zoneIngress.socketAddress.length > 0">
+                  <TextWithCopyButton :text="props.data.zoneIngress.socketAddress" />
                 </template>
 
                 <template v-else>
@@ -42,8 +42,8 @@
               </template>
 
               <template #body>
-                <template v-if="props.data.zoneIngress.networking?.advertisedAddress && props.data.zoneIngress.networking?.advertisedPort">
-                  <TextWithCopyButton :text="`${props.data.zoneIngress.networking.advertisedAddress}:${props.data.zoneIngress.networking.advertisedPort}`" />
+                <template v-if="props.data.zoneIngress.advertisedSocketAddress.length > 0">
+                  <TextWithCopyButton :text="props.data.zoneIngress.advertisedSocketAddress" />
                 </template>
 
                 <template v-else>
@@ -76,12 +76,11 @@
 </template>
 
 <script lang="ts" setup>
+import type { ZoneIngressOverview } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
-import type { ZoneIngressOverview } from '@/types/index.d'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 const props = defineProps<{
   data: ZoneIngressOverview

--- a/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -52,8 +52,8 @@
 
 <script lang="ts" setup>
 import ZoneIngressSummary from '../components/ZoneIngressSummary.vue'
+import type { ZoneIngressOverview } from '../data'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
-import type { ZoneIngressOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 
 const { t } = useI18n()

--- a/src/test-support/mocks/src/zone-ingresses/_/_overview.ts
+++ b/src/test-support/mocks/src/zone-ingresses/_/_overview.ts
@@ -36,47 +36,51 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
         }),
       },
       zoneIngressInsight: {
-        subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
-          return {
-            id: fake.string.uuid(),
-            controlPlaneInstanceId: fake.hacker.noun(),
-            ...fake.kuma.connection(item, i, arr),
-            generation: 409,
-            status: {
-              lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-              total: {
-                responsesSent: `${fake.number.int(30)}`,
-                responsesAcknowledged: `${fake.number.int(30)}`,
-              },
-              cds: {
-                responsesSent: `${fake.number.int(30)}`,
-                responsesAcknowledged: `${fake.number.int(30)}`,
-              },
-              eds: {
-                responsesSent: `${fake.number.int(30)}`,
-                responsesAcknowledged: `${fake.number.int(30)}`,
-              },
-              lds: {
-                responsesSent: `${fake.number.int(30)}`,
-                responsesAcknowledged: `${fake.number.int(30)}`,
-              },
-              rds: {},
-            },
-            version: {
-              kumaDp: {
-                version: '1.2.1',
-                gitTag: '1.2.1',
-                gitCommit: 'e88ec407e669c47d3dc9ef32fcde60e2f31c0c4d',
-                buildDate: '2021-06-30T14:32:58Z',
-              },
-              envoy: {
-                version: '1.18.3',
-                build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
-              },
-            },
+        ...(subscriptionCount !== 0
+          ? {
+            subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
+              return {
+                id: fake.string.uuid(),
+                controlPlaneInstanceId: fake.hacker.noun(),
+                ...fake.kuma.connection(item, i, arr),
+                generation: 409,
+                status: {
+                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                  total: {
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
+                  },
+                  cds: {
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
+                  },
+                  eds: {
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
+                  },
+                  lds: {
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
+                  },
+                  rds: {},
+                },
+                version: {
+                  kumaDp: {
+                    version: '1.2.1',
+                    gitTag: '1.2.1',
+                    gitCommit: 'e88ec407e669c47d3dc9ef32fcde60e2f31c0c4d',
+                    buildDate: '2021-06-30T14:32:58Z',
+                  },
+                  envoy: {
+                    version: '1.18.3',
+                    build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
+                  },
+                },
 
+              }
+            }),
           }
-        }),
+          : {}),
       },
     },
   }

--- a/src/test-support/mocks/src/zone-ingresses/_overview.ts
+++ b/src/test-support/mocks/src/zone-ingresses/_overview.ts
@@ -5,13 +5,15 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     req,
     '/zone-ingresses/_overview',
   )
-  const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
 
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
+        const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
+        const serviceCount = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
+
         const id = offset + i
         const zoneIngressName = `${fake.hacker.noun()}-${id}`
         const zone = `${fake.hacker.noun()}-${id}`
@@ -30,73 +32,68 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               port: fake.internet.port(),
               advertisedPort: fake.internet.port(),
             },
-            availableServices: [
-              {
-                tags: {
-                  app: 'demo-app',
-                  'kuma.io/protocol': fake.kuma.protocol(),
-                  'kuma.io/service': 'demo-app_kuma-demo_svc_5000',
-                  'kuma.io/zone': zoneName,
-                  'pod-template-hash': '5845d6447b',
-                },
-                instances: 1,
-                mesh: 'default',
-              },
-              {
-                tags: {
-                  app: 'redis',
-                  'kuma.io/protocol': fake.kuma.protocol(),
-                  'kuma.io/service': 'redis_kuma-demo_svc_6379',
-                  'kuma.io/zone': zoneName,
-                  'pod-template-hash': '59c9d56fc',
-                },
-                instances: 1,
-                mesh: 'default',
-              },
-            ],
-          },
-          zoneIngressInsight: {
-            subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
+            availableServices: Array.from({ length: serviceCount }).map(_ => {
+              const mesh = `${fake.hacker.noun()}-app`
               return {
-                id: fake.string.uuid(),
-                controlPlaneInstanceId: fake.hacker.noun(),
-                ...fake.kuma.connection(item, i, arr),
-                generation: 409,
-                status: {
-                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-                  total: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  cds: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  eds: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  lds: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  rds: {},
+                tags: {
+                  app: mesh,
+                  'kuma.io/protocol': fake.kuma.protocol(),
+                  'kuma.io/service': `${mesh}_${fake.hacker.noun()}_svc_${fake.number.int({ min: 0, max: 65535 })}`,
+                  'kuma.io/zone': zoneName,
+                  'pod-template-hash': fake.string.alphanumeric({ casing: 'lower', length: 10 }),
                 },
-                version: {
-                  kumaDp: {
-                    version: '1.2.1',
-                    gitTag: '1.2.1',
-                    gitCommit: 'e88ec407e669c47d3dc9ef32fcde60e2f31c0c4d',
-                    buildDate: '2021-06-30T14:32:58Z',
-                  },
-                  envoy: {
-                    version: '1.18.3',
-                    build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
-                  },
-                },
-
+                instances: fake.number.int({ min: 1, max: 100 }),
+                mesh,
               }
             }),
+          },
+          zoneIngressInsight: {
+            ...(subscriptionCount !== 0
+              ? {
+                subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
+                  return {
+                    id: fake.string.uuid(),
+                    controlPlaneInstanceId: fake.hacker.noun(),
+                    ...fake.kuma.connection(item, i, arr),
+                    generation: 409,
+                    status: {
+                      lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                      total: {
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
+                      },
+                      cds: {
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
+                      },
+                      eds: {
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
+                      },
+                      lds: {
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
+                      },
+                      rds: {},
+                    },
+                    version: {
+                      kumaDp: {
+                        version: '1.2.1',
+                        gitTag: '1.2.1',
+                        gitCommit: 'e88ec407e669c47d3dc9ef32fcde60e2f31c0c4d',
+                        buildDate: '2021-06-30T14:32:58Z',
+                      },
+                      envoy: {
+                        version: '1.18.3',
+                        build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
+                      },
+                    },
+
+                  }
+                }),
+              }
+              : {}),
+
           },
         }
       }),

--- a/src/test-support/mocks/src/zones/_overview.ts
+++ b/src/test-support/mocks/src/zones/_overview.ts
@@ -5,16 +5,17 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     req,
     '/zones/_overview',
   )
-  const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 0, max: 10 })}`))
 
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
+        const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 0, max: 10 })}`))
+        const shouldHaveZoneInsight = subscriptionCount === 0 || fake.datatype.boolean()
+
         const id = offset + i
         const name = `${fake.hacker.noun()}-${id}`
-        const shouldHaveZoneInsight = subscriptionCount === 0 || fake.datatype.boolean()
 
         return {
           type: 'ZoneOverview',


### PR DESCRIPTION
Reduces the majority of our ZoneIngress related reshaping functions.

This is pretty much the same approach as https://github.com/kumahq/kuma-gui/pull/1854 but has the additional weirdness of two types of ZoneIngress depending one whether its the root object or the child object. For the moment I'm copy/pasta'ing around this, but I a better approach would be to apply `Entity` conditionally, but I don't want to do that (or something else) here yet.

See https://github.com/kumahq/kuma-gui/issues/1264

Related https://github.com/johncowen/kuma-gui/commit/b11e78a5484df618da0b89dac585b81eaab8ea74 which aren't PRed yet as I also want to do ZoneEgress and then at least reduce repetition some more.

Oh I also updated some mocks here to:

1. replicate the fact that `subscriptions` never seems to be an empty array, its only ever absent or at least length=1
2. replicate random available services in the listing API.