### PR TITLE
chore(policies): fix flaky list view test

### DIFF
--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -4,6 +4,7 @@ Feature: mesh / policies / index
       | Alias            | Selector                                  |
       | policy-type-list | [data-testid='policy-type-list']          |
       | items            | [data-testid='policy-collection']         |
+      | detail-view      | [data-testid='policy-detail-view']        |
       | items-header     | $items th                                 |
       | item             | $items tbody tr                           |
       | button-docs      | [data-testid='policy-documentation-link'] |
@@ -45,6 +46,7 @@ Feature: mesh / policies / index
     When I click the "$item:nth-child(1) [data-testid='details-link']" element
 
     Then the URL contains "circuit-breakers/fake-cb-1/overview"
+    And the "$detail-view" element contains "fake-cb-1"
 
     When I click the "$breadcrumbs > .k-breadcrumbs-item:nth-child(3) > a" element
 

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -52,7 +52,6 @@
                 :src="`/mesh-insights/${route.params.mesh}`"
               >
                 <PolicyList
-                  :key="route.params.policyPath"
                   :page-number="route.params.page"
                   :page-size="route.params.size"
                   :current-policy-type="policyTypesData.policies.find((policyType) => policyType.path === route.params.policyPath) ?? policyTypesData.policies[0]"


### PR DESCRIPTION
Add a content-based assertion in the middle of the "Clicking the link goes to the detail page and back again" so that the "navigate" + "assert URL" + "navigate" chain doesn’t trigger the missing route params error.

Remove the `key` attribute from `PolicyList`. It no longer seems needed to trigger a re-render when switching between policy types.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
