### PR TITLE
chore(zones): fill out zone'gress types and reuse SubscriptionCollection

### DIFF
--- a/features/zones/zone-cps/egresses/Index.feature
+++ b/features/zones/zone-cps/egresses/Index.feature
@@ -8,7 +8,7 @@ Feature: zones / egresses / index
     Given the environment
       """
       KUMA_MODE: <Mode>
-      KUMA_ZONEEGRESS_COUNT: 2
+      KUMA_ZONEEGRESS_COUNT: 3
       KUMA_SUBSCRIPTION_COUNT: 2
       """
     And the URL "/zoneegresses/_overview" responds with

--- a/src/app/data-planes/data/index.ts
+++ b/src/app/data-planes/data/index.ts
@@ -1,4 +1,4 @@
-import { SubscriptionCollection } from '@/app/subscriptions/data'
+import { DiscoverySubscriptionCollection } from '@/app/subscriptions/data'
 import type { ApiKindListResponse, PaginatedApiListResponse } from '@/types/api.d'
 import type {
   DataPlane as PartialDataplane,
@@ -9,7 +9,6 @@ import type {
   DataPlaneOverview as PartialDataplaneOverview,
   DataPlaneProxyStatus as DataplaneStatusCount,
   DataplaneWarning,
-  DiscoverySubscription,
   InspectBaseRule,
   InspectRule,
   InspectRulesForDataplane as PartialInspectRulesForDataplane,
@@ -27,9 +26,6 @@ import type {
 } from '@/types/index.d'
 
 export type { TrafficEntry } from './stats'
-
-type DiscoverySubscriptionCollection = {
-} & SubscriptionCollection<DiscoverySubscription>
 
 export type DataplaneInbound = PartialDataplaneInbound & {
   health: {
@@ -129,11 +125,6 @@ export const Dataplane = {
   },
 }
 
-const DiscoverySubscriptionCollection = {
-  fromArray: (items?: DiscoverySubscription[]): DiscoverySubscriptionCollection => {
-    return SubscriptionCollection.fromArray(items)
-  },
-}
 const DataplaneInsight = {
   fromObject(item: PartialDataplaneInsight | undefined): DataplaneInsight {
     return {

--- a/src/app/subscriptions/data/index.ts
+++ b/src/app/subscriptions/data/index.ts
@@ -1,5 +1,6 @@
 import type {
   Version as PartialVersion,
+  DiscoverySubscription as PartialDiscoverySubscription,
 } from '@/types/index.d'
 
 export type Version = PartialVersion
@@ -10,10 +11,18 @@ export type Subscription = {
   }
   version?: Version
 }
+export type DiscoverySubscription = PartialDiscoverySubscription
 export type SubscriptionCollection<T extends { version?: any }> = {
   subscriptions: T[]
   connectedSubscription?: T
   version?: T['version']
+}
+export type DiscoverySubscriptionCollection = SubscriptionCollection<DiscoverySubscription>
+
+export const DiscoverySubscriptionCollection = {
+  fromArray: (items?: DiscoverySubscription[]): DiscoverySubscriptionCollection => {
+    return SubscriptionCollection.fromArray(items)
+  },
 }
 export const SubscriptionCollection = {
   fromArray: <T extends Subscription>(items?: T[]): SubscriptionCollection<T> => {

--- a/src/app/zone-egresses/data/index.spec.ts
+++ b/src/app/zone-egresses/data/index.spec.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test as _test } from 'vitest'
+
+import { ZoneEgressOverview } from './'
+import { plugin, server } from '@/test-support/data'
+import mock from '@/test-support/mocks/src/zoneegresses/_/_overview'
+
+// zoneEgress tests are very similar to zoneIngress tests
+// so anything you amend here you should consider also amending in
+// the zoneIngress tests
+describe('ZoneEgressOverview', () => {
+  const test = _test.extend(plugin<typeof ZoneEgressOverview>(
+    ZoneEgressOverview,
+    server(mock, {
+      params: {
+        name: 'zone',
+      },
+    }),
+  ))
+  //
+  describe('zoneEgressInsight.subscriptions', () => {
+    test(
+      'absent enabled, a connected subscription, config has properties',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          delete item.zoneEgressInsight
+          return item
+        })
+        expect(actual.zoneEgressInsight).toBeDefined()
+      },
+    )
+
+    test(
+      'no subscriptions, connectedSubscription remains undefined',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          if (typeof item.zoneEgressInsight !== 'undefined') {
+            item.zoneEgressInsight.subscriptions = []
+          }
+          return item
+        })
+        expect(actual.zoneEgressInsight).toBeDefined()
+        expect(actual.zoneEgressInsight.subscriptions.length).toStrictEqual(0)
+        expect(actual.zoneEgressInsight.connectedSubscription).toBeUndefined()
+      },
+    )
+
+    test(
+      'all disconnected subscriptions, connectedSubscription remains undefined',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          if (typeof item.zoneEgressInsight !== 'undefined') {
+            item.zoneEgressInsight.subscriptions.forEach((item: any) => {
+              item.connectTime = '2021-02-19T07:06:16.384057Z'
+              item.disconnectTime = '2021-03-19T07:06:16.384057Z'
+            })
+          }
+          return item
+        }, {
+          env: {
+            KUMA_SUBSCRIPTION_COUNT: '10',
+          },
+        })
+        expect(actual.zoneEgressInsight).toBeDefined()
+        expect(actual.zoneEgressInsight.subscriptions.length).toStrictEqual(10)
+        expect(actual.zoneEgressInsight.connectedSubscription).toBeUndefined()
+      },
+    )
+  })
+  describe('state', () => {
+    test(
+      'all disconnected subscriptions, state=offline',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          if (typeof item.zoneEgressInsight !== 'undefined') {
+            item.zoneEgressInsight.subscriptions.forEach((item: any) => {
+              item.connectTime = '2021-02-19T07:06:16.384057Z'
+              item.disconnectTime = '2021-03-19T07:06:16.384057Z'
+            })
+          }
+          return item
+        }, {
+          env: {
+            KUMA_SUBSCRIPTION_COUNT: '10',
+          },
+        })
+        expect(actual.state).toStrictEqual('offline')
+      },
+    )
+
+    test(
+      'all disconnected subscriptions, state=online',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          if (typeof item.zoneEgressInsight !== 'undefined') {
+            item.zoneEgressInsight.subscriptions.forEach((item: any, i: number, arr: any[]) => {
+              item.connectTime = '2021-02-19T07:06:16.384057Z'
+              if (i === arr.length - 1) {
+                delete item.disconnectTime
+              } else {
+                item.disconnectTime = '2021-03-19T07:06:16.384057Z'
+              }
+            })
+          }
+          return item
+        }, {
+          env: {
+            KUMA_SUBSCRIPTION_COUNT: '10',
+          },
+        })
+        expect(actual.state).toStrictEqual('online')
+      },
+    )
+  })
+  describe('addresses', () => {
+    test(
+      'absent addresses, socketAddress = ""',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          if (typeof item.zoneEgress.networking === 'undefined') {
+            item.zoneEgress.networking = {}
+          }
+          delete item.zoneEgress.networking?.address
+          item.zoneEgress.networking.port = '80'
+          return item
+        })
+        expect(actual.zoneEgress.socketAddress).toStrictEqual('')
+      },
+    )
+
+    test(
+      'absent ports, socketAddress = ""',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          if (typeof item.zoneEgress.networking === 'undefined') {
+            item.zoneEgress.networking = {}
+          }
+          item.zoneEgress.networking.address = '127.0.0.1'
+          delete item.zoneEgress.networking.port
+          return item
+        })
+        expect(actual.zoneEgress.socketAddress).toStrictEqual('')
+      },
+    )
+
+    test(
+      'numbered ports, socketAddress is correct advertisedSocketAddress is correct',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          if (typeof item.zoneEgress.networking === 'undefined') {
+            item.zoneEgress.networking = {}
+          }
+          item.zoneEgress.networking.address = '127.0.0.1'
+          // @ts-ignore
+          item.zoneEgress.networking.port = 80
+          return item
+        })
+        expect(actual.zoneEgress.socketAddress).toStrictEqual('127.0.0.1:80')
+      },
+    )
+
+    test(
+      'string ports, socketAddress is correct advertisedSocketAddress is correct',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          if (typeof item.zoneEgress.networking === 'undefined') {
+            item.zoneEgress.networking = {}
+          }
+          item.zoneEgress.networking.address = '127.0.0.1'
+          item.zoneEgress.networking.port = '80'
+          return item
+        })
+        expect(actual.zoneEgress.socketAddress).toStrictEqual('127.0.0.1:80')
+      },
+    )
+  })
+})

