### PR TITLE
feat(meshservice): add namespace column to listing

### DIFF
--- a/features/mesh/services/mesh-services/Index.feature
+++ b/features/mesh/services/mesh-services/Index.feature
@@ -10,7 +10,7 @@ Feature: mesh / services / mesh-services / index
       KUMA_SERVICE_COUNT: 1
       """
 
-    Rule: In a namespaced environment
+    Rule: In a namepaced environment
       Background:
         Given the environment
           """
@@ -29,8 +29,8 @@ Feature: mesh / services / mesh-services / index
         When I visit the "<URL>" URL
         Then the "$button-group" element exists
         And I click the "$item a" element
-        Then the URL contains "monitor-proxy-0"
-        And the URL doesn't contain "monitor-proxy-0/overview"
+        Then the URL contains "monitor-proxy-0.kuma-demo"
+        And the URL doesn't contain "monitor-proxy-0.kuma-demo/overview"
         Examples:
           | URL                                    |
           | /meshes/default/services/mesh-services |

--- a/features/mesh/services/mesh-services/Index.feature
+++ b/features/mesh/services/mesh-services/Index.feature
@@ -10,7 +10,7 @@ Feature: mesh / services / mesh-services / index
       KUMA_SERVICE_COUNT: 1
       """
 
-    Rule: In a namepaced environment
+    Rule: In a namespaced environment
       Background:
         Given the environment
           """
@@ -29,8 +29,8 @@ Feature: mesh / services / mesh-services / index
         When I visit the "<URL>" URL
         Then the "$button-group" element exists
         And I click the "$item a" element
-        Then the URL contains "monitor-proxy-0.kuma-demo"
-        And the URL doesn't contain "monitor-proxy-0.kuma-demo/overview"
+        Then the URL contains "monitor-proxy-0"
+        And the URL doesn't contain "monitor-proxy-0/overview"
         Examples:
           | URL                                    |
           | /meshes/default/services/mesh-services |

--- a/features/mesh/services/mesh-services/Index.feature
+++ b/features/mesh/services/mesh-services/Index.feature
@@ -10,7 +10,7 @@ Feature: mesh / services / mesh-services / index
       KUMA_SERVICE_COUNT: 1
       """
 
-    Rule: In a namepaced environment
+    Rule: In a namespaced environment
       Background:
         Given the environment
           """

--- a/src/app/services/data/index.ts
+++ b/src/app/services/data/index.ts
@@ -11,6 +11,7 @@ export type ExternalService = PartialExternalService & {
 }
 export type MeshService = PartialMeshService & {
   config: PartialMeshService
+  namespace: string
 }
 
 export type ServiceInsight = PartialServiceInsight & {
@@ -50,9 +51,15 @@ export const ServiceInsight = {
 }
 export const MeshService = {
   fromObject(item: PartialMeshService): MeshService {
+    const labels = item.labels ?? {}
+    const name = labels['kuma.io/display-name'] ?? item.name
+    const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+
     return {
       ...item,
       config: item,
+      name,
+      namespace,
     }
   },
 

--- a/src/app/services/data/index.ts
+++ b/src/app/services/data/index.ts
@@ -10,6 +10,7 @@ export type ExternalService = PartialExternalService & {
   config: PartialExternalService
 }
 export type MeshService = PartialMeshService & {
+  id: string
   config: PartialMeshService
   namespace: string
 }
@@ -57,6 +58,7 @@ export const MeshService = {
 
     return {
       ...item,
+      id: item.name,
       config: item,
       name,
       namespace,

--- a/src/app/services/views/MeshServiceListView.vue
+++ b/src/app/services/views/MeshServiceListView.vue
@@ -46,6 +46,7 @@
                   data-testid="service-collection"
                   :headers="[
                     { label: 'Name', key: 'name' },
+                    { label: 'Namespace', key: 'namespace' },
                   ]"
                   :page-number="route.params.page"
                   :page-size="route.params.size"

--- a/src/app/services/views/MeshServiceListView.vue
+++ b/src/app/services/views/MeshServiceListView.vue
@@ -64,7 +64,7 @@
                           name: 'mesh-service-summary-view',
                           params: {
                             mesh: item.mesh,
-                            service: item.name,
+                            service: item.id,
                           },
                           query: {
                             page: route.params.page,

--- a/src/app/services/views/MeshServiceSummaryView.vue
+++ b/src/app/services/views/MeshServiceSummaryView.vue
@@ -12,7 +12,7 @@
   >
     <DataCollection
       :items="props.items"
-      :predicate="item => item.name === route.params.service"
+      :predicate="item => item.id === route.params.service"
     >
       <template
         #item="{ item }"


### PR DESCRIPTION
This change splits the name in the `MeshService` listing into the `name` and the `namespace`. A new column is introduced for the `namespace`.

Closes #2560 
