### PR TITLE
chore(datasource): Various DataSource component improvements

### DIFF
--- a/src/app/application/components/data-source/DataSource.vue
+++ b/src/app/application/components/data-source/DataSource.vue
@@ -5,22 +5,19 @@
     :refresh="refresh"
   />
 
-  <span class="visually-hidden" />
+  <span />
 </template>
 
 <script lang="ts" setup>
 import { watch, ref, onBeforeUnmount } from 'vue'
 
-import { useDataSourcePool } from '@/utilities'
+import { useDataSourcePool } from '@/app/application'
 
 const data = useDataSourcePool()
 
-const props = defineProps({
-  src: {
-    type: String,
-    required: true,
-  },
-})
+const props = defineProps<{
+  src: string
+}>()
 
 const message = ref<unknown>(undefined)
 const error = ref<Error | undefined>(undefined)
@@ -30,61 +27,95 @@ const emit = defineEmits<{
   (e: 'error', error: Error): void
 }>()
 
-type State = {
-  controller?: AbortController
-  src?: string
-}
-let state: State = {}
 const sym = Symbol('')
-const open = async (src: string) => {
-  message.value = undefined
-  state = close(state)
-  state.src = src
-  if (src === '') {
-    return
-  }
-  state.controller = new AbortController()
-  // this should emit proper events
-  const source = data.source(src, sym)
 
+type DataSource = ReturnType<typeof data.source>
+
+type Close = () => void;
+
+let source: DataSource | undefined
+let controller = new AbortController()
+let close: Close = () => {}
+
+const open = (src: string): Close => {
+  // abort anything previous and reset the AbortController
+  // if open if called imediately after a close.
+  // this could be the controllers second call if it was closed first
+  if (!controller.signal.aborted) {
+    controller.abort()
+  }
+  controller = new AbortController()
+  // if src is empty then we have no source and close does nothing
+  if (src === '') {
+    source = undefined
+    return () => {}
+  }
+
+  // get a possibly shared instance of a Source
+  source = data.source(src, sym)
+
+  // add events that will be aborted by the above controler
   source.addEventListener(
     'message',
     (e) => {
       message.value = (e as MessageEvent).data
       // if we got a message we are no longer erroneous
       error.value = undefined
-
+      // this should emit proper events
       emit('change', message.value)
     },
-    { signal: state.controller.signal },
+    { signal: controller.signal },
   )
-
   source.addEventListener(
     'error',
     (e) => {
       error.value = (e as ErrorEvent).error as Error
-
+      // this should emit proper events
       emit('error', error.value)
     },
-    { signal: state.controller.signal },
+    { signal: controller.signal },
   )
-}
-const close = (state: State) => {
-  if (typeof state.controller !== 'undefined') {
-    state.controller.abort()
+
+  // close
+  return () => {
+    // abort anything
+    controller.abort()
+    // clear out data
+    message.value = undefined
+    // unregister from a possibly shared instance of a Source (i.e. close)
+    data.close(src, sym)
   }
-  if (typeof state.src !== 'undefined') {
-    data.close(state.src, sym)
-  }
-  return {}
 }
-watch(() => props.src, function (src) {
-  open(src)
-}, { immediate: true })
-onBeforeUnmount(() => {
-  state = close(state)
-})
+// refresh doesn't need to 'hard close' the Source only reopen (i.e.
+// re-request) the shared instance if it has responded already if it is still
+// in transit this is essentially a noop
 const refresh = () => {
-  open(props.src)
+  close = open(props.src)
 }
+
+// a change of src="" performs a full 'hard close' and acquiring of a new Source
+// close is updated to close this new Source
+watch(() => props.src, function (src) {
+  close()
+  close = open(src)
+}, { immediate: true })
+
+// close everything
+onBeforeUnmount(() => {
+  close()
+})
 </script>
+<style lang="scss" scoped>
+// 'visually-hidden type' rule applied here so we are dependency free
+span {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+</style>

--- a/src/app/application/index.ts
+++ b/src/app/application/index.ts
@@ -137,6 +137,18 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         $.getDataSourceCacheKeyPrefix,
       ],
     }],
