### PR TITLE
fix: ensure correct tab is selected on page load

### DIFF
--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -88,3 +88,11 @@ Feature: application / MainNavigation
     When I navigate "back"
     Then the page title contains "Overview"
     And the "[data-testid='zone-control-planes-status']" element exists
+
+  Scenario: Secondary navigation
+    When I visit the "/meshes/default/data-planes/dp-name/stats" URL
+    And the "#data-plane-stats-view-tab.active" element exists
+
+  Scenario: Tertiary navigation
+    When I visit the "/meshes/default/data-planes/dp-name/overview/inbound/driver:8080/stats" URL
+    And the "#data-plane-inbound-summary-stats-view-tab.active" element exists

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -101,7 +101,7 @@ const children: StringNamedRouteRecordRaw[] = (router.getRoutes().find((route) =
   item.name = String(item.name)
   return item as StringNamedRouteRecordRaw
 }) ?? [])
-const active = computed(() => children.find((item) => item.name === route.name || item.meta?.module === route.meta.module))
+const active = computed(() => children.find((item) => item.name === route.name || (item.meta && item.meta.module === route.meta.module)))
 
 const routeView = {
   name: props.name,


### PR DESCRIPTION
Fixes a small regression by ensuring that the correct tab is selected.

I took the code we had back in https://github.com/kumahq/kuma-gui/blob/a8550b9aafb6ce2a1dfcef82d981309605bba26d/src/app/application/components/route-view/RouteView.vue#L28 

and also added a couple of extra tests to prevent further regression

