### PR TITLE
fix(zones): If there are no zone details pages, don't link a tag to one

### DIFF
--- a/src/app/common/TagList.vue
+++ b/src/app/common/TagList.vue
@@ -27,6 +27,7 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 
+import { useCan } from '@/app/application'
 import { LabelValue } from '@/types/index.d'
 import { getLabels } from '@/utilities/getLabels'
 import type { RouteLocationNamedRaw } from 'vue-router'
@@ -44,6 +45,7 @@ const props = withDefaults(defineProps<{
   shouldTruncate: false,
   alignment: 'left',
 })
+const can = useCan()
 
 const tagList = computed<LabelValueWithRoute[]>(() => {
   const labels = Array.isArray(props.tags) ? props.tags : getLabels(props.tags)
@@ -67,6 +69,9 @@ function getRoute(tag: LabelValue): RouteLocationNamedRaw | undefined {
   try {
     switch (tag.label) {
       case 'kuma.io/zone': {
+        if (!can('use zones')) {
+          return undefined
+        }
         return {
           name: 'zone-cp-detail-view',
           params: {


### PR DESCRIPTION
Ideally I'd like TagList to work differently, but for now this prevents any `kuma.io/zone` tags from linking to a potentially non-existent page, a bit surprised we've not seen this earlier, which makes me think I might be missing something 🤔 

I guess in reality, zone tags wouldn't exist on old style standalone, but guessing that in single-zone mode things might be tagged with the name of the single zone.

---

**Edit: 5th Feb**

It looks like my guess here turned out to be correct:

>> but guessing that in single-zone mode things might be tagged with the name of the single zone.

It looks like when in "non-federated zone mode" we do get `kuma.io/zone` tags (set to `default`), which means if we try to link to the Zone detail page (using `default` as the zone name) then we will get an error (zone detail routes don't exist in "non-federated zone mode").

**Note**: Base branch is `2.6.x`, so will also require a port to `master`





 


