### PR TITLE
feat(zones): support zone mode

### DIFF
--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -17,11 +17,11 @@ Feature: application / MainNavigation
     When I visit the "/" URL
     Then the "<Element>" element <ExistsAssertion>
     Examples:
-      | Element            | Mode       | ExistsAssertion |
-      | $zones-nav         | global     | exists          |
-      | $zone-egresses-nav | global     | doesn't exist   |
-      | $zones-nav         | standalone | doesn't exist   |
-      | $zone-egresses-nav | standalone | exists          |
+      | Element            | Mode   | ExistsAssertion |
+      | $zones-nav         | global | exists          |
+      | $zone-egresses-nav | global | doesn't exist   |
+      | $zones-nav         | zone   | doesn't exist   |
+      | $zone-egresses-nav | zone   | exists          |
 
   Scenario Outline: Visiting the "<Title>" page
     Given the URL "/mesh-insights/default" responds with

--- a/features/application/Titles.feature
+++ b/features/application/Titles.feature
@@ -42,10 +42,10 @@ Feature: application / titles
       | /meshes/default/policies/circuit-breakers                    | Policies  |
       | /meshes/default/policies/circuit-breakers/program-0/overview | program-0 |
 
-  Scenario Outline: Visiting the "<Title>" page in "standalone" Mode
+  Scenario Outline: Visiting the "<Title>" page in "zone" Mode
     Given the environment
       """
-      KUMA_MODE: standalone
+      KUMA_MODE: zone
       """
     When I visit the "<URL>" URL
     Then the page title contains "<Title>"

--- a/features/main-overview/DetailViewContent.feature
+++ b/features/main-overview/DetailViewContent.feature
@@ -56,11 +56,11 @@ Feature: Overview: Detail view content
                 offline: 0
       """
 
-  Scenario: Shows expected content in standalone mode
+  Scenario: Shows expected content in zone mode
     Given the environment
       """
       KUMA_MESH_COUNT: 3
-      KUMA_MODE: standalone
+      KUMA_MODE: zone
       """
     And the URL "/global-insight" responds with
       """

--- a/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/features/mesh/dataplanes/DataplanePolicies.feature
@@ -31,10 +31,10 @@ Feature: Dataplane policies
       Then the "$standard-dataplane-policies" element exists
       And the "$policy-list" element doesn't exist
 
-    Scenario: Dataplane policies view shows expected content for standard proxy (mode: standalone)
+    Scenario: Dataplane policies view shows expected content for standard proxy (mode: zone)
       Given the environment
         """
-        KUMA_MODE: standalone
+        KUMA_MODE: zone
         """
       And the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
         """

--- a/features/zones/zone-cps/Item.feature
+++ b/features/zones/zone-cps/Item.feature
@@ -1,19 +1,18 @@
 Feature: zones / item
   Background:
     Given the CSS selectors
-      | Alias                 | Selector                                 |
-      | zone-detail-tabs-view | [data-testid='zone-cp-detail-tabs-view'] |
-      | tab-overview          | [data-testid='zone-cp-detail-view']      |
-    And the environment
-      """
-      KUMA_MODE: global
-      """
+      | Alias                  | Selector                                           |
+      | tabs-view              | [data-testid='zone-cp-detail-tabs-view']           |
+      | detail-view            | [data-testid='zone-cp-detail-view']                |
+      | config-view            | [data-testid='zone-cp-config-view']                |
+      | status-circuit-breaker | [data-testid='subscription-status-CircuitBreaker'] |
 
   Scenario: Detail view has expected content
     # We always use the final subscription
     # If the disconnectTime is empty then we are online
     Given the environment
       """
+      KUMA_MODE: global
       KUMA_SUBSCRIPTION_COUNT: 2
       """
     And the URL "/zones/zone-cp-1/_overview" responds with
@@ -30,16 +29,51 @@ Feature: zones / item
               disconnectTime: !!js/undefined
               config: |
                 { "environment": "universal", "store": {"type": "memory"}, "dpServer": { "auth": { "type": "dpToken" } } }
+              status:
+                stat:
+                  CircuitBreaker:
+                    responsesSent: '12'
+                    responsesAcknowledged: '10'
       """
 
     When I visit the "/zones/zone-cp-1/overview" URL