--- a/src/app/zone-egresses/data/index.ts
+++ b/src/app/zone-egresses/data/index.ts
@@ -1,11 +1,11 @@
+import { DiscoverySubscriptionCollection } from '@/app/subscriptions/data'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
 import type {
   ZoneEgressOverview as PartialZoneEgressOverview,
   ZoneEgress as PartialZoneEgress,
-  KDSSubscription,
+  ZoneEgressInsight as PartialZoneEgressInsight,
 } from '@/types/index.d'
 
-type PartialZoneEgressInsight = any
 type PartialInternalZoneEgress = PartialZoneEgressOverview['zoneEgress']
 
 // TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
@@ -19,15 +19,11 @@ export type ZoneEgress = {
 } & PartialZoneEgress
 // end TODO
 
-// TODO(jc) currently in our manually written types ZoneEgressInsight is any therefore
-// we have no Partial*
-export type ZoneEgressInsight = {
-  connectedSubscription?: KDSSubscription
-  subscriptions: KDSSubscription[]
-}
+export type ZoneEgressInsight = PartialZoneEgressInsight & DiscoverySubscriptionCollection & {}
+
 export type ZoneEgressOverview = PartialZoneEgressOverview & {
   zoneEgress: InternalZoneEgress
-  zoneEgressInsight?: ZoneEgressInsight
+  zoneEgressInsight: ZoneEgressInsight
   state: 'online' | 'offline'
 }
 // TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
