### PR TITLE
refactor(dataplanes): add data transformations for dataplane policies

### DIFF
--- a/src/app/data-planes/components/BuiltinGatewayPolicies.vue
+++ b/src/app/data-planes/components/BuiltinGatewayPolicies.vue
@@ -8,14 +8,25 @@
         Gateway policies
       </h3>
 
-      <ul v-if="meshGatewayRoutePolicies.length > 0">
+      <ul v-if="gatewayDataplane.routePolicies.length > 0">
         <li
-          v-for="(policy, index) in meshGatewayRoutePolicies"
+          v-for="(policy, index) in gatewayDataplane.routePolicies"
           :key="index"
         >
           <span>{{ policy.type }}</span>:
 
-          <router-link :to="policy.route">{{ policy.name }}</router-link>
+          <RouterLink
+            :to="{
+              name: 'policy-detail-view',
+              params: {
+                mesh: policy.mesh,
+                policyPath: props.policyTypesByName[policy.type]!.path,
+                policy: policy.name,
+              },
+            }"
+          >
+            {{ policy.name }}
+          </RouterLink>
         </li>
       </ul>
 
@@ -25,7 +36,7 @@
 
       <div>
         <div
-          v-for="(listenerEntry, index) in meshGatewayListenerEntries"
+          v-for="(listenerEntry, index) in gatewayDataplane.listenerEntries"
           :key="index"
         >
           <div>
@@ -50,7 +61,18 @@
                     <div class="dataplane-policy-header">
                       <div>
                         <div>
-                          <b>Route</b>: <router-link :to="routeEntry.route">{{ routeEntry.routeName }}</router-link>
+                          <b>Route</b>: <RouterLink
+                            :to="{
+                              name: 'policy-detail-view',
+                              params: {
+                                mesh: routeEntry.route.mesh,
+                                policyPath: props.policyTypesByName[routeEntry.route.type]!.path,
+                                policy: routeEntry.route.name,
+                              },
+                            }"
+                          >
+                            {{ routeEntry.route.name }}
+                          </RouterLink>
                         </div>
 
                         <div>
@@ -59,11 +81,11 @@
                       </div>
 
                       <div
-                        v-if="routeEntry.policies.length > 0"
+                        v-if="routeEntry.origins.length > 0"
                         class="badge-list"
                       >
                         <KBadge
-                          v-for="(policy, policyIndex) in routeEntry.policies"
+                          v-for="(policy, policyIndex) in routeEntry.origins"
                           :key="`${index}-${policyIndex}`"
                         >
                           {{ policy.type }}
@@ -73,17 +95,28 @@
                   </template>
 
                   <template
-                    v-if="routeEntry.policies.length > 0"
+                    v-if="routeEntry.origins.length > 0"
                     #accordion-content
                   >
                     <ul class="mt-1">
                       <li
-                        v-for="(policy, policyIndex) in routeEntry.policies"
+                        v-for="(policy, policyIndex) in routeEntry.origins"
                         :key="`${index}-${policyIndex}`"
                       >
                         {{ policy.type }}:
 
-                        <RouterLink :to="policy.route">{{ policy.name }}</RouterLink>
+                        <RouterLink
+                          :to="{
+                            name: 'policy-detail-view',
+                            params: {
+                              mesh: policy.mesh,
+                              policyPath: props.policyTypesByName[policy.type]!.path,
+                              policy: policy.name,
+                            },
+                          }"
+                        >
+                          {{ policy.name }}
+                        </RouterLink>
                       </li>
                     </ul>
                   </template>
@@ -98,88 +131,15 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
-
+import type { MeshGatewayDataplane } from '../data'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
-import type { MatchedPolicyType, MeshGatewayDataplane, MeshGatewayListenerEntry, MeshGatewayRouteEntry, MeshGatewayRoutePolicy, PolicyType } from '@/types/index.d'
+import type { PolicyType } from '@/types/index.d'
 
 const props = defineProps<{
   gatewayDataplane: MeshGatewayDataplane
   policyTypesByName: Record<string, PolicyType | undefined>
 }>()
