### PR TITLE
fix: ui not rendering in zone mode

### DIFF
--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -14,6 +14,7 @@ common:
     mode:
       standalone: Standalone
       global: Multi-Zone
+      zone: Zone
   warnings:
     CERT_EXPIRED: !!text/markdown |
       The certificate for this dataplane has expired


### PR DESCRIPTION
Fix the UI not rendering at all in zone mode on account of the mode not being listed in our translation files. This is just a small fix to make the UI work in Kuma again. More work is needed to actually support zone mode.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
