### PR TITLE
ci: cancel duplicate workflows on the same branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,10 @@
 name: 'Run CodeQL'
 
+# Ensures that only one workflow is run per branch at a time.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+
 on:
   push:
     branches: [master, 'release-[0-9]+.[0-9]+']

--- a/.github/workflows/dispatch-merged-pr-notification.yml
+++ b/.github/workflows/dispatch-merged-pr-notification.yml
@@ -1,5 +1,10 @@
 name: 'Dispatch merged PR notification'
 
+# Ensures that only one workflow is run per branch at a time.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+
 on:
   pull_request_target:
     types: [closed]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 # create-gui-pr.yaml is dependant on this name being "Tests"
 name: 'Tests'
-#
+
+# Ensures that only one workflow is run per branch at a time.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+
 on:
   push:
     branches: [master, 'release-[0-9]+.[0-9]+']


### PR DESCRIPTION
Cancel runs of the same workflow on the same branch.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
