### PR TITLE
feat(dataplanes): add showInactive toggle for dataplane traffic view

### DIFF
--- a/src/app/data-planes/components/data-plane-traffic/DataPlaneTraffic.vue
+++ b/src/app/data-planes/components/data-plane-traffic/DataPlaneTraffic.vue
@@ -26,6 +26,8 @@ import DataCard from '@/app/common/data-card/DataCard.vue'
   gap: $kui-space-40;
 }
 .actions {
+  display: flex;
+  gap: $kui-space-40;
   position: absolute;
   right: 0;
 }

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -175,6 +175,14 @@
               </DataPlaneTraffic>
               <DataPlaneTraffic>
                 <template #actions>
+                  <KInputSwitch
+                    v-model="showInactive"
+                  >
+                    <template #label>
+                      Show inactive
+                    </template>
+                  </KInputSwitch>
+
                   <KButton
                     appearance="primary"
                     @click="refresh"
@@ -230,7 +238,7 @@
                       :key="protocol"
                     >
                       <ServiceTrafficCard
-                        v-if="(protocol !== 'http' ? item.tcp?.downstream_cx_rx_bytes_total : item.http?.downstream_rq_total) as (number | undefined ) ?? 0 > 0"
+                        v-if="showInactive || ((protocol !== 'http' ? item.tcp?.downstream_cx_rx_bytes_total : item.http?.downstream_rq_total) as (number | undefined ) ?? 0 > 0)"
                         :protocol="protocol"
                         :traffic="item"
                       >
@@ -431,7 +439,7 @@
 <script lang="ts" setup>
 import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { InfoIcon, ForwardIcon, GatewayIcon, RefreshIcon } from '@kong/icons'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 import type { DataplaneOverview } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
@@ -452,6 +460,8 @@ const { t, formatIsoDate } = useI18n()
 const props = defineProps<{
   data: DataplaneOverview
 }>()
+
+const showInactive = ref(false)
 
 const warnings = computed(() => props.data.warnings.concat(...(props.data.isCertExpired ? [{ kind: 'CERT_EXPIRED' }] : [])))
 </script>

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -4,6 +4,7 @@
     :params="{
       mesh: '',
       dataPlane: '',
+      inactive: false,
     }"
     name="data-plane-detail-view"
   >
@@ -176,7 +177,7 @@
               <DataPlaneTraffic>
                 <template #actions>
                   <KInputSwitch
-                    v-model="showInactive"
+                    v-model="route.params.inactive"
                   >
                     <template #label>
                       Show inactive
@@ -238,7 +239,7 @@
                       :key="protocol"
                     >
                       <ServiceTrafficCard
-                        v-if="showInactive || ((protocol !== 'http' ? item.tcp?.downstream_cx_rx_bytes_total : item.http?.downstream_rq_total) as (number | undefined ) ?? 0 > 0)"
+                        v-if="route.params.inactive || ((protocol !== 'http' ? item.tcp?.downstream_cx_rx_bytes_total : item.http?.downstream_rq_total) as (number | undefined ) ?? 0 > 0)"
                         :protocol="protocol"
                         :traffic="item"
                       >
@@ -439,7 +440,7 @@
 <script lang="ts" setup>
 import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { InfoIcon, ForwardIcon, GatewayIcon, RefreshIcon } from '@kong/icons'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 
 import type { DataplaneOverview } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
@@ -460,8 +461,6 @@ const { t, formatIsoDate } = useI18n()
 const props = defineProps<{
   data: DataplaneOverview
 }>()
-
-const showInactive = ref(false)
 
 const warnings = computed(() => props.data.warnings.concat(...(props.data.isCertExpired ? [{ kind: 'CERT_EXPIRED' }] : [])))
 </script>

--- a/src/services/env/CookiedEnv.ts
+++ b/src/services/env/CookiedEnv.ts
@@ -1,16 +1,36 @@
 import type { EnvVars } from './Env'
-export default (
-  env: (str: keyof EnvVars, d?: string) => string,
-  doc: { cookie: string } = document,
-) => (...rest: Parameters<typeof env>) => {
-  const cookies = doc.cookie.split(';')
+
+const strToEnv = (str: string): [string, string][] => {
+  return str.split(';')
     .map((item) => item.trim())
     .filter((item) => item !== '')
-    .reduce((prev, item) => {
-      const [key, value] = item.split('=')
-      prev[key] = value
-      return prev
-    }, {} as Record<string, string>)
+    .map((item) => {
+      const [key, ...value] = item.split('=')
+      return [key, value.join('=')] as [string, string]
+    })
+    .filter(([key, _value]) => key.startsWith('KUMA_'))
+}
+
+export default (
+  env: (str: keyof EnvVars, d?: string) => string,
+  doc: {
+    cookie: string
+    location: {
+      hash: string
+    }
+  } = document,
+) => (...rest: Parameters<typeof env>) => {
+  if (doc.location.hash.length > 0) {
+    const hashEnv = strToEnv(document.location.hash.substring(1))
+    doc.location.hash = ''
+    if (hashEnv.length > 0) {
+      doc.cookie = hashEnv.map(([key, value]) => `${key}=${value}`).join(';')
+    }
+  }
+  const cookies = strToEnv(doc.cookie).reduce((prev, [key, value]) => {
+    prev[key] = value
+    return prev
+  }, {} as Record<string, string>)
   const key = rest[0]
   if (key in cookies) {
     return cookies[key]


### PR DESCRIPTION
[Preview](https://deploy-preview-1958--kuma-gui.netlify.app/gui/meshes/default/data-planes/frontend-ac58fd4fbc-hjaqs.firewall.kuma-system-proxy-1/overview#KUMA_TRAFFIC_ENABLED=true)

Adds a "Show inactive" toggle so you can toggle between either showing the viz with services that have no traffic/not showing services that have no traffic.

Note: We decided to put a straightforwards toggle at the top of the list instead of a card at the bottom with the thinking that when you have lots of services you won't want to scroll to the bottom of the list every time you want to use the toggle.

---

I added some unrelated work here to make it possible to set feature flags via a deeplink (dev and PR previews only), I split that off into a separate commit.

---

This PR doesn't persist the setting into the URL/queryParam just yet. I've done this separately as there's quite a bit of unrelated change and will come in an upcoming PR.