### PR TITLE
fix(msw): request.body is a ReadableStream, convert to an object

### DIFF
--- a/src/test-support/fake.ts
+++ b/src/test-support/fake.ts
@@ -6,7 +6,7 @@ import type { Alias } from '@/services/utils'
 export type RestRequest = {
   method: string
   params: Record<string, string | readonly string[]>
-  body: any
+  body: Record<string, any>
   url: {
     searchParams: URLSearchParams
   }

--- a/src/test-support/index.ts
+++ b/src/test-support/index.ts
@@ -70,7 +70,7 @@ export const handler = (fs: FS, env: AEnv) => {
       const response = await respond({
         method: request.method,
         url: new URL(request.url),
-        body: request.body,
+        body: request.body ? JSON.parse(await new Response(request.body).text()) : {},
         params,
       })
       return HttpResponse.json(response.body, {


### PR DESCRIPTION
Firstly, this is a bug in our usage of MSW (local dev and preview sites) and therefore doesn't effect prod, or even our tests seeing as we use Cypress there.

--- 

We barely use `request.body` in our mocks, and I'm guessing this went unnoticed in our upgrade to MSW 2 https://github.com/kumahq/kuma-gui/pull/2110.

MSW now produces a `ReadableStream` as the request body. The fix just parses that out and into JSON. I also made the type a tiny bit better to at least expect something object like.
