### PR TITLE
chore(dataplanes): show rules-based policies for built-in gateways

### DIFF
--- a/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
@@ -62,7 +62,11 @@ Feature: Dataplane details for built-in gateway
     And the "$inbounds" element doesn't exist
 
   Scenario: Policies tab has expected content
-    Given the URL "/meshes/default/dataplanes/dataplane-gateway_builtin-1/policies" responds with
+    Given the environment
+      """
+      KUMA_MODE: zone
+      """
+    And the URL "/meshes/default/dataplanes/dataplane-gateway_builtin-1/policies" responds with
       """
       body:
         listeners:

--- a/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
@@ -1,13 +1,11 @@
 Feature: Dataplane details for delegated gateway
   Background:
     Given the CSS selectors
-      | Alias              | Selector                                                        |
-      | detail-view        | [data-testid='data-plane-detail-tabs-view']                     |
-      | warnings           | [data-testid='dataplane-warnings']                              |
-      | details            | [data-testid='dataplane-details']                               |
-      | inbounds           | [data-testid='dataplane-inbounds']                              |
-      | policy-item        | [data-testid='policy-list'] .accordion-item                     |
-      | policy-item-button | $policy-item:nth-child(1) [data-testid='accordion-item-button'] |
+      | Alias       | Selector                                    |
+      | detail-view | [data-testid='data-plane-detail-tabs-view'] |
+      | warnings    | [data-testid='dataplane-warnings']          |
+      | details     | [data-testid='dataplane-details']           |
+      | inbounds    | [data-testid='dataplane-inbounds']          |
 
   Scenario: Overview tab has expected content
     Given the environment

--- a/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/features/mesh/dataplanes/DataplanePolicies.feature
@@ -375,7 +375,7 @@ Feature: Dataplane policies
         """
         KUMA_MODE: global
         """
-      And the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
+      And the URL "/meshes/default/dataplanes/dataplane-gateway_builtin-1/_overview" responds with
         """
         body:
           mesh: default
@@ -387,7 +387,7 @@ Feature: Dataplane policies
                   kuma.io/service: service-1
         """
 
-      When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
+      When I visit the "/meshes/default/data-planes/dataplane-gateway_builtin-1/policies" URL
 
       Then the "$legacy-policies" element doesn't exist
       And the "$sidecar-dataplane-policies" element doesn't exist
@@ -398,7 +398,7 @@ Feature: Dataplane policies
         """
         KUMA_MODE: zone
         """
-      And the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
+      And the URL "/meshes/default/dataplanes/dataplane-gateway_builtin-1/_overview" responds with
         """
         body:
           mesh: default
@@ -409,8 +409,26 @@ Feature: Dataplane policies
                 tags:
                   kuma.io/service: service-1
         """
+      And the URL "/meshes/default/dataplanes/dataplane-gateway_builtin-1/policies" responds with
+        """
+        body:
+          listeners:
+            - hosts:
+                - routes:
+                  - destinations:
+                      - tags:
+                          kuma.io/service: demo-app_kuma-demo_svc_5000
+                        policies:
+                          CircuitBreaker:
+                            name: circuit-breaker-1
+          policies:
+            TrafficLog:
+              name: traffic-log-1
+            TrafficTrace:
+              name: traffic-trace-1
+        """
 
-      When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
+      When I visit the "/meshes/default/data-planes/dataplane-gateway_builtin-1/policies" URL
 
       Then the "$legacy-policies" element exists
       And the "$sidecar-dataplane-policies" element doesn't exist

--- a/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/features/mesh/dataplanes/DataplanePolicies.feature
@@ -2,16 +2,17 @@ Feature: Dataplane policies
   Rule: Standard proxy
     Background:
       Given the CSS selectors
-        | Alias                       | Selector                                                            |
-        | policies-view               | [data-testid='data-plane-policies-view']                            |
-        | standard-dataplane-policies | [data-testid='standard-dataplane-policies']                         |
-        | policy-list                 | [data-testid='policy-list']                                         |
-        | proxy-rule-item             | [data-testid='proxy-rule-list'] .accordion-item                     |
-        | proxy-rule-item-button      | $proxy-rule-item:nth-child(1) [data-testid='accordion-item-button'] |
-        | to-rule-item                | [data-testid='to-rule-list'] .accordion-item                        |
-        | to-rule-item-button         | $to-rule-item:nth-child(1) [data-testid='accordion-item-button']    |
-        | from-rule-item              | [data-testid='from-rule-list-0'] .accordion-item                    |
-        | from-rule-item-button       | $from-rule-item:nth-child(1) [data-testid='accordion-item-button']  |
+        | Alias                              | Selector                                                            |
+        | policies-view                      | [data-testid='data-plane-policies-view']                            |
+        | legacy-policies                    | [data-testid='legacy-policies']                                     |
+        | sidecar-dataplane-policies         | [data-testid='sidecar-dataplane-policies']                          |
+        | builtin-gateway-dataplane-policies | [data-testid='builtin-gateway-dataplane-policies']                  |
+        | proxy-rule-item                    | [data-testid='proxy-rule-list'] .accordion-item                     |
+        | proxy-rule-item-button             | $proxy-rule-item:nth-child(1) [data-testid='accordion-item-button'] |
+        | to-rule-item                       | [data-testid='to-rule-list'] .accordion-item                        |
+        | to-rule-item-button                | $to-rule-item:nth-child(1) [data-testid='accordion-item-button']    |
+        | from-rule-item                     | [data-testid='from-rule-list-0'] .accordion-item                    |
+        | from-rule-item-button              | $from-rule-item:nth-child(1) [data-testid='accordion-item-button']  |
 
     Scenario: Dataplane policies view shows expected content for standard proxy (mode: global)
       Given the environment
@@ -28,8 +29,9 @@ Feature: Dataplane policies
         """
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
 
