### PR TITLE
chore: moves connection stats/clusters to use DataLoader/DataCollection

### DIFF
--- a/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
+++ b/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
@@ -20,46 +20,39 @@
         </h3>
       </template>
       <div>
-        <DataSource
-          v-slot="{ data: clusters, error, refresh }: ClustersDataSource"
+        <DataLoader
+          v-slot="{ data: clusters, refresh }: ClustersDataSource"
           :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/clusters`"
         >
-          <ErrorBlock
-            v-if="error"
-            :error="error"
-          />
-
-          <LoadingBlock v-else-if="clusters === undefined" />
-
-          <CodeBlock
-            v-else
-            language="json"
-            :code="(() => `${
-              clusters.split('\n')
-                .filter(item => item.startsWith(`${props.data.service}::`))
-                .map(item => item.replace(`${props.data.service}::`, ''))
-                .join('\n')
-            }`)()"
-            is-searchable
-            :query="route.params.codeSearch"
-            :is-filter-mode="route.params.codeFilter"
-            :is-reg-exp-mode="route.params.codeRegExp"
-            @query-change="route.update({ codeSearch: $event })"
-            @filter-mode-change="route.update({ codeFilter: $event })"
-            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          <DataCollection
+            v-slot="{ items: lines }"
+            :items="clusters!.split('\n')"
+            :predicate="item => item.startsWith(`${props.data.service}::`)"
           >
-            <template #primary-actions>
-              <KButton
-                appearance="primary"
-                @click="refresh"
-              >
-                <RefreshIcon />
+            <CodeBlock
+              language="json"
+              :code="lines.map(item => item.replace(`${props.data.service}::`, '')).join('\n')"
+              is-searchable
+              :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter"
+              :is-reg-exp-mode="route.params.codeRegExp"
+              @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            >
+              <template #primary-actions>
+                <KButton
+                  appearance="primary"
+                  @click="refresh"
+                >
+                  <RefreshIcon />
 
-                Refresh
-              </KButton>
-            </template>
-          </CodeBlock>
-        </DataSource>
+                  Refresh
+                </KButton>
+              </template>
+            </CodeBlock>
+          </DataCollection>
+        </DataLoader>
       </div>
     </AppView>
   </RouteView>
@@ -68,8 +61,6 @@
 import { RefreshIcon } from '@kong/icons'
 
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import type { DataplaneInbound } from '@/app/data-planes/data'
 import type { ClustersDataSource } from '@/app/data-planes/sources'
 

--- a/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
+++ b/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
@@ -20,40 +20,44 @@
         </h3>
       </template>
       <div>
-        <DataSource
-          v-slot="{ data: stats, error, refresh }: StatsSource"
-          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${route.params.service}`"
+        <DataLoader
+          v-slot="{ data: stats, refresh }: StatsSource"
+          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${props.dataplaneOverview.dataplane.networking.address}`"
         >
-          <ErrorBlock
-            v-if="error"
-            :error="error"
-          />
-
-          <LoadingBlock v-else-if="stats === undefined" />
-          <CodeBlock
-            v-else
-            language="json"
-            :code="findService(stats)"
-            is-searchable
-            :query="route.params.codeSearch"
-            :is-filter-mode="route.params.codeFilter"
-            :is-reg-exp-mode="route.params.codeRegExp"
-            @query-change="route.update({ codeSearch: $event })"
-            @filter-mode-change="route.update({ codeFilter: $event })"
-            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          <DataCollection
+            v-slot="{ items: lines }"
+            :items="stats!.raw.split('\n')"
+            :predicate="item => [
+              `listener.${props.data.name}.`,
+              `cluster.${props.data.cluster}.`,
+              `http.${props.data.cluster}.`,
+              `tcp.${props.data.cluster}.`,
+            ].some(prefix => item.startsWith(prefix)) && (!item.includes('.rds.') || item.includes(`_${props.data.port}`))"
           >
-            <template #primary-actions>
-              <KButton
-                appearance="primary"
-                @click="refresh"
-              >
-                <RefreshIcon />
+            <CodeBlock
+              language="json"
+              :code="lines.map(item => item.replace(`${props.data.name}.`, '').replace(`${props.data.cluster}.`, '')).join('\n')"
+              is-searchable
+              :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter"
+              :is-reg-exp-mode="route.params.codeRegExp"
+              @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            >
+              <template #primary-actions>
+                <KButton
+                  appearance="primary"
+                  @click="refresh"
+                >
+                  <RefreshIcon />
 
-                Refresh
-              </KButton>
-            </template>
-          </CodeBlock>
-        </DataSource>
+                  Refresh
+                </KButton>
+              </template>
+            </CodeBlock>
+          </DataCollection>
+        </DataLoader>
       </div>
     </AppView>
   </RouteView>
@@ -63,23 +67,10 @@ import { RefreshIcon } from '@kong/icons'
 
 import { StatsSource } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
-import type { DataplaneInbound } from '@/app/data-planes/data'
+import type { DataplaneInbound, DataplaneOverview } from '@/app/data-planes/data/'
 
 const props = defineProps<{
   data: DataplaneInbound
+  dataplaneOverview: DataplaneOverview
 }>()
-const findService = (data: { raw: string }) => {
-  return data.raw.split('\n')
-    .filter(item => [
-      `listener.${props.data.name}.`,
-      `cluster.${props.data.cluster}.`,
-      `http.${props.data.cluster}.`,
-      `tcp.${props.data.cluster}.`,
-    ].some(prefix => item.startsWith(prefix)))
-    .filter(item => !item.includes('.rds.') || item.includes(`_${props.data.port}`)) // find the weirder rds lines that don't correspond
-    .map((item) => item.replace(`${props.data.name}.`, '').replace(`${props.data.cluster}.`, ''))
-    .join('\n')
-}
 </script>

--- a/src/app/connections/views/ConnectionInboundSummaryView.vue
+++ b/src/app/connections/views/ConnectionInboundSummaryView.vue
@@ -10,7 +10,7 @@
     <DataCollection
       v-slot="{ items }"
       :items="props.data"
-      :predicate="(item) => `${item.port}` === route.params.service.split(':')[1]"
+      :predicate="(item) => `${item.port || route.params.service.split(':')[1]}` === route.params.service.split(':')[1]"
       :find="true"
     >
       <AppView>
@@ -44,6 +44,7 @@
           <component
             :is="child.Component"
             :data="items[0]"
+            :dataplane-overview="props.dataplaneOverview"
           />
         </RouterView>
       </AppView>
@@ -53,9 +54,10 @@
 
 <script lang="ts" setup>
 import NavTabs from '@/app/common/NavTabs.vue'
-import type { DataplaneInbound } from '@/app/data-planes/data/'
+import type { DataplaneInbound, DataplaneOverview } from '@/app/data-planes/data/'
 
 const props = defineProps<{
   data: DataplaneInbound[]
+  dataplaneOverview: DataplaneOverview
 }>()
 </script>

--- a/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
@@ -20,46 +20,39 @@
         </h3>
       </template>
       <div>
-        <DataSource
-          v-slot="{ data, error, refresh }: ClustersDataSource"
+        <DataLoader
+          v-slot="{ data, refresh }: ClustersDataSource"
           :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/clusters`"
         >
