### PR TITLE
fix: prevents a blinking upgrade alert

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
 VITE_ZONE_CREATION_FLOW=enabled
 # The following are templating placeholders for the index.html file. They’re going to be replaced using server-side templating when serving the GUI application in production.
 VITE_BASE_GUI_PATH=/gui
-VITE_KUMA_CONFIG='{"baseGuiPath":"/gui","apiUrl":"http://localhost:5681","version":"2.4.0","product":"Kuma","mode":"global","environment":"universal","storeType":"postgres","apiReadOnly":false}'
+VITE_KUMA_CONFIG='{"baseGuiPath":"/gui","apiUrl":"http://localhost:5681","version":"2.6.0","product":"Kuma","mode":"global","environment":"universal","storeType":"postgres","apiReadOnly":false}'

--- a/.env.preview
+++ b/.env.preview
@@ -1,4 +1,4 @@
 VITE_ZONE_CREATION_FLOW=enabled
 # The following are templating placeholders for the index.html file. They’re going to be replaced using server-side templating when serving the GUI application in production.
 VITE_BASE_GUI_PATH=/gui
-VITE_KUMA_CONFIG='{"baseGuiPath":"/gui","apiUrl":"http://localhost:5681","version":"2.4.0","product":"Kuma","mode":"global","environment":"universal","storeType":"postgres","apiReadOnly":false}'
+VITE_KUMA_CONFIG='{"baseGuiPath":"/gui","apiUrl":"http://localhost:5681","version":"2.6.0","product":"Kuma","mode":"global","environment":"universal","storeType":"postgres","apiReadOnly":false}'

--- a/cypress/support/step_definitions/visit.ts
+++ b/cypress/support/step_definitions/visit.ts
@@ -15,6 +15,9 @@ When('I visit the {string} URL', function (path: string) {
       const config = JSON.parse(node.textContent)
       cookies.forEach(item => {
         switch (item.name) {
+          case 'KUMA_VERSION':
+            config.version = item.value
+            break
           case 'KUMA_MODE':
             config.mode = item.value
             break

--- a/features/application/Upgrade.feature
+++ b/features/application/Upgrade.feature
@@ -3,7 +3,11 @@ Feature: application / upgrade
     Given the CSS selectors
       | Alias         | Selector                      |
       | upgrade-check | [data-testid='upgrade-check'] |
+    And the environment
+    """
+      KUMA_VERSION: 2.0.0
+    """
 
   Scenario: There is a new version available
-    When I load the "/" URL
+    When I visit the "/" URL
     And the "$upgrade-check" element exists

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuma-gui",
-  "version": "2.4.0",
+  "version": "2.6.0",
   "private": true,
   "description": "Kuma Manager",
   "author": "Kong",

--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -26,8 +26,9 @@
               v-slot="{ data }"
               :src="`/control-plane/version/latest`"
             >
+              <!-- make sure we have data but don't show errors or loaders -->
               <KAlert
-                v-if="env('KUMA_VERSION') !== data?.version"
+                v-if="data && env('KUMA_VERSION') !== data.version"
                 data-testid="upgrade-check"
                 appearance="info"
                 size="small"

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -110,7 +110,7 @@ export function getPathConfigDefault(apiUrlDefault: string = ''): PathConfig {
      * **Example**: `'http://localhost:5681'`
     */
     apiUrl: apiUrlDefault,
-    version: '2.4.0',
+    version: '2.6.0',
     product: 'Kuma',
     mode: 'global',
     environment: 'universal',

--- a/src/test-support/mocks/kuma.io/latest_version.ts
+++ b/src/test-support/mocks/kuma.io/latest_version.ts
@@ -1,7 +1,8 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
-export default (_deps: EndpointDependencies): MockResponder => (_req) => {
+export default ({ fake }: EndpointDependencies): MockResponder => (_req) => {
+  fake.kuma.seed('')
   return {
     headers: {},
-    body: '5.1.0',
+    body: fake.helpers.arrayElement(['2.1.0', '5.1.0']),
   }
 }

--- a/vite.config.preview.ts
+++ b/vite.config.preview.ts
@@ -57,7 +57,7 @@ export const config: (context: PreviewConfigContext) => UserConfigFn = ({
                   {
                     baseGuiPath: base,
                     apiUrl: api,
-                    version,
+                    version: cookies.KUMA_VERSION ?? version,
                     product: 'Kuma',
                     mode: cookies.KUMA_MODE ?? 'global',
                     environment: cookies.KUMA_ENVIRONMENT ?? 'universal',


### PR DESCRIPTION
The fix and the comment in the code probably explains this PR the best, please ask if its not clear tho.

I'll inline comment the fix as there is also the version bump in here.

Tangent: Ideally this version needs to be in one place (in the package.json file), so I should be moving to do that at some point soonish.