### PR TITLE
feat(dataplanes): removes service names the stats/cluster drawers in viz

### DIFF
--- a/src/app/common/SummaryView.vue
+++ b/src/app/common/SummaryView.vue
@@ -6,7 +6,7 @@
     close-button-alignment="end"
     :has-overlay="false"
     is-visible
-    max-width="560px"
+    :max-width="props.width"
     offset-top="var(--app-slideout-offset-top, 0)"
     data-testid="summary"
     @close="emit('close')"
@@ -30,6 +30,11 @@ onClickOutside(
     }
   }, 1, true, false),
 )
+const props = withDefaults(defineProps<{
+  width?: string
+}>(), {
+  width: '560px',
+})
 const emit = defineEmits<{
   (event: 'close'): void
 }>()

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -263,6 +263,7 @@
             v-slot="child"
           >
             <SummaryView
+              width="670px"
               @close="function (_e) {
                 route.replace({
                   name: 'data-plane-detail-view',

--- a/src/app/data-planes/views/DataPlaneInboundSummaryClustersView.vue
+++ b/src/app/data-planes/views/DataPlaneInboundSummaryClustersView.vue
@@ -46,7 +46,12 @@
               </div>
               <CodeBlock
                 language="json"
-                :code="`${data.split('\n').filter(item => item.startsWith(`localhost:${route.params.service}::`)).join('\n')}`"
+                :code="(() => `${
+                  data.split('\n')
+                    .filter(item => item.startsWith(`localhost:${route.params.service}::`))
+                    .map(item => item.replace(`localhost:${route.params.service}::`, ''))
+                    .join('\n')
+                }`)()"
                 is-searchable
                 :query="route.params.codeSearch"
                 :is-filter-mode="route.params.codeFilter"

--- a/src/app/data-planes/views/DataPlaneInboundSummaryStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneInboundSummaryStatsView.vue
@@ -46,7 +46,12 @@
               </div>
               <CodeBlock
                 language="json"
-                :code="`${data.split('\n').filter(item => item.includes(`.localhost_${route.params.service}.`)).join('\n')}`"
+                :code="(() => `${
+                  data.split('\n')
+                    .filter(item => item.includes(`.localhost_${route.params.service}.`))
+                    .map(item => item.replace(`localhost_${route.params.service}.`, ''))
+                    .join('\n')
+                }`)()"
                 is-searchable
                 :query="route.params.codeSearch"
                 :is-filter-mode="route.params.codeFilter"

--- a/src/app/data-planes/views/DataPlaneOutboundSummaryClustersView.vue
+++ b/src/app/data-planes/views/DataPlaneOutboundSummaryClustersView.vue
@@ -46,7 +46,12 @@
               </div>
               <CodeBlock
                 language="json"
-                :code="`${data.split('\n').filter(item => item.startsWith(`${route.params.service}::`)).join('\n')}`"
+                :code="(() => `${
+                  data.split('\n')
+                    .filter(item => item.startsWith(`${route.params.service}::`))
+                    .map(item => item.replace(`${route.params.service}::`, ''))
+                    .join('\n')
+                }`)()"
                 is-searchable
                 :query="route.params.codeSearch"
                 :is-filter-mode="route.params.codeFilter"

--- a/src/app/data-planes/views/DataPlaneOutboundSummaryStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneOutboundSummaryStatsView.vue
@@ -46,7 +46,12 @@
               </div>
               <CodeBlock
                 language="json"
-                :code="`${data.split('\n').filter(item => item.includes(`.${route.params.service}.`)).join('\n')}`"
+                :code="(() => `${
+                  data.split('\n')
+                    .filter(item => item.includes(`.${route.params.service}.`))
+                    .map(item => item.replace(`${route.params.service}.`, ''))
+                    .join('\n')
+                }`)()"
                 is-searchable
                 :query="route.params.codeSearch"
                 :is-filter-mode="route.params.codeFilter"

--- a/src/test-support/mocks/src/meshes/_/dataplanes/_/stats.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes/_/stats.ts
@@ -61,6 +61,7 @@ ${prefix}_rq_total: ${totalRequests}`
           http3: Number,
         }, totalRequests)
         return `${prefix}_cx_tx_bytes_total: ${fake.number.int(_minMax)}
+
 ${prefix}_cx_rx_bytes_total: ${fake.number.int(_minMax)}
 ${prefix}_rq_1xx: ${req._1xx}
 ${prefix}_rq_2xx: ${req._2xx}
@@ -97,6 +98,9 @@ ${prefix}_cx_rx_bytes_total: ${fake.number.int(_minMax)}`
         // https://grpc.github.io/grpc/core/md_doc_statuscodes.html
         return `${prefix}_cx_tx_bytes_total: ${fake.number.int(_minMax)}
 ${prefix}_cx_rx_bytes_total: ${fake.number.int(_minMax)}
+cluster.${service}.original_dst_host_invalid: 0
+cluster.${service}.outlier_detection.ejections_active: 0
+cluster.${service}.outlier_detection.ejections_detected_consecutive_local_origin_failure: 0
 cluster.${service}.grpc.0: ${totalRequests}
 cluster.${service}.grpc.request_message_count: ${totalRequests}
 cluster.${service}.grpc.response_message_count: ${req.success}


### PR DESCRIPTION
We noticed that the stats/clusters tabs when in the summary drawers are a little narrow, meaning that it's sometimes difficult to see the values as they are so far over to the right.

Following that we found that repeating the service names in the stats/clusters data in this view didn't really make sense and just led to more noise when trying to see stats/values.

This PR expands the summary drawer slightly only in this view, and also removes the service names from both stats and cluster output making it easier to see through the noise.

![screenshot_2024-01-17_at_16 57 07](https://github.com/kumahq/kuma-gui/assets/554604/2dfdb0b9-dcc2-48ea-a284-2fc81ba87970)

Theres potentially more thinking/design/work to be done here to improve this more, but for the moment this improves things.
