### PR TITLE
fix(zones): include zone name in the breadcrumbs for zone proxies

### DIFF
--- a/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
@@ -13,12 +13,23 @@
     >
       <AppView
         :breadcrumbs="[
-          ...(can('use zones') ? [{
-            to: {
-              name: 'zone-cp-list-view',
+          ...(can('use zones') ? [
+            {
+              to: {
+                name: 'zone-cp-list-view',
+              },
+              text: t('zone-cps.routes.item.breadcrumbs'),
             },
-            text: t('zone-cps.routes.item.breadcrumbs'),
-          }] : []),
+            {
+              to: {
+                name: 'zone-cp-detail-view',
+                params: {
+                  zone: route.params.zone,
+                },
+              },
+              text: route.params.zone,
+            },
+          ] : []),
           {
             to: {
               name: 'zone-egress-list-view',

--- a/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
@@ -21,6 +21,15 @@
           },
           {
             to: {
+              name: 'zone-cp-detail-view',
+              params: {
+                zone: route.params.zone,
+              },
+            },
+            text: route.params.zone,
+          },
+          {
+            to: {
               name: 'zone-ingress-list-view',
               params: {
                 zone: route.params.zone,


### PR DESCRIPTION
Adds the zone name into the breadcrumbs when in either ingresses or egresses.

(When/if previewing remember to use `KUMA_ZONE_NAME=something` to make sure you get ingress/egresses in the mocks)


Closes https://github.com/kumahq/kuma-gui/issues/2379