### PR TITLE
feat: keep the selected prev selected tab active when clicking 'bounds

### DIFF
--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -151,7 +151,7 @@
                       >
                         <RouterLink
                           :to="{
-                            name: 'data-plane-inbound-summary-overview-view',
+                            name: ((name) => name.includes('bound') ? name.replace('-outbound-', '-inbound-') : 'data-plane-inbound-summary-overview-view')(String(_route.name)),
                             params: {
                               service: item.port,
                             },
@@ -236,7 +236,7 @@
                         >
                           <RouterLink
                             :to="{
-                              name: 'data-plane-outbound-summary-overview-view',
+                              name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'data-plane-outbound-summary-overview-view')(String(_route.name)),
                               params: {
                                 service: item.name,
                               },
@@ -414,9 +414,11 @@ import ServiceTrafficCard from '@/app/data-planes/components/data-plane-traffic/
 import ServiceTrafficGroup from '@/app/data-planes/components/data-plane-traffic/ServiceTrafficGroup.vue'
 import type { TrafficSource } from '@/app/data-planes/sources'
 import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
+import { useRoute } from '@/app/vue'
 import { useI18n } from '@/utilities'
 
 const { t, formatIsoDate } = useI18n()
+const _route = useRoute()
 
 const props = defineProps<{
   data: DataplaneOverview

--- a/src/app/vue/index.ts
+++ b/src/app/vue/index.ts
@@ -8,6 +8,7 @@ import type { ServiceDefinition } from '@/services/utils'
 import { token, createInjections } from '@/services/utils'
 import type { Component } from 'vue'
 import type { Router, RouteRecordRaw, NavigationGuard } from 'vue-router'
+export { useRoute } from 'vue-router'
 
 type Token = ReturnType<typeof token>
 


### PR DESCRIPTION
In the dataplane viz, if you have a summary drawer already open and you've changed tabs, when you click on a different card/inbound/outbound, keep the active tab the same.

This makes it easier to say click the `[Stats]` tab, and then click around inbounds/outbounds to see the stats without have to keep clicking the `[Stats]` tab.

There is probably more work to come off the back of this to make it more straightforwards to do this sort of thing.
