### PR TITLE
chore(deps-dev): add missing postcss dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "lockfile-lint": "4.13.2",
     "marked": "12.0.1",
     "msw": "2.1.5",
+    "postcss": "8.4.38",
     "postcss-html": "1.6.0",
     "sass": "1.72.0",
     "standard": "17.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6764,7 +6764,7 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.0, postcss@^8.4.35, postcss@^8.4.38:
+postcss@8.4.38, postcss@^8.4.0, postcss@^8.4.35, postcss@^8.4.38:
   version "8.4.38"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
   integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==


### PR DESCRIPTION
Add postcss which was missing. It’s a peer dependency of both autoprefixer and stylelint-config-recommended-scss.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
