### PR TITLE
feat(dataplanes): add grpc traffic to dataplane connections viz

### DIFF
--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -48,6 +48,18 @@
         </template>
       </template>
       <template
+        v-else-if="props.protocol === 'grpc'"
+      >
+        <div>
+          <dt>{{ t('data-planes.components.service_traffic_card.grpc_success') }}</dt>
+          <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.success as (number | undefined) ?? 0 }) }}</dd>
+        </div>
+        <div>
+          <dt>{{ t('data-planes.components.service_traffic_card.grpc_failure') }}</dt>
+          <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.failure as (number | undefined) ?? 0 }) }}</dd>
+        </div>
+      </template>
+      <template
         v-else-if="props.protocol === 'http'"
       >
         <div
@@ -93,15 +105,13 @@
   </DataCard>
 </template>
 <script lang="ts" setup>
+import type { TrafficEntry } from '../../data'
 import { useI18n } from '@/app/application'
 import DataCard from '@/app/common/data-card/DataCard.vue'
 const { t } = useI18n()
 const props = defineProps<{
   protocol: string
-  traffic: {
-    http?: Record<string, unknown>
-    tcp?: Record<string, unknown>
-  }
+  traffic: TrafficEntry
 }>()
 const click = (e: MouseEvent) => {
   if (!e.isTrusted) {

--- a/src/app/data-planes/locales/en-us/index.yaml
+++ b/src/app/data-planes/locales/en-us/index.yaml
@@ -8,6 +8,8 @@ data-planes:
       5xx: 5xx
       tx: Bytes sent
       rx: Bytes received
+      grpc_success: Successful
+      grpc_failure: Failed
       protocol:
         passthrough: Passthrough
     data-plane-list:

--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -83,6 +83,7 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
       // the pattern
       const outbounds = getTraffic(json, (key) => {
         return ![
+          '_', // most internal names will be prefixed by `_` the rest will become legacy internal names
           'admin',
           'async-client',
           'kuma_envoy_admin',

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -240,34 +240,38 @@
                     Non mesh traffic
                   </ServiceTrafficCard>
                 </ServiceTrafficGroup>
-                <ServiceTrafficGroup
-                  type="outbound"
+                <template
+                  v-if="traffic.outbounds.length > 0"
                 >
-                  <template
-                    v-for="item in traffic.outbounds"
-                    :key="`${item.name}`"
+                  <ServiceTrafficGroup
+                    type="outbound"
                   >
-                    <ServiceTrafficCard
-                      v-if="route.params.inactive || ((item.protocol !== 'http' ? item.tcp?.downstream_cx_rx_bytes_total : item.http?.downstream_rq_total) as (number | undefined ) ?? 0 > 0)"
-                      :protocol="item.protocol"
-                      :traffic="item"
+                    <template
+                      v-for="item in traffic.outbounds"
+                      :key="`${item.name}`"
                     >
-                      <RouterLink
-                        :to="{
-                          name: 'data-plane-outbound-summary-overview-view',
-                          params: {
-                            service: item.name,
-                          },
-                          query: {
-                            inactive: route.params.inactive ? null : undefined,
-                          },
-                        }"
+                      <ServiceTrafficCard
+                        v-if="route.params.inactive || ((item.protocol === 'tcp' ? item.tcp?.downstream_cx_rx_bytes_total : item.http?.downstream_rq_total) as (number | undefined ) ?? 0 > 0)"
+                        :protocol="item.protocol"
+                        :traffic="item"
                       >
-                        {{ item.name }}
-                      </RouterLink>
-                    </ServiceTrafficCard>
-                  </template>
-                </ServiceTrafficGroup>
+                        <RouterLink
+                          :to="{
+                            name: 'data-plane-outbound-summary-overview-view',
+                            params: {
+                              service: item.name,
+                            },
+                            query: {
+                              inactive: route.params.inactive ? null : undefined,
+                            },
+                          }"
+                        >
+                          {{ item.name }}
+                        </RouterLink>
+                      </ServiceTrafficCard>
+                    </template>
+                  </ServiceTrafficGroup>
+                </template>
               </DataPlaneTraffic>
             </div>
           </KCard>

--- a/src/test-support/mocks/src/meshes/_/dataplanes/_/stats.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes/_/stats.ts
@@ -91,6 +91,7 @@ ${prefix}_cx_rx_bytes_total: ${fake.number.int(_minMax)}`
           success: Number,
           failure: Number,
         }, totalRequests)
+        // https://grpc.github.io/grpc/core/md_doc_statuscodes.html
         return `${prefix}_cx_tx_bytes_total: ${fake.number.int(_minMax)}
 ${prefix}_cx_rx_bytes_total: ${fake.number.int(_minMax)}
 cluster.${service}.grpc.0: ${totalRequests}


### PR DESCRIPTION
[Preview](https://deploy-preview-2005--kuma-gui.netlify.app/gui/meshes/default/data-planes/frontend-d28f6bc67c-tjqee.system.kuma-system-proxy-6/overview#KUMA_TRAFFIC_ENABLED=true)

Adds specific data for grpc traffic.