-          <ErrorBlock
-            v-if="error"
-            :error="error"
-          />
-
-          <LoadingBlock v-else-if="data === undefined" />
-
-          <CodeBlock
-            v-else
-            language="json"
-            :code="(() => `${
-              data.split('\n')
-                .filter(item => item.startsWith(`${route.params.service}::`))
-                .map(item => item.replace(`${route.params.service}::`, ''))
-                .join('\n')
-            }`)()"
-            is-searchable
-            :query="route.params.codeSearch"
-            :is-filter-mode="route.params.codeFilter"
-            :is-reg-exp-mode="route.params.codeRegExp"
-            @query-change="route.update({ codeSearch: $event })"
-            @filter-mode-change="route.update({ codeFilter: $event })"
-            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          <DataCollection
+            v-slot="{ items: lines }"
+            :items="data!.split('\n')"
+            :predicate="item => item.startsWith(`${route.params.service}::`)"
           >
-            <template #primary-actions>
-              <KButton
-                appearance="primary"
-                @click="refresh"
-              >
-                <RefreshIcon />
+            <CodeBlock
+              language="json"
+              :code="lines.map(item => item.replace(`${route.params.service}::`, '')).join('\n')"
+              is-searchable
+              :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter"
+              :is-reg-exp-mode="route.params.codeRegExp"
+              @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            >
+              <template #primary-actions>
+                <KButton
+                  appearance="primary"
+                  @click="refresh"
+                >
+                  <RefreshIcon />
 
-                Refresh
-              </KButton>
-            </template>
-          </CodeBlock>
-        </DataSource>
+                  Refresh
+                </KButton>
+              </template>
+            </CodeBlock>
+          </DataCollection>
+        </DataLoader>
       </div>
     </AppView>
   </RouteView>
@@ -68,7 +61,5 @@
 import { RefreshIcon } from '@kong/icons'
 
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import type { ClustersDataSource } from '@/app/data-planes/sources'
 </script>

--- a/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
@@ -20,45 +20,39 @@
         </h3>
       </template>
       <div>
-        <DataSource
-          v-slot="{ data, error, refresh }: StatsSource"
-          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${route.params.service}`"
+        <DataLoader
+          v-slot="{ data, refresh }: StatsSource"
+          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${props.dataplaneOverview.dataplane.networking.address}`"
         >
-          <ErrorBlock
-            v-if="error"
-            :error="error"
-          />
-
-          <LoadingBlock v-else-if="data === undefined" />
-
-          <CodeBlock
-            v-else
-            language="json"
-            :code="(() => data.raw.split('\n')
-              .filter((item) => item.includes(`.${route.params.service}.`))
-              .map((item) => item.replace(`${route.params.service}.`, ''))
-              .join('\n')
-            )()"
-            is-searchable
-            :query="route.params.codeSearch"
-            :is-filter-mode="route.params.codeFilter"
-            :is-reg-exp-mode="route.params.codeRegExp"
-            @query-change="route.update({ codeSearch: $event })"
-            @filter-mode-change="route.update({ codeFilter: $event })"
-            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          <DataCollection
+            v-slot="{ items: lines }"
+            :items="data!.raw.split('\n')"
+            :predicate="item => item.includes(`.${route.params.service}.`)"
           >
-            <template #primary-actions>
-              <KButton
-                appearance="primary"
-                @click="refresh"
-              >
-                <RefreshIcon />
+            <CodeBlock
+              language="json"
+              :code="lines.map((item) => item.replace(`${route.params.service}.`, '')).join('\n')"
+              is-searchable
+              :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter"
+              :is-reg-exp-mode="route.params.codeRegExp"
+              @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            >
+              <template #primary-actions>
+                <KButton
+                  appearance="primary"
+                  @click="refresh"
+                >
+                  <RefreshIcon />
 
-                Refresh
-              </KButton>
-            </template>
-          </CodeBlock>
-        </DataSource>
+                  Refresh
+                </KButton>
+              </template>
+            </CodeBlock>
+          </DataCollection>
+        </DataLoader>
       </div>
     </AppView>
   </RouteView>
@@ -68,6 +62,8 @@ import { RefreshIcon } from '@kong/icons'
 
 import { StatsSource } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
+import type { DataplaneOverview } from '@/app/data-planes/data/'
+const props = defineProps<{
+  dataplaneOverview: DataplaneOverview
+}>()
 </script>

--- a/src/app/connections/views/ConnectionOutboundSummaryView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryView.vue
@@ -4,6 +4,7 @@
     name="connection-outbound-summary-view"
     :params="{
       service: '',
+      inactive: false,
     }"
   >
     <AppView>
@@ -20,7 +21,13 @@
           #[`${item.name}`]
         >
           <RouterLink
-            :to="{ name: item.name }"
+            :to="{
+              name: item.name,
+              query: {
+                inactive: route.params.inactive ? null : undefined,
+              },
+
+            }"
           >
             {{ t(`connections.routes.item.navigation.${item.name.split('-')[3]}`) }}
           </RouterLink>
@@ -30,12 +37,13 @@
         <DataCollection
           v-slot="{ items }"
           :items="Object.entries(props.data)"
-          :predicate="([key, value]) => key === route.params.service"
+          :predicate="([key, _value]) => key === route.params.service"
           :find="true"
         >
           <component
             :is="Component"
             :data="items[0][1]"
+            :dataplane-overview="props.dataplaneOverview"
           />
         </DataCollection>
       </RouterView>
@@ -45,7 +53,9 @@
 
 <script lang="ts" setup>
 import NavTabs from '@/app/common/NavTabs.vue'
+import type { DataplaneOverview } from '@/app/data-planes/data/'
 const props = defineProps<{
   data: Record<string, any>
+  dataplaneOverview: DataplaneOverview
 }>()
 </script>

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -12,148 +12,148 @@
       v-slot="{ data: traffic, error, refresh }: StatsSource"
       :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${props.data.dataplane.networking.address}`"
     >
