### PR TITLE
feat(dataplanes): Traffic errors, remove traffic feature flag

### DIFF
--- a/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
@@ -6,7 +6,6 @@ Feature: Dataplane details for standard Data Plane Proxy
       | clusters-view | [data-testid='data-plane-clusters-view']    |
       | warnings      | [data-testid='dataplane-warnings']          |
       | details       | [data-testid='dataplane-details']           |
-      | inbounds      | [data-testid='dataplane-inbounds']          |
       | subscriptions | [data-testid='dataplane-subscriptions']     |
       | status-cds    | [data-testid='subscription-status-cds']     |
       | status-eds    | [data-testid='subscription-status-eds']     |
@@ -84,16 +83,6 @@ Feature: Dataplane details for standard Data Plane Proxy
     Then the page title contains "dpp-1-name-of-dataplane"
     And the "$detail-view" element contains "dpp-1-name-of-dataplane"
     And the "$details" element contains "online"
-    And the "$inbounds" element contains
-      | Value                 |
-      | healthy               |
-      | 193.107.134.106:1328  |
-      | 44.167.201.218:62098  |
-      | kuma.io/protocol:http |
-      | kuma.io/zone:zone-1   |
-    And the "$warnings" element doesn't exist
-    And the "$subscriptions" element contains "Connected: Feb 17, 2021, 7:33 AM"
-    And the "$subscriptions" element contains "CP instance ID: dpp-1-cp-instance-id"
 
     When I click the ".accordion-item:nth-child(1) [data-testid='accordion-item-button']" element
 

--- a/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
@@ -1,0 +1,78 @@
+Feature: Dataplane traffic
+  Background:
+    Given the CSS selectors
+      | Alias           | Selector                                    |
+      | detail-view     | [data-testid='data-plane-detail-tabs-view'] |
+      | loading-warning | [data-testid='warning-stats-loading']       |
+      | traffic         | [data-testid='dataplane-traffic']           |
+
+  Scenario: Standard sidecar proxy shows the traffic component
+    Given the environment
+      """
+      KUMA_DATAPLANEINBOUND_COUNT: 1
+      """
+    And the URL "/meshes/default/dataplanes/dpp-1-name-of-dataplane/_overview" responds with
+      """
+      body:
+        dataplane:
+          networking:
+            gateway: !!js/undefined
+      """
+
+    When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/overview" URL
+
+    And the "$detail-view" element contains "dpp-1-name-of-dataplane"
+    And the "$traffic" element exists
+
+  Scenario: Standard sidecar proxy shows the traffic component and an error warning when _stats fails
+    Given the environment
+      """
+      KUMA_DATAPLANEINBOUND_COUNT: 1
+      """
+    And the URL "/meshes/default/dataplanes/dpp-1-name-of-dataplane/_overview" responds with
+      """
+      body:
+        dataplane:
+          networking:
+            gateway: !!js/undefined
+      """
+    And the URL "/meshes/default/dataplanes/dpp-1-name-of-dataplane/stats" responds with
+      """
+      headers:
+        Status-Code: '504'
+      body: upstream request timeout
+      """
+    When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/overview" URL
+    And the "$traffic" element exists
+    And the "$loading-warning" element exists
+
+
+  Scenario: Builtin gateway proxy doesn't show the traffic component
+    Given the URL "/meshes/default/dataplanes/dpp-1-name-of-gateway_builtin/_overview" responds with
+      """
+      body:
+        dataplane:
+          networking:
+            gateway:
+              type: BUILTIN
+      """
+
+    When I visit the "/meshes/default/data-planes/dpp-1-name-of-gateway_builtin/overview" URL
+
+    And the "$detail-view" element contains "dpp-1-name-of-gateway_builtin"
+    And the "$traffic" element doesn't exist
+
+  Scenario: Delegated gateway proxy doesn't show the traffic component
+    Given the URL "/meshes/default/dataplanes/dpp-1-name-of-gateway_delegated/_overview" responds with
+      """
+      body:
+        dataplane:
+          networking:
+            gateway:
+              type: DELEGATED
+      """
+
+    When I visit the "/meshes/default/data-planes/dpp-1-name-of-gateway_delegated/overview" URL
+
+    And the "$detail-view" element contains "dpp-1-name-of-gateway_delegated"
+    And the "$traffic" element doesn't exist

--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -18,90 +18,94 @@
       </div>
     </template>
 
-    <!-- rx and tx are purposefully reversed in all the below to rx=tx and tx=rx here due to the direction of the traffic (downstream) -->
-    <dl>
-      <template
-        v-if="props.protocol === 'passthrough'"
-      >
+    <template
+      v-if="props.traffic"
+    >
+      <!-- rx and tx are purposefully reversed in all the below to rx=tx and tx=rx here due to the direction of the traffic (downstream) -->
+      <dl>
         <template
