### PR TITLE
chore(tests): Reusable data layer test approach

### DIFF
--- a/src/app/zone-ingresses/data/index.spec.ts
+++ b/src/app/zone-ingresses/data/index.spec.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test } from 'vitest'
+
+import { ZoneIngressOverview } from './'
+import { useResponder } from '@/test-support'
+import mock from '@/test-support/mocks/src/zone-ingresses/_/_overview'
+import { ZoneIngressOverview as PartialZoneIngressOverview } from '@/types/index'
+
+type Writeable<T> = { -readonly [P in keyof T]: Writeable<T[P]> };
+
+type Assert = (actual: ZoneIngressOverview, item: PartialZoneIngressOverview) => void
+type Context = {
+  message: string
+  assert: Assert
+  get: () => Promise<PartialZoneIngressOverview>
+}
+type Test = {
+  env?: Record<string, string>
+  message: string
+  assert: Assert
+  setup: (item: PartialZoneIngressOverview) => Promise<PartialZoneIngressOverview>
+}
+
+const freeze = (obj: any) => {
+  Object.keys(obj).forEach(prop => {
+    if (typeof obj[prop] === 'object' && !Object.isFrozen(obj[prop])) {
+      freeze(obj[prop])
+    }
+  })
+  return Object.freeze(obj)
+}
+
+const get = async (env: Record<string, string>) => {
+  const responder = useResponder({
+    _: mock,
+  }, (key: string, d = '') => env[key] ?? d)
+  const request = responder('_')
+  return (await request(
+    {
+      method: 'GET',
+      body: {},
+      url: {
+        searchParams: new URLSearchParams(),
+      },
+      params: {
+        name: 'zone',
+      },
+    },
+  )).body
+}
+
+const map = (test: Test) => {
+  return {
+    message: test.message,
+    assert: test.assert,
+    get: async () => {
+      const item = (await get(test.env ?? {})) as unknown as Writeable<PartialZoneIngressOverview>
+      return freeze(await test.setup(item)) as Readonly<PartialZoneIngressOverview>
+    },
+  }
+}
+const run = async ({ get, assert }: Context) => {
+  const item = await get()
+  assert(ZoneIngressOverview.fromObject(item), item)
+}
+//
+describe('ZoneIngressOverview', () => {
+  describe('zoneInsight.subscriptions', () => {
+    test.each(([
+      {
+        message: 'absent zoneInsight remains undefined',
+        setup: async (item) => {
+          delete item.zoneIngressInsight
+          return item
+        },
+        assert: (actual) => {
+          expect(actual.zoneIngressInsight).toBeUndefined()
+        },
+      },
+      {
+        message: 'no subscriptions, connectedSubscription remains undefined',
+        setup: async (item) => {
+          if (typeof item.zoneIngressInsight !== 'undefined') {
+            item.zoneIngressInsight.subscriptions = []
+          }
+          return item
+        },
+        assert: (actual) => {
+          expect(actual.zoneIngressInsight).toBeDefined()
+          expect(actual.zoneIngressInsight?.subscriptions.length).toStrictEqual(0)
+          expect(actual.zoneIngressInsight?.connectedSubscription).toBeUndefined()
+        },
+      },
+      {
+        message: 'all disconnected subscriptions, connectedSubscription remains undefined',
+        env: {
+          KUMA_SUBSCRIPTION_COUNT: '10',
+        },
+        setup: async (item) => {
+          if (typeof item.zoneIngressInsight !== 'undefined') {
+            item.zoneIngressInsight.subscriptions.forEach((item: any) => {
+              item.connectTime = '2021-02-19T07:06:16.384057Z'
+              item.disconnectTime = '2021-03-19T07:06:16.384057Z'
+            })
+          }
+          return item
+        },
+        assert: (actual) => {
+          expect(actual.zoneIngressInsight).toBeDefined()
+          expect(actual.zoneIngressInsight?.subscriptions.length).toStrictEqual(10)
+          expect(actual.zoneIngressInsight?.connectedSubscription).toBeUndefined()
+        },
+      },
+    ] as Test[]).map(map))('$message', run)
+  })
+
+  describe('state', () => {
+    test.each(([
+      {
+        message: 'all disconnected subscriptions, state=offline',
+        env: {
+          KUMA_SUBSCRIPTION_COUNT: '10',
+        },
+        setup: async (item) => {
+          if (typeof item.zoneIngressInsight !== 'undefined') {
+            item.zoneIngressInsight.subscriptions.forEach((item: any) => {
+              item.connectTime = '2021-02-19T07:06:16.384057Z'
+              item.disconnectTime = '2021-03-19T07:06:16.384057Z'
+            })
+          }
+          return item
+        },
+        assert: (actual) => {
+          expect(actual.state).toStrictEqual('offline')
+        },
+      },
+      {
+        message: 'a connected subscription, state=online',
+        env: {
+          KUMA_SUBSCRIPTION_COUNT: '10',
+        },
+        setup: async (item) => {
+          if (typeof item.zoneIngressInsight !== 'undefined') {
+            item.zoneIngressInsight.subscriptions.forEach((item: any, i: number, arr: any[]) => {
+              item.connectTime = '2021-02-19T07:06:16.384057Z'
+              if (i === arr.length - 1) {
+                delete item.disconnectTime
+              } else {
+                item.disconnectTime = '2021-03-19T07:06:16.384057Z'
+              }
+            })
+          }
+          return item
+        },
+        assert: (actual) => {
+          expect(actual.state).toStrictEqual('online')
+        },
+      },
+    ] as Test[]).map(map))('$message', run)
+  })
+
+  describe('availableServices', () => {
+    test.each(([
+      {
+        message: 'absent availableServices, availableServices=[]',
+        setup: async (item) => {
+          delete item.zoneIngress.availableServices
+          return item
+        },
+        assert: (actual) => {
+          expect(Array.isArray(actual.zoneIngress.availableServices)).toStrictEqual(true)
+          expect(actual.zoneIngress.availableServices.length).toStrictEqual(0)
+        },
+      },
+      {
+        message: 'null availableServices, availableServices=[]',
+        setup: async (item) => {
+          // @ts-ignore
+          item.zoneIngress.availableServices = null
+          return item
+        },
+        assert: (actual) => {
+          expect(Array.isArray(actual.zoneIngress.availableServices)).toStrictEqual(true)
+          expect(actual.zoneIngress.availableServices.length).toStrictEqual(0)
+        },
+      },
+      {
+        message: '[] availableServices, availableServices=[]',
+        setup: async (item) => {
+          item.zoneIngress.availableServices = []
+          return item
+        },
+        assert: (actual) => {
+          expect(Array.isArray(actual.zoneIngress.availableServices)).toStrictEqual(true)
+          expect(actual.zoneIngress.availableServices.length).toStrictEqual(0)
+        },
+      },
+      {
+        env: {
+          KUMA_SERVICE_COUNT: '1',
+        },
+        message: '1 availableService',
+        setup: async (item) => {
+          return item
+        },
+        assert: (actual) => {
+          expect(Array.isArray(actual.zoneIngress.availableServices)).toStrictEqual(true)
+          expect(actual.zoneIngress.availableServices.length).toStrictEqual(1)
+        },
+      },
+    ] as Test[]).map(map))('$message', run)
+  })
+
+  describe('addresses', () => {
+    test.each(([
+      {
+        message: 'absent addresses, socketAddress = "" advertisedSocketAddress = ""',
+        setup: async (item) => {
+          if (typeof item.zoneIngress.networking === 'undefined') {
+            item.zoneIngress.networking = {}
+          }
+          delete item.zoneIngress.networking?.address
+          item.zoneIngress.networking.port = '80'
+          delete item.zoneIngress.networking?.advertisedAddress
+          item.zoneIngress.networking.advertisedPort = '80'
+          return item
+        },
+        assert: (actual) => {
+          expect(actual.zoneIngress.socketAddress).toStrictEqual('')
+          expect(actual.zoneIngress.advertisedSocketAddress).toStrictEqual('')
+        },
+      },
+      {
+        message: 'absent ports, socketAddress = "" advertisedSocketAddress = ""',
+        setup: async (item) => {
+          if (typeof item.zoneIngress.networking === 'undefined') {
+            item.zoneIngress.networking = {}
+          }
+          item.zoneIngress.networking.address = '127.0.0.1'
+          delete item.zoneIngress.networking.port
+          item.zoneIngress.networking.advertisedAddress = '127.0.0.1'
+          delete item.zoneIngress.networking.advertisedPort
+          return item
+        },
+        assert: (actual) => {
+          expect(actual.zoneIngress.socketAddress).toStrictEqual('')
+          expect(actual.zoneIngress.advertisedSocketAddress).toStrictEqual('')
+        },
+      },
+      {
+        message: 'numbered ports, socketAddress is correct advertisedSocketAddress is correct',
+        setup: async (item) => {
+          if (typeof item.zoneIngress.networking === 'undefined') {
+            item.zoneIngress.networking = {}
+          }
+          item.zoneIngress.networking.address = '127.0.0.1'
+          // @ts-ignore
+          item.zoneIngress.networking.port = 80
+          item.zoneIngress.networking.advertisedAddress = '127.0.0.2'
+          // @ts-ignore
+          item.zoneIngress.networking.advertisedPort = 81
+          return item
+        },
+        assert: (actual) => {
+          expect(actual.zoneIngress.socketAddress).toStrictEqual('127.0.0.1:80')
+          expect(actual.zoneIngress.advertisedSocketAddress).toStrictEqual('127.0.0.2:81')
+        },
+      },
+      {
+        message: 'string ports, socketAddress is correct advertisedSocketAddress is correct',
+        setup: async (item) => {
+          if (typeof item.zoneIngress.networking === 'undefined') {
+            item.zoneIngress.networking = {}
+          }
+          item.zoneIngress.networking.address = '127.0.0.1'
+          item.zoneIngress.networking.port = '80'
+          item.zoneIngress.networking.advertisedAddress = '127.0.0.2'
+          item.zoneIngress.networking.advertisedPort = '81'
+          return item
+        },
+        assert: (actual) => {
+          expect(actual.zoneIngress.socketAddress).toStrictEqual('127.0.0.1:80')
+          expect(actual.zoneIngress.advertisedSocketAddress).toStrictEqual('127.0.0.2:81')
+        },
+      },
+    ] as Test[]).map(map))('$message', run)
+  })
+})

