### PR TITLE
refactor: replace CopyButton with KCopy

### DIFF
--- a/src/app/common/TextWithCopyButton.vue
+++ b/src/app/common/TextWithCopyButton.vue
@@ -2,20 +2,14 @@
   <div class="copy-button-wrapper">
     <span class="text"><slot>{{ props.text }}</slot></span>
 
-    <CopyButton
+    <KCopy
+      format="hidden"
       :text="props.text"
-      :copy-text="i18n.t('common.copyText')"
-      :tooltip-success-text="i18n.t('common.copySuccessText')"
     />
   </div>
 </template>
 
 <script lang="ts" setup>
-import CopyButton from './CopyButton.vue'
-import { useI18n } from '@/utilities'
-
-const i18n = useI18n()
-
 const props = defineProps<{
   text: string
 }>()


### PR DESCRIPTION
Replace the CopyButton in TextWithCopyButton with KCopy as we don’t have more specific needs here.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Note: There’s one more use of CopyButton which we can replaced as part of https://github.com/kumahq/kuma-gui/pull/2374. I think I might also try and use KCopy there so we don’t rely on multiple ways to copy stuff.