-      Then the "$standard-dataplane-policies" element exists
-      And the "$policy-list" element doesn't exist
+      Then the "$legacy-policies" element doesn't exist
+      And the "$sidecar-dataplane-policies" element doesn't exist
+      And the "$builtin-gateway-dataplane-policies" element doesn't exist
 
     Scenario: Dataplane policies view shows expected content for standard proxy (mode: zone)
       Given the environment
@@ -46,8 +48,9 @@ Feature: Dataplane policies
         """
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
 
-      Then the "$standard-dataplane-policies" element exists
-      And the "$policy-list" element exists
+      Then the "$legacy-policies" element exists
+      And the "$sidecar-dataplane-policies" element exists
+      And the "$builtin-gateway-dataplane-policies" element doesn't exist
 
     Scenario: Policies tab has expected content (MeshHTTPRoute with to rules)
       Given the environment
@@ -286,12 +289,17 @@ Feature: Dataplane policies
   Rule: Delegated gateway
     Background:
       Given the CSS selectors
-        | Alias                          | Selector                                    |
-        | standard-dataplane-policies    | [data-testid='standard-dataplane-policies'] |
-        | standard-dataplane-policy-list | [data-testid='policy-list']                 |
+        | Alias                              | Selector                                           |
+        | legacy-policies                    | [data-testid='legacy-policies']                    |
+        | sidecar-dataplane-policies         | [data-testid='sidecar-dataplane-policies']         |
+        | builtin-gateway-dataplane-policies | [data-testid='builtin-gateway-dataplane-policies'] |
 
-    Scenario: Dataplane policies view shows expected content for delegated gateway
-      Given the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
+    Scenario: Dataplane policies view shows expected content for delegated gateway (mode: global)
+      Given the environment
+        """
+        KUMA_MODE: global
+        """
+      And the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
         """
         body:
           mesh: default
@@ -305,10 +313,16 @@ Feature: Dataplane policies
 
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
 
-      Then the "$standard-dataplane-policies" element exists
+      Then the "$legacy-policies" element doesn't exist
+      And the "$sidecar-dataplane-policies" element doesn't exist
+      And the "$builtin-gateway-dataplane-policies" element doesn't exist
 