+    [token('application.datasource.data-uri'), {
+      service: () => {
+        return {
+          'data:application/json,:uri': async ({ uri }: { uri: string }) => {
+            return JSON.parse(uri)
+          },
+        }
+      },
+      labels: [
+        app.sources,
+      ],
+    }],
 
   ]
 }

--- a/src/app/application/services/data-source/Router.ts
+++ b/src/app/application/services/data-source/Router.ts
@@ -1,17 +1,26 @@
 import { URLPattern } from 'urlpattern-polyfill'
+const dataUriProtocol = 'data:'
 export default class Router<T> {
   routes: Map<URLPattern, T> = new Map()
   constructor(routes: Record<string, T>) {
     Object.entries(routes).forEach(([key, value]) => {
-      this.routes.set(new URLPattern({
-        pathname: key,
-      }), value)
+      const pattern = key.startsWith(dataUriProtocol)
+        ? new URLPattern({
+          protocol: dataUriProtocol,
+          pathname: key.substring(dataUriProtocol.length),
+
+        })
+        : new URLPattern({
+          protocol: '*',
+          pathname: key,
+        })
+      this.routes.set(pattern, value)
     })
   }
 
   match(path: string) {
     for (const [pattern, route] of this.routes) {
-      const _url = `data:${path}`
+      const _url = path.startsWith('data:') ? path : `source:${path}`
       if (pattern.test(_url)) {
         const args = pattern.exec(_url)
         return {

--- a/src/app/application/services/data-source/SharedPool.ts
+++ b/src/app/application/services/data-source/SharedPool.ts
@@ -4,9 +4,9 @@ type Entry<T> = {
   references: Set<symbol>
 }
 export default class SharedPool<K, T> {
-  protected pool: Map<K, Entry<T>> = new Map()
   constructor(
     protected transition: Transition<K, T>,
+    protected pool: Map<K, Entry<T>> = new Map(),
   ) {}
 
   // getter, not init

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,6 +1,6 @@
 import { TOKENS } from '@/services/tokens'
 import { createInjections } from '@/services/utils'
-export { useEnv, useI18n, useDataSourcePool } from '@/app/application'
+export { useEnv, useI18n } from '@/app/application'
 export { useRouter } from '@/app/vue'
 
 export const [

--- a/test-support/main.ts
+++ b/test-support/main.ts
@@ -7,7 +7,7 @@ import { beforeEach, afterEach, beforeAll } from 'vitest'
 import { services as testing } from './index'
 import { TOKENS as COMPONENT_TOKENS } from '../src/components'
 import { TOKENS as $, services as production } from '@/services/production'
-import { get, container, build, token } from '@/services/utils'
+import { get, container, build } from '@/services/utils'
 
 (async () => {
   build(
@@ -33,17 +33,3 @@ import { get, container, build, token } from '@/services/utils'
   beforeEach(() => container.capture?.())
   afterEach(() => container.restore?.())
 })()
-
-export const withSources = (sources: any) => {
-  build(
-    [
-      [token('sources'), {
-        service: sources,
-        arguments: [$.httpClient],
-        labels: [
-          $.sources,
-        ],
-      }],
-    ],
-  )
-}


### PR DESCRIPTION
1. Calling `refresh` will now no longer fire off a new request if there is already one in-flight (this is shared, so it could be the same URI but across different instances of a DataSource).
2. data URI support. Sometimes its handy to be able to get the characteristics of a DataSource by just passing it some JSON (via a data URI), i.e. for caching, sharing, tests or docs. Just to note this should mostly only be used for testing/docs purposes.

Part of https://github.com/kumahq/kuma-gui/issues/1474