### PR TITLE
fix(dataplanes): ignore inbound/listener with a `_` prefixed clustername

### DIFF
--- a/src/app/connections/data/index.spec.ts
+++ b/src/app/connections/data/index.spec.ts
@@ -37,6 +37,7 @@ describe('ConnectionCollection', () => {
         listener: {
           '10.244.0.11_8081': {
             tcp: {},
+            $clusterName: 'edge-gateway',
             http: {
               downstream_rq_1xx: 0,
             },

--- a/src/app/connections/data/index.ts
+++ b/src/app/connections/data/index.ts
@@ -19,21 +19,25 @@ export const ConnectionCollection = {
               tcp,
             }
             if (typeof http !== 'undefined') {
-              // check http protocol for existence i.e. `listener.<inbound-socket-address>.http.<cluster-name>.<...stats>`
-              // and then remove the cluster-name leaving: `listener.<inbound-address_port>.http.<...stats>`
+              // check http protocol for existence i.e. `listener.<inbound-socket-address | clustername>.http.<cluster-name>.<...stats>`
+              // and then remove the cluster-name leaving: `listener.<inbound-address_port | clustername>.http.<...stats>`
               const cluster = Object.keys(http)[0]
               return [key, {
                 ...stats,
                 http: http[cluster],
+                $clusterName: cluster,
                 // check for grpc stats `listener.<inbound-socket-address>.http.grpc.<...stats>`
                 // and un-nest if we find them `listener.<inbound-socket-address>.grpc.<...stats>`
                 ...(typeof item.cluster[cluster]?.http2 !== 'undefined' ? { http2: item.cluster[cluster].http2 } : {}),
                 ...(typeof item.cluster[cluster]?.grpc !== 'undefined' ? { grpc: item.cluster[cluster].grpc } : {}),
               }]
             } else {
-              // if there is no `listener.<inbound-socket-address>.http`
-              // just move all the stats to `.tcp` i.e. `listener.<inbound-socket-address>.tcp.<...stats>`
-              return [key, stats]
+              // if there is no `listener.<inbound-socket-address | clustername>.http`
+              // just move all the stats to `.tcp` i.e. `listener.<inbound-socket-address | clustername>.tcp.<...stats>`
+              return [key, {
+                ...stats,
+                $clusterName: '',
+              }]
             }
           }),
       )

--- a/src/app/connections/sources.ts
+++ b/src/app/connections/sources.ts
@@ -25,7 +25,7 @@ export const sources = (source: Source, api: KumaApi) => {
       // pick out the listeners/inbounds that start with our ip address (the.ip.address.1_port000)
       const inbounds = params.address === 'localhost'
         ? Object.fromEntries(Object.entries(connections.cluster).filter(([key, _value]) => key.startsWith('localhost_')))
-        : Object.fromEntries(Object.entries(connections.listener).filter(([key, _value]) => key.startsWith(`${params.address}_`)))
+        : Object.fromEntries(Object.entries(connections.listener).filter(([key, value]) => key.startsWith(`${params.address}_`) && !value.$clusterName.startsWith('_')))
       // pick out the outbounds which aren't internal outbounds
       const outbounds = Object.fromEntries(Object.entries(connections.cluster).filter(([key, _value]) => ![
         // if we don't exclude localhost_ we end up with  a `localhost_`


### PR DESCRIPTION
Port of https://github.com/kumahq/kuma-gui/pull/2420 to `master`