### PR TITLE
chore: hoist mesh data loading to avoid showing tabs on 404

### DIFF
--- a/src/app/meshes/views/MeshDetailTabsView.vue
+++ b/src/app/meshes/views/MeshDetailTabsView.vue
@@ -17,30 +17,43 @@
         </h1>
       </template>
 
-      <NavTabs
-        :active-route-name="route.active?.name"
-        data-testid="mesh-tabs"
+      <DataLoader
+        v-slot="{ data: mesh }: MeshSource"
+        :src="`/meshes/${route.params.mesh}`"
       >
-        <template
-          v-for="{ name } in route.children.filter(({ name }) => name !== 'external-service-list-view')"
-          :key="name"
-          #[`${name}`]
+        <NavTabs
+          :active-route-name="route.active?.name"
+          data-testid="mesh-tabs"
         >
-          <RouterLink
-            :to="{ name }"
-            :data-testid="`${name}-tab`"
+          <template
+            v-for="{ name } in route.children.filter(({ name }) => name !== 'external-service-list-view')"
+            :key="name"
+            #[`${name}`]
           >
-            {{ t(`meshes.routes.item.navigation.${name}`) }}
-          </RouterLink>
-        </template>
-      </NavTabs>
+            <RouterLink
+              :to="{ name }"
+              :data-testid="`${name}-tab`"
+            >
+              {{ t(`meshes.routes.item.navigation.${name}`) }}
+            </RouterLink>
+          </template>
+        </NavTabs>
 
-      <RouterView />
+        <RouterView
+          v-slot="{ Component }"
+        >
+          <component
+            :is="Component"
+            :mesh="mesh"
+          />
+        </RouterView>
+      </DataLoader>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
+import type { MeshSource } from '../sources'
 import NavTabs from '@/app/common/NavTabs.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 </script>

--- a/src/app/meshes/views/MeshDetailView.vue
+++ b/src/app/meshes/views/MeshDetailView.vue
@@ -12,69 +12,58 @@
     />
 
     <AppView>
-      <DataSource
-        v-slot="{ data: mesh, error: meshError }: MeshSource"
-        :src="`/meshes/${route.params.mesh}`"
+      <div
+        class="stack"
+        data-testid="detail-view-details"
       >
         <DataSource
           v-slot="{ data: meshInsight }: MeshInsightSource"
           :src="`/mesh-insights/${route.params.mesh}`"
         >
-          <ErrorBlock
-            v-if="meshError"
-            :error="meshError"
+          <MeshDetails
+            :mesh="props.mesh"
+            :mesh-insight="meshInsight"
           />
-
-          <LoadingBlock v-else-if="mesh === undefined" />
-
-          <div
-            v-else
-            class="stack"
-            data-testid="detail-view-details"
-          >
-            <MeshDetails
-              :mesh="mesh"
-              :mesh-insight="meshInsight"
-            />
-
-            <ResourceCodeBlock
-              v-slot="{ copy, copying }"
-              :resource="mesh.config"
-            >
-              <DataSource
-                v-if="copying"
-                :src="`/meshes/${route.params.mesh}/as/kubernetes?no-store`"
-                @change="(data) => {
-                  copy((resolve) => resolve(data))
-                }"
-                @error="(e) => {
-                  copy((_resolve, reject) => reject(e))
-                }"
-              />
-            </ResourceCodeBlock>
-
-            <div class="date-status-wrapper">
-              <ResourceDateStatus
-                :creation-time="mesh.creationTime"
-                :modification-time="mesh.modificationTime"
-              />
-            </div>
-          </div>
         </DataSource>
-      </DataSource>
+        <ResourceCodeBlock
+          v-slot="{ copy, copying }"
+          :resource="mesh.config"
+        >
+          <DataSource
+            v-if="copying"
+            :src="`/meshes/${route.params.mesh}/as/kubernetes?no-store`"
+            @change="(data) => {
+              copy((resolve) => resolve(data))
+            }"
+            @error="(e) => {
+              copy((_resolve, reject) => reject(e))
+            }"
+          />
+        </ResourceCodeBlock>
+
+        <div class="date-status-wrapper">
+          <ResourceDateStatus
+            :creation-time="mesh.creationTime"
+            :modification-time="mesh.modificationTime"
+          />
+        </div>
+      </div>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import type { MeshSource, MeshInsightSource } from '../sources'
+import type { Mesh } from '../data'
+import type { MeshInsightSource } from '../sources'
 import ResourceCodeBlock from '@/app/common/code-block/ResourceCodeBlock.vue'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import ResourceDateStatus from '@/app/common/ResourceDateStatus.vue'
 import { useMeshDetails } from '@/components'
 
 const MeshDetails = useMeshDetails()
+const props = defineProps<{
+  mesh: Mesh
+}>()
+
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
I've been working on several pieces of work that cross into our Empty and Error states and I noticed that we shouldn't really be showing the clickable tabs for a mesh if we can't load the mesh in the first place, for example in the case of a 404. So, this PR moves the data loading of mesh to the same route as the tabs (and switches to use a DataLoader). MeshInsights are no longer loaded if you land on any other tab apart from `[Overview]`.

I've been considering moving all our top-level dataloading into this level of route anyway, so this was the final reason why I thought it was a good reason to do it, and I'll probably do similar in other areas following this.