### PR TITLE
chore: enable KUMA_GATEWAYS_UI feature flag

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,8 @@ VITE_NAMESPACE=Kuma
 VITE_KUMA_API_SERVER_URL=http://localhost:5681
 VITE_KUMA_DP_SERVER_URL=https://localhost:5678
 VITE_DOCS_BASE_URL=https://kuma.io/docs
+# TODO: Remove this when unflagging KUMA_GATEWAYS_UI.
+VITE_GATEWAYS_UI=true
 # The following are templating placeholders for the index.html file. They’re going to be replaced using server-side templating when serving the GUI application in production.
 VITE_BASE_GUI_PATH='{{.BaseGuiPath}}'
 VITE_KUMA_CONFIG='{{.}}'

--- a/features/mesh/builtin-gateways/Index.feature
+++ b/features/mesh/builtin-gateways/Index.feature
@@ -1,6 +1,3 @@
-# TODO: Enable this test suite when unflagging the KUMA_GATEWAYS_UI feature.
-# Unskip to run the test.
-@skip
 Feature: mesh / builtin-gateways / index
   Background:
     Given the CSS selectors
@@ -8,10 +5,8 @@ Feature: mesh / builtin-gateways / index
       | items        | [data-testid='builtin-gateway-collection'] |
       | items-header | $items th                                  |
       | item         | $items tbody tr                            |
-    # TODO: Remove KUMA_GATEWAYS_UI when unflagging the KUMA_GATEWAYS_UI feature.
     And the environment
       """
-      KUMA_GATEWAYS_UI: true
       KUMA_MESHGATEWAY_COUNT: 1
       """
     And the URL "/meshes/default/meshgateways" responds with

--- a/features/mesh/builtin-gateways/Item.feature
+++ b/features/mesh/builtin-gateways/Item.feature
@@ -1,6 +1,3 @@
-# TODO: Enable this test suite when unflagging the KUMA_GATEWAYS_UI feature.
-# Unskip to run the test.
-@skip
 Feature: mesh / builtin-gateways / item
   Background:
     Given the CSS selectors
@@ -10,11 +7,6 @@ Feature: mesh / builtin-gateways / item
       | filter-input       | [data-testid='dataplane-search-input']           |
       | affected-dpps      | [data-testid='affected-data-plane-proxies']      |
       | affected-dpps-item | [data-testid='dataplane-name']                   |
-    # TODO: Remove KUMA_GATEWAYS_UI when unflagging the KUMA_GATEWAYS_UI feature.
-    Given the environment
-      """
-      KUMA_GATEWAYS_UI: true
-      """
     Given the URL "/meshes/default/meshgateways/gateway-1" responds with
       """
       body:

--- a/features/mesh/delegated-gateways/Index.feature
+++ b/features/mesh/delegated-gateways/Index.feature
@@ -1,6 +1,3 @@
-# TODO: Enable this test suite when unflagging the KUMA_GATEWAYS_UI feature.
-# Unskip to run the test.
-@skip
 Feature: mesh / delegated-gateways / index
   Background:
     Given the CSS selectors
@@ -8,10 +5,8 @@ Feature: mesh / delegated-gateways / index
       | items        | [data-testid='delegated-gateway-collection'] |
       | items-header | $items th                                    |
       | item         | $items tbody tr                              |
-    # TODO: Remove KUMA_GATEWAYS_UI when unflagging the KUMA_GATEWAYS_UI feature.
     And the environment
       """
-      KUMA_GATEWAYS_UI: true
       KUMA_SERVICE_COUNT: 1
       """
     And the URL "/meshes/default/service-insights" responds with
@@ -19,15 +14,25 @@ Feature: mesh / delegated-gateways / index
       body:
         items:
           - name: gateway-1
+            serviceType: gateway_delegated
+            status: partially_degraded
+            addressPort: 1.2.3.4:8000
+            dataplanes:
+              total: 2
+              online: 1
+              offline: 1
       """
 
   Scenario: The items have the correct columns
     When I visit the "/meshes/default/gateways/delegated" URL
 
-    Then the "$items-header" element exists 2 times
+    Then the "$items-header" element exists 5 times
     Then the "$items-header" elements contain
