### PR TITLE
chore: refactor UpgradeCheck to use DataSource

### DIFF
--- a/src/app/common/UpgradeCheck.vue
+++ b/src/app/common/UpgradeCheck.vue
@@ -1,9 +1,10 @@
 <template>
-  <div
-    class="upgrade-check"
+  <DataSource
+    v-slot="{ data }"
+    :src="`/control-plane/version/latest`"
   >
     <KAlert
-      v-if="showNotice"
+      v-if="env('KUMA_VERSION') !== data?.version"
       data-testid="upgrade-check"
       class="upgrade-check-alert"
       appearance="info"
@@ -26,67 +27,17 @@
         </div>
       </template>
     </KAlert>
-  </div>
+  </DataSource>
 </template>
 
 <script lang="ts" setup>
-import { KAlert, KButton } from '@kong/kongponents'
-import { ref } from 'vue'
-
-import { useEnv, useKumaApi, useI18n } from '@/utilities'
-
-const kumaApi = useKumaApi()
+import { useEnv, useI18n } from '@/utilities'
 const env = useEnv()
 const { t } = useI18n()
-
-const latestVersion = ref('')
-const showNotice = ref(false)
-
-checkVersion(env('KUMA_VERSION'))
-
-// mostly taken from semver-compare
-const compare = (a: string, b: string) => {
-  const pa = a.split('.')
-  const pb = b.split('.')
-  for (let i = 0; i < 3; i++) {
-    const na = Number(pa[i])
-    const nb = Number(pb[i])
-    if (na > nb) return 1
-    if (nb > na) return -1
-  }
-  return 0
-}
-
-async function checkVersion(currentVersion: string): Promise<void> {
-  if (!currentVersion.match('^[0-9]+.[0-9]+.[0-9]+$')) {
-    return
-  }
-
-  try {
-    latestVersion.value = await kumaApi.getLatestVersion()
-  } catch (error) {
-    console.error(error)
-    return
-  }
-  if (latestVersion.value !== '') {
-    // compare the latest version to the currently running version
-    // but only if we were able to set the latest version in the first place.
-    const comparison = compare(latestVersion.value, currentVersion)
-    showNotice.value = comparison === 1
-  } else {
-    const timespan = 3 // months
-    const today = new Date()
-    const refDate = new Date('2020-06-03 12:00:00')
-    const later = new Date(refDate.getFullYear(), refDate.getMonth() + timespan, refDate.getDate())
-
-    // compare dates and handle the notice accordingly
-    showNotice.value = today.getTime() >= later.getTime()
-  }
-}
 </script>
 
 <style lang="scss" scoped>
-.upgrade-check-alert.k-alert.small {
+.k-alert.small {
   // Uses smaller paddings for this particular alert.
   padding: $kui-space-20 $kui-space-40;
 }

--- a/src/app/control-planes/sources.ts
+++ b/src/app/control-planes/sources.ts
@@ -14,12 +14,49 @@ export type ControlPlaneConfigSource = DataSourceResponse<ControlPlaneConfig>
 
 export type GlobalInsightSource = DataSourceResponse<GlobalInsight>
 
+// mostly taken from semver-compare
+const compare = (a: string, b: string) => {
+  const pa = a.split('.')
+  const pb = b.split('.')
+  for (let i = 0; i < 3; i++) {
+    const na = Number(pa[i])
+    const nb = Number(pb[i])
+    if (na > nb) return 1
+    if (nb > na) return -1
+  }
+  return 0
+}
 export const sources = (env: Env['var'], api: KumaApi) => {
   return {
     '/control-plane/addresses': async (): Promise<ControlPlaneAddresses> => {
       return {
         http: env('KUMA_API_URL'),
         kds: env('KUMA_KDS_URL'),
+      }
+    },
+
+    '/control-plane/version/latest': async (): Promise<{version: string}> => {
+      const current = env('KUMA_VERSION')
+      // if the current version includes some sort of `-dev` then pretend we
+      // are on the latest version
+      if (!current.match('^[0-9]+.[0-9]+.[0-9]+$')) {
+        return {
+          version: current,
+        }
+      }
+      const version = await (async () => {
+        try {
+          return api.getLatestVersion()
+        } catch (e) {
+          console.error(e)
+          return ''
+        }
+      })()
+      // compare the latest version to the currently running version but only
+      // if we were able to get the latest version in the first place.
+      // Otherwise pretend we are on the latest version
+      return {
+        version: (version !== '' && compare(version, current) === 1) ? version : current,
       }
     },
 


### PR DESCRIPTION
Moves UpgradeCheck to use DataSource.

The DataSource now gets the latest version, and then we check in the template to see if that version is the same as the version we are running using `KUMA_VERSION`. I used all the same logic sort of code in the DataSource `sources.ts` file.

---

I will probably remove the `UpgradeCheck.vue` component entirely in a later PR seeing as it doesn't really contain anything anymore and we only use it once in `ApplicationShell` here https://github.com/kumahq/kuma-gui/blob/b4ff4d670eab3d349ff1524014f9ff423fab3ec3/src/app/kuma/components/ApplicationShell.vue#L25. `ApplicationShell` itself is also only used once, so it makes sense to just put the code from `UpgradeCheck.vue` into it so the code is all front and center.