### PR TITLE
fix(dataplanes): ignore inbound/listener with a `_` prefixed clustername

### DIFF
--- a/src/app/connections/data/index.spec.ts
+++ b/src/app/connections/data/index.spec.ts
@@ -37,6 +37,7 @@ describe('ConnectionCollection', () => {
         listener: {
           '10.244.0.11_8081': {
             tcp: {},
+            $clusterName: 'edge-gateway',
             http: {
               downstream_rq_1xx: 0,
             },

--- a/src/app/connections/data/index.ts
+++ b/src/app/connections/data/index.ts
@@ -19,21 +19,25 @@ export const ConnectionCollection = {
               tcp,
             }
             if (typeof http !== 'undefined') {
-              // check http protocol for existence i.e. `listener.<inbound-socket-address>.http.<cluster-name>.<...stats>`
-              // and then remove the cluster-name leaving: `listener.<inbound-address_port>.http.<...stats>`
+              // check http protocol for existence i.e. `listener.<inbound-socket-address | clustername>.http.<cluster-name>.<...stats>`
+              // and then remove the cluster-name leaving: `listener.<inbound-address_port | clustername>.http.<...stats>`
               const cluster = Object.keys(http)[0]
               return [key, {
                 ...stats,
                 http: http[cluster],
+                $clusterName: cluster,
                 // check for grpc stats `listener.<inbound-socket-address>.http.grpc.<...stats>`
                 // and un-nest if we find them `listener.<inbound-socket-address>.grpc.<...stats>`
                 ...(typeof item.cluster[cluster]?.http2 !== 'undefined' ? { http2: item.cluster[cluster].http2 } : {}),
                 ...(typeof item.cluster[cluster]?.grpc !== 'undefined' ? { grpc: item.cluster[cluster].grpc } : {}),
               }]
             } else {
-              // if there is no `listener.<inbound-socket-address>.http`
-              // just move all the stats to `.tcp` i.e. `listener.<inbound-socket-address>.tcp.<...stats>`
-              return [key, stats]
+              // if there is no `listener.<inbound-socket-address | clustername>.http`
+              // just move all the stats to `.tcp` i.e. `listener.<inbound-socket-address | clustername>.tcp.<...stats>`
+              return [key, {
+                ...stats,
+                $clusterName: '',
+              }]
             }
           }),
       )

--- a/src/app/connections/sources.ts
+++ b/src/app/connections/sources.ts
@@ -25,7 +25,7 @@ export const sources = (source: Source, api: KumaApi) => {
       // pick out the listeners/inbounds that start with our ip address (the.ip.address.1_port000)
       const inbounds = params.address === 'localhost'
         ? Object.fromEntries(Object.entries(connections.cluster).filter(([key, _value]) => key.startsWith('localhost_')))
-        : Object.fromEntries(Object.entries(connections.listener).filter(([key, _value]) => key.startsWith(`${params.address}_`)))
+        : Object.fromEntries(Object.entries(connections.listener).filter(([key, value]) => key.startsWith(`${params.address}_`) && !value.$clusterName.startsWith('_')))
       // pick out the outbounds which aren't internal outbounds
       const outbounds = Object.fromEntries(Object.entries(connections.cluster).filter(([key, _value]) => ![
         // if we don't exclude localhost_ we end up with  a `localhost_`


### PR DESCRIPTION
TLDR; This PR also applies a `_` exclusion to inbounds aswell as outbounds

---

We have an ignore/exclude list for cluster names that ignores internal cluster names, and we've recently started prefixing all internal cluster names with `_` and we ignore all `_` prefixed cluster names so moving forwards we can remove the exclude list.

https://github.com/kumahq/kuma-gui/blob/e4d3170edd2e84ea7d6b8260bc721eecd4ab59b5/src/app/connections/sources.ts#L37-L47

Thing is, we only apply this exclude list to outbounds 🙄 😅 

For reasons this wasn't as straightforward as just applying the same exclusion list.

---

For listeners we use the `ip.add.re.ss_port` as a key which we take from `listener.<ip.add.re.ss_port>`. Sometimes these can have a protocol on them followed by the clustername, followed by the blob of stats:

`listener.<ip.add.re.ss_port>.http.cluster-name.all-the-stats...`

Previous to this PR we removed/threw away the cluster name from these lines leaving: 

`listener.<ip.add.re.ss_port>.http.all-the-stats...`

...because we didn't need that information and it gave us a consistent shape for the data for both inbounds and outbounds:

```javascript
// `listener.` (inbounds) keyed by ip_port
{
  '10.0.0.1_8080': {
     tcp: {...stats},
     http: {..stats}
   }
}
// `cluster.` (used for both inbounds and outbounds) keyed by clustername
{
  'clusterName': {
     tcp: {...stats},
     http: {..stats}
   }
}
```

Because we throw away the cluster name for listeners we can't then filter for listener with a cluster name beginning with `_` from within `sources.ts`

So I could either:

1. Filter out the `_` prefixed things before we throw away the cluster name (in `data.ts`)
2. Somehow keep the cluster name and then filter for `_` in the same place that we do the same filter in for outbounds (in sources.ts)

Option 2 felt far better, so I added a reasonably safely named property called `$clusterName` to the stats, which is the available to filter by from within `sources.ts`


Closes https://github.com/kumahq/kuma-gui/issues/2416