### PR TITLE
feat(meshservice): add mesh service listing and summary panel

### DIFF
--- a/features/application/Titles.feature
+++ b/features/application/Titles.feature
@@ -39,6 +39,8 @@ Feature: application / titles
       | /meshes/default/services/external                       | External Services |
       | /meshes/default/services/external/service-name/overview | service-name      |
 
+      | /meshes/default/services/mesh-services                  | Mesh Services     |
+
       | /meshes/default/gateways/builtin                  | Built-in Gateways |
       | /meshes/default/gateways/builtin/gateway/overview | gateway           |
 

--- a/features/mesh/services/mesh-services/Index.feature
+++ b/features/mesh/services/mesh-services/Index.feature
@@ -1,0 +1,37 @@
+Feature: mesh / services / mesh-services / index
+  Background:
+    Given the CSS selectors
+      | Alias        | Selector                                  |
+      | items        | [data-testid='service-collection']        |
+      | item         | $items tbody tr                           |
+      | button-group | [data-testid='service-list-view-sub-tab'] |
+    And the environment
+      """
+      KUMA_SERVICE_COUNT: 1
+      """
+
+    Rule: In a namepaced environment
+      Background:
+        Given the environment
+          """
+          KUMA_ENVIRONMENT: kubernetes
+          """
+        And the URL "/meshes/default/meshservices" responds with
+          """
+          body:
+            items:
+            - name: monitor-proxy-0.kuma-demo
+              labels:
+                kuma.io/display-name: monitor-proxy-0
+                k8s.kuma.io/namespace: kuma-demo
+          """
+      Scenario Outline: clicking the row, opening and summary
+        When I visit the "<URL>" URL
+        Then the "$button-group" element exists
+        And I click the "$item a" element
+        Then the URL contains "monitor-proxy-0.kuma-demo"
+        And the URL doesn't contain "monitor-proxy-0.kuma-demo/overview"
+        Examples:
+          | URL                                    |
+          | /meshes/default/services/mesh-services |
+

--- a/src/app/external-services/views/ExternalServiceListView.vue
+++ b/src/app/external-services/views/ExternalServiceListView.vue
@@ -18,6 +18,17 @@
         :src="`/meshes/${route.params.mesh}/external-services?page=${route.params.page}&size=${route.params.size}`"
       >
         <AppView>
+          <template #title>
+            <XTeleportTemplate
+              :to="{ name: 'service-list-tabs-view-title'}"
+            >
+              <h2>
+                <RouteTitle
+                  :title="t(`external-services.routes.items.title`)"
+                />
+              </h2>
+            </XTeleportTemplate>
+          </template>
           <KCard>
             <ErrorBlock
               v-if="error !== undefined"

