### PR TITLE
refactor(dataplanes): add data transformations for inbounds

### DIFF
--- a/src/app/data-planes/components/DataPlaneSummary.vue
+++ b/src/app/data-planes/components/DataPlaneSummary.vue
@@ -74,13 +74,13 @@
       </div>
     </div>
 
-    <div v-if="props.dataplaneOverview.dataplane.networking.inbound">
+    <div v-if="props.dataplaneOverview.dataplane.networking.inbounds.length > 0">
       <h3>{{ t('data-planes.routes.item.inbounds') }}</h3>
 
       <div class="mt-4">
         <div class="stack">
           <div
-            v-for="(inbound, index) in props.dataplaneOverview.dataplane.networking.inbound"
+            v-for="(inbound, index) in props.dataplaneOverview.dataplane.networking.inbounds"
             :key="index"
             class="inbound"
           >
@@ -98,7 +98,7 @@
 
                 <template #body>
                   <KBadge
-                    v-if="!inbound.health || inbound.health.ready"
+                    v-if="inbound.health.ready"
                     appearance="success"
                   >
                     {{ t('data-planes.routes.item.health.ready') }}
@@ -132,7 +132,7 @@
                 </template>
 
                 <template #body>
-                  <TextWithCopyButton :text="`${inbound.address ?? props.dataplaneOverview.dataplane.networking.advertisedAddress ?? props.dataplaneOverview.dataplane.networking.address}:${inbound.port}`" />
+                  <TextWithCopyButton :text="inbound.addressPort" />
                 </template>
               </DefinitionCard>
             </div>

