### PR TITLE
feature(meshes): rework mesh detail page

### DIFF
--- a/src/app/meshes/components/MeshStatus.vue
+++ b/src/app/meshes/components/MeshStatus.vue
@@ -13,6 +13,7 @@
 
         <ResourceStatus
           :total="props.meshInsight?.dataplanesByType.standard.total ?? 0"
+          :online="props.meshInsight?.dataplanesByType.standard.online ?? 0"
           data-testid="data-plane-proxies-status"
         >
           <template #title>
@@ -28,9 +29,6 @@
             {{ t('meshes.detail.policies') }}
           </template>
         </ResourceStatus>
-      </div>
-
-      <div class="columns">
         <DefinitionCard>
           <template #title>
             {{ t('http.api.property.mtls') }}
@@ -47,37 +45,6 @@
             <template v-else>
               {{ props.mesh.mtlsBackend.type }} / {{ props.mesh.mtlsBackend.name }}
             </template>
-          </template>
-        </DefinitionCard>
-
-        <DefinitionCard>
-          <template #title>
-            {{ t('http.api.property.metrics') }}
-          </template>
-
-          <template #body>
-            <KBadge
-              v-if="!props.mesh.metricsBackend"
-              appearance="neutral"
-            >
-              {{ t('meshes.detail.disabled') }}
-            </KBadge>
-
-            <template v-else>
-              {{ props.mesh.metricsBackend.type }} / {{ props.mesh.metricsBackend.name }}
-            </template>
-          </template>
-        </DefinitionCard>
-
-        <DefinitionCard>
-          <template #title>
-            {{ t('http.api.property.zoneEgress') }}
-          </template>
-
-          <template #body>
-            <KBadge appearance="neutral">
-              {{ t(`meshes.detail.${Boolean(props.mesh.routing?.zoneEgress) ? 'enabled' : 'disabled'}`) }}
-            </KBadge>
           </template>
         </DefinitionCard>
       </div>

--- a/src/app/meshes/locales/en-us/index.yaml
+++ b/src/app/meshes/locales/en-us/index.yaml
@@ -23,6 +23,8 @@ meshes:
         data-plane-list-view: Data Plane Proxies
         policy-list-index-view: Policies
       overview: 'Overview'
+      mtls-warning: !!text/markdown |
+        mTLS is not enabled on this mesh. <a href="{KUMA_DOCS_URL}/policies/mutual-tls/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">Consider enabling mTLS to get the most of out of {KUMA_PRODUCT_NAME}</a>
     items:
       title: Meshes
       breadcrumbs: Meshes

--- a/src/app/meshes/views/MeshDetailView.vue
+++ b/src/app/meshes/views/MeshDetailView.vue
@@ -12,6 +12,12 @@
     />
 
     <AppView>
+      <template
+        v-if="!props.mesh.mtlsBackend"
+        #notifications
+      >
+        <div v-html="t('meshes.routes.item.mtls-warning')" />
+      </template>
       <div
         class="stack"
       >
@@ -21,6 +27,46 @@
             name: route.params.mesh,
           })"
         >
+          <KCard>
+            <div class="date-status-wrapper">
+              Created: {{ t('common.formats.datetime', {value: Date.parse(mesh.creationTime)}) }}
+            </div>
+            <div class="columns">
+              <template
+                v-for="policy in ['MeshMetric', 'MeshAccessLog', 'MeshTrace']"
+                :key="policy"
+              >
+                <template
+                  v-for="enabled in [Object.entries(data?.policies ?? {}).find(([key, value]) => key === policy)]"
+                  :key="enabled"
+                >
+                  <DefinitionCard>
+                    <template #title>
+                      <XAction
+                        :to="{
+                          name: 'policy-list-view',
+                          params: {
+                            mesh: route.params.mesh,
+                            policyPath: `${policy.toLowerCase()}s`,
+                          },
+                        }"
+                      >
+                        {{ policy }}
+                      </XAction>
+                    </template>
+
+                    <template #body>
+                      <KBadge
+                        appearance="neutral"
+                      >
+                        {{ enabled ? t('meshes.detail.enabled') : t('meshes.detail.disabled') }}
+                      </KBadge>
+                    </template>
+                  </DefinitionCard>
+                </template>
+              </template>
+            </div>
+          </KCard>
           <MeshStatus
             :mesh="props.mesh"
             :mesh-insight="data"
@@ -45,13 +91,6 @@
             }"
           />
         </ResourceCodeBlock>
-
-        <div class="date-status-wrapper">
-          <ResourceDateStatus
-            :creation-time="mesh.creationTime"
-            :modification-time="mesh.modificationTime"
-          />
-        </div>
       </div>
     </AppView>
   </RouteView>
@@ -61,7 +100,7 @@
 import type { Mesh } from '../data'
 import { sources } from '../sources'
 import ResourceCodeBlock from '@/app/common/code-block/ResourceCodeBlock.vue'
-import ResourceDateStatus from '@/app/common/ResourceDateStatus.vue'
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import { useMeshStatus } from '@/app/meshes/'
 
 const props = defineProps<{
@@ -76,5 +115,6 @@ const MeshStatus = useMeshStatus()
 .date-status-wrapper {
   display: flex;
   justify-content: flex-end;
+  margin-bottom: 1em
 }
 </style>


### PR DESCRIPTION
See https://github.com/kumahq/kuma-gui/issues/2413

Changes:

1. Removed showing the modification date, and moved creatojn date to the top right of the page.
2. We show enabled/disabled depending upon existence of MeshMetric, MeshAccessLog and MeshTrace and link to those policy lists (instead of showing Metrics, AccessLogs and Trace enabled/disabled)
3. Removed zoneIngress enabled/disabled
4. Added `0/0` online/total for dataplane count instead of only online.
5. If mtls is not enabled prompt users to set up mtls to get the most out of Kuma

Closes https://github.com/kumahq/kuma-gui/issues/2413

### mTLS enabled

![Screenshot 2024-06-17 at 11 18 15](https://github.com/kumahq/kuma-gui/assets/554604/3150b44b-da86-4246-bb6e-2b5baca642a8)

### mTLS disabled

![Screenshot 2024-06-17 at 11 18 06](https://github.com/kumahq/kuma-gui/assets/554604/b1a5e27d-193c-42dd-aa3a-5431d01daf26)


