### PR TITLE
chore: add clipboard debug

### DIFF
--- a/cypress/main.ts
+++ b/cypress/main.ts
@@ -6,6 +6,7 @@ import { build, token } from '@/services/utils'
   const $ = {
     // cypress doesn't need i18n but this quietens TS temporarily
     i18n: token('i18n'),
+    components: token('components'),
     ...DEV_TOKENS,
     ...TOKENS,
   }

--- a/src/app/application/components/debug-k-clipboard-provider/DebugKClipboardProvider.vue
+++ b/src/app/application/components/debug-k-clipboard-provider/DebugKClipboardProvider.vue
@@ -1,0 +1,28 @@
+<template>
+  <ClipboardProvider v-slot="{ copyToClipboard }">
+    <slot
+      name="default"
+      :copy-to-clipboard="async (text: string) => {
+        const res = await copyToClipboard(text)
+        if(res) {
+          console.info(
+            `%cdebug-k-clipboard-provider: The following was copied to the clipboard:`, 'color: blue',
+            `
+${text}`,
+          )
+        } else {
+          console.error(
+            `debug-k-clipboard-provider: The following wasn't copied to the clipboard:`,
+            `
+${text}`,
+          )
+
+        }
+        return res;
+      }"
+    />
+  </ClipboardProvider>
+</template>
+<script lang="ts" setup>
+import { KClipboardProvider as ClipboardProvider } from '@kong/kongponents'
+</script>

--- a/src/app/application/components/debug-k-clipboard-provider/README.md
+++ b/src/app/application/components/debug-k-clipboard-provider/README.md
@@ -1,0 +1,7 @@
+# DebugKClipboardProvider
+
+Wraps KClipboardProvider in a decorator to also `console.log` the text of any
+copy (and also `console.error` the text if the copy fails).
+
+The component should always be injected as a replacement for KClipboardProvider
+in debug/dev modes only and never used directly.

