### PR TITLE
fix: Copy as K8s

### DIFF
--- a/src/app/common/code-block/ResourceCodeBlock.vue
+++ b/src/app/common/code-block/ResourceCodeBlock.vue
@@ -102,6 +102,7 @@ let promise = new Promise((resolve: Resolve, reject) => {
 
 const fetcher = async (_params?: SingleResourceParameters): Promise<Entity> => {
   try {
+    // yes, this is one of those places where `return await` is important
     return await promise
   } finally {
     promise = new Promise((resolve, reject) => {

--- a/src/app/common/code-block/ResourceCodeBlock.vue
+++ b/src/app/common/code-block/ResourceCodeBlock.vue
@@ -102,7 +102,7 @@ let promise = new Promise((resolve: Resolve, reject) => {
 
 const fetcher = async (_params?: SingleResourceParameters): Promise<Entity> => {
   try {
-    return promise
+    return await promise
   } finally {
     promise = new Promise((resolve, reject) => {
       copy.value = (cb) => cb(resolve, reject)


### PR DESCRIPTION
See https://github.com/kumahq/kuma-gui/pull/2374#discussion_r1560807919

Looks like this is one of those cases where we need to make sure we await for a promise and return its result rather than just return the promise to be awaited on elsewhere.

Probably why the original code was like:

https://github.com/kumahq/kuma-gui/blob/6c158bacad13f9562d9c31a300bd16008aaaa0a4/src/app/common/code-block/ResourceCodeBlock.vue#L101-L107

But we've lost that detail through lack some good comments and subsequent upgrades/refactors there. I'll probably either refactor this code slightly to make this clearer or add some clearer comments. Putting the PR up whilst I think about that a little.

As little sidenote: I really wanted to progress the dev time clipboard coping debug I added here https://github.com/kumahq/kuma-gui/pull/1981 into something we could also use for testing clipboard interactions. 

Unfortunately we removed the clipboard debugging here https://github.com/kumahq/kuma-gui/pull/2374, but this PR shows why it would be good to get that back in and then also progressed into something we can use for e2e tests.

Closes https://github.com/kumahq/kuma-gui/issues/2513