@@ -51,34 +47,24 @@ export const ZoneEgress = {
 }
 // end TODO
 export const ZoneEgressInsight = {
-  fromObject: (item?: PartialZoneEgressInsight): ZoneEgressInsight | undefined => {
-    // if item isn't set don't even try augmenting things
-    return isSet<PartialZoneEgressInsight>(item)
-      ? ((item) => {
-        const subscriptions: KDSSubscription[] = Array.isArray(item.subscriptions) ? item.subscriptions : []
-        // figure out the connectedSubscription by looking at the connectTime
-        // and disconnectTime of the last subscription
-        const connectedSubscription = subscriptions.slice(-1).find((item) => item.connectTime?.length && !item.disconnectTime)
-        return {
-          ...item,
-          subscriptions,
-          connectedSubscription,
-        }
-      })(item)
-      : undefined
+  fromObject: (item: PartialZoneEgressInsight | undefined): ZoneEgressInsight => {
+    return {
+      ...item,
+      ...DiscoverySubscriptionCollection.fromArray(item?.subscriptions),
+    }
   },
 }
 export const ZoneEgressOverview = {
   fromObject: (item: PartialZoneEgressOverview): ZoneEgressOverview => {
-    const insight = ZoneEgressInsight.fromObject(item.zoneEgressInsight)
+    const zoneEgressInsight = ZoneEgressInsight.fromObject(item.zoneEgressInsight)
     const zoneEgress = InternalZoneEgress.fromObject(item.zoneEgress)
     return {
       ...item,
-      zoneEgressInsight: insight,
+      zoneEgressInsight,
       zoneEgress,
       // it is possible to have zoneEgresses on a 'disabled' zone but we don't
       // want to do anything special about that just now at least
-      state: typeof insight?.connectedSubscription !== 'undefined' ? 'online' : 'offline',
+      state: typeof zoneEgressInsight.connectedSubscription !== 'undefined' ? 'online' : 'offline',
     }
   },
   fromCollection: (collection: CollectionResponse<PartialZoneEgressOverview>): CollectionResponse<ZoneEgressOverview> => {
@@ -87,7 +73,4 @@ export const ZoneEgressOverview = {
       items: Array.isArray(collection.items) ? collection.items.map(ZoneEgressOverview.fromObject) : [],
     }
   },
-}
-function isSet<T>(value: T | null | undefined): value is T {
-  return value !== null && typeof value !== 'undefined'
 }

--- a/src/app/zone-egresses/views/ZoneEgressDetailView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressDetailView.vue
@@ -38,22 +38,18 @@
           </div>
         </KCard>
 
-        <template
-          v-for="subscriptions in [props.data.zoneEgressInsight?.subscriptions ?? []]"
-          :key="subscriptions"
+        <div
+          v-if="props.data.zoneEgressInsight.subscriptions.length > 0"
+          data-testid="zone-egress-subscriptions"
         >
-          <div
-            v-if="subscriptions.length > 0"
-          >
-            <h2>{{ t('zone-egresses.routes.item.subscriptions.title') }}</h2>
+          <h2>{{ t('zone-egresses.routes.item.subscriptions.title') }}</h2>
 
-            <KCard class="mt-4">
-              <SubscriptionList
-                :subscriptions="subscriptions"
-              />
-            </KCard>
-          </div>
-        </template>
+          <KCard class="mt-4">
+            <SubscriptionList
+              :subscriptions="props.data.zoneEgressInsight.subscriptions"
+            />
+          </KCard>
+        </div>
       </div>
     </AppView>
   </RouteView>

--- a/src/app/zone-ingresses/data/index.spec.ts
+++ b/src/app/zone-ingresses/data/index.spec.ts
@@ -4,6 +4,14 @@ import { ZoneIngressOverview } from './'
 import { plugin, server } from '@/test-support/data'
 import mock from '@/test-support/mocks/src/zone-ingresses/_/_overview'
 
+// zoneIngress tests are very similar to zoneEgress tests
+// so anything you amend here you should consider also amending in
+// the zoneEgress tests
+//
+// Extra things here that DO NOT exist on zoneEgress:
+// - advertisedSocketAddress
+// - availableServices
+
 describe('ZoneIngressOverview', () => {
   const test = _test.extend(plugin<typeof ZoneIngressOverview>(
     ZoneIngressOverview,
@@ -22,7 +30,7 @@ describe('ZoneIngressOverview', () => {
           delete item.zoneIngressInsight
           return item
         })
-        expect(actual.zoneIngressInsight).toBeUndefined()
+        expect(actual.zoneIngressInsight).toBeDefined()
       },
     )
 
@@ -36,8 +44,8 @@ describe('ZoneIngressOverview', () => {
           return item
         })
         expect(actual.zoneIngressInsight).toBeDefined()
-        expect(actual.zoneIngressInsight?.subscriptions.length).toStrictEqual(0)
-        expect(actual.zoneIngressInsight?.connectedSubscription).toBeUndefined()
+        expect(actual.zoneIngressInsight.subscriptions.length).toStrictEqual(0)
+        expect(actual.zoneIngressInsight.connectedSubscription).toBeUndefined()
       },
     )
 
@@ -58,8 +66,8 @@ describe('ZoneIngressOverview', () => {
           },
         })
         expect(actual.zoneIngressInsight).toBeDefined()
