### PR TITLE
backport: fix(dataplanes): avoids console.error when clicking a service

### DIFF
--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -119,11 +119,11 @@ const props = defineProps<{
 }>()
 const click = (e: MouseEvent) => {
   const $target = e.target as HTMLElement
-  if ($target.nodeName.toLowerCase() !== 'a') {
-    const $el = $target.closest('.service-traffic-card')
+  if (e.isTrusted && $target.nodeName.toLowerCase() !== 'a') {
+    const $el = $target.closest('.service-traffic-card, a')
     if ($el) {
-      const $a = $el.querySelector('a')
-      if ($a !== null) {
+      const $a = $el.nodeName.toLowerCase() === 'a' ? $el : $el.querySelector('a')
+      if ($a !== null && 'click' in $a && typeof $a.click === 'function') {
         $a.click()
       }
     }


### PR DESCRIPTION
Backport of https://github.com/kumahq/kuma-gui/pull/2085 to the 2.6 release branch

---

Fixes an issue where clicking on the on a `<b>` tag within a `<a>` tag (which occurs in our TagList component) could produce an error in the javascript console.

