### PR TITLE
chore: adds XSelect component

### DIFF
--- a/mk/run.mk
+++ b/mk/run.mk
@@ -1,9 +1,13 @@
 SCRIPT_RUNNER := npm run
 
-run/%: ## Dev: Run any package script using the form `run/name-of-script`
+run/%: ## Dev: Run any package script using the form `run/name-of-script`.
 	@$(SCRIPT_RUNNER) $*
 
 .PHONY: run
-run: install ## Dev: run local development instance of the GUI. If you are working on the GUI then you are probably looking for this
+run: install ## Dev: run local development instance of the GUI. If you are working on the GUI then you are probably looking for this.
 	@$(MAKE) run/dev
+
+.PHONY: run/docs
+run/docs: install ## Dev: run local instance of the GUI docs, either just for reference or contributing.
+	@$(MAKE) run/docs:dev
 

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -79,32 +79,31 @@
                   })"
                 />
 
-                <KSelect
-                  class="filter-select"
+                <XSelect
                   label="Type"
-                  :items="(['all', 'standard', 'builtin', 'delegated'] as const).map((value) => ({
-                    value,
-                    label: t(`data-planes.type.${value}`),
-                    selected: value === route.params.dataplaneType,
-                  }))"
-                  @selected="route.update({ dataplaneType: String($event.value) })"
+                  :selected="route.params.dataplaneType"
+                  @change="(value: string) => route.update({ dataplaneType: value })"
                 >
-                  <template #selected-item-template="{ item }">
+                  <template #selected="{ item }: { item: 'all' | 'standard' | 'builtin' | 'delegated'}">
                     <XIcon
-                      v-if="item && item.value !== 'all'"
+                      v-if="item !== 'all'"
                       :size="KUI_ICON_SIZE_40"
-                      :name="item.value as ('standard' | 'builtin' | 'delegated')"
+                      :name="item"
                     />
-                    {{ item?.label }}
+                    {{ t(`data-planes.type.${item}`) }}
                   </template>
-                  <template #item-template="{ item }">
+                  <template
+                    v-for="item in (['all', 'standard', 'builtin', 'delegated'] as const)"
+                    :key="item"
+                    #[`${item}-option`]
+                  >
                     <XIcon
-                      v-if="item.value !== 'all'"
-                      :name="item.value as ('standard' | 'builtin' | 'delegated')"
+                      v-if="item !== 'all'"
+                      :name="item"
                     />
-                    {{ item.label }}
+                    {{ t(`data-planes.type.${item}`) }}
                   </template>
-                </KSelect>
+                </XSelect>
               </template>
 
               <template #type="{ row: item }">
