### PR TITLE
chore: exposes RouteView::route.children and use for GatewayTabs

### DIFF
--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -23,6 +23,10 @@
         replace: routeReplace,
         params: routeParams,
         back: routerBack,
+        children: children,
+        active: (active: RouteLocationNormalizedLoaded) => {
+          return children.find(item => item.name === active.name || (item.meta && item.meta.module === active.meta.module))
+        },
       }"
     />
   </div>
@@ -42,6 +46,7 @@ import {
   beforePaint,
 } from '../../utilities'
 import { useEnv } from '@/utilities'
+import type { RouteLocationNormalizedLoaded, RouteRecordRaw } from 'vue-router'
 export type RouteView = {
   addTitle: (item: string, sym: Symbol) => void
   removeTitle: (sym: Symbol) => void
@@ -59,6 +64,9 @@ const sym = Symbol('route-view')
 
 type Params = { [P in keyof T]: T[P] }
 type RouteReplaceParams = Parameters<typeof router['push']>
+type StringNamedRouteRecordRaw = RouteRecordRaw & {
+  name: string
+}
 
 const props = withDefaults(defineProps<{
   name: string
@@ -89,6 +97,10 @@ const setAttrs = createAttrsSetter(document.documentElement)
 const joinTitle = (titles: string[]) => {
   return titles.reverse().concat(t('components.route-view.title', { name: t('common.product.name') })).join(' | ')
 }
+const children: StringNamedRouteRecordRaw[] = (router.getRoutes().find((route) => route.name === name.value)?.children.map(item => {
+  item.name = String(item.name)
+  return item as StringNamedRouteRecordRaw
+}) ?? [])
 
 const routeView = {
   addTitle: (item: string, sym: Symbol) => {

--- a/src/app/gateways/locales/en-us/index.yaml
+++ b/src/app/gateways/locales/en-us/index.yaml
@@ -3,8 +3,8 @@ gateways:
     items:
       title: Gateways
       navigation:
-        builtin: Built-in
-        delegated: Delegated
+        builtin-gateway-list-view: Built-in
+        delegated-gateway-list-view: Delegated
 
 builtin-gateways:
   routes:

--- a/src/app/gateways/views/GatewayListTabsView.vue
+++ b/src/app/gateways/views/GatewayListTabsView.vue
@@ -11,56 +11,56 @@
         mesh: '',
       }"
     >
-      <AppView>
-        <template #title>
-          <h2>
-            <RouteTitle :title="t(`${currentRoute.name === 'builtin-gateway-list-view' ? 'builtin' : 'delegated'}-gateways.routes.items.title`)" />
-          </h2>
-        </template>
-
-        <template #actions>
-          <LinkBox>
-            <RouterLink
-              :class="{
-                'active': currentRoute.name === 'builtin-gateway-list-view',
-              }"
-              :to="{
-                name: 'builtin-gateway-list-view',
-                params: {
-                  mesh: route.params.mesh,
-                },
-              }"
+      <RouterView
+        v-slot="{ Component, route: active }"
+      >
+        <AppView>
+          <template #title>
+            <h2>
+              <RouteTitle
+                :title="t(`${active.name === 'builtin-gateway-list-view' ? 'builtin' : 'delegated'}-gateways.routes.items.title`)"
+              />
+            </h2>
+          </template>
+          <template #actions>
+            <DataCollection
+              v-slot="{ items }"
+              :items="route.children"
+              :empty="false"
             >
-              {{ t('gateways.routes.items.navigation.builtin') }}
-            </RouterLink>
-
-            <RouterLink
-              :class="{
-                'active': currentRoute.name === 'delegated-gateway-list-view',
-              }"
-              :to="{
-                name: 'delegated-gateway-list-view',
-                params: {
-                  mesh: route.params.mesh,
-                },
-              }"
-            >
-              {{ t('gateways.routes.items.navigation.delegated') }}
-            </RouterLink>
-          </LinkBox>
-        </template>
-
-        <RouterView />
-      </AppView>
+              <LinkBox>
+                <template
+                  v-for="item in items"
+                  :key="`${item.name}`"
+                >
+                  <RouterLink
+                    :class="{
+                      'active': route.active(active)?.name === item.name,
+                    }"
+                    :to="{
+                      name: item.name,
+                      params: {
+                        mesh: route.params.mesh,
+                      },
+                    }"
+                  >
+                    {{ t(`gateways.routes.items.navigation.${item.name}`) }}
+                  </RouterLink>
+                </template>
+              </LinkBox>
+            </DataCollection>
+          </template>
+          <component
+            :is="Component"
+          />
+        </AppView>
+      </RouterView>
     </RouteView>
   </DataSource>
 </template>
 
 <script lang="ts" setup>
-import { useRoute } from 'vue-router'
-
 import LinkBox from '@/app/common/LinkBox.vue'
 import type { MeSource } from '@/app/me/sources'
 
-const currentRoute = useRoute()
 </script>


### PR DESCRIPTION
Exposes a `RouteView::route.children` so that we can easily make different types of tab-like UI interfaces automatically based on our route config, which in turn means we can completely define this sort of sub navigation from The Outside.

This PR then uses that for the `LinkBox` in `GatewayListTabsView`, but the functionality could also be re-used for all sorts of similar sub navigation widgets.

Note: Whilst DataCollection `predicate` functionality isn't being used here, as DataCollection shows nothing if `items` is zero length, this means that if we configured our router to have no children here, the tab interface would automatically not show/render at all.