### PR TITLE
chore(dataplanes): tweak new rules API-based policies

### DIFF
--- a/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/features/mesh/dataplanes/DataplanePolicies.feature
@@ -115,13 +115,15 @@ Feature: Dataplane policies
 
       When I click the "$to-rule-item:nth-child(1) [data-testid='accordion-item-button']" element
 
-      Then the "$policies-view" element contains "kuma.io/service:other-svc"
-      And the "$policies-view" element contains "kuma.io/service:backend_kuma-demo_svc_3001"
+      Then the "$to-rule-item:nth-child(1)" element contains "kuma.io/service:other-svc"
+      And the "$to-rule-item:nth-child(1)" element contains "kuma.io/service:backend_kuma-demo_svc_3001"
 
       When I click the "$to-rule-item:nth-child(2) [data-testid='accordion-item-button']" element
 
-      Then the "$policies-view" element contains "__rule-matches-hash__:waFsoIISmZDTfFWYqxvY265/GASHYEWvHQTwMh/bpuU= and kuma.io/service:backend_kuma-demo_svc_3001"
-      And the "$policies-view" element contains "!__rule-matches-hash__:waFsoIISmZDTfFWYqxvY265/GASHYEWvHQTwMh/bpuU= and kuma.io/service:backend_kuma-demo_svc_3001"
+      Then the "$to-rule-item:nth-child(2)" element contains "__rule-matches-hash__:waFsoIISmZDTfFWYqxvY265/GASHYEWvHQTwMh/bpuU= and"
+      Then the "$to-rule-item:nth-child(2)" element contains "kuma.io/service:backend_kuma-demo_svc_3001"
+      And the "$to-rule-item:nth-child(2)" element contains "!__rule-matches-hash__:waFsoIISmZDTfFWYqxvY265/GASHYEWvHQTwMh/bpuU= and"
+      And the "$to-rule-item:nth-child(2)" element contains "kuma.io/service:backend_kuma-demo_svc_3001"
 
     Scenario: Policies tab has expected content (MeshTimeout with from & to rules)
       Given the environment
@@ -218,12 +220,13 @@ Feature: Dataplane policies
 
       When I click the "$to-rule-item:nth-child(1) [data-testid='accordion-item-button']" element
 
-      Then the "$policies-view" element contains "kuma.io/service:foo"
-      And the "$policies-view" element contains "kuma.io/service:bar"
+      Then the "$to-rule-item:nth-child(1)" element contains "kuma.io/service:foo"
+      And the "$to-rule-item:nth-child(1)" element contains "kuma.io/service:bar"
 
       When I click the "$from-rule-item:nth-child(1) [data-testid='accordion-item-button']" element
 
-      Then the "$policies-view" element contains "kuma.io/service:one and !kuma.io/service:two"
+      Then the "$from-rule-item:nth-child(1)" element contains "kuma.io/service:one and"
+      Then the "$from-rule-item:nth-child(1)" element contains "!kuma.io/service:two"
 
     Scenario: Policies tab has expected content (MeshTimeout with proxy & to rule)
       Given the environment
@@ -274,11 +277,11 @@ Feature: Dataplane policies
 
       When I click the "$proxy-rule-item:nth-child(1) [data-testid='accordion-item-button']" element
 
-      Then the "$policies-view" element contains "mpp-on-gateway"
+      Then the "$proxy-rule-item:nth-child(1)" element contains "mpp-on-gateway"
 
       When I click the "$to-rule-item:nth-child(1) [data-testid='accordion-item-button']" element
 
-      Then the "$policies-view" element contains "!kuma.io/service:bar"
+      Then the "$to-rule-item:nth-child(1)" element contains "!kuma.io/service:bar"
 
   Rule: Delegated gateway
     Background:

--- a/src/app/data-planes/components/RuleEntryList.vue
+++ b/src/app/data-planes/components/RuleEntryList.vue
@@ -20,7 +20,7 @@
           <KTable
             class="policy-type-table"
             :class="{
-              'policy-type-table--with-matchers': props.showMatchers,
+              'has-matchers': props.showMatchers,
             }"
             :fetcher="() => ({ data: ruleEntry.rules, total: ruleEntry.rules.length })"
             :headers="[
@@ -46,7 +46,7 @@
                   <span
                     v-if="matcherIndex > 0"
                     class="matcher__and"
-                  > and </span><span
+                  > and<br></span><span
                     v-if="not"
                     class="matcher__not"
                   >!</span><span class="matcher__term">{{ `${key}:${value}` }}</span>