--- a/src/app/data-planes/data/index.spec.ts
+++ b/src/app/data-planes/data/index.spec.ts
@@ -20,7 +20,7 @@ describe('dataplanes data transformations', () => {
           creationTime: '',
           modificationTime: '',
           networking: {
-            address: '',
+            address: 'http://example.org',
           },
         }],
         expected: {
@@ -30,7 +30,9 @@ describe('dataplanes data transformations', () => {
           creationTime: '',
           modificationTime: '',
           networking: {
-            address: '',
+            address: 'http://example.org',
+            inbounds: [],
+            outbounds: [],
           },
         },
       },
@@ -62,7 +64,7 @@ describe('dataplanes data transformations', () => {
             modificationTime: '',
             dataplane: {
               networking: {
-                address: '',
+                address: 'http://example.org',
               },
             },
           },
@@ -76,7 +78,9 @@ describe('dataplanes data transformations', () => {
           modificationTime: '',
           dataplane: {
             networking: {
-              address: '',
+              address: 'http://example.org',
+              inbounds: [],
+              outbounds: [],
             },
           },
           dataplaneInsight: {
@@ -103,7 +107,7 @@ describe('dataplanes data transformations', () => {
             modificationTime: '',
             dataplane: {
               networking: {
-                address: '',
+                address: 'http://example.org',
                 inbound: [
                   {
                     health: {
@@ -168,8 +172,8 @@ describe('dataplanes data transformations', () => {
           modificationTime: '',
           dataplane: {
             networking: {
-              address: '',
-              inbound: [
+              address: 'http://example.org',
+              inbounds: [
                 {
                   health: {
                     ready: true,
@@ -179,8 +183,11 @@ describe('dataplanes data transformations', () => {
                     'kuma.io/zone': '',
                   },
                   port: 1,
+                  addressPort: 'http://example.org:1',
+                  serviceAddressPort: 'http://example.org:1',
                 },
               ],
+              outbounds: [],
             },
           },
           dataplaneInsight: {
@@ -290,7 +297,7 @@ describe('dataplanes data transformations', () => {
             modificationTime: '',
             dataplane: {
               networking: {
-                address: '',
+                address: 'http://example.org',
                 inbound: [
                   {
                     health: {
@@ -340,8 +347,8 @@ describe('dataplanes data transformations', () => {
           modificationTime: '',
           dataplane: {
             networking: {
-              address: '',
-              inbound: [
+              address: 'http://example.org',
+              inbounds: [
                 {
                   health: {
                     ready: true,
@@ -350,8 +357,11 @@ describe('dataplanes data transformations', () => {
                     'kuma.io/service': '',
                   },
                   port: 1,
+                  addressPort: 'http://example.org:1',
+                  serviceAddressPort: 'http://example.org:1',
                 },
               ],
+              outbounds: [],
             },
           },
           dataplaneInsight: {
@@ -400,7 +410,7 @@ describe('dataplanes data transformations', () => {
             modificationTime: '',
             dataplane: {
               networking: {
-                address: '',
+                address: 'http://example.org',
                 inbound: [
                   {
                     health: {
@@ -442,8 +452,8 @@ describe('dataplanes data transformations', () => {
           modificationTime: '',
           dataplane: {
             networking: {
-              address: '',
-              inbound: [
+              address: 'http://example.org',
+              inbounds: [
                 {
                   health: {
                     ready: false,
@@ -452,8 +462,11 @@ describe('dataplanes data transformations', () => {
                     'kuma.io/service': '',
                   },
                   port: 1,
+                  addressPort: 'http://example.org:1',
+                  serviceAddressPort: 'http://example.org:1',
                 },
               ],
+              outbounds: [],
             },
           },
           dataplaneInsight: {
@@ -509,7 +522,7 @@ describe('dataplanes data transformations', () => {
             modificationTime: '',
             dataplane: {
               networking: {
-                address: '',
+                address: 'http://example.org',
                 inbound: [
                   {
                     health: {
@@ -522,9 +535,6 @@ describe('dataplanes data transformations', () => {
                     },
                   },
                   {
-                    health: {
-                      ready: true,
-                    },
                     port: 1,
                     tags: {
                       'kuma.io/service': 'service-2',
@@ -562,29 +572,34 @@ describe('dataplanes data transformations', () => {
           modificationTime: '',
           dataplane: {
             networking: {
-              address: '',
-              inbound: [
+              address: 'http://example.org',
+              inbounds: [
                 {
                   health: {
                     ready: false,
                   },
-                  port: 1,
                   tags: {
                     'kuma.io/service': 'service-1',
                     'kuma.io/zone': 'zone-1',
                   },
+                  port: 1,
+                  addressPort: 'http://example.org:1',
+                  serviceAddressPort: 'http://example.org:1',
                 },
                 {
                   health: {
                     ready: true,
                   },
-                  port: 1,
                   tags: {
                     'kuma.io/service': 'service-2',
                     'kuma.io/zone': 'zone-1',
                   },
+                  port: 1,
+                  addressPort: 'http://example.org:1',
+                  serviceAddressPort: 'http://example.org:1',
                 },
               ],
+              outbounds: [],
             },
           },
           dataplaneInsight: {
@@ -640,7 +655,7 @@ describe('dataplanes data transformations', () => {
             modificationTime: '',
             dataplane: {
               networking: {
-                address: '',
+                address: 'http://example.org',
                 gateway: {
                   type: 'DELEGATED',
                   tags: {
@@ -679,7 +694,7 @@ describe('dataplanes data transformations', () => {
           modificationTime: '',
           dataplane: {
             networking: {
-              address: '',
+              address: 'http://example.org',
               gateway: {
                 type: 'DELEGATED',
                 tags: {
@@ -688,6 +703,8 @@ describe('dataplanes data transformations', () => {
                   'kuma.io/protocol': 'http',
                 },
               },
+              inbounds: [],
+              outbounds: [],
             },
           },
           dataplaneInsight: {
@@ -740,7 +757,7 @@ describe('dataplanes data transformations', () => {
             modificationTime: '',
             dataplane: {
               networking: {
-                address: '',
+                address: 'http://example.org',
                 gateway: {
                   tags: {
                     'kuma.io/service': 'service-1',
@@ -778,7 +795,7 @@ describe('dataplanes data transformations', () => {
           modificationTime: '',
           dataplane: {
             networking: {
-              address: '',
+              address: 'http://example.org',
               gateway: {
                 tags: {
                   'kuma.io/service': 'service-1',
@@ -786,6 +803,8 @@ describe('dataplanes data transformations', () => {
                   'kuma.io/protocol': 'http',
                 },
               },
+              inbounds: [],
+              outbounds: [],
             },
           },
           dataplaneInsight: {
@@ -838,7 +857,7 @@ describe('dataplanes data transformations', () => {
             modificationTime: '',
             dataplane: {
               networking: {
-                address: '',
+                address: 'http://example.org',
                 gateway: {
                   type: 'BUILTIN',
                   tags: {
@@ -890,13 +909,15 @@ describe('dataplanes data transformations', () => {
           modificationTime: '',
           dataplane: {
             networking: {
-              address: '',
+              address: 'http://example.org',
               gateway: {
                 type: 'BUILTIN',
                 tags: {
                   'kuma.io/service': '',
                 },
               },
+              inbounds: [],
+              outbounds: [],
             },
           },
           dataplaneInsight: {

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -233,8 +233,9 @@
             </div>
           </KCard>
         </DataSource>
+
         <div
-          v-if="props.data.dataplane.networking.inbound && props.data.dataplane.networking.inbound.length > 0"
+          v-if="props.data.dataplane.networking.inbounds.length > 0"
           data-testid="dataplane-inbounds"
         >
           <h2>{{ t('data-planes.routes.item.inbounds') }}</h2>
@@ -242,7 +243,7 @@
           <KCard class="mt-4">
             <div class="inbound-list">
               <div
-                v-for="(inbound, index) in props.data.dataplane.networking.inbound"
+                v-for="(inbound, index) in props.data.dataplane.networking.inbounds"
                 :key="index"
                 class="inbound"
               >
@@ -260,7 +261,7 @@
 
                     <template #body>
                       <KBadge
-                        v-if="!inbound.health || inbound.health.ready"
+                        v-if="inbound.health.ready"
                         appearance="success"
                       >
                         {{ t('data-planes.routes.item.health.ready') }}
@@ -291,7 +292,7 @@
                     </template>
 
                     <template #body>
-                      <TextWithCopyButton :text="`${inbound.address ?? props.data.dataplane.networking.advertisedAddress ?? props.data.dataplane.networking.address}:${inbound.port}`" />
+                      <TextWithCopyButton :text="inbound.addressPort" />
                     </template>
                   </DefinitionCard>
 
@@ -301,7 +302,7 @@
                     </template>
 
                     <template #body>
-                      <TextWithCopyButton :text="`${inbound.serviceAddress ?? inbound.address ?? props.data.dataplane.networking.address}:${inbound.servicePort ?? inbound.port}`" />
+                      <TextWithCopyButton :text="inbound.serviceAddressPort" />
                     </template>
                   </DefinitionCard>
                 </div>


### PR DESCRIPTION
Follow up to #1871.

Add data transformations for inbounds.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
