### PR TITLE
fix(dataplanes): avoids console.error when clicking a service

### DIFF
--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -126,11 +126,11 @@ const props = defineProps<{
 }>()
 const click = (e: MouseEvent) => {
   const $target = e.target as HTMLElement
-  if ($target.nodeName.toLowerCase() !== 'a') {
-    const $el = $target.closest('.service-traffic-card')
+  if (e.isTrusted && $target.nodeName.toLowerCase() !== 'a') {
+    const $el = $target.closest('.service-traffic-card, a')
     if ($el) {
-      const $a = $el.querySelector('a')
-      if ($a !== null) {
+      const $a = $el.nodeName.toLowerCase() === 'a' ? $el : $el.querySelector('a')
+      if ($a !== null && 'click' in $a && typeof $a.click === 'function') {
         $a.click()
       }
     }


### PR DESCRIPTION
Fixes an issue where clicking on the on a `<b>` tag within a `<a>` tag (which occurs in our TagList component) could produce an error in the javascript console.

Closes https://github.com/kumahq/kuma-gui/issues/2084