### PR TITLE
fix: fix `/cluster` mocks with newline join

### DIFF
--- a/src/test-support/mocks/src/meshes/_/dataplanes/_/clusters.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes/_/clusters.ts
@@ -38,7 +38,7 @@ ${service}::10.244.0.2:8080::canary::false
 ${service}::10.244.0.2:8080::priority::0
 ${service}::10.244.0.2:8080::success_rate::-1
 ${service}::10.244.0.2:8080::local_origin_success_rate::-1`
-  })
+  }).join('\n')
   fake.kuma.seed(name as string)
   const outbounds = Array.from({ length: serviceCount }).map(_ => {
     const port = fake.number.int({ min: 1, max: 65535 })
@@ -71,7 +71,7 @@ ${service}::10.244.0.2:8080::canary::false
 ${service}::10.244.0.2:8080::priority::0
 ${service}::10.244.0.2:8080::success_rate::-1
 ${service}::10.244.0.2:8080::local_origin_success_rate::-1`
-  })
+  }).join('\n')
   return {
     headers: {},
     body: `${inbounds}


### PR DESCRIPTION
## Before

<img width="663" alt="Screenshot 2024-01-23 at 11 25 16" src="https://github.com/kumahq/kuma-gui/assets/554604/bc3615d1-1845-4962-82ec-0c5695add3fa">


## After

<img width="687" alt="Screenshot 2024-01-23 at 11 24 57" src="https://github.com/kumahq/kuma-gui/assets/554604/d4a62df4-0db9-4596-85db-1a4cfd51d5c0">
