### PR TITLE
chore: removes read usage of kumaApi

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -96,6 +96,7 @@ const INLINE_NON_VOID_ELEMENTS = [
           ignoreWhenEmpty: true,
           ignores: ['router-link', 'pre', ...INLINE_NON_VOID_ELEMENTS],
         }],
+        'vue/no-v-html': 'off',
         // Reason: https://github.com/vuejs/eslint-plugin-vue/issues/2259
         'vue/no-setup-props-destructure': 'off',
         // Disallow Kongponents utility classes

--- a/features/onboarding/add-new-services-code/Index.feature
+++ b/features/onboarding/add-new-services-code/Index.feature
@@ -1,4 +1,4 @@
-Feature: onboarding / dataplanes-overview / index
+Feature: onboarding / add-new-services-code / index
   Background:
     Given the CSS selectors
       | Alias           | Selector                               |
@@ -20,11 +20,15 @@ Feature: onboarding / dataplanes-overview / index
       """
       KUMA_DATAPLANE_COUNT: 1
       """
-    And the URL "/dataplanes" responds with
+    And the URL "/dataplanes/_overview" responds with
       """
       body:
         items:
           - name: dataplane-test
+            dataplaneInsight:
+              subscriptions:
+                - connectTime: 2021-02-17T07:33:36.412683Z
+                  disconnectTime: !!js/undefined
       """
     Then the "$loading" element doesn't exist
     And the "$is-connected" element exists

--- a/features/onboarding/multi-zone/Index.feature
+++ b/features/onboarding/multi-zone/Index.feature
@@ -1,32 +1,48 @@
 Feature: onboarding / multi-zone / index
   Background:
     Given the CSS selectors
-      | Alias             | Selector                               |
-      | next-button       | [data-testid='onboarding-next-button'] |
-      | loading           | [data-testid='loading']                |
-      | zone-connected    | [data-testid='zone-connected']         |
-      | ingress-connected | [data-testid='zone-ingress-connected'] |
+      | Alias       | Selector                                   |
+      | next-button | [data-testid='onboarding-next-button']     |
+      | loading     | [data-testid='loading']                    |
+      | connected   | [data-testid='zone-online-ingress-online'] |
 
   Scenario: Loading the zone list and showing the state
     Given the environment
       """
       KUMA_ZONE_COUNT: 0
+      KUMA_ZONEINGRESS_COUNT: 0
       """
     When I visit the "/onboarding/multi-zone" URL
     Then the "$loading" element exists
-    And the "$zone-connected" element doesn't exist
+    And the "$connected" element doesn't exist
     And the "$next-button[disabled]" element exists
     And the environment
       """
       KUMA_ZONE_COUNT: 1
+      KUMA_ZONEINGRESS_COUNT: 1
       """
-    And the URL "/zones" responds with
+    And the URL "/zones/_overview" responds with
       """
       body:
         items:
           - name: zone-test
+            zone:
+              enabled: true
+            zoneInsight:
+              subscriptions:
+                - connectTime: 2021-02-17T07:33:36.412683Z
+                  disconnectTime: !!js/undefined
+      """
+    And the URL "/zone-ingresses/_overview" responds with
+      """
+      body:
+        items:
+          - name: zone-ingress-test
+            zoneIngressInsight:
+              subscriptions:
+                - connectTime: 2021-02-17T07:33:36.412683Z
+                  disconnectTime: !!js/undefined
       """
     Then the "$loading" element doesn't exist
-    And the "$zone-connected" element exists
-    And the "$ingress-connected" element exists
+    And the "$connected" element exists
     And the "$next-button:not([disabled])" element exists

