### PR TITLE
chore(dataplanes): use kuma.io/display-name if it exists

### DIFF
--- a/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
@@ -1,4 +1,4 @@
-Feature: Dataplane traffic
+Feature: mesh / dataplanes / DataplaneDetailsTraffic
   Background:
     Given the CSS selectors
       | Alias           | Selector                                            |
@@ -77,33 +77,3 @@ Feature: Dataplane traffic
     When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/overview" URL
     And the "$traffic" element exists
     And the "$loading-warning" element exists
-
-  Scenario: Builtin gateway proxy doesn't show the traffic component
-    Given the URL "/meshes/default/dataplanes/dpp-1-name-of-gateway_builtin/_overview" responds with
-      """
-      body:
-        dataplane:
-          networking:
-            gateway:
-              type: BUILTIN
-      """
-
-    When I visit the "/meshes/default/data-planes/dpp-1-name-of-gateway_builtin/overview" URL
-
-    And the "$detail-view" element contains "dpp-1-name-of-gateway_builtin"
-    And the "$traffic" element doesn't exist
-
-  Scenario: Delegated gateway proxy doesn't show the traffic component
-    Given the URL "/meshes/default/dataplanes/dpp-1-name-of-gateway_delegated/_overview" responds with
-      """
-      body:
-        dataplane:
-          networking:
-            gateway:
-              type: DELEGATED
-      """
-
-    When I visit the "/meshes/default/data-planes/dpp-1-name-of-gateway_delegated/overview" URL
-
-    And the "$detail-view" element contains "dpp-1-name-of-gateway_delegated"
-    And the "$traffic" element doesn't exist

--- a/features/mesh/dataplanes/NoSubscriptions.feature
+++ b/features/mesh/dataplanes/NoSubscriptions.feature
@@ -9,11 +9,9 @@ Feature: dataplanes / no-subscriptions
       KUMA_SUBSCRIPTION_COUNT: 0
       KUMA_DATAPLANEINBOUND_COUNT: 1
       """
-    And the URL "/meshes/default/dataplanes/dpp-1/_overview" responds with
+    And the URL "/meshes/default/dataplanes/backend/_overview" responds with
       """
       body:
-        name: fake-backend
-        mesh: fake-default
         dataplane:
           networking:
             inbound:
@@ -21,6 +19,6 @@ Feature: dataplanes / no-subscriptions
                   ready: true
       """
 
-    When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
-    And the "$detail-view" element contains "dpp-1"
+    When I visit the "/meshes/default/data-planes/backend/overview" URL
+    And the "$detail-view" element contains "backend"
     And the "$overview-content" element contains "offline"

--- a/features/mesh/dataplanes/Warnings.feature
+++ b/features/mesh/dataplanes/Warnings.feature
@@ -14,6 +14,7 @@ Feature: mesh / dataplanes / warnings
         dataplaneInsight:
           mTLS:
             certificateExpirationTime: 2022-10-03T12:40:13Z
+            lastCertificateRegeneration: 2021-10-03T12:40:13Z
       """
     When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$expired-cert-warning" element exists
@@ -25,6 +26,7 @@ Feature: mesh / dataplanes / warnings
         dataplaneInsight:
           mTLS:
             certificateExpirationTime: 3022-10-03T12:40:13Z
