### PR TITLE
ci: add restrictive permissions to remaining workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,33 +8,24 @@ on:
   schedule:
     - cron: '31 11 * * 4'
 
+permissions:
+  contents: read # for checking out the repository (e.g. actions/checkout)
+  security-events: write # for adding code alert statuses
+
 jobs:
   analyze:
     name: Run CodeQL
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
     strategy:
       fail-fast: false
       matrix:
         language: [javascript]
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: '/language:${{matrix.language}}'
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{matrix.language}}'

--- a/.github/workflows/create-gui-pr.yml
+++ b/.github/workflows/create-gui-pr.yml
@@ -34,7 +34,7 @@ jobs:
   # Creates a pull request in the main application to update its GUI.
   create-gui-pr:
     # Only runs this job when the triggering workflow run was a success (i.e. the “Tests” workflow passes).
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch'  || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     name: Create GUI update PR
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/create-gui-pr.yml
+++ b/.github/workflows/create-gui-pr.yml
@@ -22,7 +22,7 @@ on:
     branches: [master, 'release-[0-9]+.[0-9]+']
 
 permissions:
-  contents: read # needed for actions/checkout
+  contents: read # for checking out the repository (e.g. actions/checkout)
 
 # Ensures that we only run one workflow per branch at a time.
 # Already running workflows will be cancelled.

--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -1,4 +1,5 @@
 name: project-lifecycle
+
 on:
   schedule:
     - cron: 0 8 * * *
@@ -8,6 +9,10 @@ on:
       - reopened
       - opened
       - labeled
+
+permissions:
+  contents: read # for checking out the repository (e.g. actions/checkout)
+  issues: write # for editing issues (e.g. adding labels)
 
 jobs:
   lifecycle:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read # for checking out the repository (e.g. actions/checkout)
+
 jobs:
   install-dependencies:
     runs-on: ubuntu-latest


### PR DESCRIPTION
ci: add restrictive permissions to remaining workflows

Adds very restrictive workflow-level permissions to the codeql.yml, lifecycle.yml, and main.yml workflow files.

ci: fix always skipping create-gui-pr workflow if manually triggering it

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>