### PR TITLE
chore: make AppCollection rows typed

### DIFF
--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -85,7 +85,7 @@
       <template v-else>
         <slot
           :name="key"
-          :row="row"
+          :row="row as Row"
           :row-value="rowValue"
         />
       </template>

--- a/src/app/policies/components/PolicyList.vue
+++ b/src/app/policies/components/PolicyList.vue
@@ -124,7 +124,7 @@
             </template>
 
             <template #targetRef="{ row }">
-              <template v-if="props.currentPolicyType.isTargetRefBased">
+              <template v-if="props.currentPolicyType.isTargetRefBased && typeof row.spec?.targetRef !== 'undefined'">
                 <KBadge appearance="neutral">
                   {{ row.spec.targetRef.kind }}<span v-if="row.spec.targetRef.name">:<b>{{ row.spec.targetRef.name }}</b></span>
                 </KBadge>


### PR DESCRIPTION
See https://github.com/kumahq/kuma-gui/pull/1867#discussion_r1422437766

There's an additional commit I wasn't expecting to have to do here, but it seems to fix up another possible 'accessing a property of undefined' issue. I made the smallest quickest fix I could to address the typescript error as I don't have much context on this area, but please let me know if something else is required.