### PR TITLE
chore(zones): ZoneEgress data layer pt1

### DIFF
--- a/src/app/zone-egresses/data/index.ts
+++ b/src/app/zone-egresses/data/index.ts
@@ -1,0 +1,93 @@
+import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
+import type {
+  ZoneEgressOverview as PartialZoneEgressOverview,
+  ZoneEgress as PartialZoneEgress,
+  KDSSubscription,
+} from '@/types/index.d'
+
+type PartialZoneEgressInsight = any
+type PartialInternalZoneEgress = PartialZoneEgressOverview['zoneEgress']
+
+// TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
+type InternalZoneEgress = {
+  socketAddress: string
+} & PartialInternalZoneEgress
+
+export type ZoneEgress = {
+  config: PartialZoneEgress
+  socketAddress: string
+} & PartialZoneEgress
+// end TODO
+
+// TODO(jc) currently in our manually written types ZoneEgressInsight is any therefore
+// we have no Partial*
+export type ZoneEgressInsight = {
+  connectedSubscription?: KDSSubscription
+  subscriptions: KDSSubscription[]
+}
+export type ZoneEgressOverview = PartialZoneEgressOverview & {
+  zoneEgress: InternalZoneEgress
+  zoneEgressInsight?: ZoneEgressInsight
+  state: 'online' | 'offline'
+}
+// TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
+const InternalZoneEgress = {
+  fromObject: (item: PartialInternalZoneEgress): InternalZoneEgress => {
+    return {
+      ...item,
+      socketAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
+    }
+  },
+}
+
+export const ZoneEgress = {
+  fromObject: (item: PartialZoneEgress): ZoneEgress => {
+    return {
+      ...item,
+      config: item,
+      socketAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
+    }
+  },
+}
+// end TODO
+export const ZoneEgressInsight = {
+  fromObject: (item?: PartialZoneEgressInsight): ZoneEgressInsight | undefined => {
+    // if item isn't set don't even try augmenting things
+    return isSet<PartialZoneEgressInsight>(item)
+      ? ((item) => {
+        const subscriptions: KDSSubscription[] = Array.isArray(item.subscriptions) ? item.subscriptions : []
+        // figure out the connectedSubscription by looking at the connectTime
+        // and disconnectTime of the last subscription
+        const connectedSubscription = subscriptions.slice(-1).find((item) => item.connectTime?.length && !item.disconnectTime)
+        return {
+          ...item,
+          subscriptions,
+          connectedSubscription,
+        }
+      })(item)
+      : undefined
+  },
+}
+export const ZoneEgressOverview = {
+  fromObject: (item: PartialZoneEgressOverview): ZoneEgressOverview => {
+    const insight = ZoneEgressInsight.fromObject(item.zoneEgressInsight)
+    const zoneEgress = InternalZoneEgress.fromObject(item.zoneEgress)
+    return {
+      ...item,
+      zoneEgressInsight: insight,
+      zoneEgress,
+      // it is possible to have zoneEgresses on a 'disabled' zone but we don't
+      // want to do anything special about that just now at least
+      state: typeof insight?.connectedSubscription !== 'undefined' ? 'online' : 'offline',
+    }
+  },
+  fromCollection: (collection: CollectionResponse<PartialZoneEgressOverview>): CollectionResponse<ZoneEgressOverview> => {
+    return {
+      ...collection,
+      items: Array.isArray(collection.items) ? collection.items.map(ZoneEgressOverview.fromObject) : [],
+    }
+  },
+}
+function isSet<T>(value: T | null | undefined): value is T {
+  return value !== null && typeof value !== 'undefined'
+}

--- a/src/app/zone-egresses/sources.ts
+++ b/src/app/zone-egresses/sources.ts
@@ -1,7 +1,7 @@
+import { ZoneEgressOverview, ZoneEgress } from './data'
 import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
-import type { ZoneEgressOverview, ZoneEgress } from '@/types/index.d'
 type PaginationParams = {
   size: number
   page: number
@@ -42,7 +42,7 @@ export const sources = (api: KumaApi) => {
         })
         res.total = res.items.length
       }
