### PR TITLE
refactor(policies): refactor of the rules API data transformations

### DIFF
--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -28,6 +28,7 @@
     })"
     :row-attrs="getRowAttributes"
     disable-sorting
+    :disable-pagination="props.pageNumber === 0"
     hide-pagination-when-optional
     @row:click="click"
   >
@@ -139,7 +140,7 @@ const props = withDefaults(defineProps<{
 }>(), {
   isSelectedRow: null,
   total: 0,
-  pageNumber: 1,
+  pageNumber: 0,
   pageSize: 30,
   error: undefined,
   emptyStateTitle: undefined,

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -216,8 +216,8 @@ function getRowAttributes(row: Row): Record<string, string> {
 const click = (e: MouseEvent) => {
   const $tr = (e.target as HTMLElement).closest('tr')
   if ($tr) {
-    const $a = $tr.querySelector('a')
-    if ($a !== null) {
+    const $a: HTMLAnchorElement | null = $tr.querySelector('td:first-child a')
+    if ($a !== null && $a.closest('tr, li') === $tr) {
       $a.click()
     }
   }
@@ -230,6 +230,13 @@ const click = (e: MouseEvent) => {
   color: inherit;
   font-weight: $kui-font-weight-semibold;
   text-decoration: none;
+}
+.app-collection :deep(td:first-child li a) {
+  color: $kui-color-text-primary;
+  font-weight: $kui-font-weight-regular;
+}
+.app-collection :deep(td:first-child li a:hover) {
+  text-decoration: underline;
 }
 
 .app-collection-toolbar {

--- a/src/app/application/components/data-collection/DataCollection.vue
+++ b/src/app/application/components/data-collection/DataCollection.vue
@@ -45,7 +45,7 @@ const props = withDefaults(defineProps<{
   pageSize?: number
   items: T[]
   predicate?: (item: T) => boolean
-  comparator?: ((item: T) => number) | undefined
+  comparator?: ((a: T, b: T) => number) | undefined
   find?: boolean
   empty?: boolean
 }>(), {

--- a/src/app/data-planes/components/RuleEntryList.vue
+++ b/src/app/data-planes/components/RuleEntryList.vue
@@ -38,7 +38,6 @@
                 }"
                 :total="items.length"
                 :items="items"
-                :page-size="100000"
                 :headers="[
                   ...(hasMatchers ? [{ label: 'Matchers', key: 'matchers' }] : []),
                   { label: 'Origin policies', key: 'origins' },

--- a/src/app/data-planes/components/RuleEntryList.vue
+++ b/src/app/data-planes/components/RuleEntryList.vue
@@ -3,131 +3,149 @@
     :initially-open="[]"
     multiple-open
   >
-    <AccordionItem
-      v-for="(ruleEntry, index) in props.ruleEntries"
-      :key="index"
+    <template
+      v-for="policies in [props.rules.reduce<Record<string, Rule[]>>((prev, item) => {
+        if(typeof prev[item.type] === 'undefined') {
+          prev[item.type] = []
+        }
+        prev[item.type].push(item)
+        return prev
+      }, {})]"
+      :key="policies"
     >
-      <template #accordion-header>
-        <h3 class="policy-type-heading">
-          <PolicyTypeTag :policy-type="ruleEntry.type">
-            {{ ruleEntry.type }}
-          </PolicyTypeTag>
-        </h3>
-      </template>
+      <AccordionItem
+        v-for="(items, type) in policies"
+        :key="type"
+      >
+        <template #accordion-header>
+          <h3 class="policy-type-heading">
+            <PolicyTypeTag :policy-type="type">
+              {{ type }}
+            </PolicyTypeTag>
+          </h3>
+        </template>
 
-      <template #accordion-content>
-        <div class="policy-list">
-          <KTable
-            class="policy-type-table"
-            :class="{
-              'has-matchers': props.showMatchers,
-            }"
-            :fetcher="() => ({ data: ruleEntry.rules, total: ruleEntry.rules.length })"
-            :headers="[
-              ...(props.showMatchers ? [{ label: 'Matchers', key: 'matchers' }] : []),
-              { label: 'Origin policies', key: 'origins' },
-              { label: 'Conf', key: 'config' },
-            ]"
-            :cell-attrs="getCellAttributes"
-            disable-pagination
+        <template #accordion-content>
+          <template
+            v-for="hasMatchers in [items.some((item) => item.matchers.length > 0)]"
+            :key="hasMatchers"
           >
-            <template
-              v-if="props.showMatchers"
-              #matchers="{ row }: { row: RuleEntryRule }"
-            >
-              <span
-                v-if="row.matchers && row.matchers.length > 0"
-                class="matcher"
+            <div class="policy-list">
+              <AppCollection
+                class="policy-type-table"
+                :class="{
+                  'has-matchers': hasMatchers,
+                }"
+                :total="items.length"
+                :items="items"
+                :page-size="100000"
+                :headers="[
+                  ...(hasMatchers ? [{ label: 'Matchers', key: 'matchers' }] : []),
+                  { label: 'Origin policies', key: 'origins' },
+                  { label: 'Conf', key: 'config' },
+                ]"
               >
                 <template
