### PR TITLE
fix: makes codeblock sticky toolbar use a variable height

### DIFF
--- a/src/app/common/SummaryView.vue
+++ b/src/app/common/SummaryView.vue
@@ -49,6 +49,9 @@ const emit = defineEmits<{
 </script>
 
 <style lang="scss" scoped>
+.summary-slideout {
+  --app-view-content-top: 0;
+}
 :deep(.slideout-title) {
   h1, h2, h4, h5, h6 {
     font-size: $kui-font-size-70;

--- a/src/app/common/code-block/CodeBlock.vue
+++ b/src/app/common/code-block/CodeBlock.vue
@@ -92,7 +92,13 @@ async function handleCodeBlockRenderEvent({ preElement, codeElement, language, c
   gap: $kui-space-60;
   margin-bottom: $kui-space-60;
 }
-
+// Makes code block actions sticky
+:deep(.code-block-actions) {
+  position: sticky;
+  z-index: 4;
+  top: var(--app-view-content-top, var(--AppHeaderHeight, 0));
+  background-color: $kui-color-background-inverse;
+}
 // Reset some PrismJS styles that interfere with the display of the code block.
 :deep(pre[class*=language-]),
 :deep(code[class*=language-]) {


### PR DESCRIPTION
We removed the stickiness on the toolbar here https://github.com/kumahq/kuma-gui/pull/2622 as it was based on a static value.

This lets the place that it sticks at be more configurable. I also added a background color to it using the dark theme (if we ever have a theme-able GUI this will either need to be moved to kongponents or made theme-able here)