### PR TITLE
fix: make attrs utilities more type-safe

### DIFF
--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -50,7 +50,7 @@ import type { RouteLocationNormalizedLoaded, RouteRecordRaw } from 'vue-router'
 export type RouteView = {
   addTitle: (item: string, sym: Symbol) => void
   removeTitle: (sym: Symbol) => void
-  addAttrs: (item: Record<string, string>, sym: Symbol) => void
+  addAttrs: (item: Partial<Record<string, string>>, sym: Symbol) => void
   removeAttrs: (sym: Symbol) => void
 }
 
@@ -70,7 +70,7 @@ type StringNamedRouteRecordRaw = RouteRecordRaw & {
 
 const props = withDefaults(defineProps<{
   name: string
-  attrs?: Record<string, string>
+  attrs?: Partial<Record<string, string>>
   params?: T
 }>(), {
   attrs: () => ({}),
@@ -90,7 +90,7 @@ const name = computed(() => props.name)
 
 const title = ref<HTMLDivElement | null>(null)
 const titles = new Map<Symbol, string>()
-const attributes = new Map<Symbol, Record<string, string>>()
+const attributes = new Map<Symbol, Partial<Record<string, string>>>()
 const setTitle = createTitleSetter(document)
 const setAttrs = createAttrsSetter(document.documentElement)
 
@@ -116,7 +116,7 @@ const routeView = {
     titles.delete(sym)
     setTitle(joinTitle([...titles.values()]))
   },
-  addAttrs: (item: Record<string, string>, sym: Symbol) => {
+  addAttrs: (item: Partial<Record<string, string>>, sym: Symbol) => {
     attributes.set(sym, item)
     setAttrs([...attributes.values()])
   },

--- a/src/app/application/utilities/index.ts
+++ b/src/app/application/utilities/index.ts
@@ -27,14 +27,16 @@ export const createAttrsSetter = ($el = document.documentElement) => {
     return () => {}
   }
   const originalClasses = [...$el.classList]
-  return beforePaint((attrs: Record<string, string>[]) => {
-    const flat = attrs.reduce<Record<string, string[]>>((prev, item) => {
+  return beforePaint((attrs: Partial<Record<string, string>>[]) => {
+    const flat = attrs.reduce<Partial<Record<string, string[]>>>((prev, item) => {
       return Object.entries(item).reduce(
         (prev, [key, value]) => {
-          if (typeof prev[key] === 'undefined') {
-            prev[key] = []
+          if (value) {
+            if (typeof prev[key] === 'undefined') {
+              prev[key] = []
+            }
+            prev[key]!.push(value)
           }
-          prev[key].push(value)
           return prev
         }, prev,
       )
@@ -42,9 +44,9 @@ export const createAttrsSetter = ($el = document.documentElement) => {
     // omit any classes that were on the node previous to our application starting
     const currentClasses = difference([...$el.classList], originalClasses)
     // anything in currentClasses that isn't in our tree of attrs, remove
-    $el.classList.remove(...difference(currentClasses, flat.class))
+    $el.classList.remove(...difference(currentClasses, flat.class ?? []))
     // anything in our tree of attrs that isn't in currentClasses, add
-    $el.classList.add(...difference(flat.class, currentClasses))
+    $el.classList.add(...difference(flat.class ?? [], currentClasses))
   })
 }
 // normalizes url params from "value or array of values" to value


### PR DESCRIPTION
Changes the type of `attrs` values being passed around to `Partial<Record<string, string>>` to make type errors when accessing data based on empty records (i.e. `{}` as opposed to `{ class: '...' }` visible.

Fix the unsafe passing of `flat.class` to the `difference` function leading to a `Cannot read properties of undefined (reading 'includes')` error.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