-      <!-- if we are a builtin gateway proxy i.e. a 'gateway' proxy -->
-      <!-- use its first and only inbounds as a template  -->
-      <!-- and fill the inbounds out from the stats once they are loaded -->
-      <template
-        v-for="inbounds in [props.data.dataplane.networking.type === 'gateway' ? Object.entries<any>(traffic?.inbounds ?? {}).reduce<DataplaneInbound[]>((prev, [key, value]) => {
-          const [ip, port] = key.split('_')
-          // As we are just 'finding' inbounds from stats without knowing them
-          // from the dataplane overview API request, we will wrongly 'find'
-          // the envoy admin inbound that is used for kumas /stats API. Ignore
-          // the envoy admin inbound when we find it
-          if(port === (props.data.dataplane.networking.admin?.port ?? '9901')) {
-            return prev
-          }
-          return prev.concat([
-            {
-              ...props.data.dataplane.networking.inbounds[0],
-              name: key,
-              port: Number(port),
-              protocol: ['http', 'tcp'].find(item => typeof value[item] !== 'undefined') ?? 'tcp',
-              addressPort: `${props.data.dataplane.networking.inbounds[0].address}:${port}`,
-            },
-          ])
-        }, []) : props.data.dataplane.networking.inbounds]"
-        :key="inbounds"
-      >
-        <AppView>
-          <template
-            v-if="warnings.length > 0 || error"
-            #notifications
-          >
-            <ul data-testid="dataplane-warnings">
-              <!-- eslint-disable vue/no-v-html  -->
-              <li
-                v-for="warning in warnings"
-                :key="warning.kind"
-                :data-testid="`warning-${warning.kind}`"
-                v-html="t(`common.warnings.${warning.kind}`, warning.payload)"
-              />
-              <li
-                v-if="error"
-                :data-testid="`warning-stats-loading`"
-              >
-                The below view is not enhanced with runtime stats (Error loading stats: <strong>{{ error.toString() }}</strong>)
-              </li>
-              <!-- eslint-enable -->
-            </ul>
-          </template>
-
-          <div
-            class="stack"
-            data-testid="dataplane-details"
-          >
-            <KCard>
-              <div class="columns">
-                <DefinitionCard>
-                  <template #title>
-                    {{ t('http.api.property.status') }}
-                  </template>
-
-                  <template #body>
-                    <div class="status-with-reason">
-                      <StatusBadge :status="props.data.status" />
-                      <DataCollection
-                        v-if="props.data.dataplaneType === 'standard'"
-                        v-slot="{ items : unhealthyInbounds }"
-                        :items="props.data.dataplane.networking.inbounds"
-                        :predicate="item => !item.health.ready"
-                        :empty="false"
-                      >
-                        <KTooltip
-                          class="reason-tooltip"
-                        >
-                          <InfoIcon
-                            :color="KUI_COLOR_BACKGROUND_NEUTRAL"
-                            :size="KUI_ICON_SIZE_30"
-                          />
-                          <template #content>
-                            <ul>
-                              <li
-                                v-for="inbound in unhealthyInbounds"
-                                :key="`${inbound.service}:${inbound.port}`"
-                              >
-                                {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
-                              </li>
-                            </ul>
-                          </template>
-                        </KTooltip>
-                      </DataCollection>
-                    </div>
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard>
-                  <template #title>
-                    {{ t('data-planes.routes.item.last_updated') }}
-                  </template>
-
-                  <template #body>
-                    {{ t('common.formats.datetime', { value: Date.parse(props.data.modificationTime) }) }}
-                  </template>
-                </DefinitionCard>
-
-                <template v-if="props.data.dataplane.networking.gateway">
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('http.api.property.tags') }}
-                    </template>
-
-                    <template #body>
-                      <TagList :tags="props.data.dataplane.networking.gateway.tags" />
-                    </template>
-                  </DefinitionCard>
-
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('http.api.property.address') }}
-                    </template>
-
-                    <template #body>
-                      <TextWithCopyButton :text="`${props.data.dataplane.networking.address}`" />
-                    </template>
-                  </DefinitionCard>
-                </template>
-              </div>
-            </KCard>
-
-            <KCard
-              class="traffic"
-              data-testid="dataplane-traffic"
+      <AppView>
+        <template
+          v-if="warnings.length > 0 || error"
+          #notifications
+        >
+          <ul data-testid="dataplane-warnings">
+            <!-- eslint-disable vue/no-v-html  -->
+            <li
+              v-for="warning in warnings"
+              :key="warning.kind"
+              :data-testid="`warning-${warning.kind}`"
+              v-html="t(`common.warnings.${warning.kind}`, warning.payload)"
+            />
+            <li
+              v-if="error"
+              :data-testid="`warning-stats-loading`"
             >
