### PR TITLE
feat(meshservice): adds MeshService detail page

### DIFF
--- a/features/mesh/services/mesh-services/Index.feature
+++ b/features/mesh/services/mesh-services/Index.feature
@@ -1,10 +1,12 @@
 Feature: mesh / services / mesh-services / index
   Background:
     Given the CSS selectors
-      | Alias        | Selector                                  |
-      | items        | [data-testid='service-collection']        |
-      | item         | $items tbody tr                           |
-      | button-group | [data-testid='service-list-view-sub-tab'] |
+      | Alias         | Selector                                  |
+      | items         | [data-testid='service-collection']        |
+      | item          | $items tbody tr                           |
+      | button-group  | [data-testid='service-list-view-sub-tab'] |
+      | summary-title | [data-testid='slideout-title'] a          |
+      | detail-link   | $item [data-testid='details-link']        |
     And the environment
       """
       KUMA_SERVICE_COUNT: 1
@@ -25,12 +27,24 @@ Feature: mesh / services / mesh-services / index
                 kuma.io/display-name: monitor-proxy-0
                 k8s.kuma.io/namespace: kuma-demo
           """
-      Scenario Outline: clicking the row, opening and summary
+      Scenario Outline: clicking the detail link
+        When I visit the "<URL>" URL
+        And I click the "$detail-link" element
+        Then the URL contains "monitor-proxy-0.kuma-demo/overview"
+        And the "[data-testid='mesh-service-detail-view']" element exists
+        Examples:
+          | URL                                    |
+          | /meshes/default/services/mesh-services |
+
+      Scenario Outline: clicking the row, opening the summary, and clicking the title
         When I visit the "<URL>" URL
         Then the "$button-group" element exists
-        And I click the "$item a" element
+        And I click the "$item a[data-action]" element
         Then the URL contains "monitor-proxy-0.kuma-demo"
         And the URL doesn't contain "monitor-proxy-0.kuma-demo/overview"
+        Then I click the "$summary-title" element
+        Then the URL contains "monitor-proxy-0.kuma-demo/overview"
+        And the "[data-testid='mesh-service-detail-view']" element exists
         Examples:
           | URL                                    |
           | /meshes/default/services/mesh-services |

--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -119,7 +119,24 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
       }), can('use zones'))
     },
 
