### PR TITLE
chore: adds vite plugin for serving mocks locally

### DIFF
--- a/src/test-support/vite.ts
+++ b/src/test-support/vite.ts
@@ -1,0 +1,116 @@
+import { URLPattern } from 'urlpattern-polyfill'
+
+import { dependencies } from './fake'
+import type { FS } from './fake'
+import type { Plugin } from 'vite'
+
+class Router<T> {
+  routes: Map<URLPattern, T> = new Map()
+  constructor(routes: Record<string, T>) {
+    Object.entries(routes).forEach(([key, value]) => {
+      if (key.includes('://')) {
+        return
+      }
+      this.routes.set(new URLPattern({
+        pathname: key.replace('+', '\\+'),
+      }), value)
+    })
+  }
+
+  match(path: string) {
+    for (const [pattern, route] of this.routes) {
+      const _url = `data:${path}`
+      if (pattern.test(_url)) {
+        const args = pattern.exec(_url)
+        const params = args?.pathname.groups || {}
+        return {
+          route,
+          params: Object.entries(params).reduce((prev: Record<string, string>, [key, value]) => {
+            prev[key] = value || ''
+            return prev
+          }, {}),
+        }
+      }
+    }
+    throw new Error(`Matching route for '${path}' not found`)
+  }
+}
+const strToEnv = (str: string): [string, string][] => {
+  return str.split(';')
+    .map((item) => item.trim())
+    .filter((item) => item !== '')
+    .map((item) => {
+      const [key, ...value] = item.split('=')
+      return [key, value.join('=')] as [string, string]
+    })
+}
+
+type PluginOptions = {
+  fs: FS
+  env?: <T extends string>(key: T, d?: string) => string
+}
+type FetchOptions = {
+  method?: string
+  body?: Record<string, string>
+  headers?: Record<string, string | string[] | undefined>
+}
+
+export default (opts: PluginOptions): Plugin => {
+  const router = new Router(opts.fs)
+  const fetch = async (url: string, options: FetchOptions) => {
+    const cookies = strToEnv(String(options.headers?.cookie ?? '')).reduce((prev, [key, value]) => {
+      prev[key] = value
+      return prev
+    }, {} as Record<string, string>)
+
+    const _url = new URL(url)
+    const { route, params } = router.match(_url.pathname)
+
+    const cookiedEnv = <T extends Parameters<typeof dependencies['env']>[0]>(key: T, d = '') => dependencies.env(key, cookies[key] ?? d)
+
+    const request = route({
+      ...dependencies,
+      env: cookiedEnv,
+    })
+    const response = request({
+      url: _url,
+      method: options.method ?? 'GET',
+      body: options.body ?? {},
+      params,
+    })
+    await new Promise(resolve => setTimeout(resolve, parseInt(cookiedEnv('KUMA_LATENCY', '0'))))
+    return {
+      json: async () => {
+        return response.body
+      },
+      text: async () => {
+        return response.body.toString()
+      },
+      headers: new Map(Object.entries(response.headers)),
+    }
+  }
+
+  return {
+    name: 'fake-api',
+    configureServer: async (server) => {
+      server.middlewares.use(async (req, res, next) => {
+        try {
+          const response = await fetch(`http://${server.config.server.host}:${server.config.server.port}${req.url ?? ''}`, {
+            method: req.method,
+            headers: req.headers,
+          })
+          const type = response.headers.get('Content-Type') ?? 'application/json'
+          res.setHeader('Content-Type', type)
+          res.setHeader('Status-Code', response.headers.get('Status-Code') ?? '200')
+          res.end(type.endsWith('/json') ? JSON.stringify((await response.json()), null, 4) : (await response.text()))
+        } catch (e) {
+          if (e instanceof Error && e.message.endsWith('not found')) {
+            next()
+          } else {
+            throw e
+          }
+        }
+      })
+    },
+  }
+}

--- a/vite.config.production.ts
+++ b/vite.config.production.ts
@@ -3,11 +3,13 @@ import vue from '@vitejs/plugin-vue'
 import { DEFAULT_SCHEMA, Type } from 'js-yaml'
 import { marked } from 'marked'
 import { fileURLToPath, URL } from 'url'
-import { defineConfig, type UserConfigFn } from 'vite'
+import { defineConfig } from 'vite'
 import svgLoader from 'vite-svg-loader'
 
 import { hoistUseStatements } from './dev-utilities/hoistUseStatements'
-
+import { fs } from './src/test-support/mocks/fs'
+import fakeApi from './src/test-support/vite'
+import type { UserConfigFn } from 'vite'
 // https://vitejs.dev/config/
 
 export const config: UserConfigFn = () => {
@@ -26,6 +28,9 @@ export const config: UserConfigFn = () => {
             whitespace: 'preserve',
           },
         },
+      }),
+      fakeApi({
+        fs,
       }),
       svgLoader(),
       yamlLoader(


### PR DESCRIPTION
Part of https://github.com/kumahq/kuma-gui/issues/2001

I've been tweaking some rather complicated cross-file synced mocks. Usually, because we use MSW, in order to see the result of any changes you have to find a page that uses your mock, refresh you browser window, open the Web Inspector and then search through the many HTTP requests for the mock you are changing. The last step you have to do again and again and again for every change, which gets a bit tedious.

This PR serves up the mocks via `vite`, this means you can go directly to the URL of the mock you are editing and just refresh the browser to see your changes as you usually would.

---

Notes:

To try this out you need to set `KUMA_API_URL=http://localhost:8080`. `8080` being the port that vite is using, and also set `KUMA_MOCK_API_ENABLED=false` to turn off MSW.

We currently just import our kuma `fs` for the mocks (`vite` doesn't like the `msw/browser` import we have in the dev container - probable pt2 to this PR is here https://github.com/johncowen/kuma-gui/pull/8) , so this won't yet work downstream, hence it is not yet the default way to serve our mocks. But eventually you should be able to completely run and build against this in `kuma` i.e. goodbye MSW locally.

Even when this is the default way to serve mocks locally, we will still use MSW for PR previews. 

Here's a little matrix of what will be serving our mocks depending on what environment is 'active' once this work is complete:

- local dev: vite (or kuma itself)
- prod: kuma
- unit tests: vitest
- PR previews: MSW (or kuma itself)
- e2e tests: Cypress

---

Ah lastly, I've grabbed copy/pasta'ed a bit of code here. I've done this purposefully (instead of import it from a central place) because I want to bring all the related code here together and tighten it a little more before I centralize it.