-    Scenario: Dataplane policies view shows expected content for delegated gateway (with omitted type field)
-      Given the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
+    Scenario: Dataplane policies view shows expected content for delegated gateway (mode: global + omitted Dataplane type)
+      Given the environment
+        """
+        KUMA_MODE: global
+        """
+      And the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
         """
         body:
           mesh: default
@@ -322,16 +336,46 @@ Feature: Dataplane policies
 
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
 
-      Then the "$standard-dataplane-policies" element exists
+      Then the "$legacy-policies" element doesn't exist
+      And the "$sidecar-dataplane-policies" element doesn't exist
+      And the "$builtin-gateway-dataplane-policies" element doesn't exist
+
+    Scenario: Dataplane policies view shows expected content for delegated gateway (mode: zone)
+      Given the environment
+        """
+        KUMA_MODE: zone
+        """
+      And the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
+        """
+        body:
+          mesh: default
+          dataplane:
+            networking:
+              gateway:
+                type: DELEGATED
+                tags:
+                  kuma.io/service: service-1
+        """
+
+      When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
+
+      Then the "$legacy-policies" element exists
+      And the "$sidecar-dataplane-policies" element exists
 
   Rule: Built-in gateway
     Background:
       Given the CSS selectors
         | Alias                              | Selector                                           |
+        | legacy-policies                    | [data-testid='legacy-policies']                    |
+        | sidecar-dataplane-policies         | [data-testid='sidecar-dataplane-policies']         |
         | builtin-gateway-dataplane-policies | [data-testid='builtin-gateway-dataplane-policies'] |
 
-    Scenario: Dataplane policies view shows expected content for built-in gateway
-      Given the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
+    Scenario: Dataplane policies view shows expected content for built-in gateway (mode: global)
+      Given the environment
+        """
+        KUMA_MODE: global
+        """
+      And the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
         """
         body:
           mesh: default
@@ -345,4 +389,29 @@ Feature: Dataplane policies
 
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
 
-      Then the "$builtin-gateway-dataplane-policies" element exists
+      Then the "$legacy-policies" element doesn't exist
+      And the "$sidecar-dataplane-policies" element doesn't exist
+      And the "$builtin-gateway-dataplane-policies" element doesn't exist
+
+    Scenario: Dataplane policies view shows expected content for built-in gateway (mode: zone)
+      Given the environment
+        """
+        KUMA_MODE: zone
+        """
+      And the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
+        """
+        body:
+          mesh: default
+          dataplane:
+            networking:
+              gateway:
+                type: BUILTIN
+                tags:
+                  kuma.io/service: service-1
+        """
+
+      When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
+
+      Then the "$legacy-policies" element exists
+      And the "$sidecar-dataplane-policies" element doesn't exist
+      And the "$builtin-gateway-dataplane-policies" element exists

--- a/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/features/mesh/dataplanes/DataplanePolicies.feature
@@ -4,7 +4,7 @@ Feature: Dataplane policies
       Given the CSS selectors
         | Alias                              | Selector                                                            |
         | policies-view                      | [data-testid='data-plane-policies-view']                            |
-        | legacy-policies                    | [data-testid='legacy-policies']                                     |
+        | rules-based-policies               | [data-testid='rules-based-policies']                                |
         | sidecar-dataplane-policies         | [data-testid='sidecar-dataplane-policies']                          |
         | builtin-gateway-dataplane-policies | [data-testid='builtin-gateway-dataplane-policies']                  |
         | proxy-rule-item                    | [data-testid='proxy-rule-list'] .accordion-item                     |
@@ -29,7 +29,7 @@ Feature: Dataplane policies
         """
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
 
-      Then the "$legacy-policies" element doesn't exist
+      Then the "$rules-based-policies" element exists
       And the "$sidecar-dataplane-policies" element doesn't exist
       And the "$builtin-gateway-dataplane-policies" element doesn't exist
 
@@ -48,7 +48,7 @@ Feature: Dataplane policies
         """
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
 
-      Then the "$legacy-policies" element exists
+      Then the "$rules-based-policies" element exists
       And the "$sidecar-dataplane-policies" element exists
       And the "$builtin-gateway-dataplane-policies" element doesn't exist
 
@@ -290,7 +290,7 @@ Feature: Dataplane policies
     Background:
       Given the CSS selectors
         | Alias                              | Selector                                           |
-        | legacy-policies                    | [data-testid='legacy-policies']                    |
+        | rules-based-policies               | [data-testid='rules-based-policies']               |
         | sidecar-dataplane-policies         | [data-testid='sidecar-dataplane-policies']         |
         | builtin-gateway-dataplane-policies | [data-testid='builtin-gateway-dataplane-policies'] |
 
@@ -313,7 +313,7 @@ Feature: Dataplane policies
 
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
 
-      Then the "$legacy-policies" element doesn't exist
+      Then the "$rules-based-policies" element exists
       And the "$sidecar-dataplane-policies" element doesn't exist
       And the "$builtin-gateway-dataplane-policies" element doesn't exist
 
@@ -336,7 +336,7 @@ Feature: Dataplane policies
 
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
 
