### PR TITLE
fix(zones): ensure unset ZoneCreate i18n variable is set

### DIFF
--- a/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
+++ b/src/app/zones/components/ZoneCreateKubernetesInstructions.vue
@@ -155,16 +155,14 @@ const props = defineProps({
 const kubernetesCreateSecretCommand = computed(() => t('zones.form.kubernetes.secret.createSecretCommand', {
   token: props.base64EncodedToken,
 }).trim())
+
 const kubernetesConfig = computed(() => {
   const placeholders: Record<string, string> = {
     zoneName: props.zoneName,
     globalKdsAddress: props.globalKdsAddress,
     zoneIngressEnabled: String(props.zoneIngressEnabled),
     zoneEgressEnabled: String(props.zoneEgressEnabled),
-  }
-
-  if (typeof route.params.virtualControlPlaneId === 'string') {
-    placeholders.controlPlaneId = route.params.virtualControlPlaneId
+    controlPlaneId: typeof route.params.virtualControlPlaneId === 'string' ? route.params.virtualControlPlaneId : '',
   }
 
   return t('zones.form.kubernetes.connectZone.config', placeholders).trim()

--- a/src/app/zones/components/ZoneCreateUniversalInstructions.vue
+++ b/src/app/zones/components/ZoneCreateUniversalInstructions.vue
@@ -55,7 +55,6 @@ import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
 
 const { t } = useI18n()
 const route = useRoute()
-
 const props = defineProps({
   zoneName: {
     type: String,
@@ -78,10 +77,7 @@ const universalConfig = computed(() => {
   const placeholders: Record<string, string> = {
     zoneName: props.zoneName,
     globalKdsAddress: props.globalKdsAddress,
-  }
-
-  if (typeof route.params.virtualControlPlaneId === 'string') {
-    placeholders.controlPlaneId = route.params.virtualControlPlaneId
+    controlPlaneId: typeof route.params.virtualControlPlaneId === 'string' ? route.params.virtualControlPlaneId : '',
   }
 
   return t('zones.form.universal.connectZone.config', placeholders).trim()


### PR DESCRIPTION
Whilst this bug doesn't present here it does elsewhere, although even then in a place that doesn't matter.

It gave a me a bit of a fright and I took a while to confirm it was having any user facing effect. Even so I figured that even though it's not a user facing bug it would be best to fix it up.

---

Uses and inline/ternary conditional which makes it very difficult to leave a variable as unset/undefined by accident. I also considered some typescript here, but seeing as this parameter value shouldn't really be here, doing it this way will make it easier to rework at a later date whilst maintaining a similar degree of safety that the inline ternary offers.