### PR TITLE
refactor: update Kongponents to KTabs/KSelect milestone

### DIFF
--- a/features/mesh/dataplanes/Index.feature
+++ b/features/mesh/dataplanes/Index.feature
@@ -1,16 +1,16 @@
 Feature: mesh / dataplanes / index
   Background:
     Given the CSS selectors
-      | Alias            | Selector                                |
-      | table            | [data-testid='data-plane-collection']   |
-      | table-header     | $table th                               |
-      | item             | $table tbody tr                         |
-      | service-cell     | $item:nth-child(1) td:nth-child(3)      |
-      | select-type      | [data-testid='k-select-input']          |
-      | select-option    | .k-select-item                          |
-      | select-standard  | [data-testid='k-select-item-standard']  |
-      | select-builtin   | [data-testid='k-select-item-builtin']   |
-      | select-delegated | [data-testid='k-select-item-delegated'] |
+      | Alias            | Selector                              |
+      | table            | [data-testid='data-plane-collection'] |
+      | table-header     | $table th                             |
+      | item             | $table tbody tr                       |
+      | service-cell     | $item:nth-child(1) td:nth-child(3)    |
+      | select-type      | [data-testid='select-input']          |
+      | select-option    | .select-item                          |
+      | select-standard  | [data-testid='select-item-standard']  |
+      | select-builtin   | [data-testid='select-item-builtin']   |
+      | select-delegated | [data-testid='select-item-delegated'] |
     And the environment
       """
       KUMA_MODE: global

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@kong-ui-public/i18n": "2.0.7",
     "@kong/icons": "1.8.12",
-    "@kong/kongponents": "9.0.0-alpha.84",
+    "@kong/kongponents": "9.0.0-alpha.88",
     "@vueuse/core": "10.7.2",
     "brandi": "5.0.0",
     "deepmerge": "4.3.1",

--- a/src/app/common/NavTabs.vue
+++ b/src/app/common/NavTabs.vue
@@ -2,7 +2,7 @@
   <KTabs
     :tabs="kTabs"
     :model-value="currentTabHash"
-    :has-panels="false"
+    :show-panels="false"
     class="nav-tabs"
     data-testid="nav-tabs"
   >
@@ -70,29 +70,11 @@ const currentTabHash = computed(() => {
 
 <style lang="scss" scoped>
 .nav-tabs {
-  margin-bottom: $kui-space-80;
-}
-
-.nav-tabs :deep(ul) {
-  // TODO: Remove this override once KTabs was updated in Kongponents v9’s alpha version.
-  // Overrides the bottom border color to the same value KCard uses for its borders.
-  border-bottom-color: rgba(0, 0, 0, 0.1);
-}
-</style>
-
-<style lang="scss">
-.nav-tabs {
   overflow-x: auto;
   width: 100%;
 }
 
-.nav-tabs .tab-item {
+.nav-tabs :deep(.tab-item) {
   white-space: nowrap;
-}
-
-// TODO: Remove this once https://github.com/Kong/kongponents/pull/1774 is available.
-// Prevents KTabs from trigger a vertical overflow of its container.
-.nav-tabs .tab-item::after {
-  content: none !important;
 }
 </style>

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -74,7 +74,6 @@
                     label: t(`data-planes.type.${value}`),
                     selected: value === route.params.dataplaneType,
                   }))"
-                  appearance="select"
                   @selected="route.update({ dataplaneType: String($event.value) })"
                 >
                   <template #item-template="{ item: value }">
@@ -130,7 +129,9 @@ import type { MeSource } from '@/app/me/sources'
 }
 
 .filter-select {
+  flex-basis: 205px;
   display: flex;
+  flex-direction: row;
   align-items: center;
   gap: $kui-space-40;
 }

--- a/src/app/services/views/ServiceDataPlaneProxiesView.vue
+++ b/src/app/services/views/ServiceDataPlaneProxiesView.vue
@@ -75,7 +75,6 @@
                     label: t(`data-planes.type.${value}`),
                     selected: value === route.params.dataplaneType,
                   }))"
-                  appearance="select"
                   @selected="route.update({ dataplaneType: String($event.value) })"
                 >
                   <template #item-template="{ item: value }">
@@ -131,7 +130,9 @@ import type { MeSource } from '@/app/me/sources'
 }
 
 .filter-select {
+  flex-basis: 205px;
   display: flex;
+  flex-direction: row;
   align-items: center;
   gap: $kui-space-40;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1852,10 +1852,10 @@
   resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.8.12.tgz#4432f4b5dbc75537ac16db20fae486838a808f44"
   integrity sha512-UV9+Oq7Rum7VFuLb3KfTI0Nka4Y30vSjpXygz9y+DWGIO04M84QkC/iNLPY7Y8yA79h3BIXaMB2vL75Diyn2Gg==
 
-"@kong/kongponents@9.0.0-alpha.84":
-  version "9.0.0-alpha.84"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.84.tgz#07077dde50e6e61de1126a2581de1b292619014c"
-  integrity sha512-5qSn1/jt782UqRP6kOGlv6UWBr82wPJWhvrmX5f2jVagWpDy7TAPTdecvEdLjT8pxT/wDqUqTGYH6NyEgKfn9g==
+"@kong/kongponents@9.0.0-alpha.88":
+  version "9.0.0-alpha.88"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.88.tgz#b77dabd039e7b5e51a2116a7181c869d13388e1b"
+  integrity sha512-jK9nsAsY8LgXhwYbXQ8h4qZy8G/g1TwoUuy1ga1XYYpWTlC7oAORbOcEMPhev8m1dS2hr7RB2GXR0rAf44LXHw==
   dependencies:
     "@kong/icons" "^1.8.12"
     "@popperjs/core" "^2.11.8"
@@ -2424,7 +2424,7 @@
     estree-walker "^2.0.2"
     source-map-js "^1.0.2"
 
-"@vue/compiler-dom@3.3.12", "@vue/compiler-dom@^3.2.0", "@vue/compiler-dom@^3.2.47", "@vue/compiler-dom@^3.3.0":
+"@vue/compiler-dom@3.3.12":
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.3.12.tgz#267c54b388d58f30fc120ea496ebf27d4ea8368b"
   integrity sha512-RdJU9oEYaoPKUdGXCy0l+i4clesdDeLmbvRlszoc9iagsnBnMmQtYfCPVQ5BHB6o7K4SCucDdJM2Dh3oXB0D6g==
@@ -2432,7 +2432,7 @@
     "@vue/compiler-core" "3.3.12"
     "@vue/shared" "3.3.12"
 
-"@vue/compiler-dom@3.4.14":
+"@vue/compiler-dom@3.4.14", "@vue/compiler-dom@^3.2.0", "@vue/compiler-dom@^3.2.47", "@vue/compiler-dom@^3.3.0":
   version "3.4.14"
   resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.4.14.tgz#ba7269996ef12a3b9293083ac109b52d14c9ccb5"
   integrity sha512-nOZTY+veWNa0DKAceNWxorAbWm0INHdQq7cejFaWM1WYnoNSJbSEKYtE7Ir6lR/+mo9fttZpPVI9ZFGJ1juUEQ==
@@ -2440,7 +2440,7 @@
     "@vue/compiler-core" "3.4.14"
     "@vue/shared" "3.4.14"
 
-"@vue/compiler-sfc@3.3.12", "@vue/compiler-sfc@^3.2.0", "@vue/compiler-sfc@^3.2.20":
+"@vue/compiler-sfc@3.3.12":
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.3.12.tgz#6ec2c19858f264671457699c1f3a0a6fedf429fe"
   integrity sha512-yy5b9e7b79dsGbMmglCe/YnhCQgBkHO7Uf6JfjWPSf2/5XH+MKn18LhzhHyxbHdJgnA4lZCqtXzLaJz8Pd8lMw==
@@ -2456,7 +2456,7 @@
     postcss "^8.4.32"
     source-map-js "^1.0.2"
 
-"@vue/compiler-sfc@3.4.14":
+"@vue/compiler-sfc@3.4.14", "@vue/compiler-sfc@^3.2.0", "@vue/compiler-sfc@^3.2.20":
   version "3.4.14"
   resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.4.14.tgz#d472b9be05f0f958911a8aad0826a12d92fdb82f"
   integrity sha512-1vHc9Kv1jV+YBZC/RJxQJ9JCxildTI+qrhtDh6tPkR1O8S+olBUekimY0km0ZNn8nG1wjtFAe9XHij+YLR8cRQ==
@@ -2591,12 +2591,12 @@
     "@vue/compiler-ssr" "3.4.14"
     "@vue/shared" "3.4.14"
 
-"@vue/shared@3.3.12", "@vue/shared@^3.3.0":
+"@vue/shared@3.3.12":
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.3.12.tgz#7c030c4e2f1db8beb638b159cbb86d0ff78c3198"
   integrity sha512-6p0Yin0pclvnER7BLNOQuod9Z+cxSYh8pSh7CzHnWNjAIP6zrTlCdHRvSCb1aYEx6i3Q3kvfuWU7nG16CgG1ag==
 
-"@vue/shared@3.4.14":
+"@vue/shared@3.4.14", "@vue/shared@^3.3.0":
   version "3.4.14"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.4.14.tgz#bc2d199a42a87f0349492fdfb83abc205ddd4d60"
   integrity sha512-nmi3BtLpvqXAWoRZ6HQ+pFJOHBU4UnH3vD3opgmwXac7vhaHKA9nj1VeGjMggdB9eLtW83eHyPCmOU1qzdsC7Q==
@@ -2691,15 +2691,10 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.10.0:
+acorn@^8.10.0, acorn@^8.8.2, acorn@^8.9.0:
   version "8.11.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
   integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
-
-acorn@^8.8.2, acorn@^8.9.0:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
-  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
 agent-base@^7.0.2, agent-base@^7.1.0:
   version "7.1.0"
@@ -3171,17 +3166,7 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserslist@^4.21.10:
-  version "4.21.11"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.11.tgz#35f74a3e51adc4d193dcd76ea13858de7b8fecb8"
-  integrity sha512-xn1UXOKUz7DjdGlg9RrUr0GGiWzI97UQJnugHtH0OLDfJB7jMgoIkYvRIEO1l9EeEERVqeqLYOcFBW9ldjypbQ==
-  dependencies:
-    caniuse-lite "^1.0.30001538"
-    electron-to-chromium "^1.4.526"
-    node-releases "^2.0.13"
-    update-browserslist-db "^1.0.13"
-
-browserslist@^4.22.2:
+browserslist@^4.21.10, browserslist@^4.22.2:
   version "4.22.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.2.tgz#704c4943072bd81ea18997f3bd2180e89c77874b"
   integrity sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==
@@ -3257,12 +3242,7 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001538:
-  version "1.0.30001539"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001539.tgz#325a387ab1ed236df2c12dc6cd43a4fff9903a44"
-  integrity sha512-hfS5tE8bnNiNvEOEkm8HElUHroYwlqMMENEzELymy77+tJ6m+gA2krtHl5hxJaj71OlpC2cHZbdSMX1/YEqEkA==
-
-caniuse-lite@^1.0.30001565:
+caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001565:
   version "1.0.30001568"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001568.tgz#53fa9297273c9a977a560663f48cbea1767518b7"
   integrity sha512-vSUkH84HontZJ88MiNrOau1EBrCqEQYgkC5gIySiDlpsm8sGVrhU7Kx4V6h0tnqaHzIHZv08HlJIwPbL4XL9+A==
@@ -4005,11 +3985,6 @@ ejs@^3.1.6:
   integrity sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==
   dependencies:
     jake "^10.8.5"
-
-electron-to-chromium@^1.4.526:
-  version "1.4.529"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.529.tgz#8c3377a05e5737f899770d14524dd8e2e4cb2351"
-  integrity sha512-6uyPyXTo8lkv8SWAmjKFbG42U073TXlzD4R8rW3EzuznhFS2olCIAfjjQtV2dV2ar/vRF55KUd3zQYnCB0dd3A==
 
 electron-to-chromium@^1.4.601:
   version "1.4.610"
@@ -4972,12 +4947,7 @@ fsevents@~2.3.2, fsevents@~2.3.3:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
-  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
-
-function-bind@^1.1.2:
+function-bind@^1.1.1, function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
@@ -6013,14 +5983,7 @@ jstransformer@1.0.0:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-keyv@^4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.3.tgz#00873d2b046df737963157bd04f294ca818c9c25"
-  integrity sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==
-  dependencies:
-    json-buffer "3.0.1"
-
-keyv@^4.5.4:
+keyv@^4.5.3, keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
@@ -6527,11 +6490,6 @@ node-html-parser@^5.3.3:
     css-select "^4.2.1"
     he "1.2.0"
 
-node-releases@^2.0.13:
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.13.tgz#d5ed1627c23e3461e819b02e57b75e4899b1c81d"
-  integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
-
 node-releases@^2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
@@ -7008,16 +6966,7 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.0, postcss@^8.4.27, postcss@^8.4.32:
-  version "8.4.32"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.32.tgz#1dac6ac51ab19adb21b8b34fd2d93a86440ef6c9"
-  integrity sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==
-  dependencies:
-    nanoid "^3.3.7"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
-postcss@^8.4.33:
+postcss@^8.4.0, postcss@^8.4.27, postcss@^8.4.32, postcss@^8.4.33:
   version "8.4.33"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.33.tgz#1378e859c9f69bf6f638b990a0212f43e2aaa742"
   integrity sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==
@@ -7217,12 +7166,7 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^2.1.0, punycode@^2.1.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
-  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
-
-punycode@^2.3.1:
+punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -8001,12 +7945,7 @@ stylelint-config-recommended-vue@1.5.0:
     stylelint-config-html ">=1.0.0"
     stylelint-config-recommended ">=6.0.0"
 
-stylelint-config-recommended@>=6.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz#c48a358cc46b629ea01f22db60b351f703e00597"
-  integrity sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==
-
-stylelint-config-recommended@^14.0.0:
+stylelint-config-recommended@>=6.0.0, stylelint-config-recommended@^14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz#b395c7014838d2aaca1755eebd914d0bb5274994"
   integrity sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==


### PR DESCRIPTION
**chore(KTabs): addresses breaking changes**

Renames `hasPanels` to `showPanels`.

Removes no longer needed styles.

**chore(KSelect): addresses breaking changes**

Removes `appearance` prop.

Renames several data-testid attributes.

Updates the styles of `.filter-select` elements so that the element doesn’t wrap onto a new line in the table actions bar.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

---

Previous Kongponents v9 adoption PRs:

- https://github.com/kumahq/kuma-gui/pull/1532
- https://github.com/kumahq/kuma-gui/pull/1853
- https://github.com/kumahq/kuma-gui/pull/1878