### PR TITLE
chore: move some URLs from env to t

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,5 @@
-VITE_INSTALL_URL=https://kuma.io/install/latest/
 VITE_VERSION_URL=https://kuma.io/latest_version
 VITE_NAMESPACE=Kuma
 VITE_KUMA_API_SERVER_URL=http://localhost:5681
 VITE_KUMA_DP_SERVER_URL=https://localhost:5678
 VITE_DOCS_BASE_URL=https://kuma.io/docs
-VITE_FEEDBACK_URL=https://github.com/kumahq/kuma/issues/new/choose
-VITE_CHAT_URL=https://kuma-mesh.slack.com

--- a/docs/frames/default.md
+++ b/docs/frames/default.md
@@ -121,9 +121,6 @@ onMounted(async () => {
           [$.EnvVars, {
             constant: {
               KUMA_PRODUCT_NAME: '',
-              KUMA_FEEDBACK_URL: '',
-              KUMA_CHAT_URL: '',
-              KUMA_INSTALL_URL: '',
               KUMA_VERSION_URL: '',
               KUMA_DOCS_URL: '',
               KUMA_MOCK_API_ENABLED: '',

--- a/src/app/common/UpgradeCheck.vue
+++ b/src/app/common/UpgradeCheck.vue
@@ -18,7 +18,7 @@
           <div>
             <KButton
               appearance="primary"
-              :to="env('KUMA_INSTALL_URL')"
+              :to="t('common.product.href.install')"
             >
               Update
             </KButton>

--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -76,7 +76,7 @@
               </KDropdownItem>
               <KDropdownItem>
                 <a
-                  :href="env('KUMA_FEEDBACK_URL')"
+                  :href="t('common.product.href.feedback')"
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -7,6 +7,8 @@ common:
     href:
       docs:
         index: '{KUMA_DOCS_URL}/'
+      feedback: 'https://github.com/kumahq/kuma/issues/new/choose'
+      install: 'https://kuma.io/install/latest/?{KUMA_UTM_QUERY_PARAMS}'
     environment:
       universal: Universal
       kubernetes: Kubernetes

--- a/src/services/e2e.ts
+++ b/src/services/e2e.ts
@@ -31,9 +31,6 @@ export const services = <T extends Record<string, Token>>(app: T): ServiceDefini
     constant: {
       KUMA_API_URL: Cypress.env('VITE_KUMA_API_SERVER_URL'),
       KUMA_PRODUCT_NAME: Cypress.env('VITE_NAMESPACE'),
-      KUMA_FEEDBACK_URL: Cypress.env('VITE_FEEDBACK_URL'),
-      KUMA_CHAT_URL: Cypress.env('VITE_CHAT_URL'),
-      KUMA_INSTALL_URL: Cypress.env('VITE_INSTALL_URL'),
       KUMA_VERSION_URL: Cypress.env('VITE_VERSION_URL'),
       KUMA_DOCS_URL: Cypress.env('VITE_DOCS_BASE_URL'),
       KUMA_MOCK_API_ENABLED: Cypress.env('VITE_MOCK_API_ENABLED'),

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -2,9 +2,6 @@ type PathConfig = ReturnType<typeof getPathConfigDefault>
 
 export type EnvArgs = {
   KUMA_PRODUCT_NAME: string
-  KUMA_FEEDBACK_URL: string
-  KUMA_CHAT_URL: string
-  KUMA_INSTALL_URL: string
   KUMA_VERSION_URL: string
   KUMA_DOCS_URL: string
   KUMA_MOCK_API_ENABLED: string
@@ -39,7 +36,6 @@ export default class Env {
     }
     this.env = {
       ..._env as EnvVars,
-      KUMA_INSTALL_URL: `${env('KUMA_INSTALL_URL')}?${env('KUMA_UTM_QUERY_PARAMS')}`,
       // TODO(jc): not totally sure we need to use a regex here, maybe just split and join if not
       KUMA_DOCS_URL: `${env('KUMA_DOCS_URL')}/${version.patch === '0.0.0' ? 'dev' : version.patch.replace(/\.\d+$/, '.x')}`,
       KUMA_VERSION: version.pre,

--- a/src/services/env/env.spec.ts
+++ b/src/services/env/env.spec.ts
@@ -30,9 +30,6 @@ describe('env', () => {
     const env = new MockEnv(
       {
         KUMA_PRODUCT_NAME: 'product',
-        KUMA_FEEDBACK_URL: 'http://feedback.fake',
-        KUMA_CHAT_URL: 'http://chat.fake',
-        KUMA_INSTALL_URL: 'http://install.fake',
         KUMA_VERSION_URL: 'http://version.fake',
         KUMA_DOCS_URL: 'http://docs.fake',
         KUMA_MOCK_API_ENABLED: 'false',
@@ -40,12 +37,10 @@ describe('env', () => {
       },
     )
     expect(env.var('KUMA_DOCS_URL')).toBe('http://docs.fake/110.127.x')
-    expect(env.var('KUMA_INSTALL_URL')).toBe('http://install.fake?utm_source=product&utm_medium=product')
     expect(env.var('KUMA_VERSION')).toBe('110.127.30')
     expect(env.var('KUMA_API_URL')).toBe('/somewhere/else')
     expect(env.var('KUMA_BASE_PATH')).toBe('/not/gui')
     expect(env.var('KUMA_PRODUCT_NAME')).toBe('product')
-    expect(env.var('KUMA_FEEDBACK_URL')).toBe('http://feedback.fake')
   })
 
   test.each([

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -26,9 +26,6 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   [$.EnvVars, {
     constant: {
       KUMA_PRODUCT_NAME: import.meta.env.VITE_NAMESPACE,
-      KUMA_FEEDBACK_URL: import.meta.env.VITE_FEEDBACK_URL,
-      KUMA_CHAT_URL: import.meta.env.VITE_CHAT_URL,
-      KUMA_INSTALL_URL: import.meta.env.VITE_INSTALL_URL,
       KUMA_VERSION_URL: import.meta.env.VITE_VERSION_URL,
       KUMA_DOCS_URL: import.meta.env.VITE_DOCS_BASE_URL,
       KUMA_MOCK_API_ENABLED: import.meta.env.VITE_MOCK_API_ENABLED,

--- a/src/shims-env.d.ts
+++ b/src/shims-env.d.ts
@@ -1,12 +1,9 @@
 interface ImportMetaEnv {
-  readonly VITE_INSTALL_URL: string
   readonly VITE_VERSION_URL: string
   readonly VITE_NAMESPACE: string
   readonly VITE_KUMA_API_SERVER_URL: string
   readonly VITE_KUMA_DP_SERVER_URL: string
   readonly VITE_DOCS_BASE_URL: string
-  readonly VITE_FEEDBACK_URL: string
-  readonly VITE_CHAT_URL: string
   readonly VITE_UTM: string
   readonly VITE_ZONE_CREATION_FLOW?: 'disabled' | 'enabled'
 }


### PR DESCRIPTION
Moves some old `env` based URLs to use `t` instead

There are a few more strings we can move here, but they are ever so slightly more involved than these ones so I did the ones in this PR separately.