### PR TITLE
fix: add missing type export for policy type

### DIFF
--- a/src/app/policies/data/index.ts
+++ b/src/app/policies/data/index.ts
@@ -4,7 +4,7 @@ import type {
   PolicyEntity as PartialPolicy,
 } from '@/types/index.d'
 
-export { PolicyType } from '@/types/index.d'
+export type { PolicyType } from '@/types/index.d'
 
 export type PolicyDataplane = PartialPolicyDataplane
 


### PR DESCRIPTION
I looked into an lint rule to prevent/auto-fix this, but it was a bit of a can of worms. At a minimum it seems, it would mean that our lint command will take much longer to lint, but it might be worth it anyway.

Figured I'd get the PR up with the fix before thinking more/considering making some lint changes.

Just to note, I was surprised this got through our CI but it's only visible during development and has no impact on production. The visible error is that the development build fails with a cannot find export type of error in the browser console.