### PR TITLE
feat(policies): hide legacy policy types if there are no legacy policies

### DIFF
--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -108,7 +108,10 @@ Feature: mesh / policies / index
 
     When I visit the "/meshes/default/policies/meshfaultinjections" URL
 
-    Then the "[data-testid^='policy-type-link-']" element exists 14 times
+    Then the "[data-testid='policy-type-link-FaultInjection']" element doesn't exist
+    And the "[data-testid='policy-type-link-MeshFaultInjection']" element exists
+    # Always shows MeshGateway
+    And the "[data-testid='policy-type-link-MeshGateway']" element exists
 
   Scenario: Shows legacy policy types if there are any legacy policies applied
     Given the URL "/mesh-insights/default" responds with
@@ -117,34 +120,11 @@ Feature: mesh / policies / index
         policies:
           CircuitBreaker:
             total: 1
-          FaultInjection:
-            total: 0
-          HealthChecks:
-            total: 0
-          MeshGatewayRoute:
-            total: 0
-          ProxyTemplate:
-            total: 0
-          RateLimit:
-            total: 0
-          Retry:
-            total: 0
-          Timeout:
-            total: 0
-          TrafficLog:
-            total: 0
-          TrafficPermission:
-            total: 0
-          TrafficRoute:
-            total: 0
-          TrafficTrace:
-            total: 0
-          VirtualOutbound:
-            total: 0
-          MeshFaultInjection:
-            total: 2
       """
 
     When I visit the "/meshes/default/policies/meshfaultinjections" URL
 
-    Then the "[data-testid^='policy-type-link-']" element exists 27 times
+    Then the "[data-testid='policy-type-link-FaultInjection']" element exists
+    And the "[data-testid='policy-type-link-MeshFaultInjection']" element exists
+    # Always shows MeshGateway
+    And the "[data-testid='policy-type-link-MeshGateway']" element exists

--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -12,28 +12,6 @@ Feature: mesh / policies / index
       """
       KUMA_CIRCUITBREAKER_COUNT: 2
       """
-    # Makes ure that we only have CircuitBreakers so clicking back on the tabs
-    # Always takes us to the CircuitBreaker listing
-    And the URL "/mesh-insights/default" responds with
-      """
-      body:
-        policies:
-          CircuitBreaker:
-            - total: 2
-          FaultInjection: ~
-          HealthChecks: ~
-          MeshGatewayRoute: ~
-          MeshGateway: ~
-          ProxyTemplate: ~
-          RateLimit: ~
-          Retry: ~
-          Timeout: ~
-          TrafficLog: ~
-          TrafficPermission: ~
-          TrafficRoute: ~
-          TrafficTrace: ~
-          VirtualOutbound: ~
-      """
     And the URL "/meshes/default/circuit-breakers" responds with
       """
       body:
@@ -92,3 +70,81 @@ Feature: mesh / policies / index
 
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "mfi-1"
     And the "$item:nth-child(1)" element contains "MeshService:service-1"
+
+  Scenario: Hides legacy policy types if there are no legacy policies applied
+    Given the URL "/mesh-insights/default" responds with
+      """
+      body:
+        policies:
+          CircuitBreaker:
+            total: 0
+          FaultInjection:
+            total: 0
+          HealthChecks:
+            total: 0
+          MeshGatewayRoute:
+            total: 0
+          ProxyTemplate:
+            total: 0
+          RateLimit:
+            total: 0
+          Retry:
+            total: 0
+          Timeout:
+            total: 0
+          TrafficLog:
+            total: 0
+          TrafficPermission:
+            total: 0
+          TrafficRoute:
+            total: 0
+          TrafficTrace:
+            total: 0
+          VirtualOutbound:
+            total: 0
+          MeshFaultInjection:
+            total: 2
+      """
+
+    When I visit the "/meshes/default/policies/meshfaultinjections" URL
+
+    Then the "[data-testid^='policy-type-link-']" element exists 14 times
+
+  Scenario: Shows legacy policy types if there are any legacy policies applied
+    Given the URL "/mesh-insights/default" responds with
+      """
+      body:
+        policies:
+          CircuitBreaker:
+            total: 1
+          FaultInjection:
+            total: 0
+          HealthChecks:
+            total: 0
+          MeshGatewayRoute:
+            total: 0
+          ProxyTemplate:
+            total: 0
+          RateLimit:
+            total: 0
+          Retry:
+            total: 0
+          Timeout:
+            total: 0
+          TrafficLog:
+            total: 0
+          TrafficPermission:
+            total: 0
+          TrafficRoute:
+            total: 0
+          TrafficTrace:
+            total: 0
+          VirtualOutbound:
+            total: 0
+          MeshFaultInjection:
+            total: 2
+      """
+
+    When I visit the "/meshes/default/policies/meshfaultinjections" URL
+
+    Then the "[data-testid^='policy-type-link-']" element exists 27 times


### PR DESCRIPTION
Hides the legacy policy types in the policy type list view if there no legacy policies at all. Ignores MeshGateway policies which we always show.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