--- a/src/app/zones/data/index.spec.ts
+++ b/src/app/zones/data/index.spec.ts
@@ -29,7 +29,7 @@ describe('ZoneOverview', () => {
             KUMA_SUBSCRIPTION_COUNT: '1',
           },
         })
-        expect(Object.keys(actual.zoneInsight?.config || {}).length > 0).toStrictEqual(true)
+        expect(Object.keys(actual.zoneInsight.config).length > 0).toStrictEqual(true)
       },
     )
   })
@@ -111,7 +111,7 @@ describe('ZoneOverview', () => {
           delete item.zoneInsight
           return item
         })
-        expect(actual.zoneInsight).toBeUndefined()
+        expect(actual.zoneInsight).toBeDefined()
       },
     )
 
@@ -125,14 +125,14 @@ describe('ZoneOverview', () => {
           return item
         })
         expect(actual.zoneInsight).toBeDefined()
-        expect(actual.zoneInsight?.subscriptions.length).toStrictEqual(0)
-        expect(actual.zoneInsight?.connectedSubscription).toBeUndefined()
-        expect(actual.zoneInsight?.config).toStrictEqual({})
+        expect(actual.zoneInsight.subscriptions.length).toStrictEqual(0)
+        expect(actual.zoneInsight.connectedSubscription).toBeUndefined()
+        expect(actual.zoneInsight.config).toStrictEqual({})
       },
     )
 
     test(
-      'all disconnected subscriptions, connectedSubscription remains undefined, config={}',
+      'all disconnected subscriptions, connectedSubscription remains undefined',
       async ({ fixture }) => {
         const actual = await fixture.setup((item) => {
           if (typeof item.zoneInsight !== 'undefined') {
@@ -148,9 +148,8 @@ describe('ZoneOverview', () => {
           },
         })
         expect(actual.zoneInsight).toBeDefined()
-        expect(actual.zoneInsight?.subscriptions.length).toStrictEqual(10)
-        expect(actual.zoneInsight?.connectedSubscription).toBeUndefined()
-        expect(actual.zoneInsight?.config).toStrictEqual({})
+        expect(actual.zoneInsight.subscriptions.length).toStrictEqual(10)
+        expect(actual.zoneInsight.connectedSubscription).toBeUndefined()
       },
     )
   })

