### PR TITLE
fix(deps): use correct semver constraint for kongponents alpha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-    ignore:
-      # TODO: Remove this once Kongponents v9 is used from a mainline release again (i.e. neither alpha or beta).
-      # Ignores Kongponents updates. This is necessary because Kongponents publishes prerelease versions for each pull request. Dependabot then creates PRs updating to `-pr.X.Y` which we definitely need to prevent. There doesn’t seem to be a way to update only the alpha version.
-      - dependency-name: "@kong/kongponents"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@kong-ui-public/i18n": "^2.1.6",
         "@kong/icons": "^1.13.0",
-        "@kong/kongponents": "9.0.0-alpha.166",
+        "@kong/kongponents": "^9.0.0-alpha < 9.0.0-beta",
         "@vueuse/core": "^10.10.0",
         "brandi": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -4498,9 +4498,9 @@
       }
     },
     "node_modules/@kong/kongponents": {
-      "version": "9.0.0-alpha.166",
-      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-9.0.0-alpha.166.tgz",
-      "integrity": "sha512-cXlUFC/IAR2hWi0tZYevZHjIoqSb7m+Dg+1KCoLtDDMIgiIwLK4fqLHsG63Shl0/6Hg9t2oI4ixBVbw1ioaeGw==",
+      "version": "9.0.0-alpha.171",
+      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-9.0.0-alpha.171.tgz",
+      "integrity": "sha512-Tv/b2DdOuyIM+/NKIBY6qk5StKoL6A/eKqL1F4v4QSXcDwuxhXpli8/iWKc9bZY3/y4BaDEtF1K89u30jJFqJw==",
       "dependencies": {
         "@floating-ui/vue": "^1.0.6",
         "@kong/icons": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@kong-ui-public/i18n": "^2.1.6",
     "@kong/icons": "^1.13.0",
-    "@kong/kongponents": "9.0.0-alpha.166",
+    "@kong/kongponents": "^9.0.0-alpha < 9.0.0-beta",
     "@vueuse/core": "^10.10.0",
     "brandi": "^5.0.0",
     "deepmerge": "^4.3.1",


### PR DESCRIPTION
Kongponents is currently going through an alpha series of release which we are following along with, these releases follow a `9.0.0-alpha.000` versioning scheme.

Kongponents also releases PR builds to the npm registry for every single PR, using a versioning scheme of `pr-<gh-pr-number>`.

If you use a range versioning for kongponents' alpha without additional constraints, it will mean that it will get updated to the _PR version_ rather than stay on the alpha version. (`pr-000` is deemed a newer version than `9.0.0-alpha`)

Usually we use caret/range versioning `^9.0.0-alpha.000`, but to prevent us being moving to a PR version for a while now we had used exact versioning for kongponents (`9.0.0-alpha.123` without the caret).

---

Up until now we've fixed this in the wrong place in various places:

- Using exact versioning for the kongponents version
- Disabling dependabot updates for kongponents

This has then caused several other issues:

- Not having automatic dependabot updates for kongponents meaning we need to 'remember' to update it.
- Not being able to specify a range semver not only means we don't get automatic tracking, but also means we are more likely to get duplicated versions of kongponents and other more general installation issues.
- I just hit another issue, which made me look to fix this correctly, when trying to install `@kong-ui-public/app-layout`:

![Screenshot 2024-06-14 at 13 27 31](https://github.com/kumahq/kuma-gui/assets/554604/ba104c1b-640b-437e-acd1-c5abbf78d15e)

This above error happens because we current exact pin to `9.0.0-alpha.166` whereas `@kong-ui-public/app-layout` range pins its peerDependency to `^9.0.0-alpha.169` i.e. _at least_ alpha.169, therefore there is a clash between our exact version of 166 and the version that `app-layout` is requiring of _at least_ 169, even though I would guess that `@kong-ui-public/app-layout` doesn't require _at least_ 169, but probably a much lesser version of that.

https://github.com/Kong/public-ui-components/blob/main/packages/core/app-layout/package.json#L42

---

I tested this constraint on https://semver.npmjs.com/ which unfortunately doesn't use deeplinks so here are the screengrabs, notice there are no `pr` versions in the second screengrab:

![Screenshot 2024-06-14 at 13 51 07](https://github.com/kumahq/kuma-gui/assets/554604/98fdc1f4-bc81-4b75-be7d-c6685a982cf7)

![Screenshot 2024-06-14 at 13 51 15](https://github.com/kumahq/kuma-gui/assets/554604/75fe6dc2-6620-455c-ad9d-1d3b071077d0)

---

Closes https://github.com/kumahq/kuma-gui/issues/1840