-      | Value |
-      | Name  |
+      | Value                       |
+      | Name                        |
+      | Address                     |
+      | DP proxies (online / total) |
+      | Status                      |
 
   Scenario: The items have the expected content and UI elements
     When I visit the "/meshes/default/gateways/delegated" URL
@@ -35,8 +40,11 @@ Feature: mesh / delegated-gateways / index
     Then the "#gateway-list-tabs-view-tab.active" element exists
     Then the "$item" element exists 1 times
     Then the "$item:nth-child(1)" element contains
-      | Value     |
-      | gateway-1 |
+      | Value              |
+      | gateway-1          |
+      | 1.2.3.4:8000       |
+      | 1 / 2              |
+      | partially degraded |
 
   Scenario: Clicking View details goes to the detail page and back again
     When I visit the "/meshes/default/gateways/delegated" URL

--- a/features/mesh/delegated-gateways/Item.feature
+++ b/features/mesh/delegated-gateways/Item.feature
@@ -1,21 +1,28 @@
-# TODO: Enable this test suite when unflagging the KUMA_GATEWAYS_UI feature.
-# Unskip to run the test.
-@skip
 Feature: mesh / delegated-gateways / item
   Background:
     Given the CSS selectors
-      | Alias     | Selector                                           |
-      | tabs-view | [data-testid='delegated-gateway-detail-tabs-view'] |
-    # TODO: Remove KUMA_GATEWAYS_UI when unflagging the KUMA_GATEWAYS_UI feature.
-    Given the environment
+      | Alias       | Selector                                           |
+      | tabs-view   | [data-testid='delegated-gateway-detail-tabs-view'] |
+      | detail-view | [data-testid='delegated-gateway-detail-view']      |
+    Given the URL "/meshes/default/service-insights/service-1" responds with
       """
-      KUMA_GATEWAYS_UI: true
-      """
-    Given the URL "/meshes/default/service-insights/service-1-gateway_delegated" responds with
-      """
+      body:
+        name: gateway-1
+        serviceType: gateway_delegated
+        status: partially_degraded
+        addressPort: 1.2.3.4:8000
+        dataplanes:
+          total: 2
+          online: 1
+          offline: 1
       """
 
   Scenario: Overview tab has expected content
-    When I visit the "/meshes/default/gateways/delegated/service-1-gateway_delegated/overview" URL
+    When I visit the "/meshes/default/gateways/delegated/service-1/overview" URL
 
     Then the "$tabs-view" element contains "service-1"
+    Then the "$detail-view" elements contain
+      | Value              |
+      | 1.2.3.4:8000       |
+      | 1 / 2              |
+      | partially degraded |

--- a/features/mesh/external-services/Index.feature
+++ b/features/mesh/external-services/Index.feature
@@ -1,6 +1,3 @@
-# TODO: Enable this test suite when unflagging the KUMA_GATEWAYS_UI feature.
-# Unskip to run the test.
-@skip
 Feature: mesh / external-services / index
   Background:
     Given the CSS selectors
@@ -8,10 +5,8 @@ Feature: mesh / external-services / index
       | items        | [data-testid='external-service-collection'] |
       | items-header | $items th                                   |
       | item         | $items tbody tr                             |
-    # TODO: Remove KUMA_GATEWAYS_UI when unflagging the KUMA_GATEWAYS_UI feature.
     Given the environment
       """
-      KUMA_GATEWAYS_UI: true
       KUMA_EXTERNALSERVICE_COUNT: 1
       """
     Given the URL "/meshes/default/external-services" responds with
@@ -33,7 +28,7 @@ Feature: mesh / external-services / index
   Scenario: The items have the expected content and UI elements
     When I visit the "/meshes/default/external-services" URL
 
-    Then the "#external-service-list-view-tab.active" element exists
+    Then the "#service-list-view-tab.active" element exists
     Then the "$item" element exists 1 times
     Then the "$item:nth-child(1)" element contains
       | Value     |

--- a/features/mesh/external-services/Item.feature
+++ b/features/mesh/external-services/Item.feature
@@ -1,6 +1,3 @@
-# TODO: Enable this test suite when unflagging the KUMA_GATEWAYS_UI feature.
-# Unskip to run the test.
-@skip
 Feature: mesh / external-services / item
   Background:
     Given the CSS selectors

