### PR TITLE
fix(zones): error handling in creation flow polling

### DIFF
--- a/src/app/common/ErrorBlock.vue
+++ b/src/app/common/ErrorBlock.vue
@@ -7,8 +7,14 @@
       <template #title>
         <div class="error-block-header">
           <div class="error-block-title">
-            <WarningIcon
+            <DangerIcon
+              v-if="props.appearance === 'danger'"
+              :color="KUI_COLOR_TEXT_DANGER"
               display="inline-block"
+            />
+
+            <WarningIcon
+              v-else
               :size="KUI_ICON_SIZE_50"
             />
 
@@ -22,7 +28,7 @@
             class="badge-list"
           >
             <KBadge
-              :appearance="props.badgeAppearance"
+              :appearance="props.appearance"
               data-testid="error-status"
             >
               {{ error.status }}
@@ -78,9 +84,9 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_50 } from '@kong/design-tokens'
-import { type BadgeAppearance, KBadge, KEmptyState } from '@kong/kongponents'
-import { computed, PropType } from 'vue'
+import { KUI_COLOR_TEXT_DANGER, KUI_ICON_SIZE_50 } from '@kong/design-tokens'
+import { DangerIcon } from '@kong/icons'
+import { computed } from 'vue'
 
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import WarningIcon from '@/app/common/WarningIcon.vue'
@@ -89,17 +95,11 @@ import { useI18n } from '@/utilities'
 
 const { t } = useI18n()
 
-const props = defineProps({
-  error: {
-    type: Error,
-    required: true,
-  },
-
-  badgeAppearance: {
-    type: String as PropType<BadgeAppearance>,
-    required: false,
-    default: 'warning',
-  },
+const props = withDefaults(defineProps<{
+  error: Error
+  appearance?: 'warning' | 'danger'
+}>(), {
+  appearance: 'warning',
 })
 
 const invalidParameters = computed(() => props.error instanceof ApiError ? props.error.invalidParameters : [])
@@ -119,7 +119,7 @@ const invalidParameters = computed(() => props.error instanceof ApiError ? props
 
 .error-block-title {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: $kui-space-40;
   text-align: left;
 }

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -282,32 +282,28 @@
                   :src="`/zone-cps/online/${name}?no-cache=${now}`"
                   @change="success"
                 >
-                  <div
-                    v-if="!scanError"
-                    class="form-section__header"
-                  >
+                  <div class="form-section__header">
                     <h2 class="form-section-title">
                       {{ t('zones.form.section.scanner.title') }}
                     </h2>
+
                     <p>{{ t('zones.form.section.scanner.description') }}</p>
                   </div>
 
                   <div class="form-section__content">
-                    <KEmptyState cta-is-hidden>
+                    <ErrorBlock
+                      v-if="scanError"
+                      :error="scanError"
+                      appearance="danger"
+                      data-testid="error"
+                    />
+
+                    <KEmptyState
+                      v-else
+                      cta-is-hidden
+                    >
                       <template #title>
-                        <template
-                          v-if="scanError"
-                        >
-                          <DangerIcon
-                            data-testid="error"
-                            display="inline-block"
-                            :color="KUI_COLOR_TEXT_DANGER"
-                          />
-                          <h3>{{ t('zones.form.scan.errorTitle') }}</h3>
-                        </template>
-                        <template
-                          v-else-if="(typeof data === 'undefined')"
-                        >
+                        <template v-if="(typeof data === 'undefined')">
                           <ProgressIcon
                             data-testid="waiting"
                             display="inline-block"
@@ -327,14 +323,7 @@
                         </template>
                       </template>
                       <template #message>
-                        <template
-                          v-if="scanError"
-                        >
-                          <p>{{ t('zones.form.scan.errorDescription') }}</p>
-                        </template>
-                        <template
-                          v-else-if="(typeof data !== 'undefined')"
-                        >
+                        <template v-if="(typeof data !== 'undefined')">
                           <p>
                             {{ t('zones.form.scan.completeDescription', { name }) }}
                           </p>
@@ -386,13 +375,14 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_SUCCESS, KUI_ICON_SIZE_30, KUI_COLOR_TEXT_NEUTRAL_WEAK, KUI_COLOR_TEXT_DANGER } from '@kong/design-tokens'
-import { AddIcon, CheckIcon, ProgressIcon, DangerIcon, CheckCircleIcon } from '@kong/icons'
+import { KUI_COLOR_TEXT_SUCCESS, KUI_ICON_SIZE_30, KUI_COLOR_TEXT_NEUTRAL_WEAK } from '@kong/design-tokens'
+import { AddIcon, CheckIcon, ProgressIcon, CheckCircleIcon } from '@kong/icons'
 import { computed, ref } from 'vue'
 
 import ZoneCreateKubernetesInstructions from '../components/ZoneCreateKubernetesInstructions.vue'
 import ZoneCreateUniversalInstructions from '../components/ZoneCreateUniversalInstructions.vue'
 import { ZoneOverviewSource } from '../sources'
+import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import { ControlPlaneAddressesSource } from '@/app/control-planes/sources'
 import { ApiError } from '@/services/kuma-api/ApiError'
 import { useI18n, useKumaApi } from '@/utilities'

--- a/src/test-support/mocks/src/zones/_/_overview.ts
+++ b/src/test-support/mocks/src/zones/_/_overview.ts
@@ -2,6 +2,22 @@ import type { EndpointDependencies, MockResponder } from '@/test-support'
 export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
   const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
+
+  // To test the error handling of the zone creation flow’s polling mechanism
+  /* return {
+    headers: {
+      'Status-Code': '401',
+    },
+    body: {
+      type: '/std-errors',
+      status: 401,
+      title: 'Authorization error',
+      detail: '401 Unauthorized',
+      instance: '0123456789abcdefghijkl',
+      invalid_parameters: [],
+    },
+  } */
+
   return {
     headers: {
       'Status-Code': env('KUMA_STATUS_CODE', '200'),


### PR DESCRIPTION
Change the error handling of the Zone creation flow’s polling step to use our ErrorBlock component. This way, error details of any underlying API error will be surfaced in the UI.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>


![Screenshot from 2024-02-15 13-21-56](https://github.com/kumahq/kuma-gui/assets/5774638/4c88f3c6-3be5-4337-9e56-bd689402af5c)
