### PR TITLE
chore: clean up icon props

### DIFF
--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -61,7 +61,7 @@
             appearance="primary"
             :to="props.emptyStateCtaTo"
           >
-            <AddIcon :size="KUI_ICON_SIZE_30" />
+            <AddIcon />
 
             {{ props.emptyStateCtaText }}
           </KButton>
@@ -94,7 +94,6 @@
 </template>
 
 <script lang="ts" setup generic="Row extends {}">
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { AddIcon } from '@kong/icons'
 import { KButton, KTable, TableHeader } from '@kong/kongponents'
 import { useSlots, ref, watch, Ref, computed } from 'vue'

--- a/src/app/common/CopyButton.vue
+++ b/src/app/common/CopyButton.vue
@@ -8,15 +8,10 @@
         'non-visual-button': !props.hasBorder,
       }"
       data-testid="copy-button"
-      :title="!props.hideTitle ? props.copyText : undefined"
       type="button"
       @click="copy($event, copyToClipboard)"
     >
-      <CopyIcon
-        :color="props.iconColor"
-        :title="!props.hideTitle ? props.copyText : undefined"
-        :hide-title="props.hideTitle"
-      />
+      <CopyIcon :color="props.iconColor" />
 
       <slot>
         <span class="visually-hidden">{{ props.copyText }}</span>
