### PR TITLE
chore: add DataCollection#item, EmptyBlock:type

### DIFF
--- a/src/app/application/components/data-collection/DataCollection.vue
+++ b/src/app/application/components/data-collection/DataCollection.vue
@@ -1,55 +1,86 @@
 <template>
-  <slot
-    v-if="items.length === 0"
-    name="empty"
-    :items="items"
+  <template
+    v-if="slots.item"
   >
-    <EmptyBlock v-if="props.empty" />
-  </slot>
-  <slot
+    <template
+      v-for="item in [props.items.find(props.predicate)]"
+      :key="item"
+    >
+      <slot
+        v-if="item"
+        name="item"
+        :item="item as T"
+      />
+      <slot
+        v-else
+        name="empty"
+        :items="items"
+      >
+        <EmptyBlock
+          v-if="props.empty"
+          :type="props.type"
+        />
+      </slot>
+    </template>
+  </template>
+  <template
     v-else
-    name="default"
-    :items="paginated"
-  />
-
-  <slot
-    v-if="props.page !== 0 && items.length > 0"
-    name="pagination"
-    :items="paginated"
   >
-    <KPagination
-      :total-count="items.length"
-      :current-page="props.page"
-      :initial-page-size="props.pageSize"
-      :page-sizes="[15, 30, 50, 75, 100]"
-      @page-change="({ page }: PaginationChangeEvent) => {
-        emit('change', {
-          page,
-          pageSize: props.pageSize,
-        })
-      }"
+    <slot
+      v-if="items.length === 0"
+      name="empty"
+      :items="items"
+    >
+      <EmptyBlock
+        v-if="props.empty"
+        :type="props.type"
+      />
+    </slot>
+    <slot
+      v-else
+      name="default"
+      :items="paginated"
     />
-  </slot>
+
+    <slot
+      v-if="props.page !== 0 && items.length > 0"
+      name="pagination"
+      :items="paginated"
+    >
+      <KPagination
+        :total-count="items.length"
+        :current-page="props.page"
+        :initial-page-size="props.pageSize"
+        :page-sizes="[15, 30, 50, 75, 100]"
+        @page-change="({ page }: PaginationChangeEvent) => {
+          emit('change', {
+            page,
+            pageSize: props.pageSize,
+          })
+        }"
+      />
+    </slot>
+  </template>
 </template>
 <script lang="ts" generic="T" setup>
-import { computed } from 'vue'
+import { computed, useSlots } from 'vue'
 
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 type PaginationChangeEvent = {
   page: number
 }
 const props = withDefaults(defineProps<{
-  // type: string
+  type?: string
   paginationType?: 'server' | 'client'
   page?: number
   pageSize?: number
   items: T[]
   predicate?: (item: T) => boolean
   comparator?: ((a: T, b: T) => number) | undefined
-  find?: boolean
+  find?: boolean // deprecated: please use the `item` slot
   empty?: boolean
 }>(), {
-  // type: '',
+  type: '',
   paginationType: 'server',
   page: 0,
   pageSize: 50,
@@ -62,7 +93,11 @@ const emit = defineEmits<{
   (e: 'change', value: {page: number, pageSize: number}): void
   (e: 'error', error: Error): void
 }>()
+const slots = useSlots()
 const items = computed(() => {
+  if (slots.item) {
+    return props.items
+  }
   if (props.find) {
     const found = props.items.find(props.predicate)
     return typeof found === 'undefined' ? [] : [found]

--- a/src/app/application/services/i18n/I18n.ts
+++ b/src/app/application/services/i18n/I18n.ts
@@ -61,7 +61,7 @@ export default <T extends I18nRecord>(strs: T, env: Env['var']) => {
             // temporarily change any http.api terms to camelCase at runtime
             return camelCaseToWords((e as I18nError).key.split('.').pop()!)
           default:
-            if (rest[2]?.defaultMessage) {
+            if (typeof rest[2]?.defaultMessage === 'string') {
               return rest[2].defaultMessage
             }
 

--- a/src/app/common/EmptyBlock.vue
+++ b/src/app/common/EmptyBlock.vue
@@ -1,22 +1,73 @@
 <template>
-  <KEmptyState data-testid="empty-block">
-    <template #title>
-      <slot name="title">
-        {{ t('common.emptyState.title') }}
-      </slot>
-    </template>
-
-    <template v-if="$slots.default">
-      <slot />
-    </template>
-
+  <template
+    v-for="prefix in [props.type.length > 0 ? `${props.type}.` : 'components.']"
+    :key="prefix"
+  >
     <template
-      v-if="$slots.action"
-      #action
+      v-for="{title, body, href, actionLabel, actionType} in [
+        {
+          title: t(`${prefix}x-empty-state.title`, undefined, { defaultMessage: '' }),
+          body: t(`${prefix}x-empty-state.body`, undefined, { defaultMessage: '' }),
+          href: t(`${prefix}x-empty-state.action.href`, undefined, { defaultMessage: '' }),
+          actionLabel: t(`${prefix}x-empty-state.action.label`, undefined, { defaultMessage: '' }),
+          actionType: t(`${prefix}x-empty-state.action.type`, undefined, { defaultMessage: '' }),
+        },
+      ]"
+      :key="title"
     >
-      <slot name="action" />
+      <KEmptyState
+        data-testid="empty-block"
+      >
+        <template
+          #title
+        >
+          <slot
+            name="title"
+          >
+            <template
+              v-if="title.length > 0"
+            >
+              <header>
+                <!-- eslint-disable vue/no-v-text-v-html-on-component -->
+                <component
+                  :is="`h2`"
+                  v-html="title"
+                />
+                <!-- eslint-enable -->
+              </header>
+            </template>
+          </slot>
+        </template>
+
+        <template
+          v-if="$slots.default"
+        >
+          <slot name="default" />
+        </template>
+        <template
+          v-else-if="body.length > 0"
+        >
+          <div
+            v-html="body"
+          />
+        </template>
+
+        <template
+          v-if="$slots.action || href.length > 0"
+          #action
+        >
+          <slot name="action">
+            <XAction
+              :type="(['docs', 'create'] as const).find((item) => item === actionType)"
+              :href="href"
+            >
+              {{ actionLabel }}
+            </XAction>
+          </slot>
+        </template>
+      </KEmptyState>
     </template>
-  </KEmptyState>
+  </template>
 </template>
 
 <script lang="ts" setup>
@@ -25,4 +76,9 @@ import { KEmptyState } from '@kong/kongponents'
 import { useI18n } from '@/utilities'
 
 const { t } = useI18n()
+const props = withDefaults(defineProps<{
+  type: string
+}>(), {
+  type: '',
+})
 </script>

--- a/src/locales/en-us/components/index.yaml
+++ b/src/locales/en-us/components/index.yaml
@@ -6,3 +6,11 @@ components:
     tooltip:
       not_available: |
         The online or offline status of this entity is unknown
+  x-empty-state:
+    title: 'No data'
+    body: ''
+    action:
+      label: ''
+      href: ''
+
+


### PR DESCRIPTION
Adds an `item` slot to DataCollection, to be used instead of `:find="true"`

Previously when using `DataCollection:find="true"` you then also needed to do `items[0]` to always refer to the first and only item in the list. Now you can use the `#item="{ item }"` slot instead of `:find="true"`, eventually we can remove `:find` entirely.

---

Adds `EmptyBlock:type` and then uses that and makes use of `t` inside of a reusable component.

DataCollection also has `DataCollection:type` which is just passed through to `EmptyBlock`

There is a fair amount of decisions here based on supporting what we currently/used to have, whilst moving forwards with a different approach.

