### PR TITLE
feature: add DataCollection component and use it for Dataplane viz

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -126,6 +126,7 @@ const INLINE_NON_VOID_ELEMENTS = [
             // Application
             'AppView',
             'DataSource',
+            'DataCollection',
             'RouteView',
             'RouteTitle',
           ],

--- a/src/app/application/components/data-collection/DataCollection.vue
+++ b/src/app/application/components/data-collection/DataCollection.vue
@@ -1,0 +1,84 @@
+<template>
+  <slot
+    v-if="items.length === 0"
+    name="empty"
+    :items="items"
+  >
+    <EmptyBlock />
+  </slot>
+  <slot
+    v-else
+    name="default"
+    :items="paginated"
+  />
+
+  <slot
+    v-if="props.page !== 0 && items.length > 0"
+    name="pagination"
+    :items="paginated"
+  >
+    <KPagination
+      :total-count="items.length"
+      :current-page="props.page"
+      :initial-page-size="props.pageSize"
+      :page-sizes="[15, 30, 50, 75, 100]"
+      @page-changed="({ page }: PaginationChangeEvent) => {
+        emit('change', {
+          page,
+          pageSize: props.pageSize,
+        })
+      }"
+    />
+  </slot>
+</template>
+<script lang="ts" generic="T extends {} = {}" setup>
+import { computed } from 'vue'
+
+import EmptyBlock from '@/app/common/EmptyBlock.vue'
+type PaginationChangeEvent = {
+  page: number
+}
+const props = withDefaults(defineProps<{
+  // type: string
+  paginationType?: 'server' | 'client'
+  page?: number
+  pageSize?: number
+  items: T[]
+  predicate?: (item: T) => boolean
+  comparator?: ((item: T) => number) | undefined
+  find?: boolean
+}>(), {
+  // type: '',
+  paginationType: 'server',
+  page: 0,
+  pageSize: 50,
+  predicate: () => true,
+  comparator: undefined,
+  find: false,
+})
+const emit = defineEmits<{
+  (e: 'change', value: {page: number, pageSize: number}): void
+  (e: 'error', error: Error): void
+}>()
+const items = computed(() => {
+  if (props.find) {
+    const found = props.items.find(props.predicate)
+    return typeof found === 'undefined' ? [] : [found]
+  } else {
+    const found = props.items.filter(props.predicate)
+    if (typeof props.comparator !== 'undefined') {
+      return found.sort(props.comparator)
+    }
+    return found
+  }
+})
+const paginated = computed(() => {
+  if (props.paginationType === 'client') {
+    const cursor = props.pageSize * (props.page - 1)
+    return items.value.slice(cursor, cursor + props.pageSize)
+  } else {
+    return items.value
+  }
+})
+
+</script>

--- a/src/app/application/components/data-collection/README.md
+++ b/src/app/application/components/data-collection/README.md
@@ -1,0 +1,11 @@
+# DataCollection
+
+A component for working with collections/arrays of data.
+
+Features:
+
+- Filtering
+- Finding
+- Sorting
+- Paginating
+- Slottable "empty" display

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -17,6 +17,7 @@
       :env="env"
       :can="can"
       :route="{
+        name: props.name,
         update: routeUpdate,
         replace: routeReplace,
         params: routeParams,

--- a/src/app/application/index.ts
+++ b/src/app/application/index.ts
@@ -1,6 +1,7 @@
 import { i18nTComponent } from '@kong-ui-public/i18n'
 
 import AppView from './components/app-view/AppView.vue'
+import DataCollection from './components/data-collection/DataCollection.vue'
 import DataSource from './components/data-source/DataSource.vue'
 import RouteTitle from './components/route-view/RouteTitle.vue'
 import RouteView from './components/route-view/RouteView.vue'
