### PR TITLE
chore(dataplanes): More iteration on Dataplane traffic viz

### DIFF
--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -3,7 +3,7 @@
     class="service-traffic-card"
   >
     <template #title>
-      <KBadge :appearance="props.protocol === 'unknown' ? 'success' : 'info'">
+      <KBadge :appearance="props.protocol === 'passthrough' ? 'success' : 'info'">
         {{ t(
           `data-planes.components.service_traffic_card.protocol.${props.protocol}`,
           {},
@@ -17,21 +17,77 @@
       </div>
     </template>
 
+    <!-- rx and tx are purposefully reversed in all the below to rx=tx and tx=rx here due to the direction of the traffic (downstream) -->
     <dl>
-      <div>
-        <dt>{{ t('data-planes.components.service_traffic_card.tx') }}</dt>
-        <dd>{{ t('common.formats.integer', { value: props.tx }) }}</dd>
-      </div>
-      <div>
-        <dt>{{ t('data-planes.components.service_traffic_card.rx') }}</dt>
-        <dd>{{ t('common.formats.integer', { value: props.rx }) }}</dd>
-      </div>
-      <div
-        v-if="typeof props.requests !== 'undefined'"
+      <template
+        v-if="props.protocol === 'passthrough'"
       >
-        <dt>{{ t('data-planes.components.service_traffic_card.requests') }}</dt>
-        <dd>{{ t('common.formats.integer', { value: props.requests }) }}</dd>
-      </div>
+        <template
+          v-for="(item, key) in [
+            (['http', 'tcp'] as const).reduce((prev, protocol) => {
+              const direction = 'downstream'
+              // sum both the properties we need from both protocols
+              return Object.entries(props.traffic[protocol] || {}).reduce((prev, [key, value]) => {
+                return [`${direction}_cx_tx_bytes_total`, `${direction}_cx_rx_bytes_total`].includes(key) ?
+                  { ...prev, [key]: (value as number) + (prev[key] ?? 0) } :
+                  prev
+              }, prev)
+            }, {} as Record<string, number>),
+          ]"
+          :key="key"
+        >
+          <div>
+            <dt>{{ t('data-planes.components.service_traffic_card.tx') }}</dt>
+            <dd>{{ t('common.formats.bytes', { value: item.downstream_cx_rx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+          </div>
+          <div>
+            <dt>{{ t('data-planes.components.service_traffic_card.rx') }}</dt>
+            <dd>{{ t('common.formats.bytes', { value: item.downstream_cx_tx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+          </div>
+        </template>
+      </template>
+      <template
+        v-else-if="props.protocol === 'http'"
+      >
+        <div
+          v-for="value in [props.traffic.http?.downstream_rq_1xx as (number | undefined) ?? 0].filter(item => item !== 0)"
+          :key="value"
+        >
+          <dt>{{ t('data-planes.components.service_traffic_card.1xx') }}</dt>
+          <dd>{{ t('common.formats.integer', { value: value }) }}</dd>
+        </div>
+        <div>
+          <dt>{{ t('data-planes.components.service_traffic_card.2xx') }}</dt>
+          <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_2xx as (number | undefined) ?? 0 }) }}</dd>
+        </div>
+        <div
+          v-for="value in [props.traffic.http?.downstream_rq_3xx as (number | undefined) ?? 0].filter(item => item !== 0)"
+          :key="value"
+        >
+          <dt>{{ t('data-planes.components.service_traffic_card.3xx') }}</dt>
+          <dd>{{ t('common.formats.integer', { value: value }) }}</dd>
+        </div>
+        <div>
+          <dt>{{ t('data-planes.components.service_traffic_card.4xx') }}</dt>
+          <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_4xx as (number | undefined) ?? 0 }) }}</dd>
+        </div>
+        <div>
+          <dt>{{ t('data-planes.components.service_traffic_card.5xx') }}</dt>
+          <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_5xx as (number | undefined) ?? 0 }) }}</dd>
+        </div>
+      </template>
+      <template
+        v-else
+      >
+        <div>
+          <dt>{{ t('data-planes.components.service_traffic_card.tx') }}</dt>
+          <dd>{{ t('common.formats.bytes', { value: props.traffic.tcp?.downstream_cx_rx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+        </div>
+        <div>
+          <dt>{{ t('data-planes.components.service_traffic_card.rx') }}</dt>
+          <dd>{{ t('common.formats.bytes', { value: props.traffic.tcp?.downstream_cx_tx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+        </div>
+      </template>
     </dl>
   </DataCard>
 </template>
@@ -39,16 +95,13 @@
 import { useI18n } from '@/app/application'
 import DataCard from '@/app/common/data-card/DataCard.vue'
 const { t } = useI18n()
-const props = withDefaults(defineProps<{
+const props = defineProps<{
   protocol: string
-  requests?: number
-  rx: number
-  tx: number
-}>(), {
-  requests: undefined,
-  rx: 0,
-  tx: 0,
-})
+  traffic: {
+    http?: Record<string, unknown>
+    tcp?: Record<string, unknown>
+  }
+}>()
 
 </script>
 <style lang="scss" scoped>

--- a/src/app/data-planes/locales/en-us/index.yaml
+++ b/src/app/data-planes/locales/en-us/index.yaml
@@ -1,11 +1,15 @@
 data-planes:
   components:
     service_traffic_card:
-      requests: Total Requests
+      1xx: 1xx
+      2xx: 2xx
+      3xx: 3xx
+      4xx: 4xx
+      5xx: 5xx
       tx: Bytes sent
       rx: Bytes received
       protocol:
-        unknown: Passthrough
+        passthrough: Passthrough
     data-plane-list:
       version_mismatch: Version mismatch
       cert_expired: Certificate expired

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -2,6 +2,7 @@ common:
   not_applicable: N/A
   formats:
     integer: '{value, number, integer}'
+    bytes: '{value, number, integer}'
   product:
     name: Kuma
     href:

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -15,6 +15,11 @@ export class KumaModule {
     this.faker = faker
   }
 
+  seed(str: string) {
+    // sync the seed by name (temp use length until we convert strings to numbers differently)
+    return this.faker.seed(str.length)
+  }
+
   partition(min: number, max: number, length: number, sum: number): number[] {
     return Array.from(
       { length },
@@ -31,11 +36,12 @@ export class KumaModule {
     )
   }
 
-  partitionInto(props: string[], total: number) {
-    return this.partition(1, total, props.length, total).reduce((prev: Record<string, unknown>, item, i) => {
+  partitionInto(skeleton: Record<string, number>, total: number) {
+    const props = Object.entries(skeleton).filter(([_key, value]) => isNaN(value)).map(([key, _value]) => key)
+    return this.partition(0, total, props.length, total).reduce((prev, item, i) => {
       prev[props[i]] = item
       return prev
-    }, {})
+    }, skeleton)
   }
 
   serviceType() {

--- a/src/test-support/mocks/src/meshes/_/dataplanes/_/_overview.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes/_/_overview.ts
@@ -1,11 +1,12 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
 export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => {
   const { mesh, name } = req.params
-  // sync the seed by name (temp use length until we get seed(str))
-  fake.seed(name.length)
 
+  // use seed to sync the ports in stats.ts with the ports in _overview.ts
+  fake.kuma.seed(name as string)
   const inboundCount = parseInt(env('KUMA_DATAPLANEINBOUND_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
   const ports = Array.from({ length: inboundCount }).map(() => fake.number.int({ min: 1, max: 65535 }))
+  //
 
   const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
   const isMtlsEnabledOverride = env('KUMA_MTLS_ENABLED', '')


### PR DESCRIPTION
User facing additions/changes:

1. We only show a 'traffic card' if the traffic is non-zero for a service.
2. For `http` services we no longer show bytes received/sent
3. For `http` services we no longer show a total of requests, instead we show 1xx, 2xx, 3xx, 4xx, 5xx (for 1xx and 3xx we only show totals if its non-zero)

---

Code changes:

1. Most changes are around making the mocks into something that randomly shows us lots of different combinations i.e. zero requests, requests with and without 1xx's or 3xx's.
2. I moved the code which decides exactly what data to show depending on the protocol from the Route/View into the ServiceTrafficCard component - eventually this will need to show more protocols, each displaying something slightly different so I figured it was best to move this sort of code here for when we do this.
3. I've spoken a little in past PRs about having inbounds as an object keyed by port (instead of an array). Turns out you can in some edge cases having 2 inbounds using the same port (but on different IPs), so I decided not to do this. Seeing as we only wanted to improve this lookup for inbounds (which we generally only have one or two), it was starting to feel like a bit of a micro-optimisation anyway.

P.S. Remember to set your cookie to have `KUMA_TRAFFIC_ENABLED=true`