-                  v-for="({ key, value, not }, matcherIndex) in row.matchers"
-                  :key="matcherIndex"
+                  #matchers="{ row }"
                 >
                   <span
-                    v-if="matcherIndex > 0"
-                    class="matcher__and"
-                  > and<br></span><span
-                    v-if="not"
-                    class="matcher__not"
-                  >!</span><span class="matcher__term">{{ `${key}:${value}` }}</span>
-                </template>
-              </span>
-
-              <template v-else>
-                <i>{{ t('data-planes.routes.item.matches_everything') }}</i>
-              </template>
-            </template>
-
-            <template #origins="{ row }: { row: RuleEntryRule }">
-              <ul v-if="row.origins.length > 0">
-                <li
-                  v-for="(origin, originIndex) in row.origins"
-                  :key="`${index}-${originIndex}`"
-                >
-                  <RouterLink
-                    :to="{
-                      name: 'policy-detail-view',
-                      params: {
-                        mesh: origin.mesh,
-                        policyPath: props.policyTypesByName[origin.type]!.path,
-                        policy: origin.name,
-                      },
-                    }"
+                    v-if="row.matchers.length > 0"
+                    class="matcher"
                   >
-                    {{ origin.name }}
-                  </RouterLink>
-                </li>
-              </ul>
+                    <template
+                      v-for="({ key, value, not }, matcherIndex) in row.matchers"
+                      :key="matcherIndex"
+                    >
+                      <span
+                        v-if="matcherIndex > 0"
+                        class="matcher__and"
+                      > and<br></span><span
+                        v-if="not"
+                        class="matcher__not"
+                      >!</span><span class="matcher__term">{{ `${key}:${value}` }}</span>
+                    </template>
+                  </span>
 
-              <template v-else>
-                {{ t('common.collection.none') }}
-              </template>
-            </template>
+                  <template v-else>
+                    <i>{{ t('data-planes.routes.item.matches_everything') }}</i>
+                  </template>
+                </template>
 
-            <template #config="{ row }: { row: RuleEntryRule, rowKey: number }">
-              <template v-if="row.config">
-                <CodeBlock
-                  :code="toYaml(row.config)"
-                  language="yaml"
-                  :show-copy-button="false"
-                />
-              </template>
+                <template #origins="{ row }">
+                  <ul v-if="row.origins.length > 0">
+                    <li
+                      v-for="(origin, originIndex) in row.origins"
+                      :key="`${type}-${originIndex}`"
+                    >
+                      <RouterLink
+                        :to="{
+                          name: 'policy-detail-view',
+                          params: {
+                            mesh: origin.mesh,
+                            policyPath: props.policyTypesByName[origin.type]!.path,
+                            policy: origin.name,
+                          },
+                        }"
+                      >
+                        {{ origin.name }}
+                      </RouterLink>
+                    </li>
+                  </ul>
 
-              <template v-else>
-                {{ t('common.collection.none') }}
-              </template>
-            </template>
-          </KTable>
-        </div>
-      </template>
-    </AccordionItem>
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #config="{ row }">
+                  <template v-if="row.config">
+                    <CodeBlock
+                      :code="toYaml(row.config)"
+                      language="yaml"
+                      :show-copy-button="false"
+                    />
+                  </template>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+              </AppCollection>
+            </div>
+          </template>
+        </template>
+      </AccordionItem>
+    </template>
   </AccordionList>
 </template>
 
 <script lang="ts" setup>
+import type { Rule } from '../data'
 import { useI18n } from '@/app/application'
+import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
-import type { PolicyType, RuleEntry, RuleEntryRule } from '@/types/index.d'
+import type { PolicyType } from '@/types/index.d'
 import { toYaml } from '@/utilities/toYaml'
 const { t } = useI18n()
 
-const props = withDefaults(defineProps<{
-  ruleEntries: RuleEntry[]
+const props = defineProps<{
+  rules: Rule[]
   policyTypesByName: Record<string, PolicyType | undefined>
-  showMatchers?: boolean
-}>(), {
-  showMatchers: true,
-})
+}>()
 
