### PR TITLE
feat(zones): add zone version and different coloring+tooltip if outdated

### DIFF
--- a/src/app/control-planes/sources.ts
+++ b/src/app/control-planes/sources.ts
@@ -32,6 +32,19 @@ export const sources = (env: Env['var'], api: KumaApi) => {
       }
     },
 
+    // used to figure out if the currently running zone control-plane
+    // is out of date with the currently running GUI release
+    '/control-plane/outdated/:version': async (params) => {
+      // if the current version includes some sort of `-dev` then pretend we
+      // are on the latest version and therefore not outdated
+      if (!params.version.match('^[0-9]+.[0-9]+.[0-9]+$')) {
+        return false
+      }
+      return compare(env('KUMA_VERSION'), params.version) === 1
+    },
+
+    // used to figure out if the currently running global control-plane
+    // is out of date with the latest release
     '/control-plane/version/latest': async (): Promise<{ version: string }> => {
       const current = env('KUMA_VERSION')
       // if the current version includes some sort of `-dev` then pretend we

--- a/src/app/subscriptions/components/SubscriptionHeader.vue
+++ b/src/app/subscriptions/components/SubscriptionHeader.vue
@@ -17,9 +17,6 @@
     </span>
 
     <span>
-      <b>Version</b>: {{ get(props.subscription, 'version.kumaCp.version', t('common.collection.none')) }}
-    </span>
-    <span>
       <img src="@/assets/images/icon-connected.svg?url">
 
       <b>{{ t('common.detail.subscriptions.connect_time') }}</b>:{{ t('common.formats.datetime', { value: Date.parse(props.subscription.connectTime ?? '') }) }}
@@ -45,7 +42,6 @@ import { computed } from 'vue'
 import { useI18n } from '@/app/application'
 import type { DiscoverySubscription } from '@/app/subscriptions/data'
 import type { KDSSubscription } from '@/app/zones/data'
-import { get } from '@/utilities/get'
 
 const { t } = useI18n()
 

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -19,12 +19,15 @@ zone-cps:
       title: '{name}'
       breadcrumbs: Zone Control Planes
       navigation:
-        zone-cp-detail-view: 'Overview'
-        zone-cp-config-view: 'Config'
-        zone-ingress-list-view: 'Ingresses'
-        zone-egress-list-view: 'Egresses'
+        zone-cp-detail-view: Overview
+        zone-cp-config-view: Config
+        zone-ingress-list-view: Ingresses
+        zone-egress-list-view: Egresses
       authentication_type: Dataplane authentication type
-      overview: 'Overview'
+      overview: Overview
+      version: Version
+      version_warning: !!text/markdown |
+        This Zone Control Plane is using an older version than the Global Control Plane, please consider upgrading your ZoneCP.
       subscription_intro: |
         Statistics indicate requests and responses between global and zone only
     items:

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    v-slot="{ t }"
+    v-slot="{ t, uri }"
     name="zone-cp-detail-view"
   >
     <AppView>
@@ -33,7 +33,44 @@
                 <StatusBadge :status="props.data.state" />
               </template>
             </DefinitionCard>
+            <DataSource
+              v-slot="{ data: outdated }"
+              :src="uri(sources, '/control-plane/outdated/:version', {
+                version: props.data.zoneInsight.version?.kumaCp?.version ?? '-',
+              })"
+            >
+              <DefinitionCard
+                :class="{
+                  version: true,
+                  outdated,
+                }"
+              >
+                <template #title>
+                  {{ t('zone-cps.routes.item.version') }}
+                  <template
+                    v-if="outdated === true"
+                  >
+                    <KTooltip
+                      max-width="300"
+                    >
+                      <InfoIcon
+                        :color="KUI_COLOR_BACKGROUND_NEUTRAL"
+                        :size="KUI_ICON_SIZE_30"
+                      />
+                      <template #content>
+                        <div
+                          v-html="t('zone-cps.routes.item.version_warning')"
+                        />
+                      </template>
+                    </KTooltip>
+                  </template>
+                </template>
 