-    '/meshes/:mesh/dataplanes/for/:service': async (params) => {
+    '/meshes/:mesh/dataplanes/for/mesh-service/:tags': async (params) => {
+      const { mesh, size } = params
+      const offset = size * (params.page - 1)
+      const filterParams = DataplaneOverview.search(params.search)
+
+      if (typeof filterParams.tag === 'undefined') {
+        filterParams.tag = []
+      }
+      filterParams.tag = filterParams.tag.concat(Object.entries(JSON.parse(params.tags)).map(([key, value]) => `${key}:${value}`))
+
+      return DataplaneOverview.fromCollection(await api.getAllDataplaneOverviewsFromMesh({ mesh }, {
+        ...filterParams,
+        offset,
+        size,
+      }), can('use zones'))
+    },
+
+    '/meshes/:mesh/dataplanes/for/service-insight/:service': async (params) => {
       const { mesh, size } = params
       const offset = size * (params.page - 1)
 

--- a/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -26,7 +26,7 @@
             <KCard>
               <DataLoader
                 v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
-                :src="meshGateway === undefined ? '' : `/meshes/${route.params.mesh}/dataplanes/for/${meshGateway.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
+                :src="meshGateway === undefined ? '' : `/meshes/${route.params.mesh}/dataplanes/for/service-insight/${meshGateway.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
                 :data="[meshGateway]"
                 :errors="[error]"
                 :loader="false"

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -69,7 +69,7 @@
             <KCard class="mt-4">
               <DataLoader
                 v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
-                :src="`/meshes/${route.params.mesh}/dataplanes/for/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
+                :src="`/meshes/${route.params.mesh}/dataplanes/for/service-insight/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
                 :loader="false"
               >
                 <AppCollection

--- a/src/app/services/data/index.ts
+++ b/src/app/services/data/index.ts
@@ -13,6 +13,12 @@ export type MeshService = PartialMeshService & {
   id: string
   config: PartialMeshService
   namespace: string
+  spec: {
+    ports: NonNullable<PartialMeshService['spec']['ports']>
+    selector: {
+      dataplaneTags: Record<string, string>
+    }
+  }
 }
 
 export type ServiceInsight = PartialServiceInsight & {
@@ -55,13 +61,20 @@ export const MeshService = {
     const labels = item.labels ?? {}
     const name = labels['kuma.io/display-name'] ?? item.name
     const namespace = labels['k8s.kuma.io/namespace'] ?? ''
-
     return {
       ...item,
       id: item.name,
       config: item,
       name,
       namespace,
+      spec: ((spec = {}) => {
+        return {
+          ports: Array.isArray(spec.ports) ? spec.ports : [],
+          selector: {
+            dataplaneTags: Object.keys(spec.selector?.dataplaneTags ?? {}).length > 0 ? spec.selector?.dataplaneTags ?? {} : {},
+          },
+        }
+      })(item.spec),
     }
   },
 

--- a/src/app/services/locales/en-us/index.yaml
+++ b/src/app/services/locales/en-us/index.yaml
@@ -9,6 +9,8 @@ services:
       breadcrumbs: Services
       navigation:
         service-detail-view: 'Overview'
+        mesh-service-detail-view: 'Overview'
+        mesh-service-config-view: 'YAML'
       overview: 'Overview'
       config: 'YAML'
     items:

--- a/src/app/services/routes.ts
+++ b/src/app/services/routes.ts
@@ -39,6 +39,35 @@ export const routes = (can: Can) => {
               },
             ],
           },
+          ...(can('use meshservice')
+            ? [
+              {
+                path: 'mesh-services/:service',
+                name: 'mesh-service-detail-tabs-view',
+                component: () => import('@/app/services/views/MeshServiceDetailTabsView.vue'),
+                children: [
+                  {
+                    path: 'overview',
+                    name: 'mesh-service-detail-view',
+                    component: () => import('@/app/services/views/MeshServiceDetailView.vue'),
+                    children: [
+                      {
+                        path: ':dataPlane',
+                        name: 'mesh-service-data-plane-summary-view',
+                        component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
+                      },
+                    ],
+                  },
+                  {
+                    path: 'config',
+                    name: 'mesh-service-config-view',
+                    component: () => import('@/app/services/views/MeshServiceConfigView.vue'),
+                  },
+                ],
+              },
+            ]
+            : []),
+
         ],
       },
     ]

--- a/src/app/services/views/MeshServiceConfigView.vue
+++ b/src/app/services/views/MeshServiceConfigView.vue
@@ -1,0 +1,54 @@
+<template>
+  <RouteView
+    v-slot="{ route, t }"
+    name="mesh-service-config-view"
+    :params="{
+      mesh: '',
+      service: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+    }"
+  >
+    <AppView>
+      <template #title>
+        <h2>
+          {{ t('services.routes.item.navigation.mesh-service-config-view') }}
+        </h2>
+      </template>
+
+      <KCard>
+        <ResourceCodeBlock
+          v-slot="{ copy, copying }"
+          :resource="props.data.config"
+          is-searchable
+          :query="route.params.codeSearch"
+          :is-filter-mode="route.params.codeFilter"
+          :is-reg-exp-mode="route.params.codeRegExp"
+          @query-change="route.update({ codeSearch: $event })"
+          @filter-mode-change="route.update({ codeFilter: $event })"
+          @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+        >
+          <DataSource
+            v-if="copying"
+            :src="`/meshes/${props.data.mesh}/mesh-service/${props.data.id}/as/kubernetes?no-store`"
+            @change="(data) => {
+              copy((resolve) => resolve(data))
+            }"
+            @error="(e) => {
+              copy((_resolve, reject) => reject(e))
+            }"
+          />
+        </ResourceCodeBlock>
+      </KCard>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import type { MeshService } from '../data'
+import ResourceCodeBlock from '@/app/common/code-block/ResourceCodeBlock.vue'
+const props = defineProps<{
+  data: MeshService
+}>()
+</script>

--- a/src/app/services/views/MeshServiceDetailTabsView.vue
+++ b/src/app/services/views/MeshServiceDetailTabsView.vue
@@ -53,7 +53,7 @@
           :errors="[error]"
         >
           <XTabs
-            :selected="route.active?.name"
+            :selected="route.child()?.name"
           >
             <template
               v-for="{ name } in route.children"

