### PR TITLE
chore: various amends for gateway data-viz pt2

### DIFF
--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -30,7 +30,7 @@
             <template
               v-for="(item, key) in [
                 (['http', 'tcp'] as const).reduce((prev, protocol) => {
-                  // FIXME: confirm this can change to upstream
+                  // TODO: confirm this can change to upstream
                   const direction = props.direction
                   // sum both the properties we need from both protocols
                   return Object.entries(props.traffic?.[protocol] || {}).reduce((prev, [key, value]) => {

--- a/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
+++ b/src/app/data-planes/components/data-plane-traffic/ServiceTrafficCard.vue
@@ -65,7 +65,7 @@
             </div>
           </template>
           <template
-            v-else-if="props.protocol === 'http'"
+            v-else-if="props.protocol.startsWith('http')"
           >
             <div
               v-for="value in [props.traffic.http?.[`${props.direction}_rq_1xx`] as (number | undefined) ?? 0].filter(item => item !== 0)"

--- a/src/app/data-planes/data/stats.spec.ts
+++ b/src/app/data-planes/data/stats.spec.ts
@@ -7,15 +7,21 @@ describe('stats.ts', () => {
     test('it works', () => {
       const expected = statsAsJSON()
       const actual = parse(`
+cluster.localhost_9090.grpc.0: 12
+cluster.localhost_9090.grpc.request_message_count: 12
+cluster.localhost_9090.grpc.response_message_count: 12
+cluster.localhost_9090.grpc.success: 12
+cluster.localhost_9090.grpc.total: 12
+listener.10.244.0.11_8081.http.edge-gateway.downstream_rq_1xx: 0
 http.service_with_underscores_8080.strings_with_quotes: "a82b5279-497d-43ad-a5d6-2913957629a5"
 http.service_with_underscores_8080.strings_without_quotes: a82b5279-497d-43ad-a5d6-2913957629a5
 http.service_with_underscores_8080.numbers: 0
 http.service_with_underscores_8080.strings_with_quotes: "a82b5279-497d-43ad-a5d6-2913957629a5"
 http.service_with_underscores_8080.strings_without_quotes: a82b5279-497d-43ad-a5d6-2913957629a5
 http.service_with_underscores_8080.numbers: 0
-tcp.service_with_underscores_8080.strings_with_quotes: "a82b5279-497d-43ad-a5d6-2913957629a5"
-tcp.service_with_underscores_8080.strings_without_quotes: a82b5279-497d-43ad-a5d6-2913957629a5
-tcp.service_with_underscores_8080.numbers: 0
+tcp.service_with_underscores_8081.strings_with_quotes: "a82b5279-497d-43ad-a5d6-2913957629a5"
+tcp.service_with_underscores_8081.strings_without_quotes: a82b5279-497d-43ad-a5d6-2913957629a5
+tcp.service_with_underscores_8081.numbers: 0
 http.admin.connections_accepted_per_socket_event: P0(nan,1) P25(nan,1.025) P50(nan,1.05) P75(nan,1.075) P90(nan,1.09) P95(nan,1.095) P99(nan,1.099) P99.5(nan,1.0995) P99.9(nan,1.0999) P100(nan,1.1)
 http.127.0.0.1.borken_due_to_ip: 0
 not_http_or_tcp_as_root.service_with_underscores_8080.numbers: 0
@@ -25,46 +31,72 @@ not_http_or_tcp_as_root.service_with_underscores_8080.numbers: 0
   })
   describe('getTraffic', () => {
     test('picks the right name depending on the filter', () => {
-      const actual = getTraffic(statsAsJSON(), (key: string) => key === 'admin')
+      const actual = getTraffic(statsAsJSON().cluster, (key: string) => key === 'admin')
       expect(actual.length).toEqual(1)
       expect(actual[0].http?.connections_accepted_per_socket_event).toEqual('P0(nan,1) P25(nan,1.025) P50(nan,1.05) P75(nan,1.075) P90(nan,1.09) P95(nan,1.095) P99(nan,1.099) P99.5(nan,1.0995) P99.9(nan,1.0999) P100(nan,1.1)')
     })
-    test('sets cluster, http and tcp', () => {
-      const actual = getTraffic(statsAsJSON(), (key: string) => key.startsWith('service_with_underscores_'))
-      expect(actual.length).toEqual(1);
-      (['http', 'tcp'] as const).forEach((item) => {
-        expect(actual[0][item]).toBeDefined()
-      })
+    test('sets connection http, tcp and grpc', () => {
+      let actual = getTraffic(statsAsJSON().cluster, (key: string) => key.startsWith('service_with_underscores_8080'))
+      expect(actual.length).toEqual(1)
+      expect(actual[0].http).toBeDefined()
+
+      actual = getTraffic(statsAsJSON().cluster, (key: string) => key.startsWith('service_with_underscores_8081'))
+      expect(actual.length).toEqual(1)
+      expect(actual[0].tcp).toBeDefined()
+
+      actual = getTraffic(statsAsJSON().cluster, (key: string) => key.startsWith('localhost_'))
+      expect(actual.length).toEqual(1)
+      expect(actual[0].grpc).toBeDefined()
     })
   })
 })
 
 function statsAsJSON() {
   return {
-    http: {
-      service_with_underscores_8080: {
-        strings_with_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
-        strings_without_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
-        numbers: 0,
-      },
-      127: {
-        0: {
+    cluster: {
+      http: {
+        service_with_underscores_8080: {
+          strings_with_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
+          strings_without_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
+          numbers: 0,
+        },
+        127: {
           0: {
-            1: {
-              borken_due_to_ip: 0,
+            0: {
+              1: {
+                borken_due_to_ip: 0,
+              },
             },
           },
         },
+        admin: {
+          connections_accepted_per_socket_event: 'P0(nan,1) P25(nan,1.025) P50(nan,1.05) P75(nan,1.075) P90(nan,1.09) P95(nan,1.095) P99(nan,1.099) P99.5(nan,1.0995) P99.9(nan,1.0999) P100(nan,1.1)',
+        },
       },
-      admin: {
-        connections_accepted_per_socket_event: 'P0(nan,1) P25(nan,1.025) P50(nan,1.05) P75(nan,1.075) P90(nan,1.09) P95(nan,1.095) P99(nan,1.099) P99.5(nan,1.0995) P99.9(nan,1.0999) P100(nan,1.1)',
+      tcp: {
+        service_with_underscores_8081: {
+          strings_with_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
+          strings_without_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
+          numbers: 0,
+        },
+      },
+      unknown: {
+        localhost_9090: {
+          grpc: {
+            0: 12,
+            request_message_count: 12,
+            response_message_count: 12,
+            success: 12,
+            total: 12,
+          },
+        },
       },
     },
-    tcp: {
-      service_with_underscores_8080: {
-        strings_with_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
-        strings_without_quotes: 'a82b5279-497d-43ad-a5d6-2913957629a5',
-        numbers: 0,
+    listener: {
+      http: {
+        'edge-gateway_8081': {
+          downstream_rq_1xx: 0,
+        },
       },
     },
   }

--- a/src/app/data-planes/data/stats.ts
+++ b/src/app/data-planes/data/stats.ts
@@ -1,27 +1,36 @@
 interface MetricRecord {
   [key: string]: MetricRecord | string | number
 }
-export type TrafficEntry = {
-  name: string
-  protocol: string
-  port: string
-  http?: MetricRecord
-  tcp?: MetricRecord
-  grpc?: MetricRecord
-}
+
+const protocols = ['http', 'tcp'] as const
+const appProtocols = ['http2', 'grpc', 'kafka'] as const
+
+type Protocols = Partial<Record<typeof protocols[number], MetricRecord>>
+type AppProtocols = Partial<Record<typeof appProtocols[number], MetricRecord>>
+
+type ConnectionStats = {
+  unknown?: MetricRecord
+} & Protocols
 
 type EnvoyStats = {
-  cluster?: Record<string, any>
-  http?: Record<string, any>
-  tcp?: Record<string, any>
+  cluster: ConnectionStats
+  listener: ConnectionStats
 }
+export type TrafficEntry = {
+  name: string
+  protocol: keyof (Protocols & AppProtocols)
+  port: string
+} & AppProtocols & Protocols
+
+// `_` followed by 1 to 5 digits followed by a `.`
+const trailingPortRe = /_\d{1,5}\./
 
 // just does the inital response to JSON parsing
 export const parse = (lines: string): EnvoyStats => {
   // for each line
-  return lines.trim().split('\n').filter((item) => {
-    // only use data prefixed with either cluster. http. or tcp.
-    return ['http.', 'tcp.', 'cluster.'].some(prop => item.startsWith(prop))
+  const json = lines.trim().split('\n').filter((item) => {
+    // only use data prefixed with any of the following
+    return ['http.', 'tcp.', 'cluster.', 'listener.'].some(prop => item.startsWith(prop))
   }).reduce((prev, item) => {
     // split the `key: values` on the `:` and normalize the value
     const [key, ...value] = item.trim().split(':')
@@ -33,8 +42,44 @@ export const parse = (lines: string): EnvoyStats => {
       }
     })(value.join(':').trim())
 
+    let _key = key
+
+    // if we are a `listener.` prefixed line we need to avoid ipv4 and ipv6
+    // addresses. This turns the line into something similar to the rest i.e.
+    // listener.10.244.0.11_8081.http.edge-gateway.downstream_rq_1xx to
+    // listener.http.edge-gateway_8081.downstream_rq_1xx
+    if (key.startsWith('listener.')) {
+      if (!['.http.', '.tcp.'].some(item => key.includes(item))) {
+        // if its not a http or tcp one, ignore for now
+        return prev
+      }
+
+      // get rid of listener.
+      let parts = key.split('.').slice(1)
+      // save the _key to search on later
+      _key = parts.join('.')
+
+      // get rid of the actual end key name so we don't get a false _1xx
+      parts.pop()
+
+      // search for a port in the whats left
+      const pos = parts.join('.').search(trailingPortRe)
+      if (pos === -1) {
+        // if we didn't find a port, ignore
+        return prev
+      }
+
+      // 10.244.0.11_8081.http.edge-gateway.downstream_rq_1xx
+      parts = _key.substring(pos + 1).split('.')
+
+      // 8081.http.edge-gateway.downstream_rq_1xx
+      const [port, protocol, service, name] = parts
+      parts = ['listener', protocol, service.search(trailingPortRe) !== -1 ? service : `${service}_${port}`, name]
+      // listener.http.edge-gateway_8081.downstream_rq_1xx
+      _key = parts.join('.')
+    }
     // walk the path creating `json.objects: value`
-    key.split('.').reduce((prev, item, i, arr) => {
+    _key.split('.').reduce((prev, item, i, arr) => {
       if (i === arr.length - 1) {
         // if this is the last segment in the path
         // then just set the value
@@ -54,39 +99,57 @@ export const parse = (lines: string): EnvoyStats => {
 
     return prev
   }, {} as MetricRecord)
+
+  const { http, tcp, listener = {}, cluster = {} } = json as Protocols & {
+    listener: ConnectionStats
+    cluster: ConnectionStats
+  }
+
+  const { ...unknown } = cluster
+  return {
+    cluster: {
+      http,
+      tcp,
+      unknown,
+    },
+    listener,
+  }
 }
 
 // lets you specify the things you are interested in
-export const getTraffic = (json: EnvoyStats, filter: (key: string) => boolean): TrafficEntry[] => {
-  const protocols = ['http', 'tcp', 'cluster'] as const
+export const getTraffic = (json: ConnectionStats, filter: (key: string) => boolean): TrafficEntry[] => {
+  const _protocols = [...protocols, 'unknown'] as const
   const traffic: Record<string, TrafficEntry> = {}
-  protocols.map((item) => {
+
+  _protocols.map((item) => {
     return Object.entries(json[item] || {}).filter(([key, _value]) => {
       return filter(key)
     }).forEach(([key, value]) => {
       if (typeof traffic[key] === 'undefined') {
         traffic[key] = {
           name: key,
+          // FIXME Cope with _8888-sdofjsdf-big-hash
+          // we only get these on outbounds at the moment (and we don't need the port for the outbound)
+          // so we can pretend this doesn't happen
           port: key.split('_').at(-1) ?? '',
-          // TODO(jc): Not totally sure how we are going to get the protocol
-          // from the outbounds for gateways (these only have `cluster.`) so
-          // lets set it to `tcp` for now so as to now show `Cluster` as the
-          // protocol
-          protocol: item === 'cluster' ? 'tcp' : item,
+          // FIXME we need to detect the protocol based on the existence of
+          // a http property in the stats, just not sure which one yet
+          protocol: item === 'unknown' ? 'http' : item,
+        }
+        traffic[key][traffic[key].protocol] = {
+          ...(traffic[key][traffic[key].protocol] || {}),
+          ...value as Record<string, any>,
         }
       }
-      // we only look at cluster to find the grpc stats
-      if (item === 'cluster') {
-        if (typeof value.grpc !== 'undefined') {
-          // move it from cluster.service-name.grpc.* to service-name.grpc.* if we find it
-          // the entry will already have a http protocol and a .http prop
-          // so change the protocol and add the grpc stats (additional to `.http` stats)
-          traffic[key].protocol = 'grpc'
-          traffic[key].grpc = value
-        }
-        return
+      if (item === 'unknown') {
+        const obj = value as Record<string, any>
+        appProtocols.forEach((protocol) => {
+          if (typeof obj[protocol] !== 'undefined') {
+            traffic[key].protocol = protocol
+            traffic[key][protocol] = obj[protocol]
+          }
+        })
       }
-      traffic[key][item] = value
     })
   })
   return Object.values(traffic)

--- a/src/app/data-planes/data/stats.ts
+++ b/src/app/data-planes/data/stats.ts
@@ -3,7 +3,7 @@ interface MetricRecord {
 }
 
 const protocols = ['http', 'tcp'] as const
-const appProtocols = ['http2', 'grpc', 'kafka'] as const
+const appProtocols = ['http2', 'grpc'] as const
 
 type Protocols = Partial<Record<typeof protocols[number], MetricRecord>>
 type AppProtocols = Partial<Record<typeof appProtocols[number], MetricRecord>>
@@ -128,11 +128,11 @@ export const getTraffic = (json: ConnectionStats, filter: (key: string) => boole
       if (typeof traffic[key] === 'undefined') {
         traffic[key] = {
           name: key,
-          // FIXME Cope with _8888-sdofjsdf-big-hash
+          // TODO Cope with _8888-sdofjsdf-big-hash
           // we only get these on outbounds at the moment (and we don't need the port for the outbound)
           // so we can pretend this doesn't happen
           port: key.split('_').at(-1) ?? '',
-          // FIXME we need to detect the protocol based on the existence of
+          // TODO we need to detect the protocol based on the existence of
           // a http property in the stats, just not sure which one yet
           protocol: item === 'unknown' ? 'http' : item,
         }

--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -81,13 +81,12 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
 
       // inbounds are anything starting with the `inbound` we've passed in
       // we use `~` to equal "there are no inbounds", but we might not need that
-      const inbounds = inbound !== '~' ? getTraffic(json, (key) => key.startsWith(inbound)) : []
-
+      const inbounds = inbound !== '~' ? getTraffic(inbound === 'localhost_' ? json.cluster : json.listener, (key) => key.startsWith(inbound)) : []
       // outbounds are anything else unless it starts with something in the
       // below list these are likely to follow a pattern at some point at which
       // point this list can be removed and replaced by something that exludes
       // the pattern
-      const outbounds = getTraffic(json, (key) => {
+      const outbounds = getTraffic(json.cluster, (key) => {
         return ![
           ...(inbound !== '~' ? [inbound] : []), // removes inbounds if we've asked for them
           '_', // most internal names will be prefixed by `_` the rest will become legacy internal names
@@ -95,17 +94,17 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
           'async-client',
           'kuma_envoy_admin',
           'probe_listener',
-          'inbound_passthrough',
-          'outbound_passthrough',
+          'inbound_passthrough_',
+          'outbound_passthrough_',
           'access_log_sink',
           'ads_cluster',
           'meshtrace_zipkin',
           'meshtrace_opentelemetry',
         ].some(item => key.startsWith(item))
       })
-
+      //
       // passthrough traffic is anything that starts with this list
-      const passthrough = getTraffic(json, (key) => [
+      const passthrough = getTraffic(json.cluster, (key) => [
         'outbound_passthrough_',
       ].some(item => key.startsWith(item))).reduce((entry, item) => {
         return {

--- a/src/app/data-planes/views/DataPlaneInboundSummaryStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneInboundSummaryStatsView.vue
@@ -33,38 +33,7 @@
           <CodeBlock
             v-else
             language="json"
-            :code="(() => {
-              if(props.gateway) {
-                const parts = route.params.service.split(':')
-                return data.raw.split('\n')
-                  .filter((item) => item.includes(`.${parts[0]}.`))
-                  .filter((item) => {
-                    return !item.startsWith('listener.') || item.includes(`_${parts[1]}.`)
-                  })
-                  .filter((item) => {
-                    return !item.includes('.rds.') || item.includes(`_${parts[1]}_*.`)
-                  })
-                  .map((item) => item.replace(`${parts[0]}.`, ''))
-                  .map((item) => item.replace(`_${parts[1]}.`, '.'))
-                  .map((item) => {
-                    if(item.includes('.rds.')) {
-                      const tmp = item.split('.')
-                      tmp.splice(2, 1)
-                      return tmp.join('.')
-                    } else {
-                      return item;
-                    }
-                  })
-                  .join('\n')
-
-              } else {
-                const name = `localhost_${route.params.service.split(':')[1]}`
-                return data.raw.split('\n')
-                  .filter((item) => item.includes(`.${name}.`))
-                  .map((item) => item.replace(`${name}.`, ''))
-                  .join('\n')
-              }
-            })()"
+            :code="findService(data, route.params.service)"
             is-searchable
             :query="route.params.codeSearch"
             :is-filter-mode="route.params.codeFilter"
@@ -101,4 +70,36 @@ const props = defineProps<{
   inbound?: DataplaneInbound
   gateway?: DataplaneGateway
 }>()
+
+const findService = (data: { raw: string }, service: string) => {
+  if (props.gateway) {
+    const parts = service.split(':')
+    return data.raw.split('\n')
+      .filter((item) => item.includes(`.${parts[0]}.`))
+      .filter((item) => {
+        return !item.startsWith('listener.') || item.includes(`_${parts[1]}.`)
+      })
+      .filter((item) => {
+        return !item.includes('.rds.') || item.includes(`_${parts[1]}_*.`)
+      })
+      .map((item) => item.replace(`${parts[0]}.`, ''))
+      .map((item) => item.replace(`_${parts[1]}.`, '.'))
+      .map((item) => {
+        if (item.includes('.rds.')) {
+          const tmp = item.split('.')
+          tmp.splice(2, 1)
+          return tmp.join('.')
+        } else {
+          return item
+        }
+      })
+      .join('\n')
+  } else {
+    const name = `localhost_${service.split(':')[1]}`
+    return data.raw.split('\n')
+      .filter((item) => item.includes(`.${name}.`))
+      .map((item) => item.replace(`${name}.`, ''))
+      .join('\n')
+  }
+}
 </script>

--- a/src/app/data-planes/views/DataPlaneInboundSummaryStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneInboundSummaryStatsView.vue
@@ -30,15 +30,41 @@
           />
 
           <LoadingBlock v-else-if="data === undefined" />
-
           <CodeBlock
             v-else
             language="json"
-            :code="(() => data.raw.split('\n')
-              .filter((item) => item.includes(`.${route.params.service}.`))
-              .map((item) => item.replace(`${route.params.service}.`, ''))
-              .join('\n')
-            )()"
+            :code="(() => {
+              if(props.gateway) {
+                const parts = route.params.service.split(':')
+                return data.raw.split('\n')
+                  .filter((item) => item.includes(`.${parts[0]}.`))
+                  .filter((item) => {
+                    return !item.startsWith('listener.') || item.includes(`_${parts[1]}.`)
+                  })
+                  .filter((item) => {
+                    return !item.includes('.rds.') || item.includes(`_${parts[1]}_*.`)
+                  })
+                  .map((item) => item.replace(`${parts[0]}.`, ''))
+                  .map((item) => item.replace(`_${parts[1]}.`, '.'))
+                  .map((item) => {
+                    if(item.includes('.rds.')) {
+                      const tmp = item.split('.')
+                      tmp.splice(2, 1)
+                      return tmp.join('.')
+                    } else {
+                      return item;
+                    }
+                  })
+                  .join('\n')
+
+              } else {
+                const name = `localhost_${route.params.service.split(':')[1]}`
+                return data.raw.split('\n')
+                  .filter((item) => item.includes(`.${name}.`))
+                  .map((item) => item.replace(`${name}.`, ''))
+                  .join('\n')
+              }
+            })()"
             is-searchable
             :query="route.params.codeSearch"
             :is-filter-mode="route.params.codeFilter"
@@ -66,8 +92,13 @@
 import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { RefreshIcon } from '@kong/icons'
 
+import type { DataplaneInbound, DataplaneGateway } from '../data'
 import { StatsSource } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
+const props = defineProps<{
+  inbound?: DataplaneInbound
+  gateway?: DataplaneGateway
+}>()
 </script>

--- a/src/app/data-planes/views/DataPlaneInboundSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneInboundSummaryView.vue
@@ -14,7 +14,7 @@
           </template>
 
           <template v-else>
-            Inbound :{{ route.params.service.replace('localhost_', '') }}
+            Inbound {{ route.params.service.replace('localhost_', '') }}
           </template>
         </h2>
       </template>
@@ -33,7 +33,7 @@
           v-else
           v-slot="{ items }"
           :items="props.inbounds"
-          :predicate="(item) => `localhost_${item.port}` === route.params.service"
+          :predicate="(item) => `${item.port}` === route.params.service.split(':')[1]"
           :find="true"
         >
           <component


### PR DESCRIPTION
Continuation of https://github.com/kumahq/kuma-gui/pull/2151

> All in all while we still don't show multiple inbounds if there are any, and the protocol for the outbounds could be wrong. I figured there was enough improvement here (no duplication, better states, no Cluster protocol etc) to PR something and continue with these issues.

So this is continuing mainly with multiple inbounds on gateways, but also showing non-zero values for the gateways outbounds.

---

Various fixes for the built-in gateway dataplane viz. I've tried to fix by continuing to normalize the way that we figure out stats/inbound/outbounds for both sidecars and gateways. I might add some inline comments 🤔 

- Supports multi inbounds to gateways in the dataplane viz
- Fixes showing any stats in the outbounds cards for gateway outbounds. It looks like the stats for gateway outbounds can only be found from `upstream` named stats, which I believe make sense as I 'think' its the direction of traffic from the gateway to each of the `outbounds`. But would be good to confirm with people. Either way, according to the stats traffic on anything `downstream` here is always zero.

~There's potentially a tiny bit more work I want to do here, so in draft while I decide. 🤔  I might just do it in a follow up seeing as its mostly cleanup/refactor seeing as this is user facing fixes I'm inclined to PR it as is and then follow up.~ I decided this see https://github.com/kumahq/kuma-gui/pull/2181#issuecomment-1943572869 