@@ -144,36 +144,55 @@ function getCellAttributes({ headerKey }: any): Record<string, string> {
 }
 
 .policy-type-table {
+  :deep(table){
+    table-layout: fixed;
+  }
+
   :deep(td) {
     vertical-align: top;
   }
 
-  :deep(.cell-origins) {
-    width: 65%;
+  &:not(.has-matchers) {
+    :deep(th:nth-child(1)),
+    :deep(td:nth-child(1)) {
+      width: 65%;
+    }
+
+    :deep(th:nth-child(2)),
+    :deep(td:nth-child(2)) {
+      width: 35%;
+    }
   }
 
-  :deep(.cell-config) {
-    width: 35%;
+  &.has-matchers {
+    :deep(th:nth-child(1)),
+    :deep(td:nth-child(1)) {
+      width: 50%;
+    }
+
+    :deep(th:nth-child(2)),
+    :deep(td:nth-child(2)) {
+      width: 15%;
+    }
+
+    :deep(th:nth-child(3)),
+    :deep(td:nth-child(3)) {
+      width: 35%;
+    }
   }
 }
 
-.policy-type-table--with-matchers {
-  :deep(.cell-formattedMatchers) {
-    width: 50%;
-  }
-
-  :deep(.cell-origins) {
-    width: 15%;
-  }
+.matcher {
+  white-space: normal;
+  word-break: break-word;
 }
 
 .matcher__not {
   color: $kui-color-text-danger;
-  font-weight: $kui-font-weight-semibold;
 }
 
 .matcher__and {
-  color: $kui-color-text-neutral-stronger;
+  font-weight: $kui-font-weight-semibold;
 }
 
 .matcher__not,

--- a/src/app/data-planes/components/StandardDataplanePolicies.vue
+++ b/src/app/data-planes/components/StandardDataplanePolicies.vue
@@ -3,56 +3,62 @@
     data-testid="standard-dataplane-policies"
     class="stack"
   >
-    <KCard v-if="props.showPoliciesSection">
-      <PolicyTypeEntryList
-        id="policies"
-        :policy-type-entries="policyTypeEntries"
-        data-testid="policy-list"
-      />
+    <KCard v-if="(props.showPoliciesSection ? props.sidecarDataplanes.length === 0 : true) && props.inspectRulesForDataplane.rules.length === 0">
+      <EmptyBlock />
     </KCard>
 
-    <KCard v-if="proxyRule">
-      <h3>{{ t('data-planes.routes.item.proxy_rule') }}</h3>
+    <template v-else>
+      <KCard v-if="props.showPoliciesSection">
+        <PolicyTypeEntryList
+          id="policies"
+          :policy-type-entries="policyTypeEntries"
+          data-testid="policy-list"
+        />
+      </KCard>
 
-      <RuleEntryList
-        id="proxy-rules"
-        class="mt-2"
-        :rule-entries="[proxyRule]"
-        :show-matchers="false"
-        data-testid="proxy-rule-list"
-      />
-    </KCard>
-
-    <KCard v-if="toRuleEntries.length > 0">
-      <h3>{{ t('data-planes.routes.item.to_rules') }}</h3>
-
-      <RuleEntryList
-        id="to-rules"
-        class="mt-2"
-        :rule-entries="toRuleEntries"
-        data-testid="to-rule-list"
-      />
-    </KCard>
-
-    <KCard v-if="fromRuleInbounds.length > 0">
-      <h3 class="mb-2">
-        {{ t('data-planes.routes.item.from_rules') }}
-      </h3>
-
-      <div
-        v-for="(fromRule, index) in fromRuleInbounds"
-        :key="index"
-      >
-        <h4>{{ t('data-planes.routes.item.port', { port: fromRule.port }) }}</h4>
+      <KCard v-if="proxyRule">
+        <h3>{{ t('data-planes.routes.item.proxy_rule') }}</h3>
 
         <RuleEntryList
-          :id="`from-rules-${index}`"
+          id="proxy-rules"
           class="mt-2"
-          :rule-entries="fromRule.ruleEntries"
-          :data-testid="`from-rule-list-${index}`"
+          :rule-entries="[proxyRule]"
+          :show-matchers="false"
+          data-testid="proxy-rule-list"
         />
-      </div>
-    </KCard>
+      </KCard>
+
+      <KCard v-if="toRuleEntries.length > 0">
+        <h3>{{ t('data-planes.routes.item.to_rules') }}</h3>
+
+        <RuleEntryList
+          id="to-rules"
+          class="mt-2"
+          :rule-entries="toRuleEntries"
+          data-testid="to-rule-list"
+        />
+      </KCard>
+
+      <KCard v-if="fromRuleInbounds.length > 0">
+        <h3 class="mb-2">
+          {{ t('data-planes.routes.item.from_rules') }}
+        </h3>
+
+        <div
+          v-for="(fromRule, index) in fromRuleInbounds"
+          :key="index"
+        >
+          <h4>{{ t('data-planes.routes.item.port', { port: fromRule.port }) }}</h4>
+
+          <RuleEntryList
+            :id="`from-rules-${index}`"
+            class="mt-2"
+            :rule-entries="fromRule.ruleEntries"
+            :data-testid="`from-rule-list-${index}`"
+          />
+        </div>
+      </KCard>
+    </template>
   </div>
 </template>
 
@@ -62,6 +68,7 @@ import { computed } from 'vue'
 import PolicyTypeEntryList, { type PolicyTypeEntry, type PolicyTypeEntryConnection } from './PolicyTypeEntryList.vue'
 import RuleEntryList, { type RuleEntry, type RuleEntryRule } from './RuleEntryList.vue'
 import { useI18n } from '@/app/application'
+import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import {
   InspectBaseRule,
   InspectRulesForDataplane,


### PR DESCRIPTION
**chore(dataplanes): add empty state to policies tab**

**chore(dataplanes): tweak new rules API-based policies**

Change table layout to always have fixed column widths.

Make sure that table cell content that becomes too long can wrap onto new lines.

Explicitly place each matcher’s individual expressions on a separate line (after the `and`).

Resolves #1883.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

![image](https://github.com/kumahq/kuma-gui/assets/5774638/f3ba1f38-2bc1-456e-8a7b-b34603499795)

![image](https://github.com/kumahq/kuma-gui/assets/5774638/1e665fe8-aa4d-414b-823c-dcf30afe8e8d)
