### PR TITLE
feat(dataplanes): add refresh button to dataplane viz

### DIFF
--- a/src/app/data-planes/components/data-plane-traffic/DataPlaneTraffic.vue
+++ b/src/app/data-planes/components/data-plane-traffic/DataPlaneTraffic.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="service-traffic">
+    <div class="actions">
+      <slot name="actions" />
+    </div>
+
     <DataCard
       class="header"
     >
@@ -16,9 +20,14 @@ import DataCard from '@/app/common/data-card/DataCard.vue'
 </script>
 <style lang="scss" scoped>
 .service-traffic {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: $kui-space-40;
+}
+.actions {
+  position: absolute;
+  right: 0;
 }
 .data-card.header {
   border: 0;

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -90,7 +90,7 @@
 
         <DataSource
           v-if="can('read traffic') && props.data.dataplaneType === 'standard'"
-          v-slot="{ data: traffic, error }: TrafficSource"
+          v-slot="{ data: traffic, error, refresh }: TrafficSource"
           :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/traffic`"
         >
           <ErrorBlock
@@ -151,6 +151,16 @@
                 </ServiceTrafficGroup>
               </DataPlaneTraffic>
               <DataPlaneTraffic>
+                <template #actions>
+                  <KButton
+                    appearance="primary"
+                    @click="refresh"
+                  >
+                    <RefreshIcon :size="KUI_ICON_SIZE_30" />
+
+                    Refresh
+                  </KButton>
+                </template>
                 <template #title>
                   <GatewayIcon
                     display="inline-block"
@@ -414,7 +424,7 @@
 
 <script lang="ts" setup>
 import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { InfoIcon, ForwardIcon, GatewayIcon } from '@kong/icons'
+import { InfoIcon, ForwardIcon, GatewayIcon, RefreshIcon } from '@kong/icons'
 import { computed } from 'vue'
 
 import type { DataplaneOverview } from '../data'

--- a/src/test-support/mocks/src/meshes/_/dataplanes/test-dataplane/stats.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes/test-dataplane/stats.ts
@@ -1,12 +1,12 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
-export default (deps: EndpointDependencies): MockResponder => (_req) => {
+export default (_deps: EndpointDependencies): MockResponder => (_req) => {
   return {
     headers: {},
-    body: stats(deps),
+    body: stats(),
   }
 }
 
-function stats({ fake }: EndpointDependencies) {
+function stats() {
   return `cluster.api-play-000_microservice-mesh_svc_8080.version_text: "a82b5279-497d-43ad-a5d6-2913957629a5"
 cluster.api-play-001_microservice-mesh_svc_8080.version_text: "a82b5279-497d-43ad-a5d6-2913957629a5"
 cluster.api-play-002_microservice-mesh_svc_8080.version_text: "a82b5279-497d-43ad-a5d6-2913957629a5"
@@ -1520,7 +1520,7 @@ http.api-play-001_microservice-mesh_svc_8080.downstream_rq_active: 0
 http.api-play-001_microservice-mesh_svc_8080.downstream_rq_completed: 41601
 http.api-play-001_microservice-mesh_svc_8080.downstream_rq_failed_path_normalization: 0
 http.api-play-001_microservice-mesh_svc_8080.downstream_rq_header_timeout: 0
-http.api-play-001_microservice-mesh_svc_8080.downstream_rq_http1_total: ${fake.number.int({ min: 0, max: 1000000 })}
+http.api-play-001_microservice-mesh_svc_8080.downstream_rq_http1_total: 41601
 http.api-play-001_microservice-mesh_svc_8080.downstream_rq_http2_total: 0
 http.api-play-001_microservice-mesh_svc_8080.downstream_rq_http3_total: 0
 http.api-play-001_microservice-mesh_svc_8080.downstream_rq_idle_timeout: 0


### PR DESCRIPTION
Adds refresh button to the Dataplane viz by way of a new 'actions' slot for the ServiceTraffic component.

[Direct Link](https://deploy-preview-1919--kuma-gui.netlify.app/gui/meshes/default/data-planes/redis-7dc86bbf7a-yidcd.firewall.kuma-system-proxy-3/overview) (ensure you enable `KUMA_TRAFFIC_ENABLED=true` for this host)

![Screenshot 2023-12-18 at 12 06 03](https://github.com/kumahq/kuma-gui/assets/554604/fbb7d116-b956-4fcd-8848-63f93fc9409a)

Notes:

- I copied the static `stats` mock endpoint over to `test-dataplane/stats.ts` so we can keep that static real world example data.
- I started making the `stats` endpoint we use dynamic, as we move forwards with this we will no longer have a `stats()` function in this file and instead the entire mock endpoint will use faker to be completely dynamic. At the moment I only did enough so you can see the refresh button working.
