### PR TITLE
refactor: update Kongponents to KSlideout/KTruncate milestone

### DIFF
--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -95,4 +95,4 @@ Feature: application / MainNavigation
 
   Scenario: Tertiary navigation
     When I visit the "/meshes/default/data-planes/dp-name/overview/inbound/driver:8080/stats" URL
-    And the "#data-plane-inbound-summary-stats-view-tab.active" element exists
+    And the "#connection-inbound-summary-stats-view-tab.active" element exists

--- a/features/mesh/dataplanes/DataplaneSummary.feature
+++ b/features/mesh/dataplanes/DataplaneSummary.feature
@@ -4,7 +4,7 @@ Feature: Dataplane summary
       | Alias                | Selector                                       |
       | item                 | [data-testid='data-plane-collection'] tbody tr |
       | summary              | [data-testid='summary']                        |
-      | close-summary-button | $summary [data-testid^='close-button-']        |
+      | close-summary-button | $summary [data-testid='slideout-close-icon']   |
     And the environment
       """
       KUMA_SUBSCRIPTION_COUNT: 2

--- a/features/mesh/policies/PolicySummary.feature
+++ b/features/mesh/policies/PolicySummary.feature
@@ -1,10 +1,10 @@
 Feature: Policy summary
   Background:
     Given the CSS selectors
-      | Alias                | Selector                                   |
-      | item                 | [data-testid='policy-collection'] tbody tr |
-      | summary              | [data-testid='summary']                    |
-      | close-summary-button | $summary [data-testid^='close-button-']    |
+      | Alias                | Selector                                     |
+      | item                 | [data-testid='policy-collection'] tbody tr   |
+      | summary              | [data-testid='summary']                      |
+      | close-summary-button | $summary [data-testid='slideout-close-icon'] |
     And the URL "/meshes/default/meshfaultinjections" responds with
       """
       body:

--- a/features/zones/zone-cps/egresses/ZoneEgressSummary.feature
+++ b/features/zones/zone-cps/egresses/ZoneEgressSummary.feature
@@ -4,7 +4,7 @@ Feature: Zone Egress summary
       | Alias                | Selector                                        |
       | item                 | [data-testid='zone-egress-collection'] tbody tr |
       | summary              | [data-testid='summary']                         |
-      | close-summary-button | $summary [data-testid^='close-button-']         |
+      | close-summary-button | $summary [data-testid='slideout-close-icon']    |
     And the URL "/zoneegresses/_overview" responds with
       """
       body:

--- a/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
+++ b/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
@@ -4,7 +4,7 @@ Feature: Zone Ingress summary
       | Alias                | Selector                                         |
       | item                 | [data-testid='zone-ingress-collection'] tbody tr |
       | summary              | [data-testid='summary']                          |
-      | close-summary-button | $summary [data-testid^='close-button-']          |
+      | close-summary-button | $summary [data-testid='slideout-close-icon']     |
     And the URL "/zone-ingresses/_overview" responds with
       """
       body:

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@kong-ui-public/i18n": "2.1.3",
     "@kong/icons": "1.8.14",
-    "@kong/kongponents": "9.0.0-alpha.105",
+    "@kong/kongponents": "9.0.0-alpha.107",
     "@vueuse/core": "10.8.0",
     "brandi": "5.0.0",
     "deepmerge": "4.3.1",

--- a/src/app/common/SummaryView.vue
+++ b/src/app/common/SummaryView.vue
@@ -2,10 +2,9 @@
   <KSlideout
     ref="slideOutRef"
     class="summary-slideout"
-    prevent-close-on-blur
-    close-button-alignment="end"
+    :close-on-blur="false"
     :has-overlay="false"
-    is-visible
+    visible
     :max-width="props.width"
     offset-top="var(--app-slideout-offset-top, 0)"
     data-testid="summary"
@@ -35,22 +34,41 @@ const props = withDefaults(defineProps<{
 }>(), {
   width: '560px',
 })
+
 const emit = defineEmits<{
   (event: 'close'): void
 }>()
 </script>
 
 <style lang="scss" scoped>