-      Then the "$legacy-policies" element doesn't exist
+      Then the "$rules-based-policies" element exists
       And the "$sidecar-dataplane-policies" element doesn't exist
       And the "$builtin-gateway-dataplane-policies" element doesn't exist
 
@@ -359,14 +359,15 @@ Feature: Dataplane policies
 
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
 
-      Then the "$legacy-policies" element exists
+      Then the "$rules-based-policies" element exists
       And the "$sidecar-dataplane-policies" element exists
+      And the "$builtin-gateway-dataplane-policies" element doesn't exist
 
   Rule: Built-in gateway
     Background:
       Given the CSS selectors
         | Alias                              | Selector                                           |
-        | legacy-policies                    | [data-testid='legacy-policies']                    |
+        | rules-based-policies               | [data-testid='rules-based-policies']               |
         | sidecar-dataplane-policies         | [data-testid='sidecar-dataplane-policies']         |
         | builtin-gateway-dataplane-policies | [data-testid='builtin-gateway-dataplane-policies'] |
 
@@ -389,7 +390,7 @@ Feature: Dataplane policies
 
       When I visit the "/meshes/default/data-planes/dataplane-gateway_builtin-1/policies" URL
 
-      Then the "$legacy-policies" element doesn't exist
+      Then the "$rules-based-policies" element exists
       And the "$sidecar-dataplane-policies" element doesn't exist
       And the "$builtin-gateway-dataplane-policies" element doesn't exist
 
@@ -430,6 +431,6 @@ Feature: Dataplane policies
 
       When I visit the "/meshes/default/data-planes/dataplane-gateway_builtin-1/policies" URL
 
-      Then the "$legacy-policies" element exists
+      Then the "$rules-based-policies" element exists
       And the "$sidecar-dataplane-policies" element doesn't exist
       And the "$builtin-gateway-dataplane-policies" element exists

--- a/src/app/data-planes/components/BuiltinGatewayPolicies.vue
+++ b/src/app/data-planes/components/BuiltinGatewayPolicies.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    class="policies-list"
-    data-testid="builtin-gateway-dataplane-policies"
-  >
+  <div class="policies-list">
     <div class="mesh-gateway-policy-list">
       <h3 class="mb-2">
         Gateway policies

--- a/src/app/data-planes/components/StandardDataplanePolicies.vue
+++ b/src/app/data-planes/components/StandardDataplanePolicies.vue
@@ -1,87 +1,90 @@
 <template>
-  <div
-    data-testid="standard-dataplane-policies"
-    class="stack"
-  >
-    <KCard v-if="(props.showLegacyPolicies ? props.policyTypeEntries.length === 0 : true) && props.inspectRulesForDataplane.rules.length === 0">
-      <EmptyBlock />
+  <div class="stack">
+    <KCard v-if="props.inspectRulesForDataplane.proxyRules.length > 0">
+      <h3>{{ t('data-planes.routes.item.proxy_rule') }}</h3>
+
+      <RuleEntryList
+        id="proxy-rules"
+        class="mt-2"
+        :rule-entries="props.inspectRulesForDataplane.proxyRules"
+        :policy-types-by-name="props.policyTypesByName"
+        :show-matchers="false"
+        data-testid="proxy-rule-list"
+      />
     </KCard>
 
-    <template v-else>
-      <KCard v-if="props.inspectRulesForDataplane.proxyRules.length > 0">
-        <h3>{{ t('data-planes.routes.item.proxy_rule') }}</h3>
+    <KCard v-if="props.inspectRulesForDataplane.toRules.length > 0">
+      <h3>{{ t('data-planes.routes.item.to_rules') }}</h3>
+
+      <RuleEntryList
+        id="to-rules"
+        class="mt-2"
+        :rule-entries="props.inspectRulesForDataplane.toRules"
+        :policy-types-by-name="props.policyTypesByName"
+        data-testid="to-rule-list"
+      />
+    </KCard>
+
+    <KCard v-if="props.inspectRulesForDataplane.fromRuleInbounds.length > 0">
+      <h3 class="mb-2">
+        {{ t('data-planes.routes.item.from_rules') }}
+      </h3>
+
+      <div
+        v-for="(fromRule, index) in props.inspectRulesForDataplane.fromRuleInbounds"
+        :key="index"
+      >
+        <h4>{{ t('data-planes.routes.item.port', { port: fromRule.port }) }}</h4>
 
         <RuleEntryList
