### PR TITLE
fix(policies): redirect to first available policy type instead of CBs

### DIFF
--- a/src/app/policies/routes.ts
+++ b/src/app/policies/routes.ts
@@ -21,16 +21,6 @@ export const routes = () => {
             module: 'policies',
           },
           component: () => import('@/app/policies/views/PolicyTypeListView.vue'),
-          redirect: (to) => {
-            return {
-              ...to,
-              params: {
-                ...to.params,
-                policyPath: 'circuit-breakers',
-              },
-              name: 'policy-list-view',
-            }
-          },
           children: [
             {
               path: ':policyPath',

--- a/src/app/policies/views/PolicyTypeListView.vue
+++ b/src/app/policies/views/PolicyTypeListView.vue
@@ -8,8 +8,6 @@
       v-slot="{ route, t }"
       name="policy-list-view"
       :params="{
-        page: 1,
-        size: me.pageSize,
         mesh: '',
         policyPath: '',
         policy: '',
@@ -60,14 +58,14 @@
                         :key="current"
                       >
                         <div
-                          v-for="policyType in items"
+                          v-for="(policyType, i) in items"
                           :key="policyType.path"
                           class="policy-type-link-wrapper"
                           :class="{
                             'policy-type-link-wrapper--is-active': current && current.path === policyType.path,
                           }"
                         >
-                          <RouterLink
+                          <XAction
                             class="policy-type-link"
                             :to="{
                               name: 'policy-list-view',
@@ -76,10 +74,11 @@
                                 policyPath: policyType.path,
                               },
                             }"
+                            :mount="route.params.policyPath.length === 0 && i === 0 ? route.replace : undefined"
                             :data-testid="`policy-type-link-${policyType.name}`"
                           >
                             {{ policyType.name }}
-                          </RouterLink>
+                          </XAction>
 
                           <div class="policy-count">
                             {{ meshInsight?.policies?.[policyType.name]?.total ?? 0 }}

--- a/src/app/x/components/x-action/XAction.vue
+++ b/src/app/x/components/x-action/XAction.vue
@@ -38,7 +38,7 @@
   </template>
 </template>
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { RouterLink } from 'vue-router'
 
 import type { RouteLocationNamedRaw } from 'vue-router'
@@ -52,10 +52,12 @@ const props = withDefaults(defineProps<{
   href?: string
   to?: RouteLocationRawWithBooleanQuery
   for?: string
+  mount?: (to: RouteLocationNamedRaw) => void
 }>(), {
   href: '',
   to: () => ({}),
   for: '',
+  mount: undefined,
 })
 const query = computed(() => {
   return Object.entries(props.to.query ?? {}).reduce<Record<string, string | number | null | undefined>>((prev, [key, value]) => {
@@ -72,4 +74,12 @@ const query = computed(() => {
     return prev
   }, {})
 })
+watch(() => props.mount, (val) => {
+  if (typeof val === 'function') {
+    val({
+      ...props.to,
+      query: query.value,
+    })
+  }
+}, { immediate: true })
 </script>


### PR DESCRIPTION
Instead of always linking to CircuitBreakers when clicking any `[Policies]` link, we choose the first one in the list and redirect you to that one.

Closes https://github.com/kumahq/kuma-gui/issues/2415