### PR TITLE
chore: fix flaky tests

### DIFF
--- a/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
@@ -4,14 +4,14 @@ Feature: Dataplane details for built-in gateway
       | Alias             | Selector                                                           |
       | detail-view       | [data-testid='data-plane-detail-tabs-view']                        |
       | policies-view     | [data-testid='data-plane-policies-view']                           |
-      | overview-tab      | #data-plane-detail-view-tab a                                      |
-      | policies-tab      | #data-plane-policies-view-tab a                                    |
       | warnings          | [data-testid='dataplane-warnings']                                 |
       | details           | [data-testid='dataplane-details']                                  |
       | inbounds          | [data-testid='dataplane-inbounds']                                 |
       | route-item        | [data-testid='builtin-gateway-dataplane-policies'] .accordion-item |
       | route-item-button | $route-item:nth-child(1) [data-testid='accordion-item-button']     |
-    And the environment
+
+  Scenario: Overview tab has expected content
+    Given the environment
       """
       KUMA_SUBSCRIPTION_COUNT: 2
       KUMA_DATAPLANEINBOUND_COUNT: 0
@@ -50,7 +50,6 @@ Feature: Dataplane details for built-in gateway
 
     When I visit the "/meshes/default/data-planes/dataplane-gateway_builtin-1/overview" URL
 
-  Scenario: Overview tab has expected content
     Then the page title contains "dataplane-gateway_builtin-1"
     And the "$detail-view" element contains "dataplane-gateway_builtin-1"
     And the "$details" element contains
@@ -82,7 +81,7 @@ Feature: Dataplane details for built-in gateway
             name: traffic-trace-1
       """
 
-    When I click the "$policies-tab" element
+    When I visit the "/meshes/default/data-planes/dataplane-gateway_builtin-1/policies" URL
 
     Then the "$policies-view" element contains "traffic-log-1"
     And the "$policies-view" element contains "traffic-trace-1"

--- a/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
@@ -3,13 +3,14 @@ Feature: Dataplane details for delegated gateway
     Given the CSS selectors
       | Alias              | Selector                                                        |
       | detail-view        | [data-testid='data-plane-detail-tabs-view']                     |
-      | overview-tab       | #data-plane-detail-view-tab a                                   |
       | warnings           | [data-testid='dataplane-warnings']                              |
       | details            | [data-testid='dataplane-details']                               |
       | inbounds           | [data-testid='dataplane-inbounds']                              |
       | policy-item        | [data-testid='policy-list'] .accordion-item                     |
       | policy-item-button | $policy-item:nth-child(1) [data-testid='accordion-item-button'] |
-    And the environment
+
+  Scenario: Overview tab has expected content
+    Given the environment
       """
       KUMA_SUBSCRIPTION_COUNT: 2
       KUMA_DATAPLANEINBOUND_COUNT: 0
@@ -48,7 +49,6 @@ Feature: Dataplane details for delegated gateway
 
     When I visit the "/meshes/default/data-planes/dataplane-gateway_delegated-1/overview" URL
 
-  Scenario: Overview tab has expected content
     Then the page title contains "dataplane-gateway_delegated-1"
     And the "$detail-view" element contains "dataplane-gateway_delegated-1"
     And the "$details" element contains

--- a/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
@@ -4,8 +4,6 @@ Feature: Dataplane details for standard Data Plane Proxy
       | Alias         | Selector                                    |
       | detail-view   | [data-testid='data-plane-detail-tabs-view'] |
       | clusters-view | [data-testid='data-plane-clusters-view']    |
-      | overview-tab  | #data-plane-detail-view-tab a               |
-      | clusters-tab  | #data-plane-clusters-view-tab a             |
       | warnings      | [data-testid='dataplane-warnings']          |
       | details       | [data-testid='dataplane-details']           |
       | inbounds      | [data-testid='dataplane-inbounds']          |
@@ -14,7 +12,9 @@ Feature: Dataplane details for standard Data Plane Proxy
       | status-eds    | [data-testid='subscription-status-eds']     |
       | status-lds    | [data-testid='subscription-status-lds']     |
       | status-rds    | [data-testid='subscription-status-rds']     |
-    And the environment
+
+  Scenario: Overview tab has expected content
+    Given the environment
       """
       KUMA_SUBSCRIPTION_COUNT: 2
       KUMA_DATAPLANEINBOUND_COUNT: 1
@@ -81,7 +81,6 @@ Feature: Dataplane details for standard Data Plane Proxy
 
     When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/overview" URL
 
