### PR TITLE
fix(tests): unflake built-in gateway policy test

### DIFF
--- a/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/features/mesh/dataplanes/DataplanePolicies.feature
@@ -399,6 +399,13 @@ Feature: Dataplane policies
         """
         KUMA_MODE: zone
         """
+      Given the environment
+        """
+        KUMA_DATAPLANE_PROXY_RULE_ENABLED: true
+        KUMA_DATAPLANE_RULE_COUNT: 1
+        KUMA_DATAPLANE_TO_RULE_COUNT: 1
+        KUMA_DATAPLANE_FROM_RULE_COUNT: 1
+        """
       And the URL "/meshes/default/dataplanes/dataplane-gateway_builtin-1/_overview" responds with
         """
         body:
@@ -409,24 +416,6 @@ Feature: Dataplane policies
                 type: BUILTIN
                 tags:
                   kuma.io/service: service-1
-        """
-      And the URL "/meshes/default/dataplanes/dataplane-gateway_builtin-1/policies" responds with
-        """
-        body:
-          listeners:
-            - hosts:
-                - routes:
-                  - destinations:
-                      - tags:
-                          kuma.io/service: demo-app_kuma-demo_svc_5000
-                        policies:
-                          CircuitBreaker:
-                            name: circuit-breaker-1
-          policies:
-            TrafficLog:
-              name: traffic-log-1
-            TrafficTrace:
-              name: traffic-trace-1
         """
 
       When I visit the "/meshes/default/data-planes/dataplane-gateway_builtin-1/policies" URL


### PR DESCRIPTION
I've spotted a couple of new flakes lately, this test one of them.

The mock here mocked out a HTTP endpoint that didn't seem to be being called at all. So I've removed that and added some `_COUNT` env vars that should always give us the data we are looking for the test.

This seems to stabilise this test, but there are still a couple of others that have popped up. Hopefully I get figure those out after this one which seems to be the most flakey.

I also applied this here https://github.com/kumahq/kuma-gui/pull/2316 after this test flaking multiple times there, and its seems to have fixed the flake.