-              <div class="columns">
-                <ConnectionTraffic>
+              The below view is not enhanced with runtime stats (Error loading stats: <strong>{{ error.toString() }}</strong>)
+            </li>
+            <!-- eslint-enable -->
+          </ul>
+        </template>
+
+        <div
+          class="stack"
+          data-testid="dataplane-details"
+        >
+          <KCard>
+            <div class="columns">
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.status') }}
+                </template>
+
+                <template #body>
+                  <div class="status-with-reason">
+                    <StatusBadge :status="props.data.status" />
+                    <DataCollection
+                      v-if="props.data.dataplaneType === 'standard'"
+                      v-slot="{ items : unhealthyInbounds }"
+                      :items="props.data.dataplane.networking.inbounds"
+                      :predicate="item => !item.health.ready"
+                      :empty="false"
+                    >
+                      <KTooltip
+                        class="reason-tooltip"
+                      >
+                        <InfoIcon
+                          :color="KUI_COLOR_BACKGROUND_NEUTRAL"
+                          :size="KUI_ICON_SIZE_30"
+                        />
+                        <template #content>
+                          <ul>
+                            <li
+                              v-for="inbound in unhealthyInbounds"
+                              :key="`${inbound.service}:${inbound.port}`"
+                            >
+                              {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
+                            </li>
+                          </ul>
+                        </template>
+                      </KTooltip>
+                    </DataCollection>
+                  </div>
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('data-planes.routes.item.last_updated') }}
+                </template>
+
+                <template #body>
+                  {{ t('common.formats.datetime', { value: Date.parse(props.data.modificationTime) }) }}
+                </template>
+              </DefinitionCard>
+
+              <template v-if="props.data.dataplane.networking.gateway">
+                <DefinitionCard>
                   <template #title>
