### PR TITLE
chore: apply service names to all types of inbounds/outbounds

### DIFF
--- a/src/app/data-planes/components/DataPlaneSummary.vue
+++ b/src/app/data-planes/components/DataPlaneSummary.vue
@@ -12,7 +12,7 @@
 
             <KTooltip
               v-if="props.dataplaneOverview.unhealthyInbounds.length > 0"
-              :label="props.dataplaneOverview.unhealthyInbounds.map((inbound) => t('data-planes.routes.item.unhealthy_inbound', inbound)).join(', ')"
+              :label="props.dataplaneOverview.unhealthyInbounds.map((inbound) => t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port })).join(', ')"
               class="reason-tooltip"
               position-fixed
             >

--- a/src/app/data-planes/data/index.spec.ts
+++ b/src/app/data-planes/data/index.spec.ts
@@ -192,6 +192,7 @@ describe('dataplanes data transformations', () => {
                     'kuma.io/service': '',
                     'kuma.io/zone': '',
                   },
+                  service: '',
                   port: 1,
                   addressPort: 'http://example.org:1',
                   serviceAddressPort: 'http://example.org:1',
@@ -380,6 +381,7 @@ describe('dataplanes data transformations', () => {
                   tags: {
                     'kuma.io/service': '',
                   },
+                  service: '',
                   port: 1,
                   addressPort: 'http://example.org:1',
                   serviceAddressPort: 'http://example.org:1',
@@ -485,6 +487,7 @@ describe('dataplanes data transformations', () => {
                   tags: {
                     'kuma.io/service': '',
                   },
+                  service: '',
                   port: 1,
                   addressPort: 'http://example.org:1',
                   serviceAddressPort: 'http://example.org:1',
@@ -526,10 +529,20 @@ describe('dataplanes data transformations', () => {
           },
           dataplaneType: 'standard',
           status: 'offline',
-          unhealthyInbounds: [{
-            port: 1,
-            service: '',
-          }],
+          unhealthyInbounds: [
+            {
+              health: {
+                ready: false,
+              },
+              tags: {
+                'kuma.io/service': '',
+              },
+              service: '',
+              port: 1,
+              addressPort: 'http://example.org:1',
+              serviceAddressPort: 'http://example.org:1',
+            },
+          ],
           warnings: [],
           isCertExpired: false,
           services: [''],
@@ -606,6 +619,7 @@ describe('dataplanes data transformations', () => {
                     'kuma.io/service': 'service-1',
                     'kuma.io/zone': 'zone-1',
                   },
+                  service: 'service-1',
                   port: 1,
                   addressPort: 'http://example.org:1',
                   serviceAddressPort: 'http://example.org:1',
@@ -618,6 +632,7 @@ describe('dataplanes data transformations', () => {
                     'kuma.io/service': 'service-2',
                     'kuma.io/zone': 'zone-1',
                   },
+                  service: 'service-2',
                   port: 1,
                   addressPort: 'http://example.org:1',
                   serviceAddressPort: 'http://example.org:1',
@@ -659,10 +674,21 @@ describe('dataplanes data transformations', () => {
           },
           dataplaneType: 'standard',
           status: 'partially_degraded',
-          unhealthyInbounds: [{
-            port: 1,
-            service: 'service-1',
-          }],
+          unhealthyInbounds: [
+            {
+              health: {
+                ready: false,
+              },
+              tags: {
+                'kuma.io/service': 'service-1',
+                'kuma.io/zone': 'zone-1',
+              },
+              service: 'service-1',
+              port: 1,
+              addressPort: 'http://example.org:1',
+              serviceAddressPort: 'http://example.org:1',
+            },
+          ],
           warnings: [],
           isCertExpired: false,
           services: ['service-1', 'service-2'],

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -41,7 +41,7 @@
 
                   <KTooltip
                     v-if="props.data.unhealthyInbounds.length > 0"
-                    :label="props.data.unhealthyInbounds.map((inbound) => t('data-planes.routes.item.unhealthy_inbound', inbound)).join(', ')"
+                    :label="props.data.unhealthyInbounds.map((inbound) => t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port })).join(', ')"
                     class="reason-tooltip"
                   >
                     <InfoIcon

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -192,7 +192,19 @@ export class KumaModule {
     }
   }
 
-  dataplaneNetworking({ type = 'proxy', inbounds = 0, isMultizone = false, service }: { type?: 'gateway_builtin' | 'gateway_delegated' | 'proxy', inbounds?: number, isMultizone?: boolean, service?: string } = {}): DataplaneNetworking {
+  dataplaneNetworking(
+    {
+      type = 'proxy',
+      inbounds = 0,
+      isMultizone = false,
+      service,
+    }: {
+      type?: 'gateway_builtin' | 'gateway_delegated' | 'proxy'
+      inbounds?: number
+      isMultizone?: boolean
+      service?: string
+    } = {},
+  ): DataplaneNetworking {
     const address = this.faker.internet.ipv4()
     const advertisedAddress = this.faker.datatype.boolean({ probability: 0.25 }) ? this.faker.internet.ipv4() : undefined
     const dataplaneType = type === 'gateway_builtin' ? 'BUILTIN' : type === 'gateway_delegated' ? 'DELEGATED' : undefined
@@ -223,7 +235,10 @@ export class KumaModule {
               protocol: this.protocol(),
               service: service ?? this.serviceName(),
               zone: isMultizone && this.faker.datatype.boolean() ? this.faker.hacker.noun() : undefined,
-            })
+            }) as {
+              'kuma.io/service': string
+              [key: string]: string
+            }
 
             return {
               port,
@@ -245,7 +260,10 @@ export class KumaModule {
       outbound: [
         {
           port: this.faker.internet.port(),
-          tags: this.tags({ service }),
+          tags: this.tags({ service }) as {
+            'kuma.io/service': string
+            [key: string]: string
+          },
         },
       ],
     }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -210,7 +210,10 @@ export type DataplaneInbound = {
   port: number
   servicePort?: number
   serviceAddress?: string
-  tags: Record<string, string>
+  tags: {
+    'kuma.io/service': string
+    [key: string]: string
+  }
   health?: {
     ready: boolean
   }
@@ -218,7 +221,10 @@ export type DataplaneInbound = {
 
 export type DataplaneOutbound = {
   port: number
-  tags: Record<string, string>
+  tags: {
+    'kuma.io/service': string
+    [key: string]: string
+  }
 }
 
 export type DataplaneNetworking = {


### PR DESCRIPTION
This PR is a bit of a prequel to some other work I will be doing on the DataPlane viz, in that we would like to match the inbound `localhost_8080` inbound name with the service name of the inbound. In order to do that this PR first adds a `service` property/field to our DataplaneInbounds derived from the `kuma.io/service` tag.

I noticed that this reshape was almost already there but only for unhealthyInbounds, and unhealthyInbounds only contain the `service` and `port` and have all their other properties removed.

I've changed the reshaping to:

1. Add a `service` field to all inbounds and outbounds (derived from the `kuma.io/service` tag)
2. I moved things around a little as I realised I could remove the `getStatus` and `getUnhealthyInbounds` functions which where doubling/tripling up various `.filter`ing for unhealthiness.
3. Use `Array.isArray` for anything that should always be arrays instead of using truthiness `??` operators. This point applies to `inbounds` and `outbounds`
4. I figured similarly for point 3, I could use `isSet` for the healthiness check for inbounds.

Once I'd done the above I had to make a few amends to:

1. The types, because I have told the type system that `kuma.io/service` is always set on inbounds and outbounds.
2. The mocks, reflecting the type changes in point 1, plus some places where it was no longer ok to pass through the entire inbound (namely with `t` usage)
3. The unit tests for reflecting the slightly changed inbounds

Please let me know if there are any questions. 