--- a/src/app/vue/index.ts
+++ b/src/app/vue/index.ts
@@ -35,12 +35,12 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         return async (App: Component) => {
           const app = createApp(App)
 
-          components.forEach(([name, component]: [string, Component]) => {
-            app.component(name, component)
-          })
-
           plugins.forEach(([...args]) => {
             app.use(...args)
+          })
+
+          components.forEach(([name, component]: [string, Component]) => {
+            app.component(name, component)
           })
 
           return app

--- a/src/services/development.ts
+++ b/src/services/development.ts
@@ -1,6 +1,7 @@
 import { setupWorker, MockedRequest } from 'msw'
 
 import Logger from './logger/Logger'
+import DebugKClipboardProvider from '@/app/application/components/debug-k-clipboard-provider/DebugKClipboardProvider.vue'
 import debugI18n from '@/app/application/services/i18n/DebugI18n'
 import { TOKENS as CONTROL_PLANES } from '@/app/control-planes'
 import cookied from '@/services/env/CookiedEnv'
@@ -31,6 +32,7 @@ const $ = {
 
 type SupportedTokens = typeof $ & {
   i18n: Token
+  components: Token
   logger: Token
   env: Token<AEnv>
 }
@@ -65,6 +67,17 @@ export const services: ServiceConfigurator<SupportedTokens> = (app) => [
       return i18n()
     },
     decorates: app.i18n,
+  }],
+
+  [token('development.components'), {
+    service: () => {
+      return [
+        ['KClipboardProvider', DebugKClipboardProvider],
+      ]
+    },
+    labels: [
+      app.components,
+    ],
   }],
 
   [token<AEnv>('env.debug'), {

--- a/src/test-support/mocks/src/meshes/_.ts
+++ b/src/test-support/mocks/src/meshes/_.ts
@@ -8,6 +8,9 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       name,
       type: 'Mesh',
       creationTime: '2020-06-19T12:18:02.097986-04:00',

--- a/src/test-support/mocks/src/meshes/_/circuit-breakers/_.ts
+++ b/src/test-support/mocks/src/meshes/_/circuit-breakers/_.ts
@@ -4,6 +4,9 @@ export default (_deps: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'CircuitBreaker',
       mesh: params.mesh,
       name: params.name,

--- a/src/test-support/mocks/src/meshes/_/dataplanes/_.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes/_.ts
@@ -16,6 +16,9 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'Dataplane',
       mesh,
       name,

--- a/src/test-support/mocks/src/meshes/_/external-services/_.ts
+++ b/src/test-support/mocks/src/meshes/_/external-services/_.ts
@@ -6,6 +6,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'ExternalService',
       mesh,
       name,

--- a/src/test-support/mocks/src/meshes/_/fault-injections/_.ts
+++ b/src/test-support/mocks/src/meshes/_/fault-injections/_.ts
@@ -4,6 +4,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'FaultInjection',
       mesh: params.mesh,
       name: params.name,

--- a/src/test-support/mocks/src/meshes/_/health-checks/_.ts
+++ b/src/test-support/mocks/src/meshes/_/health-checks/_.ts
@@ -4,6 +4,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'HealthCheck',
       mesh: params.mesh,
       name: params.name,

--- a/src/test-support/mocks/src/meshes/_/meshfaultinjections/_.ts
+++ b/src/test-support/mocks/src/meshes/_/meshfaultinjections/_.ts
@@ -6,6 +6,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'MeshFaultInjection',
       mesh,
       name,

--- a/src/test-support/mocks/src/meshes/_/meshgatewayroutes/_.ts
+++ b/src/test-support/mocks/src/meshes/_/meshgatewayroutes/_.ts
@@ -4,6 +4,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'MeshGatewayRoute',
       mesh: params.mesh,
       name: params.name,

--- a/src/test-support/mocks/src/meshes/_/meshgateways/_.ts
+++ b/src/test-support/mocks/src/meshes/_/meshgateways/_.ts
@@ -4,6 +4,9 @@ export default (_deps: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'MeshGateway',
       mesh: params.mesh,
       name: params.name,

--- a/src/test-support/mocks/src/meshes/_/proxytemplates/_.ts
+++ b/src/test-support/mocks/src/meshes/_/proxytemplates/_.ts
@@ -4,6 +4,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'ProxyTemplate',
       mesh: params.mesh,
       name: params.name,

--- a/src/test-support/mocks/src/meshes/_/traffic-logs/_.ts
+++ b/src/test-support/mocks/src/meshes/_/traffic-logs/_.ts
@@ -4,6 +4,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'TrafficLog',
       mesh: params.mesh,
       name: params.name,

--- a/src/test-support/mocks/src/meshes/_/traffic-permissions/_.ts
+++ b/src/test-support/mocks/src/meshes/_/traffic-permissions/_.ts
@@ -4,6 +4,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'TrafficPermission',
       mesh: params.mesh,
       name: params.name,

--- a/src/test-support/mocks/src/meshes/_/traffic-traces/_.ts
+++ b/src/test-support/mocks/src/meshes/_/traffic-traces/_.ts
@@ -4,6 +4,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'TrafficTrace',
       mesh: params.mesh,
       name: params.name,

--- a/src/test-support/mocks/src/zone-ingresses/_.ts
+++ b/src/test-support/mocks/src/zone-ingresses/_.ts
@@ -7,6 +7,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'ZoneIngress',
       name,
       creationTime: '2021-07-13T08:40:59Z',

--- a/src/test-support/mocks/src/zoneegresses/_.ts
+++ b/src/test-support/mocks/src/zoneegresses/_.ts
@@ -7,6 +7,9 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   return {
     headers: {},
     body: {
+      ...(req.url.searchParams.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
       type: 'ZoneEgress',
       name,
       creationTime: '2021-07-13T08:40:59Z',

--- a/test-support/index.ts
+++ b/test-support/index.ts
@@ -26,12 +26,12 @@ export const services: ServiceConfigurator = (app) => [
       components: ComponentDefinition[],
       plugins: PluginDefinition[],
     ) => {
-      components.forEach(([name, component]: [string, Component]) => {
-        config.global.components[name] = component
-      })
-
       plugins.forEach(([...args]) => {
         config.global.plugins.push([...args])
+      })
+
+      components.forEach(([name, component]: [string, Component]) => {
+        config.global.components[name] = component
       })
 
       return async () => {


### PR DESCRIPTION
Adds a dev only console logger for clipboard copying by decorating `KClipboardProvider::copyToClipboard` via our `development.ts` service container config.

![Screenshot 2024-01-09 at 10 46 34](https://github.com/kumahq/kuma-gui/assets/554604/82c73cf8-d6b0-4d58-b96c-bd34e2641981)

Also added a single K8s property to relevant mocks (I figured this was enough to be able to tell if you'd copying the k8s format or not without having to be super realistic with the K8s formatted mock)

All in all this PR helps testing/debugging our copy buttons

---

Totally non-urgent, I did this while I was trying and figure out what was going on with https://github.com/kumahq/kuma-gui/issues/1967 and thought I may as well PR it.