### PR TITLE
chore: fix flaky tests relying on incomplete subscription mock data

### DIFF
--- a/features/main-overview/DetailViewContent.feature
+++ b/features/main-overview/DetailViewContent.feature
@@ -105,6 +105,7 @@ Feature: Overview: Detail view content
       KUMA_ZONE_COUNT: 2
       KUMA_MESH_COUNT: 3
       KUMA_MODE: global
+      KUMA_SUBSCRIPTION_COUNT: 2
       """
     And the URL "/global-insight" responds with
       """

--- a/features/onboarding/dataplanes-overview/Index.feature
+++ b/features/onboarding/dataplanes-overview/Index.feature
@@ -21,6 +21,7 @@ Feature: onboarding / dataplanes-overview / index
     Given the environment
       """
       KUMA_DATAPLANE_COUNT: 1
+      KUMA_SUBSCRIPTION_COUNT: 1
       """
     And the URL "/dataplanes/_overview" responds with
       """

--- a/features/zones/zone-cps/egresses/Item.feature
+++ b/features/zones/zone-cps/egresses/Item.feature
@@ -9,6 +9,7 @@ Feature: zones / egresses / item
     And the environment
       """
       KUMA_MODE: global
+      KUMA_SUBSCRIPTION_COUNT: 2
       """
 
   Scenario: Detail view has expected content

--- a/features/zones/zone-cps/ingresses/item/Index.feature
+++ b/features/zones/zone-cps/ingresses/item/Index.feature
@@ -11,6 +11,7 @@ Feature: zones / ingresses / item
     And the environment
       """
       KUMA_MODE: global
+      KUMA_SUBSCRIPTION_COUNT: 2
       """
 
   Scenario: Clicking through the secondary navigation


### PR DESCRIPTION
Add explicit `KUMA_SUBSCRIPTION_COUNT` values to tests mocking `subscriptions` with _partial_ objects. If a mocked API has fewer subscriptions (determined by a faker-js dice roll) than what a test mocks out, we can run into errors like "Cannot read lastUpdateTime from undefined". That happens when the extra objects from the test have partial data (like not mocking out `status` in the case of the above error). I added more variables than necessary (as we usually create at least one subscription object and so tests only adding one don’t flake) so we’re on the safe side.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