-:where(.summary-slideout) :deep(.app-view-title-bar) {
+.summary-slideout :deep(.slideout-header) {
+  position: absolute;
+  z-index: 200;
+  right: 0;
+  top: 20px;
+}
+
+.summary-slideout :deep(.app-view-title-bar) {
+  position: absolute;
+  z-index: 199;
+  top: 20px;
+  right: 20px;
+  left: 20px;
+  background-color: $kui-color-background;
+  margin-bottom: 0;
+  padding-bottom: $kui-space-50;
+  padding-right: $kui-space-90;
+  display: flex;
+  align-items: baseline;
+
+  + * {
+    margin-top: $kui-space-130;
+  }
+
   h1, h2 {
     --icon-before: url('@/assets/images/icon-wifi-tethering.svg');
-  }
-}
-.summary-slideout :deep(.app-view-title-bar) {
-  display: flex;
-  // Accounts for the absolutely-positioned close button
-  margin-right: calc($kui-space-30 + 24px);
-  h1, h2 {
+    margin-top: 0;
+
     &::before {
       color: $kui-color-text-neutral;
       mask-repeat: no-repeat;
@@ -67,31 +85,6 @@ const emit = defineEmits<{
       height: 16px;
       margin-right: $kui-space-30;
     }
-
   }
-}
-.summary-slideout :deep(.k-slideout-header-content) {
-  padding-right: $kui-space-80;
-  padding-left: $kui-space-80;
-}
-
-.summary-slideout :deep(.border-styles) {
-  // TODO: Remove this override once KSlideout was updated in Kongponents v9’s alpha version.
-  // Overrides the left border color to the same value KCard uses for its borders.
-  border-left-color: rgba(0, 0, 0, 0.1);
-}
-
-// Aligns the position of the close button with the summary slideout card’s content box.
-.summary-slideout :deep(.close-button-start),
-.summary-slideout :deep(.close-button-end) {
-  margin-top: $kui-space-80 !important;
-}
-
-.summary-slideout :deep(.close-button-start) {
-  margin-left: $kui-space-80 !important;
-}
-
-.summary-slideout :deep(.close-button-end) {
-  margin-right: $kui-space-80 !important;
 }
 </style>

--- a/src/app/common/TagList.vue
+++ b/src/app/common/TagList.vue
@@ -104,7 +104,7 @@ function getRoute(tag: LabelValue): RouteLocationNamedRaw | undefined {
 }
 
 .tag-list--align-right,
-.tag-list--align-right :deep(.k-truncate-container) {
+.tag-list--align-right :deep(.truncate-container) {
   justify-content: flex-end;
 }
 

--- a/src/app/policies/views/PolicySummaryView.vue
+++ b/src/app/policies/views/PolicySummaryView.vue
@@ -115,6 +115,6 @@ const props = withDefaults(defineProps<{
 </script>
 <style scoped>
 h2 {
-  --icon-before: url('@/assets/images/icon-circles-ext.svg?inline');
+  --icon-before: url('@/assets/images/icon-circles-ext.svg?inline') !important;
 }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
   resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.8.14.tgz#3219563df669b8bb3e260df12ac211a5072938e6"
   integrity sha512-nJUTtLpqelKCTY8lS8VByWaHYUq1CuB5cBUX/q2FEDu5o6IKH/B7fEDQpb/pB1lLRYTqZXneHR/lGYjxy4u8eQ==
 
-"@kong/kongponents@9.0.0-alpha.105":
-  version "9.0.0-alpha.105"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.105.tgz#446e13004e9199e1c821ad8ad356d50e6aa29217"
-  integrity sha512-ZCoA3RxtzHUAvBVcxmMvG7gF0nnlmj/pM+/ZvnVgOydfOIhgMPZ6Ou19XQa10gcGD+h90BhBJR4+TXAamkb/OQ==
+"@kong/kongponents@9.0.0-alpha.107":
+  version "9.0.0-alpha.107"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.107.tgz#fa90c7903d1b0a0a0bd4bea7cf752086f2f6b60b"
+  integrity sha512-467Gl4BV3WqsvDczuPir1LT2yTYo/C0AZLYh0izcCJqOGjtf8IUpW8E7d8McorLj0aGfh44+NHL6qLtVdMK3Iw==
   dependencies:
     "@kong/icons" "^1.8.14"
     "@popperjs/core" "^2.11.8"


### PR DESCRIPTION
This milestone adds a `title` slot to `KSlideout` which we should be making use of. This caused a bit more refactoring work of how we currently handle summary trays.

---

**chore(KTruncate): address breaking changes**

Rename `.k-truncate-container` to `.truncate-container`.

**chore(KSlideout): address breaking changes**

Replace `isVisible` with `visible` prop.

Replace `preventCloseOnBlur` with `:closeOnBlur="false"`.

Update custom styles to address changes in markup and layout.

**refactor(SummaryView): use KSlideout title slot**

Delete unused summary code in the mesh and zone list views.

Move the use of SummaryView from the parent views into the concrete *SummaryView components. The primary reason for this change is that this allows us to use the `title` slot of KSlideout. Not using it isn’t great because it would make for inconsistent use of KSlideout across applications, but it’s also proving more challenging to provide custom styles that re-implement the same mechanics and looks of the slideout title.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

---

Previous Kongponents v9 adoption PRs:

- https://github.com/kumahq/kuma-gui/pull/1532
- https://github.com/kumahq/kuma-gui/pull/1853
- https://github.com/kumahq/kuma-gui/pull/1878
- https://github.com/kumahq/kuma-gui/pull/1961
- https://github.com/kumahq/kuma-gui/pull/2118
- https://github.com/kumahq/kuma-gui/pull/2156