### PR TITLE
fix: center aligns text of DefinitionCard titles

### DIFF
--- a/src/app/common/DefinitionCard.vue
+++ b/src/app/common/DefinitionCard.vue
@@ -42,7 +42,7 @@ const props = withDefaults(defineProps<{
 
 .definition-card-title {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: $kui-space-40;
 }
 


### PR DESCRIPTION
Note: I almost did this just in the `ControlPlaneStatus` component which is where the problem arises. But it seemed like if was fine to do at an application level. If anyone is unsure as to whether this is fine or not, I'd be happy to move it back to fixing it in the more focussed option within `ControlPlaneStatus`.

But, it would be super helpful to get a second opinion/confirmation as to whether doing this at an application level has no negative effect.

## Before

![Screenshot 2024-04-08 at 15 44 23](https://github.com/kumahq/kuma-gui/assets/554604/62965c61-729c-4afe-8339-48cbf0c9d8e8)

## After

![Screenshot 2024-04-08 at 15 44 09](https://github.com/kumahq/kuma-gui/assets/554604/d89cbf5a-64d5-41db-b5bb-9fcebe8d2f54)

---

As a sidenote I noticed that all of the text rendered by `DefinitionCard` is rendered within `div`s. We should probably change that at some point to be more semantic (either using a `dl`, or `h*`/`p` elements) as the `<div>` element should be used only when no other semantic element is appropriate.
