### PR TITLE
refactor(dataplanes): hook-up data transformations to data sourcing

### DIFF
--- a/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/features/mesh/dataplanes/DataplanePolicies.feature
@@ -299,6 +299,8 @@ Feature: Dataplane policies
             networking:
               gateway:
                 type: DELEGATED
+                tags:
+                  kuma.io/service: service-1
         """
 
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
@@ -314,6 +316,8 @@ Feature: Dataplane policies
             networking:
               gateway:
                 type: !!js/undefined
+                tags:
+                  kuma.io/service: service-1
         """
 
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
@@ -335,6 +339,8 @@ Feature: Dataplane policies
             networking:
               gateway:
                 type: BUILTIN
+                tags:
+                  kuma.io/service: service-1
         """
 
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -16,7 +16,7 @@
     :page-number="props.pageNumber"
     :page-size="props.pageSize"
     :total="props.total"
-    :items="props.items ? transformToTableData(props.items) : undefined"
+    :items="props.items"
     :error="props.error"
     :is-selected-row="props.isSelectedRow"
     @change="emit('change', $event)"
@@ -28,7 +28,7 @@
       <slot name="toolbar" />
     </template>
 
-    <template #name="{ row: item }: { row: DataPlaneOverviewTableRow }">
+    <template #name="{ row: item }">
       <RouterLink
         class="name-link"
         :title="item.name"
@@ -48,25 +48,29 @@
       </RouterLink>
     </template>
 
-    <template #services="{ row }: { row: DataPlaneOverviewTableRow }">
+    <template #type="{ row }">
+      {{ t(`data-planes.type.${row.dataplaneType}`) }}
+    </template>
+
+    <template #services="{ row }">
       <KTruncate
         v-if="row.services.length > 0"
         width="auto"
       >
         <div
-          v-for="(tag, index) in row.services"
+          v-for="(service, index) in row.services"
           :key="index"
         >
-          <TextWithCopyButton :text="tag.value">
+          <TextWithCopyButton :text="service">
             <RouterLink
               :to="{
                 name: 'service-detail-view',
                 params: {
-                  service: tag.value,
+                  service,
                 },
               }"
             >
-              {{ tag.value }}
+              {{ service }}
             </RouterLink>
           </TextWithCopyButton>
         </div>
@@ -77,28 +81,34 @@
       </template>
     </template>
 
-    <template #status="{ row }: { row: DataPlaneOverviewTableRow }">
+    <template #certificate="{ row }">
+      <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+        {{ formatIsoDate(row.dataplaneInsight.mTLS.certificateExpirationTime) }}
+      </template>
+
+      <template v-else>
+        {{ t('data-planes.components.data-plane-list.certificate.none') }}
+      </template>
+    </template>
+
+    <template #status="{ row }">
       <StatusBadge :status="row.status" />
     </template>
 
-    <template #warnings="{ row: item }: { row: DataPlaneOverviewTableRow }">
-      <KTooltip
-        v-if="Object.values(item.warnings).some((item) => item)"
-      >
-        <template
-          #content
-        >
+    <template #warnings="{ row }">
+      <KTooltip v-if="row.isCertExpired || row.warnings.length > 0">
+        <template #content>
           <ul>
-            <template
-              v-for="(warning, i) in item.warnings"
-              :key="i"
-            >
-              <li v-if="warning">
-                {{ t(`data-planes.components.data-plane-list.${i}`) }}
-              </li>
+            <template v-if="row.warnings.length > 0">
+              <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+            </template>
+
+            <template v-if="row.isCertExpired">
+              <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
             </template>
           </ul>
         </template>
+
         <WarningIcon
           class="mr-1"
           :size="KUI_ICON_SIZE_30"
@@ -111,7 +121,7 @@
       </template>
     </template>
 
-    <template #details="{ row }: { row: DataPlaneOverviewTableRow }">
+    <template #details="{ row }">
       <RouterLink
         class="details-link"
         data-testid="details-link"
@@ -138,28 +148,14 @@
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { ArrowRightIcon } from '@kong/icons'
 
-import { getDataplaneType, getIsCertExpired, getStatusAndReason, getTags, getWarnings } from '../data/index'
+import type { DataplaneOverview } from '../data/index'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import WarningIcon from '@/app/common/WarningIcon.vue'
-import type { DataPlaneOverview, LabelValue, StatusKeyword } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 
 const { t, formatIsoDate } = useI18n()
-
-type DataPlaneOverviewTableRow = {
-  type: string
-  name: string
-  mesh: string
-  services: LabelValue[]
-  status: StatusKeyword
-  warnings: {
-    version_mismatch: boolean
-    cert_expired: boolean
-  }
-  certificate: string
-}
 
 type ChangeValue = {
   page?: number
@@ -170,11 +166,10 @@ const props = withDefaults(defineProps<{
   total?: number
   pageNumber: number
   pageSize: number
-  items: DataPlaneOverview[] | undefined
+  items: DataplaneOverview[] | undefined
   error: Error | undefined
   isSelectedRow: ((row: any) => boolean) | null
   summaryRouteName: string
-  canUseZones: boolean
 }>(), {
   total: 0,
   isSelectedRow: null,
@@ -183,41 +178,6 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   (event: 'change', value: ChangeValue): void
 }>()
-
-function transformToTableData(dataPlaneOverviews: DataPlaneOverview[]): DataPlaneOverviewTableRow[] {
-  return dataPlaneOverviews.map((dataPlaneOverview) => {
-    const { mesh, name } = dataPlaneOverview
-    const type = t(`data-planes.type.${getDataplaneType(dataPlaneOverview)}`)
-
-    const tags = getTags(dataPlaneOverview)
-    const services = tags.filter((tag) => tag.label === 'kuma.io/service')
-
-    const { status } = getStatusAndReason(dataPlaneOverview)
-
-    let certificate
-    if (dataPlaneOverview.dataplaneInsight?.mTLS?.certificateExpirationTime) {
-      certificate = formatIsoDate(dataPlaneOverview.dataplaneInsight.mTLS.certificateExpirationTime)
-    } else {
-      certificate = t('data-planes.components.data-plane-list.certificate.none')
-    }
-
-    const warnings = getWarnings(dataPlaneOverview, props.canUseZones)
-    const isCertExpired = getIsCertExpired(dataPlaneOverview)
-
-    return {
-      name,
-      type,
-      mesh,
-      services,
-      status,
-      warnings: {
-        version_mismatch: warnings.length > 0,
-        cert_expired: isCertExpired,
-      },
-      certificate,
-    }
-  })
-}
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/data-planes/components/DataPlaneSummary.vue
+++ b/src/app/data-planes/components/DataPlaneSummary.vue
@@ -8,11 +8,11 @@
 
         <template #body>
           <div class="status-with-reason">
-            <StatusBadge :status="statusWithReason.status" />
+            <StatusBadge :status="props.dataplaneOverview.status" />
 
             <KTooltip
-              v-if="statusWithReason.reason.length > 0"
-              :label="statusWithReason.reason.join(', ')"
+              v-if="props.dataplaneOverview.unhealthyInbounds.length > 0"
+              :label="props.dataplaneOverview.unhealthyInbounds.map((inbound) => t('data-planes.routes.item.unhealthy_inbound', inbound)).join(', ')"
               class="reason-tooltip"
               position-fixed
             >
@@ -32,8 +32,8 @@
         </template>
 
         <template #body>
-          <template v-if="formattedLastUpdateTime">
-            {{ formattedLastUpdateTime }}
+          <template v-if="props.dataplaneOverview.lastUpdateTime">
+            {{ formatIsoDate(props.dataplaneOverview.lastUpdateTime) }}
           </template>
 
           <template v-else>
@@ -146,27 +146,19 @@
 <script lang="ts" setup>
 import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { InfoIcon } from '@kong/icons'
-import { computed } from 'vue'
 
-import { getLastUpdateTime, getStatusAndReason } from '../data'
+import type { DataplaneOverview } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TagList from '@/app/common/TagList.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import type { DataPlaneOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 
 const { t, formatIsoDate } = useI18n()
 
 const props = defineProps<{
-  dataplaneOverview: DataPlaneOverview
+  dataplaneOverview: DataplaneOverview
 }>()
-
-const statusWithReason = computed(() => getStatusAndReason(props.dataplaneOverview))
-const formattedLastUpdateTime = computed(() => {
-  const lastUpdateTime = getLastUpdateTime(props.dataplaneOverview)
-  return lastUpdateTime !== undefined ? formatIsoDate(lastUpdateTime) : t('common.detail.none')
-})
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/data-planes/data/index.spec.ts
+++ b/src/app/data-planes/data/index.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 
-import { getDataplaneType, getIsCertExpired, getLastUpdateTime, getStatusAndReason, getTags, getWarnings } from './index'
+import { Dataplane, DataplaneInsight, DataplaneNetworking, DataplaneOverview } from './index'
 
 type TestCase<T extends (...args: any) => any> = {
   message: string
@@ -9,457 +9,171 @@ type TestCase<T extends (...args: any) => any> = {
 }
 
 describe('dataplanes data transformations', () => {
-  describe('getLastUpdateTime', () => {
-    test.each<TestCase<typeof getLastUpdateTime>>([
+  describe('DataplaneNetworking', () => {
+    test.each<TestCase<typeof DataplaneNetworking.fromObject>>([
+      {
+        message: 'minimal',
+        parameters: [{
+          address: '',
+        }],
+        expected: {
+          address: '',
+        },
+      },
+    ])('.fromObject: $message', ({ parameters, expected }) => {
+      expect(DataplaneNetworking.fromObject(...parameters)).toStrictEqual(expected)
+    })
+  })
+
+  describe('Dataplane', () => {
+    test.each<TestCase<typeof Dataplane.fromObject>>([
+      {
+        message: 'minimal',
+        parameters: [{
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'Dataplane',
+          creationTime: '',
+          modificationTime: '',
+          networking: {
+            address: '',
+          },
+        }],
+        expected: {
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'Dataplane',
+          creationTime: '',
+          modificationTime: '',
+          networking: {
+            address: '',
+          },
+        },
+      },
+    ])('.fromObject: $message', ({ parameters, expected }) => {
+      expect(Dataplane.fromObject(...parameters)).toStrictEqual(expected)
+    })
+  })
+
+  describe('DataplaneInsight', () => {
+    test.each<TestCase<typeof DataplaneInsight.fromObject>>([
+      {
+        message: 'no insight',
+        parameters: [undefined],
+        expected: {
+          subscriptions: [],
+          connectedSubscription: undefined,
+        },
+      },
       {
         message: 'empty subscriptions',
         parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-            },
-          },
+          subscriptions: [],
         }],
-        expected: undefined,
+        expected: {
+          subscriptions: [],
+          connectedSubscription: undefined,
+        },
       },
       {
-        message: 'single subscription',
+        message: 'connected subscription',
         parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-            },
-          },
-          dataplaneInsight: {
-            subscriptions: [
-              {
-                id: '',
-                controlPlaneInstanceId: '',
-                status: {
-                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-                  total: {},
-                  cds: {},
-                  eds: {},
-                  lds: {},
-                  rds: {},
-                },
+          subscriptions: [
+            {
+              id: '',
+              controlPlaneInstanceId: '',
+              status: {
+                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                total: {},
+                cds: {},
+                eds: {},
+                lds: {},
+                rds: {},
               },
-            ],
-          },
+              connectTime: '2021-07-13T09:03:11.614941842Z',
+            },
+          ],
         }],
-        expected: '2021-07-13T09:03:11.614941842Z',
+        expected: {
+          subscriptions: [
+            {
+              id: '',
+              controlPlaneInstanceId: '',
+              status: {
+                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                total: {},
+                cds: {},
+                eds: {},
+                lds: {},
+                rds: {},
+              },
+              connectTime: '2021-07-13T09:03:11.614941842Z',
+            },
+          ],
+          connectedSubscription: {
+            id: '',
+            controlPlaneInstanceId: '',
+            status: {
+              lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+              total: {},
+              cds: {},
+              eds: {},
+              lds: {},
+              rds: {},
+            },
+            connectTime: '2021-07-13T09:03:11.614941842Z',
+          },
+        },
       },
       {
-        message: 'multiple subscriptions',
+        message: 'disconnected subscription',
         parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
+          subscriptions: [
+            {
+              id: '',
+              controlPlaneInstanceId: '',
+              status: {
+                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                total: {},
+                cds: {},
+                eds: {},
+                lds: {},
+                rds: {},
+              },
+              connectTime: '2021-07-13T09:03:11.614941842Z',
+              disconnectTime: '2021-07-14T09:03:11.614941842Z',
             },
-          },
-          dataplaneInsight: {
-            subscriptions: [
-              {
-                id: '',
-                controlPlaneInstanceId: '',
-                status: {
-                  lastUpdateTime: '2020-07-13T09:03:11.614941842Z',
-                  total: {},
-                  cds: {},
-                  eds: {},
-                  lds: {},
-                  rds: {},
-                },
-              },
-              {
-                id: '',
-                controlPlaneInstanceId: '',
-                status: {
-                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-                  total: {},
-                  cds: {},
-                  eds: {},
-                  lds: {},
-                  rds: {},
-                },
-              },
-            ],
-          },
+          ],
         }],
-        expected: '2021-07-13T09:03:11.614941842Z',
+        expected: {
+          subscriptions: [
+            {
+              id: '',
+              controlPlaneInstanceId: '',
+              status: {
+                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                total: {},
+                cds: {},
+                eds: {},
+                lds: {},
+                rds: {},
+              },
+              connectTime: '2021-07-13T09:03:11.614941842Z',
+              disconnectTime: '2021-07-14T09:03:11.614941842Z',
+            },
+          ],
+          connectedSubscription: undefined,
+        },
       },
-    ])('$message', ({ parameters, expected }) => {
-      expect(getLastUpdateTime(...parameters)).toStrictEqual(expected)
+    ])('.fromObject: $message', ({ parameters, expected }) => {
+      expect(DataplaneInsight.fromObject(...parameters)).toStrictEqual(expected)
     })
   })
 
-  describe('getStatusAndReason', () => {
-    test.each<TestCase<typeof getStatusAndReason>>([
-      {
-        message: 'Built-in gateway: status determination based on subscriptions (online)',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-              gateway: {
-                type: 'BUILTIN',
-                tags: {
-                  'kuma.io/service': '',
-                },
-              },
-            },
-          },
-          dataplaneInsight: {
-            subscriptions: [
-              {
-                id: '',
-                controlPlaneInstanceId: '',
-                connectTime: '1',
-                status: {
-                  lastUpdateTime: '',
-                  total: {},
-                  cds: {},
-                  eds: {},
-                  lds: {},
-                  rds: {},
-                },
-              },
-            ],
-          },
-        }],
-        expected: {
-          status: 'online',
-          reason: [],
-        },
-      },
-      {
-        message: 'Built-in gateway: status determination based on subscriptions (offline)',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-              gateway: {
-                type: 'BUILTIN',
-                tags: {
-                  'kuma.io/service': '',
-                },
-              },
-            },
-          },
-          dataplaneInsight: {
-            subscriptions: [
-              {
-                id: '',
-                controlPlaneInstanceId: '',
-                connectTime: '1',
-                disconnectTime: '1',
-                status: {
-                  lastUpdateTime: '',
-                  total: {},
-                  cds: {},
-                  eds: {},
-                  lds: {},
-                  rds: {},
-                },
-              },
-            ],
-          },
-        }],
-        expected: {
-          status: 'offline',
-          reason: [],
-        },
-      },
-      {
-        message: 'Standard proxy: status determination based on subscriptions (online)',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-              inbound: [
-                {
-                  health: {
-                    ready: true,
-                  },
-                  tags: {
-                    'kuma.io/service': '',
-                  },
-                  port: 1,
-                },
-              ],
-            },
-          },
-          dataplaneInsight: {
-            subscriptions: [
-              {
-                id: '',
-                controlPlaneInstanceId: '',
-                connectTime: '1',
-                status: {
-                  lastUpdateTime: '',
-                  total: {},
-                  cds: {},
-                  eds: {},
-                  lds: {},
-                  rds: {},
-                },
-              },
-            ],
-          },
-        }],
-        expected: {
-          status: 'online',
-          reason: [],
-        },
-      },
-      {
-        message: 'Standard proxy: status determination based on subscriptions (offline)',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-              inbound: [
-                {
-                  health: {
-                    ready: true,
-                  },
-                  tags: {
-                    'kuma.io/service': '',
-                  },
-                  port: 1,
-                },
-              ],
-            },
-          },
-          dataplaneInsight: {
-            subscriptions: [
-              {
-                id: '',
-                controlPlaneInstanceId: '',
-                connectTime: '1',
-                disconnectTime: '1',
-                status: {
-                  lastUpdateTime: '',
-                  total: {},
-                  cds: {},
-                  eds: {},
-                  lds: {},
-                  rds: {},
-                },
-              },
-            ],
-          },
-        }],
-        expected: {
-          status: 'offline',
-          reason: [],
-        },
-      },
-      {
-        message: 'Standard proxy: one unhealthy inbound out of one inbound means offline',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-              inbound: [
-                {
-                  health: {
-                    ready: false,
-                  },
-                  port: 1,
-                  tags: {
-                    'kuma.io/service': 'service',
-                  },
-                },
-              ],
-            },
-          },
-        }],
-        expected: {
-          status: 'offline',
-          reason: ['Inbound on port 1 is not ready (kuma.io/service: service)'],
-        },
-      },
-      {
-        message: 'Standard proxy: one unhealthy inbound out of two inbounds means partially_degraded',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-              inbound: [
-                {
-                  health: {
-                    ready: false,
-                  },
-                  port: 1,
-                  tags: {
-                    'kuma.io/service': 'service',
-                  },
-                },
-                {
-                  health: {
-                    ready: true,
-                  },
-                  port: 1,
-                  tags: {
-                    'kuma.io/service': '',
-                  },
-                },
-              ],
-            },
-          },
-        }],
-        expected: {
-          status: 'partially_degraded',
-          reason: ['Inbound on port 1 is not ready (kuma.io/service: service)'],
-        },
-      },
-    ])('$message', ({ parameters, expected }) => {
-      expect(getStatusAndReason(...parameters)).toStrictEqual(expected)
-    })
-  })
-
-  describe('getTags', () => {
-    test.each<TestCase<typeof getTags>>([
-      {
-        message: 'no tags',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-            },
-          },
-        }],
-        expected: [],
-      },
-      {
-        message: 'tags from inbounds',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-              inbound: [
-                {
-                  health: {
-                    ready: true,
-                  },
-                  tags: {
-                    'kuma.io/service': 'service-1',
-                    'kuma.io/zone': 'zone-1',
-                  },
-                  port: 1,
-                },
-                {
-                  health: {
-                    ready: true,
-                  },
-                  tags: {
-                    'kuma.io/service': 'service-2',
-                    'kuma.io/protocol': 'http',
-                  },
-                  port: 1,
-                },
-              ],
-            },
-          },
-        }],
-        expected: [
-          { label: 'kuma.io/protocol', value: 'http' },
-          { label: 'kuma.io/service', value: 'service-1' },
-          { label: 'kuma.io/service', value: 'service-2' },
-          { label: 'kuma.io/zone', value: 'zone-1' },
-        ],
-      },
-      {
-        message: 'tags from gateway',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-              gateway: {
-                tags: {
-                  'kuma.io/service': 'service-1',
-                  'kuma.io/zone': 'zone-1',
-                  'kuma.io/protocol': 'http',
-                },
-              },
-            },
-          },
-        }],
-        expected: [
-          { label: 'kuma.io/protocol', value: 'http' },
-          { label: 'kuma.io/service', value: 'service-1' },
-          { label: 'kuma.io/zone', value: 'zone-1' },
-        ],
-      },
-    ])('$message', ({ parameters, expected }) => {
-      expect(getTags(...parameters)).toStrictEqual(expected)
-    })
-  })
-
-  describe('getIsCertExpired', () => {
+  describe('DataplaneOverview', () => {
     beforeAll(() => {
       vi.useFakeTimers()
+      // Needed to test certificate expiration.
       vi.setSystemTime(new Date('2023-11-28T13:00:00Z'))
     })
 
@@ -467,10 +181,25 @@ describe('dataplanes data transformations', () => {
       vi.useRealTimers()
     })
 
-    test.each<TestCase<typeof getIsCertExpired>>([
+    test.each<TestCase<typeof DataplaneOverview.fromObject>>([
       {
-        message: 'no mTLS',
-        parameters: [{
+        message: 'Standard proxy: empty subscriptions -> offline',
+        parameters: [
+          {
+            mesh: 'default',
+            name: 'dataplane',
+            type: 'DataplaneOverview',
+            creationTime: '',
+            modificationTime: '',
+            dataplane: {
+              networking: {
+                address: '',
+              },
+            },
+          },
+          true,
+        ],
+        expected: {
           mesh: 'default',
           name: 'dataplane',
           type: 'DataplaneOverview',
@@ -481,12 +210,88 @@ describe('dataplanes data transformations', () => {
               address: '',
             },
           },
-        }],
-        expected: false,
+          dataplaneInsight: {
+            subscriptions: [],
+            connectedSubscription: undefined,
+          },
+          dataplaneType: 'standard',
+          status: 'offline',
+          unhealthyInbounds: [],
+          lastUpdateTime: undefined,
+          warnings: [],
+          isCertExpired: false,
+          services: [],
+        },
       },
       {
-        message: 'mTLS cert expired',
-        parameters: [{
+        message: 'Standard proxy: healthy inbounds + connected subscription -> online',
+        parameters: [
+          {
+            mesh: 'default',
+            name: 'dataplane',
+            type: 'DataplaneOverview',
+            creationTime: '',
+            modificationTime: '',
+            dataplane: {
+              networking: {
+                address: '',
+                inbound: [
+                  {
+                    health: {
+                      ready: true,
+                    },
+                    tags: {
+                      'kuma.io/service': '',
+                      'kuma.io/zone': '',
+                    },
+                    port: 1,
+                  },
+                ],
+              },
+            },
+            dataplaneInsight: {
+              mTLS: {
+                certificateExpirationTime: '2023-11-27T13:00:00Z',
+                lastCertificateRegeneration: '',
+                certificateRegenerations: 0,
+                issuedBackend: '',
+                supportedBackends: [],
+              },
+              subscriptions: [
+                {
+                  id: '',
+                  controlPlaneInstanceId: '',
+                  status: {
+                    lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                    total: {},
+                    cds: {},
+                    eds: {},
+                    lds: {},
+                    rds: {},
+                  },
+                  connectTime: '2021-07-13T09:03:11.614941842Z',
+                  version: {
+                    kumaDp: {
+                      version: '1.2.3',
+                      gitTag: '',
+                      gitCommit: '',
+                      buildDate: '',
+                      kumaCpCompatible: false,
+                    },
+                    envoy: {
+                      version: '4.5.6',
+                      build: '',
+                      kumaDpCompatible: false,
+                    },
+                    dependencies: {},
+                  },
+                },
+              ],
+            },
+          },
+          true,
+        ],
+        expected: {
           mesh: 'default',
           name: 'dataplane',
           type: 'DataplaneOverview',
@@ -495,6 +300,18 @@ describe('dataplanes data transformations', () => {
           dataplane: {
             networking: {
               address: '',
+              inbound: [
+                {
+                  health: {
+                    ready: true,
+                  },
+                  tags: {
+                    'kuma.io/service': '',
+                    'kuma.io/zone': '',
+                  },
+                  port: 1,
+                },
+              ],
             },
           },
           dataplaneInsight: {
@@ -505,105 +322,19 @@ describe('dataplanes data transformations', () => {
               issuedBackend: '',
               supportedBackends: [],
             },
-            subscriptions: [],
-          },
-        }],
-        expected: true,
-      },
-      {
-        message: 'mTLS cert not expired',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-            },
-          },
-          dataplaneInsight: {
-            mTLS: {
-              certificateExpirationTime: '2023-11-29T13:00:00Z',
-              lastCertificateRegeneration: '',
-              certificateRegenerations: 0,
-              issuedBackend: '',
-              supportedBackends: [],
-            },
-            subscriptions: [],
-          },
-        }],
-        expected: false,
-      },
-    ])('$message', (item) => {
-      expect(getIsCertExpired(...item.parameters)).toStrictEqual(item.expected)
-    })
-  })
-
-  describe('getWarnings', () => {
-    test.each<TestCase<typeof getWarnings>>([
-      {
-        message: 'no insights',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-            },
-          },
-        }, false],
-        expected: [],
-      },
-      {
-        message: 'all warnings',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-              inbound: [
-                {
-                  health: {
-                    ready: true,
-                  },
-                  tags: {
-                    'kuma.io/service': '',
-                    'kuma.io/zone': 'zone-1',
-                  },
-                  port: 1,
-                },
-              ],
-            },
-          },
-          dataplaneInsight: {
-            mTLS: {
-              certificateExpirationTime: '2023-11-29T13:00:00Z',
-              lastCertificateRegeneration: '',
-              certificateRegenerations: 0,
-              issuedBackend: '',
-              supportedBackends: [],
-            },
             subscriptions: [
               {
                 id: '',
                 controlPlaneInstanceId: '',
                 status: {
-                  lastUpdateTime: '2020-07-13T09:03:11.614941842Z',
+                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
                   total: {},
                   cds: {},
                   eds: {},
                   lds: {},
                   rds: {},
                 },
+                connectTime: '2021-07-13T09:03:11.614941842Z',
                 version: {
                   kumaDp: {
                     version: '1.2.3',
@@ -621,40 +352,118 @@ describe('dataplanes data transformations', () => {
                 },
               },
             ],
-          },
-        }, true],
-        expected: [
-          {
-            kind: 'INCOMPATIBLE_UNSUPPORTED_KUMA_DP',
-            payload: {
-              kumaDp: '1.2.3',
+            connectedSubscription: {
+              id: '',
+              controlPlaneInstanceId: '',
+              status: {
+                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                total: {},
+                cds: {},
+                eds: {},
+                lds: {},
+                rds: {},
+              },
+              connectTime: '2021-07-13T09:03:11.614941842Z',
+              version: {
+                kumaDp: {
+                  version: '1.2.3',
+                  gitTag: '',
+                  gitCommit: '',
+                  buildDate: '',
+                  kumaCpCompatible: false,
+                },
+                envoy: {
+                  version: '4.5.6',
+                  build: '',
+                  kumaDpCompatible: false,
+                },
+                dependencies: {},
+              },
             },
           },
-          {
-            kind: 'INCOMPATIBLE_UNSUPPORTED_ENVOY',
-            payload: {
-              envoy: '4.5.6',
-              kumaDp: '1.2.3',
+          dataplaneType: 'standard',
+          status: 'online',
+          unhealthyInbounds: [],
+          lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+          warnings: [
+            {
+              kind: 'INCOMPATIBLE_UNSUPPORTED_KUMA_DP',
+              payload: {
+                kumaDp: '1.2.3',
+              },
             },
-          },
-          {
-            kind: 'INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS',
-            payload: {
-              kumaDp: '1.2.3',
+            {
+              kind: 'INCOMPATIBLE_UNSUPPORTED_ENVOY',
+              payload: {
+                envoy: '4.5.6',
+                kumaDp: '1.2.3',
+              },
             },
-          },
-        ],
+            {
+              kind: 'INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS',
+              payload: {
+                kumaDp: '1.2.3',
+              },
+            },
+          ],
+          isCertExpired: true,
+          services: [''],
+        },
       },
-    ])('$message', ({ parameters, expected }) => {
-      expect(getWarnings(...parameters)).toStrictEqual(expected)
-    })
-  })
-
-  describe('getDataplaneType', () => {
-    test.each<TestCase<typeof getDataplaneType>>([
       {
-        message: 'Standard proxy',
-        parameters: [{
+        message: 'Standard proxy: healthy inbounds + disconnected subscription -> offline',
+        parameters: [
+          {
+            mesh: 'default',
+            name: 'dataplane',
+            type: 'DataplaneOverview',
+            creationTime: '',
+            modificationTime: '',
+            dataplane: {
+              networking: {
+                address: '',
+                inbound: [
+                  {
+                    health: {
+                      ready: true,
+                    },
+                    tags: {
+                      'kuma.io/service': '',
+                    },
+                    port: 1,
+                  },
+                ],
+              },
+            },
+            dataplaneInsight: {
+              mTLS: {
+                certificateExpirationTime: '2023-11-29T13:00:00Z',
+                lastCertificateRegeneration: '',
+                certificateRegenerations: 0,
+                issuedBackend: '',
+                supportedBackends: [],
+              },
+              subscriptions: [
+                {
+                  id: '',
+                  controlPlaneInstanceId: '',
+                  status: {
+                    lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                    total: {},
+                    cds: {},
+                    eds: {},
+                    lds: {},
+                    rds: {},
+                  },
+                  connectTime: '2021-07-13T09:03:11.614941842Z',
+                  disconnectTime: '2021-07-13T09:03:11.614941842Z',
+                },
+              ],
+            },
+          },
+          true,
+        ],
+        expected: {
           mesh: 'default',
           name: 'dataplane',
           type: 'DataplaneOverview',
@@ -663,14 +472,548 @@ describe('dataplanes data transformations', () => {
           dataplane: {
             networking: {
               address: '',
+              inbound: [
+                {
+                  health: {
+                    ready: true,
+                  },
+                  tags: {
+                    'kuma.io/service': '',
+                  },
+                  port: 1,
+                },
+              ],
             },
           },
-        }],
-        expected: 'standard',
+          dataplaneInsight: {
+            mTLS: {
+              certificateExpirationTime: '2023-11-29T13:00:00Z',
+              lastCertificateRegeneration: '',
+              certificateRegenerations: 0,
+              issuedBackend: '',
+              supportedBackends: [],
+            },
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                status: {
+                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+                connectTime: '2021-07-13T09:03:11.614941842Z',
+                disconnectTime: '2021-07-13T09:03:11.614941842Z',
+              },
+            ],
+            connectedSubscription: undefined,
+          },
+          dataplaneType: 'standard',
+          status: 'offline',
+          unhealthyInbounds: [],
+          lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+          warnings: [],
+          isCertExpired: false,
+          services: [''],
+        },
       },
       {
-        message: 'Built-in gateway',
-        parameters: [{
+        message: 'Standard proxy: only unhealthy inbounds -> offline',
+        parameters: [
+          {
+            mesh: 'default',
+            name: 'dataplane',
+            type: 'DataplaneOverview',
+            creationTime: '',
+            modificationTime: '',
+            dataplane: {
+              networking: {
+                address: '',
+                inbound: [
+                  {
+                    health: {
+                      ready: false,
+                    },
+                    tags: {
+                      'kuma.io/service': '',
+                    },
+                    port: 1,
+                  },
+                ],
+              },
+            },
+            dataplaneInsight: {
+              subscriptions: [
+                {
+                  id: '',
+                  controlPlaneInstanceId: '',
+                  status: {
+                    lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                    total: {},
+                    cds: {},
+                    eds: {},
+                    lds: {},
+                    rds: {},
+                  },
+                  connectTime: '2021-07-13T09:03:11.614941842Z',
+                },
+              ],
+            },
+          },
+          true,
+        ],
+        expected: {
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
+              inbound: [
+                {
+                  health: {
+                    ready: false,
+                  },
+                  tags: {
+                    'kuma.io/service': '',
+                  },
+                  port: 1,
+                },
+              ],
+            },
+          },
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                status: {
+                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+                connectTime: '2021-07-13T09:03:11.614941842Z',
+              },
+            ],
+            connectedSubscription: {
+              id: '',
+              controlPlaneInstanceId: '',
+              status: {
+                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                total: {},
+                cds: {},
+                eds: {},
+                lds: {},
+                rds: {},
+              },
+              connectTime: '2021-07-13T09:03:11.614941842Z',
+            },
+          },
+          dataplaneType: 'standard',
+          status: 'offline',
+          unhealthyInbounds: [{
+            port: 1,
+            service: '',
+          }],
+          lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+          warnings: [],
+          isCertExpired: false,
+          services: [''],
+        },
+      },
+      {
+        message: 'Standard proxy: partially unhealthy inbounds -> partially degraded',
+        parameters: [
+          {
+            mesh: 'default',
+            name: 'dataplane',
+            type: 'DataplaneOverview',
+            creationTime: '',
+            modificationTime: '',
+            dataplane: {
+              networking: {
+                address: '',
+                inbound: [
+                  {
+                    health: {
+                      ready: false,
+                    },
+                    port: 1,
+                    tags: {
+                      'kuma.io/service': 'service-1',
+                      'kuma.io/zone': 'zone-1',
+                    },
+                  },
+                  {
+                    health: {
+                      ready: true,
+                    },
+                    port: 1,
+                    tags: {
+                      'kuma.io/service': 'service-2',
+                      'kuma.io/zone': 'zone-1',
+                    },
+                  },
+                ],
+              },
+            },
+            dataplaneInsight: {
+              subscriptions: [
+                {
+                  id: '',
+                  controlPlaneInstanceId: '',
+                  status: {
+                    lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                    total: {},
+                    cds: {},
+                    eds: {},
+                    lds: {},
+                    rds: {},
+                  },
+                  connectTime: '2021-07-13T09:03:11.614941842Z',
+                },
+              ],
+            },
+          },
+          true,
+        ],
+        expected: {
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
+              inbound: [
+                {
+                  health: {
+                    ready: false,
+                  },
+                  port: 1,
+                  tags: {
+                    'kuma.io/service': 'service-1',
+                    'kuma.io/zone': 'zone-1',
+                  },
+                },
+                {
+                  health: {
+                    ready: true,
+                  },
+                  port: 1,
+                  tags: {
+                    'kuma.io/service': 'service-2',
+                    'kuma.io/zone': 'zone-1',
+                  },
+                },
+              ],
+            },
+          },
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                status: {
+                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+                connectTime: '2021-07-13T09:03:11.614941842Z',
+              },
+            ],
+            connectedSubscription: {
+              id: '',
+              controlPlaneInstanceId: '',
+              status: {
+                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                total: {},
+                cds: {},
+                eds: {},
+                lds: {},
+                rds: {},
+              },
+              connectTime: '2021-07-13T09:03:11.614941842Z',
+            },
+          },
+          dataplaneType: 'standard',
+          status: 'partially_degraded',
+          unhealthyInbounds: [{
+            port: 1,
+            service: 'service-1',
+          }],
+          lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+          warnings: [],
+          isCertExpired: false,
+          services: ['service-1', 'service-2'],
+        },
+      },
+      {
+        message: 'Delegated gateway + single subscription + online',
+        parameters: [
+          {
+            mesh: 'default',
+            name: 'dataplane',
+            type: 'DataplaneOverview',
+            creationTime: '',
+            modificationTime: '',
+            dataplane: {
+              networking: {
+                address: '',
+                gateway: {
+                  type: 'DELEGATED',
+                  tags: {
+                    'kuma.io/service': 'service-1',
+                    'kuma.io/zone': 'zone-1',
+                    'kuma.io/protocol': 'http',
+                  },
+                },
+              },
+            },
+            dataplaneInsight: {
+              subscriptions: [
+                {
+                  id: '',
+                  controlPlaneInstanceId: '',
+                  status: {
+                    lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                    total: {},
+                    cds: {},
+                    eds: {},
+                    lds: {},
+                    rds: {},
+                  },
+                  connectTime: '2021-07-13T09:03:11.614941842Z',
+                },
+              ],
+            },
+          },
+          true,
+        ],
+        expected: {
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
+              gateway: {
+                type: 'DELEGATED',
+                tags: {
+                  'kuma.io/service': 'service-1',
+                  'kuma.io/zone': 'zone-1',
+                  'kuma.io/protocol': 'http',
+                },
+              },
+            },
+          },
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                status: {
+                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+                connectTime: '2021-07-13T09:03:11.614941842Z',
+              },
+            ],
+            connectedSubscription: {
+              id: '',
+              controlPlaneInstanceId: '',
+              status: {
+                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                total: {},
+                cds: {},
+                eds: {},
+                lds: {},
+                rds: {},
+              },
+              connectTime: '2021-07-13T09:03:11.614941842Z',
+            },
+          },
+          dataplaneType: 'delegated',
+          status: 'online',
+          unhealthyInbounds: [],
+          lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+          warnings: [],
+          isCertExpired: false,
+          services: ['service-1'],
+        },
+      },
+      {
+        message: 'Delegated gateway + single subscription + online',
+        parameters: [
+          {
+            mesh: 'default',
+            name: 'dataplane',
+            type: 'DataplaneOverview',
+            creationTime: '',
+            modificationTime: '',
+            dataplane: {
+              networking: {
+                address: '',
+                gateway: {
+                  tags: {
+                    'kuma.io/service': 'service-1',
+                    'kuma.io/zone': 'zone-1',
+                    'kuma.io/protocol': 'http',
+                  },
+                },
+              },
+            },
+            dataplaneInsight: {
+              subscriptions: [
+                {
+                  id: '',
+                  controlPlaneInstanceId: '',
+                  status: {
+                    lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                    total: {},
+                    cds: {},
+                    eds: {},
+                    lds: {},
+                    rds: {},
+                  },
+                  connectTime: '2021-07-13T09:03:11.614941842Z',
+                },
+              ],
+            },
+          },
+          true,
+        ],
+        expected: {
+          mesh: 'default',
+          name: 'dataplane',
+          type: 'DataplaneOverview',
+          creationTime: '',
+          modificationTime: '',
+          dataplane: {
+            networking: {
+              address: '',
+              gateway: {
+                tags: {
+                  'kuma.io/service': 'service-1',
+                  'kuma.io/zone': 'zone-1',
+                  'kuma.io/protocol': 'http',
+                },
+              },
+            },
+          },
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                status: {
+                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
+                },
+                connectTime: '2021-07-13T09:03:11.614941842Z',
+              },
+            ],
+            connectedSubscription: {
+              id: '',
+              controlPlaneInstanceId: '',
+              status: {
+                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                total: {},
+                cds: {},
+                eds: {},
+                lds: {},
+                rds: {},
+              },
+              connectTime: '2021-07-13T09:03:11.614941842Z',
+            },
+          },
+          dataplaneType: 'delegated',
+          status: 'online',
+          unhealthyInbounds: [],
+          lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+          warnings: [],
+          isCertExpired: false,
+          services: ['service-1'],
+        },
+      },
+      {
+        message: 'Built-in gateway + multiple subscriptions + offline',
+        parameters: [
+          {
+            mesh: 'default',
+            name: 'dataplane',
+            type: 'DataplaneOverview',
+            creationTime: '',
+            modificationTime: '',
+            dataplane: {
+              networking: {
+                address: '',
+                gateway: {
+                  type: 'BUILTIN',
+                  tags: {
+                    'kuma.io/service': '',
+                  },
+                },
+              },
+            },
+            dataplaneInsight: {
+              subscriptions: [
+                {
+                  id: '',
+                  controlPlaneInstanceId: '',
+                  status: {
+                    lastUpdateTime: '2020-07-13T09:03:11.614941842Z',
+                    total: {},
+                    cds: {},
+                    eds: {},
+                    lds: {},
+                    rds: {},
+                  },
+                  connectTime: '2021-07-13T09:03:11.614941842Z',
+                  disconnectTime: '2021-07-13T09:03:11.614941842Z',
+                },
+                {
+                  id: '',
+                  controlPlaneInstanceId: '',
+                  status: {
+                    lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                    total: {},
+                    cds: {},
+                    eds: {},
+                    lds: {},
+                    rds: {},
+                  },
+                  connectTime: '2021-07-13T09:03:11.614941842Z',
+                  disconnectTime: '2021-07-13T09:03:11.614941842Z',
+                },
+              ],
+            },
+          },
+          true,
+        ],
+        expected: {
           mesh: 'default',
           name: 'dataplane',
           type: 'DataplaneOverview',
@@ -687,54 +1030,55 @@ describe('dataplanes data transformations', () => {
               },
             },
           },
-        }],
-        expected: 'builtin',
-      },
-      {
-        message: 'Delegated gateway (explicit)',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-              gateway: {
-                type: 'DELEGATED',
-                tags: {
-                  'kuma.io/service': '',
+          dataplaneInsight: {
+            subscriptions: [
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                status: {
+                  lastUpdateTime: '2020-07-13T09:03:11.614941842Z',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
                 },
+                connectTime: '2021-07-13T09:03:11.614941842Z',
+                disconnectTime: '2021-07-13T09:03:11.614941842Z',
               },
-            },
-          },
-        }],
-        expected: 'delegated',
-      },
-      {
-        message: 'Delegated gateway (implicit)',
-        parameters: [{
-          mesh: 'default',
-          name: 'dataplane',
-          type: 'DataplaneOverview',
-          creationTime: '',
-          modificationTime: '',
-          dataplane: {
-            networking: {
-              address: '',
-              gateway: {
-                tags: {
-                  'kuma.io/service': '',
+              {
+                id: '',
+                controlPlaneInstanceId: '',
+                status: {
+                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                  total: {},
+                  cds: {},
+                  eds: {},
+                  lds: {},
+                  rds: {},
                 },
+                connectTime: '2021-07-13T09:03:11.614941842Z',
+                disconnectTime: '2021-07-13T09:03:11.614941842Z',
               },
-            },
+            ],
+            connectedSubscription: undefined,
           },
-        }],
-        expected: 'delegated',
+          dataplaneType: 'builtin',
+          status: 'offline',
+          unhealthyInbounds: [],
+          lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+          warnings: [],
+          isCertExpired: false,
+          services: [''],
+        },
       },
-    ])('$message', ({ parameters, expected }) => {
-      expect(getDataplaneType(...parameters)).toStrictEqual(expected)
+    ])('.fromObject: $message', ({ parameters, expected }) => {
+      expect(DataplaneOverview.fromObject(...parameters)).toStrictEqual(expected)
+    })
+
+    test.each<TestCase<typeof DataplaneOverview.fromCollection>>([
+    ])('.fromCollection: $message', ({ parameters, expected }) => {
+      expect(DataplaneOverview.fromCollection(...parameters)).toStrictEqual(expected)
     })
   })
 })

--- a/src/app/data-planes/data/index.spec.ts
+++ b/src/app/data-planes/data/index.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 
-import { Dataplane, DataplaneInsight, DataplaneNetworking, DataplaneOverview } from './index'
+import { Dataplane, DataplaneOverview } from './index'
 
 type TestCase<T extends (...args: any) => any> = {
   message: string
@@ -9,22 +9,6 @@ type TestCase<T extends (...args: any) => any> = {
 }
 
 describe('dataplanes data transformations', () => {
-  describe('DataplaneNetworking', () => {
-    test.each<TestCase<typeof DataplaneNetworking.fromObject>>([
-      {
-        message: 'minimal',
-        parameters: [{
-          address: '',
-        }],
-        expected: {
-          address: '',
-        },
-      },
-    ])('.fromObject: $message', ({ parameters, expected }) => {
-      expect(DataplaneNetworking.fromObject(...parameters)).toStrictEqual(expected)
-    })
-  })
-
   describe('Dataplane', () => {
     test.each<TestCase<typeof Dataplane.fromObject>>([
       {
@@ -52,121 +36,6 @@ describe('dataplanes data transformations', () => {
       },
     ])('.fromObject: $message', ({ parameters, expected }) => {
       expect(Dataplane.fromObject(...parameters)).toStrictEqual(expected)
-    })
-  })
-
-  describe('DataplaneInsight', () => {
-    test.each<TestCase<typeof DataplaneInsight.fromObject>>([
-      {
-        message: 'no insight',
-        parameters: [undefined],
-        expected: {
-          subscriptions: [],
-          connectedSubscription: undefined,
-        },
-      },
-      {
-        message: 'empty subscriptions',
-        parameters: [{
-          subscriptions: [],
-        }],
-        expected: {
-          subscriptions: [],
-          connectedSubscription: undefined,
-        },
-      },
-      {
-        message: 'connected subscription',
-        parameters: [{
-          subscriptions: [
-            {
-              id: '',
-              controlPlaneInstanceId: '',
-              status: {
-                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-                total: {},
-                cds: {},
-                eds: {},
-                lds: {},
-                rds: {},
-              },
-              connectTime: '2021-07-13T09:03:11.614941842Z',
-            },
-          ],
-        }],
-        expected: {
-          subscriptions: [
-            {
-              id: '',
-              controlPlaneInstanceId: '',
-              status: {
-                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-                total: {},
-                cds: {},
-                eds: {},
-                lds: {},
-                rds: {},
-              },
-              connectTime: '2021-07-13T09:03:11.614941842Z',
-            },
-          ],
-          connectedSubscription: {
-            id: '',
-            controlPlaneInstanceId: '',
-            status: {
-              lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-              total: {},
-              cds: {},
-              eds: {},
-              lds: {},
-              rds: {},
-            },
-            connectTime: '2021-07-13T09:03:11.614941842Z',
-          },
-        },
-      },
-      {
-        message: 'disconnected subscription',
-        parameters: [{
-          subscriptions: [
-            {
-              id: '',
-              controlPlaneInstanceId: '',
-              status: {
-                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-                total: {},
-                cds: {},
-                eds: {},
-                lds: {},
-                rds: {},
-              },
-              connectTime: '2021-07-13T09:03:11.614941842Z',
-              disconnectTime: '2021-07-14T09:03:11.614941842Z',
-            },
-          ],
-        }],
-        expected: {
-          subscriptions: [
-            {
-              id: '',
-              controlPlaneInstanceId: '',
-              status: {
-                lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-                total: {},
-                cds: {},
-                eds: {},
-                lds: {},
-                rds: {},
-              },
-              connectTime: '2021-07-13T09:03:11.614941842Z',
-              disconnectTime: '2021-07-14T09:03:11.614941842Z',
-            },
-          ],
-          connectedSubscription: undefined,
-        },
-      },
-    ])('.fromObject: $message', ({ parameters, expected }) => {
-      expect(DataplaneInsight.fromObject(...parameters)).toStrictEqual(expected)
     })
   })
 

--- a/src/app/data-planes/data/index.ts
+++ b/src/app/data-planes/data/index.ts
@@ -42,7 +42,7 @@ export type DataplaneOverview = PartialDataplaneOverview & {
   services: string[]
 }
 
-export const DataplaneNetworking = {
+const DataplaneNetworking = {
   fromObject(partialDataplaneNetworking: PartialDataplaneNetworking): DataplaneNetworking {
     // TODO: Normalize inbound and outbound omitempty arrays.
     // TODO: Consider to determine inbound address and service address here.
@@ -63,7 +63,7 @@ export const Dataplane = {
   },
 }
 
-export const DataplaneInsight = {
+const DataplaneInsight = {
   fromObject(partialDataplaneInsight: PartialDataplaneInsight | undefined): DataplaneInsight {
     const subscriptions = Array.isArray(partialDataplaneInsight?.subscriptions) ? partialDataplaneInsight.subscriptions : []
     const connectedSubscription = subscriptions.find((subscription) => !subscription.disconnectTime)

--- a/src/app/data-planes/data/index.ts
+++ b/src/app/data-planes/data/index.ts
@@ -1,8 +1,12 @@
 import { getIsConnected } from '@/app/subscriptions/data'
+import type { PaginatedApiListResponse } from '@/types/api.d'
 import type {
-  DataPlaneOverview as DataplaneOverview,
+  DataPlane as PartialDataplane,
+  DataPlaneInsight as PartialDataplaneInsight,
+  DataplaneNetworking as PartialDataplaneNetworking,
+  DataPlaneOverview as PartialDataplaneOverview,
+  DiscoverySubscription,
   LabelValue,
-  StatusKeyword,
 } from '@/types/index.d'
 
 export type DataplaneWarning = {
@@ -13,56 +17,138 @@ export type DataplaneWarning = {
   }
 }
 
-export function getLastUpdateTime(dataplaneOverview: DataplaneOverview): string | undefined {
-  const subscriptions = dataplaneOverview.dataplaneInsight?.subscriptions ?? []
-  if (subscriptions.length === 0) {
-    return undefined
-  }
+export type DataplaneNetworking = PartialDataplaneNetworking
 
-  const lastSubscription = subscriptions[subscriptions.length - 1]
-  return lastSubscription.status.lastUpdateTime
+export type Dataplane = PartialDataplane & {
+  networking: DataplaneNetworking
 }
 
-export function getStatusAndReason(dataplaneOverview: DataplaneOverview): { status: StatusKeyword, reason: string[] } {
+export type DataplaneInsight = PartialDataplaneInsight & {
+  subscriptions: DiscoverySubscription[]
+  connectedSubscription?: DiscoverySubscription
+}
+
+export type DataplaneOverview = PartialDataplaneOverview & {
+  dataplane: {
+    networking: DataplaneNetworking
+  }
+  dataplaneInsight: DataplaneInsight
+  dataplaneType: 'standard' | 'builtin' | 'delegated'
+  status: 'online' | 'offline' | 'partially_degraded'
+  unhealthyInbounds: Array<{ service: string, port: number }>
+  lastUpdateTime?: string | undefined
+  warnings: DataplaneWarning[]
+  isCertExpired: boolean
+  services: string[]
+}
+
+export const DataplaneNetworking = {
+  fromObject(partialDataplaneNetworking: PartialDataplaneNetworking): DataplaneNetworking {
+    // TODO: Normalize inbound and outbound omitempty arrays.
+    // TODO: Consider to determine inbound address and service address here.
+    // Address: `${inbound.address ?? props.data.dataplane.networking.advertisedAddress ?? props.data.dataplane.networking.address}:${inbound.port}`
+    // Service address: `${inbound.serviceAddress ?? inbound.address ?? props.data.dataplane.networking.address}:${inbound.servicePort ?? inbound.port}`
+    return {
+      ...partialDataplaneNetworking,
+    }
+  },
+}
+
+export const Dataplane = {
+  fromObject(partialDataplane: PartialDataplane): Dataplane {
+    return {
+      ...partialDataplane,
+      networking: DataplaneNetworking.fromObject(partialDataplane.networking),
+    }
+  },
+}
+
+export const DataplaneInsight = {
+  fromObject(partialDataplaneInsight: PartialDataplaneInsight | undefined): DataplaneInsight {
+    const subscriptions = Array.isArray(partialDataplaneInsight?.subscriptions) ? partialDataplaneInsight.subscriptions : []
+    const connectedSubscription = subscriptions.find((subscription) => !subscription.disconnectTime)
+
+    return {
+      ...partialDataplaneInsight,
+      connectedSubscription,
+      subscriptions,
+    }
+  },
+}
+
+export const DataplaneOverview = {
+  fromObject(partialDataplaneOverview: PartialDataplaneOverview, canUseZones: boolean): DataplaneOverview {
+    const dataplaneInsight = DataplaneInsight.fromObject(partialDataplaneOverview.dataplaneInsight)
+    const networking = DataplaneNetworking.fromObject(partialDataplaneOverview.dataplane.networking)
+
+    const dataplaneType = getDataplaneType(networking)
+    const status = getStatus(partialDataplaneOverview)
+    const unhealthyInbounds = getUnhealthyInbounds(networking)
+    const lastUpdateTime = dataplaneInsight.subscriptions.at(-1)?.status.lastUpdateTime
+    const tags = getTags(networking)
+    const services = tags.filter((tag) => tag.label === 'kuma.io/service').map(({ value }) => value)
+    const warnings = getWarnings(dataplaneInsight, tags, canUseZones)
+    const isCertExpired = getIsCertExpired(dataplaneInsight)
+
+    return {
+      ...partialDataplaneOverview,
+      dataplane: {
+        networking,
+      },
+      dataplaneInsight,
+      dataplaneType,
+      status,
+      unhealthyInbounds,
+      lastUpdateTime,
+      warnings,
+      isCertExpired,
+      services,
+    }
+  },
+
+  fromCollection(partialDataplaneOverviews: PaginatedApiListResponse<PartialDataplaneOverview>, canUseZones: boolean): PaginatedApiListResponse<DataplaneOverview> {
+    return {
+      ...partialDataplaneOverviews,
+      items: Array.isArray(partialDataplaneOverviews.items)
+        ? partialDataplaneOverviews.items.map((partialDataplaneOverview) => DataplaneOverview.fromObject(partialDataplaneOverview, canUseZones))
+        : [],
+    }
+  },
+}
+
+// TODO: Update the implementation once OnboardingDataplanesView no longer uses this function and remove the export.
+export function getStatus(dataplaneOverview: PartialDataplaneOverview): 'online' | 'offline' | 'partially_degraded' {
   const isConnected = getIsConnected(dataplaneOverview.dataplaneInsight?.subscriptions)
   // For gateways, the only relevant status criteria are subscriptions.
   if (dataplaneOverview.dataplane.networking.gateway) {
-    return {
-      status: isConnected ? 'online' : 'offline',
-      reason: [],
-    }
+    return isConnected ? 'online' : 'offline'
   }
 
   const inbounds = dataplaneOverview.dataplane.networking.inbound ?? []
-  const unhealthyInbounds = inbounds
-    .filter((inbound) => inbound.health && !inbound.health.ready)
-    .map((inbound) => `Inbound on port ${inbound.port} is not ready (kuma.io/service: ${inbound.tags['kuma.io/service']})`)
+  const unhealthyInbounds = inbounds.filter((inbound) => inbound.health && !inbound.health.ready)
 
-  let status: StatusKeyword
   switch (true) {
     case unhealthyInbounds.length === inbounds.length:
       // All inbounds being unhealthy means the Dataplane is offline.
-      status = 'offline'
-      break
+      return 'offline'
     case unhealthyInbounds.length > 0:
       // Some inbounds being unhealthy means the Dataplane is partially degraded.
-      status = 'partially_degraded'
-      break
+      return 'partially_degraded'
     default:
       // All inbounds being healthy means the Dataplane’s status is determined by whether it’s connected to a control plane.
-      status = isConnected ? 'online' : 'offline'
-  }
-
-  return {
-    status,
-    reason: unhealthyInbounds,
+      return isConnected ? 'online' : 'offline'
   }
 }
 
-export function getTags(dataplaneOverview: DataplaneOverview): LabelValue[] {
+function getUnhealthyInbounds({ inbound }: DataplaneNetworking): Array<{ service: string, port: number }> {
+  return (inbound ?? [])
+    .filter((inbound) => inbound.health && !inbound.health.ready)
+    .map(({ tags, port }) => ({ service: tags['kuma.io/service'], port }))
+}
+
+function getTags({ gateway, inbound }: DataplaneNetworking): LabelValue[] {
   let tags: string[] = []
   const separator = '='
-  const { gateway, inbound } = dataplaneOverview.dataplane.networking
 
   if (inbound) {
     tags = inbound
@@ -84,24 +170,13 @@ export function getTags(dataplaneOverview: DataplaneOverview): LabelValue[] {
   })
 }
 
-export function getIsCertExpired(dataplaneOverview: DataplaneOverview): boolean {
-  const mTLS = dataplaneOverview.dataplaneInsight?.mTLS
-
-  if (mTLS === undefined) {
-    return false
-  }
-
-  return Date.now() > new Date(mTLS.certificateExpirationTime).getTime()
+function getIsCertExpired({ mTLS }: DataplaneInsight): boolean {
+  return mTLS ? Date.now() > new Date(mTLS.certificateExpirationTime).getTime() : false
 }
 
-export function getWarnings(dataplaneOverview: DataplaneOverview, canUseZones: boolean): DataplaneWarning[] {
-  const subscriptions = dataplaneOverview.dataplaneInsight?.subscriptions ?? []
-  if (subscriptions.length === 0) {
-    return []
-  }
-
-  const lastSubscription = subscriptions[subscriptions.length - 1]
-  if (!('version' in lastSubscription) || !lastSubscription.version) {
+function getWarnings({ subscriptions }: DataplaneInsight, tags: LabelValue[], canUseZones: boolean): DataplaneWarning[] {
+  const lastSubscription = subscriptions.at(-1)
+  if (!lastSubscription || !lastSubscription.version) {
     return []
   }
 
@@ -131,7 +206,6 @@ export function getWarnings(dataplaneOverview: DataplaneOverview, canUseZones: b
   }
 
   if (canUseZones) {
-    const tags = getTags(dataplaneOverview)
     const zoneTag = tags.find(tag => tag.label === 'kuma.io/zone')
 
     if (zoneTag && typeof version.kumaDp.kumaCpCompatible === 'boolean' && !version.kumaDp.kumaCpCompatible) {
@@ -147,8 +221,7 @@ export function getWarnings(dataplaneOverview: DataplaneOverview, canUseZones: b
   return warnings
 }
 
-export function getDataplaneType(dataplaneOverview: DataplaneOverview): 'standard' | 'builtin' | 'delegated' {
-  const { gateway } = dataplaneOverview.dataplane.networking
+function getDataplaneType({ gateway }: DataplaneNetworking): 'standard' | 'builtin' | 'delegated' {
   if (gateway) {
     if (gateway.type) {
       return gateway.type.toLowerCase() as 'builtin' | 'delegated'

--- a/src/app/data-planes/index.ts
+++ b/src/app/data-planes/index.ts
@@ -12,6 +12,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       service: sources,
       arguments: [
         app.api,
+        app.can,
       ],
       labels: [
         app.sources,

--- a/src/app/data-planes/locales/en-us/index.yaml
+++ b/src/app/data-planes/locales/en-us/index.yaml
@@ -32,6 +32,7 @@ data-planes:
       health:
         ready: 'healthy'
         not_ready: 'unhealthy'
+      unhealthy_inbound: 'Inbound on port {port} is not ready (kuma.io/service: {service})'
       mtls:
         title: 'TLS'
         expiration_time:

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -5,7 +5,7 @@
   >
     <RouteView
       v-if="me"
-      v-slot="{ can, route, t }"
+      v-slot="{ route, t }"
       name="data-plane-list-view"
       :params="{
         page: 1,
@@ -46,7 +46,6 @@
               :error="error"
               :is-selected-row="(row) => row.name === route.params.dataPlane"
               summary-route-name="data-plane-summary-view"
-              :can-use-zones="can('use zones')"
               @change="route.update"
             >
               <template #toolbar>

--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -16,7 +16,7 @@
         </h2>
       </template>
 
-      <template v-if="props.data.dataplane?.networking?.gateway?.type === 'BUILTIN'">
+      <template v-if="props.data.dataplaneType === 'builtin'">
         <DataSource
           v-slot="{ data: policyTypesData, error: policyTypesError }: PolicyTypeCollectionSource"
           :src="`/*/policy-types`"
@@ -95,13 +95,13 @@
 <script lang="ts" setup>
 import BuiltinGatewayPolicies from '../components/BuiltinGatewayPolicies.vue'
 import StandardDataplanePolicies from '../components/StandardDataplanePolicies.vue'
-import { DataplaneRulesSource, MeshGatewayDataplaneSource, SidecarDataplaneCollectionSource } from '../sources'
+import type { DataplaneOverview } from '../data'
+import type { DataplaneRulesSource, MeshGatewayDataplaneSource, SidecarDataplaneCollectionSource } from '../sources'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import { PolicyTypeCollectionSource } from '@/app/policies/sources'
-import type { DataPlaneOverview } from '@/types/index.d'
+import type { PolicyTypeCollectionSource } from '@/app/policies/sources'
 
 const props = defineProps<{
-  data: DataPlaneOverview
+  data: DataplaneOverview
 }>()
 </script>

--- a/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -49,9 +49,9 @@
 <script lang="ts" setup>
 import { useRoute } from 'vue-router'
 
+import type { DataplaneOverview } from '../data'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import DataPlaneSummary from '@/app/data-planes/components/DataPlaneSummary.vue'
-import type { DataPlaneOverview } from '@/types/index.d'
 import { useI18n } from '@/utilities'
 
 const { t } = useI18n()
@@ -59,7 +59,7 @@ const route = useRoute()
 
 const props = withDefaults(defineProps<{
   name: string
-  dataplaneOverview?: DataPlaneOverview
+  dataplaneOverview?: DataplaneOverview
 }>(), {
   dataplaneOverview: undefined,
 })

--- a/src/app/onboarding/views/OnboardingDataplanesView.vue
+++ b/src/app/onboarding/views/OnboardingDataplanesView.vue
@@ -83,7 +83,7 @@ import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
-import { getStatusAndReason } from '@/app/data-planes/data'
+import { getStatus } from '@/app/data-planes/data'
 import { useKumaApi } from '@/utilities'
 
 const kumaApi = useKumaApi()
@@ -124,7 +124,7 @@ async function getAllDataplanes() {
         const { name, mesh } = dataPlane
 
         const dataPlaneOverview = await kumaApi.getDataplaneOverviewFromMesh({ mesh, name })
-        const { status } = getStatusAndReason(dataPlaneOverview)
+        const status = getStatus(dataPlaneOverview)
 
         if (status === 'offline') {
           shouldRefetch = true

--- a/src/app/services/views/ServiceDataPlaneProxiesView.vue
+++ b/src/app/services/views/ServiceDataPlaneProxiesView.vue
@@ -5,7 +5,7 @@
   >
     <RouteView
       v-if="me"
-      v-slot="{ can, route, t }"
+      v-slot="{ route, t }"
       name="service-data-plane-proxies-view"
       :params="{
         page: 1,
@@ -47,7 +47,6 @@
               :error="dataplanesError"
               :is-selected-row="(row) => row.name === route.params.dataPlane"
               summary-route-name="service-data-plane-summary-view"
-              :can-use-zones="can('use zones')"
               @change="route.update"
             >
               <template #toolbar>

--- a/vite.config.production.ts
+++ b/vite.config.production.ts
@@ -104,10 +104,8 @@ export const config: UserConfigFn = ({ mode }) => {
       coverage: {
         provider: 'istanbul',
         reporter: ['text', 'lcovonly'],
-        exclude: [
-          'cypress/**',
-          'src/test-support/mocks/**',
-        ],
+        include: ['src'],
+        exclude: ['src/test-support/mocks/**'],
       },
       deps: {
         optimizer: {


### PR DESCRIPTION
Hooks up data transformation utilities to all dataplane data sources (except anything releated to the "Policies" tab).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
