### PR TITLE
refactor(control-planes): refactors cp-details to use DataLoader

### DIFF
--- a/features/main-overview/DetailViewContent.feature
+++ b/features/main-overview/DetailViewContent.feature
@@ -2,7 +2,6 @@ Feature: Overview: Detail view content
   Background:
     Given the CSS selectors
       | Alias                       | Selector                                    |
-      | details                     | [data-testid='detail-view-details']         |
       | zone-control-planes-details | [data-testid='zone-control-planes-details'] |
       | meshes-details              | [data-testid='meshes-details']              |
     And the URL "/mesh-insights" responds with
@@ -89,7 +88,6 @@ Feature: Overview: Detail view content
 
     When I visit the "/" URL
     Then the page title contains "Overview"
-    And the "$details" element exists
 
     And the "[data-testid='zone-control-planes-status']" element doesn't exist
     And the "[data-testid='meshes-status']" element contains "3"
@@ -161,7 +159,6 @@ Feature: Overview: Detail view content
     When I visit the "/" URL
 
     Then the page title contains "Overview"
-    And the "$details" element exists
 
     And the "[data-testid='zone-control-planes-status']" element contains "1/2"
     And the "[data-testid='meshes-status']" element contains "3"

--- a/src/app/application/components/data-source/DataLoader.vue
+++ b/src/app/application/components/data-source/DataLoader.vue
@@ -23,6 +23,12 @@
         </slot>
       </template>
       <slot
+        name="loadable"
+        :data="props.src !== '' ? allData[0] : undefined"
+        :error="props.src !== '' ? allErrors[0] : undefined"
+        :refresh="props.src !== '' ? refresh : () => {}"
+      />
+      <slot
         name="default"
         :data="props.src !== '' ? allData[0] : undefined"
         :error="props.src !== '' ? allErrors[0] : undefined"
@@ -46,7 +52,13 @@
     </template>
     <template v-else>
       <slot
-        v-if="props.loader"
+        name="loadable"
+        :data="props.src !== '' ? allData[0] : undefined"
+        :error="props.src !== '' ? allErrors[0] : undefined"
+        :refresh="props.src !== '' ? refresh : () => {}"
+      />
+      <slot
+        v-if="props.loader && typeof slots.loadable === 'undefined'"
         name="connecting"
         :data="props.src !== '' ? allData[0] : undefined"
         :error="props.src !== '' ? allErrors[0] : undefined"
@@ -65,7 +77,7 @@
   </DataSource>
 </template>
 <script lang="ts" setup>
-import { computed, ref } from 'vue'
+import { computed, ref, useSlots } from 'vue'
 
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import LoadingBlock from '@/app/common/LoadingBlock.vue'
@@ -81,6 +93,8 @@ const props = withDefaults(defineProps<{
   src: '',
   loader: true,
 })
+
+const slots = useSlots()
 
 const srcData = ref<any>(undefined)
 const srcError = ref<Error | undefined>(undefined)

--- a/src/app/meshes/data/index.ts
+++ b/src/app/meshes/data/index.ts
@@ -1,6 +1,6 @@
 import { getDataplaneStatusCounts } from '@/app/data-planes/data'
 import { getServiceTypeCount } from '@/app/services/data'
-import type { PaginatedApiListResponse } from '@/types/api.d'
+import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
 import type {
   Backend,
   MeshBackend,
@@ -61,12 +61,12 @@ export const MeshInsight = {
     }
   },
 
-  fromCollection(partialMeshInsights: PaginatedApiListResponse<PartialMeshInsight>): PaginatedApiListResponse<MeshInsight> {
+  fromCollection(collection: CollectionResponse<PartialMeshInsight>): CollectionResponse<MeshInsight> {
+    const items = Array.isArray(collection.items) ? collection.items.map(MeshInsight.fromObject) : []
     return {
-      ...partialMeshInsights,
-      items: Array.isArray(partialMeshInsights.items)
-        ? partialMeshInsights.items.map((partialMeshInsight) => MeshInsight.fromObject(partialMeshInsight))
-        : [],
+      ...collection,
+      items,
+      total: collection.total ?? items.length,
     }
   },
 }

--- a/src/app/zones/data/index.ts
+++ b/src/app/zones/data/index.ts
@@ -88,9 +88,11 @@ export const ZoneOverview = {
     }
   },
   fromCollection: (collection: CollectionResponse<PartialZoneOverview>): CollectionResponse<ZoneOverview> => {
+    const items = Array.isArray(collection.items) ? collection.items.map(ZoneOverview.fromObject) : []
     return {
       ...collection,
-      items: Array.isArray(collection.items) ? collection.items.map(ZoneOverview.fromObject) : [],
+      items,
+      total: collection.total ?? items.length,
     }
   },
 }


### PR DESCRIPTION
First stage refactor of the control-plane-detail page (usually our landing page) to use DataLoader/XAction and some of the newer patterns we have in the application:

1. Uses DataLoader instead of DataSource (I think there is a bit of extra detail i need to look into here that might produce a separate PR, I'll detail in that PR if so)
2. Uses XAction over RouterLink
3. Adds DataLoader#loadable slot. This state is `loading` and `loaded`. I'm thinking we can use this instead of the `loading=false` property on `DataLoader`. I'm pretty sure it will allow us to eventually avoid having to use `data!` sometimes, in that the default slot can export `T` and the loadable slot can export `T | undefined`, meaning in a large amount of cases when not using the loadable slot we can use `data` instead of `data!` (also related https://github.com/kumahq/kuma-gui/issues/2432)

There's more work to come here I think, but I'm going to try and use this view to do several under-the-hood upgrades. Just an extra reminder that there are some additional complications involving `ControlPlaneStatus` (ideally I would like have its KCard in the `*View.vue` but I don't think that is possible yet)

One thing I found is that I almost changed the lists back to use the loading spinner instead of the KTable skeletons by accident due to the component usage hiding what was going on. It's highly likely I'll delete the components used here seeing as they are just AppCollection wrappers. I would much rather it was clear what was happening all in one place and I'm pretty sure these components are not multi-use.