### PR TITLE
refactor(onboarding): use DataSource for dataplanes view

### DIFF
--- a/features/onboarding/dataplanes-overview/Index.feature
+++ b/features/onboarding/dataplanes-overview/Index.feature
@@ -3,37 +3,69 @@ Feature: onboarding / dataplanes-overview / index
     Given the CSS selectors
       | Alias         | Selector                               |
       | next-button   | [data-testid='onboarding-next-button'] |
-      | loading       | [data-testid='loading']                |
       | state-success | [data-testid='state-success']          |
       | state-waiting | [data-testid='state-waiting']          |
 
-  Scenario: Loading the dataplane list and showing the state
+  Scenario: Next button is disabled if there are no Dataplanes
     Given the environment
       """
       KUMA_DATAPLANE_COUNT: 0
       """
+
     When I visit the "/onboarding/dataplanes-overview" URL
-    Then the "$loading" element exists
-    And the "$state-waiting" element exists
-    And the "$next-button[disabled]" element exists
-    And the environment
+
+    Then the "$next-button[disabled]" element exists
+
+  Scenario: Next button is enabled if there is at least one Dataplane
+    Given the environment
       """
       KUMA_DATAPLANE_COUNT: 1
       """
-    And the URL "/dataplanes" responds with
+    And the URL "/dataplanes/_overview" responds with
       """
       body:
         items:
           - name: dataplane-test
+            dataplaneInsight:
+              subscriptions:
+                - connectTime: 2021-02-17T07:33:36.412683Z
+                  disconnectTime: !!js/undefined
       """
-    And the URL "/meshes/default/dataplanes/dataplane-test/_overview" responds with
+
+    When I visit the "/onboarding/dataplanes-overview" URL
+
+    Then the "$next-button:not([disabled])" element exists
+
+  Scenario: UI updates in response to Dataplanes not being offline anymore
+    Given the environment
+      """
+      KUMA_DATAPLANE_COUNT: 1
+      KUMA_SUBSCRIPTION_COUNT: 1
+      """
+    And the URL "/dataplanes/_overview" responds with
       """
       body:
-        dataplaneInsight:
-          subscriptions:
-            - connectTime: 2021-02-17T07:33:36.412683Z
-              disconnectTime: !!js/undefined
+        items:
+          - name: dataplane-test
+            dataplaneInsight:
+              subscriptions:
+                - connectTime: 2021-02-17T07:33:36.412683Z
+                  disconnectTime: 2021-02-17T07:33:36.412683Z
       """
-    Then the "$loading" element doesn't exist
-    And the "$state-success" element exists
-    And the "$next-button:not([disabled])" element exists
+
+    When I visit the "/onboarding/dataplanes-overview" URL
+
+    Then the "$state-waiting" element exists
+
+    When the URL "/dataplanes/_overview" responds with
+      """
+      body:
+        items:
+          - name: dataplane-test
+            dataplaneInsight:
+              subscriptions:
+                - connectTime: 2021-02-17T07:33:36.412683Z
+                  disconnectTime: !!js/undefined
+      """
+
+    Then the "$state-success" element exists

--- a/features/onboarding/dataplanes-overview/Index.feature
+++ b/features/onboarding/dataplanes-overview/Index.feature
@@ -1,10 +1,11 @@
 Feature: onboarding / dataplanes-overview / index
   Background:
     Given the CSS selectors
-      | Alias         | Selector                               |
-      | next-button   | [data-testid='onboarding-next-button'] |
-      | state-success | [data-testid='state-success']          |
-      | state-waiting | [data-testid='state-waiting']          |
+      | Alias            | Selector                               |
+      | next-button      | [data-testid='onboarding-next-button'] |
+      | state-success    | [data-testid='state-success']          |
+      | state-waiting    | [data-testid='state-waiting']          |
+      | dataplanes-table | [data-testid='dataplanes-table']       |
 
   Scenario: Next button is disabled if there are no Dataplanes
     Given the environment
@@ -40,6 +41,7 @@ Feature: onboarding / dataplanes-overview / index
     Given the environment
       """
       KUMA_DATAPLANE_COUNT: 1
+      KUMA_DATAPLANEINBOUND_COUNT: 0
       KUMA_SUBSCRIPTION_COUNT: 1
       """
     And the URL "/dataplanes/_overview" responds with
@@ -56,6 +58,8 @@ Feature: onboarding / dataplanes-overview / index
     When I visit the "/onboarding/dataplanes-overview" URL
 
     Then the "$state-waiting" element exists
+    And the "$dataplanes-table" element contains "dataplane-test"
+    And the "$dataplanes-table" element contains "offline"
 
     When the URL "/dataplanes/_overview" responds with
       """
@@ -69,3 +73,5 @@ Feature: onboarding / dataplanes-overview / index
       """
 
     Then the "$state-success" element exists
+    And the "$dataplanes-table" element contains "dataplane-test"
+    And the "$dataplanes-table" element contains "online"