-    Then the page title contains "zone-cp-1"
-    Then the "$zone-detail-tabs-view" element contains "zone-cp-1"
 
-    Then the "$tab-overview" element contains
+    Then the page title contains "zone-cp-1"
+    And the "$tabs-view" element contains "zone-cp-1"
+    And the "$detail-view" element contains
       | Value     |
       | Universal |
       | online    |
       | dpToken   |
+    And the "$detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"
 
-    Then the "$tab-overview" element contains "Connected: Jul 28, 2020, 4:18 PM"
+    When I click the ".accordion-item:nth-child(1) [data-testid='accordion-item-button']" element
+
+    Then the "$status-circuit-breaker" element contains
+      | Value           |
+      | Circuit Breaker |
+      | 10              |
+      | 12              |
+
+  Scenario: Config view has expected content
+    Given the environment
+      """
+      KUMA_MODE: global
+      KUMA_SUBSCRIPTION_COUNT: 1
+      """
+    And the URL "/zones/zone-cp-1/_overview" responds with
+      """
+      body:
+        name: default
+        zoneInsight:
+          subscriptions:
+            - connectTime: 2020-07-28T16:18:09.743141Z
+              disconnectTime: !!js/undefined
+              config: |
+                { "multizone": { "zone": { "globalAddress": "grpcs://localhost:123" } } }
+      """
+
+    When I visit the "/zones/zone-cp-1/config" URL
+
+    Then the "$config-view" element contains "globalAddress"
+    And the "$config-view" element contains "grpcs://localhost:123"

--- a/features/zones/zone-cps/egresses/Index.feature
+++ b/features/zones/zone-cps/egresses/Index.feature
@@ -57,6 +57,6 @@ Feature: zones / egresses / index
     Then the "$item:nth-child(2) .name-column" element contains "zone-egress-2"
 
     Examples:
