### PR TITLE
fix(services): external service lookup crashing in detail view

### DIFF
--- a/src/app/services/locales/en-us/index.yaml
+++ b/src/app/services/locales/en-us/index.yaml
@@ -8,3 +8,5 @@ services:
         data_plane_proxies: 'Data Plane Proxies'
     items:
       title: Services
+  detail:
+    no_matching_external_service: 'No matching ExternalService was found for service {name}'

--- a/src/app/services/sources.ts
+++ b/src/app/services/sources.ts
@@ -16,6 +16,10 @@ type PaginationParams = {
   page: number
 }
 
+type ExternalServiceParams = CollectionParams & PaginationParams & {
+  service: string
+}
+
 type Closeable = { close: () => void }
 
 export type ServiceInsightSource = DataSourceResponse<ServiceInsight>
@@ -43,12 +47,12 @@ export const sources = (api: KumaApi) => {
       return api.getServiceInsight({ mesh, name })
     },
 
-    '/meshes/:mesh/external-services/:name': (params: DetailParams, source: Closeable) => {
+    '/meshes/:mesh/external-services/for/:service': (params: ExternalServiceParams, source: Closeable) => {
       source.close()
 
-      const { mesh, name } = params
+      const { mesh, service, size } = params
 
-      return api.getExternalServiceByServiceInsightName(mesh, name)
+      return api.getExternalServiceByServiceInsightName({ mesh }, { size, service })
     },
   }
 }

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -54,7 +54,7 @@
             <DataSource
               v-if="data.serviceType === 'external'"
               v-slot="{ data: externalService, error: externalServiceError }: ExternalServiceSource"
-              :src="`/meshes/${route.params.mesh}/external-services/${route.params.service}`"
+              :src="`/meshes/${route.params.mesh}/external-services/for/${route.params.service}?size=1000`"
             >
               <LoadingBlock v-if="externalService === undefined" />
 
@@ -62,6 +62,15 @@
                 v-else-if="externalServiceError"
                 :error="externalServiceError"
               />
+
+              <EmptyBlock
+                v-else-if="externalService === null"
+                data-testid="no-matching-external-service"
+              >
+                <template #title>
+                  <p>{{ t('services.detail.no_matching_external_service', { name: props.service }) }}</p>
+                </template>
+              </EmptyBlock>
 
               <ExternalServiceDetails
                 v-else
@@ -176,6 +185,7 @@ import AppView from '@/app/application/components/app-view/AppView.vue'
 import DataSource from '@/app/application/components/data-source/DataSource.vue'
 import RouteTitle from '@/app/application/components/route-view/RouteTitle.vue'
 import RouteView from '@/app/application/components/route-view/RouteView.vue'
+import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import KFilterBar from '@/app/common/KFilterBar.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -58,4 +58,9 @@ export interface DataPlaneOverviewParameters extends PaginationParameters {
 
 export interface ExternalServicesParameters extends PaginationParameters {
   name?: string
+
+  /**
+   * **Example**: `?tag=kuma.io/service:foo&tag=version:v1`
+   */
+  tag?: string | string[]
 }


### PR DESCRIPTION
Add an empty state when not finding the matching ExternalService to the service detail view.

Change the `size` parameter for the ExternalService lookup to 1000 to make it less likely not to find the right resource.

Change the ExternalService lookup to send a tag instead of a name parameter. The name parameter was incorrect anyway (but also not working as the Kuma API in 2.4.x doesn’t support it) as it filters by ExternalService name and not by ExternalService kuma.io/service tag. Note that the Kuma API doesn’t support the `tag` parameter in release-2.4 so this is only a forward-compatibility layer in case we want to fix this issue properly.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Relates to https://github.com/kumahq/kuma/issues/9293.