### PR TITLE
ci: tweak Cypress error annotations

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -75,8 +75,8 @@ export default defineConfig({
           for (const test of results.tests.filter((test) => test.state === 'failed')) {
             if (test.displayError) {
               const trimmedMessage = test.displayError
-                .replace(/^Error: The following error originated from your application code, not from Cypress\..+/, '')
-                .replace(/^AssertionError: cypress-fail-on-console-error:/, '')
+                .replace(/^Error: The following error originated from your application code, not from Cypress.*\n/, '')
+                .replace(/^AssertionError: cypress-fail-on-console-error.*\n/, '')
                 .trim()
                 .replace(/^> /, '')
               const newLineIndex = trimmedMessage.indexOf('\n')


### PR DESCRIPTION
Small tweak to the regexps to properly handle the following error: https://github.com/kumahq/kuma-gui/actions/runs/8752366390/job/24019886566?pr=2402

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>