-                    <ForwardIcon
-                      display="inline-block"
-                      decorative
-                      :size="KUI_ICON_SIZE_30"
-                    />
-                    Inbounds
+                    {{ t('http.api.property.tags') }}
                   </template>
-                  <ConnectionGroup
-                    type="inbound"
+
+                  <template #body>
+                    <TagList :tags="props.data.dataplane.networking.gateway.tags" />
+                  </template>
+                </DefinitionCard>
+
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('http.api.property.address') }}
+                  </template>
+
+                  <template #body>
+                    <TextWithCopyButton :text="`${props.data.dataplane.networking.address}`" />
+                  </template>
+                </DefinitionCard>
+              </template>
+            </div>
+          </KCard>
+
+          <KCard
+            class="traffic"
+            data-testid="dataplane-traffic"
+          >
+            <div class="columns">
+              <ConnectionTraffic>
+                <template #title>
+                  <ForwardIcon
+                    display="inline-block"
+                    decorative
+                    :size="KUI_ICON_SIZE_30"
+                  />
+                  Inbounds
+                </template>
+                <ConnectionGroup
+                  type="inbound"
+                >
+                  <!-- if we are a builtin gateway proxy i.e. a 'gateway' proxy -->
+                  <!-- use its first and only inbounds as a template  -->
+                  <!-- and fill the inbounds out from the stats once they are loaded -->
+                  <template
+                    v-for="inbounds in [props.data.dataplane.networking.type === 'gateway' ? Object.entries<any>(traffic?.inbounds ?? {}).reduce<DataplaneInbound[]>((prev, [key, value]) => {
+                      const [ip, port] = key.split('_')
+                      // As we are just 'finding' inbounds from stats without knowing them
+                      // from the dataplane overview API request, we will wrongly 'find'
+                      // the envoy admin inbound that is used for kumas /stats API. Ignore
+                      // the envoy admin inbound when we find it
+                      if(port === (props.data.dataplane.networking.admin?.port ?? '9901')) {
+                        return prev
+                      }
+                      return prev.concat([
+                        {
+                          ...props.data.dataplane.networking.inbounds[0],
+                          name: key,
+                          port: Number(port),
+                          protocol: ['http', 'tcp'].find(item => typeof value[item] !== 'undefined') ?? 'tcp',
+                          addressPort: `${props.data.dataplane.networking.inbounds[0].address}:${port}`,
+                        },
+                      ])
+                    }, []) : props.data.dataplane.networking.inbounds]"
+                    :key="inbounds"
                   >
                     <DataCollection
                       :items="inbounds"
@@ -213,239 +213,240 @@
                         </template>
                       </template>
                     </DataCollection>
-                  </ConnectionGroup>
-                </ConnectionTraffic>
+                  </template>
+                </ConnectionGroup>
+              </ConnectionTraffic>
 
-                <ConnectionTraffic>
-                  <template
-                    v-if="traffic"
-                    #actions
+              <ConnectionTraffic>
+                <template
+                  v-if="traffic"
+                  #actions
+                >
+                  <KInputSwitch
+                    v-model="route.params.inactive"
+                    data-testid="dataplane-outbounds-inactive-toggle"
                   >
-                    <KInputSwitch
-                      v-model="route.params.inactive"
-                      data-testid="dataplane-outbounds-inactive-toggle"
-                    >
-                      <template #label>
-                        Show inactive
-                      </template>
-                    </KInputSwitch>
+                    <template #label>
+                      Show inactive
+                    </template>
+                  </KInputSwitch>
 
