### PR TITLE
fix: remove stack class from summary tabs view

### DIFF
--- a/src/app/data-planes/views/DataPlaneInboundSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneInboundSummaryView.vue
@@ -28,9 +28,8 @@
         </template>
       </EmptyBlock>
 
-      <div
+      <template
         v-else
-        class="stack"
       >
         <NavTabs
           :tabs="tabs"
@@ -41,7 +40,7 @@
             :data="props.data"
           />
         </RouterView>
-      </div>
+      </template>
     </AppView>
   </RouteView>
 </template>

--- a/src/app/data-planes/views/DataPlaneOutboundSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneOutboundSummaryView.vue
@@ -28,9 +28,8 @@
         </template>
       </EmptyBlock>
 
-      <div
+      <template
         v-else
-        class="stack"
       >
         <NavTabs
           :tabs="tabs"
@@ -41,7 +40,7 @@
             :data="props.data"
           />
         </RouterView>
-      </div>
+      </template>
     </AppView>
   </RouteView>
 </template>


### PR DESCRIPTION
This ended up wrapped in a `class="stack"` somehow, 🤔 I guess I took the copied this from another summary panel then pasted the NavTabs into that.

At first this made no difference, but since we've upgraded KTabs this is making the space between the tabs and the content too big.