### PR TITLE
chore: various amends for gateway data-viz

### DIFF
--- a/src/app/application/components/data-collection/DataCollection.vue
+++ b/src/app/application/components/data-collection/DataCollection.vue
@@ -4,7 +4,7 @@
     name="empty"
     :items="items"
   >
-    <EmptyBlock />
+    <EmptyBlock v-if="props.empty" />
   </slot>
   <slot
     v-else
@@ -47,6 +47,7 @@ const props = withDefaults(defineProps<{
   predicate?: (item: T) => boolean
   comparator?: ((item: T) => number) | undefined
   find?: boolean
+  empty?: boolean
 }>(), {
   // type: '',
   paginationType: 'server',
@@ -55,6 +56,7 @@ const props = withDefaults(defineProps<{
   predicate: () => true,
   comparator: undefined,
   find: false,
+  empty: true,
 })
 const emit = defineEmits<{
   (e: 'change', value: {page: number, pageSize: number}): void

--- a/src/app/data-planes/components/DataPlaneSummary.vue
+++ b/src/app/data-planes/components/DataPlaneSummary.vue
@@ -9,12 +9,14 @@
         <template #body>
           <div class="status-with-reason">
             <StatusBadge :status="props.dataplaneOverview.status" />
-            <template
-              v-for="inbounds in [props.dataplaneOverview.dataplane.networking.inbounds.filter(item => !item.health.ready)]"
-              :key="inbounds"
+            <DataCollection
+              v-if="props.dataplaneOverview.dataplane.networking.type === 'standard'"
+              v-slot="{ items : inbounds }"
+              :items="props.dataplaneOverview.dataplane.networking.inbounds"
+              :predicate="item => !item.health.ready"
+              :empty="false"
             >
               <KTooltip
-                v-if="inbounds.length > 0"
                 class="reason-tooltip"
                 position-fixed
               >
@@ -34,7 +36,7 @@
                   </ul>
                 </template>
               </KTooltip>
-            </template>
+            </DataCollection>
           </div>
         </template>
       </DefinitionCard>
@@ -81,13 +83,17 @@
       </div>
     </div>
 
-    <div v-if="props.dataplaneOverview.dataplane.networking.inbounds.length > 0">
-      <h3>{{ t('data-planes.routes.item.inbounds') }}</h3>
+    <DataCollection
+      v-if="props.dataplaneOverview.dataplane.networking.type === 'standard'"
+      v-slot="{ items : inbounds }"
+      :items="props.dataplaneOverview.dataplane.networking.inbounds"
+    >
+      <div>
+        <h3>{{ t('data-planes.routes.item.inbounds') }}</h3>
 
-      <div class="mt-4">
-        <div class="stack">
+        <div class="mt-4 stack">
           <div
-            v-for="(inbound, index) in props.dataplaneOverview.dataplane.networking.inbounds"
+            v-for="(inbound, index) in inbounds"
             :key="index"
             class="inbound"
           >
@@ -146,7 +152,7 @@
           </div>
         </div>
       </div>
-    </div>
+    </DataCollection>
   </div>
 </template>
 

--- a/src/app/data-planes/data/stats.ts
+++ b/src/app/data-planes/data/stats.ts
@@ -68,7 +68,11 @@ export const getTraffic = (json: EnvoyStats, filter: (key: string) => boolean): 
         traffic[key] = {
           name: key,
           port: key.split('_').at(-1) ?? '',
-          protocol: item,
+          // TODO(jc): Not totally sure how we are going to get the protocol
+          // from the outbounds for gateways (these only have `cluster.`) so
+          // lets set it to `tcp` for now so as to now show `Cluster` as the
+          // protocol
+          protocol: item === 'cluster' ? 'tcp' : item,
         }
       }
       // we only look at cluster to find the grpc stats


### PR DESCRIPTION
Various amends for the Dataplane Gateway Viz

- Adds an `inboundName` and `inbound[].name` properties at the data layer level (see https://github.com/kumahq/kuma-gui/pull/2082#discussion_r1466188690)
- Fills in a single inbound for built-in gateways based on inferring the data from the tags of the gateway, again in the data layer. This is only temporary, gateways can have multiple inbounds.
- Using the above, removes the duplication/fork in `DataPlaneDetailView` for showing the Traffic components. This also has the benefit that all the empty/loading/error states work the same as the view when we are viewing a sidecar/standard dataplane.
- Replaces the hardcoded `HTTP` protocol for the current single gateway inbound with the correct protocol from the stats endpoint.
- Replaces instances of a `Cluster` 'protocol' with `tcp` for gateway outbounds. Whilst this is hardcoded to `tcp` for gateway outbounds only, I figure its better than showing `Cluster` for a protocol. Figuring out the protocol for gateway outbounds is going to be a little more involved using the `listeners` property of the `/stats` endpoint.
- I hid our filled out gateway inbounds from anywhere else we show inbounds for the moment at least, using DataCollection to do that in places, although I'm guessing that if a gateway has inbounds then we should also show them in other places (we currently don't)

All in all while we still don't show multiple inbounds if there are any, and the protocol for the outbounds could be wrong. I figured there was enough improvement here (no duplication, better states, no `Cluster` protocol etc) to PR something and continue with these issues.

~Lastly, filling out the tests here was a little unwieldy and makes it harder to add our own properties in the data layer. I did enough here to make the tests pass by adding all the new properties to all the dataplane tests, but I'm thinking my next PR could be replacing these tests with the approach we use in Zones which is easier to manage and test.~ This is no longer the case now https://github.com/kumahq/kuma-gui/pull/2154 has gone in an rebased