--- a/src/app/zones/data/index.spec.ts
+++ b/src/app/zones/data/index.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test as _test } from 'vitest'
+
+import { ZoneOverview } from './'
+import { plugin, server } from '@/test-support/data'
+import mock from '@/test-support/mocks/src/zones/_/_overview'
+
+describe('ZoneOverview', () => {
+  const test = _test.extend(plugin<typeof ZoneOverview>(
+    ZoneOverview,
+    server(mock, {
+      params: {
+        name: 'zone',
+      },
+    }),
+  ))
+  //
+  describe('zoneInsight.config', () => {
+    test(
+      'absent enabled, a connected subscription, config has properties',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          delete item.zone.enabled
+          if (typeof item.zoneInsight !== 'undefined' && item.zoneInsight.subscriptions.length === 1) {
+            delete item.zoneInsight.subscriptions[0].disconnectTime
+          }
+          return item
+        }, {
+          env: {
+            KUMA_SUBSCRIPTION_COUNT: '1',
+          },
+        })
+        expect(Object.keys(actual.zoneInsight?.config || {}).length > 0).toStrictEqual(true)
+      },
+    )
+
+    test(
+      'absent means enabled=true',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          delete item.zone.enabled
+          return item
+        })
+        expect(actual.zone.enabled).toStrictEqual(true)
+      },
+    )
+  })
+})

