### PR TITLE
fix(zones): breadcrumb and summary links

### DIFF
--- a/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
@@ -3,6 +3,7 @@
     v-slot="{ route, can }"
     name="zone-egress-detail-tabs-view"
     :params="{
+      zone: '',
       zoneEgress: '',
     }"
   >
@@ -17,6 +18,9 @@
         {
           to: {
             name: 'zone-egress-list-view',
+            params: {
+              zone: route.params.zone,
+            },
           },
           text: t('zone-egresses.routes.item.breadcrumbs'),
         },

--- a/src/app/zone-egresses/views/ZoneEgressListView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressListView.vue
@@ -134,7 +134,6 @@
             >
               <component
                 :is="child.Component"
-                :name="route.params.zoneEgress"
                 :zone-egress-overview="data?.items.find((item) => item.name === route.params.zoneEgress)"
               />
             </SummaryView>

--- a/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
@@ -1,5 +1,12 @@
 <template>
-  <RouteView name="zone-egress-summary-view">
+  <RouteView
+    v-slot="{ route }"
+    name="zone-egress-summary-view"
+    :params="{
+      zone: '',
+      zoneEgress: '',
+    }"
+  >
     <AppView>
       <template #title>
         <div class="summary-title-wrapper">
@@ -13,12 +20,13 @@
               :to="{
                 name: 'zone-egress-detail-view',
                 params: {
-                  zone: props.name,
+                  zone: route.params.zone,
+                  zoneEgress: route.params.zoneEgress,
                 },
               }"
             >
               <RouteTitle
-                :title="t('zone-egresses.routes.item.title', { name: props.name })"
+                :title="t('zone-egresses.routes.item.title', { name: route.params.zoneEgress })"
               />
             </RouterLink>
           </h2>
@@ -59,7 +67,6 @@ import { useI18n } from '@/utilities'
 const { t } = useI18n()
 
 const props = withDefaults(defineProps<{
-  name: string
   zoneEgressOverview?: ZoneEgressOverview
 }>(), {
   zoneEgressOverview: undefined,

--- a/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
@@ -3,6 +3,7 @@
     v-slot="{ route }"
     name="zone-ingress-detail-tabs-view"
     :params="{
+      zone: '',
       zoneIngress: '',
     }"
   >
@@ -17,6 +18,9 @@
         {
           to: {
             name: 'zone-ingress-list-view',
+            params: {
+              zone: route.params.zone,
+            },
           },
           text: t('zone-ingresses.routes.item.breadcrumbs'),
         },

--- a/src/app/zone-ingresses/views/ZoneIngressListView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressListView.vue
@@ -145,7 +145,6 @@
             >
               <component
                 :is="child.Component"
-                :name="route.params.zoneIngress"
                 :zone-ingress-overview="data?.items.find((item) => item.name === route.params.zoneIngress)"
               />
             </SummaryView>

--- a/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -1,5 +1,12 @@
 <template>
-  <RouteView name="zone-ingress-summary-view">
+  <RouteView
+    v-slot="{ route }"
+    name="zone-ingress-summary-view"
+    :params="{
+      zone: '',
+      zoneIngress: '',
+    }"
+  >
     <AppView>
       <template #title>
         <div class="summary-title-wrapper">
@@ -13,12 +20,13 @@
               :to="{
                 name: 'zone-ingress-detail-view',
                 params: {
-                  zone: props.name,
+                  zone: route.params.zone,
+                  zoneIngress: route.params.zoneIngress,
                 },
               }"
             >
               <RouteTitle
-                :title="t('zone-ingresses.routes.item.title', { name: props.name })"
+                :title="t('zone-ingresses.routes.item.title', { name: route.params.zoneIngress })"
               />
             </RouterLink>
           </h2>
@@ -59,7 +67,6 @@ import { useI18n } from '@/utilities'
 const { t } = useI18n()
 
 const props = withDefaults(defineProps<{
-  name: string
   zoneIngressOverview?: ZoneIngressOverview
 }>(), {
   zoneIngressOverview: undefined,


### PR DESCRIPTION
**fix(zones): ingresses and egresses breadcrumbs links**

Fixes the Ingress and Egresses breadcrumb links.

**fix(zones): summary tray detail links**

Fixes the Ingress and Egress summary detail links.

Resolves #1963.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
