### PR TITLE
chore(deps-dev): Manually bump @badeball/cypress-cucumber-preprocessor from 19.1.0 to 19.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@babel/core": "7.23.5",
     "@babel/preset-env": "7.23.5",
     "@babel/preset-typescript": "7.23.3",
-    "@badeball/cypress-cucumber-preprocessor": "19.1.0",
+    "@badeball/cypress-cucumber-preprocessor": "19.2.0",
     "@bahmutov/cypress-esbuild-preprocessor": "2.2.0",
     "@faker-js/faker": "8.3.1",
     "@kong/design-tokens": "1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,10 +1125,10 @@
     minimatch "^3.0.4"
     node-hook "^1.0.0"
 
-"@badeball/cypress-cucumber-preprocessor@19.1.0":
-  version "19.1.0"
-  resolved "https://registry.yarnpkg.com/@badeball/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-19.1.0.tgz#48eb1021934654cf7880a641ab2dffbc9d529474"
-  integrity sha512-pymOmG8yzyUbuFyIieLgKBTPPvdPVUKf3e19F4BejBpm+JTJbqS2ZBRxfJQ1LyQoKi6c0NbFboz6SJS1vV/Qbw==
+"@badeball/cypress-cucumber-preprocessor@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@badeball/cypress-cucumber-preprocessor/-/cypress-cucumber-preprocessor-19.2.0.tgz#e19c949b7849740ddf35aa7e439d386ebbd9c098"
+  integrity sha512-uH4E38nO+hNxEvdYYawtXTcYOSjmS5uxan35HzjqeLeVub1Eo/zcMnKpk1aoKjZHjxHfWzlam8brwhSzrNVY/w==
   dependencies:
     "@badeball/cypress-configuration" "^6.1.0"
     "@cucumber/cucumber" "^10.0.0"


### PR DESCRIPTION
Manually bumped to replace https://github.com/kumahq/kuma-gui/pull/1822 which is failing, possibly due to this being added:

https://github.com/kumahq/kuma-gui/pull/1822/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deR8018