--- a/src/app/zones/data/index.spec.ts
+++ b/src/app/zones/data/index.spec.ts
@@ -32,7 +32,8 @@ describe('ZoneOverview', () => {
         expect(Object.keys(actual.zoneInsight?.config || {}).length > 0).toStrictEqual(true)
       },
     )
-
+  })
+  describe('zone.enabled', () => {
     test(
       'absent means enabled=true',
       async ({ fixture }) => {
@@ -41,6 +42,179 @@ describe('ZoneOverview', () => {
           return item
         })
         expect(actual.zone.enabled).toStrictEqual(true)
+      },
+    )
+
+    test(
+      'true means enabled=true',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          item.zone.enabled = true
+          return item
+        })
+        expect(actual.zone.enabled).toStrictEqual(true)
+      },
+    )
+
+    test(
+      'false means enabled=false',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          item.zone.enabled = false
+          return item
+        })
+        expect(actual.zone.enabled).toStrictEqual(false)
+      },
+    )
+
+    test(
+      'null means enabled=true',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          // @ts-ignore
+          item.zone.enabled = null
+          return item
+        })
+        expect(actual.zone.enabled).toStrictEqual(true)
+      },
+    )
+
+    test(
+      '"" means enabled=true',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          // @ts-ignore
+          item.zone.enabled = ''
+          return item
+        })
+        expect(actual.zone.enabled).toStrictEqual(true)
+      },
+    )
+
+    test(
+      '0 means enabled=true',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          // @ts-ignore
+          item.zone.enabled = 0
+          return item
+        })
+        expect(actual.zone.enabled).toStrictEqual(true)
+      },
+    )
+  })
+  describe('zoneInsight.subscriptions', () => {
+    test(
+      'absent zoneInsight remains undefined',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          delete item.zoneInsight
+          return item
+        })
+        expect(actual.zoneInsight).toBeUndefined()
+      },
+    )
+
+    test(
+      'no subscriptions, connectedSubscription remains undefined, config={}',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          if (typeof item.zoneInsight !== 'undefined') {
+            item.zoneInsight.subscriptions = []
+          }
+          return item
+        })
+        expect(actual.zoneInsight).toBeDefined()
+        expect(actual.zoneInsight?.subscriptions.length).toStrictEqual(0)
+        expect(actual.zoneInsight?.connectedSubscription).toBeUndefined()
+        expect(actual.zoneInsight?.config).toStrictEqual({})
+      },
+    )
+
+    test(
+      'all disconnected subscriptions, connectedSubscription remains undefined, config={}',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          if (typeof item.zoneInsight !== 'undefined') {
+            item.zoneInsight.subscriptions.forEach((item) => {
+              item.connectTime = '2021-02-19T07:06:16.384057Z'
+              item.disconnectTime = '2021-03-19T07:06:16.384057Z'
+            })
+          }
+          return item
+        }, {
+          env: {
+            KUMA_SUBSCRIPTION_COUNT: '10',
+          },
+        })
+        expect(actual.zoneInsight).toBeDefined()
+        expect(actual.zoneInsight?.subscriptions.length).toStrictEqual(10)
+        expect(actual.zoneInsight?.connectedSubscription).toBeUndefined()
+        expect(actual.zoneInsight?.config).toStrictEqual({})
+      },
+    )
+  })
+  describe('state', () => {
+    test(
+      'enabled=false, all disconnected subscriptions, state=disabled',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          item.zone.enabled = false
+          if (typeof item.zoneInsight !== 'undefined') {
+            item.zoneInsight.subscriptions.forEach((item) => {
+              item.connectTime = '2021-02-19T07:06:16.384057Z'
+              item.disconnectTime = '2021-03-19T07:06:16.384057Z'
+            })
+          }
+          return item
+        }, {
+          env: {
+            KUMA_SUBSCRIPTION_COUNT: '10',
+          },
+        })
+        expect(actual.state).toStrictEqual('disabled')
+      },
+    )
+
+    test(
+      'absent enabled, all disconnected subscriptions, state=offline',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          delete item.zone.enabled
+          if (typeof item.zoneInsight !== 'undefined') {
+            item.zoneInsight.subscriptions.forEach((item) => {
+              item.connectTime = '2021-02-19T07:06:16.384057Z'
+              item.disconnectTime = '2021-03-19T07:06:16.384057Z'
+            })
+          }
+          return item
+        }, {
+          env: {
+            KUMA_SUBSCRIPTION_COUNT: '10',
+          },
+        })
+        expect(actual.state).toStrictEqual('offline')
+      },
+    )
+
+    test(
+      'absent enabled, all disconnected subscriptions, state=offline',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          delete item.zone.enabled
+          if (typeof item.zoneInsight !== 'undefined') {
+            item.zoneInsight.subscriptions.forEach((item, i, arr) => {
+              item.connectTime = '2021-02-19T07:06:16.384057Z'
+              if (i === arr.length - 1) {
+                delete item.disconnectTime
+              } else {
+                item.disconnectTime = '2021-03-19T07:06:16.384057Z'
+              }
+            })
+          }
+          return item
+        })
+        expect(actual.state).toStrictEqual('online')
       },
     )
   })

