### PR TITLE
feat: add dataplane viz for delegated gateways

### DIFF
--- a/src/app/data-planes/data/index.ts
+++ b/src/app/data-planes/data/index.ts
@@ -100,7 +100,9 @@ const DataplaneNetworking = {
     return {
       ...rest,
       type,
-      inboundName: typeof networking.gateway === 'undefined' ? 'localhost' : type === 'builtin' ? networking.gateway.tags['kuma.io/service'] : '~',
+      // inboundNames are `localhost` for a sidecar, the service name for a gateway.
+      // The service name "as an inbound" will never be found for a delegated gateway
+      inboundName: typeof networking.gateway === 'undefined' ? 'localhost' : networking.gateway.tags['kuma.io/service'],
       // guess a single inbound for the moment
       // we need to fill this in and make it multiple by either using the policy info
       // or the stats listeners info


### PR DESCRIPTION
Enables the dataplane viz for delegated gateways.

![Screenshot 2024-02-19 at 14 10 29](https://github.com/kumahq/kuma-gui/assets/554604/95608533-8955-4b71-998b-c8355bc0e30c)

This was pretty much just removing the guard we had in-place to not show the viz for delegated gateways. I also added an EmptyState message to explain why you don't see any inbounds.

All in all, this PR is one of those ones that looks more than it actually is due to nesting changing.

Closes https://github.com/kumahq/kuma-gui/issues/2134