@@ -25,6 +26,7 @@ declare module '@vue/runtime-core' {
   export interface GlobalComponents {
     AppView: typeof AppView
     DataSource: typeof DataSource
+    DataCollection: typeof DataCollection
     RouteView: typeof RouteView
     RouteTitle: typeof RouteTitle
     I18nT: ReturnType<typeof i18nTComponent>
@@ -58,6 +60,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         return [
           ['AppView', AppView],
           ['DataSource', DataSource],
+          ['DataCollection', DataCollection],
           ['RouteView', RouteView],
           ['RouteTitle', RouteTitle],
           ['I18nT', i18nTComponent(i18n)],

--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -21,90 +21,97 @@
     <template
       v-if="props.traffic"
     >
-      <!-- rx and tx are purposefully reversed in all the below to rx=tx and tx=rx here due to the direction of the traffic (downstream) -->
-      <dl>
-        <template
-          v-if="props.protocol === 'passthrough'"
-        >
+      <template v-if="props.traffic.name.length > 0">
+        <!-- rx and tx are purposefully reversed in all the below to rx=tx and tx=rx here due to the direction of the traffic (downstream) -->
+        <dl>
           <template
-            v-for="(item, key) in [
-              (['http', 'tcp'] as const).reduce((prev, protocol) => {
-                const direction = 'downstream'
-                // sum both the properties we need from both protocols
-                return Object.entries(props.traffic?.[protocol] || {}).reduce((prev, [key, value]) => {
-                  return [`${direction}_cx_tx_bytes_total`, `${direction}_cx_rx_bytes_total`].includes(key) ?
-                    { ...prev, [key]: (value as number) + (prev[key] ?? 0) } :
-                    prev
-                }, prev)
-              }, {} as Record<string, number>),
-            ]"
-            :key="key"
+            v-if="props.protocol === 'passthrough'"
+          >
+            <template
+              v-for="(item, key) in [
+                (['http', 'tcp'] as const).reduce((prev, protocol) => {
+                  const direction = 'downstream'
+                  // sum both the properties we need from both protocols
+                  return Object.entries(props.traffic?.[protocol] || {}).reduce((prev, [key, value]) => {
+                    return [`${direction}_cx_tx_bytes_total`, `${direction}_cx_rx_bytes_total`].includes(key) ?
+                      { ...prev, [key]: (value as number) + (prev[key] ?? 0) } :
+                      prev
+                  }, prev)
+                }, {} as Record<string, number>),
+              ]"
+              :key="key"
+            >
+              <div>
+                <dt>{{ t('data-planes.components.service_traffic_card.tx') }}</dt>
+                <dd>{{ t('common.formats.bytes', { value: item.downstream_cx_rx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+              </div>
+              <div>
+                <dt>{{ t('data-planes.components.service_traffic_card.rx') }}</dt>
+                <dd>{{ t('common.formats.bytes', { value: item.downstream_cx_tx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+              </div>
+            </template>
+          </template>
+          <template
+            v-else-if="props.protocol === 'grpc'"
+          >
+            <div>
+              <dt>{{ t('data-planes.components.service_traffic_card.grpc_success') }}</dt>
+              <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.success as (number | undefined) ?? 0 }) }}</dd>
+            </div>
+            <div>
+              <dt>{{ t('data-planes.components.service_traffic_card.grpc_failure') }}</dt>
+              <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.failure as (number | undefined) ?? 0 }) }}</dd>
+            </div>
+          </template>
+          <template
+            v-else-if="props.protocol === 'http'"
+          >
+            <div
+              v-for="value in [props.traffic.http?.downstream_rq_1xx as (number | undefined) ?? 0].filter(item => item !== 0)"
+              :key="value"
+            >
+              <dt>{{ t('data-planes.components.service_traffic_card.1xx') }}</dt>
+              <dd>{{ t('common.formats.integer', { value: value }) }}</dd>
+            </div>
+            <div>
+              <dt>{{ t('data-planes.components.service_traffic_card.2xx') }}</dt>
+              <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_2xx as (number | undefined) ?? 0 }) }}</dd>
+            </div>
+            <div
+              v-for="value in [props.traffic.http?.downstream_rq_3xx as (number | undefined) ?? 0].filter(item => item !== 0)"
+              :key="value"
+            >
+              <dt>{{ t('data-planes.components.service_traffic_card.3xx') }}</dt>
+              <dd>{{ t('common.formats.integer', { value: value }) }}</dd>
+            </div>
+            <div>
+              <dt>{{ t('data-planes.components.service_traffic_card.4xx') }}</dt>
+              <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_4xx as (number | undefined) ?? 0 }) }}</dd>
+            </div>
+            <div>
+              <dt>{{ t('data-planes.components.service_traffic_card.5xx') }}</dt>
+              <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_5xx as (number | undefined) ?? 0 }) }}</dd>
+            </div>
+          </template>
+          <template
+            v-else
           >
             <div>
               <dt>{{ t('data-planes.components.service_traffic_card.tx') }}</dt>
