### PR TITLE
fix(policies): fixes specific `!` and `and` CSS coloring for matchers

### DIFF
--- a/src/app/data-planes/components/RuleEntryList.vue
+++ b/src/app/data-planes/components/RuleEntryList.vue
@@ -200,16 +200,18 @@ const props = defineProps<{
   word-break: break-word;
 }
 
-.matcher__not {
-  color: $kui-color-text-danger;
+.app-collection :deep(td:first-child *) {
+  font-weight: $kui-font-weight-regular;
+  .matcher__not {
+    color: $kui-color-text-danger;
+  }
+  .matcher__and {
+    font-weight: $kui-font-weight-semibold;
+  }
+  .matcher__not,
+  .matcher__term {
+    font-family: $kui-font-family-code;
+  }
 }
 
-.matcher__and {
-  font-weight: $kui-font-weight-semibold;
-}
-
-.matcher__not,
-.matcher__term {
-  font-family: $kui-font-family-code;
-}
 </style>


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/2247 we moved the Rules accordion pane tables to use AppCollection instead of KTable, which mistakenly overrode some specific CSS font/coloring rules.

This PR adds that styling back in.