@@ -36,7 +31,6 @@ const props = withDefaults(defineProps<{
   tooltipSuccessText?: string
   tooltipFailText?: string
   hasBorder?: boolean
-  hideTitle?: boolean
   iconColor?: string
 }>(), {
   text: '',
@@ -45,7 +39,6 @@ const props = withDefaults(defineProps<{
   tooltipSuccessText: 'Copied code!',
   tooltipFailText: 'Failed to copy!',
   hasBorder: false,
-  hideTitle: false,
   iconColor: KUI_COLOR_TEXT_NEUTRAL,
 })
 

--- a/src/app/common/DocumentationLink.vue
+++ b/src/app/common/DocumentationLink.vue
@@ -4,10 +4,7 @@
     :href="props.href"
     target="_blank"
   >
-    <BookIcon
-      :size="KUI_ICON_SIZE_30"
-      :title="t('common.documentation')"
-    />
+    <BookIcon :size="KUI_ICON_SIZE_30" />
 
     <span><slot>{{ t('common.documentation') }}</slot></span>
   </a>

--- a/src/app/common/ErrorBlock.vue
+++ b/src/app/common/ErrorBlock.vue
@@ -8,7 +8,6 @@
         <DangerIcon
           v-if="props.appearance === 'danger'"
           :color="KUI_COLOR_TEXT_DANGER"
-          display="inline-block"
         />
 
         <WarningIcon v-else />

--- a/src/app/common/ErrorBlock.vue
+++ b/src/app/common/ErrorBlock.vue
@@ -11,10 +11,7 @@
           display="inline-block"
         />
 
-        <WarningIcon
-          v-else
-          :size="KUI_ICON_SIZE_50"
-        />
+        <WarningIcon v-else />
       </template>
 
       <template #title>
@@ -77,7 +74,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_DANGER, KUI_ICON_SIZE_50 } from '@kong/design-tokens'
+import { KUI_COLOR_TEXT_DANGER } from '@kong/design-tokens'
 import { DangerIcon } from '@kong/icons'
 import { computed } from 'vue'
 

--- a/src/app/common/LoadingBlock.vue
+++ b/src/app/common/LoadingBlock.vue
@@ -3,7 +3,6 @@
     <template #icon>
       <ProgressIcon
         class="mb-3"
-        display="inline-block"
         :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
       />
     </template>

--- a/src/app/common/WarningIcon.vue
+++ b/src/app/common/WarningIcon.vue
@@ -2,7 +2,6 @@
   <WarningIcon
     color="var(--WarningIconBackground, currentColor)"
     :size="props.size || KUI_ICON_SIZE_60"
-    :hide-title="props.hideTitle"
   />
 </template>
 
@@ -10,11 +9,7 @@
 import { KUI_ICON_SIZE_60 } from '@kong/design-tokens'
 import { WarningIcon } from '@kong/icons'
 
-const props = withDefaults(defineProps<{
+const props = defineProps<{
   size?: string
-  hideTitle?: boolean
-}>(), {
-  size: '',
-  hideTitle: false,
-})
+}>()
 </script>

--- a/src/app/common/WarningIcon.vue
+++ b/src/app/common/WarningIcon.vue
@@ -1,7 +1,6 @@
 <template>
   <WarningIcon
     color="var(--WarningIconBackground, currentColor)"
-    display="inline-block"
     :size="props.size || KUI_ICON_SIZE_60"
     :hide-title="props.hideTitle"
   />

--- a/src/app/common/code-block/EnvoyData.vue
+++ b/src/app/common/code-block/EnvoyData.vue
@@ -30,7 +30,8 @@
             appearance="primary"
             @click="refresh"
           >
-            <RefreshIcon :size="KUI_ICON_SIZE_30" />
+            <RefreshIcon />
+
             Refresh
           </KButton>
         </template>
@@ -40,7 +41,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { RefreshIcon } from '@kong/icons'
 
 import CodeBlock from './CodeBlock.vue'

--- a/src/app/common/code-block/ResourceCodeBlock.vue
+++ b/src/app/common/code-block/ResourceCodeBlock.vue
@@ -28,7 +28,6 @@
               :get-text="getYamlAsKubernetes"
               :copy-text="t('common.copyKubernetesText')"
               has-border
-              hide-title
               icon-color="currentColor"
               @click="() => {
                 if(isToggled.value === false) {

--- a/src/app/common/filter-bar/FilterBar.vue
+++ b/src/app/common/filter-bar/FilterBar.vue
@@ -17,7 +17,6 @@
         <FilterIcon
           decorative
           data-testid="k-filter-bar-filter-icon"
-          hide-title
           :size="KUI_ICON_SIZE_30"
         />
       </span>
@@ -90,7 +89,6 @@
 
             <ChevronRightIcon
               decorative
-              hide-title
               :size="KUI_ICON_SIZE_30"
             />
           </button>
@@ -110,7 +108,6 @@
 
       <ClearIcon
         decorative
-        hide-title
         :size="KUI_ICON_SIZE_30"
       />
     </button>

--- a/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
+++ b/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
@@ -53,7 +53,8 @@
                 appearance="primary"
                 @click="refresh"
               >
-                <RefreshIcon :size="KUI_ICON_SIZE_30" />
+                <RefreshIcon />
+
                 Refresh
               </KButton>
             </template>
@@ -64,7 +65,6 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { RefreshIcon } from '@kong/icons'
 
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'

--- a/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
+++ b/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
@@ -47,7 +47,8 @@
                 appearance="primary"
                 @click="refresh"
               >
-                <RefreshIcon :size="KUI_ICON_SIZE_30" />
+                <RefreshIcon />
+
                 Refresh
               </KButton>
             </template>
@@ -58,7 +59,6 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { RefreshIcon } from '@kong/icons'
 
 import { StatsSource } from '../sources'

--- a/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
@@ -53,7 +53,8 @@
                 appearance="primary"
                 @click="refresh"
               >
-                <RefreshIcon :size="KUI_ICON_SIZE_30" />
+                <RefreshIcon />
+
                 Refresh
               </KButton>
             </template>
@@ -64,7 +65,6 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { RefreshIcon } from '@kong/icons'
 
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'

--- a/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
@@ -52,7 +52,8 @@
                 appearance="primary"
                 @click="refresh"
               >
-                <RefreshIcon :size="KUI_ICON_SIZE_30" />
+                <RefreshIcon />
+
                 Refresh
               </KButton>
             </template>
@@ -63,7 +64,6 @@
   </RouteView>
 </template>
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { RefreshIcon } from '@kong/icons'
 
 import { StatsSource } from '../sources'

--- a/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -64,7 +64,7 @@
                           appearance="primary"
                           :to="{ name: 'zone-create-view' }"
                         >
-                          <AddIcon :size="KUI_ICON_SIZE_30" />
+                          <AddIcon />
 
                           {{ t('zones.index.create') }}
                         </KButton>
@@ -116,7 +116,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { AddIcon } from '@kong/icons'
 
 import { GlobalInsightSource } from '../sources'

--- a/src/app/data-planes/components/DataPlaneSummary.vue
+++ b/src/app/data-planes/components/DataPlaneSummary.vue
@@ -23,7 +23,6 @@
                 <InfoIcon
                   :color="KUI_COLOR_BACKGROUND_NEUTRAL"
                   :size="KUI_ICON_SIZE_30"
-                  hide-title
                 />
                 <template #content>
                   <ul>

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -220,7 +220,7 @@
                     appearance="primary"
                     @click="refresh"
                   >
-                    <RefreshIcon :size="KUI_ICON_SIZE_30" />
+                    <RefreshIcon />
 
                     Refresh
                   </KButton>

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -122,7 +122,6 @@
               <ConnectionTraffic>
                 <template #title>
                   <ForwardIcon
-                    display="inline-block"
                     decorative
                     :size="KUI_ICON_SIZE_30"
                   />
@@ -227,7 +226,6 @@
                 </template>
                 <template #title>
                   <GatewayIcon
-                    display="inline-block"
                     decorative
                     :size="KUI_ICON_SIZE_30"
                   />

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -62,7 +62,6 @@
                         <InfoIcon
                           :color="KUI_COLOR_BACKGROUND_NEUTRAL"
                           :size="KUI_ICON_SIZE_30"
-                          hide-title
                         />
                         <template #content>
                           <ul>

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -217,7 +217,6 @@
                   <WarningIcon
                     class="mr-1"
                     :size="KUI_ICON_SIZE_30"
-                    hide-title
                   />
                 </KTooltip>
 

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -240,7 +240,6 @@
                   {{ t('common.collection.details_link') }}
 
                   <ArrowRightIcon
-                    display="inline-block"
                     decorative
                     :size="KUI_ICON_SIZE_30"
                   />

--- a/src/app/external-services/views/ExternalServiceListView.vue
+++ b/src/app/external-services/views/ExternalServiceListView.vue
@@ -89,7 +89,6 @@
                   {{ t('common.collection.details_link') }}
 
                   <ArrowRightIcon
-                    display="inline-block"
                     decorative
                     :size="KUI_ICON_SIZE_30"
                   />

--- a/src/app/gateways/views/BuiltinGatewayDetailView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailView.vue
@@ -164,7 +164,6 @@
                     {{ t('common.collection.details_link') }}
 
                     <ArrowRightIcon
-                      display="inline-block"
                       decorative
                       :size="KUI_ICON_SIZE_30"
                     />

--- a/src/app/gateways/views/BuiltinGatewayDetailView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailView.vue
@@ -141,7 +141,6 @@
                     <WarningIcon
                       class="mr-1"
                       :size="KUI_ICON_SIZE_30"
-                      hide-title
                     />
                   </KTooltip>
 

--- a/src/app/gateways/views/BuiltinGatewayListView.vue
+++ b/src/app/gateways/views/BuiltinGatewayListView.vue
@@ -98,7 +98,6 @@
                   {{ t('common.collection.details_link') }}
 
                   <ArrowRightIcon
-                    display="inline-block"
                     decorative
                     :size="KUI_ICON_SIZE_30"
                   />

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -206,7 +206,6 @@
                       {{ t('common.collection.details_link') }}
 
                       <ArrowRightIcon
-                        display="inline-block"
                         decorative
                         :size="KUI_ICON_SIZE_30"
                       />

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -183,7 +183,6 @@
                       <WarningIcon
                         class="mr-1"
                         :size="KUI_ICON_SIZE_30"
-                        hide-title
                       />
                     </KTooltip>
 

--- a/src/app/gateways/views/DelegatedGatewayListView.vue
+++ b/src/app/gateways/views/DelegatedGatewayListView.vue
@@ -105,7 +105,6 @@
                   {{ t('common.collection.details_link') }}
 
                   <ArrowRightIcon
-                    display="inline-block"
                     decorative
                     :size="KUI_ICON_SIZE_30"
                   />

--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -85,7 +85,7 @@
               appearance="tertiary"
               icon-only
             >
-              <HelpIcon :size="KUI_ICON_SIZE_30" />
+              <HelpIcon />
 
               <span class="visually-hidden">Help</span>
             </KButton>
@@ -128,10 +128,7 @@
             icon-only
             data-testid="nav-item-diagnostics"
           >
-            <CogIcon
-              :size="KUI_ICON_SIZE_30"
-              hide-title
-            />
+            <CogIcon />
 
             <span class="visually-hidden">Diagnostics</span>
           </KButton>
@@ -180,7 +177,6 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { CogIcon, HelpIcon } from '@kong/icons'
 import GithubButton from 'vue-github-button'
 

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -88,7 +88,6 @@
                     {{ t('common.collection.details_link') }}
 
                     <ArrowRightIcon
-                      display="inline-block"
                       decorative
                       :size="KUI_ICON_SIZE_30"
                     />

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -168,7 +168,6 @@
                           {{ t('common.collection.details_link') }}
 
                           <ArrowRightIcon
-                            display="inline-block"
                             decorative
                             :size="KUI_ICON_SIZE_30"
                           />

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -275,7 +275,6 @@
                         {{ t('common.collection.details_link') }}
 
                         <ArrowRightIcon
-                          display="inline-block"
                           decorative
                           :size="KUI_ICON_SIZE_30"
                         />

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -252,7 +252,6 @@
                         <WarningIcon
                           class="mr-1"
                           :size="KUI_ICON_SIZE_30"
-                          hide-title
                         />
                       </KTooltip>
 

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -108,7 +108,6 @@
                   {{ t('common.collection.details_link') }}
 
                   <ArrowRightIcon
-                    display="inline-block"
                     decorative
                     :size="KUI_ICON_SIZE_30"
                   />

--- a/src/app/zone-egresses/views/ZoneEgressListView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressListView.vue
@@ -106,7 +106,6 @@
                   {{ t('common.collection.details_link') }}
 
                   <ArrowRightIcon
-                    display="inline-block"
                     decorative
                     :size="KUI_ICON_SIZE_30"
                   />

--- a/src/app/zone-ingresses/views/ZoneIngressListView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressListView.vue
@@ -117,7 +117,6 @@
                   {{ t('common.collection.details_link') }}
 
                   <ArrowRightIcon
-                    display="inline-block"
                     decorative
                     :size="KUI_ICON_SIZE_30"
                   />

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -296,14 +296,12 @@
                         <ProgressIcon
                           v-if="data === undefined"
                           data-testid="waiting"
-                          display="inline-block"
                           :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
                         />
 
                         <CheckCircleIcon
                           v-else
                           data-testid="connected"
-                          display="inline-block"
                           :color="KUI_COLOR_TEXT_SUCCESS"
                         />
                       </template>

--- a/src/app/zones/views/ZoneCreateView.vue
+++ b/src/app/zones/views/ZoneCreateView.vue
@@ -138,13 +138,9 @@
                   <ProgressIcon
                     v-if="isChangingZone"
                     :color="KUI_COLOR_TEXT_NEUTRAL_WEAK"
-                    :size="KUI_ICON_SIZE_30"
                   />
 
-                  <AddIcon
-                    v-else
-                    :size="KUI_ICON_SIZE_30"
-                  />
+                  <AddIcon v-else />
 
                   {{ t('zones.form.createZoneButtonLabel') }}
                 </KButton>
@@ -367,7 +363,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_TEXT_SUCCESS, KUI_ICON_SIZE_30, KUI_COLOR_TEXT_NEUTRAL_WEAK } from '@kong/design-tokens'
+import { KUI_COLOR_TEXT_SUCCESS, KUI_COLOR_TEXT_NEUTRAL_WEAK } from '@kong/design-tokens'
 import { AddIcon, CheckIcon, ProgressIcon, CheckCircleIcon } from '@kong/icons'
 import { computed, ref } from 'vue'
 

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -186,7 +186,6 @@
                   {{ t('common.collection.details_link') }}
 
                   <ArrowRightIcon
-                    display="inline-block"
                     decorative
                     :size="KUI_ICON_SIZE_30"
                   />

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -31,7 +31,7 @@
             :to="{ name: 'zone-create-view' }"
             data-testid="create-zone-link"
           >
-            <AddIcon :size="KUI_ICON_SIZE_30" />
+            <AddIcon />
 
             {{ t('zones.index.create') }}
           </KButton>

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -162,7 +162,6 @@
                       data-testid="warning"
                       class="mr-1"
                       :size="KUI_ICON_SIZE_30"
-                      hide-title
                     />
                   </KTooltip>
 


### PR DESCRIPTION
**chore: remove unnecessary icon size props**

Remove the icon size prop from all icons in buttons as inside buttons, the icon size is always overridden and so setting it doesn’t have any effect.

**chore: remove unnecessary display="inline-block" prop**

**chore: remove hideTitle and title props from icons**

Remove all `hideTitle` props from icons as this prop doesn’t exist and so it does nothing.

Remove all `title` props from icons as we generally don’t want them (we only had a few anyway).

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
