### PR TITLE
chore: moves UTM query params to i18n

### DIFF
--- a/src/app/application/services/i18n/I18n.ts
+++ b/src/app/application/services/i18n/I18n.ts
@@ -32,7 +32,7 @@ export default <T extends I18nRecord>(strs: T, env: Env['var']) => {
   const globals = {
     KUMA_VERSION: env('KUMA_VERSION'),
     KUMA_DOCS_URL: env('KUMA_DOCS_URL'),
-    KUMA_UTM_QUERY_PARAMS: env('KUMA_UTM_QUERY_PARAMS'),
+    KUMA_UTM_QUERY_PARAMS: i18n.t('common.product.utm_query_params' as Parameters<typeof i18n['t']>[0]),
     KUMA_PRODUCT_NAME: i18n.t('common.product.name' as Parameters<typeof i18n['t']>[0]),
   }
   return {

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -10,9 +10,10 @@ common:
       }
   product:
     name: Kuma
+    utm_query_params: utm_source=Kuma&utm_medium=Kuma
     href:
       docs:
-        index: '{KUMA_DOCS_URL}/'
+        index: '{KUMA_DOCS_URL}/?{KUMA_UTM_QUERY_PARAMS}'
       feedback: 'https://github.com/kumahq/kuma/issues/new/choose'
       install: 'https://kuma.io/install/latest/?{KUMA_UTM_QUERY_PARAMS}'
     environment:

--- a/src/services/env/Env.ts
+++ b/src/services/env/Env.ts
@@ -22,7 +22,6 @@ type EnvProps = {
   KUMA_BASE_PATH: string
   KUMA_API_URL: string
   KUMA_KDS_URL: string
-  KUMA_UTM_QUERY_PARAMS: string
   KUMA_MODE: string
   KUMA_ENVIRONMENT: string
   KUMA_STORE_TYPE: string
@@ -33,18 +32,13 @@ type EnvInternal = EnvArgs & Partial<EnvProps>
 export default class Env {
   protected env: EnvVars | undefined
   constructor(envArgs: EnvArgs) {
-    let _env: EnvInternal = envArgs
+    const _env: EnvInternal = envArgs
     const env = (str: keyof EnvInternal, d: string = '') => this.var(str, _env?.[str] ?? d)
 
     const config = this.getConfig()
     const mode = env('KUMA_MODE') || config.mode
     const version = semver(env('KUMA_VERSION', config.version))
 
-    const productName = encodeURIComponent(env('KUMA_PRODUCT_NAME'))
-    _env = {
-      ..._env,
-      KUMA_UTM_QUERY_PARAMS: `utm_source=${productName}&utm_medium=${productName}`,
-    }
     this.env = {
       ..._env as EnvVars,
       // TODO(jc): not totally sure we need to use a regex here, maybe just split and join if not


### PR DESCRIPTION
Quite a while back we started using an i18n lib/util for all our strings instead of env vars. We never really finished moving everything seeing as there was no real need/urgency to.

At some point I want to refactor our env util (behind the `env('URI')` interface) and make it easier to work with, so the more I can clean up things that should no longer be in `env` first the better.