### PR TITLE
ci: set write permission on job-level only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,12 +10,13 @@ on:
 
 permissions:
   contents: read # for checking out the repository (e.g. actions/checkout)
-  security-events: write # for adding code alert statuses
 
 jobs:
   analyze:
     name: Run CodeQL
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write # for adding code alert statuses
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -12,10 +12,11 @@ on:
 
 permissions:
   contents: read # for checking out the repository (e.g. actions/checkout)
-  issues: write # for editing issues (e.g. adding labels)
 
 jobs:
   lifecycle:
     uses: kumahq/.github/.github/workflows/wfc_lifecycle.yml@main
+    permissions:
+      issues: write # for editing issues (e.g. adding labels)
     with:
       filesToIgnore: CODEOWNERS


### PR DESCRIPTION
See https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
