### PR TITLE
fix(dataplanes): querying legacy policies when not used

### DIFF
--- a/src/app/data-planes/components/StandardDataplanePolicies.vue
+++ b/src/app/data-planes/components/StandardDataplanePolicies.vue
@@ -3,20 +3,11 @@
     data-testid="standard-dataplane-policies"
     class="stack"
   >
-    <KCard v-if="(props.showPoliciesSection ? props.policyTypeEntries.length === 0 : true) && props.inspectRulesForDataplane.rules.length === 0">
+    <KCard v-if="(props.showLegacyPolicies ? props.policyTypeEntries.length === 0 : true) && props.inspectRulesForDataplane.rules.length === 0">
       <EmptyBlock />
     </KCard>
 
     <template v-else>
-      <KCard v-if="props.showPoliciesSection">
-        <PolicyTypeEntryList
-          id="policies"
-          :policy-type-entries="props.policyTypeEntries"
-          :policy-types-by-name="props.policyTypesByName"
-          data-testid="policy-list"
-        />
-      </KCard>
-
       <KCard v-if="props.inspectRulesForDataplane.proxyRule">
         <h3>{{ t('data-planes.routes.item.proxy_rule') }}</h3>
 
@@ -62,6 +53,19 @@
           />
         </div>
       </KCard>
+
+      <div v-if="props.showLegacyPolicies">
+        <h3>{{ t('data-planes.routes.item.legacy_policies') }}</h3>
+
+        <KCard class="mt-4">
+          <PolicyTypeEntryList
+            id="policies"
+            :policy-type-entries="props.policyTypeEntries"
+            :policy-types-by-name="props.policyTypesByName"
+            data-testid="policy-list"
+          />
+        </KCard>
+      </div>
     </template>
   </div>
 </template>
@@ -80,6 +84,6 @@ const props = defineProps<{
   policyTypeEntries: PolicyTypeEntry[]
   inspectRulesForDataplane: InspectRulesForDataplane
   policyTypesByName: Record<string, PolicyType | undefined>
-  showPoliciesSection: boolean
+  showLegacyPolicies: boolean
 }>()
 </script>

--- a/src/app/data-planes/locales/en-us/index.yaml
+++ b/src/app/data-planes/locales/en-us/index.yaml
@@ -56,6 +56,7 @@ data-planes:
       proxy_rule: Proxy rule
       to_rules: To rules
       from_rules: From rules
+      legacy_policies: Legacy policies
       matches_everything: 'Matches everything'
     items:
       title: Data Plane Proxies

--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -82,7 +82,7 @@
                 :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
                 :policy-type-entries="sidecarDataplaneData.policyTypeEntries"
                 :inspect-rules-for-dataplane="rulesData"
-                :show-policies-section="!can('use zones')"
+                :show-legacy-policies="!can('use zones')"
               />
             </DataSource>
           </DataSource>

--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -54,7 +54,7 @@
         >
           <DataSource
             v-slot="{ data: sidecarDataplaneData, error }: SidecarDataplaneCollectionSource"
-            :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/sidecar-dataplane-policies`"
+            :src="!can('use zones') ? `/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/sidecar-dataplane-policies` : ''"
           >
             <DataSource
               v-slot="{ data: rulesData, error: rulesError }: DataplaneRulesSource"
@@ -75,12 +75,12 @@
                 :error="rulesError"
               />
 
-              <LoadingBlock v-else-if="policyTypesData === undefined || sidecarDataplaneData === undefined || rulesData === undefined" />
+              <LoadingBlock v-else-if="policyTypesData === undefined || (!can('use zones') && sidecarDataplaneData === undefined) || rulesData === undefined" />
 
               <StandardDataplanePolicies
                 v-else
                 :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
-                :policy-type-entries="sidecarDataplaneData.policyTypeEntries"
+                :policy-type-entries="sidecarDataplaneData?.policyTypeEntries ?? []"
                 :inspect-rules-for-dataplane="rulesData"
                 :show-legacy-policies="!can('use zones')"
               />


### PR DESCRIPTION
**chore(dataplanes): tweak policies hierarchy**

Moves the legacy policies below the new-style ones based on the `/_rules` API and adds a heading to them.

**fix(dataplanes): querying legacy policies when not used**

Fixes querying the legacy `/policies` endpoint when not using its data (i.e. when in global mode).

Resolves #1934.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
