### PR TITLE
fix(policies): ensure policy detail link uses id

### DIFF
--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -165,7 +165,7 @@
                             params: {
                               mesh: row.mesh,
                               policyPath: policyType.path,
-                              policy: row.name,
+                              policy: row.id,
                             },
                           }"
                         >

--- a/src/app/policies/views/PolicySummaryView.vue
+++ b/src/app/policies/views/PolicySummaryView.vue
@@ -46,7 +46,7 @@
                   }"
                 >
                   <RouteTitle
-                    :title="t('policies.routes.item.title', { name: route.params.policy })"
+                    :title="t('policies.routes.item.title', { name: item.name })"
                   />
                 </RouterLink>
               </h2>


### PR DESCRIPTION
Similar to https://github.com/kumahq/kuma-gui/pull/2380 and https://github.com/kumahq/kuma-gui/pull/2384

Tests for all these are here https://github.com/kumahq/kuma-gui/pull/2386 but wanted to get this fix in separately as it should be easier to review like this.