### PR TITLE
chore: require latest yarn version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "engines": {
     "node": ">=20.9"
   },
-  "packageManager": "yarn@1.22.21",
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "@kong-ui-public/i18n": "2.1.4",
     "@kong/icons": "1.8.15",


### PR DESCRIPTION
I noticed CI is using a different Yarn version than we have listed in the package manifest. Since Yarn v1 is no longer being developed, we should use the latest version. I also have a suspicion that might explain lock file differences being produced between CI and local environments.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>