-      return res
+      return ZoneEgressOverview.fromCollection(res)
     },
 
     '/zone-egresses/:name': async (params: DetailParams, source: Closeable) => {
@@ -50,7 +50,7 @@ export const sources = (api: KumaApi) => {
 
       const { name } = params
 
-      return await api.getZoneEgress({ name })
+      return ZoneEgress.fromObject(await api.getZoneEgress({ name }))
     },
 
     '/zone-egresses/:name/data-path/:dataPath': (params: EnvoyDataParams, source: Closeable) => {
@@ -67,7 +67,7 @@ export const sources = (api: KumaApi) => {
       const { size } = params
       const offset = params.size * (params.page - 1)
 
-      return await api.getAllZoneEgressOverviews({ size, offset })
+      return ZoneEgressOverview.fromCollection(await api.getAllZoneEgressOverviews({ size, offset }))
     },
 
     '/zone-egress-overviews/:name': async (params: DetailParams, source: Closeable) => {
@@ -75,7 +75,7 @@ export const sources = (api: KumaApi) => {
 
       const { name } = params
 
-      return await api.getZoneEgressOverview({ name })
+      return ZoneEgressOverview.fromObject(await api.getZoneEgressOverview({ name }))
     },
   }
 }

--- a/src/app/zone-egresses/views/ZoneEgressConfigView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressConfigView.vue
@@ -33,7 +33,7 @@
           <template v-else>
             <ResourceCodeBlock
               id="code-block-zone-egress"
-              :resource="data"
+              :resource="data.config"
               :resource-fetcher="(params) => kumaApi.getZoneEgress({ name: route.params.zoneEgress }, params)"
               is-searchable
               :query="route.params.codeSearch"

--- a/src/app/zone-egresses/views/ZoneEgressDetailView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressDetailView.vue
@@ -16,7 +16,7 @@
               </template>
 
               <template #body>
-                <StatusBadge :status="getItemStatusFromInsight(props.data.zoneEgressInsight)" />
+                <StatusBadge :status="props.data.state" />
               </template>
             </DefinitionCard>
 
@@ -26,8 +26,8 @@
               </template>
 
               <template #body>
-                <template v-if="props.data.zoneEgress.networking?.address && props.data.zoneEgress.networking?.port">
-                  <TextWithCopyButton :text="`${props.data.zoneEgress.networking.address}:${props.data.zoneEgress.networking.port}`" />
+                <template v-if="props.data.zoneEgress.socketAddress.length > 0">
+                  <TextWithCopyButton :text="props.data.zoneEgress.socketAddress" />
                 </template>
 
                 <template v-else>
@@ -60,12 +60,11 @@
 </template>
 
 <script lang="ts" setup>
+import type { ZoneEgressOverview } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
-import type { ZoneEgressOverview } from '@/types/index.d'
-import { getItemStatusFromInsight } from '@/utilities/dataplane'
 
 const props = defineProps<{
   data: ZoneEgressOverview

--- a/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
@@ -52,8 +52,8 @@
 
 <script lang="ts" setup>
 import ZoneEgressSummary from '../components/ZoneEgressSummary.vue'
+import type { ZoneEgressOverview } from '../data'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
-import type { ZoneEgressOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 
 const { t } = useI18n()

--- a/src/test-support/mocks/src/zoneegresses/_/_overview.ts
+++ b/src/test-support/mocks/src/zoneegresses/_/_overview.ts
@@ -22,47 +22,51 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
         },
       },
       zoneEgressInsight: {
-        subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
-          return {
-            id: fake.string.uuid(),
-            controlPlaneInstanceId: fake.hacker.noun(),
-            ...fake.kuma.connection(item, i, arr),
-            generation: 409,
-            status: {
-              lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-              total: {
-                responsesSent: `${fake.number.int(30)}`,
-                responsesAcknowledged: `${fake.number.int(30)}`,
-              },
-              cds: {
-                responsesSent: `${fake.number.int(30)}`,
-                responsesAcknowledged: `${fake.number.int(30)}`,
-              },
-              eds: {
-                responsesSent: `${fake.number.int(30)}`,
-                responsesAcknowledged: `${fake.number.int(30)}`,
-              },
-              lds: {
-                responsesSent: `${fake.number.int(30)}`,
-                responsesAcknowledged: `${fake.number.int(30)}`,
-              },
-              rds: {},
-            },
-            version: {
-              kumaDp: {
-                version: '1.2.1',
-                gitTag: '1.2.1',
-                gitCommit: 'e88ec407e669c47d3dc9ef32fcde60e2f31c0c4d',
-                buildDate: '2021-06-30T14:32:58Z',
-              },
-              envoy: {
-                version: '1.18.3',
-                build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
-              },
-            },
+        ...(subscriptionCount !== 0
+          ? {
+            subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
+              return {
+                id: fake.string.uuid(),
+                controlPlaneInstanceId: fake.hacker.noun(),
+                ...fake.kuma.connection(item, i, arr),
+                generation: 409,
+                status: {
+                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                  total: {
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
+                  },
+                  cds: {
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
+                  },
+                  eds: {
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
+                  },
+                  lds: {
+                    responsesSent: `${fake.number.int(30)}`,
+                    responsesAcknowledged: `${fake.number.int(30)}`,
+                  },
+                  rds: {},
+                },
+                version: {
+                  kumaDp: {
+                    version: '1.2.1',
+                    gitTag: '1.2.1',
+                    gitCommit: 'e88ec407e669c47d3dc9ef32fcde60e2f31c0c4d',
+                    buildDate: '2021-06-30T14:32:58Z',
+                  },
+                  envoy: {
+                    version: '1.18.3',
+                    build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
+                  },
+                },
 
+              }
+            }),
           }
-        }),
+          : {}),
       },
     },
   }