--- a/src/app/services/views/MeshServiceDetailTabsView.vue
+++ b/src/app/services/views/MeshServiceDetailTabsView.vue
@@ -1,0 +1,88 @@
+<template>
+  <RouteView
+    v-slot="{ route, t, uri }"
+    name="mesh-service-detail-tabs-view"
+    :params="{
+      mesh: '',
+      service: '',
+    }"
+  >
+    <DataSource
+      v-slot="{ data, error }"
+      :src="uri(sources, '/meshes/:mesh/mesh-service/:name', {
+        mesh: route.params.mesh,
+        name: route.params.service,
+      })"
+    >
+      <AppView
+        :breadcrumbs="[
+          {
+            to: {
+              name: 'mesh-detail-view',
+              params: {
+                mesh: route.params.mesh,
+              },
+            },
+            text: route.params.mesh,
+          },
+          {
+            to: {
+              name: 'mesh-service-list-view',
+              params: {
+                mesh: route.params.mesh,
+              },
+            },
+            text: t('services.routes.mesh-service-list-view.title'),
+          },
+        ]"
+      >
+        <template #title>
+          <h1
+            v-if="data"
+          >
+            <TextWithCopyButton :text="route.params.service">
+              <RouteTitle
+                :title="t('services.routes.item.title', { name: data.name })"
+              />
+            </TextWithCopyButton>
+          </h1>
+        </template>
+
+        <DataLoader
+          :data="[data]"
+          :errors="[error]"
+        >
+          <XTabs
+            :selected="route.active?.name"
+          >
+            <template
+              v-for="{ name } in route.children"
+              :key="name"
+              #[`${name}-tab`]
+            >
+              <XAction
+                :to="{ name }"
+              >
+                {{ t(`services.routes.item.navigation.${name}`) }}
+              </XAction>
+            </template>
+          </XTabs>
+
+          <RouterView
+            v-slot="child"
+          >
+            <component
+              :is="child.Component"
+              :data="data"
+            />
+          </RouterView>
+        </DataLoader>
+      </AppView>
+    </DataSource>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import { sources } from '../sources'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+</script>

--- a/src/app/services/views/MeshServiceDetailView.vue
+++ b/src/app/services/views/MeshServiceDetailView.vue
@@ -77,9 +77,9 @@
               class="mt-4"
             >
               <DataLoader
-                :src="uri(sources, '/meshes/:mesh/dataplanes/for/:service', {
+                :src="uri(sources, '/meshes/:mesh/dataplanes/for/mesh-service/:tags', {
                   mesh: route.params.mesh,
