### PR TITLE
fix: Ensure route.active doesn't force a page re-render

### DIFF
--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -25,7 +25,7 @@
         params: routeParams,
         back: routerBack,
         children,
-        active,
+        child,
       }"
     />
   </div>
@@ -106,7 +106,10 @@ const children: StringNamedRouteRecordRaw[] = (router.getRoutes().find((route) =
   item.name = String(item.name)
   return item as StringNamedRouteRecordRaw
 }) ?? [])
-const active = computed(() => children.find((item) => item.name === route.name || (item.meta && item.meta.module === route.meta.module)))
+const child = () => {
+  const matched = route.matched.map(item => item.name)
+  return children.find((item) => matched.includes(item.name))
+}
 
 const routeView = {
   name: props.name,

--- a/src/app/connections/views/ConnectionInboundSummaryView.vue
+++ b/src/app/connections/views/ConnectionInboundSummaryView.vue
@@ -23,7 +23,7 @@
         </template>
 
         <XTabs
-          :selected="route.active?.name"
+          :selected="route.child()?.name"
         >
           <template
             v-for="{ name } in route.children"

--- a/src/app/connections/views/ConnectionOutboundSummaryView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryView.vue
@@ -14,7 +14,7 @@
         </h2>
       </template>
 
-      <XTabs :active-route-name="route.active?.name">
+      <XTabs :selected="route.child()?.name">
         <template
           v-for="item in route.children"
           :key="`${item.name}`"

--- a/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -50,7 +50,7 @@
           :errors="[error]"
         >
           <XTabs
-            :selected="route.active?.name"
+            :selected="route.child()?.name"
           >
             <template
               v-for="{ name } in route.children"

--- a/src/app/external-services/views/ExternalServiceDetailTabsView.vue
+++ b/src/app/external-services/views/ExternalServiceDetailTabsView.vue
@@ -38,7 +38,7 @@
       </template>
 
       <XTabs
-        :selected="route.active?.name"
+        :selected="route.child()?.name"
       >
         <template
           v-for="{ name } in route.children"

--- a/src/app/gateways/views/BuiltinGatewayDetailTabsView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailTabsView.vue
@@ -38,7 +38,7 @@
       </template>
 
       <XTabs
-        :selected="route.active?.name"
+        :selected="route.child()?.name"
       >
         <template
           v-for="{ name } in route.children"

--- a/src/app/gateways/views/DelegatedGatewayDetailTabsView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailTabsView.vue
@@ -38,7 +38,7 @@
       </template>
 
       <XTabs
-        :selected="route.active?.name"
+        :selected="route.child()?.name"
       >
         <template
           v-for="{ name } in route.children"

--- a/src/app/gateways/views/GatewayListTabsView.vue
+++ b/src/app/gateways/views/GatewayListTabsView.vue
@@ -9,7 +9,7 @@
     <AppView>
       <template #title>
         <h2>
-          <RouteTitle :title="t(`${route.active?.name === 'builtin-gateway-list-view' ? 'builtin' : 'delegated'}-gateways.routes.items.title`)" />
+          <RouteTitle :title="t(`${route.child()?.name === 'builtin-gateway-list-view' ? 'builtin' : 'delegated'}-gateways.routes.items.title`)" />
         </h2>
       </template>
 
@@ -24,7 +24,7 @@
               v-for="{ name } in items"
               :key="`${name}`"
               :class="{
-                'active': route.active?.name === name,
+                'active': route.child()?.name === name,
               }"
               :to="{
                 name: name,

--- a/src/app/meshes/views/MeshDetailTabsView.vue
+++ b/src/app/meshes/views/MeshDetailTabsView.vue
@@ -22,7 +22,7 @@
         :src="`/meshes/${route.params.mesh}`"
       >
         <XTabs
-          :selected="route.active?.name"
+          :selected="route.child()?.name"
           data-testid="mesh-tabs"
         >
           <template

--- a/src/app/services/views/ServiceDetailTabsView.vue
+++ b/src/app/services/views/ServiceDetailTabsView.vue
@@ -40,7 +40,7 @@
       </template>
 
       <XTabs
-        :selected="route.active?.name"
+        :selected="route.child()?.name"
       >
         <template
           v-for="{ name } in route.children"

--- a/src/app/services/views/ServiceListTabsView.vue
+++ b/src/app/services/views/ServiceListTabsView.vue
@@ -19,7 +19,7 @@
             v-for="{ name } in route.children"
             :key="name"
             :class="{
-              'active': route.active?.name === name,
+              'active': route.child()?.name === name,
             }"
             :to="{
               name,

--- a/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
@@ -48,7 +48,7 @@
           :errors="[error]"
         >
           <XTabs
-            :selected="route.active?.name"
+            :selected="route.child()?.name"
           >
             <template
               v-for="{ name } in route.children"

--- a/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
@@ -50,7 +50,7 @@
           :errors="[error]"
         >
           <XTabs
-            :selected="route.active?.name"
+            :selected="route.child()?.name"
             data-testid="zone-ingress-tabs"
           >
             <template

--- a/src/app/zones/views/ZoneDetailTabsView.vue
+++ b/src/app/zones/views/ZoneDetailTabsView.vue
@@ -78,7 +78,7 @@
         </template>
 
         <XTabs
-          :selected="route.active?.name"
+          :selected="route.child()?.name"
         >
           <template
             v-for="{ name } in route.children"


### PR DESCRIPTION
Back in https://github.com/kumahq/kuma-gui/pull/2192 we made `route.children` and `route.active()` to make it easier to create sub-child navigation in parent routes (mainly our Tabs). A function was chosen as the interface for `route.active()` as the `active()` function never changes and therefore doesn't trigger a template re-render.

This was then changed to use a property rather than a function in https://github.com/kumahq/kuma-gui/pull/2186/files#r1499072744. but as this is a computed property that depends on the `route.name`, every time the routing changes the entire routing tree is re-rendered (despite what the comment in the above link says)

---

This PR changes `route.active` back to be a function, and also renames it something which describes what it does a little better i.e. I called it `route.child()` a route (at least in our application) can only have one active `child`, this naming also works well with `route.children`.

Whilst doing this I also realised a much better way of figuring out the active child of each parent route: `route.matches` gives you a hierarchical list of all the 'active' routes in the chain 'vertically'. Therefore given a single `route` and its `children`, if a child exists in the hierarchical chain, that means it is one of the active ones, and therefore the `route.child` of the `route.children` for a single route. Bit weird to follow, so if there are any questions around that please ask.