-          v-for="(item, key) in [
-            (['http', 'tcp'] as const).reduce((prev, protocol) => {
-              const direction = 'downstream'
-              // sum both the properties we need from both protocols
-              return Object.entries(props.traffic[protocol] || {}).reduce((prev, [key, value]) => {
-                return [`${direction}_cx_tx_bytes_total`, `${direction}_cx_rx_bytes_total`].includes(key) ?
-                  { ...prev, [key]: (value as number) + (prev[key] ?? 0) } :
-                  prev
-              }, prev)
-            }, {} as Record<string, number>),
-          ]"
-          :key="key"
+          v-if="props.protocol === 'passthrough'"
+        >
+          <template
+            v-for="(item, key) in [
+              (['http', 'tcp'] as const).reduce((prev, protocol) => {
+                const direction = 'downstream'
+                // sum both the properties we need from both protocols
+                return Object.entries(props.traffic?.[protocol] || {}).reduce((prev, [key, value]) => {
+                  return [`${direction}_cx_tx_bytes_total`, `${direction}_cx_rx_bytes_total`].includes(key) ?
+                    { ...prev, [key]: (value as number) + (prev[key] ?? 0) } :
+                    prev
+                }, prev)
+              }, {} as Record<string, number>),
+            ]"
+            :key="key"
+          >
+            <div>
+              <dt>{{ t('data-planes.components.service_traffic_card.tx') }}</dt>
+              <dd>{{ t('common.formats.bytes', { value: item.downstream_cx_rx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+            </div>
+            <div>
+              <dt>{{ t('data-planes.components.service_traffic_card.rx') }}</dt>
+              <dd>{{ t('common.formats.bytes', { value: item.downstream_cx_tx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+            </div>
+          </template>
+        </template>
+        <template
+          v-else-if="props.protocol === 'grpc'"
+        >
+          <div>
+            <dt>{{ t('data-planes.components.service_traffic_card.grpc_success') }}</dt>
+            <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.success as (number | undefined) ?? 0 }) }}</dd>
+          </div>
+          <div>
+            <dt>{{ t('data-planes.components.service_traffic_card.grpc_failure') }}</dt>
+            <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.failure as (number | undefined) ?? 0 }) }}</dd>
+          </div>
+        </template>
+        <template
+          v-else-if="props.protocol === 'http'"
+        >
+          <div
+            v-for="value in [props.traffic.http?.downstream_rq_1xx as (number | undefined) ?? 0].filter(item => item !== 0)"
+            :key="value"
+          >
+            <dt>{{ t('data-planes.components.service_traffic_card.1xx') }}</dt>
+            <dd>{{ t('common.formats.integer', { value: value }) }}</dd>
+          </div>
+          <div>
+            <dt>{{ t('data-planes.components.service_traffic_card.2xx') }}</dt>
+            <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_2xx as (number | undefined) ?? 0 }) }}</dd>
+          </div>
+          <div
+            v-for="value in [props.traffic.http?.downstream_rq_3xx as (number | undefined) ?? 0].filter(item => item !== 0)"
+            :key="value"
+          >
+            <dt>{{ t('data-planes.components.service_traffic_card.3xx') }}</dt>
+            <dd>{{ t('common.formats.integer', { value: value }) }}</dd>
+          </div>
+          <div>
+            <dt>{{ t('data-planes.components.service_traffic_card.4xx') }}</dt>
+            <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_4xx as (number | undefined) ?? 0 }) }}</dd>
+          </div>
+          <div>
+            <dt>{{ t('data-planes.components.service_traffic_card.5xx') }}</dt>
+            <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_5xx as (number | undefined) ?? 0 }) }}</dd>
+          </div>
+        </template>
+        <template
+          v-else
         >
           <div>
             <dt>{{ t('data-planes.components.service_traffic_card.tx') }}</dt>
