### PR TITLE
refactor: update Kongponents to KAlert/KEmptyState/KPagination milestone

### DIFF
--- a/features/application/MainNavigation.feature
+++ b/features/application/MainNavigation.feature
@@ -53,11 +53,11 @@ Feature: application / MainNavigation
       """
     When I visit the "/meshes" URL
     And the URL contains "page=1&size=50"
-    And the "[data-testid='page-1-btn'].active" element exists
+    And the "[data-testid='page-1-button'].active" element exists
 
     When I visit the "/meshes?page=2&size=" URL
     And the URL contains "page=2&size=50"
-    And the "[data-testid='page-2-btn'].active" element exists
+    And the "[data-testid='page-2-button'].active" element exists
 
     When I visit the "/meshes/default/data-planes" URL
     And the URL contains "page=1&size=50"
@@ -75,15 +75,15 @@ Feature: application / MainNavigation
 
     When I click the "$meshes-nav" element
     Then the page title contains "Meshes"
-    And the "[data-testid='page-1-btn'].active" element exists
+    And the "[data-testid='page-1-button'].active" element exists
 
-    When I click the "[data-testid='next-btn'] > a" element
+    When I click the "[data-testid='next-button']" element
     Then the page title contains "Meshes"
-    And the "[data-testid='page-2-btn'].active" element exists
+    And the "[data-testid='page-2-button'].active" element exists
 
     When I navigate "back"
     Then the page title contains "Meshes"
-    And the "[data-testid='page-1-btn'].active" element exists
+    And the "[data-testid='page-1-button'].active" element exists
 
     When I navigate "back"
     Then the page title contains "Overview"

--- a/features/mesh/policies/Data.feature
+++ b/features/mesh/policies/Data.feature
@@ -1,12 +1,12 @@
 Feature: mesh / policies / data
   Background:
     Given the CSS selectors
-      | Alias         | Selector                            |
-      | items         | [data-testid='policy-collection']   |
-      | item          | $items tbody tr                     |
-      | state-empty   | [data-testid='k-table-empty-state'] |
-      | state-error   | [data-testid='error-state']         |
-      | state-loading | [data-testid='loading-block']       |
+      | Alias         | Selector                          |
+      | items         | [data-testid='policy-collection'] |
+      | item          | $items tbody tr                   |
+      | state-empty   | [data-testid='empty-block']       |
+      | state-error   | [data-testid='error-block']       |
+      | state-loading | [data-testid='loading-block']     |
     And the URL "/mesh-insights/default" responds with
       """
       body:

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@kong-ui-public/i18n": "2.1.3",
     "@kong/icons": "1.8.14",
-    "@kong/kongponents": "9.0.0-alpha.107",
+    "@kong/kongponents": "9.0.0-alpha.113",
     "@vueuse/core": "10.9.0",
     "brandi": "5.0.0",
     "deepmerge": "4.3.1",

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -37,18 +37,17 @@
       #empty-state
     >
       <EmptyBlock>
-        {{ props.emptyStateTitle ?? t('common.emptyState.title') }}
+        <template #title>
+          {{ props.emptyStateTitle ?? t('common.emptyState.title') }}
+        </template>
 
-        <template
-          v-if="props.emptyStateMessage"
-          #message
-        >
+        <template v-if="props.emptyStateMessage">
           {{ props.emptyStateMessage }}
         </template>
 
         <template
           v-if="props.emptyStateCtaTo"
-          #cta
+          #action
         >
           <DocumentationLink
             v-if="typeof props.emptyStateCtaTo === 'string'"

--- a/src/app/application/components/app-view/AppView.vue
+++ b/src/app/application/components/app-view/AppView.vue
@@ -44,9 +44,7 @@
           class="mb-4"
           appearance="warning"
         >
-          <template #alertMessage>
-            <slot name="notifications" />
-          </template>
+          <slot name="notifications" />
         </KAlert>
       </aside>
 

--- a/src/app/application/components/data-collection/DataCollection.vue
+++ b/src/app/application/components/data-collection/DataCollection.vue
@@ -22,7 +22,7 @@
       :current-page="props.page"
       :initial-page-size="props.pageSize"
       :page-sizes="[15, 30, 50, 75, 100]"
