### PR TITLE
chore(docs): add tldr page plus expands on docs linked from tldr

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -70,6 +70,10 @@ export default defineConfig({
         text: 'Overview',
         items: [
           {
+            text: 'TLDR',
+            link: 'docs/tldr.md',
+          },
+          {
             text: 'Getting started',
             link: 'docs/getting-started.md',
           },

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -1,3 +1,12 @@
+.custom-block:is(.danger, .warning) {
+  padding-top: 8px;
+}
+
+.custom-block:is(.danger, .warning) p.custom-block-title {
+  display: none;
+}
+
+
 /* Hide theme switching */
 .VPNav .VPMenu,
 .VPNavBar .VPFlyout,

--- a/docs/tldr.md
+++ b/docs/tldr.md
@@ -1,0 +1,147 @@
+# TLDR
+
+## Run the thing
+
+Clone the repository if you haven't already and `cd` into it:
+
+```sh
+git clone https://github.com/kumahq/kuma-gui.git
+cd kuma-gui
+```
+
+Start the development server.
+
+```sh
+make run
+```
+
+Visit the GUI at <http://localhost:8080>
+
+
+::: warning
+`make help` gives you a list of all make targets and a short description for what they are for.
+:::
+
+## Add/build a page/route
+
+::: warning
+The easiest thing to do is to copy/paste a similar route from elsewhere and then amend your new version.
+:::
+
+Routing configuration is stored in a modules `routes.ts` file i.e.
+`@/app/module.name/routes.ts`. If your route is brand new add the JSON
+configuration in there.
+
+All route views should use `RouteView`s and `AppView`s. Please make use of
+Vue's nested routing/`RouterView` when required. Remember you can pass data
+down through `RouterView`s.
+
+For more detail see:
+
+- [RouteView](/src/app/application/components/route-view/README)
+- [AppView](/src/app/application/components/app-view/README)
+
+```vue
+<RouteView
+  v-slot="{ route }"
+  name="the-name-of-the-route"
+  :params="{
+    policyName: '',
+    page: 1
+  }"
+>
+  <AppView>
+    <!-- your content goes in here -->
+    Page: {{ route.params.page }}
+
+    <!-- Make use of Nested Routing -->
+    <RouterView v-slot="{ Component }">
+      <component
+        :is="Component"
+        :data="..."
+      />
+    </RouterView>
+  </AppView>
+</RouteView>
+```
+
+
+## Working with data
+
+All read data interactions should use `DataSource` and or `DataLoader`.
+
+`DataSource` is **non-blocking** i.e. its contents will show always whether the data
+is loaded or not.
+
+`DataLoader` is **blocking** and can be used with or without `DataSource`
+depending on which parts of the UI you want to be blocked. `DataLoader` can
+also load multiple `DataSource`s.
+
+We often use `DataCollection` for filtering/finding data inline and providing
+empty states.
+
+For more detail see:
+
+- [DataSource](/src/app/application/components/data-source/README)
+- [DataLoader](/src/app/application/components/data-source/README#simple-dataloader-usage)
+- [DataCollection](src/app/application/components/data-collection/README)
+
+```vue
+<DataSource
+  v-slot="{ data }"
+  src="/mesh-insights"
+>
+    {{ data?.items.length }}
+</DataSource>
+```
+
+## GUI Components
+
+Apart from our `Data*` components we also have a set of `X*` components which
+are generic GUI specific components and we also use the
+[Kongponents](https://alpha--kongponents.netlify.app/) component library which
+use `K*` a naming scheme.
+
+These 'x' components are generally 'thin wrappers' over either native Vue
+components or Kongponents to make them easier to work with.
+
+For example:
+
+- `XAction`: Use these for `<a>`s or `<button>`s. They wrap Vue's `RouterLink`.
+- `XTeleportTemplate`/`XTeleportSlot`: Use these for rendering things in a
+different place to where you are writing it. They wrap Vue's `Teleport`.
+- `XTabs`: Basic tab navigation. They wrap `KTabs`.
+- ...
+
+We globally import both our generic GUI 'x' components and
+[Kongponents](https://alpha--kongponents.netlify.app/)
+
+We also use:
+
+- Design Tokens from <https://github.com/Kong/design-tokens>
+- Icons from <https://github.com/Kong/icons>
+
+
+## Test the thing
+
+CLI based unit tests
+
+```sh
+make test/unit
+```
+
+Browser based 'e2e' tests
+
+```sh
+make test/e2e
+```
+
+If you are new to the GUI you will probably be writing e2e tests rather than
+unit tests. We have very little logic in the GUI that isn't tested elsewhere
+and most new GUI features can be built using existing utilities, components and
+tooling.
+
+:::warning
+When running e2e tests locally the GUI must already be running at <http://localhost:8080/gui>.
+You can use `make run` to do this in a separate terminal to do this.
+:::

--- a/src/app/application/components/app-view/README.md
+++ b/src/app/application/components/app-view/README.md
@@ -1,13 +1,13 @@
 # AppView
 
-Similar `RouteView` the `AppView` component should be used in every routable
-`*View.vue` component. But it does not need to be used in a particular position
-although its likely that it would be a fairly close child of the `RouteView`
-component for the route:
+Similar to `RouteView`, the `AppView` component should be used in every
+routable `*View.vue` component. But it does not need to be used in a particular
+position although its likely that it would be a fairly close child of the
+`RouteView` component for the route:
 
 ```vue
 <RouteView
-  v-slot="{route}"
+  v-slot="{ route }"
 >
   <AppView
     :breadcrumbs="[]"
@@ -16,27 +16,31 @@ component for the route:
       <RouteTitle
         :title="route.params.service"
       />
-      {{ route.params.service }}
     </h1>
     ...
   </AppView>
 </RouteView>
 ```
 
-It contains functionality to set the breadcrumbs for the application.
+`AppView` mainly contains functionality to set the breadcrumbs for the
+application, but also includes a slot for correctly positioning the
+header/title for the page.
+
+```warning
+Even if you do not need to set a breadcrumb please still wrap your route/page
+in an `AppView`. This means every route/page is consistent.
+```
 
 ## Setting breadcrumbs for the application
 
 Only the topmost `AppView` (usually in `App.vue`) contains an instance of
-`KBreadcrumbs`, all other instances of `AppView` automatically forward its
+`XBreadcrumbs`, all other instances of `AppView` automatically forward its
 breadcrumbs to the top most `AppView` in order to be combined and rendered using
-`KBreadcrumbs`.
+`XBreadcrumbs`.
 
 Therefore you only need to specify the breadcrumbs for your `*View.vue`
 route/view component, the breadcrumbs will automatically be prepended with the
 breadcrumbs from any parent components in a nested route structure.
-
-You can of course specify mutiple breadcrumbs for a single route/view component.
 
 ```vue
 <AppView
@@ -53,3 +57,36 @@ You can of course specify mutiple breadcrumbs for a single route/view component.
 </AppView>
 ```
 
+You can of course specify multiple breadcrumbs for a single route/view component.
+
+```vue
+<AppView
+  :breadcrumbs="[
+    {
+      to: {
+        name: 'route-name-view',
+      },
+      text: 'The Breadcrumb Text'
+    },
+    {
+      to: {
+        name: 'route-sub-name-view',
+      },
+      text: 'The Sub Breadcrumb Text'
+    },
+  ]"
+>
+...
+</AppView>
+```
+If you need to tell the application not to show any breadcrumbs all (for example a child route that is fullscreen). Specify an empty set of breadcrumbs.
+
+This is different to specify no breadcrumb property at all, specifying no property all all will just not append a new breadcrumb to the current set.
+
+```vue
+<AppView
+  :breadcrumbs="[]"
+>
+...
+</AppView>
+```

--- a/src/app/application/components/data-source/README.md
+++ b/src/app/application/components/data-source/README.md
@@ -1,0 +1,166 @@
+# DataSource
+
+`DataSource` is used for loading/reading data in the application. Used on its
+own it is **non-blocking**. `DataLoader` is a blocking data loader that uses
+`DataSource` under the hood, or can be used in conjunction with `DataSource` to
+create more detailed blocking/non-blocking loading use cases.
+
+The simplest example is:
+
+```vue
+<DataSource
+  v-slot="{ data }"
+  src="/mesh-insights"
+>
+  {{ data?.items.length }}
+</DataSource>
+```
+
+The `src` is a string based [Uniform Resource
+Identifier](https://developer.mozilla.org/en-US/docs/Glossary/URI) that refers
+to a piece of data a.k.a. a resource.
+
+
+::: warning
+All resources/sources for our application are defined in a modules
+corresponding `@/app/module-name/sources.ts` file. Also see [Creating new
+URIs/sources](#creating-new-uris-sources)
+:::
+
+For improved typing for `DataSource` you can our `uri` helper to define URIs. Our
+`uri` helper is exported from `RouteView`
+
+```vue
+<RouteView
+  v-slot="{ uri }"
+>
+    <DataSource
+      v-slot="{ data }"
+      :src="uri(sources, '/mesh-insights')"
+    >
+      {{ data?.items.length }}
+    </DataSource>
+</RouteView>
+<script lang="ts" setup>
+import { sources} from '@/app/meshes/sources'
+</script>
+```
+
+Whilst you can just use strings for `uri`s, using `uri` helper exported by
+`RouteView` will give you correct typing:
+
+```vue
+<RouteView
+  v-slot="{ route, uri }"
+  name="the-name-of-the-route"
+  :params="{
+    policyName: '',
+    page: 1
+  }"
+>
+  <AppView>
+    <DataSource
+      v-slot="{ data }"
+      :src="uri(sources, '/mesh-insights')"
+    >
+        {{ data?.items.length }}
+    </DataSource>
+  </AppView>
+</RouteView>
+<script lang="ts" setup>
+import { sources} from '@/app/meshes/sources'
+</script>
+```
+
+### Simple DataLoader usage
+
+The following is the most common use case, just block until the data is loaded.
+
+```vue
+<RouteView
+  v-slot="{ route, uri }"
+  name="the-name-of-the-route"
+  :params="{
+    policyName: '',
+    page: 1
+  }"
+>
+  <AppView>
+    <DataLoader
+      v-slot="{ data }"
+      :src="uri(sources, '/mesh-insights')"
+    >
+        We won't see this until the data is completely loaded
+        {{ data?.items.length }}
+    </DataLoader>
+  </AppView>
+</RouteView>
+<script lang="ts" setup>
+import { sources} from '@/app/meshes/sources'
+</script>
+```
+
+### Loading multiple sources
+
+To load multiple sources use a mix of `DataSource` and `DataLoader`. Be sure to
+pass through both `data` and `error`:
+
+```vue
+<DataSource
+  v-slot="{ data: meshes, error: meshError }"
+  :src="uri(sources, '/mesh-insights')"
+>
+  <DataSource
+    v-slot="{ data: zones, error: zoneError }"
+    :src="uri(sources, '/zones')"
+  >
+    <DataLoader
+      :data="[
+        meshes,
+        zones
+      ]"
+      :errors="[
+        meshError,
+        zoneError
+      ]"
+    >
+      We won't see this until the data is completely loaded
+      {{ data?.items.length }}
+    </DataLoader>
+  </DataSource>
+</DataSource>
+```
+
+## Creating new URIs/sources
+
+Most modules contain a file called `sources.ts` to define how the application
+fetches it's resources for a URI:
+
+```ts
+export const sources = (api) => {
+  return defineSources({
+    '/meshes/:name': async (params) => {
+      const { name } = params
+      // i.e. Promise.resolve({ name: 'default', creationTime: '0000-00-00 00:00:00'})
+      // or an API/HTTP call
+      return api.getMesh({ name })
+    },
+  })
+}
+```
+
+They are a simple "String to Promise" map. i.e. "use this string as your URI get
+the result of this Promise".
+
+```vue
+<DataSource
+  v-slot="{ data }"
+  :src="`/mesh/${'default'}`"
+>
+  Name: {{ data?.name }} <== "default"
+  Creation Time: {{ data?.creationTime }}
+</DataSource>
+```
+
+
+

--- a/src/app/application/components/route-view/README.md
+++ b/src/app/application/components/route-view/README.md
@@ -1,18 +1,64 @@
 # RouteView
 
-Our `RouteView` component should be used as the top-most component for every
-routable `*View.vue` component.
+Our `RouteView` component should be used as the top-most component for **every
+routable `*View.vue` component**. Think of it as your `<html>` tag.
 
-It contains functionality to make it easy to set top-level DOM values that you
-usually woudn't have direct access to.
-
+::: danger
 When using this you should specify the name of the route you are creating as
 the RouteView's `name` property.
+:::
+
+`RouteView` contains functionality to:
+
+- make it easy to set top-level DOM values that you usually wouldn't have
+direct access to, for example [setting the HTML `<title>`](#setting-the-title-of-the-page) or [the HTML `class` attribute](#setting-html-node-attributes).
+- [provide access to utilities/tooling commonly used in route views](#exposing-commonly-used-utilities) i.e.
+`route`, `t` and `uri`
+
+## Setting the `<title>` of the page
+
+`RouteView` works in tandem with `RouteTitle` allowing you to set the HTML title for
+the page from anywhere in your `*View.vue` component.
+
+```vue
+<RouteView
+  name="route-name"
+>
+  <h1>
+    <RouteTitle
+      title="The title"
+    />
+  </h1>
+...
+</RouteView>
+```
+`RouteTitle` also renders the title you give it into the page, meaning that you
+can easily use the same text for your page header and the HTML title.
+
+Titles are automatically joined together as you would expect in a nested route
+structure and finally suffixed by the title of the product (taken from our i18n
+strings). The above code, depending on nested routes could end up like:
+
+
+```vue
+<html>
+  <head>
+    <title>The title | Parent title | Kuma Manager</title>
+  </head>
+  ...
+</html>
+```
+
+Additionally `RouteTitle` adds additional HTML markup at the root of the
+application to announce the HTML title to a11y screenreaders.
 
 ## Setting HTML node attributes
 
-**Note: Currently we only support setting the className if you need to add
-further attributes PRs are welcome**
+::: warning
+Currently we only support setting the `className`. If you need to add further
+attributes such as `data-*`, you'll need to add that functionality to
+`RouteView` then please submit a PR.
+:::
 
 ```vue
 <RouteView
@@ -38,64 +84,48 @@ The logic is careful not to remove/change any statically added attributes that
 existed on the node previously, and any attributes you add will be automatically
 removed when the `*View.vue` route/view component is removed from the page/DOM.
 
-## Setting the `<title>` of the page
+## Exposing commonly used utilities
 
-`RouteView` works in tandem with `RouteTitle` allowing you to set the HTML title for
-the page from anywhere in your `*View.vue` component.
+`RouteView` exposes a selection of commonly used utilities from its default slot.
 
 ```vue
 <RouteView
+  v-slot="{ route, t, env, uri, can }"
   name="route-name"
->
-  <h1>
-    <RouteTitle
-      title="The title"
-    />
-    The title
-  </h1>
-...
-</RouteView>
-```
-
-Titles are automatically joined together as you would expect in a nested route
-structure and finally suffixed by the title of the product (taken from our i18n
-strings). The above code, depending on nested routes could end up like:
-
-
-```vue
-<html>
-  <head>
-    <title>The title | Parent title | Kuma Manager</title>
-  </head>
   ...
-</html>
+>
 ```
 
-We **currently do not render** the contents of the `title=""` attribute in the same
-place that you use the `RouteTitle`, but in the future we might. Therefore you
-would only have to set the title once, and it will be render both to the HTML
-`<title>` and to your page header (say inside a `<h1>`)
+- `t`: The usual i18n `t` function i.e. `t('a.i18n.key')`
+- `env`: Access string based environment variables i.e. `env('KUMA_API_URL')`
+- `can`: Make decisions based on a users abilities/enabled featureset i.e. `can('use meshservice')`
+- `uri`: Helper for creating type-safe URI strings specifically for use with [DataSource](/src/app/application/components/data-source/README)
+- `route`: Access several route utilities `route.params`, `route,children`, `route.update()` etc.
 
-## v-slot="{route, t, env}"
-
-RouteView also exports a subset of the `route`. **This is not an entire
-`vue-router` route as you know it!**. This lets you easily set titles (or other
-things) based on the route params (or load data using the route params to set
-your title)
+::: warning
+`route` is not an instance of `vue-router`'s `route`. It is very similar but
+removes access to some things and dds functionality to others.
+:::
 
 ```vue
 <RouteView
   name="route-name"
-  v-slot="{route}"
+  v-slot="{ route }"
+  :params="{
+    service: '',
+    page: 1
+  }"
 >
   <h1>
     <RouteTitle
       :title="route.params.service"
     />
+    Page: {{ route.params.page }}
   </h1>
 ...
 </RouteView>
 ```
+
 ## Props
 
 | Name  | Description |
@@ -110,7 +140,9 @@ your title)
 
 | Name  | Description |
 | --- | --- |
-| `route` | an object with route based utilties (this, is **not** vue route, see above) |
-| `t` | A reference to our `t` function/service |
-| `env` | A reference to our `env` function/service |
+| `route` | an object with route based utilties (this, is **not** Vue route, see above) |
+| `t`     | A reference to our `t` function/service                                     |
+| `env`   | A reference to our `env` function/service                                   |
+| `can`   | A reference to our `can` function/service                                   |
+| `uri`   | A reference to our `uri` helper                                             |
 

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -17,6 +17,7 @@
       disableFix: true,
       severity: 'error',
     }],
+    'no-duplicate-selectors': [null],
   },
 }
 


### PR DESCRIPTION
I wanted a single page `TLDR` in our Engineering docs for anyone who quickly wants to get up to speed with adding or working on new features for the GUI.

This PR adds this page and expands/updates the pages that the new `TLDR` page links to.

To view these use `make run/docs`, at some point we'll hook them up to our PR previews.

Note: These docs are for kuma-gui engineers and nothing more.