-        expect(actual.zoneIngressInsight?.subscriptions.length).toStrictEqual(10)
-        expect(actual.zoneIngressInsight?.connectedSubscription).toBeUndefined()
+        expect(actual.zoneIngressInsight.subscriptions.length).toStrictEqual(10)
+        expect(actual.zoneIngressInsight.connectedSubscription).toBeUndefined()
       },
     )
   })

--- a/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -54,22 +54,18 @@
           </div>
         </KCard>
 
-        <template
-          v-for="subscriptions in [props.data.zoneIngressInsight?.subscriptions ?? []]"
-          :key="subscriptions"
+        <div
+          v-if="props.data.zoneIngressInsight.subscriptions.length > 0"
+          data-testid="zone-ingress-subscriptions"
         >
-          <div
-            v-if="subscriptions.length > 0"
-          >
-            <h2>{{ t('zone-ingresses.routes.item.subscriptions.title') }}</h2>
+          <h2>{{ t('zone-ingresses.routes.item.subscriptions.title') }}</h2>
 
-            <KCard class="mt-4">
-              <SubscriptionList
-                :subscriptions="subscriptions"
-              />
-            </KCard>
-          </div>
-        </template>
+          <KCard class="mt-4">
+            <SubscriptionList
+              :subscriptions="props.data.zoneIngressInsight.subscriptions"
+            />
+          </KCard>
+        </div>
       </div>
     </AppView>
   </RouteView>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -544,6 +544,10 @@ export interface ZoneIngress extends MeshEntity {
   availableServices?: AvailableService[]
 }
 
+export interface ZoneIngressInsight {
+  subscriptions: DiscoverySubscription[]
+}
+
 export interface ZoneIngressOverview extends MeshEntity {
   type: 'ZoneIngressOverview'
   zoneIngress: {
@@ -551,7 +555,7 @@ export interface ZoneIngressOverview extends MeshEntity {
     networking?: ZoneIngressNetworking
     availableServices?: AvailableService[]
   }
-  zoneIngressInsight: any
+  zoneIngressInsight?: ZoneIngressInsight
 }
 
 export interface ZoneEgressNetworking {
@@ -563,6 +567,9 @@ export interface ZoneEgress extends MeshEntity {
   zone?: string
   networking?: ZoneEgressNetworking
 }
+export interface ZoneEgressInsight {
+  subscriptions: DiscoverySubscription[]
+}
 
 export interface ZoneEgressOverview extends MeshEntity {
   type: 'ZoneEgressOverview'
@@ -570,7 +577,7 @@ export interface ZoneEgressOverview extends MeshEntity {
     zone?: string
     networking?: ZoneEgressNetworking
   }
-  zoneEgressInsight: any
+  zoneEgressInsight?: ZoneEgressInsight
 }
 
 export interface DpCert {


### PR DESCRIPTION
ZoneIngresses and ZoneEgress have been a little behind what we did for the data layer in regards to `Subscriptions` as they were waiting on https://github.com/kumahq/kuma-gui/pull/1910.

This PR uses the work that was done to create `Subscriptions`, in doing this it ensures `subscriptions` are all the same throughout the application.

Note: I noticed that of the 4 `isSet` occurrences mentioned in https://github.com/kumahq/kuma-gui/pull/1918#issuecomment-1887197713, in reusing `Subscriptions` this PR was able to remove 2 of those, leaving just the one duplication.

Closes https://github.com/kumahq/kuma-gui/issues/1674