-                  service: props.data.name,
+                  tags: JSON.stringify(props.data.spec.selector.dataplaneTags),
                 }, {
                   page: route.params.page,
                   size: route.params.size,

--- a/src/app/services/views/MeshServiceDetailView.vue
+++ b/src/app/services/views/MeshServiceDetailView.vue
@@ -25,6 +25,27 @@
         >
           <KCard>
             <div class="columns">
+              <DefinitionCard
+                v-if="data.status.addresses.length > 0"
+              >
+                <template
+                  #title
+                >
+                  Addresses
+                </template>
+                <template
+                  #body
+                >
+                  <KTruncate>
+                    <span
+                      v-for="address in data.status.addresses"
+                      :key="address.hostname"
+                    >
+                      {{ address.hostname }}
+                    </span>
+                  </KTruncate>
+                </template>
+              </DefinitionCard>
               <DefinitionCard>
                 <template
                   #title
@@ -62,6 +83,28 @@
                     >
                       {{ key }}:{{ value }}
                     </KBadge>
+                  </KTruncate>
+                </template>
+              </DefinitionCard>
+              <DefinitionCard
+                v-if="data.status.vips.length > 0"
+                class="ip"
+              >
+                <template
+                  #title
+                >
+                  VIPs
+                </template>
+                <template
+                  #body
+                >
+                  <KTruncate>
+                    <span
+                      v-for="address in data.status.vips"
+                      :key="address.ip"
+                    >
+                      {{ address.ip }}
+                    </span>
                   </KTruncate>
                 </template>
               </DefinitionCard>
@@ -280,6 +323,9 @@ const props = defineProps<{
 </script>
 
 <style lang="scss" scoped>
+.ip span {
+  font-size: $kui-font-size-30;
+}
 .data-plane-proxy-filter {
   flex-basis: 350px;
   flex-grow: 1;

--- a/src/app/services/views/MeshServiceDetailView.vue
+++ b/src/app/services/views/MeshServiceDetailView.vue
@@ -1,0 +1,306 @@
+<template>
+  <DataSource
+    v-slot="{ data: me }: MeSource"
+    src="/me"
+  >
+    <RouteView
+      v-if="me"
+      v-slot="{ can, route, t, uri }"
+      name="mesh-service-detail-view"
+      :params="{
+        mesh: '',
+        service: '',
+        page: 1,
+        size: me.pageSize,
+        s: '',
+        dataPlane: '',
+        codeSearch: '',
+        codeFilter: false,
+        codeRegExp: false,
+      }"
+    >
+      <AppView>
+        <div
+          class="stack"
+        >
+          <KCard>
+            <div class="columns">
+              <DefinitionCard>
+                <template
+                  #title
+                >
+                  Ports
+                </template>
+                <template
+                  #body
+                >
+                  <KTruncate>
+                    <KBadge
+                      v-for="connection in data.spec.ports"
+                      :key="connection.port"
+                      appearance="info"
+                    >
+                      {{ connection.port }}:{{ connection.targetPort }}/{{ connection.protocol }}
+                    </KBadge>
+                  </KTruncate>
+                </template>
+              </DefinitionCard>
+              <DefinitionCard>
+                <template
+                  #title
+                >
+                  Dataplane Tags
+                </template>
+                <template
+                  #body
+                >
+                  <KTruncate>
+                    <KBadge
+                      v-for="(value, key) in data.spec.selector.dataplaneTags"
+                      :key="`${key}:${value}`"
+                      appearance="info"
+                    >
+                      {{ key }}:{{ value }}
+                    </KBadge>
+                  </KTruncate>
+                </template>
+              </DefinitionCard>
+            </div>
+          </KCard>
+
+          <div>
+            <h3>
+              {{ t('services.detail.data_plane_proxies') }}
+            </h3>
+
+            <KCard
+              class="mt-4"
+            >
+              <DataLoader
+                :src="uri(sources, '/meshes/:mesh/dataplanes/for/:service', {
+                  mesh: route.params.mesh,
+                  service: props.data.name,
+                }, {
+                  page: route.params.page,
+                  size: route.params.size,
+                  search: route.params.s,
+                })"
+              >
+                <template
+                  #loadable="{ data: dataplanes }"
+                >
+                  <AppCollection
+                    class="data-plane-collection"
+                    data-testid="data-plane-collection"
+                    :page-number="route.params.page"
+                    :page-size="route.params.size"
+                    :headers="[
+                      { label: 'Name', key: 'name' },
+                      { label: 'Namespace', key: 'namespace' },
+                      ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
+                      { label: 'Certificate Info', key: 'certificate' },
+                      { label: 'Status', key: 'status' },
+                      { label: 'Warnings', key: 'warnings', hideLabel: true },
+                      { label: 'Details', key: 'details', hideLabel: true },
+                    ]"
+                    :items="dataplanes?.items"
+                    :total="dataplanes?.total"
+                    :is-selected-row="(row) => row.name === route.params.dataPlane"
+                    summary-route-name="service-data-plane-summary-view"
+                    :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
+                    :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
+                    :empty-state-cta-text="t('common.documentation')"
+                    @change="route.update"
+                  >
+                    <template #toolbar>
+                      <FilterBar
+                        class="data-plane-proxy-filter"
+                        :placeholder="`name:dataplane-name`"
+                        :query="route.params.s"
+                        :fields="{
+                          name: { description: 'filter by name or parts of a name' },
+                          protocol: { description: 'filter by “kuma.io/protocol” value' },
+                          tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                          ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+                        }"
+                        @change="(e) => route.update({
+                          ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                        })"
+                      />
+                    </template>
+
+                    <template #name="{ row: item }">
+                      <RouterLink
+                        class="name-link"
+                        :to="{
+                          name: 'mesh-service-data-plane-summary-view',
+                          params: {
+                            mesh: item.mesh,
+                            dataPlane: item.id,
+                          },
+                          query: {
+                            page: route.params.page,
+                            size: route.params.size,
+                            s: route.params.s,
+                          },
+                        }"
+                      >
+                        {{ item.name }}
+                      </RouterLink>
+                    </template>
+
+                    <template #namespace="{ row: item }">
+                      {{ item.namespace }}
+                    </template>
+
+                    <template #zone="{ row }">
+                      <RouterLink
+                        v-if="row.zone"
+                        :to="{
+                          name: 'zone-cp-detail-view',
+                          params: {
+                            zone: row.zone,
+                          },
+                        }"
+                      >
+                        {{ row.zone }}
+                      </RouterLink>
+
+                      <template v-else>
+                        {{ t('common.collection.none') }}
+                      </template>
+                    </template>
+
+                    <template #certificate="{ row }">
+                      <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                        {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                      </template>
+
+                      <template v-else>
+                        {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                      </template>
+                    </template>
+
+                    <template #status="{ row }">
+                      <StatusBadge :status="row.status" />
+                    </template>
+
+                    <template #warnings="{ row }">
+                      <XIcon
+                        v-if="row.isCertExpired || row.warnings.length > 0"
+                        class="mr-1"
+                        name="warning"
+                      >
+                        <ul>
+                          <template v-if="row.warnings.length > 0">
+                            <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+                          </template>
+
+                          <template v-if="row.isCertExpired">
+                            <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
+                          </template>
+                        </ul>
+                      </XIcon>
+
+                      <template v-else>
+                        {{ t('common.collection.none') }}
+                      </template>
+                    </template>
+
+                    <template #details="{ row: item }">
+                      <RouterLink
+                        class="details-link"
+                        data-testid="details-link"
+                        :to="{
+                          name: 'data-plane-detail-view',
+                          params: {
+                            dataPlane: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.details_link') }}
+
+                        <ArrowRightIcon
+                          decorative
+                          :size="KUI_ICON_SIZE_30"
+                        />
+                      </RouterLink>
+                    </template>
+                  </AppCollection>
+                  <RouterView
+                    v-if="route.params.dataPlane"
+                    v-slot="child"
+                  >
+                    <SummaryView
+                      @close="route.replace({
+                        name: route.name,
+                        params: {
+                          mesh: route.params.mesh,
+                        },
+                        query: {
+                          page: route.params.page,
+                          size: route.params.size,
+                          s: route.params.s,
+                        },
+                      })"
+                    >
+                      <component
+                        :is="child.Component"
+                        v-if="typeof dataplanes !== 'undefined'"
+                        :items="dataplanes.items"
+                      />
+                    </SummaryView>
+                  </RouterView>
+                </template>
+              </DataLoader>
+            </KCard>
+          </div>
+        </div>
+      </AppView>
+    </RouteView>
+  </DataSource>
+</template>
+
+<script lang="ts" setup>
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { ArrowRightIcon } from '@kong/icons'
+
+import type { MeshService } from '../data'
+import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
+import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
+import StatusBadge from '@/app/common/StatusBadge.vue'
+import SummaryView from '@/app/common/SummaryView.vue'
+import { sources } from '@/app/data-planes/sources'
+import type { MeSource } from '@/app/me/sources'
+
+const props = defineProps<{
+  data: MeshService
+}>()
+</script>
+
+<style lang="scss" scoped>
+.data-plane-proxy-filter {
+  flex-basis: 350px;
+  flex-grow: 1;
+}
+
+.name-link {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.details-link {
+  display: inline-flex;
+  align-items: center;
+  gap: $kui-space-20;
+}
+
+.data-plane-collection :deep(.name-column) {
+  max-width: 400px;
+}
+</style>

--- a/src/app/services/views/MeshServiceListView.vue
+++ b/src/app/services/views/MeshServiceListView.vue
@@ -47,6 +47,9 @@
                   :headers="[
                     { label: 'Name', key: 'name' },
                     { label: 'Namespace', key: 'namespace' },
+                    { label: 'Ports', key: 'ports' },
+                    { label: 'Tags', key: 'tags' },
+                    { label: 'Details', key: 'details', hideLabel: true },
                   ]"
                   :page-number="route.params.page"
                   :page-size="route.params.size"
@@ -60,6 +63,7 @@
                       :text="item.name"
                     >
                       <XAction
+                        data-action
                         :to="{
                           name: 'mesh-service-summary-view',
                           params: {
@@ -75,6 +79,52 @@
                         {{ item.name }}
                       </XAction>
                     </TextWithCopyButton>
+                  </template>
+                  <template
+                    #ports="{ row: item }"
+                  >
+                    <KTruncate>
+                      <KBadge
+                        v-for="connection in item.spec.ports"
+                        :key="connection.port"
+                        appearance="info"
+                      >
+                        {{ connection.port }}:{{ connection.targetPort }}/{{ connection.protocol }}
+                      </KBadge>
+                    </KTruncate>
+                  </template>
+                  <template
+                    #tags="{ row: item }"
+                  >
+                    <KTruncate>
+                      <KBadge
+                        v-for="(value, key) in item.spec.selector.dataplaneTags"
+                        :key="`${key}:${value}`"
+                        appearance="info"
+                      >
+                        {{ key }}:{{ value }}
+                      </KBadge>
+                    </KTruncate>
+                  </template>
+                  <template #details="{ row: item }">
+                    <XAction
+                      class="details-link"
+                      data-testid="details-link"
+                      :to="{
+                        name: 'mesh-service-detail-view',
+                        params: {
+                          mesh: item.mesh,
+                          service: item.id,
+                        },
+                      }"
+                    >
+                      {{ t('common.collection.details_link') }}
+
+                      <ArrowRightIcon
+                        decorative
+                        :size="KUI_ICON_SIZE_30"
+                      />
+                    </XAction>
                   </template>
                 </AppCollection>
                 <RouterView
@@ -109,9 +159,19 @@
 </template>
 
 <script lang="ts" setup>
+import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { ArrowRightIcon } from '@kong/icons'
+
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
+<style lang="scss" scoped>
+.details-link {
+  display: inline-flex;
+  align-items: center;
+  gap: $kui-space-20;
+}
+</style>

--- a/src/app/services/views/MeshServiceListView.vue
+++ b/src/app/services/views/MeshServiceListView.vue
@@ -5,7 +5,7 @@
   >
     <RouteView
       v-if="me"
-      v-slot="{ route, t, uri }"
+      v-slot="{ route, t, can, uri }"
       name="mesh-service-list-view"
       :params="{
         page: 1,
@@ -47,6 +47,8 @@
                   :headers="[
                     { label: 'Name', key: 'name' },
                     { label: 'Namespace', key: 'namespace' },
+                    ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
+                    { label: 'Addresses', key: 'addresses' },
                     { label: 'Ports', key: 'ports' },
                     { label: 'Tags', key: 'tags' },
                     { label: 'Details', key: 'details', hideLabel: true },
@@ -79,6 +81,42 @@
                         {{ item.name }}
                       </XAction>
                     </TextWithCopyButton>
+                  </template>
+                  <template
+                    #namespace="{ row: item }"
+                  >
+                    {{ item.namespace }}
+                  </template>
+                  <template #zone="{ row: item }">
+                    <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
+                      <RouterLink
+                        v-if="item.labels['kuma.io/zone']"
+                        :to="{
+                          name: 'zone-cp-detail-view',
+                          params: {
+                            zone: item.labels['kuma.io/zone'],
+                          },
+                        }"
+                      >
+                        {{ item.labels['kuma.io/zone'] }}
+                      </RouterLink>
+                    </template>
+
+                    <template v-else>
+                      {{ t('common.detail.none') }}
+                    </template>
+                  </template>
+                  <template
+                    #addresses="{ row: item }"
+                  >
+                    <KTruncate>
+                      <span
+                        v-for="address in item.status.addresses"
+                        :key="address.hostname"
+                      >
+                        {{ address.hostname }}
+                      </span>
+                    </KTruncate>
                   </template>
                   <template
                     #ports="{ row: item }"