--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -38,14 +38,40 @@ const includes = <T extends readonly string[]>(arr: T, item: string): item is T[
 
 export const sources = (source: Source, api: KumaApi, can: Can) => {
   return defineSources({
+    // always resolves and keeps polling until we have at least one dataplane and all dataplanes are online
     '/dataplanes/poll': (params) => {
       const { size, page } = params
       const offset = size * (page - 1)
       const canUseZones = can('use zones')
 
-      return source(async () => {
-        return DataplaneOverview.fromCollection(await api.getAllDataplaneOverviews({ size, offset }), canUseZones)
+      return source(async (source) => {
+        const res = DataplaneOverview.fromCollection(await api.getAllDataplaneOverviews({ size, offset }), canUseZones)
+        if (res.total > 0 && res.items.every(item => item.status === 'online')) {
+          source.close()
+        }
+        return res
       }, { interval: 1000 })
+    },
+    // doesn't resolve until we have at least one dataplane and all dataplanes are online
+    '/dataplanes/online': (params) => {
+      const OfflineError = class extends Error { }
+      const { size, page } = params
+      const offset = size * (page - 1)
+      const canUseZones = can('use zones')
+      return source(async () => {
+        const res = DataplaneOverview.fromCollection(await api.getAllDataplaneOverviews({ size, offset }), canUseZones)
+        if (res.total > 0 && res.items.every((item) => item.status === 'online')) {
+          return res
+        } else {
+          throw new OfflineError()
+        }
+      }, {
+        retry: (e) => {
+          if (e instanceof OfflineError) {
+            return new Promise((resolve) => setTimeout(resolve, 1000))
+          }
+        },
+      })
     },
 
     '/meshes/:mesh/dataplanes/:name': async (params) => {

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -18,7 +18,6 @@
           #notifications
         >
           <ul data-testid="dataplane-warnings">
-            <!-- eslint-disable vue/no-v-html  -->
             <li
               v-for="warning in warnings"
               :key="warning.kind"
@@ -31,7 +30,6 @@
             >
               The below view is not enhanced with runtime stats (Error loading stats: <strong>{{ error.toString() }}</strong>)
             </li>
-            <!-- eslint-enable -->
           </ul>
         </template>
 

--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -162,12 +162,10 @@
             appearance="warning"
           >
             <ul>
-              <!-- eslint-disable vue/no-v-html  -->
               <li
                 data-testid="warning-GLOBAL_STORE_TYPE_MEMORY"
                 v-html="t('common.warnings.GLOBAL_STORE_TYPE_MEMORY')"
               />
-              <!-- eslint-enable -->
             </ul>
           </KAlert>
         </slot>

--- a/src/app/onboarding/components/OnboardingAlert.vue
+++ b/src/app/onboarding/components/OnboardingAlert.vue
@@ -7,8 +7,9 @@
     @dismiss="closeAlert"
   >
     <div class="onboarding-alert-content">
-      <!-- eslint-disable-next-line vue/no-v-html  -->
-      <div v-html="t('main-overview.detail.onboarding.message', { name: t('common.product.name') })" />
+      <div
+        v-html="t('main-overview.detail.onboarding.message', { name: t('common.product.name') })"
+      />
 
       <KButton
         appearance="primary"

--- a/src/app/onboarding/locales/en-us/index.yaml
+++ b/src/app/onboarding/locales/en-us/index.yaml
@@ -1,7 +1,4 @@
 onboarding:
-  href:
-    docs:
-      install: '{KUMA_DOCS_URL}/deployments/multi-zone?{KUMA_UTM_QUERY_PARAMS}#zone-control-plane'
   routes:
     welcome:
       title: Welcome to {name}!
@@ -11,12 +8,30 @@ onboarding:
       title: Configuration Types
     multizone:
       title: Multizone
+      body: !!text/markdown |
+        A zone requires both the zone control plane and zone ingress. On Kubernetes, you run a single command to create both resources. On Universal, you must create them separately.
+
+        **See <a href="{KUMA_DOCS_URL}/production/deployment/multi-zone/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">the documentation for options to install</a>.**
+      status: !!text/markdown |
+        Zone status: {zone, select,
+          online { *Connected* }
+          offline { **Disconnected** }
+          other { - }}
+
+        Zone ingress status: {ingress, select,
+          online { *Connected* }
+          offline { **Disconnected** }
+          other { - }}
+
     create-mesh:
       title: Create the Mesh
     add-services:
       title: Add new services
     add-services-code:
       title: Add new services
+      repo: https://github.com/kumahq/kuma-counter-demo/
+      readme: https://github.com/kumahq/kuma-counter-demo/blob/master/README.md
+      k8s: kubectl apply -f https://bit.ly/3Kh2Try
     dataplanes-overview:
       title: Data plane overview
       header:

--- a/src/app/onboarding/views/OnboardingAddNewServicesCodeView.vue
+++ b/src/app/onboarding/views/OnboardingAddNewServicesCodeView.vue
@@ -8,135 +8,106 @@
       :render="false"
     />
     <AppView>
-      <OnboardingPage>
-        <template #header>
-          <OnboardingHeading>
-            <template #title>
-              Add services
-            </template>
-          </OnboardingHeading>
-        </template>
-
-        <template #content>
-          <p class="mb-4 text-center">
-            The demo application includes two services: a Redis backend to store a counter value, and a frontend web UI to show and increment the counter.
-          </p>
-
-          <template v-if="can('use kubernetes')">
-            <p>To run execute the following command:</p>
-
-            <CodeBlock
-              language="bash"
-              :code="k8sRunCommand"
-            />
+      <DataSource
+        v-slot="{ data, error }: DataplaneOverviewCollectionSource"
+        :src="`/dataplanes/online?page=1&size=10`"
+      >
+        <OnboardingPage>
+          <template #header>
+            <OnboardingHeading>
+              <template #title>
+                Add services
+              </template>
+            </OnboardingHeading>
           </template>
 
-          <div v-else>
+          <template #content>
             <p class="mb-4 text-center">
-              Clone <a
-                :href="githubLink"
-                target="_blank"
-              >the GitHub repository</a> for the demo application:
+              The demo application includes two services: a Redis backend to store a counter value, and a frontend web UI to show and increment the counter.
             </p>
 
-            <CodeBlock
-              language="bash"
-              :code="`git clone ${githubLink}`"
-            />
+            <template v-if="can('use kubernetes')">
+              <p>To run execute the following command:</p>
 
-            <p class="mt-4 text-center">
-              And follow the instructions in <a
-                :href="githubLinkReadme"
-                target="_blank"
-              >the README</a>.
-            </p>
-          </div>
+              <CodeBlock
+                language="bash"
+                :code="t('onboarding.routes.add-services-code.k8s')"
+              />
+            </template>
 
-          <div>
-            <p class="status-box mt-4">
-              DPPs status:
+            <div v-else>
+              <p class="mb-4 text-center">
+                Clone <a
+                  :href="t('onboarding.routes.add-services-code.repo')"
+                  target="_blank"
+                >the GitHub repository</a> for the demo application:
+              </p>
 
-              <span
-                v-if="hasDPPs"
-                class="status--is-connected"
-                data-testid="dpps-connected"
-              >Connected</span>
+              <CodeBlock
+                language="bash"
+                :code="`git clone ${t('onboarding.routes.add-services-code.repo')}`"
+              />
 
-              <span
-                v-else
-                class="status--is-disconnected"
-                data-testid="dpps-disconnected"
-              >Disconnected</span>
-            </p>
-
-            <div
-              v-if="!hasDPPs"
-              class="status-loading-box mt-4"
-            >
-              <LoadingBox />
+              <p class="mt-4 text-center">
+                And follow the instructions in <a
+                  :href="t('onboarding.routes.add-services-code.readme')"
+                  target="_blank"
+                >the README</a>.
+              </p>
             </div>
-          </div>
-        </template>
 
-        <template #navigation>
-          <OnboardingNavigation
-            next-step="onboarding-dataplanes-view"
-            previous-step="onboarding-add-new-services-view"
-            :should-allow-next="hasDPPs"
-          />
-        </template>
-      </OnboardingPage>
+            <div>
+              <DataLoader
+                :data="[data]"
+                :errors="[error]"
+                :loader="false"
+              >
+                <p class="status-box mt-4">
+                  DPPs status:
+
+                  <span
+                    v-if="typeof data !== 'undefined'"
+                    class="status--is-connected"
+                    data-testid="dpps-connected"
+                  >Connected</span>
+
+                  <span
+                    v-else
+                    class="status--is-disconnected"
+                    data-testid="dpps-disconnected"
+                  >Disconnected</span>
+                </p>
+
+                <div
+                  v-if="typeof data === 'undefined'"
+                  class="status-loading-box mt-4"
+                >
+                  <LoadingBox />
+                </div>
+              </DataLoader>
+            </div>
+          </template>
+
+          <template #navigation>
+            <OnboardingNavigation
+              next-step="onboarding-dataplanes-view"
+              previous-step="onboarding-add-new-services-view"
+              :should-allow-next="typeof data !== 'undefined'"
+            />
+          </template>
+        </OnboardingPage>
+      </DataSource>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import { onUnmounted, ref } from 'vue'
-
 import LoadingBox from '../components/LoadingBox.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
-import { useKumaApi } from '@/utilities'
-
-const kumaApi = useKumaApi()
-
-const LONG_POOLING_INTERVAL = 1000
-
-const githubLink = 'https://github.com/kumahq/kuma-counter-demo/'
-const githubLinkReadme = 'https://github.com/kumahq/kuma-counter-demo/blob/master/README.md'
-const k8sRunCommand = 'kubectl apply -f https://bit.ly/3Kh2Try'
-
-const hasDPPs = ref(false)
-const dppsTimeout = ref<number | null>(null)
-
-getDPPs()
-
-onUnmounted(function () {
-  clearTimeout()
-})
-
-async function getDPPs() {
-  try {
-    const { total } = await kumaApi.getAllDataplanes()
-
-    hasDPPs.value = total > 0
-  } catch (err) {
-    console.error(err)
-  } finally {
-    if (!hasDPPs.value) {
-      clearTimeout()
-      dppsTimeout.value = window.setTimeout(() => getDPPs(), LONG_POOLING_INTERVAL)
-    }
-  }
-}
-
-function clearTimeout(): void {
-  if (dppsTimeout.value !== null) {
-    window.clearTimeout(dppsTimeout.value)
-  }
-}
+import type { DataplaneOverviewCollectionSource } from '@/app/data-planes/sources'
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/onboarding/views/OnboardingMultiZoneView.vue
+++ b/src/app/onboarding/views/OnboardingMultiZoneView.vue
@@ -8,168 +8,105 @@
       :render="false"
     />
     <AppView>
-      <OnboardingPage>
-        <template #header>
-          <OnboardingHeading>
-            <template #title>
-              Add zones
+      <DataSource
+        v-slot="{ data, error }: ZoneOverviewCollectionSource"
+        :src="`/zone-cps/~online?page=1&size=10`"
+      >
+        <DataSource
+          v-slot="{ data: ingresses, error: ingressesError }: ZoneIngressOverviewCollectionSource"
+          :src="`/zone-ingress-overviews/~online?page=1&size=10`"
+        >
+          <OnboardingPage>
+            <template #header>
+              <OnboardingHeading>
+                <template #title>
+                  Add zones
+                </template>
+              </OnboardingHeading>
             </template>
-          </OnboardingHeading>
-        </template>
 
-        <template #content>
-          <p class="mb-4 text-center">
-            A zone requires both the zone control plane and zone ingress. On Kubernetes, you run a single command to create both resources. On Universal, you must create them separately.
-          </p>
+            <template #content>
+              <div
+                class="onboarding-multi-zone-view-body"
+                v-html="t('onboarding.routes.multizone.body')"
+              />
 
-          <p class="mb-4 text-center">
-            <b>See <a
-              :href="t('onboarding.href.docs.install')"
-              target="_blank"
-            >the documentation for options to install</a>.</b>
-          </p>
+              <div>
+                <DataLoader
+                  :data="[data, ingresses]"
+                  :errors="[error, ingressesError]"
+                  :loader="false"
+                >
+                  <template
+                    v-for="status in [{
+                      zone: typeof data !== 'undefined' ? 'online' : 'offline',
+                      ingress: typeof ingresses !== 'undefined' ? 'online' : 'offline',
+                    }]"
+                    :key="status"
+                  >
+                    <div
+                      class="onboarding-multi-zone-view-status"
+                      :data-testid="`zone-${status.zone}-ingress-${status.ingress}`"
+                      v-html="t('onboarding.routes.multizone.status', {
+                        zone: status.zone,
+                        ingress: status.ingress,
+                      })"
+                    />
 
-          <div>
-            <p class="status-box mt-4">
-              Zone status:
+                    <div
+                      v-if="(['zone', 'ingress'] as const).some(item => status[item] === 'offline')"
+                      class="onboarding-multi-zone-view-status-loading"
+                    >
+                      <LoadingBox />
+                    </div>
+                  </template>
+                </DataLoader>
+              </div>
+            </template>
 
-              <span
-                v-if="hasZones"
-                class="status--is-connected"
-                data-testid="zone-connected"
-              >Connected</span>
-
-              <span
-                v-else
-                class="status--is-disconnected"
-                data-testid="zone-disconnected"
-              >Disconnected</span>
-            </p>
-
-            <p class="status-box mt-4">
-              Zone ingress status:
-
-              <span
-                v-if="hasZoneIngresses"
-                class="status--is-connected"
-                data-testid="zone-ingress-connected"
-              >Connected</span>
-
-              <span
-                v-else
-                class="status--is-disconnected"
-                data-testid="zone-ingress-disconnected"
-              >Disconnected</span>
-            </p>
-
-            <div
-              v-if="!hasZoneIngresses || !hasZones"
-              class="status-loading-box mt-4"
-            >
-              <LoadingBox />
-            </div>
-          </div>
-        </template>
-
-        <template #navigation>
-          <OnboardingNavigation
-            next-step="onboarding-create-mesh-view"
-            previous-step="onboarding-configuration-types-view"
-            :should-allow-next="hasZones && hasZoneIngresses"
-          />
-        </template>
-      </OnboardingPage>
+            <template #navigation>
+              <OnboardingNavigation
+                next-step="onboarding-create-mesh-view"
+                previous-step="onboarding-configuration-types-view"
+                :should-allow-next="typeof ingresses !== 'undefined' || typeof data !== 'undefined'"
+              />
+            </template>
+          </OnboardingPage>
+        </DataSource>
+      </DataSource>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import { onUnmounted, ref } from 'vue'
-
 import LoadingBox from '../components/LoadingBox.vue'
 import OnboardingHeading from '../components/OnboardingHeading.vue'
 import OnboardingNavigation from '../components/OnboardingNavigation.vue'
 import OnboardingPage from '../components/OnboardingPage.vue'
-import { useKumaApi } from '@/utilities'
-
-const kumaApi = useKumaApi()
-
-const LONG_POLLING_INTERVAL = 1000
-
-const hasZones = ref(false)
-const hasZoneIngresses = ref(false)
-const zoneTimeout = ref<number | null>(null)
-const zoneIngressTimeout = ref<number | null>(null)
-
-onUnmounted(function () {
-  clearZoneTimeout()
-  clearZoneIngressTimeout()
-})
-
-getZones()
-getZoneIngresses()
-
-async function getZones() {
-  try {
-    const { total } = await kumaApi.getZones()
-
-    hasZones.value = total > 0
-  } catch (error) {
-    hasZones.value = false
-
-    console.error(error)
-  } finally {
-    if (!hasZones.value) {
-      clearZoneTimeout()
-      zoneTimeout.value = window.setTimeout(getZones, LONG_POLLING_INTERVAL)
-    }
-  }
-}
-
-async function getZoneIngresses() {
-  try {
-    const { total } = await kumaApi.getAllZoneIngressOverviews()
-
-    hasZoneIngresses.value = total > 0
-  } catch (error) {
-    hasZoneIngresses.value = false
-
-    console.error(error)
-  } finally {
-    if (!hasZoneIngresses.value) {
-      clearZoneIngressTimeout()
-      zoneIngressTimeout.value = window.setTimeout(getZoneIngresses, LONG_POLLING_INTERVAL)
-    }
-  }
-}
-
-function clearZoneTimeout() {
-  if (zoneTimeout.value !== null) {
-    window.clearTimeout(zoneTimeout.value)
-  }
-}
-
-function clearZoneIngressTimeout() {
-  if (zoneIngressTimeout.value !== null) {
-    window.clearTimeout(zoneIngressTimeout.value)
-  }
-}
+import { ZoneIngressOverviewCollectionSource } from '@/app/zone-ingresses/sources'
+import { ZoneOverviewCollectionSource } from '@/app/zones/sources'
 </script>
 
-<style lang="scss" scoped>
-.status-box {
+<style lang="scss">
+.onboarding-multi-zone-view-body {
   text-align: center;
 }
-
-.status--is-connected {
-  color: $kui-color-text-success;
+.onboarding-multi-zone-view-status {
+  text-align: center;
+  margin-top: $kui-space-60;
+  p {
+    em {
+      color: $kui-color-text-success;
+      font-style: normal;
+    }
+    strong {
+      color: $kui-color-text-danger;
+      font-weight: $kui-font-weight-regular;
+    }
+  }
 }
-
-.status--is-disconnected {
-  color: $kui-color-text-danger;
-}
-
-.status-loading-box {
+.onboarding-multi-zone-view-status-loading {
+  margin-top: $kui-space-60;
   display: flex;
   justify-content: center;
 }

--- a/src/app/zone-ingresses/sources.ts
+++ b/src/app/zone-ingresses/sources.ts
@@ -1,5 +1,5 @@
 import { ZoneIngressOverview, ZoneIngress } from './data'
-import type { DataSourceResponse } from '@/app/application'
+import type { DataSourceResponse, Source } from '@/app/application'
 import { defineSources } from '@/app/application/services/data-source'
 import type KumaApi from '@/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
@@ -15,9 +15,28 @@ export type ZoneIngressOverviewCollectionSource = DataSourceResponse<ZoneIngress
 
 export type EnvoyDataSource = DataSourceResponse<object | string>
 
-export const sources = (api: KumaApi) => {
+export const sources = (source: Source, api: KumaApi) => {
   return defineSources({
-
+    // doesn't resolve until we have at least one ingress and one ingress is online
+    '/zone-ingress-overviews/~online': (params) => {
+      const { size } = params
+      const offset = size * (params.page - 1)
+      const OfflineError = class extends Error { }
+      return source(async () => {
+        const res = ZoneIngressOverview.fromCollection(await api.getAllZoneIngressOverviews({ size, offset }))
+        if (res.total > 0 && res.items.some((item) => item.state === 'online')) {
+          return res
+        } else {
+          throw new OfflineError()
+        }
+      }, {
+        retry: (e) => {
+          if (e instanceof OfflineError) {
+            return new Promise((resolve) => setTimeout(resolve, 2000))
+          }
+        },
+      })
+    },
     '/zone-cps/:name/ingresses': async (params): Promise<ZoneIngressOverviewCollection> => {
       const { name, size, page } = params
       const offset = size * (page - 1)

--- a/src/app/zones/views/ZoneConfigView.vue
+++ b/src/app/zones/views/ZoneConfigView.vue
@@ -15,7 +15,6 @@
         #notifications
       >
         <ul>
-          <!-- eslint-disable vue/no-v-html  -->
           <li
             v-for="warning in props.notifications"
             :key="warning.kind"
@@ -23,7 +22,6 @@
 
             v-html="t(`common.warnings.${warning.kind}`, warning.payload)"
           />
-          <!-- eslint-enable -->
         </ul>
       </template>
 

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -9,7 +9,6 @@
         #notifications
       >
         <ul>
-          <!-- eslint-disable vue/no-v-html  -->
           <li
             v-for="warning in props.notifications"
             :key="warning.kind"
@@ -17,7 +16,6 @@
 
             v-html="t(`common.warnings.${warning.kind}`, warning.payload)"
           />
-          <!-- eslint-enable -->
         </ul>
       </template>
       <div

--- a/src/services/kuma-api/README.md
+++ b/src/services/kuma-api/README.md
@@ -1,8 +1,7 @@
 # kuma-api
 
 The `KumaApi` service contains all the methods for calling Kuma HTTP API methods
-via a `fetch` based HTTP client. All HTTP requests in the application should use
-this service.
+via a `fetch` based HTTP client.
 
 This service is currently available via:
 
@@ -11,4 +10,3 @@ import { useKumaApi } from '@/utilities'
 const kumaApi = useKumaApi()
 kumaApi.getConfig()
 ```
-


### PR DESCRIPTION
Generally our onboarding area is pretty frozen, but it still has older code that we have to continue supporting unless we get rid of it (in this case `kumaApi` usage vs DataSource/DataLoader).

I had a bit of time whilst waiting on other PRs so, this PR switches the remaining areas of onboarding to use DataSource/DataLoader, and in doing so:

1. Removes all the older imperative code from onboarding and replaces it with DataSource
2. Changes some places where we were looking for a count of at least one zone/dataplane/zone-ingress and instead looks for at least a count of one _and_ one is online.
3. Uses the newer `_overview` endpoints for gathering data
4. Removes the last occurrences of us using `useKumaApi()` / `kumaApi` for reading data, which means we are closer to being able to use an OpenAPI spec auto-generated typescript http client.
5. I noticed that the URL for the documentation link was wrong in multizone onboarding, so I corrected that with a little more i18n markdown-ing while I was here. This then led to being unable to use `v-html` and `class` on the same element due to a clash with eslint rules (`class` has to be above `v-html` which means you can't disable the `v-html` on the next line because an eslint fix that reorders `class` and `v-html` means its no longer on the next line). Due to this I disabled the no-v-html rule entirely. Thinking being, we need to/will need to use this a lot. That being said, `v-html` should only be used for i18n purposes.

I might add some inlines as this PR snowballed into something bigger than I originally imagined.

---

An important note here. Ideally our DataSource URIs would be split into using plural-name/singular-name i.e. `/zone-cps` and `/zone-cp/:name`. This means we can safely add 'actions' on collections of things without worrying about clashing with the `:name` part of a singular. 

For example, in the case of this PR, I very easily clashed with `/zone-cps/online` with `/zone-cps/:name` without realising. If we used `/zone-cp/:name` instead (i.e. the singular for the singular request) this wouldn't be an issue. Also importantly, if we ever need to perform an 'action' request on a singular item the URI would be `/zone-cp/:name/:action` meaning we again avoid the clash.

To temporarily work around this issue in this PR I've used the 'DNS trick' `/zone-cps/~online` seeing as we can't use the `~` character in the name of a zone-cp and ordered the source to come before `/zone-cps/:name` therefore avoiding a potential clash. But we should change all our source URIs to have plural/singular forms.