--- a/src/app/data-planes/index.ts
+++ b/src/app/data-planes/index.ts
@@ -11,6 +11,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     [token('data-planes.sources'), {
       service: sources,
       arguments: [
+        app.source,
         app.api,
         app.can,
       ],

--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -45,7 +45,7 @@ const includes = <T extends readonly string[]>(arr: T, item: string): item is T[
 
 export const sources = (source: Source, api: KumaApi, can: Can) => {
   return defineSources({
-    '/dataplanes': (params) => {
+    '/dataplanes/poll': (params) => {
       const { size, page } = params
       const offset = size * (page - 1)
       const canUseZones = can('use zones')

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -18,7 +18,7 @@
       }"
     >
       <DataSource
-        v-slot="{data, error}: DataPlaneCollectionSource"
+        v-slot="{data, error}: DataplaneOverviewCollectionSource"
         :src="`/meshes/${route.params.mesh}/dataplanes/of/${route.params.dataplaneType}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
       >
         <AppView>
@@ -116,7 +116,7 @@
 
 <script lang="ts" setup>
 import DataPlaneList from '../components/DataPlaneList.vue'
-import type { DataPlaneCollectionSource } from '../sources'
+import type { DataplaneOverviewCollectionSource } from '../sources'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
 import SummaryView from '@/app/common/SummaryView.vue'

--- a/src/app/onboarding/views/OnboardingDataplanesView.vue
+++ b/src/app/onboarding/views/OnboardingDataplanesView.vue
@@ -10,7 +10,7 @@
     <AppView>
       <DataSource
         v-slot="{ error }: DataplaneOverviewCollectionSource"
-        :src="hasOfflineDataplanes ? `/dataplanes?page=1&size=10` : ''"
+        :src="hasOfflineDataplanes ? `/dataplanes/poll?page=1&size=10` : ''"
         @change="setDataplanes"
       >
         <ErrorBlock

--- a/src/app/onboarding/views/OnboardingDataplanesView.vue
+++ b/src/app/onboarding/views/OnboardingDataplanesView.vue
@@ -55,6 +55,7 @@
 
               <KTable
                 class="mb-4"
+                data-testid="dataplanes-table"
                 :fetcher-cache-key="String(cacheKey)"
                 :fetcher="() => ({
                   data: dataplanes,

--- a/src/app/onboarding/views/OnboardingDataplanesView.vue
+++ b/src/app/onboarding/views/OnboardingDataplanesView.vue
@@ -8,148 +8,112 @@
       :render="false"
     />
     <AppView>
-      <OnboardingPage>
-        <template #header>
-          <template
-            v-for="item in [
-              tableData.data.length > 0 ? 'success' : 'waiting',
-            ]"
-            :key="item"
-          >
-            <OnboardingHeading :data-testid="`state-${item}`">
-              <template #title>
-                {{ t(`onboarding.routes.dataplanes-overview.header.${item}.title`) }}
-              </template>
+      <DataSource
+        v-slot="{ error }: DataplaneOverviewCollectionSource"
+        :src="hasOfflineDataplanes ? `/dataplanes?page=1&size=10` : ''"
+        @change="setDataplanes"
+      >
+        <ErrorBlock
+          v-if="error !== undefined"
+          :error="error"
+        />
 
-              <template
-                #description
-              >
-                <p>{{ t(`onboarding.routes.dataplanes-overview.header.${item}.description`) }}</p>
-              </template>
-            </OnboardingHeading>
-          </template>
-        </template>
+        <LoadingBlock v-else-if="dataplanes === undefined" />
 
-        <template #content>
-          <div
-            v-if="tableData.data.length === 0"
-            class="status-loading-box mb-4"
-          >
-            <LoadingBox />
-          </div>
-
-          <div v-else>
-            <p class="mb-4">
-              <b>Found {{ tableData.data.length }} DPPs:</b>
-            </p>
-
-            <KTable
-              class="mb-4"
-              :fetcher="() => tableData"
-              :headers="TABLE_HEADERS"
-              disable-pagination
+        <OnboardingPage v-else>
+          <template #header>
+            <template
+              v-for="item in [!hasOfflineDataplanes ? 'success' : 'waiting']"
+              :key="item"
             >
-              <template #status="{ rowValue }">
-                <StatusBadge
-                  v-if="rowValue"
-                  :status="rowValue"
-                />
-
-                <template v-else>
-                  —
+              <OnboardingHeading :data-testid="`state-${item}`">
+                <template #title>
+                  {{ t(`onboarding.routes.dataplanes-overview.header.${item}.title`) }}
                 </template>
-              </template>
-            </KTable>
-          </div>
-        </template>
 
-        <template #navigation>
-          <OnboardingNavigation
-            next-step="onboarding-completed-view"
-            previous-step="onboarding-add-new-services-code-view"
-            :should-allow-next="tableData.data.length > 0"
-          />
-        </template>
-      </OnboardingPage>
+                <template
+                  #description
+                >
+                  <p>{{ t(`onboarding.routes.dataplanes-overview.header.${item}.description`) }}</p>
+                </template>
+              </OnboardingHeading>
+            </template>
+          </template>
+
+          <template #content>
+            <div
+              v-if="dataplanes.length === 0"
+              class="status-loading-box mb-4"
+            >
+              <LoadingBox />
+            </div>
+
+            <div v-else>
+              <p class="mb-4">
+                <b>Found {{ dataplanes.length }} DPPs:</b>
+              </p>
+
+              <KTable
+                class="mb-4"
+                :fetcher-cache-key="String(cacheKey)"
+                :fetcher="() => ({
+                  data: dataplanes,
+                  total: dataplanes?.length,
+                })"
+                :headers="[
+                  { label: 'Mesh', key: 'mesh' },
+                  { label: 'Name', key: 'name' },
+                  { label: 'Status', key: 'status' },
+                ]"
+                disable-pagination
+              >
+                <template #status="{ row }">
+                  <StatusBadge :status="row.status" />
+                </template>
+              </KTable>
+            </div>
+          </template>
+
+          <template #navigation>
+            <OnboardingNavigation
+              next-step="onboarding-completed-view"
+              previous-step="onboarding-add-new-services-code-view"
+              :should-allow-next="dataplanes.length > 0"
+            />
+          </template>
+        </OnboardingPage>
+      </DataSource>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import { onBeforeUnmount, ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import LoadingBox from '../components/LoadingBox.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
-import { useCan } from '@/app/application'
+import ErrorBlock from '@/app/common/ErrorBlock.vue'
+import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
-import { DataplaneOverview } from '@/app/data-planes/data'
-import { useKumaApi } from '@/utilities'
+import type { DataplaneOverview, DataplaneOverviewCollection, DataplaneOverviewCollectionSource } from '@/app/data-planes/sources'
 
-const kumaApi = useKumaApi()
-const can = useCan()
+const dataplanes = ref<DataplaneOverview[] | undefined>()
+const cacheKey = ref(0)
 
-const TABLE_HEADERS = [
-  { label: 'Mesh', key: 'mesh' },
-  { label: 'Name', key: 'name' },
-  { label: 'Status', key: 'status' },
-]
-
-const tableData = ref<{ total: number, data: any [] }>({
-  total: 0,
-  data: [],
-})
-const timeout = ref<number | null>(null)
-
-onBeforeUnmount(function () {
-  clearTimeout()
-})
-
-getAllDataplanes()
-
-function clearTimeout() {
-  if (timeout.value !== null) {
-    window.clearTimeout(timeout.value)
-  }
-}
-
-async function getAllDataplanes() {
-  let shouldRefetch = false
-  const result = []
-
-  try {
-    const { items } = await kumaApi.getAllDataplanes({ size: 10 })
-
-    if (Array.isArray(items) && items.length > 0) {
-      for (const dataPlane of items) {
-        const { name, mesh } = dataPlane
-
-        const dataPlaneOverview = DataplaneOverview.fromObject(await kumaApi.getDataplaneOverviewFromMesh({ mesh, name }), can('use zones'))
-
-        if (dataPlaneOverview.status === 'offline') {
-          shouldRefetch = true
-        }
-
-        result.push({
-          status: dataPlaneOverview.status,
-          name,
-          mesh,
-        })
-      }
-    } else {
-      shouldRefetch = true
-    }
-  } catch (error) {
-    console.error(error)
+const hasOfflineDataplanes = computed(() => {
+  if (Array.isArray(dataplanes.value)) {
+    return dataplanes.value.some((dataplaneOverview) => dataplaneOverview.status === 'offline')
   }
 
-  tableData.value.data = result
-  tableData.value.total = tableData.value.data.length
+  return true
+})
 
-  if (shouldRefetch) {
-    clearTimeout()
-    timeout.value = window.setTimeout(getAllDataplanes, 1000)
+function setDataplanes(data: DataplaneOverviewCollection | undefined) {
+  if (data) {
+    dataplanes.value = data.items
+    cacheKey.value++
   }
 }
 </script>

--- a/src/app/services/views/ServiceDataPlaneProxiesView.vue
+++ b/src/app/services/views/ServiceDataPlaneProxiesView.vue
@@ -28,7 +28,7 @@
         </template>
 
         <DataSource
-          v-slot="{ data: dataplanesData, error: dataplanesError }: DataPlaneCollectionSource"
+          v-slot="{ data: dataplanesData, error: dataplanesError }: DataplaneOverviewCollectionSource"
           :src="`/meshes/${route.params.mesh}/dataplanes/for/${route.params.service}/of/${route.params.dataplaneType}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
         >
           <KCard>
@@ -119,7 +119,7 @@ import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import DataPlaneList from '@/app/data-planes/components/DataPlaneList.vue'
-import { DataPlaneCollectionSource } from '@/app/data-planes/sources'
+import { DataplaneOverviewCollectionSource } from '@/app/data-planes/sources'
 import type { MeSource } from '@/app/me/sources'
 </script>
 


### PR DESCRIPTION
Migrates the OnboardingDataplanesView component to use DataSource. This is necessary in order to remove the access of the data layer transformation utility in this file.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>