### PR TITLE
chore(policies): fix policy list test

### DIFF
--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -97,7 +97,7 @@ Feature: mesh / policies / index
             total: 0
           FaultInjection:
             total: 0
-          HealthChecks:
+          HealthCheck:
             total: 0
           MeshGatewayRoute:
             total: 0
@@ -125,10 +125,10 @@ Feature: mesh / policies / index
 
     When I visit the "/meshes/default/policies/meshfaultinjections" URL
 
-    Then the "[data-testid='policy-type-link-FaultInjection']" element doesn't exist
-    And the "[data-testid='policy-type-link-MeshFaultInjection']" element exists
+    Then the "[data-testid='policy-type-link-MeshFaultInjection']" element exists
     # Always shows MeshGateway
     And the "[data-testid='policy-type-link-MeshGateway']" element exists
+    And the "[data-testid='policy-type-link-FaultInjection']" element doesn't exist
 
   Scenario: Shows legacy policy types if there are any legacy policies applied
     Given the URL "/mesh-insights/default" responds with

--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -124,10 +124,6 @@ Feature: mesh / policies / index
       """
 
     When I visit the "/meshes/default/policies/meshfaultinjections" URL
-    And the URL "/mesh-insights/default" was requested with
-      """
-      method: GET
-      """
 
     Then the "[data-testid='policy-type-link-MeshFaultInjection']" element exists
     # Always shows MeshGateway
@@ -144,10 +140,6 @@ Feature: mesh / policies / index
       """
 
     When I visit the "/meshes/default/policies/meshfaultinjections" URL
-    And the URL "/mesh-insights/default" was requested with
-      """
-      method: GET
-      """
 
     Then the "[data-testid='policy-type-link-FaultInjection']" element exists
     And the "[data-testid='policy-type-link-MeshFaultInjection']" element exists

--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -124,6 +124,10 @@ Feature: mesh / policies / index
       """
 
     When I visit the "/meshes/default/policies/meshfaultinjections" URL
+    And the URL "/mesh-insights/default" was requested with
+      """
+      method: GET
+      """
 
     Then the "[data-testid='policy-type-link-MeshFaultInjection']" element exists
     # Always shows MeshGateway
@@ -140,6 +144,10 @@ Feature: mesh / policies / index
       """
 
     When I visit the "/meshes/default/policies/meshfaultinjections" URL
+    And the URL "/mesh-insights/default" was requested with
+      """
+      method: GET
+      """
 
     Then the "[data-testid='policy-type-link-FaultInjection']" element exists
     And the "[data-testid='policy-type-link-MeshFaultInjection']" element exists

--- a/src/app/policies/components/PolicyList.vue
+++ b/src/app/policies/components/PolicyList.vue
@@ -225,6 +225,10 @@ const emit = defineEmits<{
 }>()
 
 const visiblePolicyTypes = computed(() => {
+  if (props.meshInsight?.policies === undefined) {
+    return props.policyTypes
+  }
+
   const hasAnyLegacyPolicies = props.policyTypes
     // Consider only legacy policy types. Ignore MeshGateway because we’ll always show it in the list. Therefore, its policies shouldn’t influence whether we show _legacy_ policy types.
     .filter((policyType) => !policyType.isTargetRefBased && policyType.name !== 'MeshGateway')


### PR DESCRIPTION
Fixes a misspelled policy type name in mock data causing a test to behave incorrectly. Also switches the assertion order to first check for element visibility.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