-
-const meshGatewayListenerEntries = computed(() => getMeshGatewayListenerEntries(props.gatewayDataplane))
-const meshGatewayRoutePolicies = computed(() => getPolicyRoutes(props.gatewayDataplane.policies))
-
-function getMeshGatewayListenerEntries(meshGatewayDataplane: MeshGatewayDataplane): MeshGatewayListenerEntry[] {
-  const meshGatewayListenerEntries: MeshGatewayListenerEntry[] = []
-
-  const listeners = meshGatewayDataplane.listeners ?? []
-  for (const listener of listeners) {
-    for (const host of listener.hosts) {
-      for (const route of host.routes) {
-        const routeEntries: MeshGatewayRouteEntry[] = []
-
-        for (const destination of route.destinations) {
-          const policies = getPolicyRoutes(destination.policies)
-
-          const routeEntry: MeshGatewayRouteEntry = {
-            routeName: route.route,
-            route: {
-              name: 'policy-detail-view',
-              params: {
-                mesh: meshGatewayDataplane.gateway.mesh,
-                policyPath: 'meshgatewayroutes',
-                policy: route.route,
-              },
-            },
-            service: destination.tags['kuma.io/service'],
-            policies,
-          }
-
-          routeEntries.push(routeEntry)
-        }
-
-        meshGatewayListenerEntries.push({
-          protocol: listener.protocol,
-          port: listener.port,
-          hostName: host.hostName,
-          routeEntries,
-        })
-      }
-    }
-  }
-
-  return meshGatewayListenerEntries
-}
-
-function getPolicyRoutes(policies: Record<string, MatchedPolicyType> | undefined): MeshGatewayRoutePolicy[] {
-  if (policies === undefined) {
-    return []
-  }
-
-  const policyRoutes: MeshGatewayRoutePolicy[] = []
-
-  for (const policy of Object.values(policies)) {
-    const policyType = props.policyTypesByName[policy.type] as PolicyType
-
-    policyRoutes.push({
-      type: policy.type,
-      name: policy.name,
-      route: {
-        name: 'policy-detail-view',
-        params: {
-          mesh: policy.mesh,
-          policyPath: policyType.path,
-          policy: policy.name,
-        },
-      },
-    })
-  }
-
-  return policyRoutes
-}
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/data-planes/components/RuleEntryList.vue
+++ b/src/app/data-planes/components/RuleEntryList.vue
@@ -64,7 +64,16 @@
                   v-for="(origin, originIndex) in row.origins"
                   :key="`${index}-${originIndex}`"
                 >
-                  <RouterLink :to="origin.route">
+                  <RouterLink
+                    :to="{
+                      name: 'policy-detail-view',
+                      params: {
+                        mesh: origin.mesh,
+                        policyPath: props.policyTypesByName[origin.type]!.path,
+                        policy: origin.name,
+                      },
+                    }"
+                  >
                     {{ origin.name }}
                   </RouterLink>
                 </li>
@@ -76,10 +85,10 @@
             </template>
 
             <template #config="{ row, rowKey }: { row: RuleEntryRule, rowKey: number }">
-              <template v-if="row.config !== undefined">
+              <template v-if="row.config">
                 <CodeBlock
                   :id="`${props.id}-${index}-${rowKey}-code-block`"
-                  :code="row.config"
+                  :code="toYaml(row.config)"
                   language="yaml"
                   :show-copy-button="false"
                 />
@@ -102,25 +111,14 @@ import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
 import CodeBlock from '@/app/common/CodeBlock.vue'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