--- a/src/app/services/views/MeshServiceSummaryView.vue
+++ b/src/app/services/views/MeshServiceSummaryView.vue
@@ -20,15 +20,74 @@
         <AppView>
           <template #title>
             <h2>
-              <RouteTitle
-                :title="t('services.routes.item.title', { name: item.name })"
-              />
+              <XAction
+                :to="{
+                  name: 'mesh-service-detail-view',
+                  params: {
+                    mesh: route.params.mesh,
+                    service: route.params.service,
+                  },
+
+                }"
+              >
+                <RouteTitle
+                  :title="t('services.routes.item.title', { name: item.name })"
+                />
+              </XAction>
             </h2>
           </template>
 
           <div
             class="stack"
           >
+            <div
+              class="stack-with-borders"
+            >
+              <DefinitionCard
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
+                  Ports
+                </template>
+                <template
+                  #body
+                >
+                  <KTruncate>
+                    <KBadge
+                      v-for="connection in item.spec.ports"
+                      :key="connection.port"
+                      appearance="info"
+                    >
+                      {{ connection.port }}:{{ connection.targetPort }}/{{ connection.protocol }}
+                    </KBadge>
+                  </KTruncate>
+                </template>
+              </DefinitionCard>
+              <DefinitionCard
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
+                  Dataplane Tags
+                </template>
+                <template
+                  #body
+                >
+                  <KTruncate>
+                    <KBadge
+                      v-for="(value, key) in item.spec.selector.dataplaneTags"
+                      :key="`${key}:${value}`"
+                      appearance="info"
+                    >
+                      {{ key }}:{{ value }}
+                    </KBadge>
+                  </KTruncate>
+                </template>
+              </DefinitionCard>
+            </div>
             <div>
               <h3>
                 {{ t('services.routes.item.config') }}