-                    <KButton
-                      appearance="primary"
-                      @click="refresh"
-                    >
-                      <RefreshIcon />
+                  <KButton
+                    appearance="primary"
+                    @click="refresh"
+                  >
+                    <RefreshIcon />
 
-                      Refresh
-                    </KButton>
-                  </template>
-                  <template #title>
-                    <GatewayIcon
-                      display="inline-block"
-                      decorative
-                      :size="KUI_ICON_SIZE_30"
-                    />
-                    <span>Outbounds</span>
-                  </template>
-                  <!-- we don't want to show an error here -->
-                  <!-- instead we show a No Data EmptyBlock -->
-                  <template v-if="typeof error === 'undefined'">
-                    <LoadingBlock v-if="typeof traffic === 'undefined'" />
+                    Refresh
+                  </KButton>
+                </template>
+                <template #title>
+                  <GatewayIcon
+                    display="inline-block"
+                    decorative
+                    :size="KUI_ICON_SIZE_30"
+                  />
+                  <span>Outbounds</span>
+                </template>
+                <!-- we don't want to show an error here -->
+                <!-- instead we show a No Data EmptyBlock -->
+                <template v-if="typeof error === 'undefined'">
+                  <LoadingBlock v-if="typeof traffic === 'undefined'" />
+                  <template
+                    v-else
+                  >
+                    <!-- Outbounds for gateways report actual traffic on the upstream so we switch to upstream here for non-standard-->
                     <template
-                      v-else
+                      v-for="direction in ['upstream'] as const"
+                      :key="direction"
                     >
-                      <!-- Outbounds for gateways report actual traffic on the upstream so we switch to upstream here for non-standard-->
-                      <template
-                        v-for="direction in ['upstream'] as const"
-                        :key="direction"
+                      <ConnectionGroup
+                        type="passthrough"
+                      >
+                        <ConnectionCard
+                          :protocol="`passthrough`"
+                          :traffic="traffic.passthrough"
+                        >
+                          Non mesh traffic
+                        </ConnectionCard>
+                      </ConnectionGroup>
+                      <DataCollection
+                        v-slot="{ items: outbounds }"
+                        :predicate="route.params.inactive ? undefined : ([key, item]) => ((typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) as (number | undefined) ?? 0) > 0"
+                        :items="Object.entries<any>(traffic.outbounds)"
                       >
                         <ConnectionGroup
-                          type="passthrough"
+                          v-if="outbounds.length > 0"
+                          type="outbound"
+                          data-testid="dataplane-outbounds"
                         >
-                          <ConnectionCard
-                            :protocol="`passthrough`"
-                            :traffic="traffic.passthrough"
+                          <template
+                            v-for="[name, outbound] in outbounds"
+                            :key="`${name}`"
                           >
-                            Non mesh traffic
-                          </ConnectionCard>
-                        </ConnectionGroup>
-                        <DataCollection
-                          v-slot="{ items: outbounds }"
-                          :predicate="route.params.inactive ? undefined : ([key, item]) => ((typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) as (number | undefined) ?? 0) > 0"
-                          :items="Object.entries<any>(traffic.outbounds)"
-                        >
-                          <ConnectionGroup
-                            v-if="outbounds.length > 0"
-                            type="outbound"
-                            data-testid="dataplane-outbounds"
-                          >
-                            <template
-                              v-for="[name, outbound] in outbounds"
-                              :key="`${name}`"
+                            <ConnectionCard
+                              :protocol="['grpc', 'http', 'tcp'].find(protocol => typeof outbound[protocol] !== 'undefined') ?? 'tcp'"
+                              :traffic="outbound"
+                              :direction="direction"
                             >
-                              <ConnectionCard
-                                :protocol="['grpc', 'http', 'tcp'].find(protocol => typeof outbound[protocol] !== 'undefined') ?? 'tcp'"
-                                :traffic="outbound"
-                                :direction="direction"
+                              <RouterLink
+                                data-action
+                                :to="{
+                                  name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'connection-outbound-summary-overview-view')(String(_route.name)),
+                                  params: {
+                                    service: name,
+                                  },
+                                  query: {
+                                    inactive: route.params.inactive ? null : undefined,
+                                  },
+                                }"
                               >
-                                <RouterLink
-                                  data-action
-                                  :to="{
-                                    name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'connection-outbound-summary-overview-view')(String(_route.name)),
-                                    params: {
-                                      service: name,
-                                    },
-                                    query: {
-                                      inactive: route.params.inactive ? null : undefined,
-                                    },
-                                  }"
-                                >
-                                  {{ name }}
-                                </RouterLink>
-                              </ConnectionCard>
-                            </template>
-                          </ConnectionGroup>
-                        </DataCollection>
-                      </template>
+                                {{ name }}
+                              </RouterLink>
+                            </ConnectionCard>
+                          </template>
+                        </ConnectionGroup>
+                      </DataCollection>
                     </template>
                   </template>