-  Scenario: Overview tab has expected content
     Then the page title contains "dpp-1-name-of-dataplane"
     And the "$detail-view" element contains "dpp-1-name-of-dataplane"
     And the "$details" element contains "online"
@@ -127,6 +126,6 @@ Feature: Dataplane details for standard Data Plane Proxy
         access_log_sink::default_priority::max_requests::1024
       """
 
-    When I click the "$clusters-tab" element
+    When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/clusters" URL
 
     Then the "$clusters-view" element contains "access_log_sink::observability_name::access_log_sink"

--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -41,31 +41,34 @@ Feature: mesh / policies / index
         - name: fake-cb-1
         - name: fake-cb-2
       """
+
+  Scenario: Listing has expected content
     When I visit the "/meshes/default/policies/circuit-breakers" URL
 
-  Scenario: We have a documentation link
     Then the "$button-docs" element exists
 
-  Scenario: The items have the correct columns
-    Then the "$items-header" element exists 2 times
-    Then the "$items-header" elements contain
+    And the "$items-header" element exists 2 times
+    And the "$items-header" elements contain
       | Value |
       | Name  |
 
-  Scenario: The items have the expected content and UI elements
-    Then the "#policy-list-index-view-tab.active" element exists
-    Then the "$item" element exists 2 times
-    Then the "$item:nth-child(1)" element contains
+    And the "#policy-list-index-view-tab.active" element exists
+    And the "$item" element exists 2 times
+    And the "$item:nth-child(1)" element contains
       | Value     |
       | fake-cb-1 |
 
   Scenario: Clicking the link goes to the detail page and back again
+    When I visit the "/meshes/default/policies/circuit-breakers" URL
+
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "fake-cb-1"
-    When I click the "$item:nth-child(1) td:first-of-type a" element
-    Then I click the "$item:nth-child(1) [data-testid='details-link']" element
-    Then the URL contains "circuit-breakers/fake-cb-1"
+
+    When I click the "$item:nth-child(1) [data-testid='details-link']" element
+
+    Then the URL contains "circuit-breakers/fake-cb-1/overview"
 
     When I click the "$breadcrumbs > .k-breadcrumbs-item:nth-child(3) > a" element
+
     Then the "$item" element exists 2 times
 
   Scenario: Clicking policy types in the sidebar switches listing
@@ -82,8 +85,10 @@ Feature: mesh / policies / index
       """
 
     When I visit the "/meshes/default/policies/circuit-breakers" URL
-    Then the "$item:nth-child(1)" element contains "fake-cb-1"
+
+    Then the "$item:nth-child(1) td:nth-child(1)" element contains "fake-cb-1"
 
     When I click the "[data-testid='policy-type-link-MeshFaultInjection']" element
-    Then the "$item:nth-child(1)" element contains "mfi-1"
+
+    Then the "$item:nth-child(1) td:nth-child(1)" element contains "mfi-1"
     And the "$item:nth-child(1)" element contains "MeshService:service-1"

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -83,7 +83,6 @@
                   >
                     <component
                       :is="child.Component"
-                      :name="route.params.policy"
                       :policy="data?.items.find((item) => item.name === route.params.policy)"
                       :policy-type="policyTypesData.policies.find((policyType) => policyType.path === route.params.policyPath)"
                     />

--- a/src/app/policies/views/PolicySummaryView.vue
+++ b/src/app/policies/views/PolicySummaryView.vue
@@ -24,12 +24,14 @@
               :to="{
                 name: 'policy-detail-view',
                 params: {
-                  policy: props.name,
+                  mesh: route.params.mesh,
+                  policyPath: route.params.policyPath,
+                  policy: route.params.policy,
                 },
               }"
             >
               <RouteTitle
-                :title="t('policies.routes.item.title', { name: props.name })"
+                :title="t('policies.routes.item.title', { name: route.params.policy })"
               />
             </RouterLink>
           </h2>
@@ -112,7 +114,6 @@ import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ResourceCodeBlock from '@/app/common/ResourceCodeBlock.vue'
 
 const props = withDefaults(defineProps<{
-  name: string
   policy?: Policy
   policyType: PolicyType
 }>(), {


### PR DESCRIPTION
**chore(policies): fix flaky test**

Fixes a flaky policy test caused by sourcing a route parameter from a prop (see https://github.com/kumahq/kuma-gui/pull/1993#discussion_r1447134988 for details).

Avoids double navigations (specifically in the "Clicking the link goes to the detail page and back again" and "Clicking policy types in the sidebar switches listing" tests).

**chore(dataplanes): fix flaky test**

Fixes a flaky test by avoiding quick double navigations (specifically in the "Clusters tab has expected content" and "Policies tab has expected content" tests).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