@@ -68,6 +127,7 @@
 
 <script lang="ts" setup>
 import ResourceCodeBlock from '@/app/common/code-block/ResourceCodeBlock.vue'
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import { MeshService } from '@/app/services/data'
 const props = defineProps<{
   items: MeshService[]

--- a/src/app/services/views/MeshServiceSummaryView.vue
+++ b/src/app/services/views/MeshServiceSummaryView.vue
@@ -44,6 +44,28 @@
               class="stack-with-borders"
             >
               <DefinitionCard
+                v-if="item.status.addresses.length > 0"
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
+                  Addresses
+                </template>
+                <template
+                  #body
+                >
+                  <KTruncate>
+                    <span
+                      v-for="address in item.status.addresses"
+                      :key="address.hostname"
+                    >
+                      {{ address.hostname }}
+                    </span>
+                  </KTruncate>
+                </template>
+              </DefinitionCard>
+              <DefinitionCard
                 layout="horizontal"
               >
                 <template

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -81,7 +81,7 @@
               <KCard class="mt-4">
                 <DataSource
                   v-slot="{ data: dataplanesData, error: dataplanesError }: DataplaneOverviewCollectionSource"
-                  :src="`/meshes/${route.params.mesh}/dataplanes/for/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
+                  :src="`/meshes/${route.params.mesh}/dataplanes/for/service-insight/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
                 >
                   <ErrorBlock
                     v-if="dataplanesError !== undefined"

--- a/src/test-support/mocks/src/meshes/_/meshservices.ts
+++ b/src/test-support/mocks/src/meshes/_/meshservices.ts
@@ -39,6 +39,18 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               },
             }
             : {}),