-                  <template v-else>
-                    <EmptyBlock />
-                  </template>
-                </ConnectionTraffic>
-              </div>
-            </KCard>
-
-            <RouterView
-              v-slot="child"
-            >
-              <SummaryView
-                v-if="child.route.name !== route.name"
-                width="670px"
-                @close="function (_e) {
-                  route.replace({
-                    name: 'data-plane-detail-view',
-                    params: {
-                      mesh: route.params.mesh,
-                      dataPlane: route.params.dataPlane,
-                    },
-                    query: {
-                      inactive: route.params.inactive ? null : undefined,
-                    },
-                  })
-
-                }"
-              >
-                <component
-                  :is="child.Component"
-                  :data="(child.route.name as string).includes('-inbound-') ? inbounds : traffic?.outbounds || {}"
-                />
-              </SummaryView>
-            </RouterView>
-
-            <div data-testid="dataplane-mtls">
-              <h2>{{ t('data-planes.routes.item.mtls.title') }}</h2>
-
-              <template
-                v-if="props.data.dataplaneInsight.mTLS"
-              >
-                <template
-                  v-for="mTLS in [
-                    props.data.dataplaneInsight.mTLS,
-                  ]"
-                  :key="mTLS"
-                >
-                  <KCard
-                    class="mt-4"
-                  >
-                    <div class="columns">
-                      <DefinitionCard>
-                        <template #title>
-                          {{ t('data-planes.routes.item.mtls.expiration_time.title') }}
-                        </template>
-
-                        <template #body>
-                          {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
-                        </template>
-                      </DefinitionCard>
-
-                      <DefinitionCard>
-                        <template #title>
-                          {{ t('data-planes.routes.item.mtls.generation_time.title') }}
-                        </template>
-
-                        <template #body>
-                          {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
-                        </template>
-                      </DefinitionCard>
-
-                      <DefinitionCard>
-                        <template #title>
-                          {{ t('data-planes.routes.item.mtls.regenerations.title') }}
-                        </template>
-
-                        <template #body>
-                          {{ t('common.formats.integer', {value: mTLS.certificateRegenerations}) }}
-                        </template>
-                      </DefinitionCard>
-                      <DefinitionCard>
-                        <template #title>
-                          {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
-                        </template>
-
-                        <template #body>
-                          {{ mTLS.issuedBackend }}
-                        </template>
-                      </DefinitionCard>
-
-                      <DefinitionCard>
-                        <template #title>
-                          {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
-                        </template>
-
-                        <template #body>
-                          <ul>
-                            <li
-                              v-for="item in mTLS.supportedBackends"
-                              :key="item"
-                            >
-                              {{ item }}
-                            </li>
-                          </ul>
-                        </template>
-                      </DefinitionCard>
-                    </div>
-                  </KCard>
                 </template>
-              </template>
-
-              <template
-                v-else
-              >
-                <KAlert
-                  class="mt-4"
-                  appearance="warning"
-                >
-                  <div
-                    v-html="t('data-planes.routes.item.mtls.disabled')"
-                  />
-                </KAlert>
-              </template>
+                <template v-else>
+                  <EmptyBlock />
+                </template>
+              </ConnectionTraffic>
             </div>
+          </KCard>
 
-            <div
-              v-if="props.data.dataplaneInsight.subscriptions.length > 0"
-              data-testid="dataplane-subscriptions"
+          <RouterView
+            v-slot="child"
+          >
+            <SummaryView
+              v-if="child.route.name !== route.name"
+              width="670px"
+              @close="function (_e) {
+                route.replace({
+                  name: 'data-plane-detail-view',
+                  params: {
+                    mesh: route.params.mesh,
+                    dataPlane: route.params.dataPlane,
+                  },
+                  query: {
+                    inactive: route.params.inactive ? null : undefined,
+                  },
+                })
+
+              }"
             >
-              <h2>{{ t('data-planes.routes.item.subscriptions.title') }}</h2>
+              <component
+                :is="child.Component"
+                :data="(child.route.name as string).includes('-inbound-') ? props.data.dataplane.networking.inbounds : traffic?.outbounds || {}"
+                :dataplane-overview="props.data"
+              />
+            </SummaryView>
+          </RouterView>
 
-              <KCard class="mt-4">
-                <SubscriptionList :subscriptions="props.data.dataplaneInsight.subscriptions" />
-              </KCard>
-            </div>
+          <div data-testid="dataplane-mtls">
+            <h2>{{ t('data-planes.routes.item.mtls.title') }}</h2>
+
+            <template
+              v-if="props.data.dataplaneInsight.mTLS"
+            >
+              <template
+                v-for="mTLS in [
+                  props.data.dataplaneInsight.mTLS,
+                ]"
+                :key="mTLS"
+              >
+                <KCard
+                  class="mt-4"
+                >
+                  <div class="columns">
+                    <DefinitionCard>
+                      <template #title>
+                        {{ t('data-planes.routes.item.mtls.expiration_time.title') }}
+                      </template>
+
+                      <template #body>
+                        {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
+                      </template>
+                    </DefinitionCard>
+
+                    <DefinitionCard>
+                      <template #title>
+                        {{ t('data-planes.routes.item.mtls.generation_time.title') }}
+                      </template>
+
+                      <template #body>
+                        {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
+                      </template>
+                    </DefinitionCard>
+
+                    <DefinitionCard>
+                      <template #title>
+                        {{ t('data-planes.routes.item.mtls.regenerations.title') }}
+                      </template>
+
+                      <template #body>
+                        {{ t('common.formats.integer', {value: mTLS.certificateRegenerations}) }}
+                      </template>
+                    </DefinitionCard>
+                    <DefinitionCard>
+                      <template #title>
+                        {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
+                      </template>
+
+                      <template #body>
+                        {{ mTLS.issuedBackend }}
+                      </template>
+                    </DefinitionCard>
+
+                    <DefinitionCard>
+                      <template #title>
+                        {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
+                      </template>
+
+                      <template #body>
+                        <ul>
+                          <li
+                            v-for="item in mTLS.supportedBackends"
+                            :key="item"
+                          >
+                            {{ item }}
+                          </li>
+                        </ul>
+                      </template>
+                    </DefinitionCard>
+                  </div>
+                </KCard>
+              </template>
+            </template>
+
+            <template
+              v-else
+            >
+              <KAlert
+                class="mt-4"
+                appearance="warning"
+              >
+                <div
+                  v-html="t('data-planes.routes.item.mtls.disabled')"
+                />
+              </KAlert>
+            </template>
           </div>
-        </AppView>
-      </template>
+
+          <div
+            v-if="props.data.dataplaneInsight.subscriptions.length > 0"
+            data-testid="dataplane-subscriptions"
+          >
+            <h2>{{ t('data-planes.routes.item.subscriptions.title') }}</h2>
+
+            <KCard class="mt-4">
+              <SubscriptionList :subscriptions="props.data.dataplaneInsight.subscriptions" />
+            </KCard>
+          </div>
+        </div>
+      </AppView>
     </DataSource>
   </RouteView>
 </template>

--- a/src/app/data-planes/views/DataPlaneStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneStatsView.vue
@@ -20,21 +20,13 @@
       </template>
 
       <KCard>
-        <DataSource
-          v-slot="{ data: statsData, error, refresh }: StatsSource"
-          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${props.data.dataplaneType === 'builtin' && props.data.dataplane.networking.gateway ? props.data.dataplane.networking.gateway.tags['kuma.io/service'] : 'localhost_'}`"
+        <DataLoader
+          v-slot="{ data: statsData, refresh }: StatsSource"
+          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${props.data.dataplane.networking.address}`"
         >
-          <ErrorBlock
-            v-if="error"
-            :error="error"
-          />
-
-          <LoadingBlock v-else-if="statsData === undefined" />
-
           <CodeBlock
-            v-else
             language="json"
-            :code="statsData.raw"
+            :code="statsData!.raw"
             is-searchable
             :query="route.params.codeSearch"
             :is-filter-mode="route.params.codeFilter"
@@ -53,7 +45,7 @@
               </KButton>
             </template>
           </CodeBlock>
-        </DataSource>
+        </DataLoader>
       </KCard>
     </AppView>
   </RouteView>
@@ -65,8 +57,6 @@ import { RefreshIcon } from '@kong/icons'
 
 import type { DataplaneOverview } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import type { StatsSource } from '@/app/connections/sources'
 
 const props = defineProps<{


### PR DESCRIPTION
Moves stats/clusters  to use `DataLoader` and `DataCollection`. DataCollection has an "auto empty state", so if no matching lines are found, then instead of getting an empty code editor we can an empty state instead.

I also changed the URI for the DataLoaders to use the `.../stats/ip-address` here so things synced up correctly. This also meant that I had to re-nest some `template`s in `DataPlaneDetailView`. Therefore it looks like there is loads of change in that file when actually its pretty much just a re-nest, there is one tweak in that file but I'll inline comment to point that out.


Closes https://github.com/kumahq/kuma-gui/issues/2303