### PR TITLE
feat(dataplanes): Use service name for naming the inbounds instead of localhost

### DIFF
--- a/src/app/common/data-card/DataCard.vue
+++ b/src/app/common/data-card/DataCard.vue
@@ -25,6 +25,7 @@
 
 .card,
 .title,
+.body,
 .body > :deep(dl),
 .body > :deep(dl) > div {
   display: flex;
@@ -35,6 +36,7 @@
 .body > :deep(dl) {
   column-gap: $kui-space-80;
 }
+.body,
 .card {
   flex-direction: column;
 }

--- a/src/app/common/data-card/DataCard.vue
+++ b/src/app/common/data-card/DataCard.vue
@@ -43,6 +43,7 @@
 .title {
   font-weight: $kui-font-weight-semibold;
   font-size: $kui-font-size-60;
+  width: 100%;
 }
 .body > :deep(dl) > div {
   column-gap: $kui-space-20;

--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -12,15 +12,10 @@
           },
         ) }}
       </KBadge>
-      <span class="title">
+      <div class="title">
         <slot name="default" />
-      </span>
+      </div>
     </template>
-
-    <TagList
-      v-if="props.tags.length > 0"
-      :tags="props.tags"
-    />
 
     <dl>
       <div>
@@ -43,16 +38,13 @@
 <script lang="ts" setup>
 import { useI18n } from '@/app/application'
 import DataCard from '@/app/common/data-card/DataCard.vue'