+          spec: {
+            ports: Array.from({ length: 5 }).map(_ => (
+              {
+                port: fake.internet.port(),
+                targetPort: fake.internet.port(),
+                protocol: fake.kuma.protocol(),
+              }
+            )),
+            selector: {
+              dataplaneTags: fake.kuma.tags({}),
+            },
+          },
         } satisfies MeshService
       }),
     },

--- a/src/test-support/mocks/src/meshes/_/meshservices.ts
+++ b/src/test-support/mocks/src/meshes/_/meshservices.ts
@@ -36,6 +36,8 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               labels: {
                 'kuma.io/display-name': displayName,
                 'k8s.kuma.io/namespace': nspace,
+                'kuma.io/origin': 'zone',
+                'kuma.io/zone': fake.hacker.noun(),
               },
             }
             : {}),
@@ -49,6 +51,17 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             )),
             selector: {
               dataplaneTags: fake.kuma.tags({}),
+            },
+          },
+          status: {
+            addresses: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
+              hostname: fake.internet.domainName(),
+            })),
+            vips: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
+              ip: fake.internet.ip(),
+            })),
+            tls: {
+              status: '',
             },
           },
         } satisfies MeshService

--- a/src/test-support/mocks/src/meshes/_/meshservices/_.ts
+++ b/src/test-support/mocks/src/meshes/_/meshservices/_.ts
@@ -1,7 +1,7 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
 import type { MeshService } from '@/types/index.d'
 
-export default ({ env }: EndpointDependencies): MockResponder => (req) => {
+export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => {
   const query = req.url.searchParams
 
   const mesh = req.params.mesh as string
@@ -31,6 +31,18 @@ export default ({ env }: EndpointDependencies): MockResponder => (req) => {
           },
         }
         : {}),
+      spec: {
+        ports: Array.from({ length: 5 }).map(_ => (
+          {
+            port: fake.internet.port(),
+            targetPort: fake.internet.port(),
+            protocol: fake.kuma.protocol(),
+          }
+        )),
+        selector: {
+          dataplaneTags: fake.kuma.tags({}),
+        },
+      },
     } satisfies MeshService,
   }
 }

