### PR TITLE
chore: ensure defineSources returns the correct return types

### DIFF
--- a/src/app/application/services/data-source/index.ts
+++ b/src/app/application/services/data-source/index.ts
@@ -7,8 +7,14 @@ export type DataSourceResponse<T> = {
   error: Error | undefined
   refresh: () => void
 }
+type PaginationParams = {
+  size: number
+  page: number
+  search: string
+  cacheControl: string
+}
 
-type ExtractRouteParams<T extends string> =
+type ExtractRouteParams<T extends PropertyKey> =
   string extends T
     ? Record<string, string>
     : T extends `${infer _Start}:${infer Param}/${infer Rest}`
@@ -17,18 +23,11 @@ type ExtractRouteParams<T extends string> =
         ? { [k in Param]: string }
         : {};
 
-type PaginationParams = {
-  size: number
-  page: number
-  search: string
-  cacheControl: string
+export type ExtractSources<T extends Record<PropertyKey, unknown>> = {
+  [Route in keyof T]: (params: ExtractRouteParams<Route> & PaginationParams, source: { close: () => void }) => T[Route]
 }
 
-type ExtractSources<T extends string, K> = {
-  [Route in T]: (params: ExtractRouteParams<Route> & K, source: { close: () => void }) => unknown
-}
-
-export const defineSources = <T extends string>(sources: ExtractSources<T, PaginationParams>) => {
+export const defineSources = <T extends Record<PropertyKey, unknown>>(sources: ExtractSources<T>) => {
   return sources
 }
 


### PR DESCRIPTION
A little while back in https://github.com/kumahq/kuma-gui/pull/1525 we added automatic types to our sources

> `"/services/:name": (params) => { params.name }`

The thing I didn't realise at the time was we had lost the return type of the source.

This PR corrects that so now the sources have automatic types for their URI based parameters, plus the resulting return types are correct for each individual source. Now this is correct it means we can start looking at automatically passing these through to our DataSources so that the URIs auto-complete and the emitted data from the DataSources correctly corresponds to the URIs (see https://github.com/kumahq/kuma-gui/issues/1474)

---

I've not gone ahead and rolled this out as yet, but I'd like to after this PR has gone in in a separate PR. In the meantime you can look at `data-planes/sources.ts` which already uses `defineSources`.