-              <dd>{{ t('common.formats.bytes', { value: item.downstream_cx_rx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+              <dd>{{ t('common.formats.bytes', { value: props.traffic.tcp?.downstream_cx_rx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
             </div>
             <div>
               <dt>{{ t('data-planes.components.service_traffic_card.rx') }}</dt>
-              <dd>{{ t('common.formats.bytes', { value: item.downstream_cx_tx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
+              <dd>{{ t('common.formats.bytes', { value: props.traffic.tcp?.downstream_cx_tx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
             </div>
           </template>
-        </template>
-        <template
-          v-else-if="props.protocol === 'grpc'"
-        >
-          <div>
-            <dt>{{ t('data-planes.components.service_traffic_card.grpc_success') }}</dt>
-            <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.success as (number | undefined) ?? 0 }) }}</dd>
-          </div>
-          <div>
-            <dt>{{ t('data-planes.components.service_traffic_card.grpc_failure') }}</dt>
-            <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.failure as (number | undefined) ?? 0 }) }}</dd>
-          </div>
-        </template>
-        <template
-          v-else-if="props.protocol === 'http'"
-        >
-          <div
-            v-for="value in [props.traffic.http?.downstream_rq_1xx as (number | undefined) ?? 0].filter(item => item !== 0)"
-            :key="value"
-          >
-            <dt>{{ t('data-planes.components.service_traffic_card.1xx') }}</dt>
-            <dd>{{ t('common.formats.integer', { value: value }) }}</dd>
-          </div>
-          <div>
-            <dt>{{ t('data-planes.components.service_traffic_card.2xx') }}</dt>
-            <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_2xx as (number | undefined) ?? 0 }) }}</dd>
-          </div>
-          <div
-            v-for="value in [props.traffic.http?.downstream_rq_3xx as (number | undefined) ?? 0].filter(item => item !== 0)"
-            :key="value"
-          >
-            <dt>{{ t('data-planes.components.service_traffic_card.3xx') }}</dt>
-            <dd>{{ t('common.formats.integer', { value: value }) }}</dd>
-          </div>
-          <div>
-            <dt>{{ t('data-planes.components.service_traffic_card.4xx') }}</dt>
-            <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_4xx as (number | undefined) ?? 0 }) }}</dd>
-          </div>
-          <div>
-            <dt>{{ t('data-planes.components.service_traffic_card.5xx') }}</dt>
-            <dd>{{ t('common.formats.integer', { value: props.traffic.http?.downstream_rq_5xx as (number | undefined) ?? 0 }) }}</dd>
-          </div>
-        </template>
-        <template
-          v-else
-        >
-          <div>
-            <dt>{{ t('data-planes.components.service_traffic_card.tx') }}</dt>
-            <dd>{{ t('common.formats.bytes', { value: props.traffic.tcp?.downstream_cx_rx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
-          </div>
-          <div>
-            <dt>{{ t('data-planes.components.service_traffic_card.rx') }}</dt>
-            <dd>{{ t('common.formats.bytes', { value: props.traffic.tcp?.downstream_cx_tx_bytes_total as (number | undefined) ?? 0 }) }}</dd>
-          </div>
-        </template>
-      </dl>
+        </dl>
+      </template>
+    </template>
+    <template v-else>
+      <KSkeletonBox
+        :width="10"
+      />
     </template>
   </DataCard>
 </template>

--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -110,7 +110,7 @@
     </template>
     <template v-else>
       <KSkeletonBox
-        :width="10"
+        width="10"
       />
     </template>
   </DataCard>

--- a/src/app/data-planes/views/DataPlaneInboundSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneInboundSummaryView.vue
@@ -20,27 +20,22 @@
         </div>
       </template>
 
-      <EmptyBlock v-if="typeof props.data === 'undefined'">
-        {{ t('common.collection.summary.empty_title', { type: 'Inbound' }) }}
-
-        <template #message>
-          <p>{{ t('common.collection.summary.empty_message', { type: 'Inbound' }) }}</p>
-        </template>
-      </EmptyBlock>
-
-      <template
-        v-else
-      >
-        <NavTabs
-          :tabs="tabs"
-        />
-        <RouterView v-slot="child">
+      <NavTabs
+        :tabs="tabs"
+      />
+      <RouterView v-slot="child">
+        <DataCollection
+          v-slot="{ items }"
+          :items="props.data"
+          :predicate="(item) => `${item.port}` === route.params.service"
+          :find="true"
+        >
           <component
             :is="child.Component"
-            :data="props.data"
+            :data="items[0]"
           />
-        </RouterView>
-      </template>
+        </DataCollection>
+      </RouterView>
     </AppView>
   </RouteView>
 </template>
@@ -50,14 +45,13 @@ import { RouteRecordRaw, useRouter } from 'vue-router'
 
 import type { DataplaneInbound } from '../data'
 import { useI18n } from '@/app/application'
-import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import NavTabs, { NavTab } from '@/app/common/NavTabs.vue'
 
 const { t } = useI18n()
 
 const router = useRouter()
 const props = defineProps<{
-  data?: DataplaneInbound
+  data: DataplaneInbound[]
 }>()
 const routes = router.getRoutes().find((route) => route.name === 'data-plane-inbound-summary-view')?.children ?? []
 const tabs: NavTab[] = routes.map((route) => {

--- a/src/app/data-planes/views/DataPlaneOutboundSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneOutboundSummaryView.vue
@@ -20,27 +20,22 @@
         </div>
       </template>
 
-      <EmptyBlock v-if="typeof props.data === 'undefined'">
-        {{ t('common.collection.summary.empty_title', { type: 'Data Plane Proxy' }) }}
-
-        <template #message>
-          <p>{{ t('common.collection.summary.empty_message', { type: 'Data Plane Proxy' }) }}</p>
-        </template>
-      </EmptyBlock>
-
-      <template
-        v-else
-      >
-        <NavTabs
-          :tabs="tabs"
-        />
-        <RouterView v-slot="child">
+      <NavTabs
+        :tabs="tabs"
+      />
+      <RouterView v-slot="child">
+        <DataCollection
+          v-slot="{ items }"
+          :items="props.data"
+          :predicate="(item) => item.name === route.params.service"
+          :find="true"
+        >
           <component
             :is="child.Component"
-            :data="props.data"
+            :data="items[0]"
           />
-        </RouterView>
-      </template>
+        </DataCollection>
+      </RouterView>
     </AppView>
   </RouteView>
 </template>
@@ -50,14 +45,13 @@ import { RouteRecordRaw, useRouter } from 'vue-router'
 
 import type { TrafficEntry } from '../data'
 import { useI18n } from '@/app/application'
-import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import NavTabs, { NavTab } from '@/app/common/NavTabs.vue'
 
 const { t } = useI18n()
 
 const router = useRouter()
 const props = defineProps<{
-  data?: TrafficEntry
+  data: TrafficEntry[]
 }>()
 const routes = router.getRoutes().find((route) => route.name === 'data-plane-outbound-summary-view')?.children ?? []
 const tabs: NavTab[] = routes.map((route) => {

--- a/src/test-support/mocks/src/meshes/_/dataplanes/_/stats.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes/_/stats.ts
@@ -163,7 +163,9 @@ tcp.${service}.${direction}_cx_rx_bytes_total: ${fake.number.int(minMax)}`
   }).join('\n')
 
   return {
-    headers: {},
+    headers: {
+      // 'Status-Code': '500',
+    },
     body: `${outbounds}
 ${inbounds}
 ${passthrough}


### PR DESCRIPTION
Feature-wise this PR:

- Adds EmptyStates/EmptyBlocks to the DPP viz (which we also use for the "in-viz ErrorState")
- Adds a Loading spinner into the Outbounds column
- Reduces the amount of re-renders of the DPP viz when clicking ono the Cards

To do this I made a new component called `DataCollection` which:

- Provides a component for filtering/finding, sorting (and pagination outside of a AppCollection table should we need that) and also a default EmptyState for empty collections (which is slottable)
- Replaces some of our usage of `<template v-for="">`

I've moved the finding of the exact 'item' we need to show in the drawer to the drawer itself.

I've done this because we need to use `route.params.service` in order to find the 'item'. Moving the find (and the dependency on `route.params.service`) out of the main view and into the drawer means that the main view doesn't re-render whenever `route.params.service` changes, which happens whenever you click on a card.


### Loading State

![Screenshot 2024-01-23 at 10 19 58](https://github.com/kumahq/kuma-gui/assets/554604/71746233-ce11-4279-861c-85e2a1b8f380)

### `/stats` Error State

![Screenshot 2024-01-23 at 10 20 05](https://github.com/kumahq/kuma-gui/assets/554604/1b1716aa-a741-4006-9def-5c656ba6a414)
