### PR TITLE
fix(deps): tell dependabot to stick to the version ranges we specify

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    versioning-strategy: lockfile-only
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Tell dependabot to only update things dependant on the ranges a human has specified in the package file.