--- a/features/mesh/services/Item.feature
+++ b/features/mesh/services/Item.feature
@@ -21,27 +21,9 @@ Feature: mesh / services / item
     Then the "$data-plane-proxies-tab" element exists
 
     Examples:
-      | ServiceType       |
-      | !!js/undefined    |
-      | internal          |
-      | gateway_builtin   |
-      | gateway_delegated |
-
-  # TODO: Remove this when removing external services from the Services tab.
-  Scenario Outline: Shows correct tabs for service type <ServiceType>
-    Given the URL "/meshes/default/service-insights/firewall-1" responds with
-      """
-        body:
-          serviceType: <ServiceType>
-      """
-
-    When I visit the "/meshes/default/services/firewall-1/overview" URL
-    Then the "$config-tab" element exists
-    Then the "$data-plane-proxies-tab" element doesn't exist
-
-    Examples:
-      | ServiceType |
-      | external    |
+      | ServiceType    |
+      | !!js/undefined |
+      | internal       |
 
   Rule: With an internal service
     Background:
@@ -149,43 +131,3 @@ Feature: mesh / services / item
       Then the "$item:nth-child(1) td:nth-child(1) a" element contains "fake-dataplane"
       And I click the "$item:nth-child(1) [data-testid='details-link']" element
       Then the URL contains "/meshes/default/data-planes/fake-dataplane/overview"
-
-    # TODO: Remove this when removing external services from the Services tab.
-    Scenario: Service with matching ExternalService doesn't show empty state
-      Given the environment
-        """
-        KUMA_EXTERNALSERVICE_COUNT: 1
-        """
-      And the URL "/meshes/default/service-insights/service-1" responds with
-        """
-          body:
-            serviceType: external
-        """
-      And the URL "/meshes/default/external-services" responds with
-        """
-          body:
-            items:
-              - name: external-service-1
-                tags:
-                  kuma.io/service: service-1
-        """
-
-      When I visit the "/meshes/default/services/service-1/overview" URL
-
-      Then the "[data-testid='no-matching-external-service']" element doesn't exist
-
-    # TODO: Remove this when removing external services from the Services tab.
-    Scenario: Service without matching ExternalService shows empty state
-      Given the environment
-        """
-        KUMA_EXTERNALSERVICE_COUNT: 0
-        """
-      And the URL "/meshes/default/service-insights/service-1" responds with
-        """
-          body:
-            serviceType: external
-        """
-
-      When I visit the "/meshes/default/services/service-1/overview" URL
-
-      Then the "[data-testid='no-matching-external-service']" element exists

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -28,6 +28,8 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
       KUMA_VERSION_URL: import.meta.env.VITE_VERSION_URL,
       KUMA_DOCS_URL: import.meta.env.VITE_DOCS_BASE_URL,
       KUMA_MOCK_API_ENABLED: import.meta.env.VITE_MOCK_API_ENABLED,
+      // TODO: Remove this when unflagging KUMA_GATEWAYS_UI.
+      KUMA_GATEWAYS_UI: import.meta.env.VITE_GATEWAYS_UI,
       KUMA_ZONE_CREATION_FLOW: import.meta.env.VITE_ZONE_CREATION_FLOW,
     } as EnvArgs,
   }],

--- a/src/shims-env.d.ts
+++ b/src/shims-env.d.ts
@@ -5,6 +5,8 @@ interface ImportMetaEnv {
   readonly VITE_KUMA_DP_SERVER_URL: string
   readonly VITE_DOCS_BASE_URL: string
   readonly VITE_UTM: string
+  // TODO: Remove this when unflagging KUMA_GATEWAYS_UI.
+  readonly VITE_GATEWAYS_UI?: string
   readonly VITE_ZONE_CREATION_FLOW?: 'disabled' | 'enabled'
 }
 


### PR DESCRIPTION
Enable the KUMA_GATEWAYS_UI in all environments by default.

Enable all tests relying on `KUMA_GATEWAYS_UI` being enabled and adjust existing tests.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