--- a/src/test-support/mocks/src/zoneegresses/_overview.ts
+++ b/src/test-support/mocks/src/zoneegresses/_overview.ts
@@ -5,12 +5,12 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     req,
     '/zoneegresses/_overview',
   )
-  const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
+        const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
         const id = offset + i
         const zoneEgressName = `${fake.hacker.noun()}-${id}`
         const zone = `${fake.hacker.noun()}-${id}`
@@ -32,47 +32,51 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             },
           },
           zoneEgressInsight: {
-            subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
-              return {
-                id: fake.string.uuid(),
-                controlPlaneInstanceId: fake.hacker.noun(),
-                ...fake.kuma.connection(item, i, arr),
-                generation: 409,
-                status: {
-                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-                  total: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  cds: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  eds: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  lds: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  rds: {},
-                },
-                version: {
-                  kumaDp: {
-                    version: '1.2.1',
-                    gitTag: '1.2.1',
-                    gitCommit: 'e88ec407e669c47d3dc9ef32fcde60e2f31c0c4d',
-                    buildDate: '2021-06-30T14:32:58Z',
-                  },
-                  envoy: {
-                    version: '1.18.3',
-                    build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
-                  },
-                },
+            ...(subscriptionCount !== 0
+              ? {
+                subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
+                  return {
+                    id: fake.string.uuid(),
+                    controlPlaneInstanceId: fake.hacker.noun(),
+                    ...fake.kuma.connection(item, i, arr),
+                    generation: 409,
+                    status: {
+                      lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                      total: {
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
+                      },
+                      cds: {
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
+                      },
+                      eds: {
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
+                      },
+                      lds: {
+                        responsesSent: `${fake.number.int(30)}`,
+                        responsesAcknowledged: `${fake.number.int(30)}`,
+                      },
+                      rds: {},
+                    },
+                    version: {
+                      kumaDp: {
+                        version: '1.2.1',
+                        gitTag: '1.2.1',
+                        gitCommit: 'e88ec407e669c47d3dc9ef32fcde60e2f31c0c4d',
+                        buildDate: '2021-06-30T14:32:58Z',
+                      },
+                      envoy: {
+                        version: '1.18.3',
+                        build: '98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL',
+                      },
+                    },
 
+                  }
+                }),
               }
-            }),
+              : {}),
           },
         }
       }),


### PR DESCRIPTION
Reduces the majority of our ZoneEgress related reshaping functions, copy/pasta'ed from https://github.com/kumahq/kuma-gui/pull/1867 with `availableServices` and `advertisedSocketAddress` removed.

This is pretty much the same approach as https://github.com/kumahq/kuma-gui/pull/1854 but has the additional weirdness of two types of ZoneEgress depending one whether its the root object or the child object. For the moment I'm copy/pasta'ing around this, but I a better approach would be to apply `Entity` conditionally, but I don't want to do that (or something else) here yet.

See https://github.com/kumahq/kuma-gui/issues/1264 and https://github.com/kumahq/kuma-gui/pull/1867

No tests here yet, or even a branch this time, I just copy pasted it from https://github.com/kumahq/kuma-gui/pull/1867 and didn't want to copy pasta the tests again at least not yet.

Also note this is currently in draft until https://github.com/kumahq/kuma-gui/pull/1867 is approved (this PR may need amends depending on what happens with https://github.com/kumahq/kuma-gui/pull/1867)