### PR TITLE
fix: use plain KDropdownItems instead of nested anchors in the help menu

### DIFF
--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -54,7 +54,9 @@
             {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
           </p>
 
-          <KDropdown :kpop-attributes="{ placement: 'bottomEnd' }">
+          <KDropdown
+            :kpop-attributes="{ placement: 'bottomEnd' }"
+          >
             <KButton
               appearance="tertiary"
               icon-only
@@ -65,31 +67,34 @@
             </KButton>
 
             <template #items>
-              <KDropdownItem>
-                <a
-                  :href="t('common.product.href.docs.index')"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Documentation
-                </a>
+              <KDropdownItem
+                :item="{
+                  to: t('common.product.href.docs.index'),
+                  label: '',
+                }"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Documentation
               </KDropdownItem>
-              <KDropdownItem>
-                <a
-                  :href="t('common.product.href.feedback')"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Feedback
-                </a>
+              <KDropdownItem
+                :item="{
+                  to: t('common.product.href.feedback'),
+                  label: '',
+                }"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Feedback
               </KDropdownItem>
-
               <KDropdownItem
                 :item="{
                   to: { name: 'onboarding-welcome-view' },
-                  label: 'Onboarding',
+                  label: '',
                 }"
-              />
+              >
+                Onboarding
+              </KDropdownItem>
             </template>
           </KDropdown>
 
@@ -286,5 +291,4 @@ nav :deep(.app-navigator) > a {
     display: none;
   }
 }
-
 </style>


### PR DESCRIPTION
I noticed a bit of weirdness with our help menu:

#### Before

![Screenshot 2023-12-08 at 13 57 45](https://github.com/kumahq/kuma-gui/assets/554604/21a81a66-f649-4d74-98d6-2442e0ff3528)

#### After

![Screenshot 2023-12-08 at 14 44 34](https://github.com/kumahq/kuma-gui/assets/554604/e313fadf-5cc7-46fe-8f2a-0959d105050c)


### Notes:

I tried to use KDropdownItem as much as possible instead of continuing to use anchors and then overwriting padding/colors etc, but I wanted to keep the text in the textContent rather than an attribute. At which point I noticed that the `:to` attribute requires a `label` but it doesn't use it hence the `""`. I noticed its like this in the kongponent documentation also (they just add placeholder values for the `label`) so I might file an issue over there abut this.

I also noticed that in using only KDropdownItem extra attributes such as `target` and `rel` get added to the `li`s aswell as the anchor tags, but all in all I think not having the CSS overwrites is preferable, if I file an issue over in kongponents I'll mention this also.