--- a/src/test-support/data/index.ts
+++ b/src/test-support/data/index.ts
@@ -1,0 +1,51 @@
+import { test as _test } from 'vitest'
+export { server } from '@/test-support'
+
+type Writeable<T> = { -readonly [P in keyof T]: Writeable<T[P]> };
+
+const freeze = (obj: any) => {
+  Object.keys(obj).forEach(prop => {
+    if (typeof obj[prop] === 'object' && !Object.isFrozen(obj[prop])) {
+      freeze(obj[prop])
+    }
+  })
+  return Object.freeze(obj)
+}
+
+type Transformer<T> = T extends {
+  fromObject: infer R
+} ? { fromObject: R } : { fromObject: any }
+
+type TestOptions = {
+  env?: Record<string, string>
+  params?: Record<string, string>
+}
+
+export const plugin = <T>(
+  transformer: Transformer<T>,
+  get: (
+    env: Record<string, string>,
+    params: Record<string, string>
+  ) => Promise<unknown>,
+) => {
+  type K = ReturnType<typeof transformer['fromObject']>
+  type Partial = Parameters<typeof transformer['fromObject']>[0]
+  return {
+    // vite doesn't seem to let us have a function here so use a fixture object
+    // containing a function
+    fixture: {
+      setup: async (
+        fn: (item: Partial) => Partial,
+        options: TestOptions = {},
+      ): Promise<K> => {
+        // recreate the mock/partial from our mocks for every test
+        // entirely replacing the env and request params each time i.e. non-merging
+        const res = await get(options.env ?? {}, options.params ?? {}) as Writeable<Partial>
+        // freeze the result of any setup/mutation so we can make sure our transformers don't overwrite
+        const partial = freeze(fn(res)) as Readonly<Partial>
+        // return the transformed/augmented object/entity
+        return transformer.fromObject(partial)
+      },
+    },
+  }
+}


### PR DESCRIPTION
Note: we've already discussed this offline why this PR is a little weird and decided this was the best way for review.

---

I've kept 2 test files here:

1. My previous suite of tests for ZoneIngresses that I hadn't yet PRed. This approach had copy/pasted test utils and quite verbose table-like tests for testing the data transformations.
2. A different approach for Zones (that used to use the approach from point 1)

I'd like to use the new approach for the tests for Zones, ZoneIngresses and ZoneInsights for the following reasons (some of them already discussed offline and online here https://github.com/kumahq/kuma-gui/pull/1854#issuecomment-1839009146)

1. We are using our existing mocks for mock generation as our single source of truth.
2. We are avoiding copy pasting over and over our data structures and having to fill out these data structures in their entirety in order to test a small part of that structure. Here we only setup and the part of the structure we are interested in testing.
3. We are freezing the data structures being transforming them into something else to test that we aren't overwrite any of the original data structure.
4. Most importantly now we are avoiding copy/pasting the test utils and have a vitest test extension to help us achieve this.
5. I've tried to get this to a point so that it feels as close to normal testing as possible, as I was doing that I got to the point where it seemed like it wasn't even worth using table tests here. edit: I also noticed that not using table tests makes it much easier to use `.only`

Ok so just to outline the most important thing to review are the test utils and the couple of usage examples I've added for Zones. The ZoneIngress tests are just for comparison to the previous approach.

If I can get an informal 👍 on the new approach here I'll convert all these tests to use the new approach before looking for final approval.
