### PR TITLE
refactor: update Kongponents to KBreadcrumbs milestone

### DIFF
--- a/features/mesh/Index.feature
+++ b/features/mesh/Index.feature
@@ -32,7 +32,7 @@ Feature: mesh / index
     Then I click the "$navigation li:nth-child(4) a" element
     Then I click the "$navigation li:nth-child(1) a" element
 
-    And I click the "$breadcrumbs > .k-breadcrumbs-item:nth-child(1) > a" element
+    And I click the "$breadcrumbs > .breadcrumbs-item-container:nth-child(1) > a" element
     Then the "$item" element exists 2 times
 
     Examples:

--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -48,7 +48,7 @@ Feature: mesh / policies / index
     Then the URL contains "circuit-breakers/fake-cb-1/overview"
     And the "$detail-view" element contains "fake-cb-1"
 
-    When I click the "$breadcrumbs > .k-breadcrumbs-item:nth-child(3) > a" element
+    When I click the "$breadcrumbs > .breadcrumbs-item-container:nth-child(3) > a" element
 
     Then the "$item" element exists 2 times
 

--- a/features/mesh/services/Index.feature
+++ b/features/mesh/services/Index.feature
@@ -47,5 +47,5 @@ Feature: mesh / services / index
     Then the URL contains "/services/internal/service-1/overview"
     Then the "#service-detail-view-tab a" element exists
 
-    When I click the "$breadcrumbs > .k-breadcrumbs-item:nth-child(3) > a" element
+    When I click the "$breadcrumbs > .breadcrumbs-item-container:nth-child(3) > a" element
     Then the "$item" element exists 1 times

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@kong-ui-public/i18n": "2.1.4",
     "@kong/icons": "1.8.14",
-    "@kong/kongponents": "9.0.0-alpha.113",
+    "@kong/kongponents": "9.0.0-alpha.123",
     "@vueuse/core": "10.9.0",
     "brandi": "5.0.0",
     "deepmerge": "4.3.1",

--- a/src/app/application/components/app-view/AppView.vue
+++ b/src/app/application/components/app-view/AppView.vue
@@ -7,7 +7,10 @@
       v-if="!hasParent && _breadcrumbs.length > 0"
       aria-label="Breadcrumb"
     >
-      <KBreadcrumbs :items="_breadcrumbs" />
+      <KBreadcrumbs
+        :items="_breadcrumbs"
+        :item-max-width="'150px'"
+      />
     </nav>
 
     <section

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,15 +1878,15 @@
   resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.8.14.tgz#3219563df669b8bb3e260df12ac211a5072938e6"
   integrity sha512-nJUTtLpqelKCTY8lS8VByWaHYUq1CuB5cBUX/q2FEDu5o6IKH/B7fEDQpb/pB1lLRYTqZXneHR/lGYjxy4u8eQ==
 
-"@kong/kongponents@9.0.0-alpha.113":
-  version "9.0.0-alpha.113"
-  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.113.tgz#15322b11b39a56d20421cc34edc4bcb057bb4ddb"
-  integrity sha512-MDs6dsdTG26tWiS5795R1a7y94SoATEtlynx6PqSfWrum0NgCxcqnpIq7lHhdquGnMCYVocw/3hOe3gDG4LOJw==
+"@kong/kongponents@9.0.0-alpha.123":
+  version "9.0.0-alpha.123"
+  resolved "https://registry.yarnpkg.com/@kong/kongponents/-/kongponents-9.0.0-alpha.123.tgz#f0d46f0c501476ba1279f70ae2906f86be4020cf"
+  integrity sha512-YmdZHksjRdQU238/kjHGUuwskhDSAt0ULSOW7aOZhLTsYksd36f4+z5JS58cGtcw1C+4nc5QBnqALDuDpEbr6A==
   dependencies:
     "@kong/icons" "^1.8.14"
     "@popperjs/core" "^2.11.8"
     date-fns "^2.30.0"
-    date-fns-tz "^2.0.0"
+    date-fns-tz "^2.0.1"
     focus-trap "^7.5.4"
     focus-trap-vue "^4.0.3"
     popper.js "^1.16.1"
@@ -3676,6 +3676,11 @@ date-fns-tz@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
   integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
+
+date-fns-tz@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.1.tgz#0a9b2099031c0d74120b45de9fd23192e48ea495"
+  integrity sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==
 
 date-fns@^2.16.1, date-fns@^2.30.0:
   version "2.30.0"


### PR DESCRIPTION
**chore(KBreadcrumbs): address breaking changes**

Replace `.k-breadcrumbs-item` with `.breadcrumbs-item-container`.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

---

Previous Kongponents v9 adoption PRs:

- https://github.com/kumahq/kuma-gui/pull/1532
- https://github.com/kumahq/kuma-gui/pull/1853
- https://github.com/kumahq/kuma-gui/pull/1878
- https://github.com/kumahq/kuma-gui/pull/1961
- https://github.com/kumahq/kuma-gui/pull/2118
- https://github.com/kumahq/kuma-gui/pull/2156
- https://github.com/kumahq/kuma-gui/pull/2184
- https://github.com/kumahq/kuma-gui/pull/2270