### PR TITLE
feat(builtin-gateways): turn affected DPPs into dataplane list

### DIFF
--- a/features/mesh/builtin-gateways/Item.feature
+++ b/features/mesh/builtin-gateways/Item.feature
@@ -1,12 +1,10 @@
 Feature: mesh / builtin-gateways / item
   Background:
     Given the CSS selectors
-      | Alias              | Selector                                         |
-      | tabs-view          | [data-testid='builtin-gateway-detail-tabs-view'] |
-      | detail-view        | [data-testid='builtin-gateway-detail-view']      |
-      | filter-input       | [data-testid='dataplane-search-input']           |
-      | affected-dpps      | [data-testid='affected-data-plane-proxies']      |
-      | affected-dpps-item | [data-testid='dataplane-name']                   |
+      | Alias      | Selector                                         |
+      | tabs-view  | [data-testid='builtin-gateway-detail-tabs-view'] |
+      | dataplanes | [data-testid='data-plane-collection']            |
+      | config     | [data-testid='config']                           |
     Given the URL "/meshes/default/meshgateways/gateway-1" responds with
       """
       body:
@@ -26,25 +24,9 @@ Feature: mesh / builtin-gateways / item
     When I visit the "/meshes/default/gateways/builtin/gateway-1/overview" URL
 
     Then the "$tabs-view" element contains "gateway-1"
-    Then the "$detail-view" element contains "gateway-1"
+    Then the "$dataplanes" element exists
 
-  Scenario: Affected DPPs can be filtered
-    When I visit the "/meshes/default/gateways/builtin/gateway-1/overview" URL
+  Scenario: Config tab has expected content
+    When I visit the "/meshes/default/gateways/builtin/gateway-1/config" URL
 
-    Then the "$affected-dpps-item" element exists 3 times
-    And the "$affected-dpps" element contains "backend"
-    And the "$affected-dpps" element contains "db"
-    And the "$affected-dpps" element contains "frontend"
-
-    When I "type" "db" into the "$filter-input" element
-
-    Then the "$affected-dpps-item" element exists 1 time
-    And the "$affected-dpps" element contains "db"
-    And the URL contains "/overview?dataplane=db"
-
-  Scenario: URL with dataplane query parameter filters affected DPP list
-    When I visit the "/meshes/default/gateways/builtin/gateway-1/overview?dataplane=db" URL
-
-    Then the "$affected-dpps-item" element exists 1 time
-    And the "$affected-dpps" element contains "db"
-    And the URL contains "/overview?dataplane=db"
+    Then the "$config" element exists

--- a/src/app/gateways/locales/en-us/index.yaml
+++ b/src/app/gateways/locales/en-us/index.yaml
@@ -13,11 +13,9 @@ builtin-gateways:
       breadcrumbs: Built-in Gateways
       navigation:
         builtin-gateway-detail-view: Overview
+        builtin-gateway-config-view: YAML
     items:
       title: Built-in Gateways
-  detail:
-    affected_dpps: Affected Data Plane Proxies
-    dataplane_input_placeholder: Filter by name
   href:
     docs: '{KUMA_DOCS_URL}/using-mesh/managing-ingress-traffic/builtin?{KUMA_UTM_QUERY_PARAMS}'
 

--- a/src/app/gateways/routes.ts
+++ b/src/app/gateways/routes.ts
@@ -16,6 +16,18 @@ export const routes = () => {
                 path: 'overview',
                 name: 'builtin-gateway-detail-view',
                 component: () => import('@/app/gateways/views/BuiltinGatewayDetailView.vue'),
+                children: [
+                  {
+                    path: ':dataPlane',
+                    name: 'builtin-gateway-data-plane-summary-view',
+                    component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
+                  },
+                ],
+              },
+              {
+                path: 'config',
+                name: 'builtin-gateway-config-view',
+                component: () => import('@/app/gateways/views/BuiltinGatewayConfigView.vue'),
               },
             ],
           },

--- a/src/app/gateways/views/BuiltinGatewayConfigView.vue
+++ b/src/app/gateways/views/BuiltinGatewayConfigView.vue
@@ -1,0 +1,69 @@
+<template>
+  <RouteView
+    v-slot="{ route, t }"
+    name="builtin-gateway-config-view"
+    :params="{
+      mesh: '',
+      gateway: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+    }"
+  >
+    <AppView>
+      <template #title>
+        <h2>
+          <RouteTitle
+            :title="t('builtin-gateways.routes.item.navigation.builtin-gateway-config-view')"
+          />
+        </h2>
+      </template>
+
+      <KCard>
+        <DataSource
+          v-slot="{ data, error }: MeshGatewaySource"
+          :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}`"
+        >
+          <ErrorBlock
+            v-if="error"
+            :error="error"
+          />
+
+          <LoadingBlock v-else-if="data === undefined" />
+
+          <ResourceCodeBlock
+            v-else
+            v-slot="{ copy, copying }"
+            data-testid="config"
+            :resource="data.config"
+            is-searchable
+            :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter"
+            :is-reg-exp-mode="route.params.codeRegExp"
+            @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          >
+            <DataSource
+              v-if="copying"
+              :src="`/meshes/${data.mesh}/mesh-gateways/${data.name}/as/kubernetes?no-store`"
+              @change="(data) => {
+                copy((resolve) => resolve(data))
+              }"
+              @error="(error) => {
+                copy((_resolve, reject) => reject(error))
+              }"
+            />
+          </ResourceCodeBlock>
+        </DataSource>
+      </KCard>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import { MeshGatewaySource } from '../sources'
+import ResourceCodeBlock from '@/app/common/code-block/ResourceCodeBlock.vue'
+import ErrorBlock from '@/app/common/ErrorBlock.vue'
+import LoadingBlock from '@/app/common/LoadingBlock.vue'
+</script>

--- a/src/app/gateways/views/BuiltinGatewayDetailView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailView.vue
@@ -10,9 +10,6 @@
       :params="{
         mesh: '',
         gateway: '',
-        codeSearch: '',
-        codeFilter: false,
-        codeRegExp: false,
         page: 1,
         size: me.pageSize,
         query: '',

--- a/src/app/gateways/views/BuiltinGatewayDetailView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailView.vue
@@ -1,116 +1,259 @@
 <template>
-  <RouteView
-    v-slot="{ route, t }"
-    name="builtin-gateway-detail-view"
-    :params="{
-      mesh: '',
-      gateway: '',
-      codeSearch: '',
-      codeFilter: false,
-      codeRegExp: false,
-      dataplane: '',
-    }"
+  <DataSource
+    v-slot="{ data: me }: MeSource"
+    src="/me"
   >
-    <AppView>
-      <DataSource
-        v-slot="{ data, error }: MeshGatewaySource"
-        :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}`"
-      >
-        <ErrorBlock
-          v-if="error"
-          :error="error"
-        />
-
-        <LoadingBlock v-else-if="data === undefined" />
-
-        <div
-          v-else
-          class="stack"
+    <RouteView
+      v-if="me"
+      v-slot="{ can, route, t }"
+      name="builtin-gateway-detail-view"
+      :params="{
+        mesh: '',
+        gateway: '',
+        codeSearch: '',
+        codeFilter: false,
+        codeRegExp: false,
+        page: 1,
+        size: me.pageSize,
+        query: '',
+        s: '',
+        dataPlane: '',
+      }"
+    >
+      <AppView>
+        <DataSource
+          v-slot="{ data, error }: MeshGatewaySource"
+          :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}`"
         >
-          <KCard>
-            <h2>{{ t('builtin-gateways.detail.affected_dpps') }}</h2>
+          <ErrorBlock
+            v-if="error"
+            :error="error"
+          />
 
-            <div class="mt-4">
-              <KInput
-                :model-value="route.params.dataplane"
-                type="text"
-                :placeholder="t('builtin-gateways.detail.dataplane_input_placeholder')"
-                required
-                data-testid="dataplane-search-input"
-                @input="route.update({ dataplane: $event })"
+          <LoadingBlock v-else-if="data === undefined" />
+
+          <KCard v-else>
+            <DataSource
+              v-slot="{ data: dataplanesData, error: dataplanesError }: DataplaneOverviewCollectionSource"
+              :src="`/meshes/${route.params.mesh}/dataplanes/for/${data.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
+            >
+              <ErrorBlock
+                v-if="dataplanesError !== undefined"
+                :error="dataplanesError"
               />
 
-              <DataSource
-                v-slot="{ data: dataplanesData, error: dataplanesError }: PolicyDataplaneCollectionSource"
-                :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}/dataplanes`"
+              <AppCollection
+                v-else
+                class="data-plane-collection"
+                data-testid="data-plane-collection"
+                :page-number="route.params.page"
+                :page-size="route.params.size"
+                :headers="[
+                  { label: 'Name', key: 'name' },
+                  ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
+                  { label: 'Certificate Info', key: 'certificate' },
+                  { label: 'Status', key: 'status' },
+                  { label: 'Warnings', key: 'warnings', hideLabel: true },
+                  { label: 'Details', key: 'details', hideLabel: true },
+                ]"
+                :items="dataplanesData?.items"
+                :total="dataplanesData?.total"
+                :error="dataplanesError"
+                :is-selected-row="(row) => row.name === route.params.dataPlane"
+                summary-route-name="builtin-gateway-data-plane-summary-view"
+                :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
+                :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
+                :empty-state-cta-text="t('common.documentation')"
+                @change="route.update"
               >
-                <ErrorBlock
-                  v-if="dataplanesError"
-                  :error="dataplanesError"
-                />
-
-                <LoadingBlock v-else-if="dataplanesData === undefined" />
-
-                <EmptyBlock v-else-if="dataplanesData.items.length === 0" />
-
-                <template v-else>
-                  <ul data-testid="affected-data-plane-proxies">
-                    <li
-                      v-for="(policyDataplane, key) in dataplanesData.items.filter((policyDataplane) => policyDataplane.name.toLowerCase().includes(route.params.dataplane.toLowerCase()))"
-                      :key="key"
-                      data-testid="dataplane-name"
-                    >
-                      <RouterLink
-                        :to="{
-                          name: 'data-plane-detail-view',
-                          params: {
-                            mesh: policyDataplane.mesh,
-                            dataPlane: policyDataplane.name,
-                          },
-                        }"
-                      >
-                        {{ policyDataplane.name }}
-                      </RouterLink>
-                    </li>
-                  </ul>
+                <template #toolbar>
+                  <FilterBar
+                    class="data-plane-proxy-filter"
+                    :placeholder="`tag: 'kuma.io/protocol: http'`"
+                    :query="route.params.query"
+                    :fields="{
+                      name: { description: 'filter by name or parts of a name' },
+                      protocol: { description: 'filter by “kuma.io/protocol” value' },
+                      tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                      zone: { description: 'filter by “kuma.io/zone” value' },
+                    }"
+                    @fields-change="route.update({
+                      query: $event.query,
+                      s: $event.query.length > 0 ? JSON.stringify($event.fields) : '',
+                    })"
+                  />
                 </template>
-              </DataSource>
-            </div>
-          </KCard>
 
-          <ResourceCodeBlock
-            v-slot="{ copy, copying }"
-            :resource="data.config"
-            is-searchable
-            :query="route.params.codeSearch"
-            :is-filter-mode="route.params.codeFilter"
-            :is-reg-exp-mode="route.params.codeRegExp"
-            @query-change="route.update({ codeSearch: $event })"
-            @filter-mode-change="route.update({ codeFilter: $event })"
-            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
-          >
-            <DataSource
-              v-if="copying"
-              :src="`/meshes/${data.mesh}/mesh-gateways/${data.name}/as/kubernetes?no-store`"
-              @change="(data) => {
-                copy((resolve) => resolve(data))
-              }"
-              @error="(error) => {
-                copy((_resolve, reject) => reject(error))
-              }"
-            />
-          </ResourceCodeBlock>
-        </div>
-      </DataSource>
-    </AppView>
-  </RouteView>
+                <template #name="{ row }">
+                  <RouterLink
+                    class="name-link"
+                    :title="row.name"
+                    :to="{
+                      name: 'builtin-gateway-data-plane-summary-view',
+                      params: {
+                        mesh: row.mesh,
+                        dataPlane: row.name,
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                        query: route.params.query,
+                      },
+                    }"
+                  >
+                    {{ row.name }}
+                  </RouterLink>
+                </template>
+
+                <template #zone="{ row }">
+                  <RouterLink
+                    v-if="row.zone"
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: row.zone,
+                      },
+                    }"
+                  >
+                    {{ row.zone }}
+                  </RouterLink>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #certificate="{ row }">
+                  <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                    {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                  </template>
+
+                  <template v-else>
+                    {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                  </template>
+                </template>
+
+                <template #status="{ row }">
+                  <StatusBadge :status="row.status" />
+                </template>
+
+                <template #warnings="{ row }">
+                  <KTooltip v-if="row.isCertExpired || row.warnings.length > 0">
+                    <template #content>
+                      <ul>
+                        <template v-if="row.warnings.length > 0">
+                          <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+                        </template>
+
+                        <template v-if="row.isCertExpired">
+                          <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
+                        </template>
+                      </ul>
+                    </template>
+
+                    <WarningIcon
+                      class="mr-1"
+                      :size="KUI_ICON_SIZE_30"
+                      hide-title
+                    />
+                  </KTooltip>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #details="{ row }">
+                  <RouterLink
+                    class="details-link"
+                    data-testid="details-link"
+                    :to="{
+                      name: 'data-plane-detail-view',
+                      params: {
+                        dataPlane: row.name,
+                      },
+                    }"
+                  >
+                    {{ t('common.collection.details_link') }}
+
+                    <ArrowRightIcon
+                      display="inline-block"
+                      decorative
+                      :size="KUI_ICON_SIZE_30"
+                    />
+                  </RouterLink>
+                </template>
+              </AppCollection>
+
+              <RouterView
+                v-if="route.params.dataPlane"
+                v-slot="child"
+              >
+                <SummaryView
+                  @close="route.replace({
+                    name: route.name,
+                    params: {
+                      mesh: route.params.mesh,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                    },
+                  })"
+                >
+                  <component
+                    :is="child.Component"
+                    :name="route.params.dataPlane"
+                    :dataplane-overview="dataplanesData?.items.find((dataplaneOverview) => dataplaneOverview.name === route.params.dataPlane)"
+                  />
+                </SummaryView>
+              </RouterView>
+            </DataSource>
+          </KCard>
+        </DataSource>
+      </AppView>
+    </RouteView>
+  </DataSource>
 </template>
 
 <script lang="ts" setup>
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { ArrowRightIcon } from '@kong/icons'
+
 import type { MeshGatewaySource } from '../sources'
-import ResourceCodeBlock from '@/app/common/code-block/ResourceCodeBlock.vue'
-import EmptyBlock from '@/app/common/EmptyBlock.vue'
+import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
+import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import type { PolicyDataplaneCollectionSource } from '@/app/policies/sources'
+import StatusBadge from '@/app/common/StatusBadge.vue'
+import SummaryView from '@/app/common/SummaryView.vue'
+import WarningIcon from '@/app/common/WarningIcon.vue'
+import type { DataplaneOverviewCollectionSource } from '@/app/data-planes/sources'
+import type { MeSource } from '@/app/me/sources'
 </script>
+
+<style lang="scss" scoped>
+.data-plane-proxy-filter {
+  flex-basis: 350px;
+  flex-grow: 1;
+}
+
+.name-link {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.details-link {
+  display: inline-flex;
+  align-items: center;
+  gap: $kui-space-20;
+}
+
+.data-plane-collection :deep(.name-column) {
+  max-width: 400px;
+}
+</style>


### PR DESCRIPTION
Follow up to #2211.

Replace the Affected DPPs section in the built-in gateway detail view with a regular Dataplane list.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Resolves #2210.