-          id="proxy-rules"
+          :id="`from-rules-${index}`"
           class="mt-2"
-          :rule-entries="props.inspectRulesForDataplane.proxyRules"
+          :rule-entries="fromRule.ruleEntries"
           :policy-types-by-name="props.policyTypesByName"
-          :show-matchers="false"
-          data-testid="proxy-rule-list"
+          :data-testid="`from-rule-list-${index}`"
         />
-      </KCard>
-
-      <KCard v-if="props.inspectRulesForDataplane.toRules.length > 0">
-        <h3>{{ t('data-planes.routes.item.to_rules') }}</h3>
-
-        <RuleEntryList
-          id="to-rules"
-          class="mt-2"
-          :rule-entries="props.inspectRulesForDataplane.toRules"
-          :policy-types-by-name="props.policyTypesByName"
-          data-testid="to-rule-list"
-        />
-      </KCard>
-
-      <KCard v-if="props.inspectRulesForDataplane.fromRuleInbounds.length > 0">
-        <h3 class="mb-2">
-          {{ t('data-planes.routes.item.from_rules') }}
-        </h3>
-
-        <div
-          v-for="(fromRule, index) in props.inspectRulesForDataplane.fromRuleInbounds"
-          :key="index"
-        >
-          <h4>{{ t('data-planes.routes.item.port', { port: fromRule.port }) }}</h4>
-
-          <RuleEntryList
-            :id="`from-rules-${index}`"
-            class="mt-2"
-            :rule-entries="fromRule.ruleEntries"
-            :policy-types-by-name="props.policyTypesByName"
-            :data-testid="`from-rule-list-${index}`"
-          />
-        </div>
-      </KCard>
-
-      <div v-if="props.showLegacyPolicies">
-        <h3>{{ t('data-planes.routes.item.legacy_policies') }}</h3>
-
-        <KCard class="mt-4">
-          <PolicyTypeEntryList
-            id="policies"
-            :policy-type-entries="props.policyTypeEntries"
-            :policy-types-by-name="props.policyTypesByName"
-            data-testid="policy-list"
-          />
-        </KCard>
       </div>
-    </template>
+    </KCard>
+
+    <div
+      v-if="props.showLegacyPolicies"
+      data-testid="legacy-policies"
+    >
+      <h3>{{ t('data-planes.routes.item.legacy_policies') }}</h3>
+
+      <KCard class="mt-4">
+        <PolicyTypeEntryList
+          v-if="props.policyTypeEntries.length > 0"
+          id="policies"
+          :policy-type-entries="props.policyTypeEntries"
+          :policy-types-by-name="props.policyTypesByName"
+          data-testid="sidecar-dataplane-policies"
+        />
+
+        <BuiltinGatewayPolicies
+          v-if="props.gatewayDataplane !== undefined"
+          :policy-types-by-name="props.policyTypesByName"
+          :gateway-dataplane="props.gatewayDataplane"
+          data-testid="builtin-gateway-dataplane-policies"
+        />
+      </KCard>
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
 import PolicyTypeEntryList from './PolicyTypeEntryList.vue'
 import RuleEntryList from './RuleEntryList.vue'
-import type { InspectRulesForDataplane } from '../data'
+import BuiltinGatewayPolicies from '../components/BuiltinGatewayPolicies.vue'
+import type { InspectRulesForDataplane, MeshGatewayDataplane } from '../data'
 import { useI18n } from '@/app/application'
