### PR TITLE
chore: add DataLoader component

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -125,6 +125,7 @@ const INLINE_NON_VOID_ELEMENTS = [
             'I18nT',
             // Application
             'AppView',
+            'DataLoader',
             'DataSource',
             'DataCollection',
             'RouteView',

--- a/src/app/application/components/data-source/DataLoader.vue
+++ b/src/app/application/components/data-source/DataLoader.vue
@@ -1,0 +1,100 @@
+<template>
+  <DataSource
+    v-slot="{ refresh }"
+    :src="props.src"
+    @change="(data) => srcData = data"
+    @error="(e) => srcError = e"
+  >
+    <template
+      v-if="allData.length > 0 && allData.every(item => typeof item !== 'undefined')"
+    >
+      <!-- if the data is loaded and then we get an error -->
+      <!-- keep the old data visible but also show a disconnected slot -->
+      <template
+        v-if="allErrors.length > 0"
+      >
+        <slot
+          name="disconnected"
+          :data="props.src !== '' ? allData[0] : undefined"
+          :errors="props.src !== '' ? allErrors[0] : undefined"
+          :refresh="props.src !== '' ? refresh : () => {}"
+        >
+          <!-- KAlert -->
+        </slot>
+      </template>
+      <slot
+        name="default"
+        :data="props.src !== '' ? allData[0] : undefined"
+        :errors="props.src !== '' ? allErrors[0] : undefined"
+        :refresh="props.src !== '' ? refresh : () => {}"
+      />
+    </template>
+
+    <template
+      v-else-if="allErrors.length > 0"
+    >
+      <slot
+        name="error"
+        :data="props.src !== '' ? allData[0] : undefined"
+        :errors="props.src !== '' ? allErrors[0] : undefined"
+        :refresh="props.src !== '' ? refresh : () => {}"
+      >
+        <ErrorBlock
+          :error="allErrors[0]"
+        />
+      </slot>
+    </template>
+    <template v-else>
+      <slot
+        v-if="props.loader"
+        name="connecting"
+        :data="props.src !== '' ? allData[0] : undefined"
+        :errors="props.src !== '' ? allErrors[0] : undefined"
+        :refresh="props.src !== '' ? refresh : () => {}"
+      >
+        <LoadingBlock />
+      </slot>
+      <slot
+        v-else
+        name="default"
+        :data="props.src !== '' ? allData[0] : undefined"
+        :errors="props.src !== '' ? allErrors[0] : undefined"
+        :refresh="props.src !== '' ? refresh : () => {}"
+      />
+    </template>
+  </DataSource>
+</template>
+<script lang="ts" setup>
+import { computed, ref } from 'vue'
+
+import ErrorBlock from '@/app/common/ErrorBlock.vue'
+import LoadingBlock from '@/app/common/LoadingBlock.vue'
+
+const props = withDefaults(defineProps<{
+  data: any[]
+  errors: (Error | undefined)[]
+  src: string
+  loader?: boolean
+}>(), {
+  errors: () => [],
+  data: () => [],
+  src: '',
+  loader: true,
+})
+
+const srcData = ref<any>(undefined)
+const srcError = ref<Error | undefined>(undefined)
+
+const allData = computed(() => {
+  if (props.src !== '') {
+    return [srcData.value].concat(props.data)
+  }
+  return props.data
+})
+
+const allErrors = computed(() => {
+  const errors = typeof srcError.value === 'undefined' ? props.errors : ([srcError.value] as (Error | undefined)[]).concat(props.errors)
+  return errors.filter(<T, >(item: T): item is NonNullable<T> => Boolean(item))
+})
+
+</script>

--- a/src/app/application/index.ts
+++ b/src/app/application/index.ts
@@ -2,6 +2,7 @@ import { i18nTComponent } from '@kong-ui-public/i18n'
 
 import AppView from './components/app-view/AppView.vue'
 import DataCollection from './components/data-collection/DataCollection.vue'
+import DataLoader from './components/data-source/DataLoader.vue'
 import DataSource from './components/data-source/DataSource.vue'
 import RouteTitle from './components/route-view/RouteTitle.vue'
 import RouteView from './components/route-view/RouteView.vue'
@@ -68,6 +69,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       service: (i18n: ReturnType<typeof I18n>) => {
         return [
           ['AppView', AppView],
+          ['DataLoader', DataLoader],
           ['DataSource', DataSource],
           ['DataCollection', DataCollection],
           ['RouteView', RouteView],

--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -17,101 +17,92 @@
       </template>
 
       <div class="stack">
+        <!-- we load in policyTypes for everything so we can use `path` for links/URLs/API requests -->
+        <!-- we ask for the policyTypes here and always share the errors/data with all the DataLoaders below -->
         <DataSource
           v-slot="{ data: policyTypesData, error: policyTypesError }: PolicyTypeCollectionSource"
           :src="`/*/policy-types`"
         >
-          <DataSource
-            v-slot="{ data: rulesData, error }: DataplaneRulesSource"
+          <!-- always try and load and show the rules for everything dataplane type -->
+          <DataLoader
+            v-slot="{ data: rulesData }: DataplaneRulesSource"
             :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/rules`"
+            :data="[policyTypesData]"
+            :errors="[policyTypesError]"
           >
-            <ErrorBlock
-              v-if="policyTypesError"
-              :error="policyTypesError"
-            />
-
-            <ErrorBlock
-              v-else-if="error"
-              :error="error"
-            />
-
-            <LoadingBlock v-else-if="policyTypesData === undefined || rulesData === undefined" />
-
-            <EmptyBlock v-else-if="rulesData.rules.length === 0" />
-
-            <StandardDataplanePolicies
-              v-else
-              :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
-              :inspect-rules-for-dataplane="rulesData"
-              data-testid="rules-based-policies"
-            />
-          </DataSource>
-
-          <template v-if="!can('use zones')">
-            <DataSource
-              v-slot="{ data: sidecarDataplaneData, error }: SidecarDataplaneCollectionSource"
-              :src="props.data.dataplaneType !== 'builtin' ? `/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/sidecar-dataplane-policies` : ''"
+            <DataCollection
+              v-if="rulesData && policyTypesData"
+              :items="rulesData.rules"
             >
-              <DataSource
-                v-slot="{ data: gatewayDataplane, error: gatewayDataplaneError }: MeshGatewayDataplaneSource"
-                :src="props.data.dataplaneType === 'builtin' ? `/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/gateway-dataplane-policies` : ''"
-              >
-                <div>
-                  <h3>{{ t('data-planes.routes.item.legacy_policies') }}</h3>
+              <StandardDataplanePolicies
+                :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
+                :inspect-rules-for-dataplane="rulesData"
+                data-testid="rules-based-policies"
+              />
+            </DataCollection>
+          </DataLoader>
 
-                  <ErrorBlock
-                    v-if="policyTypesError"
-                    :error="policyTypesError"
-                  />
+          <!-- if we are in non-federated zone mode try and load/show legacy policies -->
+          <template v-if="!can('use zones')">
+            <div>
+              <h3>{{ t('data-planes.routes.item.legacy_policies') }}</h3>
 
-                  <ErrorBlock
-                    v-else-if="error"
-                    :error="error"
-                  />
-
-                  <ErrorBlock
-                    v-else-if="gatewayDataplaneError"
-                    :error="gatewayDataplaneError"
-                  />
-
-                  <LoadingBlock v-else-if="policyTypesData === undefined" />
-
-                  <template v-else-if="props.data.dataplaneType === 'builtin'">
-                    <LoadingBlock v-if="gatewayDataplane === undefined" />
-
-                    <EmptyBlock v-else-if="gatewayDataplane.routePolicies.length === 0 && gatewayDataplane.listenerEntries.length === 0" />
-
+              <!-- builtin gateways have different data/visuals than other types of dataplanes -->
+              <template v-if="props.data.dataplaneType === 'builtin'">
+                <DataLoader
+                  v-slot="{ data: gatewayDataplane }: MeshGatewayDataplaneSource"
+                  :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/gateway-dataplane-policies`"
+                  :data="[policyTypesData]"
+                  :errors="[policyTypesError]"
+                >
+                  <DataCollection
+                    v-if="gatewayDataplane"
+                    :items="gatewayDataplane.routePolicies"
+                  >
+                    <!-- we need to check routePolicies and listenerEntries for emptyness -->
+                    <EmptyBlock v-if="gatewayDataplane.listenerEntries.length === 0" />
                     <KCard
                       v-else
                       class="mt-4"
                     >
                       <BuiltinGatewayPolicies
+                        v-if="policyTypesData"
                         :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
                         :gateway-dataplane="gatewayDataplane"
                         data-testid="builtin-gateway-dataplane-policies"
                       />
                     </KCard>
-                  </template>
+                  </DataCollection>
+                </DataLoader>
+              </template>
 
-                  <template v-else>
-                    <LoadingBlock v-if="sidecarDataplaneData === undefined" />
-
-                    <EmptyBlock v-else-if="sidecarDataplaneData.policyTypeEntries.length === 0" />
-
+              <!-- anything but builtin gateways -->
+              <template v-else>
+                <DataLoader
+                  v-slot="{ data: sidecarDataplaneData}: SidecarDataplaneCollectionSource"
+                  :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/sidecar-dataplane-policies`"
+                  :data="[policyTypesData]"
+                  :errors="[policyTypesError]"
+                >
+                  <DataCollection
+                    v-if="sidecarDataplaneData"
+                    v-slot="{items: policyTypeEntries}"
+                    :items="sidecarDataplaneData.policyTypeEntries"
+                  >
                     <KCard
-                      v-else
                       class="mt-4"
                     >
                       <PolicyTypeEntryList
-                        :policy-type-entries="sidecarDataplaneData.policyTypeEntries"
+                        v-if="policyTypesData"
+                        :policy-type-entries="policyTypeEntries"
                         :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
                         data-testid="sidecar-dataplane-policies"
                       />
                     </KCard>
-                  </template>
-                </div>
-              </DataSource>
-            </DataSource>
+                  </DataCollection>
+                </DataLoader>
+              </template>
+            </div>
           </template>
         </DataSource>
       </div>
@@ -126,8 +117,6 @@ import StandardDataplanePolicies from '../components/StandardDataplanePolicies.v
 import type { DataplaneOverview } from '../data'
 import type { DataplaneRulesSource, MeshGatewayDataplaneSource, SidecarDataplaneCollectionSource } from '../sources'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import type { PolicyTypeCollectionSource } from '@/app/policies/sources'
 
 const props = defineProps<{

--- a/src/app/diagnostics/views/DiagnosticsDetailView.vue
+++ b/src/app/diagnostics/views/DiagnosticsDetailView.vue
@@ -1,9 +1,3 @@
-<script lang="ts" setup>
-import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import type { ControlPlaneConfigSource } from '@/app/control-planes/sources'
-</script>
 <template>
   <RouteView
     v-slot="{ route, t }"
@@ -14,38 +8,30 @@ import type { ControlPlaneConfigSource } from '@/app/control-planes/sources'
       codeRegExp: false,
     }"
   >
-    <DataSource
-      v-slot="{ data, error }: ControlPlaneConfigSource"
-      :src="`/config`"
-    >
-      <AppView
-        :breadcrumbs="[
-          {
-            to: {
-              name: 'diagnostics',
-            },
-            text: t('diagnostics.routes.item.breadcrumbs'),
+    <AppView
+      :breadcrumbs="[
+        {
+          to: {
+            name: 'diagnostics',
           },
-        ]"
-      >
-        <template #title>
-          <h1>
-            <RouteTitle
-              :title="t('diagnostics.routes.item.title')"
-            />
-          </h1>
-        </template>
-
-        <KCard>
-          <ErrorBlock
-            v-if="error"
-            :error="error"
+          text: t('diagnostics.routes.item.breadcrumbs'),
+        },
+      ]"
+    >
+      <template #title>
+        <h1>
+          <RouteTitle
+            :title="t('diagnostics.routes.item.title')"
           />
+        </h1>
+      </template>
 
-          <LoadingBlock v-else-if="data === undefined" />
-
+      <KCard>
+        <DataLoader
+          v-slot="{ data }: ControlPlaneConfigSource"
+          :src="`/config`"
+        >
           <CodeBlock
-            v-else
             data-testid="code-block-diagnostics"
             language="json"
             :code="JSON.stringify(data, null, 2)"
@@ -57,8 +43,12 @@ import type { ControlPlaneConfigSource } from '@/app/control-planes/sources'
             @filter-mode-change="route.update({ codeFilter: $event })"
             @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           />
-        </KCard>
-      </AppView>
-    </DataSource>
+        </DataLoader>
+      </KCard>
+    </AppView>
   </RouteView>
 </template>
+<script lang="ts" setup>
+import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
+import type { ControlPlaneConfigSource } from '@/app/control-planes/sources'
+</script>

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -13,28 +13,23 @@
         mesh: '',
       }"
     >
-      <DataSource
-        v-slot="{data, error}: MeshInsightCollectionSource"
-        :src="`/mesh-insights?page=${route.params.page}&size=${route.params.size}`"
-      >
-        <AppView>
-          <template #title>
-            <h1>
-              <RouteTitle
-                :title="t('meshes.routes.items.title')"
-              />
-            </h1>
-          </template>
+      <AppView>
+        <template #title>
+          <h1>
+            <RouteTitle
+              :title="t('meshes.routes.items.title')"
+            />
+          </h1>
+        </template>
 
-          <div class="stack">
-            <KCard>
-              <ErrorBlock
-                v-if="error !== undefined"
-                :error="error"
-              />
-
+        <div class="stack">
+          <KCard>
+            <DataLoader
+              v-slot="{ data, error }: MeshInsightCollectionSource"
+              :src="`/mesh-insights?page=${route.params.page}&size=${route.params.size}`"
+              :loader="false"
+            >
               <AppCollection
-                v-else
                 class="mesh-collection"
                 data-testid="mesh-collection"
                 :headers="[
@@ -100,34 +95,10 @@
                   </RouterLink>
                 </template>
               </AppCollection>
-            </KCard>
-
-            <RouterView
-              v-if="route.params.mesh"
-              v-slot="child"
-            >
-              <SummaryView
-                @close="route.replace({
-                  name: 'mesh-list-view',
-                  params: {
-                    mesh: route.params.mesh,
-                  },
-                  query: {
-                    page: route.params.page,
-                    size: route.params.size,
-                  },
-                })"
-              >
-                <component
-                  :is="child.Component"
-                  :name="route.params.mesh"
-                  :mesh-insight="data?.items.find((item) => item.name === route.params.mesh)"
-                />
-              </SummaryView>
-            </RouterView>
-          </div>
-        </AppView>
-      </DataSource>
+            </DataLoader>
+          </KCard>
+        </div>
+      </AppView>
     </RouteView>
   </DataSource>
 </template>
@@ -138,8 +109,6 @@ import { ArrowRightIcon } from '@kong/icons'
 
 import type { MeshInsightCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import SummaryView from '@/app/common/SummaryView.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
 


### PR DESCRIPTION
Adds a new `DataLoader` component, which is can be used as a bit of a "DataSource-with-loading-and-error-states" or a "DataSource-with-dependant-data-and-errors" or a mix of the two.

This is a little bit of a WIP in that I 'think' this is the API I want, I've purposefully used it in three areas to try it out and get a feel for it:

1. A simple 'item' view in Diagnostics, where I pretty much just want a DataSource with automatic loading and error states.
2. A listing that has a visual skeleton in our Mesh listing, where I pretty much just want a DataSource with just an error state (the loading state is contained in the visual we feed the data to)
3. A more complex UI (DataPlanePolicy view) where we load in several sets of data which are sometimes dependant on each other but sometimes not, here I want to load data without any blocking loading states and also load data with a blocking loading state, that also depends on the previous non-blocking data load (plus errors with the same dependency idea). I also use DataCollection here to help with Empty states seeing as we don't have `AppCollection` with its embedded Empty state.

---

You can use DataLoader in one of three ways:

1. Exactly like a DataSource. Give it a `src` and it will load the data, but unlike DataSource itself, it will block showing its child nodes until the data is loaded. If there is an error it will automatically show a default error state using our ErrorBlock.
2. Instead of giving it a `src` you can give it an array "dependant data/errors". DataLoader will block showing its child nodes until _all_ of the dependant data is loaded, or if _any_ of the errors is defined, then show the error state.
3. A mix of the above two, i.e. a `src` _and_ dependent data/errors. DataLoader will block showing its child nodes until _all_ of the dependant data _and_ the `src` is loaded, or if _any_ of the errors is defined (including the potential error from the `src`, then show the error state.

All of the above can also use a `loading="true/false"` which will control whether to show the child nodes when in a loading state or not (sometimes we have components that have their own loading state).

---

Separately I noticed that the more complex DataPlanePolicyView seemed a little simpler to follow using DataLoader as the majority of the loading/error/empty functionality happens elsewhere.

Related: https://github.com/kumahq/kuma-gui/issues/1474
