### PR TITLE
fix(policies): columns not always showing correctly

### DIFF
--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -147,3 +147,12 @@ Feature: mesh / policies / index
     And the "[data-testid='policy-type-link-MeshFaultInjection']" element exists
     # Always shows MeshGateway
     And the "[data-testid='policy-type-link-MeshGateway']" element exists
+
+  Scenario: Regression test: Zone column is visible when navigating from legacy policy type
+    When I visit the "/meshes/default/policies/circuit-breakers" URL
+
+    Then the "$items-header" element exists 2 times
+
+    When I click the "[data-testid='policy-type-link-MeshFaultInjection']" element
+
+    Then the "$items-header" element exists 4 times

--- a/src/app/policies/components/PolicyList.vue
+++ b/src/app/policies/components/PolicyList.vue
@@ -17,7 +17,7 @@
           :to="{
             name: 'policy-list-view',
             params: {
-              mesh: route.params.mesh,
+              mesh: props.mesh,
               policyPath: policyType.path,
             },
           }"
@@ -189,7 +189,6 @@
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { ArrowRightIcon } from '@kong/icons'
 import { computed } from 'vue'
-import { useRoute } from 'vue-router'
 
 import type { PolicyType } from '../data'
 import { PolicyCollection } from '../sources'
@@ -206,11 +205,11 @@ type ChangeValue = {
 }
 
 const { t } = useI18n()
-const route = useRoute()
 
 const props = withDefaults(defineProps<{
   pageNumber: number
   pageSize: number
+  mesh: string
   policyTypes: PolicyType[]
   currentPolicyType: PolicyType
   policyCollection: PolicyCollection | undefined

--- a/src/app/policies/components/PolicyList.vue
+++ b/src/app/policies/components/PolicyList.vue
@@ -86,6 +86,7 @@
 
           <AppCollection
             v-else
+            :key="currentPolicyType.path"
             class="policy-collection"
             data-testid="policy-collection"
             :empty-state-message="t('common.emptyState.message', { type: `${props.currentPolicyType.name} policies` })"

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -54,6 +54,7 @@
                 <PolicyList
                   :page-number="route.params.page"
                   :page-size="route.params.size"
+                  :mesh="route.params.mesh"
                   :current-policy-type="policyTypesData.policies.find((policyType) => policyType.path === route.params.policyPath) ?? policyTypesData.policies[0]"
                   :policy-types="policyTypesData.policies"
                   :mesh-insight="meshInsight"


### PR DESCRIPTION
fix(policies): add regression test for columns not always showing correctly

fix(policies): columns not always showing correctly

Trigger a re-render of AppCollection when the current policy type changes to make sure the table re-renders with the correct columns.

refactor(policies): move route access into list view

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
