### PR TITLE
fix(dataplanes): Always show stats error even if there are no warnings

### DIFF
--- a/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
@@ -57,6 +57,7 @@ Feature: Dataplane traffic
     Given the environment
       """
       KUMA_DATAPLANEINBOUND_COUNT: 1
+      KUMA_SUBSCRIPTION_COUNT: 1
       """
     And the URL "/meshes/default/dataplanes/dpp-1-name-of-dataplane/_overview" responds with
       """
@@ -64,6 +65,14 @@ Feature: Dataplane traffic
         dataplane:
           networking:
             gateway: !!js/undefined
+        dataplaneInsight:
+          mTLS: !!js/undefined
+          subscriptions:
+            - version:
+                kumaDp:
+                  kumaCpCompatible: true
+                envoy:
+                  kumaDpCompatible: true
       """
     And the URL "/meshes/default/dataplanes/dpp-1-name-of-dataplane/stats" responds with
       """

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -15,7 +15,7 @@
     >
       <AppView>
         <template
-          v-if="warnings.length > 0"
+          v-if="warnings.length > 0 || error"
           #notifications
         >
           <ul data-testid="dataplane-warnings">
@@ -30,7 +30,7 @@
               v-if="error"
               :data-testid="`warning-stats-loading`"
             >
-              Error loading outbound stats: <strong>{{ error.toString() }}</strong>
+              The below view is not enhanced with runtime stats (Error loading stats: <strong>{{ error.toString() }}</strong>)
             </li>
           <!-- eslint-enable -->
           </ul>


### PR DESCRIPTION
Ensure the `/stats` error warning shows even if there are no other warnings.

Expanded the test to make sure we produce this exact scenario. The test we show here was also tweaked as a result of an offine convo.

Just to note I'm waiting to move all the code into its own module before I `i18n` everything.