--- a/src/test-support/mocks/src/meshes/_/meshservices/_.ts
+++ b/src/test-support/mocks/src/meshes/_/meshservices/_.ts
@@ -43,6 +43,17 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
           dataplaneTags: fake.kuma.tags({}),
         },
       },
+      status: {
+        addresses: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
+          hostname: fake.internet.domainName(),
+        })),
+        vips: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
+          ip: fake.internet.ip(),
+        })),
+        tls: {
+          status: '',
+        },
+      },
     } satisfies MeshService,
   }
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -63,7 +63,7 @@ export interface RequestRedirectFilter {
   type: 'RequestRedirect'
   requestRedirect: {
     hostname?: string
-    path?: { type: 'ReplaceFullPath', replaceFullPath: string } | { type: 'ReplacePrefixMatch', replacePrefixMatch: string}
+    path?: { type: 'ReplaceFullPath', replaceFullPath: string } | { type: 'ReplacePrefixMatch', replacePrefixMatch: string }
     port?: number
     schema?: 'http' | 'https'
     statusCode?: number
@@ -75,7 +75,7 @@ export interface URLRewriteFilter {
   urlRewrite: {
     hostToBackendHostname?: boolean
     hostname?: string
-    path?: { type: 'ReplaceFullPath', replaceFullPath: string } | { type: 'ReplacePrefixMatch', replacePrefixMatch: string}
+    path?: { type: 'ReplaceFullPath', replaceFullPath: string } | { type: 'ReplacePrefixMatch', replacePrefixMatch: string }
   }
 }
 
@@ -606,12 +606,18 @@ export interface MeshService extends MeshEntity {
   type: 'MeshService'
   labels?: {
     'kuma.io/display-name'?: string
+    'kuma.io/zone'?: string
     'k8s.kuma.io/namespace'?: string
     [key: string]: string | undefined
   }
   spec: {
     ports?: { port: number, targetPort: number, protocol: string }[]
     selector?: { dataplaneTags?: Record<string, string> }
+  }
+  status: {
+    tls?: { status: string }
+    vips?: { ip: string }[]
+    addresses?: { hostname: string }[]
   }
 }
 
@@ -790,7 +796,7 @@ export interface TlsConfDataSource {
   inlineString?: string
 }
 
-export interface TlsConfOptions {}
+export interface TlsConfOptions { }
 
 export interface MeshGatewayTlsConf {
   mode?: 'TERMINATE' | 'PASSTHROUGH'

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -609,6 +609,10 @@ export interface MeshService extends MeshEntity {
     'k8s.kuma.io/namespace'?: string
     [key: string]: string | undefined
   }
+  spec: {
+    ports?: { port: number, targetPort: number, protocol: string }[]
+    selector?: { dataplaneTags?: Record<string, string> }
+  }
 }
 
 export interface Zone {


### PR DESCRIPTION
Direct Links:

- [Listing](https://deploy-preview-2564--kuma-gui.netlify.app/gui/meshes/default/services/mesh-services?page=1&size=50)
- [Detail](https://deploy-preview-2564--kuma-gui.netlify.app/gui/meshes/default/services/mesh-services/program-0/overview?page=1&size=50)

New things:

- Ports and Tags in listing rows
- Ports and Tags in the summary drawer
- New Detail > Overview page with Ports, Tags and Dataplane listing with search and summary drawer.
- New Detail > YAML page just repeating the same YAML from the summary drawer

Overall pretty happy we can build all this with almost zero Javascript 🎉 


### Listing

![Screenshot 2024-05-17 at 14 09 36](https://github.com/kumahq/kuma-gui/assets/554604/20facc4b-3275-456e-823f-a733a6156162)

### Listing with summary

![Screenshot 2024-05-17 at 14 09 45](https://github.com/kumahq/kuma-gui/assets/554604/96cfad67-be67-44eb-af62-aa3f4532533f)

### Detail

![Screenshot 2024-05-17 at 14 09 53](https://github.com/kumahq/kuma-gui/assets/554604/349da67c-01d1-4a39-bc2f-975a4a096535)

### Detail with summary

![Screenshot 2024-05-17 at 14 09 59](https://github.com/kumahq/kuma-gui/assets/554604/d6ac4841-41f4-4048-ae28-8288f03546f7)



