### PR TITLE
fix(dataplanes): ignore service-less inbounds in the overview

### DIFF
--- a/features/mesh/dataplanes/overview/Inbounds.feature
+++ b/features/mesh/dataplanes/overview/Inbounds.feature
@@ -1,0 +1,40 @@
+Feature: mesh / dataplanes / connections / Inbounds
+  Background:
+    Given the CSS selectors
+      | Alias       | Selector                                    |
+      | detail-view | [data-testid='data-plane-detail-tabs-view'] |
+      | traffic     | [data-testid='dataplane-traffic']           |
+      | inbound     | [data-testid='dataplane-inbound']           |
+      | outbound    | [data-testid='dataplane-outbound']          |
+
+  Scenario: An inbound with port 49151 isn't shown
+    Given the environment
+      """
+      KUMA_DATAPLANEINBOUND_COUNT: 1
+      KUMA_DATAPLANE_TYPE: standard
+      """
+    And the URL "/meshes/default/dataplanes/service-less/_overview" responds with
+      """
+      body:
+        dataplane:
+          networking:
+            inbound:
+              - port: 49151
+      """
+    When I visit the "/meshes/default/data-planes/service-less/overview" URL
+
+    And the "$detail-view" element contains "service-less"
+    And the "$traffic" element exists
+    And the "$inbound" element exists 0 times
+
+  Scenario: Delegated gateways show no inbounds
+    Given the environment
+      """
+      KUMA_DATAPLANE_TYPE: delegated
+      """
+    When I visit the "/meshes/default/data-planes/delegated/overview" URL
+
+    And the "$detail-view" element contains "delegated"
+    And the "$traffic" element exists
+    And the "$inbound" element exists 0 times
+

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -178,8 +178,10 @@
                     }, []) : props.data.dataplane.networking.inbounds]"
                     :key="inbounds"
                   >
+                    <!-- don't show a card for anything on port 49151 as those are service-less inbounds -->
                     <DataCollection
                       :items="inbounds"
+                      :predicate="(item) => item.port !== 49151"
                     >
                       <template
                         v-if="props.data.dataplaneType === 'delegated'"
@@ -189,9 +191,9 @@
                           This proxy is a delegated gateway therefore {{ t('common.product.name') }} does not have any visibility into inbounds for this gateway
                         </EmptyBlock>
                       </template>
-                      <template #default>
+                      <template #default="{ items: _inbounds }">
                         <template
-                          v-for="item in inbounds"
+                          v-for="item in _inbounds"
                           :key="`${item.name}`"
                         >
                           <template


### PR DESCRIPTION
Port of #2422 to `master`

--- 
Also added a test for not showing any inbounds for delegated gateways whilst I was there as it was the same sort of test/feature.