-function getCellAttributes({ headerKey }: any): Record<string, string> {
-  return { class: `cell-${headerKey}` }
-}
 </script>
 
 <style lang="scss" scoped>
+:deep(.app-collection .k-table.is-clickable tr) {
+  cursor: default;
+}
+:deep(.app-collection .k-table.has-hover tr:hover) {
+  background-color: transparent;
+}
+
 .policy-type-heading {
   font-size: inherit;
   font-weight: $kui-font-weight-regular;

--- a/src/app/data-planes/components/StandardDataplanePolicies.vue
+++ b/src/app/data-planes/components/StandardDataplanePolicies.vue
@@ -1,60 +1,96 @@
 <template>
   <div class="stack">
-    <KCard v-if="props.inspectRulesForDataplane.proxyRules.length > 0">
-      <h3>{{ t('data-planes.routes.item.proxy_rule') }}</h3>
-
-      <RuleEntryList
-        class="mt-2"
-        :rule-entries="props.inspectRulesForDataplane.proxyRules"
-        :policy-types-by-name="props.policyTypesByName"
-        :show-matchers="false"
-        data-testid="proxy-rule-list"
-      />
-    </KCard>
-
-    <KCard v-if="props.inspectRulesForDataplane.toRules.length > 0">
-      <h3>{{ t('data-planes.routes.item.to_rules') }}</h3>
-
-      <RuleEntryList
-        class="mt-2"
-        :rule-entries="props.inspectRulesForDataplane.toRules"
-        :policy-types-by-name="props.policyTypesByName"
-        data-testid="to-rule-list"
-      />
-    </KCard>
-
-    <KCard v-if="props.inspectRulesForDataplane.fromRuleInbounds.length > 0">
-      <h3 class="mb-2">
-        {{ t('data-planes.routes.item.from_rules') }}
-      </h3>
-
-      <div
-        v-for="(fromRule, index) in props.inspectRulesForDataplane.fromRuleInbounds"
-        :key="index"
-      >
-        <h4>{{ t('data-planes.routes.item.port', { port: fromRule.port }) }}</h4>
+    <DataCollection
+      v-slot="{ items }"
+      :items="props.rules"
+      :predicate="(item) => item.ruleType === 'proxy'"
+      :empty="false"
+    >
+      <KCard>
+        <h3>
+          {{ t('data-planes.routes.item.proxy_rule') }}
+        </h3>
 
         <RuleEntryList
           class="mt-2"
-          :rule-entries="fromRule.ruleEntries"
+          :rules="items"
           :policy-types-by-name="props.policyTypesByName"
-          :data-testid="`from-rule-list-${index}`"
+          data-testid="proxy-rule-list"
         />
-      </div>
-    </KCard>
+      </KCard>
+    </DataCollection>
+
+    <DataCollection
+      v-slot="{ items }"
+      :items="props.rules"
+      :predicate="(item) => item.ruleType === 'to'"
+      :empty="false"
+    >
+      <KCard>
+        <h3>
+          {{ t('data-planes.routes.item.to_rules') }}
+        </h3>
+
+        <RuleEntryList
+          class="mt-2"
+          :rules="items"
+          :policy-types-by-name="props.policyTypesByName"
+          data-testid="to-rule-list"
+        />
+      </KCard>
+    </DataCollection>
+
+    <DataCollection
+      v-slot="{ items }"
+      :items="props.rules"
+      :predicate="(item) => item.ruleType === 'from'"
+      :empty="false"
+    >
+      <KCard>
+        <h3 class="mb-2">
+          {{ t('data-planes.routes.item.from_rules') }}
+        </h3>
+        <template
+          v-for="inbounds in [items.reduce<Record<number, Rule[]>>((prev, item) => {
+            if(typeof item.inbound?.port !== 'undefined') {
+              if (typeof prev[item.inbound.port] === 'undefined') {
+                prev[item.inbound.port] = []
+              }
+              prev[item.inbound.port].push(item)
+            }
+            return prev
+          }, {})]"
+          :key="inbounds"
+        >
+          <div
+            v-for="([port, rs], index) in Object.entries(inbounds).sort(([a], [b]) => Number(b) - Number(a))"
+            :key="index"
+          >
+            <h4>{{ t('data-planes.routes.item.port', { port }) }}</h4>
+
+            <RuleEntryList
+              class="mt-2"
+              :rules="rs"
+              :policy-types-by-name="props.policyTypesByName"
+              :data-testid="`from-rule-list-${index}`"
+            />
+          </div>
+        </template>
+      </KCard>
+    </DataCollection>
   </div>
 </template>
 
 <script lang="ts" setup>
 import RuleEntryList from './RuleEntryList.vue'
