### PR TITLE
fix: DataLoader exported errors > error

### DIFF
--- a/src/app/application/components/data-collection/DataCollection.vue
+++ b/src/app/application/components/data-collection/DataCollection.vue
@@ -31,7 +31,7 @@
     />
   </slot>
 </template>
-<script lang="ts" generic="T extends {} = {}" setup>
+<script lang="ts" generic="T" setup>
 import { computed } from 'vue'
 
 import EmptyBlock from '@/app/common/EmptyBlock.vue'

--- a/src/app/application/components/data-source/DataLoader.vue
+++ b/src/app/application/components/data-source/DataLoader.vue
@@ -16,7 +16,7 @@
         <slot
           name="disconnected"
           :data="props.src !== '' ? allData[0] : undefined"
-          :errors="props.src !== '' ? allErrors[0] : undefined"
+          :error="props.src !== '' ? allErrors[0] : undefined"
           :refresh="props.src !== '' ? refresh : () => {}"
         >
           <!-- KAlert -->
@@ -25,7 +25,7 @@
       <slot
         name="default"
         :data="props.src !== '' ? allData[0] : undefined"
-        :errors="props.src !== '' ? allErrors[0] : undefined"
+        :error="props.src !== '' ? allErrors[0] : undefined"
         :refresh="props.src !== '' ? refresh : () => {}"
       />
     </template>
@@ -36,7 +36,7 @@
       <slot
         name="error"
         :data="props.src !== '' ? allData[0] : undefined"
-        :errors="props.src !== '' ? allErrors[0] : undefined"
+        :error="props.src !== '' ? allErrors[0] : undefined"
         :refresh="props.src !== '' ? refresh : () => {}"
       >
         <ErrorBlock
@@ -49,7 +49,7 @@
         v-if="props.loader"
         name="connecting"
         :data="props.src !== '' ? allData[0] : undefined"
-        :errors="props.src !== '' ? allErrors[0] : undefined"
+        :error="props.src !== '' ? allErrors[0] : undefined"
         :refresh="props.src !== '' ? refresh : () => {}"
       >
         <LoadingBlock />
@@ -58,7 +58,7 @@
         v-else
         name="default"
         :data="props.src !== '' ? allData[0] : undefined"
-        :errors="props.src !== '' ? allErrors[0] : undefined"
+        :error="props.src !== '' ? allErrors[0] : undefined"
         :refresh="props.src !== '' ? refresh : () => {}"
       />
     </template>

--- a/src/app/application/index.ts
+++ b/src/app/application/index.ts
@@ -36,6 +36,7 @@ declare module '@vue/runtime-core' {
   export interface GlobalComponents {
     AppView: typeof AppView
     DataSource: typeof DataSource
+    DataLoader: typeof DataLoader
     DataCollection: typeof DataCollection
     RouteView: typeof RouteView
     RouteTitle: typeof RouteTitle


### PR DESCRIPTION
Typo in https://github.com/kumahq/kuma-gui/pull/2126 `errors` > `error`.

DataLoader should export the same shape as DataSource