@@ -321,19 +320,6 @@ import type { MeSource } from '@/app/me/sources'
 .data-plane-proxy-filter {
   flex-basis: 310px;
   flex-grow: 1;
-}
-
-.filter-select {
-  flex-basis: 245px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: $kui-space-40;
-}
-
-.filter-select :deep(.k-label) {
-  // Removes the bottom margin as we’re aligning the label with the select in a horizontal layout.
-  margin-bottom: 0 !important;
 }
 
 .name-link {

--- a/src/app/x/components/x-breadcrumbs/XBreadcrumbs.vue
+++ b/src/app/x/components/x-breadcrumbs/XBreadcrumbs.vue
@@ -16,8 +16,9 @@
 </template>
 <script lang="ts" setup>
 import { KBreadcrumbs } from '@kong/kongponents'
-import type { BreadcrumbItem } from '@kong/kongponents'
 import { useSlots } from 'vue'
+
+import type { BreadcrumbItem } from '@kong/kongponents'
 
 const slots = useSlots()
 const props = defineProps<{

--- a/src/app/x/components/x-select/README.md
+++ b/src/app/x/components/x-select/README.md
@@ -1,0 +1,16 @@
+# x-select
+
+<Story>
+  <XSelect
+    :selected="`one`"
+  >
+    <template
+      v-for="{ value } in [{ value: 'one'}, {value: 'two'}]"
+      :key="value"
+      #[`${value}-option`]
+    >
+      {{ value }}
+    </template>
+  </XSelect>
+</Story>
+

--- a/src/app/x/components/x-select/XSelect.vue
+++ b/src/app/x/components/x-select/XSelect.vue
@@ -1,0 +1,83 @@
+<template>
+  <KSelect
+    :label="props.label"
+    :items="items"
+    @selected="emit('change', String($event.value))"
+  >
+    <template #selected-item-template="{ item }">
+      <slot
+        v-if="slots.selected"
+        :item="item!.value as any"
+        name="selected"
+      />
+      <slot
+        v-else
+        :item="item!.value as any"
+        :name="`${item?.value}-option`"
+      />
+    </template>
+    <template #item-template="{ item }">
+      <slot
+        :name="`${item.value}-option`"
+      />
+    </template>
+  </KSelect>
+</template>
+<script lang="ts" setup>
+import { computed, useSlots } from 'vue'
+
+const emit = defineEmits<{
+  (event: 'change', value: string): void
+}>()
+const props = withDefaults(defineProps<{
+  label?: string
+  selected?: string
+}>(), {
+  label: '',
+  selected: '',
+})
+
+const slots = useSlots()
+
+const items = computed(() => {
+  const items = Object.keys(slots).reduce<
+  {
+    value: string
+    label: string
+    selected: boolean
+  }[]
+  >((prev, key) => {
+    const pos = key.lastIndexOf('-option')
+    if (pos !== -1) {
+      const item = key.substring(0, pos)
+      prev.push(
+        {
+          value: item,
+          label: item,
+          selected: item === props.selected,
+        },
+      )
+    }
+    return prev
+  }, [])
+  if (items.find(item => item.selected) === undefined) {
+    items[0].selected = true
+  }
+  return items
+})
+
+</script>
+<style lang="scss" scoped>
+.k-select {
+  flex-basis: 245px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: $kui-space-40;
+}
+.k-select :deep(.k-label) {
+  // Removes the bottom margin as we’re aligning the label with the select in a horizontal layout.
+  margin-bottom: 0 !important;
+}
+
+</style>

--- a/src/app/x/index.ts
+++ b/src/app/x/index.ts
@@ -2,6 +2,7 @@ import XAction from './components/x-action/XAction.vue'
 import XBreadcrumbs from './components/x-breadcrumbs/XBreadcrumbs.vue'
 import XDisclosure from './components/x-disclosure/XDisclosure.vue'
 import XIcon from './components/x-icon/XIcon.vue'
+import XSelect from './components/x-select/XSelect.vue'
 import XInput from './components/x-input/XInput.vue'
 import XTabs from './components/x-tabs/XTabs.vue'
 import XTeleportSlot from './components/x-teleport/XTeleportSlot.vue'
@@ -17,6 +18,7 @@ declare module '@vue/runtime-core' {
     XInput: typeof XInput
     XAction: typeof XAction
     XBreadcrumbs: typeof XBreadcrumbs
+    XSelect: typeof XSelect
     XTabs: typeof XTabs
     XTeleportTemplate: typeof XTeleportTemplate
     XTeleportSlot: typeof XTeleportSlot
@@ -34,6 +36,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
             ['XBreadcrumbs', XBreadcrumbs],
             ['XIcon', XIcon],
             ['XInput', XInput],
+            ['XSelect', XSelect],
             ['XTabs', XTabs],
             ['XTeleportTemplate', XTeleportTemplate],
             ['XTeleportSlot', XTeleportSlot],


### PR DESCRIPTION
Adds an eXtra eXtension around KSelect to:

1. Use slots for adding `options` (to make it the same as XTabs)
2. Use `@change` for the event name (to make it the same as DataSource/Loader plus others)
3. Always have a horizontally aligned label (we never use the vertically aligned label and I doubt we ever will)
4. Automatically select the first option if no items are selected (or you specify an option that doesn't exist, such as by typing that into the URL)