### PR TITLE
fix: removes CodeBlock toolbar stickiness

### DIFF
--- a/src/app/common/code-block/CodeBlock.vue
+++ b/src/app/common/code-block/CodeBlock.vue
@@ -93,13 +93,6 @@ async function handleCodeBlockRenderEvent({ preElement, codeElement, language, c
   margin-bottom: $kui-space-60;
 }
 
-// Makes code block actions sticky
-:deep(.code-block-actions) {
-  position: sticky;
-  z-index: 4;
-  top: var(--AppHeaderHeight);
-}
-
 // Reset some PrismJS styles that interfere with the display of the code block.
 :deep(pre[class*=language-]),
 :deep(code[class*=language-]) {


### PR DESCRIPTION
Removes `position: sticky` from our CodeBlock wrapper to prevent toolbar stickiness, which was causing issues in certain areas.

It looks like this is based on the CodeBlock always being a certain distance underneath the AppHeader, which we can never guarantee.

