### PR TITLE
feature(dataplanes): adds matchers and origins to rules in panel

### DIFF
--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -224,8 +224,7 @@ const click = (e: MouseEvent) => {
 </script>
 
 <style lang="scss" scoped>
-.app-collection :deep(td:first-child),
-.app-collection :deep(td:first-child *) {
+.app-collection :deep(td:first-child a) {
   color: inherit;
   font-weight: $kui-font-weight-semibold;
   text-decoration: none;

--- a/src/app/connections/views/ConnectionInboundSummaryOverviewView.vue
+++ b/src/app/connections/views/ConnectionInboundSummaryOverviewView.vue
@@ -105,23 +105,103 @@
               :predicate="(item) => { return item.ruleType === 'from' && Number(item.inbound!.port) === Number(route.params.service.substring(1))}"
               :items="rulesData!.rules"
             >
-              <dl class="stack mt-4">
+              <div class="stack mt-4">
                 <template
                   v-for="item in items"
                   :key="item"
                 >
-                  <div>
-                    <dt>{{ item.type }}</dt>
-                    <dd class="mt-1">
-                      <CodeBlock
-                        :code="toYaml(item.config)"
-                        language="yaml"
-                        :show-copy-button="false"
-                      />
-                    </dd>
-                  </div>
+                  <KCard>
+                    <div
+                      class="stack-with-borders mt-4"
+                    >
+                      <DefinitionCard
+                        class="mt-2"
+                        layout="horizontal"
+                      >
+                        <template #title>
+                          Type
+                        </template>
+
+                        <template #body>
+                          {{ item.type }}
+                        </template>
+                      </DefinitionCard>
+                      <DefinitionCard
+                        v-if="item.matchers.length > 0"
+                        layout="horizontal"
+                      >
+                        <template #title>
+                          From
+                        </template>
+
+                        <template #body>
+                          <p><RuleMatchers :items="item.matchers" /></p>
+                        </template>
+                      </DefinitionCard>
+                      <DefinitionCard
+                        v-if="item.origins.length > 0"
+                        layout="horizontal"
+                      >
+                        <template #title>
+                          Origin Policies
+                        </template>
+
+                        <template #body>
+                          <DataSource
+                            v-slot="{ data: policyTypes }: PolicyTypeCollectionSource"
+                            :src="`/*/policy-types`"
+                          >
+                            <template
+                              v-for="types in [Object.groupBy((policyTypes?.policies ?? []), (item) => item.name)]"
+                              :key="types"
+                            >
+                              <ul>
+                                <li
+                                  v-for="origin in item.origins"
+                                  :key="`${origin.mesh}-${origin.name}`"
+                                >
+                                  <RouterLink
+                                    v-if="types[origin.type]"
+                                    :to="{
+                                      name: 'policy-detail-view',
+                                      params: {
+                                        mesh: origin.mesh,
+                                        policyPath: types[origin.type]![0].path,
+                                        policy: origin.name,
+                                      },
+                                    }"
+                                  >
+                                    {{ origin.name }}
+                                  </RouterLink>
+                                  <template
+                                    v-else
+                                  >
+                                    {{ origin.name }}
+                                  </template>
+                                </li>
+                              </ul>
+                            </template>
+                          </DataSource>
+                        </template>
+                      </DefinitionCard>
+                      <div>
+                        <dt>
+                          Config
+                        </dt>
+                        <dd class="mt-2">
+                          <div>
+                            <CodeBlock
+                              :code="toYaml(item.config)"
+                              language="yaml"
+                              :show-copy-button="false"
+                            />
+                          </div>
+                        </dd>
+                      </div>
+                    </div>
+                  </KCard>
                 </template>
-              </dl>
+              </div>
             </DataCollection>
           </DataLoader>
         </div>
@@ -137,6 +217,8 @@ import TagList from '@/app/common/TagList.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { DataplaneGateway, DataplaneInbound } from '@/app/data-planes/data'
 import type { DataplaneRulesSource } from '@/app/data-planes/sources'
+import type { PolicyTypeCollectionSource } from '@/app/policies/sources'
+import RuleMatchers from '@/app/rules/components/RuleMatchers.vue'
 import { toYaml } from '@/utilities/toYaml'
 
 const props = defineProps<{

--- a/src/app/rules/components/RuleMatchers.vue
+++ b/src/app/rules/components/RuleMatchers.vue
@@ -1,0 +1,43 @@
+<template>
+  <template
+    v-for="({ key, value, not }, i) in props.items"
+    :key="i"
+  >
+    <span class="rule-matchers"><span
+      v-if="i > 0"
+      class="and"
+    > and<br></span><abbr
+      v-if="not"
+      class="not"
+      title="not"
+    >!</abbr><span
+      class="term"
+    >{{ `${key}:${value}` }}</span></span>
+  </template>
+</template>
+<script lang="ts" generic="T extends {key: string, value: string, not: boolean}" setup>
+const props = defineProps<{
+  items: T[]
+}>()
+</script>
+<style lang="scss" scoped>
+.rule-matchers {
+  font-weight: $kui-font-weight-regular;
+}
+abbr {
+  text-decoration: none;
+}
+.not {
+  color: $kui-color-text-danger;
+}
+
+.and {
+  font-weight: $kui-font-weight-semibold;
+}
+
+.not,
+.term {
+  font-family: $kui-font-family-code;
+}
+
+</style>

--- a/src/app/rules/components/RuleMatchers.vue
+++ b/src/app/rules/components/RuleMatchers.vue
@@ -15,9 +15,10 @@
     >{{ `${key}:${value}` }}</span></span>
   </template>
 </template>
-<script lang="ts" generic="T extends {key: string, value: string, not: boolean}" setup>
+<script lang="ts" setup>
+import type { InspectRuleMatcher } from '@/types/index.d'
 const props = defineProps<{
-  items: T[]
+  items: InspectRuleMatcher[]
 }>()
 </script>
 <style lang="scss" scoped>

--- a/src/test-support/fake.ts
+++ b/src/test-support/fake.ts
@@ -41,6 +41,7 @@ const pager: Pager = (_total: string | number, req: RestRequest, self) => {
 export type AEnv = Alias<AppEnv['var']>
 export type MockEnvKeys = keyof {
   FAKE_SEED: string
+  KUMA_RULE_MATCHER_COUNT: string
   KUMA_DATAPLANE_COUNT: string
   KUMA_DATAPLANE_TYPE: string
   KUMA_DATAPLANEINBOUND_COUNT: string

--- a/src/test-support/mocks/src/meshes/_/dataplanes/_/_rules.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes/_/_rules.ts
@@ -8,6 +8,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
   const hasProxyRuleOverride = env('KUMA_DATAPLANE_PROXY_RULE_ENABLED', '')
   const hasProxyRule = hasProxyRuleOverride !== '' ? hasProxyRuleOverride === 'true' : fake.datatype.boolean()
   const ruleCount = parseInt(env('KUMA_DATAPLANE_RULE_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
+  const matcherCount = parseInt(env('KUMA_RULE_MATCHER_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
   const toRuleCount = parseInt(env('KUMA_DATAPLANE_TO_RULE_COUNT', `${fake.number.int({ min: 0, max: 3 })}`))
   const fromRuleCount = parseInt(env('KUMA_DATAPLANE_FROM_RULE_COUNT', `${fake.number.int({ min: 0, max: 3 })}`))
 
@@ -57,13 +58,11 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
                 },
                 rules: Array.from({ length: fake.number.int({ min: 1, max: 3 }) }).map(() => {
                   return {
-                    matchers: [
-                      {
-                        key: 'kuma.io/service',
-                        not: fake.datatype.boolean(),
-                        value: fake.kuma.serviceName('internal'),
-                      },
-                    ],
+                    matchers: Array.from({ length: matcherCount }).map(() => ({
+                      key: 'kuma.io/service',
+                      not: fake.datatype.boolean(),
+                      value: fake.kuma.serviceName('internal'),
+                    })),
                     origin: [
                       {
                         mesh,
@@ -84,13 +83,11 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
               const service1 = fake.kuma.serviceName('internal')
 
               return {
-                matchers: [
-                  {
-                    key: 'kuma.io/service',
-                    not: fake.datatype.boolean(),
-                    value: service1,
-                  },
-                ],
+                matchers: Array.from({ length: matcherCount }).map(() => ({
+                  key: 'kuma.io/service',
+                  not: fake.datatype.boolean(),
+                  value: service1,
+                })),
                 origin: [
                   {
                     mesh,


### PR DESCRIPTION
~Requires https://github.com/kumahq/kuma-gui/pull/2287 for the `Object.groupBy` polyfill.~ This is now merged

Adds matchers and origins to the rules in the summary panel for sidecar inbounds.

Likely to be some design amends as a follow up.

![Screenshot 2024-03-13 at 12 59 22](https://github.com/kumahq/kuma-gui/assets/554604/4048635c-1ce6-4968-9dae-7284f9c3e72d)
