### PR TITLE
fix(data-planes/DataPlanePolicySummaryView): extra spacing and scrollbar

### DIFF
--- a/src/app/application/components/data-source/DataSource.vue
+++ b/src/app/application/components/data-source/DataSource.vue
@@ -116,8 +116,8 @@ onBeforeUnmount(() => {
 // 'visually-hidden type' rule applied here so we are dependency free
 span {
   position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
+  width: 0px !important;
+  height: 0px !important;
   padding: 0 !important;
   margin: -1px !important;
   overflow: hidden !important;

--- a/src/app/data-planes/views/DataPlanePolicySummaryView.vue
+++ b/src/app/data-planes/views/DataPlanePolicySummaryView.vue
@@ -11,65 +11,63 @@
       codeRegExp: false,
     }"
   >
-    <AppView>
-      <template #title>
-        <h2>
-          <RouterLink
-            :to="{
-              name: 'policy-detail-view',
-              params: {
-                mesh: route.params.mesh,
-                policyPath: route.params.policyPath,
-                policy: route.params.policy,
-              },
-            }"
-          >
-            <RouteTitle
-              :title="t('policies.routes.item.title', { name: route.params.policy })"
-            />
-          </RouterLink>
-        </h2>
-      </template>
-      <div class="relative">
-        <DataSource
-          v-slot="{ data, error }: PolicySource"
-          :src="`/meshes/${route.params.mesh}/policy-path/${route.params.policyPath}/policy/${route.params.policy}`"
-        >
-          <DataLoader
-            :data="[data]"
-            :errors="[error]"
-          >
-            <PolicySummary
-              v-if="data"
-              :policy="data"
+    <DataSource
+      v-slot="{ data, error }: PolicySource"
+      :src="`/meshes/${route.params.mesh}/policy-path/${route.params.policyPath}/policy/${route.params.policy}`"
+    >
+      <AppView>
+        <template #title>
+          <h2>
+            <RouterLink
+              :to="{
+                name: 'policy-detail-view',
+                params: {
+                  mesh: route.params.mesh,
+                  policyPath: route.params.policyPath,
+                  policy: route.params.policy,
+                },
+              }"
             >
-              <ResourceCodeBlock
-                v-slot="{ copy, copying }"
-                :resource="data.config"
-                is-searchable
-                :query="route.params.codeSearch"
-                :is-filter-mode="route.params.codeFilter"
-                :is-reg-exp-mode="route.params.codeRegExp"
-                @query-change="route.update({ codeSearch: $event })"
-                @filter-mode-change="route.update({ codeFilter: $event })"
-                @reg-exp-mode-change="route.update({ codeRegExp: $event })"
-              >
-                <DataSource
-                  v-if="copying"
-                  :src="`/meshes/${route.params.mesh}/policy-path/${route.params.policyPath}/policy/${route.params.policy}/as/kubernetes?no-store`"
-                  @change="(data) => {
-                    copy((resolve) => resolve(data))
-                  }"
-                  @error="(e) => {
-                    copy((_resolve, reject) => reject(e))
-                  }"
-                />
-              </ResourceCodeBlock>
-            </PolicySummary>
-          </DataLoader>
-        </DataSource>
-      </div>
-    </AppView>
+              <RouteTitle
+                :title="t('policies.routes.item.title', { name: route.params.policy })"
+              />
+            </RouterLink>
+          </h2>
+        </template>
+        <DataLoader
+          :data="[data]"
+          :errors="[error]"
+        >
+          <PolicySummary
+            v-if="data"
+            :policy="data"
+          >
+            <ResourceCodeBlock
+              v-slot="{ copy, copying }"
+              :resource="data.config"
+              is-searchable
+              :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter"
+              :is-reg-exp-mode="route.params.codeRegExp"
+              @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            >
+              <DataSource
+                v-if="copying"
+                :src="`/meshes/${route.params.mesh}/policy-path/${route.params.policyPath}/policy/${route.params.policy}/as/kubernetes?no-store`"
+                @change="(data) => {
+                  copy((resolve) => resolve(data))
+                }"
+                @error="(e) => {
+                  copy((_resolve, reject) => reject(e))
+                }"
+              />
+            </ResourceCodeBlock>
+          </PolicySummary>
+        </DataLoader>
+      </AppView>
+    </DataSource>
   </RouteView>
 </template>
 
@@ -82,8 +80,5 @@ import { PolicySource } from '@/app/policies/sources'
 <style scoped>
 h2 {
   --icon-before: url('@/assets/images/icon-circles-ext.svg?inline') !important;
-}
-.relative {
-  position: relative;
 }
 </style>

--- a/src/app/data-planes/views/DataPlanePolicySummaryView.vue
+++ b/src/app/data-planes/views/DataPlanePolicySummaryView.vue
@@ -11,63 +11,65 @@
       codeRegExp: false,
     }"
   >
