### PR TITLE
fix(test): avoid component re-registration warning during unit tests

### DIFF
--- a/src/services/development.ts
+++ b/src/services/development.ts
@@ -71,9 +71,14 @@ export const services: ServiceConfigurator<SupportedTokens> = (app) => [
 
   [token('development.components'), {
     service: () => {
-      return [
-        ['KClipboardProvider', DebugKClipboardProvider],
-      ]
+      // unit testing is likely to have process
+      // no matter which runner is used
+      // if we are unit testing don't decorate KClipboardProvider
+      return typeof process === 'undefined'
+        ? [
+          ['KClipboardProvider', DebugKClipboardProvider],
+        ]
+        : []
     },
     labels: [
       app.components,


### PR DESCRIPTION
I noticed we were getting warnings for re-registering a component due to https://github.com/kumahq/kuma-gui/pull/1981

This happens both in browser development environments (PR previews and locally) and also CLI based unit tests.

The unit test ones are noisier than the browser ones, seeing as the browser ones need to be looked for.

This PR only does the re-registration if we don't have a `process` meaning it doesn't happen in anything CLI based.

Longer term, if I can't find a documented way to un-register components or overwrite them without causing this warning I might put this functionality behind one of our dev cookies so you have to explicitly enable it if you are looking at copy/paste things. In the meantime this silences the CLI based warnings.