### PR TITLE
chore: export control-planes compare

### DIFF
--- a/src/app/control-planes/sources.ts
+++ b/src/app/control-planes/sources.ts
@@ -12,7 +12,7 @@ export type ControlPlaneAddresses = {
 export type ControlPlaneAddressesSource = DataSourceResponse<ControlPlaneAddresses>
 
 // mostly taken from semver-compare
-const compare = (a: string, b: string) => {
+export const compare = (a: string, b: string) => {
   const pa = a.split('.')
   const pb = b.split('.')
   for (let i = 0; i < 3; i++) {


### PR DESCRIPTION
I forgot to export `compare` during https://github.com/kumahq/kuma-gui/pull/2621, which I realized after that I needed to access from elsewhere (See below GH PR links).