### PR TITLE
[WIP] chore: use x-action to not crash when links have empty params

### DIFF
--- a/src/app/policies/components/PolicyTypeEntryList.vue
+++ b/src/app/policies/components/PolicyTypeEntryList.vue
@@ -73,7 +73,7 @@
                   v-for="(origin, originIndex) in row.origins"
                   :key="`${index}-${originIndex}`"
                 >
-                  <RouterLink
+                  <XAction
                     :to="{
                       name: 'policy-detail-view',
                       params: {
@@ -84,7 +84,7 @@
                     }"
                   >
                     {{ origin.name }}
-                  </RouterLink>
+                  </XAction>
                 </li>
               </ul>
 

--- a/src/app/policies/views/PolicyTypeListView.vue
+++ b/src/app/policies/views/PolicyTypeListView.vue
@@ -66,7 +66,7 @@
                           }"
                         >
                           <XAction
-                            class="policy-type-link"
+                            :class="$style['policy-type-link']"
                             :to="{
                               name: 'policy-list-view',
                               params: {
@@ -106,9 +106,11 @@
 </template>
 
 <script lang="ts" setup>
+
 import type { MeSource } from '@/app/me/sources'
 import type { MeshInsightSource } from '@/app/meshes/sources'
 import type { PolicyTypeCollectionSource } from '@/app/policies/sources'
+
 </script>
 <style lang="scss" scoped>
 .policy-list-content {
@@ -139,15 +141,16 @@ import type { PolicyTypeCollectionSource } from '@/app/policies/sources'
   color: $kui-color-text-neutral;
 }
 
-.policy-type-link {
-  color: currentColor;
-  flex-grow: 1;
-  padding: $kui-space-40 $kui-space-60;
-}
-
 .policy-count {
   text-align: right;
   padding-right: $kui-space-60;
 }
 
+</style>
+<style lang="scss" module>
+.policy-type-link {
+  color: currentColor;
+  flex-grow: 1;
+  padding: $kui-space-40 $kui-space-60;
+}
 </style>


### PR DESCRIPTION
DO NOT MERGE, and all that business.

This is in draft as there is undoubtedly some more work to do here, but I would like some review at this stage if poss.

---

We had a conversation in https://github.com/kumahq/kuma-gui/pull/2347#discussion_r1560608637 around using Typescripts `!` (ignore any null/undefined access) and using `?.thing ?? ''` instead and then dealing more gracefully with the error.

I'd kinda had the approach in this PR in mind, but hadn't really finished it up (and still haven't I don't think), but I wanted to put it up to get some help/feedback on the approach:

Ok, so we are balancing a fine line here, where want to keep erroring so we are aware of problems, but we also don't want to completely block the user by completely crashing the GUI.

In order to try and get this balance we:

1. Avoid using `!` and send a `''` through to XAction instead. This means we deal with the error outside of XAction by deadling with the null/undefined access and replacing the outcome with a `''`.
2. Vue's router won't accept empty strings as a valid route parameter, so we watch for those parameters and `console.error` the errors instead of throwing. i.e. we want to see the errors, but we don't want to completely crash the GUI and block the user.
3. We provide a fallback for the user in the form of a dotted underlined piece of text with a native tooltip explanation rather than a link (the link would be wrong). This means if the user didn't even want to click the link but view something else on the page, they can still do so.

I'm still not totally sure I want to do this, but I'm 90% sure I do. But if we do then I want to make sure we still fail tests/report errors whilst not crashing the GUI. This is not a solution to fix flaky tests.

Right now, I doubt this fails tests so we'd hav to look at that - but I wanted to share and get feedback opinion on the approach, before finally deciding whether or not to do something like this at all.

---

Kinda unrelated, I spotted what I think is a Vue bug here with `attr`, if you undo the style changes I made here, then the policy type list styles aren't applied. Unless I missed where I've done something wrong with `attrs` it looks like scoped styling isn't being applied properly.

I noticed the other day that Vue natively supports CSS modules for CSS isolation so I tried that approach and it worked. Any feedback/opinion on the possible bug/CSS modules thing here would also be appreciated.





