### PR TITLE
fix(services): fixes internal service navigation test

### DIFF
--- a/features/mesh/services/Index.feature
+++ b/features/mesh/services/Index.feature
@@ -16,6 +16,7 @@ Feature: mesh / services / index
       body:
         items:
           - name: service-1
+            serviceType: internal
       """
     When I visit the "/meshes/default/services/internal" URL
 

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -84,6 +84,7 @@
 
       <template v-else>
         <slot
+          v-if="(props.items ?? []).length > 0"
           :name="key"
           :row="row as Row"
           :row-value="rowValue"


### PR DESCRIPTION
Fixes (🤞 ) flakey service insight by mocking the serviceType to be `internal`

---

I found that the above change still produced the flake, then I also remembered that we also have a very similar flake in `policies / index` which made me look for commonalities that might cause both tests to occasionally flake, which points to KTable.

After looking at KTable's source I've tried adding an additional guard in our own `AppCollection` which should avoid any potentially incorrect and/or racey behaviour in KTable. There might not be any, but we won't know if this fixes both flakes or not for a little while I suppose. Thought it was worth a try.

This is green right now, so I would say we merge and let it sit for a while and report if we see either of these flakes types of flakes:

![Screenshot 2024-03-15 at 14 49 33](https://github.com/kumahq/kuma-gui/assets/554604/1320a642-2b6c-46ed-a666-25622c00eae0)

![Screenshot 2024-03-19 at 09 55 20](https://github.com/kumahq/kuma-gui/assets/554604/8e7ac2ee-b7c5-45a1-9ada-3d9593e89d4d)



