### PR TITLE
chore: adds XBreadcrumbs

### DIFF
--- a/src/app/application/components/app-view/AppView.vue
+++ b/src/app/application/components/app-view/AppView.vue
@@ -7,9 +7,8 @@
       v-if="!hasParent && _breadcrumbs.length > 0"
       aria-label="Breadcrumb"
     >
-      <KBreadcrumbs
+      <XBreadcrumbs
         :items="_breadcrumbs"
-        :item-max-width="'150px'"
       />
     </nav>
 
@@ -61,12 +60,12 @@
 
 <script lang="ts" setup>
 import { KongIcon } from '@kong/icons'
-import { KBreadcrumbs, BreadcrumbItem } from '@kong/kongponents'
 import { provide, inject, watch, ref, onBeforeUnmount } from 'vue'
 
 import { ROUTE_VIEW_PARENT } from '../route-view/index'
 import type { RouteView } from '../route-view/RouteView.vue'
 import { useMainView } from '@/components'
+import type { BreadcrumbItem } from '@kong/kongponents'
 type AppView = {
   addBreadcrumbs: (items: BreadcrumbItem[], sym: Symbol) => void
   removeBreadcrumbs: (sym: Symbol) => void

--- a/src/app/x/components/x-breadcrumbs/README.md
+++ b/src/app/x/components/x-breadcrumbs/README.md
@@ -1,0 +1,1 @@
+# x-breadcrumbs

--- a/src/app/x/components/x-breadcrumbs/XBreadcrumbs.vue
+++ b/src/app/x/components/x-breadcrumbs/XBreadcrumbs.vue
@@ -1,0 +1,26 @@
+<template>
+  <KBreadcrumbs
+    :items="props.items"
+    :item-max-width="'150px'"
+  >
+    <template
+      v-for="(slot, key) in slots"
+      :key="key"
+      #[`${key}`]
+    >
+      <slot
+        :name="key"
+      />
+    </template>
+  </KBreadcrumbs>
+</template>
+<script lang="ts" setup>
+import { KBreadcrumbs } from '@kong/kongponents'
+import type { BreadcrumbItem } from '@kong/kongponents'
+import { useSlots } from 'vue'
+
+const slots = useSlots()
+const props = defineProps<{
+  items: BreadcrumbItem[]
+}>()
+</script>

--- a/src/app/x/components/x-icon/XIcon.vue
+++ b/src/app/x/components/x-icon/XIcon.vue
@@ -4,6 +4,7 @@
     :placement="props.placement"
   >
     <component
+      v-bind="attrs"
       :is="icons[props.name]"
       :aria-described-by="slots.default ? id : undefined"
       :tabindex="slots.default ? 0 : undefined"
@@ -31,18 +32,25 @@ import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import {
   WarningIcon,
   PortalIcon,
+  MeshIcon,
 } from '@kong/icons'
 import { KTooltip, PopPlacements } from '@kong/kongponents'
-import { useSlots } from 'vue'
+import { useSlots, useAttrs } from 'vue'
 
 import { uniqueId } from '@/app/application'
 import AnonymousComponent from '@/app/application/components/anonymous-component/AnonymousComponent.vue'
 
+defineOptions({
+  inheritAttrs: false,
+})
+
+const attrs = useAttrs()
 const icons = {
   standard: 'span',
   builtin: PortalIcon,
   delegated: PortalIcon,
   warning: WarningIcon,
+  mesh: MeshIcon,
 } as const
 const id = uniqueId('-x-icon-tooltip')
 const slots = useSlots()
@@ -59,6 +67,9 @@ const props = withDefaults(defineProps<{
 })
 </script>
 <style lang="scss" scoped>
+.x-icon-mesh-icon {
+  --meshIconColor: #{$kui-color-text-decorative-aqua};
+}
 .x-icon-icon {
   --warningIconColor: #ffa600;
 }

--- a/src/app/x/index.ts
+++ b/src/app/x/index.ts
@@ -1,4 +1,5 @@
 import XAction from './components/x-action/XAction.vue'
+import XBreadcrumbs from './components/x-breadcrumbs/XBreadcrumbs.vue'
 import XDisclosure from './components/x-disclosure/XDisclosure.vue'
 import XIcon from './components/x-icon/XIcon.vue'
 import XTeleportSlot from './components/x-teleport/XTeleportSlot.vue'
@@ -12,6 +13,7 @@ declare module '@vue/runtime-core' {
   export interface GlobalComponents {
     XIcon: typeof XIcon
     XAction: typeof XAction
+    XBreadcrumbs: typeof XBreadcrumbs
     XTeleportTemplate: typeof XTeleportTemplate
     XTeleportSlot: typeof XTeleportSlot
     XDisclosure: typeof XDisclosure
@@ -25,6 +27,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         service: () => {
           return [
             ['XAction', XAction],
+            ['XBreadcrumbs', XBreadcrumbs],
             ['XIcon', XIcon],
             ['XTeleportTemplate', XTeleportTemplate],
             ['XTeleportSlot', XTeleportSlot],


### PR DESCRIPTION
There are times when we want to eXtend our breadcrumbs centrally or otherwise add eXtra bits to it, whilst we can almost do that as it stands (we only use it once in AppView). We may need to do it in a more inject-y/indirect way.

This adds an eXtra eXtension over KBreadcrumbs allowing us centrally configure it, but also inject into it.

