### PR TITLE
chore(zones): update zones/proxies to use connectedSubscription

### DIFF
--- a/src/app/zones/data/index.ts
+++ b/src/app/zones/data/index.ts
@@ -7,7 +7,6 @@ import type {
   KDSSubscription,
 } from '@/types/index.d'
 import { get } from '@/utilities/get'
-import { isSet } from '@/utilities/isSet'
 
 type KDSSubscriptionCollection = {
   config: Record<string, unknown>
@@ -46,7 +45,7 @@ const KDSSubscriptionCollection = {
     const config: Record<string, unknown> = (() => {
       // just find the first that has a config
       const withConfig = collection.subscriptions.find(item => typeof item.config !== 'undefined')
-      const str = isSet(withConfig?.config) ? withConfig.config : '{}'
+      const str = typeof withConfig?.config !== 'undefined' ? withConfig.config : '{}'
       try {
         return JSON.parse(str)
       } catch (e) {
@@ -83,7 +82,7 @@ export const ZoneOverview = {
       zoneInsight: insight,
       zone,
       // first check see if the zone is disabled, if not look for the connectedSubscription
-      state: !zone.enabled ? 'disabled' : typeof insight?.connectedSubscription !== 'undefined' ? 'online' : 'offline',
+      state: !zone.enabled ? 'disabled' : typeof insight.connectedSubscription !== 'undefined' ? 'online' : 'offline',
     }
   },
   fromCollection: (collection: CollectionResponse<PartialZoneOverview>): CollectionResponse<ZoneOverview> => {

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -286,7 +286,6 @@ import WarningIcon from '@/app/common/WarningIcon.vue'
 import type { MeSource } from '@/app/me/sources'
 import type { ZoneEgressOverview } from '@/app/zone-egresses/data'
 import type { ZoneIngressOverview } from '@/app/zone-ingresses/data'
-import type { DiscoverySubscription } from '@/types/index.d'
 import { useKumaApi } from '@/utilities'
 import { get } from '@/utilities/get'
 
@@ -300,18 +299,6 @@ type ZoneProxies<T> = Record<string, {online: T[], offline: T[]}>
 const ingresses = ref<ZoneProxies<ZoneIngressOverview>>({})
 const egresses = ref<ZoneProxies<ZoneEgressOverview>>({})
 
-const getState = (subscriptions: DiscoverySubscription[]) => {
-  let state: 'online' | 'offline' = 'offline'
-  if (subscriptions.length > 0) {
-    state = 'online'
-    const lastSubscription = subscriptions[subscriptions.length - 1]
-    if (typeof lastSubscription.disconnectTime !== 'undefined') {
-      state = 'offline'
-    }
-  }
-  return state
-}
-
 const getIngresses = (data: {items: ZoneIngressOverview[]}) => {
   const prop = 'zoneIngress'
   ingresses.value = data.items.reduce((prev, item) => {
@@ -323,8 +310,7 @@ const getIngresses = (data: {items: ZoneIngressOverview[]}) => {
           offline: [],
         }
       }
-      const subscriptions = item[`${prop}Insight`]?.subscriptions || []
-      const state = getState(subscriptions)
+      const state = typeof item[`${prop}Insight`].connectedSubscription !== 'undefined' ? 'online' : 'offline'
       prev[name][state].push(item)
     }
     return prev
@@ -341,8 +327,7 @@ const getEgresses = (data: {items: ZoneEgressOverview[]}) => {
           offline: [],
         }
       }
-      const subscriptions = item[`${prop}Insight`]?.subscriptions || []
-      const state = getState(subscriptions)
+      const state = typeof item[`${prop}Insight`].connectedSubscription !== 'undefined' ? 'online' : 'offline'
       prev[name][state].push(item)
     }
     return prev


### PR DESCRIPTION
Simplifies the 'knitting' of Zones and their Proxies by using connectedSubscription.

I think this is the last place where we had a subscription inspection without using our new `Subscription` data layer things. See https://github.com/kumahq/kuma-gui/issues/1890

---

Separately, I spent a lot of time trying to get typescript to understand `Object.groupBy` and/or a type safe polyfill for it, which would simplify this even more and use even less of our own code, but I kinda gave up trying. I can come back to that at a later date. edit: I didn't PR this branch straight away for reasons, and luckily I found out today `Object.groupBy` is coming to typescript in the next release in around a month or so, so I'll wait for that. I still have a branch or stash here with the native `Object.groupBy` usage, so I can PR that once the support comes with typescript.

Also, its important for me to make sure I note in relation to https://github.com/kumahq/kuma-gui/pull/1918#issuecomment-1910227683 that I've removed an instance of `isSet` usage whilst I was here. For the following reason: Unless I've missed something, `withConfig` here can never be `null` (its the result of `Array.find` which never returns `null`) so I don't see any point using `isSet` where we can just use straight/native JS instead i.e. this is the better refactor/fix.

There are other places where I think we no longer need `isSet`, but seeing as I was changing code here anyway, I only updated things here for the moment.
