### PR TITLE
feat: sync refreshing between data viz and drawer

### DIFF
--- a/src/app/application/components/data-source/DataSource.spec.ts
+++ b/src/app/application/components/data-source/DataSource.spec.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from 'vitest'
 import DataSource from './DataSource.vue'
 import { withSources } from '@/../test-support/main'
 
-describe('DataSourcePool', () => {
+describe('DataSource', () => {
   test("passing an empty uri doesn't fire change", async () => {
     const wrapper = mount(DataSource, {
       props: {

--- a/src/app/application/services/data-source/CallableEventSource.ts
+++ b/src/app/application/services/data-source/CallableEventSource.ts
@@ -5,7 +5,7 @@ export const isClosed = (source: { readyState: number }) => source.readyState ==
 // CallableEventSource turns a Promise returning function into an EventTarget,
 // making it act like a standard EventSource.
 
-export default class CallableEventSource<T = {}> extends EventTarget {
+export default class CallableEventSource<T extends {} = {}> extends EventTarget {
   url = ''
   withCredentials = false
   readonly CONNECTING = CONNECTING
@@ -22,7 +22,7 @@ export default class CallableEventSource<T = {}> extends EventTarget {
     public configuration: T,
   ) {
     super()
-    this._open()
+    this.open()
   }
 
   protected _open() {
@@ -41,9 +41,6 @@ export default class CallableEventSource<T = {}> extends EventTarget {
         }
         self.readyState = CLOSED
       } catch (e) {
-        // temporarily commented until we can avoid console.errors being
-        // reported in environments where we don't want to see them
-        // console.error(e)
         self.close()
         self.dispatchEvent(new ErrorEvent('error', {
           error: e,
@@ -53,7 +50,7 @@ export default class CallableEventSource<T = {}> extends EventTarget {
   }
 
   open(): void {
-    if (this.readyState !== CLOSED) {
+    if (this.readyState === CLOSED) {
       this._open()
     }
   }

--- a/src/app/application/services/data-source/DataSourcePool.spec.ts
+++ b/src/app/application/services/data-source/DataSourcePool.spec.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import DataSourcePool from './DataSourcePool'
+
+class DataSourcePoolWithExposedPool extends DataSourcePool {
+  get pool() {
+    return this._pool
+  }
+}
+
+class EventSource extends EventTarget {
+  constructor(
+    public configuration = {},
+  ) {
+    super()
+  }
+
+  open() {}
+  close() {}
+}
+const spyableEventSource = () => {
+  const add = vi.fn()
+  class EventSourceProxy extends EventSource {
+    addEventListener(...args: Parameters<EventTarget['addEventListener']>) {
+      switch (args[0]) {
+        case 'message':
+        case 'error':
+          add(args[0], args[2])
+          break
+      }
+      return super.addEventListener(...args)
+    }
+  }
+  return {
+    add,
+    EventSourceProxy,
+  }
+}
+
+describe('DataSourcePool', () => {
+  test('shared pooling', () => {
+    const createCount = vi.fn()
+    const destroyCount = vi.fn()
+    const data = new DataSourcePool({
+      '/one': async () => {},
+      '/two': async () => {},
+    }, {
+      create: (_src: string) => {
+        createCount()
+        return new EventSource()
+      },
+      destroy: () => {
+        destroyCount()
+      },
+    })
+    // acquire 10 times, with the last one being a different URI
+    // they should all be the same instance apart from the last one
+    Array.from({ length: 10 }).map((_, i) => i !== 9 ? data.source('/one') : data.source('/two')).reduce((prev, item, i) => {
+      i !== 9 ? expect(prev === item).toBe(true) : expect(prev === item).toBe(false)
+      return item
+    }, data.source('/one'))
+    data.destroy()
+
+    expect(createCount).toHaveBeenCalledTimes(2)
+    expect(destroyCount).toHaveBeenCalledTimes(2)
+  })
+
+  test('event registration', () => {
+    const { EventSourceProxy, add } = spyableEventSource()
+
+    const source = new EventSourceProxy()
+
+    const data = new DataSourcePoolWithExposedPool({
+      '/one': async () => {},
+    }, {
+      create: (_src: string) => {
+        return source
+      },
+    })
+    // acquire 10 times, they all use the same ref so they are exactly the same object
+    // and we only add one EventSource into the pool
+    const ref = Symbol('')
+    Array.from({ length: 10 }).map(() => data.source('/one', ref))
+
+    const controller = data.pool.acquire('/one', ref).controller
+    const abort = vi.spyOn(controller, 'abort')
+
+    // close the source with one call as we only added one EventSource to the pool
+    data.close('/one', ref)
+
+    expect(abort).toHaveBeenCalledTimes(1)
+    expect(add).toHaveBeenCalledTimes(2)
+    expect(add).toHaveBeenCalledWith('message', { signal: controller.signal })
+    expect(add).toHaveBeenCalledWith('error', { signal: controller.signal })
+
+    data.destroy()
+  })
+  test('cacheControl: ""', async () => {
+    const { EventSourceProxy, add } = spyableEventSource()
+
+    const source = new EventSourceProxy()
+
+    const data = new DataSourcePoolWithExposedPool({
+      '/one': async () => {},
+    }, {
+      create: (_src: string) => {
+        return source
+      },
+    })
+
+    const ref = Symbol('')
+    data.source('/one', ref)
+
+    // fill the cache with something once the pool is looking after it
+    source.dispatchEvent(new MessageEvent('message', { data: 'hello' }))
+
+    const controller = data.pool.acquire('/one', ref).controller
+    const abort = vi.spyOn(controller, 'abort')
+
+    // make sure we wait for the first cache to fire before we spy on it
+    await Promise.resolve()
+    const dispatch = vi.spyOn(source, 'dispatchEvent')
+
+    // close the source with one call as we only added one EventSource to the pool
+    data.close('/one', ref)
+
+    // this is the one we are actually spying on the cache for
+    data.source('/one', ref)
+    data.close('/one', ref)
+
+    // we only set up the spy for one abort
+    expect(abort).toHaveBeenCalledTimes(1)
+    // but we still expect add to be called twice for each message and error, making 4
+    expect(add).toHaveBeenCalledTimes(4)
+    expect(add).toHaveBeenCalledWith('message', { signal: controller.signal })
+    expect(add).toHaveBeenCalledWith('error', { signal: controller.signal })
+    // wait for the tick before checking dispatch
+    await Promise.resolve()
+    expect(dispatch).toHaveBeenCalledTimes(1)
+
+    data.destroy()
+  })
+  test('cacheControl: no-cache', async () => {
+    const { EventSourceProxy, add } = spyableEventSource()
+
+    const source = new EventSourceProxy({
+      cacheControl: 'no-cache',
+    })
+
+    const data = new DataSourcePoolWithExposedPool({
+      '/one': async () => {},
+    }, {
+      create: (_src: string) => {
+        return source
+      },
+    })
+
+    const ref = Symbol('')
+    data.source('/one', ref)
+
+    // fill the cache with something once the pool is looking after it
+    source.dispatchEvent(new MessageEvent('message', { data: 'hello' }))
+
+    const controller = data.pool.acquire('/one', ref).controller
+    const abort = vi.spyOn(controller, 'abort')
+
+    // make sure we wait for the first cache to fire before we spy on it
+    await Promise.resolve()
+    const dispatch = vi.spyOn(source, 'dispatchEvent')
+
+    // close the source with one call as we only added one EventSource to the pool
+    data.close('/one', ref)
+
+    // this is the one we are actually spying on the cache for
+    data.source('/one', ref)
+    data.close('/one', ref)
+
+    // we only set up the spy for one abort
+    expect(abort).toHaveBeenCalledTimes(1)
+    // but we still expect add to be called twice for each message and error, making 4
+    expect(add).toHaveBeenCalledTimes(4)
+    expect(add).toHaveBeenCalledWith('message', { signal: controller.signal })
+    expect(add).toHaveBeenCalledWith('error', { signal: controller.signal })
+    // wait for the tick before checking dispatch
+    await Promise.resolve()
+    expect(dispatch).toHaveBeenCalledTimes(0)
+
+    data.destroy()
+  })
+  test('cacheControl: no-store', () => {
+    const { EventSourceProxy, add } = spyableEventSource()
+
+    const source = new EventSourceProxy({
+      cacheControl: 'no-store',
+    })
+
+    const data = new DataSourcePoolWithExposedPool({
+      '/one': async () => {
+        return true
+      },
+    }, {
+      create: (_src: string) => {
+        return source
+      },
+    })
+    // acquire 10 times, they all use the same ref so they are exactly the same object
+    // and we only add one EventSource into the pool
+    const ref = Symbol('')
+    Array.from({ length: 10 }).map(() => data.source('/one', ref))
+
+    const controller = data.pool.acquire('/one', ref).controller
+    const abort = vi.spyOn(controller, 'abort')
+
+    // close the source with one call as we only added one EventSource to the pool
+    data.close('/one', ref)
+
+    expect(abort).toHaveBeenCalledTimes(1)
+    expect(add).toHaveBeenCalledTimes(1)
+    expect(add).not.toHaveBeenCalledWith('message', { signal: controller.signal })
+    expect(add).toHaveBeenCalledWith('error', { signal: controller.signal })
+
+    data.destroy()
+  })
+})

--- a/src/app/application/services/data-source/DataSourcePool.ts
+++ b/src/app/application/services/data-source/DataSourcePool.ts
@@ -1,67 +1,105 @@
-import CallableEventSource from './CallableEventSource'
 import Router from './Router'
 import SharedPool from './SharedPool'
 
+type EventSource = {
+  configuration: {}
+  open: () => void
+  close: () => void
+} & EventTarget
+
 // The user definable 'Sources' themselves i.e. `/uri/:param` => HTTP call
-export type Source = (params: Record<string, unknown>, source: { close: () => void }) => Promise<unknown>
-export type Sources = Record<string, Source>
-// reusable Type Utility for easy to use Types within Vue templates
-export type DataSourceResponse<T> = {
-  data: T | undefined
-  error: Error | undefined
-  refresh: () => void
+export type Source = (params: Record<string, unknown>, source: { close: () => void }) => unknown
+type Sources = Record<string, Source>
+type Connection = {
+  source: EventSource
+  controller: AbortController
 }
-export type Creator = (str: string, router: Router<Source>) => CallableEventSource
-export type Destroyer = (str: string, source: CallableEventSource) => void
+export type Creator<T extends EventSource = EventSource> = (str: string, router: Router<Source>) => T
+export type Destroyer<T extends EventSource = EventSource> = (str: string, source: T) => void
 
-export class DataSourcePool {
-  // a currently unbounded cache of previous JSON responses that is used to
-  // prevent loading spinners etc. i.e. we only use this cache during the time
-  // it takes to fire off a request and then receive an updated response
-  cache: Map<string, unknown> = new Map()
+type Cache = Map<string, unknown>
 
+export default class DataSourcePool {
   // a 'pool' of in use DataSources to manage creation and destruction and
   // ensure they are shared singletons
-  pool: SharedPool<string, CallableEventSource>
+  protected _pool: SharedPool<string, Connection>
 
-  getCacheKeyPrefix: () => string
+  constructor(
+    requests: Sources,
+    { create, destroy = () => {}, error = () => {} }: { create: Creator, destroy?: Destroyer, error?: (e: Event) => void },
+    getCacheKeyPrefix: () => string = () => '',
 
-  constructor(requests: Sources, { create, destroy }: { create: Creator, destroy: Destroyer }, getCacheKeyPrefix: () => string) {
+    // a currently unbounded cache of previous JSON responses that is used to
+    // prevent loading spinners etc. i.e. we only use this cache during the time
+    // it takes to fire off a request and then receive an updated response
+    protected _cache: Cache = new Map(),
+    //
+  ) {
     const requestRouter: Router<Source> = new Router(requests)
 
-    this.pool = new SharedPool<string, CallableEventSource>(
-      (src: string) => {
-        return create(src, requestRouter)
-      },
-      (src: string, source: CallableEventSource) => {
-        destroy(src, source)
+    this._pool = new SharedPool(
+      (state, src, connection) => {
+        const cacheKey = `${getCacheKeyPrefix()}${src}`
+        const dispatchCache = async (source: EventSource) => {
+          // we check cache.has() at the call site
+          if (!('cacheControl' in source.configuration) || source.configuration.cacheControl !== 'no-cache') {
+            await Promise.resolve()
+            source.dispatchEvent(
+              new MessageEvent('message', { data: this._cache.get(cacheKey) }),
+            )
+          }
+        }
+        switch (state) {
+          case 'creating': {
+            const source = create(src, requestRouter)
+            // CallableEventSources are opened upon creation
+            // but others maybe not
+            source.open()
+            const controller = new AbortController()
+            // always fill the cache on a successful response and `?no-store` isn't set
+            if (!('cacheControl' in source.configuration) || source.configuration.cacheControl !== 'no-store') {
+              source.addEventListener('message', (e: Event) => this._cache.set(cacheKey, (e as MessageEvent).data), { signal: controller.signal })
+            }
+            source.addEventListener('error', error, { signal: controller.signal })
+            if (this._cache.has(cacheKey)) {
+              dispatchCache(source)
+            }
+            return {
+              source,
+              controller,
+            }
+          }
+          case 'destroying':
+            if (connection) {
+              connection.controller.abort()
+              destroy(src, connection.source)
+            }
+            return connection
+          case 'releasing':
+            return connection
+          case 'acquiring': {
+            if (this._cache.has(cacheKey)) {
+              dispatchCache(connection.source)
+            }
+            // CallableEventSources need reopening but are guarded in CallableEventSource
+            connection.source.open()
+            return connection
+          }
+        }
       },
     )
-
-    this.getCacheKeyPrefix = getCacheKeyPrefix
   }
 
-  source(src: string, ref: symbol): CallableEventSource {
-    const cacheKey = this.getCacheKeyPrefix() + src
-    const source = this.pool.acquire(src, ref)
-    source.addEventListener('message', (e: Event) => {
-      const target = e.target as CallableEventSource<{ cacheControl?: string }>
-      // always fill the cache on a successful response and `?no-store` isn't set
-      if (target?.configuration.cacheControl !== 'no-store') {
-        this.cache.set(cacheKey, (e as MessageEvent).data)
-      }
-    })
-    if (this.cache.has(cacheKey)) {
-      Promise.resolve().then(() => {
-        source?.dispatchEvent(
-          new MessageEvent('message', { data: this.cache.get(cacheKey) }),
-        )
-      })
-    }
-    return source
+  source(src: string, ref: symbol = Symbol('')): EventSource {
+    return this._pool.acquire(src, ref).source
   }
 
-  close(src: string, ref: symbol) {
-    return this.pool.release(src, ref)
+  close(src: string, ref: symbol = Symbol('')) {
+    return this._pool.release(src, ref)
+  }
+
+  destroy() {
+    this._cache.clear()
+    this._pool.destroy()
   }
 }

--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -25,7 +25,6 @@ export type DataplaneOverviewCollection = CollectionResponse<DataplaneOverview>
 export type DataplaneOverviewCollectionSource = DataSourceResponse<DataplaneOverviewCollection>
 
 export type EnvoyDataSource = DataSourceResponse<object | string>
-export type StatsDataSource = DataSourceResponse<string>
 export type ClustersDataSource = DataSourceResponse<string>
 
 export type SidecarDataplaneCollection = KindCollectionResponse<SidecarDataplane> & { policyTypeEntries: PolicyTypeEntry[] }
@@ -35,10 +34,11 @@ export type MeshGatewayDataplaneSource = DataSourceResponse<MeshGatewayDataplane
 
 export type DataplaneRulesSource = DataSourceResponse<InspectRulesForDataplane>
 
-export type TrafficSource = DataSourceResponse<{
+export type StatsSource = DataSourceResponse<{
   inbounds: TrafficEntry[]
   outbounds: TrafficEntry[]
   passthrough: TrafficEntry
+  raw: string
 }>
 
 const includes = <T extends readonly string[]>(arr: T, item: string): item is T[number] => {
@@ -65,7 +65,7 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
       return api.getDataplaneFromMesh(params, { format: 'kubernetes' })
     },
 
-    '/meshes/:mesh/dataplanes/:name/traffic': async (params) => {
+    '/meshes/:mesh/dataplanes/:name/stats': async (params) => {
       const { mesh, name } = params
       const res = await api.getDataplaneData({
         mesh,
@@ -123,7 +123,7 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
         inbounds,
         outbounds,
         $raw: res,
-        config: res,
+        raw: res,
       }
     },
 

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -10,8 +10,8 @@
     name="data-plane-detail-view"
   >
     <DataSource
-      v-slot="{ data: traffic, error, refresh }: TrafficSource"
-      :src="props.data.dataplaneType === 'standard' ? `/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/traffic` : ''"
+      v-slot="{ data: traffic, error, refresh }: StatsSource"
+      :src="props.data.dataplaneType === 'standard' ? `/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats` : ''"
     >
       <AppView>
         <template
@@ -412,7 +412,7 @@ import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import DataPlaneTraffic from '@/app/data-planes/components/data-plane-traffic/DataPlaneTraffic.vue'
 import ServiceTrafficCard from '@/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue'
 import ServiceTrafficGroup from '@/app/data-planes/components/data-plane-traffic/ServiceTrafficGroup.vue'
-import type { TrafficSource } from '@/app/data-planes/sources'
+import type { StatsSource } from '@/app/data-planes/sources'
 import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
 import { useI18n } from '@/utilities'
 

--- a/src/app/data-planes/views/DataPlaneInboundSummaryStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneInboundSummaryStatsView.vue
@@ -21,8 +21,8 @@
       </template>
       <div>
         <DataSource
-          v-slot="{ data, error, refresh }: StatsDataSource"
-          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/stats`"
+          v-slot="{ data, error, refresh }: StatsSource"
+          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats`"
         >
           <ErrorBlock
             v-if="error"
@@ -35,7 +35,7 @@
             v-else
             language="json"
             :code="(() => `${
-              data.split('\n')
+              data.raw.split('\n')
                 .filter(item => item.includes(`.localhost_${route.params.service}.`))
                 .map(item => item.replace(`localhost_${route.params.service}.`, ''))
                 .join('\n')
@@ -67,7 +67,7 @@
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { RefreshIcon } from '@kong/icons'
 
-import type { StatsDataSource } from '../sources'
+import { StatsSource } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'

--- a/src/app/data-planes/views/DataPlaneOutboundSummaryStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneOutboundSummaryStatsView.vue
@@ -21,8 +21,8 @@
       </template>
       <div>
         <DataSource
-          v-slot="{ data, error, refresh }: StatsDataSource"
-          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/stats`"
+          v-slot="{ data, error, refresh }: StatsSource"
+          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats`"
         >
           <ErrorBlock
             v-if="error"
@@ -35,7 +35,7 @@
             v-else
             language="json"
             :code="(() => `${
-              data.split('\n')
+              data.raw.split('\n')
                 .filter(item => item.includes(`.${route.params.service}.`))
                 .map(item => item.replace(`${route.params.service}.`, ''))
                 .join('\n')
@@ -67,7 +67,7 @@
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { RefreshIcon } from '@kong/icons'
 
-import type { StatsDataSource } from '../sources'
+import { StatsSource } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'

--- a/src/app/data-planes/views/DataPlaneStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneStatsView.vue
@@ -20,21 +20,51 @@
       </template>
 
       <KCard>
-        <EnvoyData
-          resource="Data Plane Proxy"
-          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/stats`"
-          :query="route.params.codeSearch"
-          :is-filter-mode="route.params.codeFilter"
-          :is-reg-exp-mode="route.params.codeRegExp"
-          @query-change="route.update({ codeSearch: $event })"
-          @filter-mode-change="route.update({ codeFilter: $event })"
-          @reg-exp-mode-change="route.update({ codeRegExp: $event })"
-        />
+        <DataSource
+          v-slot="{ data, error, refresh }: StatsSource"
+          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats`"
+        >
+          <ErrorBlock
+            v-if="error"
+            :error="error"
+          />
+
+          <LoadingBlock v-else-if="data === undefined" />
+
+          <CodeBlock
+            v-else
+            language="json"
+            :code="data.raw"
+            is-searchable
+            :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter"
+            :is-reg-exp-mode="route.params.codeRegExp"
+            @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          >
+            <template #primary-actions>
+              <KButton
+                appearance="primary"
+                @click="refresh"
+              >
+                <RefreshIcon :size="KUI_ICON_SIZE_30" />
+                Refresh
+              </KButton>
+            </template>
+          </CodeBlock>
+        </DataSource>
       </KCard>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import EnvoyData from '@/app/common/code-block/EnvoyData.vue'
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { RefreshIcon } from '@kong/icons'
+
+import { StatsSource } from '../sources'
+import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
+import ErrorBlock from '@/app/common/ErrorBlock.vue'
+import LoadingBlock from '@/app/common/LoadingBlock.vue'
 </script>

--- a/src/app/me/sources.ts
+++ b/src/app/me/sources.ts
@@ -1,4 +1,4 @@
-import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
+import type { DataSourceResponse } from '@/app/application'
 
 type Closeable = { close: () => void }
 

--- a/src/app/meshes/sources.ts
+++ b/src/app/meshes/sources.ts
@@ -1,5 +1,5 @@
 import { Mesh, MeshInsight } from './data'
-import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
+import type { DataSourceResponse } from '@/app/application'
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
 

--- a/src/app/policies/sources.ts
+++ b/src/app/policies/sources.ts
@@ -1,5 +1,5 @@
 import { Policy, PolicyDataplane } from './data'
-import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
+import type { DataSourceResponse } from '@/app/application'
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
 import type { PolicyType } from '@/types/index.d'

--- a/src/app/services/sources.ts
+++ b/src/app/services/sources.ts
@@ -1,5 +1,5 @@
 import { ExternalService, ServiceInsight } from './data'
-import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
+import type { DataSourceResponse } from '@/app/application'
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
 

--- a/src/app/zone-egresses/sources.ts
+++ b/src/app/zone-egresses/sources.ts
@@ -1,5 +1,5 @@
 import { ZoneEgressOverview, ZoneEgress } from './data'
-import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
+import type { DataSourceResponse } from '@/app/application'
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
 type PaginationParams = {

--- a/src/app/zone-ingresses/sources.ts
+++ b/src/app/zone-ingresses/sources.ts
@@ -1,5 +1,5 @@
 import { ZoneIngressOverview, ZoneIngress } from './data'
-import { DataSourceResponse } from '@/app/application/services/data-source/DataSourcePool'
+import type { DataSourceResponse } from '@/app/application'
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
 


### PR DESCRIPTION
This PR ensures that clicking the summary drawer `[Refresh]` button in the dataplane viz will refresh the data both in the drawer and in the main viz.

There is a bit of refactoring work here as I noticed that, in the specific case where you have 2 of the exact same DataSources on the page _and_ you had a refresh button, clicking that button would not refresh. Pretty sure this is the first instance where we have this exact case. So whilst this DataSource syncing wasn't quite functioning correctly in this case, its not currently the source of a bug. But, it did prevent me from getting this working without having to do the work in this PR.

- `SharedPool` now works via a little state machine with distinct `creating`, `acquiring`, `releasing` and `destroying` states, which make this a lot clearer plus makes it control what happens when these states happen in one place rather than having to define entirely separate functions for each state.
- I added `cacheControl: no-cache` to DataSourcePool whilst I was here seeing as I was testing all this out it kinda made sense to add this now.
- Moved all data-plane `/stats` requesting to use the same DataSource. This means all requests for stats for dataplanes perform the same parsing logic even if they don't need it, but they also use the same cache. Seeing as you mostly always navigate to `DataplaneDetail > [Overview]` on your way to look at the `DataplaneDetail > [Stats]` tab, you will no longer see a loading spinner for the `DataplaneDetail > [Stats]` page. Consequently, even if the parsing did take JS a little longer millisecond-wise to do, the user will not see any difference. In fact, given we now use the cache, we provide a better experience for the user as a result of not needing to show a loading spinner.
- I did a little bit of cleanup whilst I was here, mainly moving some DataSource related exports to `@/app/application`.

---

At some point soon, I would like to do more work here to make the caching a little more generic i.e. we would pass a cache in that has its own way to `has`, `get` and `set` and we would move the `cacheControl` code into the cache implementation itself. I'd also then deal with the cachePrefix string in the injectable cache itself. Seeing as the cache is now injected, it makes it configurable per application. Lastly `has` and `get` themselves will be moved to use an `async` interface. This work won't happen immediately but probably pretty soon. I didn't do this extra cache related work here as it here as it requires some amends in other code that I didn't want to do just yet.