+                <template #body>
+                  {{ props.data.zoneInsight.version?.kumaCp?.version ?? '—' }}
+                </template>
+              </DefinitionCard>
+            </DataSource>
             <DefinitionCard>
               <template #title>
                 {{ t('http.api.property.type') }}
@@ -75,9 +112,13 @@
 </template>
 
 <script lang="ts" setup>
+import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { InfoIcon } from '@kong/icons'
+
 import type { ZoneOverview } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
+import { sources } from '@/app/control-planes/sources'
 import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
 
 const props = withDefaults(defineProps<{
@@ -87,3 +128,8 @@ const props = withDefaults(defineProps<{
   notifications: () => [],
 })
 </script>
+<style lang="scss" scoped>
+.version.outdated :deep(.definition-card-container) {
+  color: #{$kui-color-text-warning};
+}
+</style>

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -16,7 +16,7 @@ type Tags<T extends Record<string, string | undefined>> =
 export class K8sModule {
   constructor(
     protected faker: Faker,
-  ) {}
+  ) { }
 
   deploymentId() {
     return this.faker.string.hexadecimal({ length: 9, casing: 'lower', prefix: '' })
@@ -43,7 +43,7 @@ export class KumaModule {
   constructor(
     protected faker: Faker,
     protected k8s: K8sModule,
-  ) {}
+  ) { }
 
   seed(str: string = '') {
     // sync the seed by name (temp use length until we convert strings to numbers differently)
@@ -79,6 +79,10 @@ export class KumaModule {
 
   serviceType({ serviceTypes = ['internal', 'external', 'gateway_delegated', 'gateway_builtin'] }: { serviceTypes?: Array<'internal' | 'external' | 'gateway_delegated' | 'gateway_builtin'> } = { serviceTypes: ['internal', 'external', 'gateway_delegated', 'gateway_builtin'] }) {
     return this.faker.helpers.arrayElement(serviceTypes)
+  }
+
+  version() {
+    return this.faker.helpers.arrayElement([this.faker.system.semver(), `${this.faker.system.semver()}-${this.faker.git.branch()}-${this.faker.git.shortSha()}`])
   }
 
   serviceName(serviceType: 'internal' | 'external' | 'gateway_builtin' | 'gateway_delegated' = 'internal') {

--- a/src/test-support/mocks/src/zones/_/_overview.ts
+++ b/src/test-support/mocks/src/zones/_/_overview.ts
@@ -44,8 +44,8 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
                 zoneInstanceId: `zone-${fake.hacker.noun()}`,
                 version: {
                   kumaCp: {
-                    version: '1.0.0-rc2-211-g823fe8ce',
-                    gitTag: '1.0.0-rc2-211-g823fe8ce',
+                    version: fake.kuma.version(),
+                    gitTag: fake.kuma.version(),
                     gitCommit: fake.git.commitSha(),
                     buildDate: '2021-02-18T13:22:30Z',
                     kumaCpGlobalCompatible: fake.datatype.boolean(),


### PR DESCRIPTION
- Adds the latest subscriptions version the main information
- If this is lower than KUMA_VERSION (i.e. the version of the current global cp), we color the version using our 'warning' color and add a tooltip explanation.
- I re-removed the version from the subscription accordion pane titles that were added very recently. I figured the additions in this PR were what we actually wanted, and I can't think of the value/use case for wanting to know the version for every single subscription.

![Screenshot 2024-06-12 at 14 02 43](https://github.com/kumahq/kuma-gui/assets/554604/00639598-8f93-4429-b8d9-55482e5b52d3)

![Screenshot 2024-06-12 at 14 02 51](https://github.com/kumahq/kuma-gui/assets/554604/a0c4c58b-5cc2-4067-bc63-a4a8cd09fb03)


Closes https://github.com/kumahq/kuma-gui/issues/2164