### PR TITLE
fix(dataplane): maintain viz inactive state in the URL when changing tabs

### DIFF
--- a/src/app/data-planes/views/DataPlaneInboundSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneInboundSummaryView.vue
@@ -4,6 +4,7 @@
     name="data-plane-inbound-summary-view"
     :params="{
       service: '',
+      inactive: false,
     }"
   >
     <AppView>
@@ -26,7 +27,12 @@
           #[`${name}`]
         >
           <RouterLink
-            :to="{ name }"
+            :to="{
+              name,
+              query: {
+                inactive: route.params.inactive ? null : undefined,
+              },
+            }"
             :data-testid="`${name}-tab`"
           >
             {{ t(`data-planes.routes.item.navigation.${name}`) }}

--- a/src/app/data-planes/views/DataPlaneOutboundSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneOutboundSummaryView.vue
@@ -4,6 +4,7 @@
     name="data-plane-outbound-summary-view"
     :params="{
       service: '',
+      inactive: false,
     }"
   >
     <AppView>
@@ -20,7 +21,12 @@
           #[`${name}`]
         >
           <RouterLink
-            :to="{ name }"
+            :to="{
+              name,
+              query: {
+                inactive: route.params.inactive ? null : undefined,
+              },
+            }"
             :data-testid="`${name}-tab`"
           >
             {{ t(`data-planes.routes.item.navigation.${name}`) }}


### PR DESCRIPTION
Ensures that the `?inactive` toggle is persisted in the URL when clicking between drawer tabs.