+            lastCertificateRegeneration: 3021-10-03T12:40:13Z
       """
     When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$expired-cert-warning" element doesn't exist

--- a/features/mesh/dataplanes/overview/Connections.feature
+++ b/features/mesh/dataplanes/overview/Connections.feature
@@ -1,4 +1,4 @@
-Feature: Dataplane traffic
+Feature: mesh / dataplanes / connections / Connections
   Background:
     Given the CSS selectors
       | Alias       | Selector                                    |
@@ -15,7 +15,7 @@ Feature: Dataplane traffic
   Scenario: Builtin gateway with inbound and outbound stats
     When I visit the "/meshes/default/data-planes/default-gateway-instance-1-86cbb55644-6rxhg.kuma-demo/overview" URL
 
-    And the "$detail-view" element contains "default-gateway-instance-1-86cbb55644-6rxhg.kuma-demo"
+    And the "$detail-view" element contains "default-gateway-instance-1-86cbb55644-6rxhg"
     And the "$inbound" element exists 4 times
     And the "$outbound" element exists 3 times
 
@@ -43,7 +43,7 @@ Feature: Dataplane traffic
   Scenario: Delegated gateway with inbound and outbound stats
     When I visit the "/meshes/default/data-planes/kong-gateway-5bcc776cb4-578gc.kong/overview" URL
 
-    And the "$detail-view" element contains "kong-gateway-5bcc776cb4-578gc.kong"
+    And the "$detail-view" element contains "kong-gateway-5bcc776cb4-578gc"
     And the "$inbound" element exists 0 times
     And the "$outbound" element exists 1 times
 
@@ -54,7 +54,7 @@ Feature: Dataplane traffic
   Scenario: HTTP sidecar with inbound and outbound stats
     When I visit the "/meshes/default/data-planes/demo-app-fcc8bc4cb-5xjwd.kuma-demo/overview" URL
 
-    And the "$detail-view" element contains "demo-app-fcc8bc4cb-5xjwd.kuma-demo"
+    And the "$detail-view" element contains "demo-app-fcc8bc4cb-5xjwd"
     And the "$inbound" element exists 1 time
     And the "$outbound" element exists 1 time
 
@@ -70,7 +70,7 @@ Feature: Dataplane traffic
   Scenario: gRPC sidecar with inbound and outbound stats
     When I visit the "/meshes/default/data-planes/grpc-service-75b4ccdfd5-z2jmp.kuma-demo/overview" URL
 
-    And the "$detail-view" element contains "grpc-service-75b4ccdfd5-z2jmp.kuma-demo"
+    And the "$detail-view" element contains "grpc-service-75b4ccdfd5-z2jmp"
     And the "$inbound" element exists 1 time
     And the "$outbound" element exists 0 times
 
@@ -80,7 +80,7 @@ Feature: Dataplane traffic
   Scenario: TCP sidecar with inbound and outbound stats
     When I visit the "/meshes/default/data-planes/redis-54754f5b57-xl2tw.kuma-demo/overview" URL
 
-    And the "$detail-view" element contains "redis-54754f5b57-xl2tw.kuma-demo"
+    And the "$detail-view" element contains "redis-54754f5b57-xl2tw"
     And the "$inbound" element exists 1 time
     And the "$outbound" element exists 0 times
 

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -198,6 +198,9 @@ watch(() => props.pageNumber, function () {
     kTableMountKey.value++
   }
 })
+watch(() => props.headers, function () {
+  kTableMountKey.value++
+})
 
 function getRowAttributes(row: Row): Record<string, string> {
   if (!row) {

--- a/src/app/data-planes/data/index.spec.ts
+++ b/src/app/data-planes/data/index.spec.ts
@@ -15,6 +15,7 @@ describe('Dataplane', () => {
       },
     }),
   ))
+
   describe('dataplane.config', () => {
     test(
       'config is the same as the original API object',
@@ -77,6 +78,43 @@ describe('DataplaneOverview', () => {
       },
     }),
   ))
+  describe('labels', () => {
+    test(
+      "if labels isn't set we default it to {}",
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          if (typeof item.labels !== 'undefined') {
+            delete item.labels
+          }
+          return item
+        }, {
+          env: {
+          },
+        })
+        expect(actual.labels).toBeDefined()
+        expect(Object.keys(actual.labels).length === 0).toBeDefined()
+      },
+    )
+    test(
+      'display-name and namespace reshaping',
+      async ({ fixture }) => {
+        const actual = await fixture.setup((item) => {
+          item.name = 'old-name.namespace'
+          item.labels = {
+            'kuma.io/display-name': 'new-name',
+            'k8s.kuma.io/namespace': 'namespace',
+          }
+          return item
+        }, {
+          env: {
+          },
+        })
+        expect(actual.name).toStrictEqual('new-name')
+        expect(actual.namespace).toStrictEqual('namespace')
+      },
+    )
+  })
+
   describe('dataplaneInsight.subscriptions', () => {
     test(
       'absent dataplaneInsight remains defined',

--- a/src/app/data-planes/locales/en-us/index.yaml
+++ b/src/app/data-planes/locales/en-us/index.yaml
@@ -40,6 +40,7 @@ data-planes:
       inbound_name: '{service}'
       port: ':{port}'
       last_updated: 'Last updated'
+      namespace: 'Namespace'
       certificate_info: 'Certificate info'
       no_certificate: 'No certificate'
       health:

--- a/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -7,79 +7,71 @@
       dataPlane: '',
     }"
   >
-    <AppView
-      :breadcrumbs="[
-        {
-          to: {
-            name: 'mesh-detail-view',
-            params: {
-              mesh: route.params.mesh,
-            },
-          },
-          text: route.params.mesh,
-        },
-        {
-          to: {
-            name: 'data-plane-list-view',
-            params: {
-              mesh: route.params.mesh,
-            },
-          },
-          text: t('data-planes.routes.item.breadcrumbs'),
-        },
-      ]"
+    <DataLoader
+      v-slot="{ data }: DataplaneOverviewSource"
+      :src="`/meshes/${route.params.mesh}/dataplane-overviews/${route.params.dataPlane}`"
     >
-      <template #title>
-        <h1>
-          <TextWithCopyButton :text="route.params.dataPlane">
-            <RouteTitle :title="t('data-planes.routes.item.title', { name: route.params.dataPlane })" />
-          </TextWithCopyButton>
-        </h1>
-      </template>
-
-      <DataSource
-        v-slot="{ data, error }: DataplaneOverviewSource"
-        :src="`/meshes/${route.params.mesh}/dataplane-overviews/${route.params.dataPlane}`"
+      <AppView
+        v-if="data"
+        :breadcrumbs="[
+          {
+            to: {
+              name: 'mesh-detail-view',
+              params: {
+                mesh: route.params.mesh,
+              },
+            },
+            text: route.params.mesh,
+          },
+          {
+            to: {
+              name: 'data-plane-list-view',
+              params: {
+                mesh: route.params.mesh,
+              },
+            },
+            text: t('data-planes.routes.item.breadcrumbs'),
+          },
+        ]"
       >
-        <ErrorBlock
-          v-if="error"
-          :error="error"
-        />
-
-        <LoadingBlock v-else-if="data === undefined" />
-
-        <template v-else>
-          <NavTabs :active-route-name="route.active?.name">
-            <template
-              v-for="{ name } in route.children"
-              :key="name"
-              #[`${name}`]
-            >
-              <RouterLink
-                :to="{ name }"
-                :data-testid="`${name}-tab`"
-              >
-                {{ t(`data-planes.routes.item.navigation.${name}`) }}
-              </RouterLink>
-            </template>
-          </NavTabs>
-
-          <RouterView v-slot="child">
-            <component
-              :is="child.Component"
-              :data="data"
-            />
-          </RouterView>
+        <template #title>
+          <h1>
+            <TextWithCopyButton :text="data.name">
+              <RouteTitle
+                :title="t('data-planes.routes.item.title', { name: data.name })"
+              />
+            </TextWithCopyButton>
+          </h1>
         </template>
-      </DataSource>
-    </AppView>
+
+        <NavTabs :active-route-name="route.active?.name">
+          <template
+            v-for="{ name } in route.children"
+            :key="name"
+            #[`${name}`]
+          >
+            <RouterLink
+              :to="{ name }"
+              :data-testid="`${name}-tab`"
+            >
+              {{ t(`data-planes.routes.item.navigation.${name}`) }}
+            </RouterLink>
+          </template>
+        </NavTabs>
+
+        <RouterView v-slot="child">
+          <component
+            :is="child.Component"
+            :data="data"
+          />
+        </RouterView>
+      </AppView>
+    </DataLoader>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
 import { DataplaneOverviewSource } from '../sources'
-import ErrorBlock from '@/app/common/ErrorBlock.vue'
-import LoadingBlock from '@/app/common/LoadingBlock.vue'
 import NavTabs from '@/app/common/NavTabs.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 </script>

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -89,6 +89,18 @@
                 </template>
               </DefinitionCard>
 
+              <DefinitionCard
+                v-if="props.data.namespace.length > 0"
+              >
+                <template #title>
+                  Namespace
+                </template>
+
+                <template #body>
+                  {{ props.data.namespace }}
+                </template>
+              </DefinitionCard>
+
               <DefinitionCard>
                 <template #title>
                   {{ t('data-planes.routes.item.last_updated') }}

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -44,6 +44,7 @@
               :page-size="route.params.size"
               :headers="[
                 { label: 'Name', key: 'name' },
+                ...((data?.items[0].namespace ?? '').length > 0 ? [{ label: 'Namespace', key: 'namespace' }] : []),
                 { label: 'Type', key: 'type' },
                 { label: 'Services', key: 'services' },
                 ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
@@ -116,6 +117,10 @@
                 >
                   {{ item.name }}
                 </RouterLink>
+              </template>
+
+              <template #namespace="{ row: item }">
+                {{ item.namespace }}
               </template>
 
               <template #type="{ row }">

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -96,15 +96,15 @@
                 </KSelect>
               </template>
 
-              <template #name="{ row }">
+              <template #name="{ row: item }">
                 <RouterLink
                   class="name-link"
-                  :title="row.name"
+                  :title="item.name"
                   :to="{
                     name: 'data-plane-summary-view',
                     params: {
-                      mesh: row.mesh,
-                      dataPlane: row.name,
+                      mesh: item.mesh,
+                      dataPlane: item.id,
                     },
                     query: {
                       page: route.params.page,
@@ -114,7 +114,7 @@
                     },
                   }"
                 >
-                  {{ row.name }}
+                  {{ item.name }}
                 </RouterLink>
               </template>
 
@@ -264,8 +264,8 @@
               >
                 <component
                   :is="child.Component"
-                  :name="route.params.dataPlane"
-                  :dataplane-overview="data?.items.find((item) => item.name === route.params.dataPlane)"
+                  v-if="typeof data !== 'undefined'"
+                  :items="data.items"
                 />
               </SummaryView>
             </RouterView>

--- a/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -1,240 +1,269 @@
 <template>
   <RouteView
-    v-slot="{ t }"
+    v-slot="{ t, route }"
     name="data-plane-summary-view"
+    :params="{
+      dataPlane: '',
+    }"
   >
-    <AppView>
-      <template #title>
-        <h2>
-          <RouterLink
-            :to="{
-              name: 'data-plane-detail-view',
-              params: {
-                dataPlane: props.name,
-              },
-            }"
-          >
-            <RouteTitle
-              :title="t('data-planes.routes.item.title', { name: props.name })"
-            />
-          </RouterLink>
-        </h2>
+    <DataCollection
+      :items="props.items"
+      :predicate="item => item.id === route.params.dataPlane"
+      :find="true"
+    >
+      <template #empty>
+        <EmptyBlock>
+          <template #title>
+            {{ t('common.collection.summary.empty_title', { type: 'Data Plane Proxy' }) }}
+          </template>
+
+          <p>{{ t('common.collection.summary.empty_message', { type: 'Data Plane Proxy' }) }}</p>
+        </EmptyBlock>
       </template>
-
-      <EmptyBlock
-        v-if="props.dataplaneOverview === undefined"
+      <template
+        #default="{ items: proxies }"
       >
-        <template #title>
-          {{ t('common.collection.summary.empty_title', { type: 'Data Plane Proxy' }) }}
-        </template>
-
-        <p>{{ t('common.collection.summary.empty_message', { type: 'Data Plane Proxy' }) }}</p>
-      </EmptyBlock>
-
-      <div
-        v-else
-        class="stack"
-      >
-        <div
-          class="stack-with-borders"
+        <template
+          v-for="item in [proxies[0]]"
+          :key="item.id"
         >
-          <DefinitionCard
-            layout="horizontal"
-          >
+          <AppView>
             <template #title>
-              {{ t('http.api.property.status') }}
-            </template>
-
-            <template #body>
-              <div
-                class="status-with-reason"
-              >
-                <StatusBadge
-                  :status="props.dataplaneOverview.status"
-                />
-                <DataCollection
-                  v-if="props.dataplaneOverview.dataplaneType === 'standard'"
-                  v-slot="{ items : inbounds }"
-                  :items="props.dataplaneOverview.dataplane.networking.inbounds"
-                  :predicate="item => !item.health.ready"
-                  :empty="false"
+              <h2>
+                <RouterLink
+                  :to="{
+                    name: 'data-plane-detail-view',
+                    params: {
+                      dataPlane: item.id,
+                    },
+                  }"
                 >
-                  <KTooltip
-                    class="reason-tooltip"
-                    placement="bottomEnd"
-                  >
-                    <InfoIcon
-                      :color="KUI_COLOR_BACKGROUND_NEUTRAL"
-                      :size="KUI_ICON_SIZE_30"
-                    />
-                    <template #content>
-                      <ul>
-                        <li
-                          v-for="inbound in inbounds"
-                          :key="`${inbound.service}:${inbound.port}`"
-                        >
-                          {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
-                        </li>
-                      </ul>
-                    </template>
-                  </KTooltip>
-                </DataCollection>
-              </div>
-            </template>
-          </DefinitionCard>
-
-          <DefinitionCard
-            layout="horizontal"
-          >
-            <template #title>
-              Type
-            </template>
-
-            <template #body>
-              {{ t(`data-planes.type.${props.dataplaneOverview.dataplaneType}`) }}
-            </template>
-          </DefinitionCard>
-
-          <DefinitionCard
-            layout="horizontal"
-          >
-            <template #title>
-              {{ t('data-planes.routes.item.last_updated') }}
-            </template>
-
-            <template #body>
-              {{ t('common.formats.datetime', { value: Date.parse(props.dataplaneOverview.modificationTime) }) }}
-            </template>
-          </DefinitionCard>
-        </div>
-
-        <div
-          v-if="props.dataplaneOverview.dataplane.networking.gateway"
-        >
-          <h3>{{ t('data-planes.routes.item.gateway') }}</h3>
-
-          <div
-            class="mt-4"
-          >
-            <div
-              class="stack-with-borders"
-            >
-              <DefinitionCard
-                layout="horizontal"
-              >
-                <template #title>
-                  {{ t('http.api.property.tags') }}
-                </template>
-
-                <template #body>
-                  <TagList
-                    alignment="right"
-                    :tags="props.dataplaneOverview.dataplane.networking.gateway.tags"
+                  <RouteTitle
+                    :title="t('data-planes.routes.item.title', { name: item.name })"
                   />
-                </template>
-              </DefinitionCard>
-
-              <DefinitionCard
-                layout="horizontal"
-              >
-                <template #title>
-                  {{ t('http.api.property.address') }}
-                </template>
-
-                <template #body>
-                  <TextWithCopyButton
-                    :text="`${props.dataplaneOverview.dataplane.networking.address}`"
-                  />
-                </template>
-              </DefinitionCard>
-            </div>
-          </div>
-        </div>
-
-        <DataCollection
-          v-if="props.dataplaneOverview.dataplaneType === 'standard'"
-          v-slot="{ items : inbounds }"
-          :items="props.dataplaneOverview.dataplane.networking.inbounds"
-        >
-          <div>
-            <h3>{{ t('data-planes.routes.item.inbounds') }}</h3>
+                </RouterLink>
+              </h2>
+            </template>
 
             <div
-              class="mt-4 stack"
+              class="stack"
             >
               <div
-                v-for="(inbound, index) in inbounds"
-                :key="index"
-                class="inbound"
+                class="stack-with-borders"
               >
-                <h4>
-                  <TextWithCopyButton
-                    :text="inbound.tags['kuma.io/service']"
-                  >
-                    {{ t('data-planes.routes.item.inbound_name', { service: inbound.tags['kuma.io/service'] }) }}
-                  </TextWithCopyButton>
-                </h4>
+                <DefinitionCard
+                  layout="horizontal"
+                >
+                  <template #title>
+                    {{ t('http.api.property.status') }}
+                  </template>
+
+                  <template #body>
+                    <div
+                      class="status-with-reason"
+                    >
+                      <StatusBadge
+                        :status="item.status"
+                      />
+                      <DataCollection
+                        v-if="item.dataplaneType === 'standard'"
+                        v-slot="{ items : inbounds }"
+                        :items="item.dataplane.networking.inbounds"
+                        :predicate="item => !item.health.ready"
+                        :empty="false"
+                      >
+                        <KTooltip
+                          class="reason-tooltip"
+                          placement="bottomEnd"
+                        >
+                          <InfoIcon
+                            :color="KUI_COLOR_BACKGROUND_NEUTRAL"
+                            :size="KUI_ICON_SIZE_30"
+                          />
+                          <template #content>
+                            <ul>
+                              <li
+                                v-for="inbound in inbounds"
+                                :key="`${inbound.service}:${inbound.port}`"
+                              >
+                                {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
+                              </li>
+                            </ul>
+                          </template>
+                        </KTooltip>
+                      </DataCollection>
+                    </div>
+                  </template>
+                </DefinitionCard>
+
+                <DefinitionCard
+                  layout="horizontal"
+                >
+                  <template #title>
+                    Type
+                  </template>
+
+                  <template #body>
+                    {{ t(`data-planes.type.${item.dataplaneType}`) }}
+                  </template>
+                </DefinitionCard>
+
+                <DefinitionCard
+                  v-if="item.namespace.length > 0"
+                  layout="horizontal"
+                >
+                  <template #title>
+                    {{ t('data-planes.routes.item.namespace') }}
+                  </template>
+
+                  <template #body>
+                    {{ item.namespace }}
+                  </template>
+                </DefinitionCard>
+
+                <DefinitionCard
+                  layout="horizontal"
+                >
+                  <template #title>
+                    {{ t('data-planes.routes.item.last_updated') }}
+                  </template>
+
+                  <template #body>
+                    {{ t('common.formats.datetime', { value: Date.parse(item.modificationTime) }) }}
+                  </template>
+                </DefinitionCard>
+              </div>
+
+              <div
+                v-if="item.dataplane.networking.gateway"
+              >
+                <h3>{{ t('data-planes.routes.item.gateway') }}</h3>
 
                 <div
-                  class="mt-2 stack-with-borders"
+                  class="mt-4"
                 >
-                  <DefinitionCard
-                    layout="horizontal"
+                  <div
+                    class="stack-with-borders"
                   >
-                    <template #title>
-                      {{ t('http.api.property.status') }}
-                    </template>
+                    <DefinitionCard
+                      layout="horizontal"
+                    >
+                      <template #title>
+                        {{ t('http.api.property.tags') }}
+                      </template>
 
-                    <template #body>
-                      <KBadge
-                        v-if="inbound.health.ready"
-                        appearance="success"
-                      >
-                        {{ t('data-planes.routes.item.health.ready') }}
-                      </KBadge>
+                      <template #body>
+                        <TagList
+                          alignment="right"
+                          :tags="item.dataplane.networking.gateway.tags"
+                        />
+                      </template>
+                    </DefinitionCard>
 
-                      <KBadge
-                        v-else
-                        appearance="danger"
-                      >
-                        {{ t('data-planes.routes.item.health.not_ready') }}
-                      </KBadge>
-                    </template>
-                  </DefinitionCard>
+                    <DefinitionCard
+                      layout="horizontal"
+                    >
+                      <template #title>
+                        {{ t('http.api.property.address') }}
+                      </template>
 
-                  <DefinitionCard
-                    layout="horizontal"
-                  >
-                    <template #title>
-                      {{ t('http.api.property.tags') }}
-                    </template>
-
-                    <template #body>
-                      <TagList
-                        alignment="right"
-                        :tags="inbound.tags"
-                      />
-                    </template>
-                  </DefinitionCard>
-
-                  <DefinitionCard
-                    layout="horizontal"
-                  >
-                    <template #title>
-                      {{ t('http.api.property.address') }}
-                    </template>
-
-                    <template #body>
-                      <TextWithCopyButton :text="inbound.addressPort" />
-                    </template>
-                  </DefinitionCard>
+                      <template #body>
+                        <TextWithCopyButton
+                          :text="`${item.dataplane.networking.address}`"
+                        />
+                      </template>
+                    </DefinitionCard>
+                  </div>
                 </div>
               </div>
+
+              <DataCollection
+                v-if="item.dataplaneType === 'standard'"
+                v-slot="{ items : inbounds }"
+                :items="item.dataplane.networking.inbounds"
+              >
+                <div>
+                  <h3>{{ t('data-planes.routes.item.inbounds') }}</h3>
+
+                  <div
+                    class="mt-4 stack"
+                  >
+                    <div
+                      v-for="(inbound, index) in inbounds"
+                      :key="index"
+                      class="inbound"
+                    >
+                      <h4>
+                        <TextWithCopyButton
+                          :text="inbound.tags['kuma.io/service']"
+                        >
+                          {{ t('data-planes.routes.item.inbound_name', { service: inbound.tags['kuma.io/service'] }) }}
+                        </TextWithCopyButton>
+                      </h4>
+
+                      <div
+                        class="mt-2 stack-with-borders"
+                      >
+                        <DefinitionCard
+                          layout="horizontal"
+                        >
+                          <template #title>
+                            {{ t('http.api.property.status') }}
+                          </template>
+
+                          <template #body>
+                            <KBadge
+                              v-if="inbound.health.ready"
+                              appearance="success"
+                            >
+                              {{ t('data-planes.routes.item.health.ready') }}
+                            </KBadge>
+
+                            <KBadge
+                              v-else
+                              appearance="danger"
+                            >
+                              {{ t('data-planes.routes.item.health.not_ready') }}
+                            </KBadge>
+                          </template>
+                        </DefinitionCard>
+
+                        <DefinitionCard
+                          layout="horizontal"
+                        >
+                          <template #title>
+                            {{ t('http.api.property.tags') }}
+                          </template>
+
+                          <template #body>
+                            <TagList
+                              alignment="right"
+                              :tags="inbound.tags"
+                            />
+                          </template>
+                        </DefinitionCard>
+
+                        <DefinitionCard
+                          layout="horizontal"
+                        >
+                          <template #title>
+                            {{ t('http.api.property.address') }}
+                          </template>
+
+                          <template #body>
+                            <TextWithCopyButton :text="inbound.addressPort" />
+                          </template>
+                        </DefinitionCard>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </DataCollection>
             </div>
-          </div>
-        </DataCollection>
-      </div>
-    </AppView>
+          </AppView>
+        </template>
+      </template>
+    </DataCollection>
   </RouteView>
 </template>
 
@@ -249,12 +278,9 @@ import StatusBadge from '@/app/common/StatusBadge.vue'
 import TagList from '@/app/common/TagList.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 
-const props = withDefaults(defineProps<{
-  name: string
-  dataplaneOverview?: DataplaneOverview
-}>(), {
-  dataplaneOverview: undefined,
-})
+const props = defineProps<{
+  items: DataplaneOverview[]
+}>()
 </script>
 <style lang="scss" scoped>
 .status-with-reason {

--- a/src/app/gateways/views/BuiltinGatewayDetailView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailView.vue
@@ -71,15 +71,14 @@
                   />
                 </template>
 
-                <template #name="{ row }">
+                <template #name="{ row: item }">
                   <RouterLink
                     class="name-link"
-                    :title="row.name"
                     :to="{
                       name: 'builtin-gateway-data-plane-summary-view',
                       params: {
-                        mesh: row.mesh,
-                        dataPlane: row.name,
+                        mesh: item.mesh,
+                        dataPlane: item.id,
                       },
                       query: {
                         page: route.params.page,
@@ -88,7 +87,7 @@
                       },
                     }"
                   >
-                    {{ row.name }}
+                    {{ item.name }}
                   </RouterLink>
                 </template>
 
@@ -149,14 +148,14 @@
                   </template>
                 </template>
 
-                <template #details="{ row }">
+                <template #details="{ row: item }">
                   <RouterLink
                     class="details-link"
                     data-testid="details-link"
                     :to="{
                       name: 'data-plane-detail-view',
                       params: {
-                        dataPlane: row.name,
+                        dataPlane: item.id,
                       },
                     }"
                   >
@@ -188,8 +187,8 @@
                 >
                   <component
                     :is="child.Component"
-                    :name="route.params.dataPlane"
-                    :dataplane-overview="dataplanesData?.items.find((dataplaneOverview) => dataplaneOverview.name === route.params.dataPlane)"
+                    v-if="typeof dataplanesData !== 'undefined'"
+                    :items="dataplanesData.items"
                   />
                 </SummaryView>
               </RouterView>

--- a/src/app/gateways/views/BuiltinGatewayDetailView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailView.vue
@@ -37,6 +37,7 @@
                 :page-size="route.params.size"
                 :headers="[
                   { label: 'Name', key: 'name' },
+                  ...((dataplanesData?.items[0].namespace ?? '').length > 0 ? [{ label: 'Namespace', key: 'namespace' }] : []),
                   ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
                   { label: 'Certificate Info', key: 'certificate' },
                   { label: 'Status', key: 'status' },
@@ -89,6 +90,10 @@
                   >
                     {{ item.name }}
                   </RouterLink>
+                </template>
+
+                <template #namespace="{ row: item }">
+                  {{ item.namespace }}
                 </template>
 
                 <template #zone="{ row }">

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -80,6 +80,7 @@
                   :page-size="route.params.size"
                   :headers="[
                     { label: 'Name', key: 'name' },
+                    ...((dataplanesData?.items[0].namespace ?? '').length > 0 ? [{ label: 'Namespace', key: 'namespace' }] : []),
                     ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
                     { label: 'Certificate Info', key: 'certificate' },
                     { label: 'Status', key: 'status' },
@@ -131,6 +132,10 @@
                     >
                       {{ item.name }}
                     </RouterLink>
+                  </template>
+
+                  <template #namespace="{ row: item }">
+                    {{ item.namespace }}
                   </template>
 
                   <template #zone="{ row }">

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -113,15 +113,14 @@
                     />
                   </template>
 
-                  <template #name="{ row }">
+                  <template #name="{ row: item }">
                     <RouterLink
                       class="name-link"
-                      :title="row.name"
                       :to="{
                         name: 'delegated-gateway-data-plane-summary-view',
                         params: {
-                          mesh: row.mesh,
-                          dataPlane: row.name,
+                          mesh: item.mesh,
+                          dataPlane: item.id,
                         },
                         query: {
                           page: route.params.page,
@@ -130,7 +129,7 @@
                         },
                       }"
                     >
-                      {{ row.name }}
+                      {{ item.name }}
                     </RouterLink>
                   </template>
 
@@ -191,14 +190,14 @@
                     </template>
                   </template>
 
-                  <template #details="{ row }">
+                  <template #details="{ row: item }">
                     <RouterLink
                       class="details-link"
                       data-testid="details-link"
                       :to="{
                         name: 'data-plane-detail-view',
                         params: {
-                          dataPlane: row.name,
+                          dataPlane: item.id,
                         },
                       }"
                     >
@@ -230,8 +229,8 @@
                   >
                     <component
                       :is="child.Component"
-                      :name="route.params.dataPlane"
-                      :dataplane-overview="dataplanesData?.items.find((dataplaneOverview) => dataplaneOverview.name === route.params.dataPlane)"
+                      v-if="typeof dataplanesData !== 'undefined'"
+                      :items="dataplanesData.items"
                     />
                   </SummaryView>
                 </RouterView>

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -97,6 +97,7 @@
                     :page-size="route.params.size"
                     :headers="[
                       { label: 'Name', key: 'name' },
+                      ...((dataplanesData?.items[0].namespace ?? '').length > 0 ? [{ label: 'Namespace', key: 'namespace' }] : []),
                       ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
                       { label: 'Certificate Info', key: 'certificate' },
                       { label: 'Status', key: 'status' },
@@ -149,6 +150,10 @@
                       >
                         {{ item.name }}
                       </RouterLink>
+                    </template>
+
+                    <template #namespace="{ row: item }">
+                      {{ item.namespace }}
                     </template>
 
                     <template #zone="{ row }">

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -131,15 +131,14 @@
                       />
                     </template>
 
-                    <template #name="{ row }">
+                    <template #name="{ row: item }">
                       <RouterLink
                         class="name-link"
-                        :title="row.name"
                         :to="{
                           name: 'service-data-plane-summary-view',
                           params: {
-                            mesh: row.mesh,
-                            dataPlane: row.name,
+                            mesh: item.mesh,
+                            dataPlane: item.id,
                           },
                           query: {
                             page: route.params.page,
@@ -148,7 +147,7 @@
                           },
                         }"
                       >
-                        {{ row.name }}
+                        {{ item.name }}
                       </RouterLink>
                     </template>
 
@@ -209,14 +208,14 @@
                       </template>
                     </template>
 
-                    <template #details="{ row }">
+                    <template #details="{ row: item }">
                       <RouterLink
                         class="details-link"
                         data-testid="details-link"
                         :to="{
                           name: 'data-plane-detail-view',
                           params: {
-                            dataPlane: row.name,
+                            dataPlane: item.id,
                           },
                         }"
                       >
@@ -248,8 +247,8 @@
                     >
                       <component
                         :is="child.Component"
-                        :name="route.params.dataPlane"
-                        :dataplane-overview="dataplanesData?.items.find((dataplaneOverview) => dataplaneOverview.name === route.params.dataPlane)"
+                        v-if="typeof dataplanesData !== 'undefined'"
+                        :items="dataplanesData.items"
                       />
                     </SummaryView>
                   </RouterView>

--- a/src/test-support/mocks/src/meshes/_/dataplanes/_overview.ts
+++ b/src/test-support/mocks/src/meshes/_/dataplanes/_overview.ts
@@ -7,6 +7,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
   const _name = query.get('name') ?? ''
   const _tags = query.get('tag') ?? ''
 
+  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
   const inbounds = parseInt(env('KUMA_DATAPLANEINBOUND_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
   const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
   const isMtlsEnabledOverride = env('KUMA_MTLS_ENABLED', '')
@@ -48,18 +49,28 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const isMtlsEnabled = isMtlsEnabledOverride !== '' ? isMtlsEnabledOverride === 'true' : fake.datatype.boolean()
 
         const type = filterType ?? fake.helpers.arrayElement(['gateway_builtin', 'gateway_delegated', 'proxy'])
-        const name = `${_name || fake.kuma.dataPlaneProxyName()}-${type}-${id}`
         const service = tags['kuma.io/service']
+
+        const displayName = `${_name || fake.hacker.noun()}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
+        const nspace = fake.k8s.namespace()
 
         return {
           type: 'DataplaneOverview',
           mesh,
-          name,
+          name: `${displayName}${k8s ? `.${nspace}` : ''}`,
           creationTime: '2021-02-17T08:33:36.442044+01:00',
           modificationTime: '2021-02-17T08:33:36.442044+01:00',
           dataplane: {
             networking: fake.kuma.dataplaneNetworking({ type, inbounds, isMultizone, service }),
           },
+          ...(k8s
+            ? {
+              labels: {
+                'kuma.io/display-name': displayName,
+                'k8s.kuma.io/namespace': nspace,
+              },
+            }
+            : {}),
           dataplaneInsight: {
             ...(isMtlsEnabled ? { mTLS: fake.kuma.dataplaneMtls() } : {}),
             subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -296,6 +296,7 @@ export interface DataPlane extends MeshEntity {
  */
 export interface DataPlaneOverview extends MeshEntity {
   type: 'DataplaneOverview'
+  labels?: Record<string, string>
   dataplane: {
     networking: DataplaneNetworking
   }


### PR DESCRIPTION
Uses `kuma.io/display-name` as the dataplane `name` if it exists.

We also always set a new `.id` property, which we use for hrefs instead of `name` now.

I added a couple of places to show the `namespace` of a dataplane based on the namespace label (if it exists), but I didn't add this into our list/table views.

Oh I also removed the HTML `title`s we have in a couple of places, I figured those are less necessary now, but let me know if those should stay.

This PR only applies this to everywhere we have dataplanes (or should do). I noticed we probably could do this for policies also, which I'll do separately.

Closes https://github.com/kumahq/kuma-gui/issues/2051

If you view the preview make sure to set it to use a kubernetes-like environment via your cookies or via this link: https://deploy-preview-2348--kuma-gui.netlify.app/gui/#KUMA_ENVIRONMENT=kubernetes

### Screenshots of where the namespace was conditionally added:

![Screenshot 2024-03-27 at 18 52 23](https://github.com/kumahq/kuma-gui/assets/554604/d337048a-138a-4324-9fc0-fab07bc9d78d)

![Screenshot 2024-03-27 at 18 52 31](https://github.com/kumahq/kuma-gui/assets/554604/135d6c7a-1a64-47c5-882b-d7592c46bc65)

