### PR TITLE
chore(tests): remove some dead code from our unit test runner

### DIFF
--- a/test-support/main.ts
+++ b/test-support/main.ts
@@ -2,10 +2,9 @@
 // When running via vitest this file is added first using
 // vitest's `setupFiles` property, please see `/vite.config.production.ts`
 
-import { beforeEach, afterEach, beforeAll } from 'vitest'
+import { beforeEach, afterEach } from 'vitest'
 
 import { services as testing } from './index'
-import { TOKENS as COMPONENT_TOKENS } from '../src/components'
 import { TOKENS as $, services as production } from '@/services/production'
 import { get, container, build, token } from '@/services/utils'
 
@@ -16,20 +15,6 @@ import { get, container, build, token } from '@/services/utils'
   )
   // initializes vue-test-utils with any global components and/or plugins etc
   get($.app)
-
-  // unless we actually use COMPONENT_TOKENS it won't actually get executed
-  // probably due to tree shaking/rollup import ordering. This mixed with
-  // container capturing/restoring to make our tests isolated means that
-  // potentially we can capture an empty container before all the tokens are set,
-  // then set the TOKENS/fill the container during a test then the container can
-  // get restored to empty whilst we still have TOKENS with now non-existent
-  // services accessing TOKENS before we do anything means we set the TOKENS and
-  // fill the container with the default services i.e. before we capture if we
-  // ever make a test mocking utility to mock out components (similar to
-  // withVersion) will will then use COMPONENT_TOKENS here also, which means we
-  // can remove the following line
-  beforeAll(() => (_ = COMPONENT_TOKENS) => {})
-  //
   beforeEach(() => container.capture?.())
   afterEach(() => container.restore?.())
 })()


### PR DESCRIPTION
I spotted some more code that we could remove from our unit test runner, plus this code was a little weird when we needed to add it so I good thing to get rid of