### PR TITLE
chore: adds better inline type documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
       - if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: |
-          npm clean-install
+          make install
       - id: set-groups
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -1,6 +1,6 @@
 .PHONY: install
 install: check/node ## Dev: install all dependencies
-	@npm install
+	@npm clean-install
 
 .PHONY: install/sync
 install/sync:

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -1,10 +1,10 @@
 .PHONY: test
 
 .PHONY: test/unit
-test/unit: ## Dev: run unit tests.
+test/unit: check/node ## Dev: run unit tests.
 	@$(MAKE) run/test
 
 .PHONY: test/e2e
-test/e2e: ## Dev: run in-browser e2e tests against a running `make run` and a mocked HTTP API
+test/e2e: check/node ## Dev: run in-browser e2e tests against a running `make run` and a mocked HTTP API
 	@$(MAKE) run/test:browser:view
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
       "marked",
       "vite/client"
     ],
+    "noErrorTruncation": true,
     "baseUrl": ".",
     "paths": {
       "@badeball/cypress-cucumber-preprocessor/*": [


### PR DESCRIPTION
Some extra dev niceties, the biggest being:

```ts
"noErrorTruncation": true
```

Note the `...6 more...` in the screengrabs below.

## Before 
![Screenshot 2024-05-22 at 12 43 06](https://github.com/kumahq/kuma-gui/assets/554604/b229b1b1-0426-48f5-9fd0-b18a93382198)

## After

![Screenshot 2024-05-22 at 12 43 31](https://github.com/kumahq/kuma-gui/assets/554604/0d0d34b2-6778-458c-9934-a1c3e8b007a9)

All in all our type hinting is getting much more visible compared to just `import MeshService` which wasn't really helpful until you click all the way through to see.

Honestly, I don't know why we haven't had this from the beginning. I can't see a downside, but if there is we can always take it back out.

### Other

1. I realized in https://github.com/kumahq/kuma-gui/pull/2582 that aswell as CI performing clean installs (i.e. don't touch package-lock), local devs should also use the same. Dependabot owns package-lock.json so it should be the only one amending it (unless we install a new package). This means one less non-Makefile script in our GHA yamls 🎉 
2. I hit a thing where I was running unit tests and they were failing, then I realized I was on the wrong version of node, and that was the reason. The addition here would warn me if that happens and will save me a good few minutes going 🤔 