-import type { InspectRulesForDataplane } from '../data'
+import type { Rule } from '../data'
 import { useI18n } from '@/app/application'
 import type { PolicyType } from '@/types/index.d'
 
 const { t } = useI18n()
 
 const props = defineProps<{
-  inspectRulesForDataplane: InspectRulesForDataplane
+  rules: Rule[]
   policyTypesByName: Record<string, PolicyType | undefined>
 }>()
 </script>

--- a/src/app/data-planes/components/StandardDataplanePolicies.vue
+++ b/src/app/data-planes/components/StandardDataplanePolicies.vue
@@ -4,6 +4,7 @@
       v-slot="{ items }"
       :items="props.rules"
       :predicate="(item) => item.ruleType === 'proxy'"
+      :comparator="(a, b) => a.type.localeCompare(b.type)"
       :empty="false"
     >
       <KCard>
@@ -24,6 +25,7 @@
       v-slot="{ items }"
       :items="props.rules"
       :predicate="(item) => item.ruleType === 'to'"
+      :comparator="(a, b) => a.type.localeCompare(b.type)"
       :empty="false"
     >
       <KCard>
@@ -44,6 +46,7 @@
       v-slot="{ items }"
       :items="props.rules"
       :predicate="(item) => item.ruleType === 'from'"
+      :comparator="(a, b) => a.type.localeCompare(b.type)"
       :empty="false"
     >
       <KCard>

--- a/src/app/data-planes/data/index.ts
+++ b/src/app/data-planes/data/index.ts
@@ -209,7 +209,6 @@ export type Rule = Omit<InspectBaseRule, 'conf' | 'origin'> & {
   origins: InspectBaseRule['origin']
 }
 export type RuleCollection = Omit<PartialInspectRulesForDataplane, 'rules'> & {
-  // httpMatches: unknown[]
   rules: Rule[]
 }
 export const Rule = {
@@ -261,8 +260,7 @@ export const Rule = {
     }, []) : []
     return {
       ...partialInspectRules,
-      // httpMatches: Array.isArray(partialInspectRules.httpMatches) ? partialInspectRules.httpMatches : [],
-      rules: rules.sort((a, b) => a.ruleType.localeCompare(b.ruleType)),
+      rules,
     }
   },
 }

--- a/src/app/data-planes/data/index.ts
+++ b/src/app/data-planes/data/index.ts
@@ -1,4 +1,3 @@
-/* eslint multiline-ternary: ["off"] */
 import type { Connection } from '@/app/connections/data'
 import { DiscoverySubscriptionCollection, type DiscoverySubscription } from '@/app/subscriptions/data'
 import type { ApiKindListResponse, PaginatedApiListResponse } from '@/types/api.d'
