### PR TITLE
chore: update mockServiceWorker file

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.2.13'
+const PACKAGE_VERSION = '2.2.14'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()


### PR DESCRIPTION
This is an example for why it’s kind of annoying that Dependabot doesn’t "just" use `yarn install` (evidently) because its updates miss changed files like that.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
