### PR TITLE
chore(CopyButton): tweak appearance

### DIFF
--- a/src/app/common/CopyButton.vue
+++ b/src/app/common/CopyButton.vue
@@ -13,7 +13,7 @@
       @click="copy($event, copyToClipboard)"
     >
       <CopyIcon
-        :size="KUI_ICON_SIZE_30"
+        :color="KUI_COLOR_TEXT_NEUTRAL"
         :title="!props.hideTitle ? props.copyText : undefined"
         :hide-title="props.hideTitle"
       />
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { KUI_COLOR_TEXT_NEUTRAL } from '@kong/design-tokens'
 import { CopyIcon } from '@kong/icons'
 import { KButton, KClipboardProvider } from '@kong/kongponents'
 


### PR DESCRIPTION
Use a neutral text color for the CopyIcon to de-emphasize it in our UI.

Remove `KUI_ICON_SIZE_30` from CopyIcon (it has no effect as it’s inside a KButton which enforces a standard icon size).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
