### PR TITLE
chore: adds additional error message to XAction and use it in service/policy listings

### DIFF
--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -104,7 +104,7 @@
                       @change="route.update"
                     >
                       <template #name="{ row }">
-                        <RouterLink
+                        <XAction
                           :to="{
                             name: 'policy-summary-view',
                             params: {
@@ -119,7 +119,7 @@
                           }"
                         >
                           {{ row.name }}
-                        </RouterLink>
+                        </XAction>
                       </template>
                       <template #namespace="{ row: item }">
                         {{ item.namespace.length > 0 ? item.namespace : t('common.detail.none') }}
@@ -157,7 +157,7 @@
                       </template>
 
                       <template #details="{ row }">
-                        <RouterLink
+                        <XAction
                           class="details-link"
                           data-testid="details-link"
                           :to="{
@@ -175,7 +175,7 @@
                             decorative
                             :size="KUI_ICON_SIZE_30"
                           />
-                        </RouterLink>
+                        </XAction>
                       </template>
                     </AppCollection>
                     <RouterView

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -47,7 +47,7 @@
             >
               <template #name="{ row: item }">
                 <TextWithCopyButton :text="item.name">
-                  <RouterLink
+                  <XAction
                     :to="{
                       name: 'service-detail-view',
                       params: {
@@ -61,7 +61,7 @@
                     }"
                   >
                     {{ item.name }}
-                  </RouterLink>
+                  </XAction>
                 </TextWithCopyButton>
               </template>
 
@@ -94,7 +94,7 @@
               </template>
 
               <template #details="{ row }">
-                <RouterLink
+                <XAction
                   class="details-link"
                   data-testid="details-link"
                   :to="{
@@ -111,7 +111,7 @@
                     decorative
                     :size="KUI_ICON_SIZE_30"
                   />
-                </RouterLink>
+                </XAction>
               </template>
             </AppCollection>
           </KCard>

--- a/src/app/x/components/x-action/XAction.vue
+++ b/src/app/x/components/x-action/XAction.vue
@@ -39,7 +39,7 @@
 </template>
 <script lang="ts" setup>
 import { computed, watch } from 'vue'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRouter } from 'vue-router'
 
 import type { RouteLocationNamedRaw } from 'vue-router'
 type BooleanLocationQueryValue = string | number | undefined | boolean
@@ -47,6 +47,7 @@ type BooleanLocationQueryRaw = Record<string | number, BooleanLocationQueryValue
 type RouteLocationRawWithBooleanQuery = Omit<RouteLocationNamedRaw, 'query'> & {
   query?: BooleanLocationQueryRaw
 }
+const router = useRouter()
 
 const props = withDefaults(defineProps<{
   href?: string
@@ -74,12 +75,27 @@ const query = computed(() => {
     return prev
   }, {})
 })
+
 watch(() => props.mount, (val) => {
   if (typeof val === 'function') {
     val({
       ...props.to,
       query: query.value,
     })
+  }
+}, { immediate: true })
+
+watch(() => props.to, (val) => {
+  try {
+    router.resolve({
+      ...val,
+      query: query.value,
+    })
+  } catch (e) {
+    if (e instanceof Error) {
+      e.message = `${e.toString()}: ${JSON.stringify(val)}`
+    }
+    console.error(e)
   }
 }, { immediate: true })
 </script>


### PR DESCRIPTION
I'm using this to try and get a flake/error on a couple of tests that commonly flake, whilst it could go in, I want to keep running it until I get a flake. Also, I'm considering adding something on this PR that reruns certain tests multiple times to make any potential flakes more likely to come up in the PR.

~DO NOT MERGE!11!! No honestly, don't 😅~

---

edit: I've run this a few times, and I can't get a flake out of it. I'd rather merge this seeing as it doesn't really change any functionality and uses `XAction` (which we'll probably end up rolling out everywhere) and see if flake continue to appear over time.
