### PR TITLE
fix(zones): create error being associated with current zone name

### DIFF
--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -156,8 +156,13 @@ Feature: zones / create
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
 
-    Then the "$create-error" element exists
-    Then the "$instructions" element doesn't exist
+    Then the "$create-error" element contains "test"
+    And the "$instructions" element doesn't exist
+
+    When I clear the "$name-input" element
+    And I "type" "different-name" into the "$name-input" element
+
+    Then the "$create-error" element contains "test"
 
   Scenario: The form shows expected error for 400 response
     Given the URL "/provision-zone" responds with

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -48,7 +48,7 @@
             <template
               v-if="(error instanceof ApiError && [409, 500].includes(error.status))"
             >
-              <p>{{ t(`zones.create.status_error.${error.status}.title`, { name }) }}</p>
+              <p>{{ t(`zones.create.status_error.${error.status}.title`, { name: zoneNameWithError }) }}</p>
 
               <p>{{ t(`zones.create.status_error.${error.status}.description`) }}</p>
             </template>
@@ -419,6 +419,7 @@ const isChangingZone = ref(false)
 const isConfirmModalVisible = ref(false)
 const error = ref<Error | null>(null)
 const frontendNameError = ref<string | null>(null)
+const zoneNameWithError = ref('')
 
 const isZoneConnected = ref(false)
 const now = ref(new Date())
@@ -460,6 +461,7 @@ const nameError = computed(() => {
 async function createZone() {
   isChangingZone.value = true
   error.value = null
+  zoneNameWithError.value = ''
 
   try {
     const isValidName = validateName(name.value)
@@ -470,6 +472,7 @@ async function createZone() {
     zone.value = await kumaApi.createZone({ name: name.value })
   } catch (err) {
     if (err instanceof Error) {
+      zoneNameWithError.value = name.value
       error.value = err
     } else {
       console.error(err)


### PR DESCRIPTION
Resolves #1804.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

![image](https://github.com/kumahq/kuma-gui/assets/5774638/a72602ef-99c3-4225-bd8a-c9816d294789)
