### PR TITLE
fix(CopyButton): incorrect copy icon color in ResourceCodeBlock

### DIFF
--- a/src/app/common/CopyButton.vue
+++ b/src/app/common/CopyButton.vue
@@ -13,7 +13,7 @@
       @click="copy($event, copyToClipboard)"
     >
       <CopyIcon
-        :color="KUI_COLOR_TEXT_NEUTRAL"
+        :color="props.iconColor"
         :title="!props.hideTitle ? props.copyText : undefined"
         :hide-title="props.hideTitle"
       />
@@ -37,6 +37,7 @@ const props = withDefaults(defineProps<{
   tooltipFailText?: string
   hasBorder?: boolean
   hideTitle?: boolean
+  iconColor?: string
 }>(), {
   text: '',
   getText: null,
@@ -45,6 +46,7 @@ const props = withDefaults(defineProps<{
   tooltipFailText: 'Failed to copy!',
   hasBorder: false,
   hideTitle: false,
+  iconColor: KUI_COLOR_TEXT_NEUTRAL,
 })
 
 async function copy(event: Event, copyToClipboard: (text: string) => Promise<boolean>) {

--- a/src/app/common/ResourceCodeBlock.vue
+++ b/src/app/common/ResourceCodeBlock.vue
@@ -29,6 +29,7 @@
             :copy-text="t('common.copyKubernetesText')"
             has-border
             hide-title
+            icon-color="currentColor"
             @click="() => {
               if(isToggled.value === false) {
                 toggle()


### PR DESCRIPTION
Fixes the copy icon color being wrong here:
![image](https://github.com/kumahq/kuma-gui/assets/5774638/07343a54-b395-4ccb-afb8-3e57f8b5a404)


Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
