### PR TITLE
chore(deps): upgrade kongponents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@kong-ui-public/i18n": "^2.1.5",
         "@kong/icons": "^1.9.1",
-        "@kong/kongponents": "9.0.0-alpha.154",
+        "@kong/kongponents": "9.0.0-alpha.156",
         "@vueuse/core": "^10.9.0",
         "brandi": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -4416,9 +4416,9 @@
       }
     },
     "node_modules/@kong/kongponents": {
-      "version": "9.0.0-alpha.154",
-      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-9.0.0-alpha.154.tgz",
-      "integrity": "sha512-yz1Cw4NdXhq26NtWHKGPpTy2nFX0dRhZP7RbgjpP/ETMBYDYMFF/KvQvtQzBtm3Q/P/1jFPDKH6UzbMxuJ2E8w==",
+      "version": "9.0.0-alpha.156",
+      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-9.0.0-alpha.156.tgz",
+      "integrity": "sha512-AXBmo63qgfwtFe+xdcNdEkfyXJrH5y91yjgR3EE9EDXpTw4f2WfaFh80kbwaQVs1pkUeKcKwzDw8KFu2EGjCkQ==",
       "dependencies": {
         "@kong/icons": "^1.9.1",
         "@popperjs/core": "^2.11.8",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@kong-ui-public/i18n": "^2.1.5",
     "@kong/icons": "^1.9.1",
-    "@kong/kongponents": "9.0.0-alpha.154",
+    "@kong/kongponents": "9.0.0-alpha.156",
     "@vueuse/core": "^10.9.0",
     "brandi": "^5.0.0",
     "deepmerge": "^4.3.1",


### PR DESCRIPTION
Upgrades kongponents to the latest alpha version

Ideally https://github.com/kumahq/kuma-gui/pull/2559 would go in first, but since the thing that https://github.com/kumahq/kuma-gui/pull/2559 fixes didn't work anyway, it kinda doesn't matter which order they go in.