-            <dd>{{ t('common.formats.bytes', { value: item.downstream_cx_rx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+            <dd>{{ t('common.formats.bytes', { value: props.traffic.tcp?.downstream_cx_rx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
           </div>
           <div>
             <dt>{{ t('data-planes.components.service_traffic_card.rx') }}</dt>
-            <dd>{{ t('common.formats.bytes', { value: item.downstream_cx_tx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+            <dd>{{ t('common.formats.bytes', { value: props.traffic.tcp?.downstream_cx_tx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
           </div>
         </template>
-      </template>
-      <template
-        v-else-if="props.protocol === 'grpc'"
-      >
-        <div>
-          <dt>{{ t('data-planes.components.service_traffic_card.grpc_success') }}</dt>
-          <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.success as (number | undefined) ?? 0 }) }}</dd>
-        </div>
-        <div>
-          <dt>{{ t('data-planes.components.service_traffic_card.grpc_failure') }}</dt>
-          <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.failure as (number | undefined) ?? 0 }) }}</dd>
-        </div>
-      </template>
-      <template
-        v-else-if="props.protocol === 'http'"
-      >
-        <div
-          v-for="value in [props.traffic.http?.downstream_rq_1xx as (number | undefined) ?? 0].filter(item => item !== 0)"
-          :key="value"
-        >
-          <dt>{{ t('data-planes.components.service_traffic_card.1xx') }}</dt>
-          <dd>{{ t('common.formats.integer', { value: value }) }}</dd>
-        </div>
-        <div>
-          <dt>{{ t('data-planes.components.service_traffic_card.2xx') }}</dt>
-          <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_2xx as (number | undefined) ?? 0 }) }}</dd>
-        </div>
-        <div
-          v-for="value in [props.traffic.http?.downstream_rq_3xx as (number | undefined) ?? 0].filter(item => item !== 0)"
-          :key="value"
-        >
-          <dt>{{ t('data-planes.components.service_traffic_card.3xx') }}</dt>
-          <dd>{{ t('common.formats.integer', { value: value }) }}</dd>
-        </div>
-        <div>
-          <dt>{{ t('data-planes.components.service_traffic_card.4xx') }}</dt>
-          <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_4xx as (number | undefined) ?? 0 }) }}</dd>
-        </div>
-        <div>
-          <dt>{{ t('data-planes.components.service_traffic_card.5xx') }}</dt>
-          <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_5xx as (number | undefined) ?? 0 }) }}</dd>
-        </div>
-      </template>
-      <template
-        v-else
-      >
-        <div>
-          <dt>{{ t('data-planes.components.service_traffic_card.tx') }}</dt>
-          <dd>{{ t('common.formats.bytes', { value: props.traffic.tcp?.downstream_cx_rx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
-        </div>
-        <div>
-          <dt>{{ t('data-planes.components.service_traffic_card.rx') }}</dt>
-          <dd>{{ t('common.formats.bytes', { value: props.traffic.tcp?.downstream_cx_tx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
-        </div>
-      </template>
-    </dl>
+      </dl>
+    </template>
   </DataCard>
 </template>
 <script lang="ts" setup>
@@ -111,7 +115,7 @@ import DataCard from '@/app/common/data-card/DataCard.vue'
 const { t } = useI18n()
 const props = defineProps<{
   protocol: string
-  traffic: TrafficEntry
+  traffic?: TrafficEntry
 }>()
 const click = (e: MouseEvent) => {
   if (!e.isTrusted) {

--- a/src/app/data-planes/data/stats.ts
+++ b/src/app/data-planes/data/stats.ts
@@ -4,6 +4,7 @@ interface MetricRecord {
 export type TrafficEntry = {
   name: string
   protocol: string
+  port: string
   http?: MetricRecord
   tcp?: MetricRecord
   grpc?: MetricRecord
@@ -66,6 +67,7 @@ export const getTraffic = (json: EnvoyStats, filter: (key: string) => boolean): 
       if (typeof traffic[key] === 'undefined') {
         traffic[key] = {
           name: key,
+          port: key.split('_').at(-1) ?? '',
           protocol: item,
         }
       }

--- a/src/app/data-planes/features.ts
+++ b/src/app/data-planes/features.ts
@@ -1,13 +1,6 @@
 import type { Features } from '@/app/application/services/can'
 import type Env from '@/services/env/Env'
-export const features = (env: Env['var']): Features => {
+export const features = (_env: Env['var']): Features => {
   return {
-    'read traffic': () => {
-      try {
-        return !!JSON.parse(env('KUMA_TRAFFIC_ENABLED', 'false'))
-      } catch (e) {
-        return false
-      }
-    },
   }
 }

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    v-slot="{ can, route }"
+    v-slot="{ route }"
     :params="{
       mesh: '',
       dataPlane: '',
@@ -9,117 +9,116 @@
     }"
     name="data-plane-detail-view"
   >
-    <AppView>
-      <template
-        v-if="warnings.length > 0"
-        #notifications
-      >
-        <ul data-testid="dataplane-warnings">
-          <!-- eslint-disable vue/no-v-html  -->
-          <li
-            v-for="warning in warnings"
-            :key="warning.kind"
-            :data-testid="`warning-${warning.kind}`"
-            v-html="t(`common.warnings.${warning.kind}`, warning.payload)"
-          />
-          <!-- eslint-enable -->
-        </ul>
-      </template>
-
-      <div
-        class="stack"
-        data-testid="dataplane-details"
-      >
-        <KCard>
-          <div class="columns">
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.status') }}
-              </template>
-
-              <template #body>
-                <div class="status-with-reason">
-                  <StatusBadge :status="props.data.status" />
-
-                  <template
-                    v-for="inbounds in [props.data.dataplane.networking.inbounds.filter(item => !item.health.ready)]"
-                    :key="inbounds"
-                  >
-                    <KTooltip
-                      v-if="inbounds.length > 0"
-                      class="reason-tooltip"
-                      position-fixed
-                    >
-                      <InfoIcon
-                        :color="KUI_COLOR_BACKGROUND_NEUTRAL"
-                        :size="KUI_ICON_SIZE_30"
-                        hide-title
-                      />
-                      <template #content>
-                        <ul>
-                          <li
-                            v-for="inbound in inbounds"
-                            :key="`${inbound.service}:${inbound.port}`"
-                          >
-                            {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
-                          </li>
-                        </ul>
-                      </template>
-                    </KTooltip>
-                  </template>
-                </div>
-              </template>
-            </DefinitionCard>
-
-            <DefinitionCard>
-              <template #title>
-                {{ t('data-planes.routes.item.last_updated') }}
-              </template>
-
-              <template #body>
-                {{ formatIsoDate(props.data.modificationTime) }}
-              </template>
-            </DefinitionCard>
-
-            <template v-if="props.data.dataplane.networking.gateway">
-              <DefinitionCard>
-                <template #title>
-                  {{ t('http.api.property.tags') }}
-                </template>
-
-                <template #body>
-                  <TagList :tags="props.data.dataplane.networking.gateway.tags" />
-                </template>
-              </DefinitionCard>
-
-              <DefinitionCard>
-                <template #title>
-                  {{ t('http.api.property.address') }}
-                </template>
-
-                <template #body>
-                  <TextWithCopyButton :text="`${props.data.dataplane.networking.address}`" />
-                </template>
-              </DefinitionCard>
-            </template>
-          </div>
-        </KCard>
-
-        <DataSource
-          v-if="can('read traffic') && props.data.dataplaneType === 'standard'"
-          v-slot="{ data: traffic, error, refresh }: TrafficSource"
-          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/traffic`"
+    <DataSource
+      v-slot="{ data: traffic, error, refresh }: TrafficSource"
+      :src="props.data.dataplaneType === 'standard' ? `/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/traffic` : ''"
+    >
+      <AppView>
+        <template
+          v-if="warnings.length > 0"
+          #notifications
         >
-          <ErrorBlock
-            v-if="error"
-            :error="error"
-          />
+          <ul data-testid="dataplane-warnings">
+            <!-- eslint-disable vue/no-v-html  -->
+            <li
+              v-for="warning in warnings"
+              :key="warning.kind"
+              :data-testid="`warning-${warning.kind}`"
+              v-html="t(`common.warnings.${warning.kind}`, warning.payload)"
+            />
+            <li
+              v-if="error"
+              :data-testid="`warning-stats-loading`"
+            >
+              Error loading outbound stats: <strong>{{ (error as ApiError).status }} {{ error.message }}</strong>
+            </li>
+          <!-- eslint-enable -->
+          </ul>
+        </template>
 
-          <LoadingBlock v-else-if="traffic === undefined" />
+        <div
+          class="stack"
+          data-testid="dataplane-details"
+        >
+          <KCard>
+            <div class="columns">
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.status') }}
+                </template>
+
+                <template #body>
+                  <div class="status-with-reason">
+                    <StatusBadge :status="props.data.status" />
+
+                    <template
+                      v-for="inbounds in [props.data.dataplane.networking.inbounds.filter(item => !item.health.ready)]"
+                      :key="inbounds"
+                    >
+                      <KTooltip
+                        v-if="inbounds.length > 0"
+                        class="reason-tooltip"
+                        position-fixed
+                      >
+                        <InfoIcon
+                          :color="KUI_COLOR_BACKGROUND_NEUTRAL"
+                          :size="KUI_ICON_SIZE_30"
+                          hide-title
+                        />
+                        <template #content>
+                          <ul>
+                            <li
+                              v-for="inbound in inbounds"
+                              :key="`${inbound.service}:${inbound.port}`"
+                            >
+                              {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
+                            </li>
+                          </ul>
+                        </template>
+                      </KTooltip>
+                    </template>
+                  </div>
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('data-planes.routes.item.last_updated') }}
+                </template>
+
+                <template #body>
+                  {{ formatIsoDate(props.data.modificationTime) }}
+                </template>
+              </DefinitionCard>
+
+              <template v-if="props.data.dataplane.networking.gateway">
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('http.api.property.tags') }}
+                  </template>
+
+                  <template #body>
+                    <TagList :tags="props.data.dataplane.networking.gateway.tags" />
+                  </template>
+                </DefinitionCard>
+
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('http.api.property.address') }}
+                  </template>
+
+                  <template #body>
+                    <TextWithCopyButton :text="`${props.data.dataplane.networking.address}`" />
+                  </template>
+                </DefinitionCard>
+              </template>
+            </div>
+          </KCard>
 
           <KCard
-            v-else
+            v-if="props.data.dataplaneType === 'standard'"
             class="traffic"
+            data-testid="dataplane-traffic"
           >
             <div class="columns">
               <DataPlaneTraffic>
@@ -143,52 +142,48 @@
                   type="inbound"
                 >
                   <template
-                    v-for="item in traffic.inbounds"
-                    :key="`${item.name}`"
+                    v-for="item in props.data.dataplane.networking.inbounds"
+                    :key="`${item.port}`"
                   >
+                    <!-- the finding here would be expensive if inbounds was commonly large -->
+                    <!-- inbounds are mostly singular and even when they are not they are small -->
                     <template
-                      v-for="port in [
-                        item.name.split('_').at(-1),
+                      v-for="inbound in [
+                        (traffic || {inbounds: []}).inbounds.find(inbound => `${inbound.port}` === `${item.port}`),
                       ]"
-                      :key="port"
+                      :key="inbound"
                     >
-                      <!-- the finding here would be expensive if inbounds was commonly large -->
-                      <!-- inbounds are mostly singular and even when they are not they are small -->
-                      <template
-                        v-for="inbound in [
-                          props.data.dataplane.networking.inbounds.find(item => `${item.port}` === `${port}`),
-                        ]"
-                        :key="inbound"
+                      <ServiceTrafficCard
+                        :protocol="item.protocol"
+                        :traffic="inbound"
                       >
-                        <ServiceTrafficCard
-                          v-if="inbound"
-                          :protocol="item.protocol"
-                          :traffic="item"
+                        <RouterLink
+                          :to="{
+                            name: 'data-plane-inbound-summary-overview-view',
+                            params: {
+                              service: item.port,
+                            },
+                            query: {
+                              inactive: route.params.inactive ? null : undefined,
+                            },
+                          }"
                         >
-                          <RouterLink
-                            :to="{
-                              name: 'data-plane-inbound-summary-overview-view',
-                              params: {
-                                service: inbound.port,
-                              },
-                              query: {
-                                inactive: route.params.inactive ? null : undefined,
-                              },
-                            }"
-                          >
-                            :{{ inbound.port }}
-                          </RouterLink>
-                          <TagList
-                            :tags="[{label: 'kuma.io/service', value: inbound.tags['kuma.io/service']}]"
-                          />
-                        </ServiceTrafficCard>
-                      </template>
+                          :{{ item.port }}
+                        </RouterLink>
+                        <TagList
+                          :tags="[{label: 'kuma.io/service', value: item.tags['kuma.io/service']}]"
+                        />
+                      </ServiceTrafficCard>
                     </template>
                   </template>
                 </ServiceTrafficGroup>
               </DataPlaneTraffic>
+
               <DataPlaneTraffic>
-                <template #actions>
+                <template
+                  v-if="traffic"
+                  #actions
+                >
                   <KInputSwitch
                     v-model="route.params.inactive"
                   >
@@ -214,63 +209,51 @@
                   />
                   <span>Outbounds</span>
                 </template>
-                <template #data>
-                  <dl>
-                    <div>
-                      <dt class="passthrough">
-                        {{ t('services.components.service_traffic.passthrough', {}, {defaultMessage: 'Passthrough Requests'}) }}
-                      </dt>
-                      <dd>{{ t('common.formats.integer', {value: 1000}) }}</dd>
-                    </div>
-                    <div>
-                      <dt class="outbounds">
-                        {{ t('services.components.service_traffic.mesh', {}, {defaultMessage: 'Mesh Requests'}) }}
-                      </dt>
-                      <dd>{{ t('common.formats.integer', {value: 1000}) }}</dd>
-                    </div>
-                  </dl>
-                </template>
-                <ServiceTrafficGroup
-                  type="passthrough"
-                >
-                  <ServiceTrafficCard
-                    :protocol="`passthrough`"
-                    :traffic="traffic.passthrough"
-                  >
-                    Non mesh traffic
-                  </ServiceTrafficCard>
-                </ServiceTrafficGroup>
                 <template
-                  v-if="traffic.outbounds.length > 0"
+                  v-if="traffic"
                 >
                   <ServiceTrafficGroup
-                    type="outbound"
+                    type="passthrough"
                   >
-                    <template
-                      v-for="item in traffic.outbounds"
-                      :key="`${item.name}`"
+                    <ServiceTrafficCard
+                      :protocol="`passthrough`"
+                      :traffic="traffic.passthrough"
                     >
-                      <ServiceTrafficCard
-                        v-if="route.params.inactive || ((item.protocol === 'tcp' ? item.tcp?.downstream_cx_rx_bytes_total : item.http?.downstream_rq_total) as (number | undefined ) ?? 0 > 0)"
-                        :protocol="item.protocol"
-                        :traffic="item"
-                      >
-                        <RouterLink
-                          :to="{
-                            name: 'data-plane-outbound-summary-overview-view',
-                            params: {
-                              service: item.name,
-                            },
-                            query: {
-                              inactive: route.params.inactive ? null : undefined,
-                            },
-                          }"
-                        >
-                          {{ item.name }}
-                        </RouterLink>
-                      </ServiceTrafficCard>
-                    </template>
+                      Non mesh traffic
+                    </ServiceTrafficCard>
                   </ServiceTrafficGroup>
+                  <template
+                    v-if="traffic.outbounds.length > 0"
+                  >
+                    <ServiceTrafficGroup
+                      type="outbound"
+                    >
+                      <template
+                        v-for="item in traffic.outbounds"
+                        :key="`${item.name}`"
+                      >
+                        <ServiceTrafficCard
+                          v-if="route.params.inactive || ((item.protocol === 'tcp' ? item.tcp?.downstream_cx_rx_bytes_total : item.http?.downstream_rq_total) as (number | undefined ) ?? 0 > 0)"
+                          :protocol="item.protocol"
+                          :traffic="item"
+                        >
+                          <RouterLink
+                            :to="{
+                              name: 'data-plane-outbound-summary-overview-view',
+                              params: {
+                                service: item.name,
+                              },
+                              query: {
+                                inactive: route.params.inactive ? null : undefined,
+                              },
+                            }"
+                          >
+                            {{ item.name }}
+                          </RouterLink>
+                        </ServiceTrafficCard>
+                      </template>
+                    </ServiceTrafficGroup>
+                  </template>
                 </template>
               </DataPlaneTraffic>
             </div>
@@ -283,7 +266,7 @@
             v-slot="child"
           >
             <SummaryView
-              @close="function (e) {
+              @close="function (_e) {
                 route.replace({
                   name: 'data-plane-detail-view',
                   params: {
@@ -308,189 +291,112 @@
               />
             </SummaryView>
           </RouterView>
-        </DataSource>
 
-        <div
-          v-if="props.data.dataplane.networking.inbounds.length > 0"
-          data-testid="dataplane-inbounds"
-        >
-          <h2>{{ t('data-planes.routes.item.inbounds') }}</h2>
+          <div data-testid="dataplane-mtls">
+            <h2>{{ t('data-planes.routes.item.mtls.title') }}</h2>
 
-          <KCard class="mt-4">
-            <div class="inbound-list">
-              <div
-                v-for="(inbound, index) in props.data.dataplane.networking.inbounds"
-                :key="index"
-                class="inbound"
-              >
-                <h4>
-                  <TextWithCopyButton :text="inbound.tags['kuma.io/service']">
-                    {{ t('data-planes.routes.item.inbound_name', { service: inbound.tags['kuma.io/service'] }) }}
-                  </TextWithCopyButton>
-                </h4>
-
-                <div class="mt-4 columns">
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('http.api.property.status') }}
-                    </template>
-
-                    <template #body>
-                      <KBadge
-                        v-if="inbound.health.ready"
-                        appearance="success"
-                      >
-                        {{ t('data-planes.routes.item.health.ready') }}
-                      </KBadge>
-
-                      <KBadge
-                        v-else
-                        appearance="danger"
-                      >
-                        {{ t('data-planes.routes.item.health.not_ready') }}
-                      </KBadge>
-                    </template>
-                  </DefinitionCard>
-
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('http.api.property.tags') }}
-                    </template>
-
-                    <template #body>
-                      <TagList :tags="inbound.tags" />
-                    </template>
-                  </DefinitionCard>
-
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('http.api.property.address') }}
-                    </template>
-
-                    <template #body>
-                      <TextWithCopyButton :text="inbound.addressPort" />
-                    </template>
-                  </DefinitionCard>
-
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('http.api.property.serviceAddress') }}
-                    </template>
-
-                    <template #body>
-                      <TextWithCopyButton :text="inbound.serviceAddressPort" />
-                    </template>
-                  </DefinitionCard>
-                </div>
-              </div>
-            </div>
-          </KCard>
-        </div>
-
-        <div data-testid="dataplane-mtls">
-          <h2>{{ t('data-planes.routes.item.mtls.title') }}</h2>
-
-          <template
-            v-if="props.data.dataplaneInsight.mTLS"
-          >
             <template
-              v-for="mTLS in [
-                props.data.dataplaneInsight.mTLS,
-              ]"
-              :key="mTLS"
+              v-if="props.data.dataplaneInsight.mTLS"
             >
-              <KCard
-                class="mt-4"
+              <template
+                v-for="mTLS in [
+                  props.data.dataplaneInsight.mTLS,
+                ]"
+                :key="mTLS"
               >
-                <div class="columns">
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('data-planes.routes.item.mtls.expiration_time.title') }}
-                    </template>
+                <KCard
+                  class="mt-4"
+                >
+                  <div class="columns">
+                    <DefinitionCard>
+                      <template #title>
+                        {{ t('data-planes.routes.item.mtls.expiration_time.title') }}
+                      </template>
 
-                    <template #body>
-                      {{ formatIsoDate(mTLS.certificateExpirationTime) }}
-                    </template>
-                  </DefinitionCard>
+                      <template #body>
+                        {{ formatIsoDate(mTLS.certificateExpirationTime) }}
+                      </template>
+                    </DefinitionCard>
 
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('data-planes.routes.item.mtls.generation_time.title') }}
-                    </template>
+                    <DefinitionCard>
+                      <template #title>
+                        {{ t('data-planes.routes.item.mtls.generation_time.title') }}
+                      </template>
 
-                    <template #body>
-                      {{ formatIsoDate(mTLS.lastCertificateRegeneration) }}
-                    </template>
-                  </DefinitionCard>
+                      <template #body>
+                        {{ formatIsoDate(mTLS.lastCertificateRegeneration) }}
+                      </template>
+                    </DefinitionCard>
 
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('data-planes.routes.item.mtls.regenerations.title') }}
-                    </template>
+                    <DefinitionCard>
+                      <template #title>
+                        {{ t('data-planes.routes.item.mtls.regenerations.title') }}
+                      </template>
 
-                    <template #body>
-                      {{ t('common.formats.integer', {value: mTLS.certificateRegenerations}) }}
-                    </template>
-                  </DefinitionCard>
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
-                    </template>
+                      <template #body>
+                        {{ t('common.formats.integer', {value: mTLS.certificateRegenerations}) }}
+                      </template>
+                    </DefinitionCard>
+                    <DefinitionCard>
+                      <template #title>
+                        {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
+                      </template>
 
-                    <template #body>
-                      {{ mTLS.issuedBackend }}
-                    </template>
-                  </DefinitionCard>
+                      <template #body>
+                        {{ mTLS.issuedBackend }}
+                      </template>
+                    </DefinitionCard>
 
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
-                    </template>
+                    <DefinitionCard>
+                      <template #title>
+                        {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
+                      </template>
 
-                    <template #body>
-                      <ul>
-                        <li
-                          v-for="item in mTLS.supportedBackends"
-                          :key="item"
-                        >
-                          {{ item }}
-                        </li>
-                      </ul>
-                    </template>
-                  </DefinitionCard>
-                </div>
-              </KCard>
-            </template>
-          </template>
-
-          <template
-            v-else
-          >
-            <KAlert
-              class="mt-4"
-              appearance="warning"
-            >
-              <template #alertMessage>
-                <div
-                  v-html="t('data-planes.routes.item.mtls.disabled')"
-                />
+                      <template #body>
+                        <ul>
+                          <li
+                            v-for="item in mTLS.supportedBackends"
+                            :key="item"
+                          >
+                            {{ item }}
+                          </li>
+                        </ul>
+                      </template>
+                    </DefinitionCard>
+                  </div>
+                </KCard>
               </template>
-            </KAlert>
-          </template>
-        </div>
+            </template>
 
-        <div
-          v-if="props.data.dataplaneInsight.subscriptions.length > 0"
-          data-testid="dataplane-subscriptions"
-        >
-          <h2>{{ t('data-planes.routes.item.subscriptions.title') }}</h2>
+            <template
+              v-else
+            >
+              <KAlert
+                class="mt-4"
+                appearance="warning"
+              >
+                <template #alertMessage>
+                  <div
+                    v-html="t('data-planes.routes.item.mtls.disabled')"
+                  />
+                </template>
+              </KAlert>
+            </template>
+          </div>
 
-          <KCard class="mt-4">
-            <SubscriptionList :subscriptions="props.data.dataplaneInsight.subscriptions" />
-          </KCard>
+          <div
+            v-if="props.data.dataplaneInsight.subscriptions.length > 0"
+            data-testid="dataplane-subscriptions"
+          >
+            <h2>{{ t('data-planes.routes.item.subscriptions.title') }}</h2>
+
+            <KCard class="mt-4">
+              <SubscriptionList :subscriptions="props.data.dataplaneInsight.subscriptions" />
+            </KCard>
+          </div>
         </div>
-      </div>
-    </AppView>
+      </AppView>
+    </DataSource>
   </RouteView>
 </template>
 
@@ -501,8 +407,6 @@ import { computed } from 'vue'
 
 import type { DataplaneOverview } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TagList from '@/app/common/TagList.vue'
@@ -512,6 +416,7 @@ import ServiceTrafficCard from '@/app/data-planes/components/data-plane-traffic/
 import ServiceTrafficGroup from '@/app/data-planes/components/data-plane-traffic/ServiceTrafficGroup.vue'
 import type { TrafficSource } from '@/app/data-planes/sources'
 import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
+import type { ApiError } from '@/services/kuma-api/ApiError'
 import { useI18n } from '@/utilities'
 
 const { t, formatIsoDate } = useI18n()

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -30,7 +30,7 @@
               v-if="error"
               :data-testid="`warning-stats-loading`"
             >
-              Error loading outbound stats: <strong>{{ (error as ApiError).status }} {{ error.message }}</strong>
+              Error loading outbound stats: <strong>{{ error.toString() }}</strong>
             </li>
           <!-- eslint-enable -->
           </ul>
@@ -416,7 +416,6 @@ import ServiceTrafficCard from '@/app/data-planes/components/data-plane-traffic/
 import ServiceTrafficGroup from '@/app/data-planes/components/data-plane-traffic/ServiceTrafficGroup.vue'
 import type { TrafficSource } from '@/app/data-planes/sources'
 import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
-import type { ApiError } from '@/services/kuma-api/ApiError'
 import { useI18n } from '@/utilities'
 
 const { t, formatIsoDate } = useI18n()

--- a/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -7,6 +7,18 @@
       <div class="stack-with-borders">
         <DefinitionCard layout="horizontal">
           <template #title>
+            Tags
+          </template>
+
+          <template #body>
+            <TagList
+              :tags="props.data.tags"
+              alignment="right"
+            />
+          </template>
+        </DefinitionCard>
+        <DefinitionCard layout="horizontal">
+          <template #title>
             Status
           </template>
 
@@ -31,6 +43,28 @@
             </KBadge>
           </template>
         </DefinitionCard>
+        <DefinitionCard layout="horizontal">
+          <template #title>
+            Address
+          </template>
+
+          <template #body>
+            <TextWithCopyButton
+              :text="`${props.data.addressPort}`"
+            />
+          </template>
+        </DefinitionCard>
+        <DefinitionCard layout="horizontal">
+          <template #title>
+            Service Address
+          </template>
+
+          <template #body>
+            <TextWithCopyButton
+              :text="`${props.data.serviceAddressPort}`"
+            />
+          </template>
+        </DefinitionCard>
       </div>
     </AppView>
   </RouteView>
@@ -38,6 +72,8 @@
 <script lang="ts" setup>
 import type { DataplaneInbound } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
+import TagList from '@/app/common/TagList.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 const props = defineProps<{
   data: DataplaneInbound
 }>()

--- a/src/services/kuma-api/ApiError.ts
+++ b/src/services/kuma-api/ApiError.ts
@@ -54,4 +54,8 @@ export class ApiError extends Error {
       invalidParameters: this.invalidParameters,
     }
   }
+
+  toString() {
+    return `${this.status}: ${this.message}`
+  }
 }


### PR DESCRIPTION
This PR does several things:

1. Adds tags and addresses to the summary panel for an inbound
2. Re-jigs the stitching together of an inbound and its stats so that its possible to show part of the information in the viz without having loaded any `/stats` (or is the stats endpoint responds with an error)
3. Removes the feature flag we were using to show this now that we've replicated the same data in the summary panel
4. Removes the old inbounds table.
5. Adds basic e2e tests for making sure the viz is only visible for sidecars and erroring shows a warning instead of wiping out the viz entirely.

Q: I noticed that we aren't showing health state for the inbounds in the page anymore, you have to click on each of them to see if they are healthy or not. I think this is just a omission from design and we could potentially add this back into the inbound cards. wdyt?

Heres how it looks in an error state:

![Screenshot 2024-01-15 at 12 19 30](https://github.com/kumahq/kuma-gui/assets/554604/d340c6b0-5fd5-4186-aefa-863502301a6c)

Open to suggestions potentially clearer erroring, not totally sure on this myself.


