### PR TITLE
chore: sniff the protocol of unknown outbounds

### DIFF
--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -95,4 +95,4 @@ Feature: application / MainNavigation
 
   Scenario: Tertiary navigation
     When I visit the "/meshes/default/data-planes/dp-name/overview/inbound/driver:8080/stats" URL
-    And the "#data-plane-inbound-summary-stats-view-tab.active" element exists
+    And the "#connection-inbound-summary-stats-view-tab.active" element exists

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -244,7 +244,7 @@
                   >
                     <!-- Outbounds for gateways report actual traffic on the upstream so we switch to upstream here for non-standard-->
                     <template
-                      v-for="direction in [props.data.dataplane.networking.type !== 'standard' ? 'upstream' : 'downstream'] as const"
+                      v-for="direction in ['upstream'] as const"
                       :key="direction"
                     >
                       <ConnectionGroup


### PR DESCRIPTION
Looks at the stats values to try to figure out whether a service is http or not. See inline comments for a little more info.