-      | Mode       | URL                       | Items |
-      | global     | /zones/zone-cp-1/egresses | 2     |
-      | standalone | /zones/egresses           | 3     |
+      | Mode   | URL                       | Items |
+      | global | /zones/zone-cp-1/egresses | 2     |
+      | zone   | /zones/egresses           | 3     |

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -1,4 +1,14 @@
-type PathConfig = ReturnType<typeof getPathConfigDefault>
+type PathConfig = {
+  baseGuiPath: string
+  apiUrl: string
+  version: string
+  product: string
+  mode: string
+  zone?: string
+  environment: string
+  storeType: string
+  apiReadOnly: boolean
+}
 
 export type EnvArgs = {
   KUMA_PRODUCT_NAME: string
@@ -15,6 +25,8 @@ type EnvProps = {
   KUMA_KDS_URL: string
   KUMA_UTM_QUERY_PARAMS: string
   KUMA_MODE: string
+  // TODO: Enable this once https://github.com/kumahq/kuma/issues/8767 has been merged.
+  // KUMA_ZONE: string | undefined
   KUMA_ENVIRONMENT: string
   KUMA_STORE_TYPE: string
 }
@@ -28,6 +40,7 @@ export default class Env {
     const env = (str: keyof EnvInternal, d: string = '') => this.var(str, _env?.[str] ?? d)
 
     const config = this.getConfig()
+    const mode = env('KUMA_MODE') || config.mode
     const version = semver(env('KUMA_VERSION', config.version))
 
     const productName = encodeURIComponent(env('KUMA_PRODUCT_NAME'))
@@ -42,7 +55,9 @@ export default class Env {
       KUMA_VERSION: version.pre,
       KUMA_API_URL: env('KUMA_API_URL') || config.apiUrl,
       KUMA_BASE_PATH: env('KUMA_BASE_PATH') || config.baseGuiPath,
-      KUMA_MODE: env('KUMA_MODE') || config.mode,
+      KUMA_MODE: mode,
+      // TODO: Enable this once https://github.com/kumahq/kuma/issues/8767 has been merged.
+      // KUMA_ZONE: mode === 'zone' ? config.zone || 'default' : undefined,
       KUMA_ENVIRONMENT: env('KUMA_ENVIRONMENT') || config.environment,
       KUMA_STORE_TYPE: env('KUMA_STORE_TYPE') || config.storeType,
       KUMA_KDS_URL: 'grpcs://<global-kds-address>:5685',
@@ -86,7 +101,7 @@ export default class Env {
     return config
   }
 }
-export function getPathConfigDefault(apiUrlDefault: string = '') {
+export function getPathConfigDefault(apiUrlDefault: string = ''): PathConfig {
   return {
     /**
      * The base GUI path. Will include a leading slash. Won’t include a trailing slash.
@@ -102,7 +117,8 @@ export function getPathConfigDefault(apiUrlDefault: string = '') {
     apiUrl: apiUrlDefault,
     version: '2.4.0',
     product: 'Kuma',
-    mode: 'global',
+    mode: 'zone',
+    zone: 'default',
     environment: 'universal',
     storeType: 'postgres',
     apiReadOnly: false,

--- a/src/services/env/env.spec.ts
+++ b/src/services/env/env.spec.ts
@@ -20,7 +20,7 @@ describe('env', () => {
           apiUrl: '/somewhere/else',
           version: '110.127.30',
           product: 'Kuma',
-          mode: 'standalone',
+          mode: 'zone',
           environment: 'universal',
           storeType: 'postgres',
           apiReadOnly: false,

--- a/src/test-support/mocks/src/config.ts
+++ b/src/test-support/mocks/src/config.ts
@@ -1,5 +1,11 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
-export default ({ env }: EndpointDependencies): MockResponder => (_req) => {
+
+export default ({ env, fake }: EndpointDependencies): MockResponder => (_req) => {
+  const mode = env('KUMA_MODE', 'global') === 'global' ? 'global' : 'zone'
+  // TODO: Enable this once https://github.com/kumahq/kuma/issues/8767 has been merged and remove the line below.
+  // const zoneName = mode === 'zone' ? env('KUMA_ZONE', fake.hacker.noun()) : undefined
+  const zoneName = mode === 'zone' ? fake.hacker.noun() : undefined
+
   return {
     headers: {},
     body: {
@@ -114,7 +120,7 @@ export default ({ env }: EndpointDependencies): MockResponder => (_req) => {
           subscriptionLimit: 10,
         },
       },
-      mode: env('KUMA_MODE', 'global') === 'global' ? 'global' : 'standalone',
+      mode,
       monitoringAssignmentServer: {
         apiVersions: ['v1'],
         assignmentRefreshInterval: '1s',
@@ -134,11 +140,13 @@ export default ({ env }: EndpointDependencies): MockResponder => (_req) => {
           },
         },
         zone: {
+          globalAddress: fake.datatype.boolean() ? 'grpcs://localhost:35685' : '',
           kds: {
             maxMsgSize: 10485760,
             refreshInterval: '1s',
             rootCaFile: '',
           },
+          ...(zoneName ? { name: zoneName } : {}),
         },
       },
       reports: {

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -164,6 +164,8 @@ export interface Kds2 {
 
 export interface Zone2 {
   kds: Kds2
+  globalAddress?: string
+  name?: string
 }
 
 export interface Multizone {


### PR DESCRIPTION
Deprecates standalone mode in favor of zone mode. This is a change only affecting our tests as our code already only checks for "is global mode" or "is not global mode".

Updates the /config mock to use `zone` instead of `standalone`. Also adds `multizone.zone.globalAddress` (indicates whether KDS is enabled) and `multizone.zone.name` (indicates the Zone name in zone mode).

Resolves #1686.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