-import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import type { PolicyType, PolicyTypeEntry } from '@/types/index.d'
 
 const { t } = useI18n()
 
 const props = defineProps<{
   policyTypeEntries: PolicyTypeEntry[]
+  gatewayDataplane: MeshGatewayDataplane | undefined
   inspectRulesForDataplane: InspectRulesForDataplane
   policyTypesByName: Record<string, PolicyType | undefined>
   showLegacyPolicies: boolean

--- a/src/app/data-planes/components/StandardDataplanePolicies.vue
+++ b/src/app/data-planes/components/StandardDataplanePolicies.vue
@@ -45,48 +45,19 @@
         />
       </div>
     </KCard>
-
-    <div
-      v-if="props.showLegacyPolicies"
-      data-testid="legacy-policies"
-    >
-      <h3>{{ t('data-planes.routes.item.legacy_policies') }}</h3>
-
-      <KCard class="mt-4">
-        <PolicyTypeEntryList
-          v-if="props.policyTypeEntries.length > 0"
-          id="policies"
-          :policy-type-entries="props.policyTypeEntries"
-          :policy-types-by-name="props.policyTypesByName"
-          data-testid="sidecar-dataplane-policies"
-        />
-
-        <BuiltinGatewayPolicies
-          v-if="props.gatewayDataplane !== undefined"
-          :policy-types-by-name="props.policyTypesByName"
-          :gateway-dataplane="props.gatewayDataplane"
-          data-testid="builtin-gateway-dataplane-policies"
-        />
-      </KCard>
-    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import PolicyTypeEntryList from './PolicyTypeEntryList.vue'
 import RuleEntryList from './RuleEntryList.vue'
-import BuiltinGatewayPolicies from '../components/BuiltinGatewayPolicies.vue'
-import type { InspectRulesForDataplane, MeshGatewayDataplane } from '../data'
+import type { InspectRulesForDataplane } from '../data'
 import { useI18n } from '@/app/application'
-import type { PolicyType, PolicyTypeEntry } from '@/types/index.d'
+import type { PolicyType } from '@/types/index.d'
 
 const { t } = useI18n()
 
 const props = defineProps<{
-  policyTypeEntries: PolicyTypeEntry[]
-  gatewayDataplane: MeshGatewayDataplane | undefined
   inspectRulesForDataplane: InspectRulesForDataplane
   policyTypesByName: Record<string, PolicyType | undefined>
-  showLegacyPolicies: boolean
 }>()
 </script>

--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -43,6 +43,7 @@
               v-else
               :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
               :inspect-rules-for-dataplane="rulesData"
+              data-testid="rules-based-policies"
             />
           </DataSource>
 
@@ -55,7 +56,7 @@
                 v-slot="{ data: gatewayDataplane, error: gatewayDataplaneError }: MeshGatewayDataplaneSource"
                 :src="props.data.dataplaneType === 'builtin' ? `/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/gateway-dataplane-policies` : ''"
               >
-                <div data-testid="legacy-policies">
+                <div>
                   <h3>{{ t('data-planes.routes.item.legacy_policies') }}</h3>
 
                   <ErrorBlock

--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -16,76 +16,112 @@
         </h2>
       </template>
 
-      <DataSource
-        v-slot="{ data: policyTypesData, error: policyTypesError }: PolicyTypeCollectionSource"
-        :src="`/*/policy-types`"
-      >
+      <div class="stack">
         <DataSource
-          v-slot="{ data: sidecarDataplaneData, error }: SidecarDataplaneCollectionSource"
-          :src="!can('use zones') && props.data.dataplaneType !== 'builtin' ? `/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/sidecar-dataplane-policies` : ''"
+          v-slot="{ data: policyTypesData, error: policyTypesError }: PolicyTypeCollectionSource"
+          :src="`/*/policy-types`"
         >
           <DataSource
-            v-slot="{ data: gatewayDataplane, error: gatewayDataplaneError }: MeshGatewayDataplaneSource"
-            :src="!can('use zones') && props.data.dataplaneType === 'builtin' ? `/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/gateway-dataplane-policies` : ''"
+            v-slot="{ data: rulesData, error }: DataplaneRulesSource"
+            :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/rules`"
           >
-            <DataSource
-              v-slot="{ data: rulesData, error: rulesError }: DataplaneRulesSource"
-              :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/rules`"
-            >
-              <ErrorBlock
-                v-if="policyTypesError"
-                :error="policyTypesError"
-              />
+            <ErrorBlock
+              v-if="policyTypesError"
+              :error="policyTypesError"
+            />
 
-              <ErrorBlock
-                v-else-if="error"
-                :error="error"
-              />
+            <ErrorBlock
+              v-else-if="error"
+              :error="error"
+            />
 
-              <ErrorBlock
-                v-else-if="gatewayDataplaneError"
-                :error="gatewayDataplaneError"
-              />
+            <LoadingBlock v-else-if="policyTypesData === undefined || rulesData === undefined" />
 
-              <ErrorBlock
-                v-else-if="rulesError"
-                :error="rulesError"
-              />
+            <EmptyBlock v-else-if="rulesData.rules.length === 0" />
 
-              <!-- The conditions here have gotten a bit unwieldy due to us only showing "Legacy policies" in zone mode and so we only query the corresponding APIs in zone mode, too. Therefore, the conditions for both the loading and empty block have to take this into account. We’re eventually getting rid of the /meshes/:mesh/dataplanes/:dataplane/policies endpoint which will simplify matters again. -->
-              <LoadingBlock
-                v-else-if="
-                  policyTypesData === undefined ||
-                    rulesData === undefined ||
-                    (!can('use zones') && props.data.dataplaneType !== 'builtin' && sidecarDataplaneData === undefined) ||
-                    (!can('use zones') && props.data.dataplaneType === 'builtin' && gatewayDataplane === undefined)
-                "
-              />
-
-              <EmptyBlock
-                v-else-if="
-                  (!can('use zones') ? (sidecarDataplaneData?.policyTypeEntries ?? []).length === 0 || gatewayDataplane === undefined : true) &&
-                    rulesData.rules.length === 0
-                "
-              />
-
-              <StandardDataplanePolicies
-                v-else
-                :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
-                :policy-type-entries="sidecarDataplaneData?.policyTypeEntries ?? []"
-                :gateway-dataplane="gatewayDataplane"
-                :inspect-rules-for-dataplane="rulesData"
-                :show-legacy-policies="!can('use zones')"
-              />
-            </DataSource>
+            <StandardDataplanePolicies
+              v-else
+              :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
+              :inspect-rules-for-dataplane="rulesData"
+            />
           </DataSource>
+
+          <template v-if="!can('use zones')">
+            <DataSource
+              v-slot="{ data: sidecarDataplaneData, error }: SidecarDataplaneCollectionSource"
+              :src="props.data.dataplaneType !== 'builtin' ? `/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/sidecar-dataplane-policies` : ''"
+            >
+              <DataSource
+                v-slot="{ data: gatewayDataplane, error: gatewayDataplaneError }: MeshGatewayDataplaneSource"
+                :src="props.data.dataplaneType === 'builtin' ? `/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/gateway-dataplane-policies` : ''"
+              >
+                <div data-testid="legacy-policies">
+                  <h3>{{ t('data-planes.routes.item.legacy_policies') }}</h3>
+
+                  <ErrorBlock
+                    v-if="policyTypesError"
+                    :error="policyTypesError"
+                  />
+
+                  <ErrorBlock
+                    v-else-if="error"
+                    :error="error"
+                  />
+
+                  <ErrorBlock
+                    v-else-if="gatewayDataplaneError"
+                    :error="gatewayDataplaneError"
+                  />
+
+                  <LoadingBlock v-else-if="policyTypesData === undefined" />
+
+                  <template v-else-if="props.data.dataplaneType === 'builtin'">
+                    <LoadingBlock v-if="gatewayDataplane === undefined" />
+
+                    <EmptyBlock v-else-if="gatewayDataplane.routePolicies.length === 0 && gatewayDataplane.listenerEntries.length === 0" />
+
+                    <KCard
+                      v-else
+                      class="mt-4"
+                    >
+                      <BuiltinGatewayPolicies
+                        :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
+                        :gateway-dataplane="gatewayDataplane"
+                        data-testid="builtin-gateway-dataplane-policies"
+                      />
+                    </KCard>
+                  </template>
+
+                  <template v-else>
+                    <LoadingBlock v-if="sidecarDataplaneData === undefined" />
+
+                    <EmptyBlock v-else-if="sidecarDataplaneData.policyTypeEntries.length === 0" />
+
+                    <KCard
+                      v-else
+                      class="mt-4"
+                    >
+                      <PolicyTypeEntryList
+                        id="policies"
+                        :policy-type-entries="sidecarDataplaneData.policyTypeEntries"
+                        :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
+                        data-testid="sidecar-dataplane-policies"
+                      />
+                    </KCard>
+                  </template>
+                </div>
+              </DataSource>
+            </DataSource>
+          </template>
         </DataSource>
-      </DataSource>
+      </div>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
+import BuiltinGatewayPolicies from '../components/BuiltinGatewayPolicies.vue'
+import PolicyTypeEntryList from '../components/PolicyTypeEntryList.vue'
 import StandardDataplanePolicies from '../components/StandardDataplanePolicies.vue'
 import type { DataplaneOverview } from '../data'
 import type { DataplaneRulesSource, MeshGatewayDataplaneSource, SidecarDataplaneCollectionSource } from '../sources'


### PR DESCRIPTION
Changes the behavior of the Dataplane policies tab to show data based on the /_rules API for built-in gateways (i.e. rules-based data is now shown for _all_ Dataplane types).

Resolves #2034.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
