### PR TITLE
ci: exclude go-module-binary-cataloger from sbom

### DIFF
--- a/.github/workflows/create-gui-pr.yml
+++ b/.github/workflows/create-gui-pr.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           asset_prefix: kuma-gui
           dir: '.'
+          config: .syft.yaml
           fail_build: 'true' # Fail job if critical vulnerabilities are detected
 
       - run: yarn run build

--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,2 @@
+select-catalogers:
+  - -go-module-binary-cataloger


### PR DESCRIPTION
Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