-      @page-changed="({ page }: PaginationChangeEvent) => {
+      @page-change="({ page }: PaginationChangeEvent) => {
         emit('change', {
           page,
           pageSize: props.pageSize,

--- a/src/app/common/DeleteResourceModal.vue
+++ b/src/app/common/DeleteResourceModal.vue
@@ -14,28 +14,25 @@
       v-if="error !== null"
       class="mt-4"
       appearance="danger"
-      is-dismissible
     >
-      <template #alertMessage>
-        <template v-if="(error instanceof ApiError)">
-          <p>{{ t('common.error_state.api_error', { status: error.status, title: error.detail }) }}</p>
+      <template v-if="(error instanceof ApiError)">
+        <p>{{ t('common.error_state.api_error', { status: error.status, title: error.detail }) }}</p>
 
-          <ul
-            v-if="error.invalidParameters.length > 0"
-            :data-testid="`error-${error.status}`"
+        <ul
+          v-if="error.invalidParameters.length > 0"
+          :data-testid="`error-${error.status}`"
+        >
+          <li
+            v-for="(parameter, index) in error.invalidParameters"
+            :key="index"
           >
-            <li
-              v-for="(parameter, index) in error.invalidParameters"
-              :key="index"
-            >
-              <b><code>{{ parameter.field }}</code></b>: {{ parameter.reason }}
-            </li>
-          </ul>
-        </template>
+            <b><code>{{ parameter.field }}</code></b>: {{ parameter.reason }}
+          </li>
+        </ul>
+      </template>
 
-        <template v-else>
-          <p>{{ t('common.error_state.default_error') }}</p>
-        </template>
+      <template v-else>
+        <p>{{ t('common.error_state.default_error') }}</p>
       </template>
     </KAlert>
   </KPrompt>

--- a/src/app/common/DocumentationLink.vue
+++ b/src/app/common/DocumentationLink.vue
@@ -29,7 +29,7 @@ const props = defineProps<{
 <style lang="scss" scoped>
 .docs-link {
   display: inline-flex;
-  align-items: flex-end;
+  align-items: center;
   gap: $kui-space-20;
   padding-right: $kui-space-40;
   padding-left: $kui-space-40;

--- a/src/app/common/EmptyBlock.vue
+++ b/src/app/common/EmptyBlock.vue
@@ -1,28 +1,20 @@
 <template>
-  <KEmptyState
-    data-testid="empty-state"
-    cta-is-hidden
-    :icon="t('common.emptyState.icon')"
-    icon-size="96"
-  >
+  <KEmptyState data-testid="empty-block">
     <template #title>
       <slot name="title">
-        <p><slot>{{ t('common.emptyState.title') }}</slot></p>
+        {{ t('common.emptyState.title') }}
       </slot>
     </template>
 
-    <template
-      v-if="$slots.message"
-      #message
-    >
-      <slot name="message" />
+    <template v-if="$slots.default">
+      <slot />
     </template>
 
     <template
-      v-if="$slots.cta"
-      #cta
+      v-if="$slots.action"
+      #action
     >
-      <slot name="cta" />
+      <slot name="action" />
     </template>
   </KEmptyState>
 </template>

--- a/src/app/common/ErrorBlock.vue
+++ b/src/app/common/ErrorBlock.vue
@@ -1,84 +1,77 @@
 <template>
   <div
-    data-testid="error-state"
+    data-testid="error-block"
     class="error-block"
   >
-    <KEmptyState cta-is-hidden>
+    <KEmptyState>
+      <template #icon>
+        <DangerIcon
+          v-if="props.appearance === 'danger'"
+          :color="KUI_COLOR_TEXT_DANGER"
+          display="inline-block"
+        />
+
+        <WarningIcon
+          v-else
+          :size="KUI_ICON_SIZE_50"
+        />
+      </template>
+
       <template #title>
-        <div class="error-block-header">
-          <div class="error-block-title">
-            <DangerIcon
-              v-if="props.appearance === 'danger'"
-              :color="KUI_COLOR_TEXT_DANGER"
-              display="inline-block"
-            />
-
-            <WarningIcon
-              v-else
-              :size="KUI_ICON_SIZE_50"
-            />
-
-            <slot>
-              <p>{{ error instanceof ApiError ? error.detail : t('common.error_state.title') }}</p>
-            </slot>
-          </div>
-
-          <span
-            v-if="(error instanceof ApiError)"
-            class="badge-list"
-          >
-            <KBadge
-              :appearance="props.appearance"
-              data-testid="error-status"
-            >
-              {{ error.status }}
-            </KBadge>
-
-            <KBadge
-              v-if="error.type"
-              appearance="neutral"
-              data-testid="error-type"
-              max-width="auto"
-            >
-              type: {{ error.type }}
-            </KBadge>
-
-            <KBadge
-              v-if="error.instance"
-              appearance="neutral"
-              data-testid="error-trace"
-              max-width="auto"
-            >
-              trace: <TextWithCopyButton :text="error.instance" />
-            </KBadge>
-          </span>
-        </div>
+        <slot name="title">
+          {{ error instanceof ApiError && error.detail ? error.detail : t('common.error_state.title') }}
+        </slot>
       </template>
 
-      <template #message>
-        <div class="error-block-message">
-          <slot
-            v-if="$slots.message"
-            name="message"
-          />
+      <div
+        v-if="(error instanceof ApiError)"
+        class="badge-list"
+      >
+        <KBadge
+          :appearance="props.appearance"
+          data-testid="error-status"
+        >
+          {{ error.status }}
+        </KBadge>
 
-          <p v-else>
-            {{ error.message }}
-          </p>
+        <KBadge
+          v-if="error.type"
+          appearance="neutral"
+          data-testid="error-type"
+          max-width="auto"
+        >
+          type: {{ error.type }}
+        </KBadge>
 
-          <ul
-            v-if="invalidParameters.length > 0"
-            data-testid="error-invalid-parameters"
+        <KBadge
+          v-if="error.instance"
+          appearance="neutral"
+          data-testid="error-trace"
+          max-width="auto"
+        >
+          trace: <TextWithCopyButton :text="error.instance" />
+        </KBadge>
+      </div>
+
+      <div class="error-block-message mt-4">
+        <slot v-if="$slots.default" />
+
+        <p v-else>
+          {{ error.message }}
+        </p>
+
+        <ul
+          v-if="invalidParameters.length > 0"
+          data-testid="error-invalid-parameters"
+        >
+          <li
+            v-for="(parameter, index) in invalidParameters"
+            :key="index"
           >
-            <li
-              v-for="(parameter, index) in invalidParameters"
-              :key="index"
-            >
-              {{ t('common.error_state.field') }} <b><code>{{ parameter.field }}</code></b>: {{ parameter.reason }}
-            </li>
-          </ul>
-        </div>
-      </template>
+            {{ t('common.error_state.field') }} <b><code>{{ parameter.field }}</code></b>: {{ parameter.reason }}
+          </li>
+        </ul>
+      </div>
     </KEmptyState>
   </div>
 </template>
@@ -106,24 +99,6 @@ const invalidParameters = computed(() => props.error instanceof ApiError ? props
 </script>
 
 <style lang="scss" scoped>
-.error-block-header {
-  max-width: 50%;
-  margin-right: auto;
-  margin-left: auto;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: $kui-space-40;
-}
-
-.error-block-title {
-  display: flex;
-  align-items: center;
-  gap: $kui-space-40;
-  text-align: left;
-}
-
 .error-block-message {
   text-align: left;
 }
@@ -132,11 +107,5 @@ const invalidParameters = computed(() => props.error instanceof ApiError ? props
   display: flex;
   gap: $kui-space-40;
   flex-wrap: wrap;
-}
-</style>
-
-<style lang="scss">
-.error-block-title p {
-  margin-top: 0;
 }
 </style>

--- a/src/app/common/LoadingBlock.vue
+++ b/src/app/common/LoadingBlock.vue
@@ -1,18 +1,15 @@
 <template>
-  <KEmptyState
-    cta-is-hidden
-    data-testid="loading-block"
-  >
-    <template #title>
+  <KEmptyState data-testid="loading-block">
+    <template #icon>
       <ProgressIcon
         class="mb-3"
         display="inline-block"
         :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
       />
+    </template>
 
-      <slot>
-        <p>Loading data …</p>
-      </slot>
+    <template #title>
+      Loading data …
     </template>
   </KEmptyState>
 </template>

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -416,11 +416,7 @@
                 class="mt-4"
                 appearance="warning"
               >
-                <template #alertMessage>
-                  <div
-                    v-html="t('data-planes.routes.item.mtls.disabled')"
-                  />
-                </template>
+                <div v-html="t('data-planes.routes.item.mtls.disabled')" />
               </KAlert>
             </template>
           </div>

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -146,9 +146,7 @@
                       #empty
                     >
                       <EmptyBlock>
-                        <template #message>
-                          This proxy is a delegated gateway therefore {{ t('common.product.name') }} does not have any visibility into inbounds for this gateway
-                        </template>
+                        <p>This proxy is a delegated gateway therefore {{ t('common.product.name') }} does not have any visibility into inbounds for this gateway</p>
                       </EmptyBlock>
                     </template>
                     <template #default="{ items: inbounds }">

--- a/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -22,11 +22,11 @@
       </template>
 
       <EmptyBlock v-if="props.dataplaneOverview === undefined">
-        {{ t('common.collection.summary.empty_title', { type: 'Data Plane Proxy' }) }}
-
-        <template #message>
-          <p>{{ t('common.collection.summary.empty_message', { type: 'Data Plane Proxy' }) }}</p>
+        <template #title>
+          {{ t('common.collection.summary.empty_title', { type: 'Data Plane Proxy' }) }}
         </template>
+
+        <p>{{ t('common.collection.summary.empty_message', { type: 'Data Plane Proxy' }) }}</p>
       </EmptyBlock>
 
       <div

--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -29,24 +29,22 @@
               <!-- make sure we have data but don't show errors or loaders -->
               <KAlert
                 v-if="data && env('KUMA_VERSION') !== data.version"
+                class="upgrade-alert"
                 data-testid="upgrade-check"
                 appearance="info"
-                size="small"
               >
-                <template #alertMessage>
-                  <div class="alert-content">
-                    <p>
-                      {{ t('common.product.name') }} update available
-                    </p>
+                <div class="alert-content">
+                  <p>
+                    {{ t('common.product.name') }} update available
+                  </p>
 
-                    <KButton
-                      appearance="primary"
-                      :to="t('common.product.href.install')"
-                    >
-                      Update
-                    </KButton>
-                  </div>
-                </template>
+                  <KButton
+                    appearance="primary"
+                    :to="t('common.product.href.install')"
+                  >
+                    Update
+                  </KButton>
+                </div>
               </KAlert>
             </DataSource>
           </div>
@@ -166,16 +164,14 @@
             class="mb-4"
             appearance="warning"
           >
-            <template #alertMessage>
-              <ul>
-                <!-- eslint-disable vue/no-v-html  -->
-                <li
-                  data-testid="warning-GLOBAL_STORE_TYPE_MEMORY"
-                  v-html="t('common.warnings.GLOBAL_STORE_TYPE_MEMORY')"
-                />
-                <!-- eslint-enable -->
-              </ul>
-            </template>
+            <ul>
+              <!-- eslint-disable vue/no-v-html  -->
+              <li
+                data-testid="warning-GLOBAL_STORE_TYPE_MEMORY"
+                v-html="t('common.warnings.GLOBAL_STORE_TYPE_MEMORY')"
+              />
+              <!-- eslint-enable -->
+            </ul>
           </KAlert>
         </slot>
         <slot name="default" />
@@ -315,7 +311,7 @@ nav :deep(.app-navigator) > a {
   @media screen and (max-width: 800px) {
     display: none;
   }
-  .k-alert.small {
+  .upgrade-alert {
     // Uses smaller paddings for this particular alert.
     padding: $kui-space-20 $kui-space-40;
   }

--- a/src/app/kuma/views/KumaNotFoundView.vue
+++ b/src/app/kuma/views/KumaNotFoundView.vue
@@ -5,20 +5,19 @@
     <AppView>
       <div class="overview">
         <KEmptyState>
-          <template #title>
+          <template #icon>
             <WarningIcon class="mb-3" />
+          </template>
+
+          <template #title>
             <h1>
-              <RouteTitle
-                title="Page Not Found"
-              />
+              <RouteTitle title="Page Not Found" />
             </h1>
           </template>
 
-          <template #message>
-            <p>The page or entity you were looking for does not exist.</p>
-          </template>
+          <p>The page or entity you were looking for does not exist.</p>
 
-          <template #cta>
+          <template #action>
             <KButton
               appearance="primary"
               :to="{ name: 'home' }"
@@ -31,6 +30,7 @@
     </AppView>
   </RouteView>
 </template>
+
 <script lang="ts" setup>
 import WarningIcon from '@/app/common/WarningIcon.vue'
 </script>

--- a/src/app/onboarding/components/OnboardingAlert.vue
+++ b/src/app/onboarding/components/OnboardingAlert.vue
@@ -2,25 +2,23 @@
   <KAlert
     v-if="isShowingOnboardingAlert"
     appearance="success"
-    dismiss-type="icon"
+    dismissible
     data-testid="onboarding-notification"
-    @closed="closeAlert"
+    @dismiss="closeAlert"
   >
-    <template #alertMessage>
-      <div class="onboarding-alert-content">
-        <!-- eslint-disable-next-line vue/no-v-html  -->
-        <div v-html="t('main-overview.detail.onboarding.message', { name: t('common.product.name') })" />
+    <div class="onboarding-alert-content">
+      <!-- eslint-disable-next-line vue/no-v-html  -->
+      <div v-html="t('main-overview.detail.onboarding.message', { name: t('common.product.name') })" />
 
-        <KButton
-          appearance="primary"
-          size="small"
-          class="action-button"
-          :to="{ name: 'onboarding-welcome-view' }"
-        >
-          {{ t('main-overview.detail.onboarding.get_started_link') }}
-        </KButton>
-      </div>
-    </template>
+      <KButton
+        appearance="primary"
+        size="small"
+        class="action-button"
+        :to="{ name: 'onboarding-welcome-view' }"
+      >
+        {{ t('main-overview.detail.onboarding.get_started_link') }}
+      </KButton>
+    </div>
   </KAlert>
 </template>
 

--- a/src/app/policies/views/PolicySummaryView.vue
+++ b/src/app/policies/views/PolicySummaryView.vue
@@ -32,11 +32,11 @@
       </template>
 
       <EmptyBlock v-if="props.policy === undefined">
-        {{ t('common.collection.summary.empty_title', { type: props.policyType.name }) }}
-
-        <template #message>
-          <p>{{ t('common.collection.summary.empty_message', { type: props.policyType.name }) }}</p>
+        <template #title>
+          {{ t('common.collection.summary.empty_title', { type: props.policyType.name }) }}
         </template>
+
+        <p>{{ t('common.collection.summary.empty_message', { type: props.policyType.name }) }}</p>
       </EmptyBlock>
 
       <div

--- a/src/app/services/views/ServiceConfigView.vue
+++ b/src/app/services/views/ServiceConfigView.vue
@@ -37,7 +37,7 @@
               data-testid="no-matching-external-service"
             >
               <template #title>
-                <p>{{ t('services.detail.no_matching_external_service', { name: route.params.service }) }}</p>
+                {{ t('services.detail.no_matching_external_service', { name: route.params.service }) }}
               </template>
             </EmptyBlock>
 

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -54,7 +54,7 @@
                     data-testid="no-matching-external-service"
                   >
                     <template #title>
-                      <p>{{ t('services.detail.no_matching_external_service', { name: route.params.service }) }}</p>
+                      {{ t('services.detail.no_matching_external_service', { name: route.params.service }) }}
                     </template>
                   </EmptyBlock>
 
@@ -330,7 +330,7 @@
                     data-testid="no-matching-external-service"
                   >
                     <template #title>
-                      <p>{{ t('services.detail.no_matching_external_service', { name: route.params.service }) }}</p>
+                      {{ t('services.detail.no_matching_external_service', { name: route.params.service }) }}
                     </template>
                   </EmptyBlock>
 

--- a/src/app/subscriptions/components/SubscriptionDetails.vue
+++ b/src/app/subscriptions/components/SubscriptionDetails.vue
@@ -4,13 +4,11 @@
       v-if="statuses.length === 0"
       appearance="info"
     >
-      <template #alertIcon>
+      <template #icon>
         <PortalIcon />
       </template>
 
-      <template #alertMessage>
-        {{ t('common.detail.subscriptions.no_stats', { id: props.subscription.id }) }}
-      </template>
+      {{ t('common.detail.subscriptions.no_stats', { id: props.subscription.id }) }}
     </KAlert>
 
     <template v-else>

--- a/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
@@ -27,11 +27,11 @@
       </template>
 
       <EmptyBlock v-if="props.zoneEgressOverview === undefined">
-        {{ t('common.collection.summary.empty_title', { type: 'ZoneEgress' }) }}
-
-        <template #message>
-          <p>{{ t('common.collection.summary.empty_message', { type: 'ZoneEgress' }) }}</p>
+        <template #title>
+          {{ t('common.collection.summary.empty_title', { type: 'ZoneEgress' }) }}
         </template>
+
+        <p>{{ t('common.collection.summary.empty_message', { type: 'ZoneEgress' }) }}</p>
       </EmptyBlock>
 
       <div

--- a/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -27,11 +27,11 @@
       </template>
 
       <EmptyBlock v-if="props.zoneIngressOverview === undefined">
-        {{ t('common.collection.summary.empty_title', { type: 'ZoneIngress' }) }}
-
-        <template #message>
-          <p>{{ t('common.collection.summary.empty_message', { type: 'ZoneIngress' }) }}</p>
+        <template #title>
+          {{ t('common.collection.summary.empty_title', { type: 'ZoneIngress' }) }}
         </template>
+
+        <p>{{ t('common.collection.summary.empty_message', { type: 'ZoneIngress' }) }}</p>
       </EmptyBlock>
 
       <div

--- a/src/app/zones/views/ZoneConfigView.vue
+++ b/src/app/zones/views/ZoneConfigView.vue
@@ -55,9 +55,7 @@
           data-testid="warning-no-subscriptions"
           appearance="warning"
         >
-          <template #alertMessage>
-            {{ t('zone-cps.detail.no_subscriptions') }}
-          </template>
+          {{ t('zone-cps.detail.no_subscriptions') }}
         </KAlert>
       </KCard>
     </AppView>

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -295,49 +295,44 @@
                       data-testid="error"
                     />
 
-                    <KEmptyState
-                      v-else
-                      cta-is-hidden
-                    >
-                      <template #title>
-                        <template v-if="(typeof data === 'undefined')">
-                          <ProgressIcon
-                            data-testid="waiting"
-                            display="inline-block"
-                            :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
-                          />
-                          {{ t('zones.form.scan.waitTitle') }}
-                        </template>
-                        <template
+                    <KEmptyState v-else>
+                      <template #icon>
+                        <ProgressIcon
+                          v-if="data === undefined"
+                          data-testid="waiting"
+                          display="inline-block"
+                          :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
+                        />
+
+                        <CheckCircleIcon
                           v-else
-                        >
-                          <CheckCircleIcon
-                            data-testid="connected"
-                            display="inline-block"
-                            :color="KUI_COLOR_TEXT_SUCCESS"
-                          />
-                          {{ t('zones.form.scan.completeTitle') }}
-                        </template>
+                          data-testid="connected"
+                          display="inline-block"
+                          :color="KUI_COLOR_TEXT_SUCCESS"
+                        />
                       </template>
-                      <template #message>
-                        <template v-if="(typeof data !== 'undefined')">
-                          <p>
-                            {{ t('zones.form.scan.completeDescription', { name }) }}
-                          </p>
-                          <p class="mt-2">
-                            <KButton
-                              appearance="primary"
-                              :to="{
-                                name: 'zone-cp-detail-view',
-                                params: {
-                                  zone: name,
-                                },
-                              }"
-                            >
-                              {{ t('zones.form.scan.completeButtonLabel', { name }) }}
-                            </KButton>
-                          </p>
-                        </template>
+
+                      <template #title>
+                        {{ data === undefined ? t('zones.form.scan.waitTitle') : t('zones.form.scan.completeTitle') }}
+                      </template>
+
+                      <template v-if="(typeof data !== 'undefined')">
+                        <p>
+                          {{ t('zones.form.scan.completeDescription', { name }) }}
+                        </p>
+                        <p class="mt-2">
+                          <KButton
+                            appearance="primary"
+                            :to="{
+                              name: 'zone-cp-detail-view',
+                              params: {
+                                zone: name,
+                              },
+                            }"
+                          >
+                            {{ t('zones.form.scan.completeButtonLabel', { name }) }}
+                          </KButton>
+                        </p>
                       </template>
                     </KEmptyState>
                   </div>

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -41,25 +41,22 @@
           v-if="error !== null"
           appearance="danger"
           class="mb-4"
-          dismiss-type="icon"
           data-testid="create-zone-error"
         >
-          <template #alertMessage>
-            <template
-              v-if="(error instanceof ApiError && [409, 500].includes(error.status))"
-            >
-              <p>{{ t(`zones.create.status_error.${error.status}.title`, { name: zoneNameWithError }) }}</p>
+          <template
+            v-if="(error instanceof ApiError && [409, 500].includes(error.status))"
+          >
+            <p>{{ t(`zones.create.status_error.${error.status}.title`, { name: zoneNameWithError }) }}</p>
 
-              <p>{{ t(`zones.create.status_error.${error.status}.description`) }}</p>
-            </template>
+            <p>{{ t(`zones.create.status_error.${error.status}.description`) }}</p>
+          </template>
 
-            <template v-else-if="(error instanceof ApiError)">
-              <p>{{ t('common.error_state.api_error', { status: error.status, title: error.detail }) }}</p>
-            </template>
+          <template v-else-if="(error instanceof ApiError)">
+            <p>{{ t('common.error_state.api_error', { status: error.status, title: error.detail }) }}</p>
+          </template>
 
-            <template v-else>
-              <p>{{ t('common.error_state.default_error') }}</p>
-            </template>
+          <template v-else>
+            <p>{{ t('common.error_state.default_error') }}</p>
           </template>
         </KAlert>
 

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -57,7 +57,6 @@ common:
   emptyState:
     title: 'No data'
     message: 'There are no {type} present'
-    icon: 'stateNoData'
   collection:
     none: ''
     details_link: 'Go to details'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
   resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.8.14.tgz#3219563df669b8bb3e260df12ac211a5072938e6"
   integrity sha512-nJUTtLpqelKCTY8lS8VByWaHYUq1CuB5cBUX/q2FEDu5o6IKH/B7fEDQpb/pB1lLRYTqZXneHR/lGYjxy4u8eQ==
 
-"@kong/kongponents@9.0.0-alpha.107":
-  version "9.0.0-alpha.107"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.107.tgz#fa90c7903d1b0a0a0bd4bea7cf752086f2f6b60b"
-  integrity sha512-467Gl4BV3WqsvDczuPir1LT2yTYo/C0AZLYh0izcCJqOGjtf8IUpW8E7d8McorLj0aGfh44+NHL6qLtVdMK3Iw==
+"@kong/kongponents@9.0.0-alpha.113":
+  version "9.0.0-alpha.113"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.113.tgz#15322b11b39a56d20421cc34edc4bcb057bb4ddb"
+  integrity sha512-MDs6dsdTG26tWiS5795R1a7y94SoATEtlynx6PqSfWrum0NgCxcqnpIq7lHhdquGnMCYVocw/3hOe3gDG4LOJw==
   dependencies:
     "@kong/icons" "^1.8.14"
     "@popperjs/core" "^2.11.8"


### PR DESCRIPTION
**chore(KAlert): address breaking changes**

Use default slot instead of `alertMessage` slot.

Rename the `is-dismissibile` prop to `dismissible` (also remove two instances that didn’t have the corresponding close handling).

Rename `closed` event to `dismiss`.

Rename the `alertIcon` slot to `icon`.

Remove the `size` prop.

**chore(KPagination): address breaking changes**

**chore(KEmptyState): address breaking changes**

Replace the `cta-is-hidden` prop with `:action-button-visible="false"`.

Remove the use of the `icon` and `iconSize` prop. There is no longer a way to use the Kongponent "state" icons like `stateNoData` with KEmptyState so I removed it from our use of the component.

Replace the use of the `title` slot with providing the `title` prop. This required changing out ErrorBlock and EmptyBlock components to do the same. The only place where we really made use of slotting in not-just-text content was the ErrorBlock component where title and the badge list now appear on separate rows.

Replace the use of the `message` slot with using the default slot instead.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

---

Previous Kongponents v9 adoption PRs:

- https://github.com/kumahq/kuma-gui/pull/1532
- https://github.com/kumahq/kuma-gui/pull/1853
- https://github.com/kumahq/kuma-gui/pull/1878
- https://github.com/kumahq/kuma-gui/pull/1961
- https://github.com/kumahq/kuma-gui/pull/2118
- https://github.com/kumahq/kuma-gui/pull/2156
- https://github.com/kumahq/kuma-gui/pull/2184