-import TagList from '@/app/common/TagList.vue'
 const { t } = useI18n()
 const props = withDefaults(defineProps<{
   protocol: string
-  tags?: ({ label: string, value: string })[]
   requests?: number
   rx: number
   tx: number
 }>(), {
-  tags: () => [],
   requests: undefined,
   rx: 0,
   tx: 0,
@@ -62,6 +54,8 @@ const props = withDefaults(defineProps<{
 <style lang="scss" scoped>
 .title {
   font-size: $kui-font-size-40;
+  display: flex;
+  flex: 1 1 auto;
 }
 
 </style>

--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -16,6 +16,12 @@
         <slot name="default" />
       </span>
     </template>
+
+    <TagList
+      v-if="props.tags.length > 0"
+      :tags="props.tags"
+    />
+
     <dl>
       <div>
         <dt>{{ t('data-planes.components.service_traffic_card.tx') }}</dt>
@@ -37,13 +43,16 @@
 <script lang="ts" setup>
 import { useI18n } from '@/app/application'
 import DataCard from '@/app/common/data-card/DataCard.vue'
+import TagList from '@/app/common/TagList.vue'
 const { t } = useI18n()
 const props = withDefaults(defineProps<{
   protocol: string
+  tags?: ({ label: string, value: string })[]
   requests?: number
   rx: number
   tx: number
 }>(), {
+  tags: () => [],
   requests: undefined,
   rx: 0,
   tx: 0,

--- a/src/app/data-planes/data/stats.spec.ts
+++ b/src/app/data-planes/data/stats.spec.ts
@@ -7,18 +7,18 @@ describe('stats.ts', () => {
     test('it works', () => {
       const expected = statsAsJSON()
       const actual = parse(`
-cluster.service_with_underscores_8080.strings_with_quotes: "a82b5279-497d-43ad-a5d6-2913957629a5"
-cluster.service_with_underscores_8080.strings_without_quotes: a82b5279-497d-43ad-a5d6-2913957629a5
-cluster.service_with_underscores_8080.numbers: 0
+http.service_with_underscores_8080.strings_with_quotes: "a82b5279-497d-43ad-a5d6-2913957629a5"
+http.service_with_underscores_8080.strings_without_quotes: a82b5279-497d-43ad-a5d6-2913957629a5
+http.service_with_underscores_8080.numbers: 0
 http.service_with_underscores_8080.strings_with_quotes: "a82b5279-497d-43ad-a5d6-2913957629a5"
 http.service_with_underscores_8080.strings_without_quotes: a82b5279-497d-43ad-a5d6-2913957629a5
 http.service_with_underscores_8080.numbers: 0
 tcp.service_with_underscores_8080.strings_with_quotes: "a82b5279-497d-43ad-a5d6-2913957629a5"
 tcp.service_with_underscores_8080.strings_without_quotes: a82b5279-497d-43ad-a5d6-2913957629a5
 tcp.service_with_underscores_8080.numbers: 0
-cluster.admin.connections_accepted_per_socket_event: P0(nan,1) P25(nan,1.025) P50(nan,1.05) P75(nan,1.075) P90(nan,1.09) P95(nan,1.095) P99(nan,1.099) P99.5(nan,1.0995) P99.9(nan,1.0999) P100(nan,1.1)
-cluster.127.0.0.1.borken_due_to_ip: 0
-not_cluster_http_or_tcp_as_root.service_with_underscores_8080.numbers: 0
+http.admin.connections_accepted_per_socket_event: P0(nan,1) P25(nan,1.025) P50(nan,1.05) P75(nan,1.075) P90(nan,1.09) P95(nan,1.095) P99(nan,1.099) P99.5(nan,1.0995) P99.9(nan,1.0999) P100(nan,1.1)
+http.127.0.0.1.borken_due_to_ip: 0
+not_http_or_tcp_as_root.service_with_underscores_8080.numbers: 0
 `)
       expect(actual).toStrictEqual(expected)
     })
@@ -27,12 +27,12 @@ not_cluster_http_or_tcp_as_root.service_with_underscores_8080.numbers: 0
     test('picks the right name depending on the filter', () => {
       const actual = getTraffic(statsAsJSON(), (key: string) => key === 'admin')
       expect(actual.length).toEqual(1)
-      expect(actual[0].cluster?.connections_accepted_per_socket_event).toEqual('P0(nan,1) P25(nan,1.025) P50(nan,1.05) P75(nan,1.075) P90(nan,1.09) P95(nan,1.095) P99(nan,1.099) P99.5(nan,1.0995) P99.9(nan,1.0999) P100(nan,1.1)')
+      expect(actual[0].http?.connections_accepted_per_socket_event).toEqual('P0(nan,1) P25(nan,1.025) P50(nan,1.05) P75(nan,1.075) P90(nan,1.09) P95(nan,1.095) P99(nan,1.099) P99.5(nan,1.0995) P99.9(nan,1.0999) P100(nan,1.1)')
     })
     test('sets cluster, http and tcp', () => {
       const actual = getTraffic(statsAsJSON(), (key: string) => key.startsWith('service_with_underscores_'))
       expect(actual.length).toEqual(1);
-      (['cluster', 'http', 'tcp'] as const).forEach((item) => {
+      (['http', 'tcp'] as const).forEach((item) => {
         expect(actual[0][item]).toBeDefined()
       })
     })
@@ -41,7 +41,12 @@ not_cluster_http_or_tcp_as_root.service_with_underscores_8080.numbers: 0
 
 function statsAsJSON() {
   return {
-    cluster: {
+    http: {
+      service_with_underscores_8080: {
+        strings_with_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
+        strings_without_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
+        numbers: 0,
+      },
       127: {
         0: {
           0: {
@@ -51,20 +56,8 @@ function statsAsJSON() {
           },
         },
       },
-      service_with_underscores_8080: {
-        strings_with_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
-        strings_without_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
-        numbers: 0,
-      },
       admin: {
         connections_accepted_per_socket_event: 'P0(nan,1) P25(nan,1.025) P50(nan,1.05) P75(nan,1.075) P90(nan,1.09) P95(nan,1.095) P99(nan,1.099) P99.5(nan,1.0995) P99.9(nan,1.0999) P100(nan,1.1)',
-      },
-    },
-    http: {
-      service_with_underscores_8080: {
-        strings_with_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
-        strings_without_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
-        numbers: 0,
       },
     },
     tcp: {

--- a/src/app/data-planes/data/stats.ts
+++ b/src/app/data-planes/data/stats.ts
@@ -3,7 +3,6 @@ interface MetricRecord {
 }
 export type TrafficEntry = {
   name: string
-  cluster?: MetricRecord
   http?: MetricRecord
   tcp?: MetricRecord
 }
@@ -13,7 +12,7 @@ export const parse = (lines: string) => {
   // for each line
   return lines.trim().split('\n').filter((item) => {
     // only use data prefixed with either cluster. http. or tcp.
-    return ['cluster.', 'http.', 'tcp.'].some(prop => item.startsWith(prop))
+    return ['http.', 'tcp.'].some(prop => item.startsWith(prop))
   }).reduce((prev, item) => {
     // split the `key: values` on the `:` and normalize the value
     const [key, ...value] = item.trim().split(':')
@@ -50,7 +49,7 @@ export const parse = (lines: string) => {
 
 // lets you specify the things you are interested in
 export const getTraffic = (json: ReturnType<typeof parse>, filter: (key: string) => boolean): TrafficEntry[] => {
-  const protocols = ['cluster', 'http', 'tcp'] as const
+  const protocols = ['http', 'tcp'] as const
   const traffic: Record<string, TrafficEntry> = {}
   protocols.map((item) => {
     return Object.entries(json[item]).filter(([key, _value]) => {

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -145,7 +145,21 @@
                         :tx="item[meta.protocol]?.[`${meta.direction}_cx_rx_bytes_total`] as (number | undefined)"
                         :requests="meta.protocol === 'http' ? ['http1_total', 'http2_total', 'http3_total'].reduce((prev, key) => prev + (item.http?.[`${meta.direction}_rq_${key}`] as (number | undefined) ?? 0), 0) : undefined"
                       >
-                        {{ item.name }}
+                        <template
+                          v-for="port in [
+                            item.name.split('_')[1],
+                          ]"
+                          :key="port"
+                        >
+                          <template
+                            v-for="inbound in [
+                              props.data.dataplane.networking.inbounds.find(item => `${item.port}` === `${port}`),
+                            ]"
+                            :key="inbound"
+                          >
+                            {{ inbound?.tags['kuma.io/service'] ?? `` }}:{{ port }}
+                          </template>
+                        </template>
                       </ServiceTrafficCard>
                     </template>
                   </template>
@@ -190,19 +204,24 @@
                   type="passthrough"
                 >
                   <template
-                    v-for="meta in [
-                      {
-                        protocol: 'cluster',
-                        direction: 'downstream',
-                      },
+                    v-for="(item, key) in [
+                      (['http', 'tcp'] as const).reduce((prev, protocol) => {
+                        const direction = 'downstream'
+                        // sum both the properties we need from both protocols
+                        return Object.entries(traffic.passthrough[protocol] || {}).reduce((prev, [key, value]) => {
+                          return [`${direction}_cx_tx_bytes_total`, `${direction}_cx_rx_bytes_total`].includes(key) ?
+                            { ...prev, [key]: (value as number) + (prev[key] ?? 0) } :
+                            prev
+                        }, prev)
+                      }, {} as Record<string, number>),
                     ]"
-                    :key="meta.protocol"
+                    :key="key"
                   >
                     <!-- rx and tx are purposefully reversed to rx=tx and tx=rx here due to the direction of the traffic (downstream) -->
                     <ServiceTrafficCard
                       :protocol="`unknown`"
-                      :rx="traffic.passthrough.reduce((prev: number, item: any) => prev + (item[meta.protocol]?.[`${meta.direction}_cx_tx_bytes_total`] ?? 0), 0)"
-                      :tx="traffic.passthrough.reduce((prev: number, item: any) => prev + (item[meta.protocol]?.[`${meta.direction}_cx_rx_bytes_total`] ?? 0), 0)"
+                      :rx="item.downstream_cx_tx_bytes_total"
+                      :tx="item.downstream_cx_rx_bytes_total"
                     >
                       Non mesh traffic
                     </ServiceTrafficCard>

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -154,12 +154,14 @@
                           <ServiceTrafficCard
                             v-if="inbound"
                             :protocol="meta.protocol"
-                            :tags="[{label: 'kuma.io/service', value: inbound.tags['kuma.io/service']}]"
                             :rx="item[meta.protocol]?.[`${meta.direction}_cx_tx_bytes_total`] as (number | undefined)"
                             :tx="item[meta.protocol]?.[`${meta.direction}_cx_rx_bytes_total`] as (number | undefined)"
                             :requests="meta.protocol === 'http' ? ['http1_total', 'http2_total', 'http3_total'].reduce((prev, key) => prev + (item.http?.[`${meta.direction}_rq_${key}`] as (number | undefined) ?? 0), 0) : undefined"
                           >
                             :{{ inbound.port }}
+                            <TagList
+                              :tags="[{label: 'kuma.io/service', value: inbound.tags['kuma.io/service']}]"
+                            />
                           </ServiceTrafficCard>
                         </template>
                       </template>
@@ -486,6 +488,9 @@ const warnings = computed(() => props.data.warnings.concat(...(props.data.isCert
     background-repeat: repeat-y;
     background-size: 50%;
   }
+}
+.traffic .tag-list {
+  margin-left: auto;
 }
 @container traffic (max-width: 40.95rem) {
   .traffic .columns {


### PR DESCRIPTION
There's a few things going on here, but I mainly wanted to get something up for a PR preview to get some feedback on what we are rendering here.

Please make sure you have `KUMA_TRAFFIC_ENABLED=true` before previewing:

[Preview](https://deploy-preview-1932--kuma-gui.netlify.app/gui/meshes/default/data-planes/frontend-ac58fd4fbc-hjaqs.firewall.kuma-system-proxy-1/overview)

![Screenshot 2023-12-22 at 11 35 55](https://github.com/kumahq/kuma-gui/assets/554604/682e2707-164d-439f-bca6-d401dc6691b4)

Additionally:

- There is also a fix in here for showing the aggregate passthrough traffic correctly.
- Overall there is quite a lot of work here in beginning to flesh out the mock for the `stats` endpoint which includes making sure our stateless mocks use "fake state" by setting the seed used for randomization based on the stateful URL, therefore making sure the randomness produces the same results on two different API URLs.


Important note:

~This is unfinished/WIP as of right now I'm looking to make sure I'm rendering what we want correctly etc. Following that I'll probably make some changes before taking out of draft. As an extra important note, once I'm super sure what data we want and what our reshaping needs might be, I would guess we might move some of this shaping to the data layer. For the moment, in order to have something for feedback, I'm kinda overusing `find`s etc where in under other circumstances I might not choose to do that.~

I've amended the rendering above slightly to what we want here so I'm taking this PR out of draft, but I have not yet changed the way we pick out the data we want (so I'm still overusing `find`s). I'm pretty sure I want to reshape our inbounds everywhere to be an object keyed by port instead of an array, that way we can just refer to the port of the inbound to find the thing rather than having to search through an array. I rather do that in a follow up though especially considering this feature is currently feature flagged, so I'm taking this out of draft for review.
