### PR TITLE
feat: allow copying service name from service/dataplane list views

### DIFF
--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -225,11 +225,13 @@ const click = (e: MouseEvent) => {
 </script>
 
 <style lang="scss" scoped>
-.app-collection :deep(td:first-child),
-.app-collection :deep(td:first-child > *) {
+.app-collection :deep(td:first-child) {
   color: inherit;
   font-weight: $kui-font-weight-semibold;
-  text-decoration: none;
+}
+
+.app-collection :deep(td:first-child a) {
+  color: currentColor;
 }
 
 .app-collection-toolbar {

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -225,13 +225,10 @@ const click = (e: MouseEvent) => {
 </script>
 
 <style lang="scss" scoped>
-.app-collection :deep(td:first-child) {
+.app-collection :deep(td:first-child),
+.app-collection :deep(td:first-child *) {
   color: inherit;
   font-weight: $kui-font-weight-semibold;
-}
-
-.app-collection :deep(td:first-child a) {
-  color: currentColor;
   text-decoration: none;
 }
 

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -232,6 +232,7 @@ const click = (e: MouseEvent) => {
 
 .app-collection :deep(td:first-child a) {
   color: currentColor;
+  text-decoration: none;
 }
 
 .app-collection-toolbar {

--- a/src/app/common/CopyButton.vue
+++ b/src/app/common/CopyButton.vue
@@ -96,7 +96,7 @@ export default {
 
 .copy-button[data-tooltip-text]::after {
   background-color: var(--tooltip-background-color);
-  border-radius: $kui-border-radius-20;
+  border-radius: $kui-border-radius-10;
   color: $kui-color-text-inverse;
   content: attr(data-tooltip-text);
   font-weight: $kui-font-weight-regular;

--- a/src/app/common/CopyButton.vue
+++ b/src/app/common/CopyButton.vue
@@ -28,50 +28,23 @@
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { CopyIcon } from '@kong/icons'
-import { KButton, KClipboardProvider } from '@kong/kongponents'
 
-import type { PropType } from 'vue'
-
-const props = defineProps({
-  text: {
-    type: String,
-    required: false,
-    default: '',
-  },
-
-  getText: {
-    type: Function as PropType<() => string | Promise<string>>,
-    required: false,
-    default: null,
-  },
-
-  copyText: {
-    type: String,
-    required: false,
-    default: 'Copy',
-  },
-
-  tooltipSuccessText: {
-    type: String,
-    required: false,
-    default: 'Copied code!',
-  },
-
-  tooltipFailText: {
-    type: String,
-    required: false,
-    default: 'Failed to copy!',
-  },
-
-  hasBorder: {
-    type: Boolean,
-    default: false,
-  },
-
-  hideTitle: {
-    type: Boolean,
-    default: false,
-  },
+const props = withDefaults(defineProps<{
+  text?: string
+  getText?: (() => string | Promise<string>) | null
+  copyText?: string
+  tooltipSuccessText?: string
+  tooltipFailText?: string
+  hasBorder?: boolean
+  hideTitle?: boolean
+}>(), {
+  text: '',
+  getText: null,
+  copyText: 'Copy',
+  tooltipSuccessText: 'Copied code!',
+  tooltipFailText: 'Failed to copy!',
+  hasBorder: false,
+  hideTitle: false,
 })
 
 async function copy(event: Event, copyToClipboard: (text: string) => Promise<boolean>) {

--- a/src/app/common/TagList.vue
+++ b/src/app/common/TagList.vue
@@ -18,13 +18,7 @@
         :is="tag.route ? 'RouterLink' : 'span'"
         :to="tag.route"
       >
-        <template v-if="props.hideLabelKey">
-          {{ tag.value }}
-        </template>
-
-        <template v-else>
-          {{ tag.label }}:<b>{{ tag.value }}</b>
-        </template>
+        {{ tag.label }}:<b>{{ tag.value }}</b>
       </component>
     </KBadge>
   </component>
@@ -45,11 +39,9 @@ interface LabelValueWithRoute extends LabelValue {
 const props = withDefaults(defineProps<{
   tags: LabelValue[] | Record<string, string> | null | undefined
   shouldTruncate?: boolean
-  hideLabelKey?: boolean
   alignment?: 'left' | 'right'
 }>(), {
   shouldTruncate: false,
-  hideLabelKey: false,
   alignment: 'left',
 })
 

--- a/src/app/common/TextWithCopyButton.vue
+++ b/src/app/common/TextWithCopyButton.vue
@@ -16,12 +16,9 @@ import { useI18n } from '@/utilities'
 
 const i18n = useI18n()
 
-const props = defineProps({
-  text: {
-    type: String,
-    required: true,
-  },
-})
+const props = defineProps<{
+  text: string
+}>()
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/data-planes/components/DataPlaneList.vue
+++ b/src/app/data-planes/components/DataPlaneList.vue
@@ -49,12 +49,28 @@
     </template>
 
     <template #services="{ row }: { row: DataPlaneOverviewTableRow }">
-      <TagList
+      <KTruncate
         v-if="row.services.length > 0"
-        :tags="row.services"
-        should-truncate
-        hide-label-key
-      />
+        width="auto"
+      >
+        <div
+          v-for="(tag, index) in row.services"
+          :key="index"
+        >
+          <TextWithCopyButton :text="tag.value">
+            <RouterLink
+              :to="{
+                name: 'service-detail-view',
+                params: {
+                  service: tag.value,
+                },
+              }"
+            >
+              {{ tag.value }}
+            </RouterLink>
+          </TextWithCopyButton>
+        </div>
+      </KTruncate>
 
       <template v-else>
         {{ t('common.collection.none') }}
@@ -125,7 +141,7 @@ import { ArrowRightIcon } from '@kong/icons'
 import { getDataplaneType, getIsCertExpired, getStatusAndReason, getTags, getWarnings } from '../data/index'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
-import TagList from '@/app/common/TagList.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import WarningIcon from '@/app/common/WarningIcon.vue'
 import type { DataPlaneOverview, LabelValue, StatusKeyword } from '@/types/index.d'
 import { useI18n } from '@/utilities'

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -55,21 +55,23 @@
               @change="route.update"
             >
               <template #name="{ row: item }">
-                <RouterLink
-                  :to="{
-                    name: 'service-detail-view',
-                    params: {
-                      mesh: item.mesh,
-                      service: item.name,
-                    },
-                    query: {
-                      page: route.params.page,
-                      size: route.params.size,
-                    },
-                  }"
-                >
-                  {{ item.name }}
-                </RouterLink>
+                <TextWithCopyButton :text="item.name">
+                  <RouterLink
+                    :to="{
+                      name: 'service-detail-view',
+                      params: {
+                        mesh: item.mesh,
+                        service: item.name,
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                      },
+                    }"
+                  >
+                    {{ item.name }}
+                  </RouterLink>
+                </TextWithCopyButton>
               </template>
 
               <template #serviceType="{ rowValue }">


### PR DESCRIPTION
**feat(services): add copy button to service name in list view**

**refactor(CopyButton): use type syntax for props**

**feat(dataplanes): show copy button for services in list view**

Add support for showing a copy button to the TagList component.

Resolves #1747.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
