### PR TITLE
fix(dataplanes): clicking links in ServiceTraffic cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@kong-ui-public/i18n": "2.0.5",
     "@kong/icons": "1.8.10",
     "@kong/kongponents": "9.0.0-alpha.82",
+    "@vueuse/core": "10.7.1",
     "brandi": "5.0.0",
     "deepmerge": "4.3.1",
     "js-yaml": "4.1.0",

--- a/src/app/common/SummaryView.vue
+++ b/src/app/common/SummaryView.vue
@@ -1,6 +1,8 @@
 <template>
   <KSlideout
+    ref="slideOutRef"
     class="summary-slideout"
+    prevent-close-on-blur
     close-button-alignment="end"
     :has-overlay="false"
     is-visible
@@ -14,6 +16,20 @@
 </template>
 
 <script lang="ts" setup>
+import { onClickOutside, useThrottleFn } from '@vueuse/core'
+import { ref } from 'vue'
+// recreates KSlideOuts close on blur, but ignores clicks on any anchors
+const slideOutRef = ref(null)
+onClickOutside(
+  // @ts-ignore CI only ts error
+  slideOutRef,
+  useThrottleFn((event: PointerEvent) => {
+    const $el = event.target as HTMLElement
+    if (event.isTrusted && $el.nodeName.toLowerCase() !== 'a') {
+      emit('close')
+    }
+  }, 1, true, false),
+)
 const emit = defineEmits<{
   (event: 'close'): void
 }>()

--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -114,16 +114,14 @@ const props = defineProps<{
   traffic: TrafficEntry
 }>()
 const click = (e: MouseEvent) => {
-  if (!e.isTrusted) {
-    return
-  }
-  const $el = (e.target as HTMLElement).closest('.service-traffic-card')
-  if ($el) {
-    const $a = $el.querySelector('a')
-    if ($a !== null) {
-      window.requestAnimationFrame(() => {
+  const $target = e.target as HTMLElement
+  if ($target.nodeName.toLowerCase() !== 'a') {
+    const $el = $target.closest('.service-traffic-card')
+    if ($el) {
+      const $a = $el.querySelector('a')
+      if ($a !== null) {
         $a.click()
-      })
+      }
     }
   }
 }


### PR DESCRIPTION
I took this out inplace of a different approach in https://github.com/kumahq/kuma-gui/pull/1997#issuecomment-1885100683 but I found that the newer approach had at least a couple of user facing issues.

1. When a summary was open clicking a port in the case of inbounds or the service name in the case of outbounds (which are `a` tags, would cause the summary drawer to close instead of switching to the newly clicking inbound/outbound.
2. Clicking the service tag link in the top right corner of the card would navigate to the correct place but produce an error in the JS console about `dataPlane` not being defined on a route (one of the hard to trace vue-router ones).

After playing with it a while, and trying several tweaks to the different approach I decided to just revert back to my original code seeing as that seems to have none of the above issues.

---

While I was doing this I thought about it a little more about the onClickOutside link clicking and I can't think of an occasion where you would want the `@close` called from the `onClickOutside` used in `KSlideout`  if you have outside clicked on a link. I'm probably navigating somewhere without the KSlideout being shown (or at least I'm controlling that via the URL), hence it would close on its on by just not being there. It feels very much like the same as when we had issues back with our Tabs where the Tabs were not built taking into account that we always want to save the state of our current page/view in the URL of the browser.

I had a few other thoughts around this, but for the moment this seems as though it works more reliably from a user perspective, so at least for the moment I'd rather use this approach.


