### PR TITLE
chore: Move ResourceCodeBlock to use DataSource

### DIFF
--- a/src/app/meshes/sources.ts
+++ b/src/app/meshes/sources.ts
@@ -26,6 +26,11 @@ export const sources = (api: KumaApi) => {
       return Mesh.fromObject(await api.getMesh({ name }))
     },
 
+    '/meshes/:name/as/kubernetes': (params: DetailParams) => {
+      const { name } = params
+      return api.getMesh({ name }, { format: 'kubernetes' })
+    },
+
     '/mesh-insights': async (params: PaginationParams) => {
       const { size } = params
       const offset = params.size * (params.page - 1)

--- a/src/app/meshes/views/MeshConfigView.vue
+++ b/src/app/meshes/views/MeshConfigView.vue
@@ -30,10 +30,20 @@
 
           <template v-else>
             <ResourceCodeBlock
-              id="code-block-mesh"
+              v-slot="{ copy, copying }"
               :resource="data.config"
-              :resource-fetcher="(params) => kumaApi.getMesh({ name: route.params.mesh }, params)"
-            />
+            >
+              <DataSource
+                v-if="copying"
+                :src="`/meshes/${route.params.mesh}/as/kubernetes?no-store`"
+                @change="(data) => {
+                  copy((resolve) => resolve(data))
+                }"
+                @error="(e) => {
+                  copy((_resolve, reject) => reject(e))
+                }"
+              />
+            </ResourceCodeBlock>
           </template>
         </DataSource>
       </KCard>
@@ -46,7 +56,4 @@ import { MeshSource } from '../sources'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import ResourceCodeBlock from '@/app/common/ResourceCodeBlock.vue'
-import { useKumaApi } from '@/utilities'
-
-const kumaApi = useKumaApi()
 </script>


### PR DESCRIPTION
This PR is a path to do several things:

1. Move all our data re-shaping to use our new data layer
2. Remove all `kumaApi` usage from the application (something we've wanted to do for a while)

Seeing as we are doing point 1 at the moment, it seemed like a good moment to look into this.

---

Please note this is a step one, the next step will be moving the data reshaping form within ResourceCodeBlock into the data layer and making the copy functionality take a string rather than an `Entity`, probably also worth noting that this will completely decouple the component from `?format=kubernetes` so we can use this approach for other things if we like.

Oh I also noticed that copying doesn't seem to work in Safari, which I 'think' is a kongponent thing, but even then we should consider either fixing it, or hiding the button is Safari. I'll make an issue for this if someone can confirm its also broken for them.

Lastly, this should be backwards compatible, so I've only changed one instance, happy to change them all here or in another PR if someone has a preference on that.