@@ -224,40 +223,48 @@ export const Rule = {
     }
   },
   fromCollection(partialInspectRules: PartialInspectRulesForDataplane): RuleCollection {
-    const rules = Array.isArray(partialInspectRules.rules) ? partialInspectRules.rules.reduce<Rule[]>((prev, item) => {
+    const rules = Array.isArray(partialInspectRules.rules)
+      ? partialInspectRules.rules.reduce<Rule[]>((prev, item) => {
       // to rules we can just reshape.
-      const to = Array.isArray(item.toRules) ? item.toRules.map(rule => {
-        return {
-          ...Rule.fromObject(rule),
-          type: item.type,
-          ruleType: 'to',
-        }
-      }) : []
+        const to = Array.isArray(item.toRules)
+          ? item.toRules.map(rule => {
+            return {
+              ...Rule.fromObject(rule),
+              type: item.type,
+              ruleType: 'to',
+            }
+          })
+          : []
 
-      // from rules we can need to flatten out with reduce
-      const from = Array.isArray(item.fromRules) ? item.fromRules.reduce<Rule[]>((prev, rule) => {
-        const { rules, ...rest } = rule
-        return prev.concat(rules.map(r => {
-          return {
-            ...rest,
-            ...Rule.fromObject(r),
+        // from rules we can need to flatten out with reduce
+        const from = Array.isArray(item.fromRules)
+          ? item.fromRules.reduce<Rule[]>((prev, rule) => {
+            const { rules, ...rest } = rule
+            return prev.concat(rules.map(r => {
+              return {
+                ...rest,
+                ...Rule.fromObject(r),
+                type: item.type,
+                ruleType: 'from',
+              }
+            }))
+          }, [])
+          : []
+
+        // the proxyRule is only ever a single one, but we turn it into an array
+        // with a single entry so it looks like to and from rules
+        const proxy = typeof item.proxyRule !== 'undefined'
+          ? [{
+            ...Rule.fromObject(item.proxyRule as InspectBaseRule),
             type: item.type,
-            ruleType: 'from',
-          }
-        }))
-      }, []) : []
+            ruleType: 'proxy',
+          }]
+          : []
 
-      // the proxyRule is only ever a single one, but we turn it into an array
-      // with a single entry so it looks like to and from rules
-      const proxy = typeof item.proxyRule !== 'undefined' ? [{
-        ...Rule.fromObject(item.proxyRule as InspectBaseRule),
-        type: item.type,
-        ruleType: 'proxy',
-      }] : []
-
-      // concat all the rules now thay all look the same
-      return prev.concat(to).concat(from).concat(proxy)
-    }, []) : []
+        // concat all the rules now thay all look the same
+        return prev.concat(to).concat(from).concat(proxy)
+      }, [])
+      : []
     return {
       ...partialInspectRules,
       rules,

--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -1,8 +1,8 @@
 import {
   Dataplane,
   DataplaneOverview,
-  InspectRules,
-  InspectRulesForDataplane,
+  Rule,
+  RuleCollection,
   MeshGatewayDataplane,
   SidecarDataplane,
 } from './data'
@@ -30,7 +30,7 @@ export type SidecarDataplaneCollectionSource = DataSourceResponse<SidecarDatapla
 
 export type MeshGatewayDataplaneSource = DataSourceResponse<MeshGatewayDataplane>
 
-export type DataplaneRulesSource = DataSourceResponse<InspectRulesForDataplane>
+export type DataplaneRulesSource = DataSourceResponse<RuleCollection>
 
 const includes = <T extends readonly string[]>(arr: T, item: string): item is T[number] => {
   return arr.includes(item as T[number])
@@ -72,7 +72,7 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
     },
 
     '/meshes/:mesh/dataplanes/:name/rules': async (params) => {
-      return InspectRules.fromCollection(await api.getDataplaneRules(params))
+      return Rule.fromCollection(await api.getDataplaneRules(params))
     },
 
     '/meshes/:mesh/dataplanes/:name/gateway-dataplane-policies': async (params) => {

--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -36,7 +36,7 @@
             >
               <StandardDataplanePolicies
                 :policy-types-by-name="policyTypesData.policies.reduce((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})"
-                :inspect-rules-for-dataplane="rulesData"
+                :rules="rulesData.rules"
                 data-testid="rules-based-policies"
               />
             </DataCollection>

--- a/src/test-support/mocks/src/meshes/_/dataplanes/_/_rules.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes/_/_rules.ts
@@ -5,8 +5,8 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
   const mesh = req.params.mesh as string
   const name = req.params.name as string
 
-  const haxProxyRuleOverride = env('KUMA_DATAPLANE_PROXY_RULE_ENABLED', '')
-  const haxProxyRule = haxProxyRuleOverride !== '' ? haxProxyRuleOverride === 'true' : fake.datatype.boolean()
+  const hasProxyRuleOverride = env('KUMA_DATAPLANE_PROXY_RULE_ENABLED', '')
+  const hasProxyRule = hasProxyRuleOverride !== '' ? hasProxyRuleOverride === 'true' : fake.datatype.boolean()
   const ruleCount = parseInt(env('KUMA_DATAPLANE_RULE_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
   const toRuleCount = parseInt(env('KUMA_DATAPLANE_TO_RULE_COUNT', `${fake.number.int({ min: 0, max: 3 })}`))
   const fromRuleCount = parseInt(env('KUMA_DATAPLANE_FROM_RULE_COUNT', `${fake.number.int({ min: 0, max: 3 })}`))
@@ -20,7 +20,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
         name,
       },
       rules: [
-        ...haxProxyRule
+        ...(hasProxyRule
           ? [{
             type: 'MeshProxyPatch',
             proxyRule: {
@@ -43,7 +43,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
               ],
             },
           }]
-          : [],
+          : []),
         ...Array.from({ length: ruleCount }).map(() => {
           const type = fake.helpers.arrayElement(['MeshHTTPRoute', 'MeshTimeout'])
 


### PR DESCRIPTION
Refactors the 'Rule' objects to use a similar `Rule.fromObject/fromCollection` interface of our data layer.

We'll be using these objects in the dataplane viz side panels soon, so wanted to get familiar with the shape of things as well as move things over to our `toObject` interfaces.

The shape of these has changed slightly in that we just produce a big list of `rules` then filter/pick what we want from those in the view.

I guess there will be a file move PR to come after this, but I wanted to avoid renaming and moving files around too much in a PR with this amount of change in it.