### PR TITLE
refactor(gateways): use DataLoader for detail views

### DIFF
--- a/src/app/application/components/data-source/DataLoader.vue
+++ b/src/app/application/components/data-source/DataLoader.vue
@@ -71,14 +71,13 @@ import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
 
 const props = withDefaults(defineProps<{
-  data: any[]
-  errors: (Error | undefined)[]
+  data?: any[]
+  errors?: (Error | undefined)[]
   src: string
   loader?: boolean
 }>(), {
   errors: () => [],
   data: () => [],
-  src: '',
   loader: true,
 })
 

--- a/src/app/application/components/data-source/DataLoader.vue
+++ b/src/app/application/components/data-source/DataLoader.vue
@@ -73,11 +73,12 @@ import LoadingBlock from '@/app/common/LoadingBlock.vue'
 const props = withDefaults(defineProps<{
   data?: any[]
   errors?: (Error | undefined)[]
-  src: string
+  src?: string
   loader?: boolean
 }>(), {
   errors: () => [],
   data: () => [],
+  src: '',
   loader: true,
 })
 

--- a/src/app/gateways/views/BuiltinGatewayDetailView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailView.vue
@@ -23,7 +23,7 @@
           :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}`"
         >
           <DataLoader
-            v-slot="{ data: dataplanesData, error: dataplanesError }: DataplaneOverviewCollectionSource"
+            v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
             :src="data === undefined ? '' : `/meshes/${route.params.mesh}/dataplanes/for/${data.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
             :data="[data]"
             :errors="[error]"
@@ -45,7 +45,6 @@
                 ]"
                 :items="dataplanesData?.items"
                 :total="dataplanesData?.total"
-                :error="dataplanesError"
                 :is-selected-row="(row) => row.name === route.params.dataPlane"
                 summary-route-name="builtin-gateway-data-plane-summary-view"
                 :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"

--- a/src/app/gateways/views/BuiltinGatewayDetailView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailView.vue
@@ -18,29 +18,19 @@
       }"
     >
       <AppView>
-        <DataSource
+        <DataLoader
           v-slot="{ data, error }: MeshGatewaySource"
           :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}`"
         >
-          <ErrorBlock
-            v-if="error"
-            :error="error"
-          />
-
-          <LoadingBlock v-else-if="data === undefined" />
-
-          <KCard v-else>
-            <DataSource
-              v-slot="{ data: dataplanesData, error: dataplanesError }: DataplaneOverviewCollectionSource"
-              :src="`/meshes/${route.params.mesh}/dataplanes/for/${data.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
-            >
-              <ErrorBlock
-                v-if="dataplanesError !== undefined"
-                :error="dataplanesError"
-              />
-
+          <DataLoader
+            v-if="data"
+            v-slot="{ data: dataplanesData, error: dataplanesError }: DataplaneOverviewCollectionSource"
+            :src="`/meshes/${route.params.mesh}/dataplanes/for/${data.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
+            :data="[data]"
+            :errors="[error]"
+          >
+            <KCard v-if="dataplanesData">
               <AppCollection
-                v-else
                 class="data-plane-collection"
                 data-testid="data-plane-collection"
                 :page-number="route.params.page"
@@ -206,9 +196,9 @@
                   />
                 </SummaryView>
               </RouterView>
-            </DataSource>
-          </KCard>
-        </DataSource>
+            </KCard>
+          </DataLoader>
+        </DataLoader>
       </AppView>
     </RouteView>
   </DataSource>
@@ -220,9 +210,7 @@ import { ArrowRightIcon } from '@kong/icons'
 
 import type { MeshGatewaySource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import WarningIcon from '@/app/common/WarningIcon.vue'

--- a/src/app/gateways/views/BuiltinGatewayDetailView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailView.vue
@@ -18,18 +18,18 @@
       }"
     >
       <AppView>
-        <DataLoader
+        <DataSource
           v-slot="{ data, error }: MeshGatewaySource"
           :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}`"
         >
           <DataLoader
-            v-if="data"
             v-slot="{ data: dataplanesData, error: dataplanesError }: DataplaneOverviewCollectionSource"
-            :src="`/meshes/${route.params.mesh}/dataplanes/for/${data.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
+            :src="data === undefined ? '' : `/meshes/${route.params.mesh}/dataplanes/for/${data.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
             :data="[data]"
             :errors="[error]"
+            :loader="false"
           >
-            <KCard v-if="dataplanesData">
+            <KCard>
               <AppCollection
                 class="data-plane-collection"
                 data-testid="data-plane-collection"
@@ -198,7 +198,7 @@
               </RouterView>
             </KCard>
           </DataLoader>
-        </DataLoader>
+        </DataSource>
       </AppView>
     </RouteView>
   </DataSource>

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -18,19 +18,12 @@
       }"
     >
       <AppView>