-import type { InspectRuleMatcher } from '@/types/index.d'
-import type { RouteLocationNamedRaw } from 'vue-router'
-
-export type RuleEntryRule = {
-  config: string | undefined
-  matchers?: InspectRuleMatcher[]
-  origins: Array<{ name: string, route: RouteLocationNamedRaw }>
-}
-
-export type RuleEntry = {
-  type: string
-  rules: RuleEntryRule[]
-}
-
+import type { PolicyType, RuleEntry, RuleEntryRule } from '@/types/index.d'
+import { toYaml } from '@/utilities/toYaml'
 const { t } = useI18n()
 
 const props = withDefaults(defineProps<{
   id: string
   ruleEntries: RuleEntry[]
+  policyTypesByName: Record<string, PolicyType | undefined>
   showMatchers?: boolean
 }>(), {
   showMatchers: true,

--- a/src/app/data-planes/components/StandardDataplanePolicies.vue
+++ b/src/app/data-planes/components/StandardDataplanePolicies.vue
@@ -3,7 +3,7 @@
     data-testid="standard-dataplane-policies"
     class="stack"
   >
-    <KCard v-if="(props.showPoliciesSection ? props.sidecarDataplanes.length === 0 : true) && props.inspectRulesForDataplane.rules.length === 0">
+    <KCard v-if="(props.showPoliciesSection ? props.policyTypeEntries.length === 0 : true) && props.inspectRulesForDataplane.rules.length === 0">
       <EmptyBlock />
     </KCard>
 
@@ -11,41 +11,44 @@
       <KCard v-if="props.showPoliciesSection">
         <PolicyTypeEntryList
           id="policies"
-          :policy-type-entries="policyTypeEntries"
+          :policy-type-entries="props.policyTypeEntries"
+          :policy-types-by-name="props.policyTypesByName"
           data-testid="policy-list"
         />
       </KCard>
 
-      <KCard v-if="proxyRule">
+      <KCard v-if="props.inspectRulesForDataplane.proxyRule">
         <h3>{{ t('data-planes.routes.item.proxy_rule') }}</h3>
 
         <RuleEntryList
           id="proxy-rules"
           class="mt-2"
-          :rule-entries="[proxyRule]"
+          :rule-entries="[props.inspectRulesForDataplane.proxyRule]"
+          :policy-types-by-name="props.policyTypesByName"
           :show-matchers="false"
           data-testid="proxy-rule-list"
         />
       </KCard>
 
-      <KCard v-if="toRuleEntries.length > 0">
+      <KCard v-if="props.inspectRulesForDataplane.toRules.length > 0">
         <h3>{{ t('data-planes.routes.item.to_rules') }}</h3>
 
         <RuleEntryList
           id="to-rules"
           class="mt-2"
-          :rule-entries="toRuleEntries"
+          :rule-entries="props.inspectRulesForDataplane.toRules"
+          :policy-types-by-name="props.policyTypesByName"
           data-testid="to-rule-list"
         />
       </KCard>
 
-      <KCard v-if="fromRuleInbounds.length > 0">
+      <KCard v-if="props.inspectRulesForDataplane.fromRuleInbounds.length > 0">
         <h3 class="mb-2">
           {{ t('data-planes.routes.item.from_rules') }}
         </h3>
 
         <div
-          v-for="(fromRule, index) in fromRuleInbounds"
+          v-for="(fromRule, index) in props.inspectRulesForDataplane.fromRuleInbounds"
           :key="index"
         >
           <h4>{{ t('data-planes.routes.item.port', { port: fromRule.port }) }}</h4>
@@ -54,6 +57,7 @@
             :id="`from-rules-${index}`"
             class="mt-2"
             :rule-entries="fromRule.ruleEntries"
+            :policy-types-by-name="props.policyTypesByName"
             :data-testid="`from-rule-list-${index}`"
           />
         </div>
@@ -63,225 +67,19 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
-
-import PolicyTypeEntryList, { type PolicyTypeEntry, type PolicyTypeEntryConnection } from './PolicyTypeEntryList.vue'
-import RuleEntryList, { type RuleEntry, type RuleEntryRule } from './RuleEntryList.vue'
+import PolicyTypeEntryList from './PolicyTypeEntryList.vue'
+import RuleEntryList from './RuleEntryList.vue'
+import type { InspectRulesForDataplane } from '../data'
 import { useI18n } from '@/app/application'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
-import {
-  InspectBaseRule,
-  InspectRulesForDataplane,
-  LabelValue,
-  MatchedPolicyType,
-  PolicyType,
-  SidecarDataplane,
-} from '@/types/index.d'
-import { toYaml } from '@/utilities/toYaml'
-import type { RouteLocationNamedRaw } from 'vue-router'
+import type { PolicyType, PolicyTypeEntry } from '@/types/index.d'
 
 const { t } = useI18n()
 
 const props = defineProps<{
-  sidecarDataplanes: SidecarDataplane[]
+  policyTypeEntries: PolicyTypeEntry[]
   inspectRulesForDataplane: InspectRulesForDataplane
   policyTypesByName: Record<string, PolicyType | undefined>
   showPoliciesSection: boolean
 }>()
-
-const policyTypeEntries = computed(() => getPolicyTypeEntries(props.sidecarDataplanes))
-
-const proxyRule = computed<RuleEntry | null>(() => {
-  // Note, there can only be one proxy rule.
-  const rule = props.inspectRulesForDataplane.rules.find((rule) => rule.proxyRule)
-  if (!rule || !rule.proxyRule) {
-    return null
-  }
-
-  const { type, proxyRule } = rule
-
-  const config = proxyRule.conf && Object.keys(proxyRule.conf).length > 0 ? toYaml(proxyRule.conf) : undefined
-  const origins = proxyRule.origin.map((origin) => {
-    const policyType = props.policyTypesByName[origin.type]!
-
-    return {
-      name: origin.name,
-      route: {
-        name: 'policy-detail-view',
-        params: {
-          mesh: origin.mesh,
-          policyPath: policyType.path,
-          policy: origin.name,
-        },
-      },
-    }
-  })
-
-  return {
-    type,
-    rules: [
-      {
-        config,
-        origins,
-      },
-    ],
-  }
-})
-
-/**
- * The to rule entries are grouped by policy type.
- */
-const toRuleEntries = computed<RuleEntry[]>(() => {
-  const ruleEntries: RuleEntry[] = []
-
-  for (const rule of props.inspectRulesForDataplane.rules) {
-    const toRules = rule.toRules ?? []
-
-    if (toRules.length > 0) {
-      ruleEntries.push({
-        type: rule.type,
-        rules: getRules(toRules),
-      })
-    }
-  }
-
-  ruleEntries.sort((ruleEntryA, ruleEntryB) => ruleEntryA.type.localeCompare(ruleEntryB.type))
-
-  return ruleEntries
-})
-
-const fromRuleInbounds = computed<Array<{ port: number, ruleEntries: RuleEntry[] }>>(() => {
-  // Group rule entries by inbound
-  const ruleEntriesByInbound = new Map<number, RuleEntry[]>()
-
-  for (const rule of props.inspectRulesForDataplane.rules) {
-    const fromRules = rule.fromRules ?? []
-    if (fromRules.length === 0) {
-      continue
-    }
-
-    for (const fromRule of fromRules) {
-      if (!ruleEntriesByInbound.has(fromRule.inbound.port)) {
-        ruleEntriesByInbound.set(fromRule.inbound.port, [])
-      }
-
-      // This access is safe because we previously ensured this Map item exists.
-      const ruleEntries = ruleEntriesByInbound.get(fromRule.inbound.port)!
-      ruleEntries.push({
-        type: rule.type,
-        rules: getRules(fromRule.rules),
-      })
-    }
-  }
-
-  for (const [, ruleEntries] of ruleEntriesByInbound) {
-    ruleEntries.sort((ruleEntryA, ruleEntryB) => ruleEntryA.type.localeCompare(ruleEntryB.type))
-  }
-
-  const fromRules = Array.from(ruleEntriesByInbound)
-  fromRules.sort(([portA], [portB]) => portB - portA)
-
-  return fromRules.map(([port, ruleEntries]) => ({ port, ruleEntries }))
-})
-
-/**
- * Transforms `SidecarDataplane` objects into policy type entries which are going to be displayed in this view.
- */
-function getPolicyTypeEntries(sidecarDataplanes: SidecarDataplane[]): PolicyTypeEntry[] {
-  // Uses a `Map` to store entries by type so they can be retrieved and updated while iterating over the `SidecarDataplane` objects.
-  const policyTypeEntriesByType = new Map<string, PolicyTypeEntry>()
-
-  for (const sidecarDataplane of sidecarDataplanes) {
-    const { type, service } = sidecarDataplane
-
-    // The `service` field, when set, represents the name of the destination service of traffic.
-    const destinationTags: LabelValue[] = typeof service === 'string' && service !== '' ? [{ label: 'kuma.io/service', value: service }] : []
-    const name = type === 'inbound' || type === 'outbound' ? sidecarDataplane.name : null
-
-    for (const [policyTypeName, policies] of Object.entries(sidecarDataplane.matchedPolicies)) {
-      if (!policyTypeEntriesByType.has(policyTypeName)) {
-        policyTypeEntriesByType.set(policyTypeName, {
-          type: policyTypeName,
-          connections: [],
-        })
-      }
-
-      const policyTypeEntry = policyTypeEntriesByType.get(policyTypeName) as PolicyTypeEntry
-      const policyType = props.policyTypesByName[policyTypeName] as PolicyType
-
-      for (const policy of policies) {
-        const connections = getPolicyTypeEntryConnections(policy, policyType, sidecarDataplane, destinationTags, name)
-
-        policyTypeEntry.connections.push(...connections)
-      }
-    }
-  }
-
-  const policyTypeEntries = Array.from(policyTypeEntriesByType.values())
-
-  policyTypeEntries.sort((policyTypeEntryA, policyTypeEntryB) => policyTypeEntryA.type.localeCompare(policyTypeEntryB.type))
-
-  return policyTypeEntries
-}
-
-function getPolicyTypeEntryConnections(policy: MatchedPolicyType, policyType: PolicyType, sidecarDataplane: SidecarDataplane, destinationTags: LabelValue[], name: string | null): PolicyTypeEntryConnection[] {
-  const config = policy.conf && Object.keys(policy.conf).length > 0 ? toYaml(policy.conf) : null
-  const origin: { name: string, route: RouteLocationNamedRaw } = {
-    name: policy.name,
-    route: {
-      name: 'policy-detail-view',
-      params: {
-        mesh: policy.mesh,
-        policyPath: policyType.path,
-        policy: policy.name,
-      },
-    },
-  }
-  const origins = [origin]
-
-  const policyTypeEntryConnections: PolicyTypeEntryConnection[] = []
-
-  if (sidecarDataplane.type === 'inbound' && Array.isArray(policy.sources)) {
-    for (const { match } of policy.sources) {
-      const sourceTags: LabelValue[] = [{ label: 'kuma.io/service', value: match['kuma.io/service'] }]
-      const connection: PolicyTypeEntryConnection = { sourceTags, destinationTags, name, config, origins }
-
-      policyTypeEntryConnections.push(connection)
-    }
-  } else {
-    const sourceTags: LabelValue[] = []
-    const connection: PolicyTypeEntryConnection = { sourceTags, destinationTags, name, config, origins }
-
-    policyTypeEntryConnections.push(connection)
-  }
-
-  return policyTypeEntryConnections
-}
-
-function getRules(rules: InspectBaseRule[]): RuleEntryRule[] {
-  return rules.map(({ conf, matchers, origin }) => {
-    const config = conf && Object.keys(conf).length > 0 ? toYaml(conf) : undefined
-    const origins = origin.map((origin) => {
-      const policyType = props.policyTypesByName[origin.type]!
-
-      return {
-        name: origin.name,
-        route: {
-          name: 'policy-detail-view',
-          params: {
-            mesh: origin.mesh,
-            policyPath: policyType.path,
-            policy: origin.name,
-          },
-        },
-      }
-    })
-
-    return {
-      config,
-      matchers,
-      origins,
-    }
-  })
-}
 </script>

--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -1,4 +1,11 @@
-import { Dataplane, DataplaneOverview } from './data'
+import {
+  Dataplane,
+  DataplaneOverview,
+  InspectRules,
+  InspectRulesForDataplane,
+  MeshGatewayDataplane,
+  SidecarDataplane,
+} from './data'
 import type { Can } from '../application/services/can'
 import { defineSources } from '@/app/application/services/data-source'
 import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
@@ -7,7 +14,7 @@ import { parse, getTraffic } from '@/app/data-planes/data/stats'
 import type { TrafficEntry } from '@/app/data-planes/data/stats'
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse, ApiKindListResponse as KindCollectionResponse } from '@/types/api.d'
-import type { InspectRulesForDataplane, MeshGatewayDataplane, SidecarDataplane } from '@/types/index.d'
+import type { PolicyTypeEntry } from '@/types/index.d'
 
 export type { Dataplane, DataplaneOverview } from './data'
 
@@ -18,7 +25,7 @@ export type DataPlaneCollectionSource = DataSourceResponse<DataPlaneCollection>
 
 export type EnvoyDataSource = DataSourceResponse<object | string>
 
-export type SidecarDataplaneCollection = KindCollectionResponse<SidecarDataplane>
+export type SidecarDataplaneCollection = KindCollectionResponse<SidecarDataplane> & { policyTypeEntries: PolicyTypeEntry[] }
 export type SidecarDataplaneCollectionSource = DataSourceResponse<SidecarDataplaneCollection>
 
 export type MeshGatewayDataplaneSource = DataSourceResponse<MeshGatewayDataplane>
@@ -40,6 +47,7 @@ export const sources = (api: KumaApi, can: Can) => {
     '/meshes/:mesh/dataplanes/:name': async (params) => {
       return Dataplane.fromObject(await api.getDataplaneFromMesh(params))
     },
+
     '/meshes/:mesh/dataplanes/:name/traffic': async (params) => {
       const { mesh, name } = params
       const res = await api.getDataplaneData({
@@ -95,15 +103,15 @@ export const sources = (api: KumaApi, can: Can) => {
     },
 
     '/meshes/:mesh/dataplanes/:name/sidecar-dataplane-policies': async (params) => {
-      return api.getSidecarDataplanePolicies(params)
+      return SidecarDataplane.fromCollection(await api.getSidecarDataplanePolicies(params))
     },
 
     '/meshes/:mesh/dataplanes/:name/rules': async (params) => {
-      return api.getDataplaneRules(params)
+      return InspectRules.fromCollection(await api.getDataplaneRules(params))
     },
 
-    '/meshes/:mesh/dataplanes/:name/gateway-dataplane-policies': (params) => {
-      return api.getMeshGatewayDataplane(params)
+    '/meshes/:mesh/dataplanes/:name/gateway-dataplane-policies': async (params) => {
+      return MeshGatewayDataplane.fromObject(await api.getMeshGatewayDataplane(params))
     },
 
     '/meshes/:mesh/dataplane-overviews/:name': async (params) => {

--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -80,7 +80,7 @@
               <StandardDataplanePolicies
                 v-else
                 :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
-                :sidecar-dataplanes="sidecarDataplaneData.items"
+                :policy-type-entries="sidecarDataplaneData.policyTypeEntries"
                 :inspect-rules-for-dataplane="rulesData"
                 :show-policies-section="!can('use zones')"
               />

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,5 +1,3 @@
-import { RouteLocationNamedRaw } from 'vue-router'
-
 /**
  * Creates an “unsaved” variant of a resource type which is missing the fields that are only present on an object once its saved in the database.
  */
@@ -197,6 +195,14 @@ export type DataplaneGateway = {
    * Type of the gateway. **Default**: `'DELEGATED'`
    */
   type?: 'BUILTIN' | 'DELEGATED'
+}
+
+export type DataplaneWarning = {
+  kind: string
+  payload?: {
+    kumaDp: string
+    envoy?: string
+  }
 }
 
 export type DataplaneInbound = {
@@ -419,22 +425,34 @@ export interface MeshGatewayDataplane {
   policies?: Record<string, MatchedPolicyType>
 }
 
-export type SidecarDataplaneRuleEntry = {
-  rule: DataplaneRule
-  policyRoutes: Map<{ name: string, route: RouteLocationNamedRaw }>
+export type PolicyTypeEntryConnection = {
+  sourceTags: LabelValue[]
+  destinationTags: LabelValue[]
+  name: string | null
+  origins: Meta[]
+  config: string | undefined
 }
 
-export type MeshGatewayRoutePolicy = {
+export type PolicyTypeEntry = {
   type: string
-  name: string
-  route: RouteLocationNamedRaw
+  connections: PolicyTypeEntryConnection[]
+}
+
+export type RuleEntryRule = {
+  config: object | undefined
+  matchers?: InspectRuleMatcher[]
+  origins: Meta[]
+}
+
+export type RuleEntry = {
+  type: string
+  rules: RuleEntryRule[]
 }
 
 export type MeshGatewayRouteEntry = {
-  route: RouteLocationNamedRaw
-  routeName: string
+  route: Meta
   service: string
-  policies: MeshGatewayRoutePolicy[]
+  origins: Meta[]
 }
 
 export type MeshGatewayListenerEntry = {


### PR DESCRIPTION
Follow up to #1871.

Move all data transformations happening in the Dataplane Policies tab components into the data layer.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
