### PR TITLE
chore(deps): upgrade kongponents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@kong-ui-public/i18n": "^2.1.6",
         "@kong/icons": "^1.9.1",
-        "@kong/kongponents": "9.0.0-alpha.156",
+        "@kong/kongponents": "9.0.0-alpha.158",
         "@vueuse/core": "^10.9.0",
         "brandi": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -4416,9 +4416,9 @@
       }
     },
     "node_modules/@kong/kongponents": {
-      "version": "9.0.0-alpha.156",
-      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-9.0.0-alpha.156.tgz",
-      "integrity": "sha512-AXBmo63qgfwtFe+xdcNdEkfyXJrH5y91yjgR3EE9EDXpTw4f2WfaFh80kbwaQVs1pkUeKcKwzDw8KFu2EGjCkQ==",
+      "version": "9.0.0-alpha.158",
+      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-9.0.0-alpha.158.tgz",
+      "integrity": "sha512-f/z5LVjHPd5JFEptDg4MEyrH+ncqR52RCwM7HfJKVBDoPGXOBrHlLQtLaieUOCLx+6b6kvDx/3kPd49hVFQ30w==",
       "dependencies": {
         "@kong/icons": "^1.9.1",
         "@popperjs/core": "^2.11.8",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@kong-ui-public/i18n": "^2.1.6",
     "@kong/icons": "^1.9.1",
-    "@kong/kongponents": "9.0.0-alpha.156",
+    "@kong/kongponents": "9.0.0-alpha.158",
     "@vueuse/core": "^10.9.0",
     "brandi": "^5.0.0",
     "deepmerge": "^4.3.1",

--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -85,8 +85,8 @@
             :kpop-attributes="{ placement: 'bottomEnd' }"
           >
             <KButton
+              icon
               appearance="tertiary"
-              icon-only
             >
               <HelpIcon />
 
@@ -128,7 +128,7 @@
           <KButton
             :to="{ name: 'diagnostics' }"
             appearance="tertiary"
-            icon-only
+            icon
             data-testid="nav-item-diagnostics"
           >
             <CogIcon />

--- a/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
@@ -70,7 +70,7 @@
                 <KButton
                   class="non-visual-button"
                   appearance="secondary"
-                  icon-only
+                  icon
                 >
                   <MoreIcon />
                 </KButton>

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -196,7 +196,7 @@
                       <KButton
                         class="non-visual-button"
                         appearance="secondary"
-                        icon-only
+                        icon
                       >
                         <MoreIcon />
                       </KButton>


### PR DESCRIPTION
Upgrades kongponents to next version

See https://github.com/Kong/kongponents/pull/2183

~package version should be updated to the non-PR release before merge.~ < This is done

---

The integration change here was to change the old `icon-only` prop to just `icon`.
