### PR TITLE
fix(gateways): don't hardcode pagesize different to global default (#2541)

### DIFF
--- a/src/app/gateways/views/BuiltinGatewayListView.vue
+++ b/src/app/gateways/views/BuiltinGatewayListView.vue
@@ -9,7 +9,7 @@
       name="builtin-gateway-list-view"
       :params="{
         page: 1,
-        size: 10,
+        size: me.pageSize,
         mesh: '',
         gateway: '',
       }"


### PR DESCRIPTION
Backport of #2541 to `release-2.7`

---

We have a global value to use for our default page size:

https://github.com/kumahq/kuma-gui/blob/d6d20ac1f56975cbaf6b0f1a2207476867135ff3/src/app/me/sources.ts#L10-L12

We expose this via a `/me` DataSource on every listing page.

This PR uses this value for our default page size rather than a hardcoded value of `10`

Closes https://github.com/kumahq/kuma-gui/issues/2540

