### PR TITLE
chore: add build and install make commands

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[{Makefile,**.mk}]
+indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,5 @@ SHELL := /usr/bin/env bash
 
 ## make help: if you're aren't sure use `make help`
 include mk/help.mk
+include mk/install.mk
+include mk/build.mk

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -1,7 +1,7 @@
-.PHONY: build/sync
-build/sync:
-	make build
-
 .PHONY: build
 build:
 	yarn run build
+
+.PHONY: build/sync
+build/sync:
+	make build

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -1,3 +1,7 @@
+.PHONY: build/sync
+build/sync:
+	make build
+
 .PHONY: build
 build:
 	yarn run build

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -1,0 +1,3 @@
+.PHONY: build
+build:
+	yarn run build

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -1,0 +1,11 @@
+.PHONY: install
+install:
+	yarn install
+
+.PHONY: clean-install
+clean-install:
+	yarn install --frozen-lockfile
+
+.PHONY: clean
+clean: ## Delete all node_modules directories
+	find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -2,9 +2,17 @@
 install:
 	yarn install
 
+.PHONY: install/sync
+install/sync:
+	make install
+
 .PHONY: clean-install
 clean-install:
 	yarn install --frozen-lockfile
+
+.PHONY: clean-install/sync
+clean-install/sync:
+	make clean-install
 
 .PHONY: clean
 clean: ## Delete all node_modules directories


### PR DESCRIPTION
Add the commands `make install`, `make clean-install`, `make clean`, and `make build`. The main purpose of these commands is to provide a wrapper around the package manager-specific commands. This is needed for the create-gui-pr.yml workflow which currently runs `yarn run build`. Since release branches use the file from the `master` branch for this workflow (as it uses `workflow_dispatch`), they use `yarn run build`, too. If we switch to another package manager, create-gui-pr workflow runs triggered from release branches will start failing as they will then call, for example, `npm run build` while actually still using yarn. With the make commands, this can be solved.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>

Note: If we decide to merge this, I’ll back-port the Makefile setup to the 5 current release branches. Only then can create-gui-pr.yml be updated to use the make commands.