-    <DataSource
-      v-slot="{ data, error }: PolicySource"
-      :src="`/meshes/${route.params.mesh}/policy-path/${route.params.policyPath}/policy/${route.params.policy}`"
-    >
-      <AppView>
-        <template #title>
-          <h2>
-            <RouterLink
-              :to="{
-                name: 'policy-detail-view',
-                params: {
-                  mesh: route.params.mesh,
-                  policyPath: route.params.policyPath,
-                  policy: route.params.policy,
-                },
-              }"
-            >
-              <RouteTitle
-                :title="t('policies.routes.item.title', { name: route.params.policy })"
-              />
-            </RouterLink>
-          </h2>
-        </template>
-        <DataLoader
-          :data="[data]"
-          :errors="[error]"
-        >
-          <PolicySummary
-            v-if="data"
-            :policy="data"
+    <AppView>
+      <template #title>
+        <h2>
+          <RouterLink
+            :to="{
+              name: 'policy-detail-view',
+              params: {
+                mesh: route.params.mesh,
+                policyPath: route.params.policyPath,
+                policy: route.params.policy,
+              },
+            }"
           >
-            <ResourceCodeBlock
-              v-slot="{ copy, copying }"
-              :resource="data.config"
-              is-searchable
-              :query="route.params.codeSearch"
-              :is-filter-mode="route.params.codeFilter"
-              :is-reg-exp-mode="route.params.codeRegExp"
-              @query-change="route.update({ codeSearch: $event })"
-              @filter-mode-change="route.update({ codeFilter: $event })"
-              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            <RouteTitle
+              :title="t('policies.routes.item.title', { name: route.params.policy })"
+            />
+          </RouterLink>
+        </h2>
+      </template>
+      <div class="relative">
+        <DataSource
+          v-slot="{ data, error }: PolicySource"
+          :src="`/meshes/${route.params.mesh}/policy-path/${route.params.policyPath}/policy/${route.params.policy}`"
+        >
+          <DataLoader
+            :data="[data]"
+            :errors="[error]"
+          >
+            <PolicySummary
+              v-if="data"
+              :policy="data"
             >
-              <DataSource
-                v-if="copying"
-                :src="`/meshes/${route.params.mesh}/policy-path/${route.params.policyPath}/policy/${route.params.policy}/as/kubernetes?no-store`"
-                @change="(data) => {
-                  copy((resolve) => resolve(data))
-                }"
-                @error="(e) => {
-                  copy((_resolve, reject) => reject(e))
-                }"
-              />
-            </ResourceCodeBlock>
-          </PolicySummary>
-        </DataLoader>
-      </AppView>
-    </DataSource>
+              <ResourceCodeBlock
+                v-slot="{ copy, copying }"
+                :resource="data.config"
+                is-searchable
+                :query="route.params.codeSearch"
+                :is-filter-mode="route.params.codeFilter"
+                :is-reg-exp-mode="route.params.codeRegExp"
+                @query-change="route.update({ codeSearch: $event })"
+                @filter-mode-change="route.update({ codeFilter: $event })"
+                @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+              >
+                <DataSource
+                  v-if="copying"
+                  :src="`/meshes/${route.params.mesh}/policy-path/${route.params.policyPath}/policy/${route.params.policy}/as/kubernetes?no-store`"
+                  @change="(data) => {
+                    copy((resolve) => resolve(data))
+                  }"
+                  @error="(e) => {
+                    copy((_resolve, reject) => reject(e))
+                  }"
+                />
+              </ResourceCodeBlock>
+            </PolicySummary>
+          </DataLoader>
+        </DataSource>
+      </div>
+    </AppView>
   </RouteView>
 </template>
 
@@ -80,5 +82,8 @@ import { PolicySource } from '@/app/policies/sources'
 <style scoped>
 h2 {
   --icon-before: url('@/assets/images/icon-circles-ext.svg?inline') !important;
+}
+.relative {
+  position: relative;
 }
 </style>


### PR DESCRIPTION
This change makes sure that there is no extra spacing and scrollbar being added to the `.slideout-container` in the `DataPlanePolicySummaryView`.

The reason for the issue that adds the extra spacing which led to the extra scrollbar, is [an empty span](https://github.com/kumahq/kuma-gui/blob/9691ec3ab7ed877d5b10a802dff29076ba66304d/src/app/application/components/data-source/DataSource.vue#L7). It is part of the `DataSource` component and due to the [absolute positioning](https://github.com/kumahq/kuma-gui/blob/9691ec3ab7ed877d5b10a802dff29076ba66304d/src/app/application/components/data-source/DataSource.vue#L118) it was pulled up style-wise to the next element that has a `position` set, which is the `.slideout-container`'s `position: fixed` in this case. Therefore I've moved and surrounded the `DataSource` and `DataLoader` in the `DataPlanPolicySummaryView` with a container element that has `position: relative` set. This could also be solved by removing the empty `span` element from the `DataSource`, removing the `position: absolute` or by adding a `position` to an element in the `DataLoader` or `DataSource`, but this would have impacts on other areas too.

Closes #2588 
