### PR TITLE
chore: stop passing a 'closable' through to all sources

### DIFF
--- a/src/app/application/services/data-source/DataSourcePool.ts
+++ b/src/app/application/services/data-source/DataSourcePool.ts
@@ -8,7 +8,7 @@ type EventSource = {
 } & EventTarget
 
 // The user definable 'Sources' themselves i.e. `/uri/:param` => HTTP call
-export type Source = (params: Record<string, unknown>, source: { close: () => void }) => unknown
+export type Source = (params: Record<string, unknown>) => unknown
 type Sources = Record<string, Source>
 type Connection = {
   source: EventSource

--- a/src/app/application/services/data-source/index.ts
+++ b/src/app/application/services/data-source/index.ts
@@ -26,7 +26,7 @@ type ExtractRouteParams<T extends PropertyKey> =
         : {};
 
 export type ExtractSources<T extends Record<PropertyKey, unknown>> = {
-  [Route in keyof T]: (params: ExtractRouteParams<Route> & PaginationParams, source: { close: () => void }) => T[Route]
+  [Route in keyof T]: (params: ExtractRouteParams<Route> & PaginationParams) => T[Route]
 }
 
 export const defineSources = <T extends Record<PropertyKey, unknown>>(sources: ExtractSources<T>) => {
@@ -40,7 +40,7 @@ export type TypeOf<T> = T extends { typeOf(): any } ? ReturnType<T['typeOf']> : 
 class TypedString<T = unknown> {
   constructor(
     protected str: string,
-  ) {}
+  ) { }
 
   toString() {
     return this.str
@@ -143,15 +143,13 @@ export const create: Creator = (src, router) => {
     ...route.params,
   }
   try {
-    // TODO(jc) Once we remove all the source.closes in the sources.ts files the
-    // second argument here can go
-    const init = route.route(params, { close: () => { } })
+    const init = route.route(params)
     let inited = false
     const eventSource = init instanceof CallableEventSource
       ? init
       : source(() => {
         if (inited) {
-          return Promise.resolve(route.route(params, { close: () => { } }))
+          return Promise.resolve(route.route(params))
         } else {
           inited = true
           return Promise.resolve(init)


### PR DESCRIPTION
See TODO removed in the changeset below

```
// TODO(jc) Once we remove all the source.closes in the sources.ts files the
// second argument here can go
```