### PR TITLE
fix(policies): ensure legacy policies section has an empty state

### DIFF
--- a/src/app/data-planes/components/PolicyTypeEntryList.vue
+++ b/src/app/data-planes/components/PolicyTypeEntryList.vue
@@ -4,7 +4,7 @@
     multiple-open
   >
     <AccordionItem
-      v-for="(policyTypeEntry, index) in legacyPolicyTypeEntries"
+      v-for="(policyTypeEntry, index) in items"
       :key="index"
     >
       <template #accordion-header>
@@ -78,7 +78,7 @@
                       name: 'policy-detail-view',
                       params: {
                         mesh: origin.mesh,
-                        policyPath: props.policyTypesByName[origin.type]!.path,
+                        policyPath: props.types[origin.type]!.path,
                         policy: origin.name,
                       },
                     }"
@@ -114,7 +114,6 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
 
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
@@ -125,11 +124,9 @@ import type { PolicyType, PolicyTypeEntry, PolicyTypeEntryConnection } from '@/t
 import { toYaml } from '@/utilities/toYaml'
 
 const props = defineProps<{
-  policyTypeEntries: PolicyTypeEntry[]
-  policyTypesByName: Record<string, PolicyType | undefined>
+  items: PolicyTypeEntry[]
+  types: Record<string, PolicyType | undefined>
 }>()
-
-const legacyPolicyTypeEntries = computed(() => props.policyTypeEntries.filter((policyTypeEntry) => props.policyTypesByName[policyTypeEntry.type]?.isTargetRefBased === false))
 
 function getCellAttributes({ headerKey }: any): Record<string, string> {
   return { class: `cell-${headerKey}` }

--- a/src/app/policies/sources.ts
+++ b/src/app/policies/sources.ts
@@ -1,9 +1,9 @@
 import { Policy, PolicyDataplane } from './data'
+import type { PolicyType } from './data'
 import { defineSources } from '../application/services/data-source'
 import type { DataSourceResponse } from '@/app/application'
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
-import type { PolicyType } from '@/types/index.d'
 
 export type PolicyCollection = CollectionResponse<Policy>
 export type PolicySource = DataSourceResponse<Policy>


### PR DESCRIPTION
Whilst playing around with kuma I spotted a bug when using non-federated/single-zone mode where we show a legacy policies section but we don't show an empty state, and instead its just a blank space which looks broken:

### Before:
![Screenshot 2024-03-05 at 11 37 17](https://github.com/kumahq/kuma-gui/assets/554604/5cb0e074-dd6d-497b-9a33-7b3e527dbb34)

### After:

![Screenshot 2024-03-05 at 11 39 56](https://github.com/kumahq/kuma-gui/assets/554604/c016553e-ada3-407c-b1b6-930fcfae0fa6)

I noticed that this was for "sidecar" dataplanes only, "gateway" dataplanes where showing an empty state, but I decided to add a KCard around the empty state in both places so there is a little change there also to make them consistent.

Theres a question about whether we should show the "Legacy Policies" block at all if its empty, but seeing as we do for gateway dataplanes I decided at least for the moment to continue to show it.

I stopped short of doing a bit more work here as I know there is work in progress that is altering this code for different reasons, but there is likely to be a follow up in this area later.