--- a/src/app/services/data/index.ts
+++ b/src/app/services/data/index.ts
@@ -1,5 +1,6 @@
 import type { PaginatedApiListResponse } from '@/types/api.d'
 import type {
+  MeshService as PartialMeshService,
   ExternalService as PartialExternalService,
   ServiceInsight as PartialServiceInsight,
   ServiceStatus as ServiceTypeCount,
@@ -7,6 +8,9 @@ import type {
 
 export type ExternalService = PartialExternalService & {
   config: PartialExternalService
+}
+export type MeshService = PartialMeshService & {
+  config: PartialMeshService
 }
 
 export type ServiceInsight = PartialServiceInsight & {
@@ -41,6 +45,23 @@ export const ServiceInsight = {
       items: Array.isArray(partialServiceInsights.items)
         ? partialServiceInsights.items.map((partialServiceInsight) => ServiceInsight.fromObject(partialServiceInsight))
         : [],
+    }
+  },
+}
+export const MeshService = {
+  fromObject(item: PartialMeshService): MeshService {
+    return {
+      ...item,
+      config: item,
+    }
+  },
+
+  fromCollection(collection: PaginatedApiListResponse<PartialMeshService>): PaginatedApiListResponse<MeshService> {
+    const items = Array.isArray(collection.items) ? collection.items.map(MeshService.fromObject) : []
+    return {
+      ...collection,
+      items,
+      total: collection.total ?? items.length,
     }
   },
 }

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -1,7 +1,6 @@
 import { features } from './features'
 import { routes } from './routes'
 import { sources } from './sources'
-import type { Can } from '@/app/application/services/can'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
 
@@ -19,12 +18,9 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
     }],
     [token('services.routes'), {
-      service: (can: Can) => {
-        return [routes(can)]
+      service: () => {
+        return [routes()]
       },
-      arguments: [
-        app.can,
-      ],
       labels: [
         app.routes,
       ],

--- a/src/app/services/locales/en-us/index.yaml
+++ b/src/app/services/locales/en-us/index.yaml
@@ -1,5 +1,9 @@
 services:
+  x-empty-state:
+    title: There are no Services present
   routes:
+    mesh-service-list-view:
+      title: Mesh Services
     item:
       title: "{name}"
       breadcrumbs: Services

--- a/src/app/services/routes.ts
+++ b/src/app/services/routes.ts
@@ -1,7 +1,6 @@
-import type { Can } from '@/app/application/services/can'
 import type { RouteRecordRaw } from 'vue-router'
 
-export const routes = (can: Can) => {
+export const routes = () => {
   const item = (): RouteRecordRaw[] => {
     return [
       {
@@ -56,20 +55,6 @@ export const routes = (can: Can) => {
           },
           component: () => import('@/app/services/views/ServiceListTabsView.vue'),
           children: [
-            ...(can('use meshservice')
-              ? [
-                {
-                  path: 'mesh-service',
-                  name: 'mesh-service-list-view',
-                  component: () => import('@/app/services/views/ServiceListView.vue'),
-                },
-                {
-                  path: 'mesh-external-service',
-                  name: 'mesh-external-service-list-view',
-                  component: () => import('@/app/services/views/ServiceListView.vue'),
-                },
-              ]
-              : []),
             {
               path: 'internal',
               name: 'service-list-view',
@@ -79,6 +64,18 @@ export const routes = (can: Can) => {
               path: 'external',
               name: 'external-service-list-view',
               component: () => import('@/app/external-services/views/ExternalServiceListView.vue'),
+            },
+            {
+              path: 'mesh-services',
+              name: 'mesh-service-list-view',
+              component: () => import('@/app/services/views/MeshServiceListView.vue'),
+              children: [
+                {
+                  path: ':service',
+                  name: 'mesh-service-summary-view',
+                  component: () => import('@/app/services/views/MeshServiceSummaryView.vue'),
+                },
+              ],
             },
           ],
         },

--- a/src/app/services/sources.ts
+++ b/src/app/services/sources.ts
@@ -1,4 +1,4 @@
-import { ExternalService, ServiceInsight } from './data'
+import { MeshService, ExternalService, ServiceInsight } from './data'
 import type { DataSourceResponse } from '@/app/application'
 import { defineSources } from '@/app/application/services/data-source'
 import type KumaApi from '@/services/kuma-api/KumaApi'
@@ -14,6 +14,27 @@ export type ExternalServiceSource = DataSourceResponse<ExternalService | null>
 
 export const sources = (api: KumaApi) => {
   return defineSources({
+    '/meshes/:mesh/mesh-services': async (params) => {
+      const { mesh, size } = params
+      const offset = params.size * (params.page - 1)
+
+      return MeshService.fromCollection(await api.getAllMeshServicesFromMesh({ mesh }, { size, offset }))
+    },
+
+    '/meshes/:mesh/mesh-service/:name': async (params) => {
+      const { mesh, name } = params
+
+      return MeshService.fromObject(await api.getMeshService({ mesh, name }))
+    },
+
+    '/meshes/:mesh/mesh-service/:name/as/kubernetes': async (params) => {
+      const { mesh, name } = params
+
+      return api.getMeshService({ mesh, name }, {
+        format: 'kubernetes',
+      })
+    },
+
     '/meshes/:mesh/service-insights/of/:serviceType': async (params) => {
       const { mesh, size, serviceType } = params
       const offset = params.size * (params.page - 1)

--- a/src/app/services/views/MeshServiceSummaryView.vue
+++ b/src/app/services/views/MeshServiceSummaryView.vue
@@ -1,0 +1,75 @@
+<template>
+  <RouteView
+    v-slot="{ route, t }"
+    name="mesh-service-summary-view"
+    :params="{
+      mesh: '',
+      service: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+    }"
+  >
+    <DataCollection
+      :items="props.items"
+      :predicate="item => item.name === route.params.service"
+    >
+      <template
+        #item="{ item }"
+      >
+        <AppView>
+          <template #title>
+            <h2>
+              <RouteTitle
+                :title="t('services.routes.item.title', { name: item.name })"
+              />
+            </h2>
+          </template>
+
+          <div
+            class="stack"
+          >
+            <div>
+              <h3>
+                {{ t('services.routes.item.config') }}
+              </h3>
+
+              <div class="mt-4">
+                <ResourceCodeBlock
+                  v-slot="{ copy, copying }"
+                  :resource="item.config"
+                  is-searchable
+                  :query="route.params.codeSearch"
+                  :is-filter-mode="route.params.codeFilter"
+                  :is-reg-exp-mode="route.params.codeRegExp"
+                  @query-change="route.update({ codeSearch: $event })"
+                  @filter-mode-change="route.update({ codeFilter: $event })"
+                  @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+                >
+                  <DataSource
+                    v-if="copying"
+                    :src="`/meshes/${route.params.mesh}/mesh-service/${route.params.service}/as/kubernetes?no-store`"
+                    @change="(data) => {
+                      copy((resolve) => resolve(data))
+                    }"
+                    @error="(e) => {
+                      copy((_resolve, reject) => reject(e))
+                    }"
+                  />
+                </ResourceCodeBlock>
+              </div>
+            </div>
+          </div>
+        </AppView>
+      </template>
+    </DataCollection>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import ResourceCodeBlock from '@/app/common/code-block/ResourceCodeBlock.vue'
+import { MeshService } from '@/app/services/data'
+const props = defineProps<{
+  items: MeshService[]
+}>()
+</script>

--- a/src/app/services/views/ServiceListTabsView.vue
+++ b/src/app/services/views/ServiceListTabsView.vue
@@ -8,11 +8,9 @@
   >
     <AppView>
       <template #title>
-        <h2>
-          <RouteTitle
-            :title="t(`${route.active?.name === 'service-list-view' ? '' : 'external-'}services.routes.items.title`)"
-          />
-        </h2>
+        <XTeleportSlot
+          name="service-list-tabs-view-title"
+        />
       </template>
 
       <template #actions>

--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -19,6 +19,7 @@ import type {
   MeshGateway,
   MeshGatewayDataplane,
   MeshInsight,
+  MeshService,
   PolicyDataplane,
   PolicyEntity,
   PolicyType,
@@ -171,6 +172,14 @@ export default class KumaApi extends Api {
    */
   getDataplaneData({ mesh, dppName, dataPath }: { mesh: string, dppName: string, dataPath: 'xds' | 'stats' | 'clusters' }, params?: any): Promise<string> {
     return this.client.get(`/meshes/${mesh}/dataplanes/${dppName}/${dataPath}`, { params })
+  }
+
+  getAllMeshServicesFromMesh({ mesh }: { mesh: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<MeshService>> {
+    return this.client.get(`/meshes/${mesh}/meshservices`, { params })
+  }
+
+  getMeshService({ mesh, name }: { mesh: string, name: string }, params?: SingleResourceParameters): Promise<MeshService> {
+    return this.client.get(`/meshes/${mesh}/meshservices/${name}`, { params })
   }
 
   getAllServiceInsights(params?: ServiceInsightsParameters): Promise<PaginatedApiListResponse<ServiceInsight>> {

--- a/src/test-support/mocks/fs.ts
+++ b/src/test-support/mocks/fs.ts
@@ -53,6 +53,8 @@ import _134 from './src/meshes/_/meshgateways/test-meshgateway/_'
 import _135 from './src/meshes/_/meshgateways/test-meshgateway/_rules'
 import _132 from './src/meshes/_/meshhttproutes'
 import _133 from './src/meshes/_/meshhttproutes/_'
+import _136 from './src/meshes/_/meshservices'
+import _137 from './src/meshes/_/meshservices/_'
 import _35 from './src/meshes/_/proxytemplates'
 import _36 from './src/meshes/_/proxytemplates/_'
 import _37 from './src/meshes/_/rate-limits'
@@ -152,6 +154,8 @@ export const fs: FS = {
   '/meshes/:mesh/meshgateways/:name': _34,
   '/meshes/:mesh/meshgateways/:name/_resources/dataplanes': _130,
   '/meshes/:mesh/meshgateways/:name/_rules': _131,
+  '/meshes/:mesh/meshservices': _136,
+  '/meshes/:mesh/meshservices/:name': _137,
   '/meshes/:mesh/meshhttproutes': _132,
   '/meshes/:mesh/meshhttproutes/:name': _133,
   '/meshes/:mesh/proxytemplates': _35,

--- a/src/test-support/mocks/src/meshes/_/meshservices.ts
+++ b/src/test-support/mocks/src/meshes/_/meshservices.ts
@@ -1,0 +1,46 @@
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+import type { MeshService } from '@/types/index.d'
+
+export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (req) => {
+  const query = req.url.searchParams
+
+  const mesh = req.params.mesh as string
+  const _name = query.get('name') ?? ''
+
+  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
+  const { offset, total, next, pageTotal } = pager(
+    env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 1, max: 120 })}`),
+    req,
+    `/meshes/${req.params.mesh}/meshservices`,
+  )
+
+  return {
+    headers: {},
+    body: {
+      total,
+      next,
+      items: Array.from({ length: pageTotal }).map((_, i) => {
+        const id = offset + i
+        const name = `${fake.hacker.noun()}`
+        const displayName = `${_name || name}-${id}`
+        const nspace = fake.k8s.namespace()
+
+        return {
+          type: 'MeshService',
+          mesh,
+          name: `${displayName}${k8s ? `.${nspace}` : ''}`,
+          creationTime: '2021-02-19T08:06:15.14624+01:00',
+          modificationTime: '2021-02-19T08:07:37.539229+01:00',
+          ...(k8s
+            ? {
+              labels: {
+                'kuma.io/display-name': displayName,
+                'k8s.kuma.io/namespace': nspace,
+              },
+            }
+            : {}),
+        } satisfies MeshService
+      }),
+    },
+  }
+}

--- a/src/test-support/mocks/src/meshes/_/meshservices/_.ts
+++ b/src/test-support/mocks/src/meshes/_/meshservices/_.ts
@@ -1,0 +1,36 @@
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+import type { MeshService } from '@/types/index.d'
+
+export default ({ env }: EndpointDependencies): MockResponder => (req) => {
+  const query = req.url.searchParams
+
+  const mesh = req.params.mesh as string
+  const name = req.params.name as string
+
+  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
+  const parts = String(name).split('.')
+  const displayName = parts.slice(0, -1).join('.')
+  const nspace = parts.pop()
+
+  return {
+    headers: {},
+    body: {
+      ...(query.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
+      type: 'MeshService',
+      mesh,
+      name,
+      creationTime: '2021-02-19T08:06:15.14624+01:00',
+      modificationTime: '2021-02-19T08:07:37.539229+01:00',
+      ...(k8s
+        ? {
+          labels: {
+            'kuma.io/display-name': displayName,
+            'k8s.kuma.io/namespace': nspace,
+          },
+        }
+        : {}),
+    } satisfies MeshService,
+  }
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -602,6 +602,14 @@ export interface ExternalService extends MeshEntity {
   }
   tags: ServiceTags
 }
+export interface MeshService extends MeshEntity {
+  type: 'MeshService'
+  labels?: {
+    'kuma.io/display-name'?: string
+    'k8s.kuma.io/namespace'?: string
+    [key: string]: string | undefined
+  }
+}
 
 export interface Zone {
   name: string


### PR DESCRIPTION
Adds minimal "List plus Summary" views for MeshService. Minimal meaning the list only has a `name`, clicking on which shows a summary containing only the YAML config (which has the same functionality as all our resource YAML views). The plan is to then iterate on this in further PRs.

Note: there is no feature flagging here, all users will see the new `MeshServices` button. Please shout if this isn't desired, there is the possibility of flagging based on the output of `/config` if we wanted to do that.

![Screenshot 2024-05-14 at 10 51 06](https://github.com/kumahq/kuma-gui/assets/554604/a0fdbb2c-8c2e-45a7-8246-2c89e47ab5e7)

![Screenshot 2024-05-14 at 10 51 22](https://github.com/kumahq/kuma-gui/assets/554604/366b4e79-3b21-4897-8002-05c03d500f01)

