### PR TITLE
ci: switch to create-github-app-token action

### DIFF
--- a/.github/workflows/create-gui-pr.yml
+++ b/.github/workflows/create-gui-pr.yml
@@ -61,12 +61,11 @@ jobs:
 
       - run: yarn run build
 
-      # https://github.com/tibdex/github-app-token
-      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+      - uses: actions/create-github-app-token@f04aa94d10cf56334d1c580e077ce2e3569e805d
         id: github-app-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Replaces tibdex/github-app-token with actions/create-github-app-token.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
