### PR TITLE
chore: minor amends to dataplane viz

### DIFF
--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -62,7 +62,10 @@ export const sources = (api: KumaApi, can: Can) => {
       // inbounds is anything starting with `localhost_`
       const inbounds = getTraffic(json, (key) => key.startsWith('localhost_'))
 
-      // outbounds are anything else unless it starts with something in the below list
+      // outbounds are anything else unless it starts with something in the
+      // below list these are likely to follow a pattern at some point at which
+      // point this list can be removed and replaced by something that exludes
+      // the pattern
       const outbounds = getTraffic(json, (key) => {
         return ![
           'admin',
@@ -74,6 +77,7 @@ export const sources = (api: KumaApi, can: Can) => {
           'outbound_passthrough',
           'access_log_sink',
           'ads_cluster',
+          'meshtrace_zipkin',
         ].some(item => key.startsWith(item))
       })
 

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -138,10 +138,11 @@
                       ]"
                       :key="meta.protocol"
                     >
+                      <!-- rx and tx are purposefully reversed to rx=tx and tx=rx here due to the direction of the traffic (downstream) -->
                       <ServiceTrafficCard
                         :protocol="meta.protocol"
-                        :tx="item[meta.protocol]?.[`${meta.direction}_cx_tx_bytes_total`] as (number | undefined)"
-                        :rx="item[meta.protocol]?.[`${meta.direction}_cx_rx_bytes_total`] as (number | undefined)"
+                        :rx="item[meta.protocol]?.[`${meta.direction}_cx_tx_bytes_total`] as (number | undefined)"
+                        :tx="item[meta.protocol]?.[`${meta.direction}_cx_rx_bytes_total`] as (number | undefined)"
                         :requests="meta.protocol === 'http' ? ['http1_total', 'http2_total', 'http3_total'].reduce((prev, key) => prev + (item.http?.[`${meta.direction}_rq_${key}`] as (number | undefined) ?? 0), 0) : undefined"
                       >
                         {{ item.name }}
@@ -187,10 +188,11 @@
                     ]"
                     :key="meta.protocol"
                   >
+                    <!-- rx and tx are purposefully reversed to rx=tx and tx=rx here due to the direction of the traffic (downstream) -->
                     <ServiceTrafficCard
                       :protocol="`unknown`"
-                      :tx="traffic.passthrough.reduce((prev: number, item: any) => prev + (item[meta.protocol]?.[`${meta.direction}_cx_tx_bytes_total`] ?? 0), 0)"
-                      :rx="traffic.passthrough.reduce((prev: number, item: any) => prev + (item[meta.protocol]?.[`${meta.direction}_cx_rx_bytes_total`] ?? 0), 0)"
+                      :rx="traffic.passthrough.reduce((prev: number, item: any) => prev + (item[meta.protocol]?.[`${meta.direction}_cx_tx_bytes_total`] ?? 0), 0)"
+                      :tx="traffic.passthrough.reduce((prev: number, item: any) => prev + (item[meta.protocol]?.[`${meta.direction}_cx_rx_bytes_total`] ?? 0), 0)"
                     >
                       Non mesh traffic
                     </ServiceTrafficCard>
@@ -212,10 +214,11 @@
                       ]"
                       :key="meta.protocol"
                     >
+                      <!-- rx and tx are purposefully reversed to rx=tx and tx=rx here due to the direction of the traffic (downstream) -->
                       <ServiceTrafficCard
                         :protocol="meta.protocol"
-                        :tx="item[meta.protocol]?.[`${meta.direction}_cx_tx_bytes_total`] as (number | undefined)"
-                        :rx="item[meta.protocol]?.[`${meta.direction}_cx_rx_bytes_total`] as (number | undefined)"
+                        :rx="item[meta.protocol]?.[`${meta.direction}_cx_tx_bytes_total`] as (number | undefined)"
+                        :tx="item[meta.protocol]?.[`${meta.direction}_cx_rx_bytes_total`] as (number | undefined)"
                         :requests="meta.protocol === 'http' ? ['http1_total', 'http2_total', 'http3_total'].reduce((prev, key) => prev + (item.http?.[`${meta.direction}_rq_${key}`] as (number | undefined) ?? 0), 0) : undefined"
                       >
                         {{ item.name }}


### PR DESCRIPTION
- Adds `meshtrace_zipkin` to excluded list
- Switches tx/rx to the reverse on all cards as we are using `downstreams` for everything. (I'm guessing I need to do it for everything and not just outbounds, please let me know if not)