### PR TITLE
chore(services): adds basic feature flagging for services

### DIFF
--- a/src/app/data-planes/index.ts
+++ b/src/app/data-planes/index.ts
@@ -1,9 +1,9 @@
 import { features } from './features'
+import { routes } from './routes'
 import { sources } from './sources'
 import { services as connections } from '@/app/connections'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
-export * from './routes'
 
 type Token = ReturnType<typeof token>
 
@@ -18,6 +18,14 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
       labels: [
         app.sources,
+      ],
+    }],
+    [token('data-planes.routes'), {
+      service: () => {
+        return [routes()]
+      },
+      labels: [
+        app.routes,
       ],
     }],
     [token('data-planes.features'), {

--- a/src/app/gateways/index.ts
+++ b/src/app/gateways/index.ts
@@ -1,3 +1,4 @@
+import { routes } from './routes'
 import { sources } from './sources'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
@@ -14,6 +15,14 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
       labels: [
         app.sources,
+      ],
+    }],
+    [token('gateway.routes'), {
+      service: () => {
+        return [routes()]
+      },
+      labels: [
+        app.routes,
       ],
     }],
   ]

--- a/src/app/policies/index.ts
+++ b/src/app/policies/index.ts
@@ -1,7 +1,7 @@
+import { routes } from './routes'
 import { sources } from './sources'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
-export * from './routes'
 
 type Token = ReturnType<typeof token>
 
@@ -14,6 +14,14 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
       labels: [
         app.sources,
+      ],
+    }],
+    [token('policies.routes'), {
+      service: () => {
+        return [routes()]
+      },
+      labels: [
+        app.routes,
       ],
     }],
   ]

--- a/src/app/services/features.ts
+++ b/src/app/services/features.ts
@@ -1,0 +1,8 @@
+import type { Features } from '@/app/application/services/can'
+export const features = (): Features => {
+  return {
+    'use meshservice': () => {
+      return false
+    },
+  }
+}

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -1,13 +1,15 @@
+import { features } from './features'
+import { routes } from './routes'
 import { sources } from './sources'
+import type { Can } from '@/app/application/services/can'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
-export * from './routes'
 
 type Token = ReturnType<typeof token>
 
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
-    [token('service.sources'), {
+    [token('services.sources'), {
       service: sources,
       arguments: [
         app.api,
@@ -16,5 +18,23 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         app.sources,
       ],
     }],
+    [token('services.routes'), {
+      service: (can: Can) => {
+        return [routes(can)]
+      },
+      arguments: [
+        app.can,
+      ],
+      labels: [
+        app.routes,
+      ],
+    }],
+    [token('services.features'), {
+      service: features,
+      labels: [
+        app.features,
+      ],
+    }],
+
   ]
 }

--- a/src/app/services/locales/en-us/index.yaml
+++ b/src/app/services/locales/en-us/index.yaml
@@ -10,6 +10,8 @@ services:
     items:
       title: Services
       navigation:
+        mesh-service-list-view: MeshService
+        mesh-external-service-list-view: MeshExternalService
         service-list-view: Internal
         external-service-list-view: External
   detail:

--- a/src/app/services/routes.ts
+++ b/src/app/services/routes.ts
@@ -1,6 +1,7 @@
+import type { Can } from '@/app/application/services/can'
 import type { RouteRecordRaw } from 'vue-router'
 
-export const routes = () => {
+export const routes = (can: Can) => {
   const item = (): RouteRecordRaw[] => {
     return [
       {
@@ -55,6 +56,20 @@ export const routes = () => {
           },
           component: () => import('@/app/services/views/ServiceListTabsView.vue'),
           children: [
+            ...(can('use meshservice')
+              ? [
+                {
+                  path: 'mesh-service',
+                  name: 'mesh-service-list-view',
+                  component: () => import('@/app/services/views/ServiceListView.vue'),
+                },
+                {
+                  path: 'mesh-external-service',
+                  name: 'mesh-external-service-list-view',
+                  component: () => import('@/app/services/views/ServiceListView.vue'),
+                },
+              ]
+              : []),
             {
               path: 'internal',
               name: 'service-list-view',

--- a/src/app/services/views/ServiceListTabsView.vue
+++ b/src/app/services/views/ServiceListTabsView.vue
@@ -9,7 +9,9 @@
     <AppView>
       <template #title>
         <h2>
-          <RouteTitle :title="t(`${route.active?.name === 'service-list-view' ? '' : 'external-'}services.routes.items.title`)" />
+          <RouteTitle
+            :title="t(`${route.active?.name === 'service-list-view' ? '' : 'external-'}services.routes.items.title`)"
+          />
         </h2>
       </template>
 


### PR DESCRIPTION
Adds basic feature flagging for the services module. Mostly prep for upcoming work.

---

There is a fair amount of re-plumbing here for the sub-routes of meshes. In order to plumb through `can` I noticed that the sub-routes for meshes still weren't really using our DI layer like other modules, so I changed this up for services so I could inject `can` through, and also changed the other mesh sub-routes to use the same approach as everywhere else.

I added some place holder routes in here, which in turn add new buttons to the service listing page sub-menu/LinkBox, but the feature is hardcoded to `false` so they don't show up as yet.