-        <DataSource
+        <DataLoader
           v-slot="{ data, error }: ServiceInsightSource"
           :src="`/meshes/${route.params.mesh}/service-insights/${route.params.service}`"
         >
-          <ErrorBlock
-            v-if="error"
-            :error="error"
-          />
-
-          <LoadingBlock v-else-if="data === undefined" />
-
           <div
-            v-else
+            v-if="data"
             class="stack"
           >
             <KCard>
@@ -77,17 +70,14 @@
               <h3>{{ t('delegated-gateways.detail.data_plane_proxies') }}</h3>
 
               <KCard class="mt-4">
-                <DataSource
+                <DataLoader
                   v-slot="{ data: dataplanesData, error: dataplanesError }: DataplaneOverviewCollectionSource"
                   :src="`/meshes/${route.params.mesh}/dataplanes/for/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
+                  :data="[data]"
+                  :errors="[error]"
                 >
-                  <ErrorBlock
-                    v-if="dataplanesError !== undefined"
-                    :error="dataplanesError"
-                  />
-
                   <AppCollection
-                    v-else
+                    v-if="dataplanesData"
                     class="data-plane-collection"
                     data-testid="data-plane-collection"
                     :page-number="route.params.page"
@@ -252,11 +242,11 @@
                       />
                     </SummaryView>
                   </RouterView>
-                </DataSource>
+                </DataLoader>
               </KCard>
             </div>
           </div>
-        </DataSource>
+        </DataLoader>
       </AppView>
     </RouteView>
   </DataSource>
@@ -268,9 +258,7 @@ import { ArrowRightIcon } from '@kong/icons'
 
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import ResourceStatus from '@/app/common/ResourceStatus.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -72,6 +72,7 @@
                   :src="`/meshes/${route.params.mesh}/dataplanes/for/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
                   :data="[data]"
                   :errors="[error]"
+                  :loader="false"
                 >
                   <AppCollection
                     v-if="dataplanesData"

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -69,7 +69,7 @@
 
             <KCard class="mt-4">
               <DataLoader
-                v-slot="{ data: dataplanesData, error: dataplanesError }: DataplaneOverviewCollectionSource"
+                v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
                 :src="`/meshes/${route.params.mesh}/dataplanes/for/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
                 :loader="false"
               >
@@ -88,7 +88,6 @@
                   ]"
                   :items="dataplanesData?.items"
                   :total="dataplanesData?.total"
-                  :error="dataplanesError"
                   :is-selected-row="(row) => row.name === route.params.dataPlane"
                   summary-route-name="delegated-gateway-data-plane-summary-view"
                   :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -18,15 +18,12 @@
       }"
     >
       <AppView>
-        <DataLoader
+        <DataSource
           v-slot="{ data, error }: ServiceInsightSource"
           :src="`/meshes/${route.params.mesh}/service-insights/${route.params.service}`"
         >
-          <div
-            v-if="data"
-            class="stack"
-          >
-            <KCard>
+          <div class="stack">
+            <KCard v-if="data">
               <div class="columns">
                 <DefinitionCard>
                   <template #title>
@@ -246,7 +243,7 @@
               </KCard>
             </div>
           </div>
-        </DataLoader>
+        </DataSource>
       </AppView>
     </RouteView>
   </DataSource>


### PR DESCRIPTION
**chore(DataLouder): make data and errors optional**

Make the `data` and `errors` prop so users of DataLoader can actually not provide them.

Remove the unused default value from the `src` prop. Providing an empty source should require an explicit action on the usage side.

**refactor(gateways): use DataLoader for detail views**

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
