### PR TITLE
chore: backport syft config (release-2.6)

### DIFF
--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,2 @@
+select-catalogers:
+  - -go-module-binary-cataloger


### PR DESCRIPTION
Addressing the create-gui-pr workflow failing on account of the missing syft config yielding critical vulnerabilities in go which we decided to ignore.

Signed-off-by: Philipp Rudloff <philipp.rudloff@konghq.com>