### PR TITLE
feat: add XTeleport* components

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -121,6 +121,8 @@ const INLINE_NON_VOID_ELEMENTS = [
             'RouterView',
             // @kong/kongponents
             'K[A-Z].*',
+            //
+            'X[A-Z].*',
             // @kong-ui-public/i18n
             'I18nT',
             // Application

--- a/src/app/application/components/app-view/AppView.vue
+++ b/src/app/application/components/app-view/AppView.vue
@@ -23,6 +23,7 @@
         <div
           class="actions"
         >
+          <XTeleportSlot :name="`${routeView.name}-actions`" />
           <slot name="actions" />
         </div>
       </header>
@@ -48,8 +49,9 @@ import { KongIcon } from '@kong/icons'
 import { KBreadcrumbs, BreadcrumbItem } from '@kong/kongponents'
 import { provide, inject, watch, ref, onBeforeUnmount } from 'vue'
 
+import { ROUTE_VIEW_PARENT } from '../route-view/index'
+import type { RouteView } from '../route-view/RouteView.vue'
 import { useMainView } from '@/components'
-
 type AppView = {
   addBreadcrumbs: (items: BreadcrumbItem[], sym: Symbol) => void
   removeBreadcrumbs: (sym: Symbol) => void
@@ -57,6 +59,8 @@ type AppView = {
 type Breadcrumbs = Map<Symbol, BreadcrumbItem[]>
 
 const MainView = useMainView()
+
+const routeView = inject<RouteView>(ROUTE_VIEW_PARENT)!
 
 const props = withDefaults(defineProps<{
   breadcrumbs?: BreadcrumbItem[] | null

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -33,7 +33,7 @@
 import { computed, provide, inject, ref, watch, onBeforeUnmount, reactive } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-import { ROUTE_VIEW_PARENT } from '.'
+import { ROUTE_VIEW_PARENT, ROUTE_VIEW_ROOT } from '.'
 import { useCan, useI18n, uniqueId } from '../../index'
 import {
   urlParam,
@@ -46,6 +46,7 @@ import {
 import { useEnv } from '@/utilities'
 import type { RouteRecordRaw } from 'vue-router'
 export type RouteView = {
+  name: string
   addTitle: (item: string, sym: Symbol) => void
   removeTitle: (sym: Symbol) => void
   addAttrs: (item: Record<string, string>, sym: Symbol) => void
@@ -103,6 +104,7 @@ const children: StringNamedRouteRecordRaw[] = (router.getRoutes().find((route) =
 const active = computed(() => children.find((item) => item.name === route.name || item.meta?.module === route.meta.module))
 
 const routeView = {
+  name: props.name,
   addTitle: (item: string, sym: Symbol) => {
     const $title = title.value
     if ($title) {
@@ -201,12 +203,13 @@ const routerBack = (...args: RouteReplaceParams) => {
   routeReplace(...args)
 }
 
-const hasParent: RouteView | undefined = inject(ROUTE_VIEW_PARENT, undefined)
+const hasParent: RouteView | undefined = inject(ROUTE_VIEW_ROOT, undefined)
 if (!hasParent) {
   // use the default title if we are the topmost RouteView
   setTitle(t('components.route-view.title', { name: t('common.product.name') }))
-  provide(ROUTE_VIEW_PARENT, routeView)
+  provide(ROUTE_VIEW_ROOT, routeView)
 }
+provide(ROUTE_VIEW_PARENT, routeView)
 const parent: RouteView = hasParent || routeView
 
 watch(() => props.attrs, (attrs) => {

--- a/src/app/application/components/route-view/index.ts
+++ b/src/app/application/components/route-view/index.ts
@@ -1,1 +1,2 @@
+export const ROUTE_VIEW_ROOT = Symbol('route-view-root')
 export const ROUTE_VIEW_PARENT = Symbol('route-view-parent')

--- a/src/app/x/components/x-teleport/XTeleportSlot.vue
+++ b/src/app/x/components/x-teleport/XTeleportSlot.vue
@@ -1,0 +1,11 @@
+<template>
+  <div
+    :data-x-teleport-id="props.name"
+  />
+</template>
+<script lang="ts" setup>
+const props = defineProps<{
+  name: string
+}>()
+
+</script>

--- a/src/app/x/components/x-teleport/XTeleportTemplate.vue
+++ b/src/app/x/components/x-teleport/XTeleportTemplate.vue
@@ -1,0 +1,25 @@
+<template>
+  <Teleport
+    v-if="ready"
+    :to="`[data-x-teleport-id='${props.to.name}']`"
+  >
+    <slot name="default" />
+  </Teleport>
+</template>
+<script lang="ts" setup>
+import { onMounted, ref } from 'vue'
+const props = defineProps<{
+  to: {
+    name: string
+  }
+}>()
+
+const ready = ref<boolean>(false)
+onMounted(() => {
+  if (document.querySelector(`[data-x-teleport-id='${props.to.name}']`) !== null) {
+    ready.value = true
+  } else {
+    throw new Error(`The '[data-x-teleport-id='${props.to.name}']' element could not be found to teleport to`)
+  }
+})
+</script>

--- a/src/app/x/index.ts
+++ b/src/app/x/index.ts
@@ -1,0 +1,24 @@
+import XTeleportSlot from './components/x-teleport/XTeleportSlot.vue'
+import XTeleportTemplate from './components/x-teleport/XTeleportTemplate.vue'
+import type { ServiceDefinition } from '@/services/utils'
+import { token } from '@/services/utils'
+
+type Token = ReturnType<typeof token>
+
+export const services = (app: Record<string, Token>): ServiceDefinition[] => {
+  return [
+    [token('x.vue.components'),
+      {
+        service: () => {
+          return [
+            ['XTeleportTemplate', XTeleportTemplate],
+            ['XTeleportSlot', XTeleportSlot],
+          ]
+        },
+        labels: [
+          app.components,
+        ],
+      },
+    ],
+  ]
+}

--- a/src/services/production.ts
+++ b/src/services/production.ts
@@ -6,6 +6,7 @@ import { services as kuma } from '@/app/kuma'
 import { services as me } from '@/app/me'
 import { services as meshes } from '@/app/meshes'
 import { services as vue, TOKENS as VUE } from '@/app/vue'
+import { services as x } from '@/app/x'
 import { services as zones } from '@/app/zones'
 import i18nEnUs from '@/locales/en-us'
 import type { EnvArgs } from '@/services/env/Env'
@@ -72,6 +73,7 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
     ...$,
     routes: $.routesLabel,
   }),
+  ...x($),
   ...me($),
   ...kuma($),
   //


### PR DESCRIPTION
Adds a small eXtra wrapper eXtension around Vue's teleport:

1. Vue's teleport is a bit weird in that one side is JS/Vue and the other is DOM i.e. `:to` is a DOM selector.
2. Having an explicit XTeleportSlot to put things in rather than just a DOM element makes it way clearer that the element is needed (see https://github.com/kumahq/kuma-gui/pull/2184#pullrequestreview-1896198851 and https://github.com/kumahq/kuma-gui/pull/1729).
3. Having a wrapper means we can validate things exist, and probably in the future add get a bit tighter with the coupling of templates/slots (i.e. we could keep a record of existing slots somewhere)
4. I've also made the previous `actions` "DOM based teleport slot" unique per `RouteView`. Previously there could be multiple DOM teleport slots called `actions` (I think I pointed this out at somepoint, and also pointed out that it wasn't currently a problem but could become one if we didn't unique-ify these at some point, this should solve that)

---

Overall I've tried to stay very close to Vue semantics/words so this feels as natural as possible. i.e. You define slots that are `:name`d, and then you define templates for those slots, just as you would with components. i.e. I've tried to make it look exactly like normal Vue component template/slot relationships.

In this respect the only thing I couldn't do was use `<XTeleportTemplate :slot="" />` to relate to `<template v-slot="">`. So I went with the original `<Teleport :to="" />` attribute name, but I shaped it like a `RouterLink :to="{name: "slot-name"}"`. Then all `:to`s look/feel the same.