### PR TITLE
feat(zones): move KDSSubscriptions to use a table/summary

### DIFF
--- a/features/zones/zone-cps/Item.feature
+++ b/features/zones/zone-cps/Item.feature
@@ -53,7 +53,7 @@ Feature: zones / item
       |   100.0.0 |
       | online    |
       | dpToken   |
-    And the "$detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"
+    And the "$detail-view" element contains "Jul 28, 2020, 4:18 PM"
     And the "$version-outdated" element doesn't exist
 
   Scenario: Outdated versions are highlighted

--- a/src/app/subscriptions/data/index.ts
+++ b/src/app/subscriptions/data/index.ts
@@ -26,7 +26,7 @@ export const DiscoverySubscriptionCollection = {
 }
 export const SubscriptionCollection = {
   fromArray: <T extends Subscription>(items?: T[]): SubscriptionCollection<T> => {
-    const subscriptions = Array.isArray(items) ? items : []
+    const subscriptions = Array.isArray(items) ? items.map(item => item) : []
 
     // make a copy of the original array so we don't change its order
     const subs = subscriptions.slice()

--- a/src/app/subscriptions/index.ts
+++ b/src/app/subscriptions/index.ts
@@ -1,8 +1,16 @@
-import type { ServiceDefinition, token } from '@/services/utils'
+import locales from './locales/en-us/index.yaml'
+import type { ServiceDefinition } from '@/services/utils'
+import { token } from '@/services/utils'
 
 type Token = ReturnType<typeof token>
 
-export const services = (_app: Record<string, Token>): ServiceDefinition[] => {
+export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
+    [token('subscriptions.locales'), {
+      service: () => locales,
+      labels: [
+        app.enUs,
+      ],
+    }],
   ]
 }

--- a/src/app/subscriptions/locales/en-us/index.yaml
+++ b/src/app/subscriptions/locales/en-us/index.yaml
@@ -1,0 +1,6 @@
+subscriptions:
+  routes:
+    item:
+      navigation:
+        subscription-summary-overview-view: Overview
+        subscription-summary-config-view: Config

--- a/src/app/subscriptions/locales/en-us/index.yaml
+++ b/src/app/subscriptions/locales/en-us/index.yaml
@@ -3,4 +3,4 @@ subscriptions:
     item:
       navigation:
         subscription-summary-overview-view: Overview
-        subscription-summary-config-view: Config
+        subscription-summary-config-view: YAML

--- a/src/app/subscriptions/locales/en-us/index.yaml
+++ b/src/app/subscriptions/locales/en-us/index.yaml
@@ -4,3 +4,14 @@ subscriptions:
       navigation:
         subscription-summary-overview-view: Overview
         subscription-summary-config-view: YAML
+      headers:
+        config: Config
+        version: Version
+        connected: Connected
+        disconnected: Disconnected
+        responses: Total Responses (sent/ack'ed)
+        zoneInstanceId: Zone Leader Instance ID
+        globalInstanceId: Global Instance ID
+        id: ID
+        type: Type
+        stat: Responses sent/ack'ed

--- a/src/app/subscriptions/routes.ts
+++ b/src/app/subscriptions/routes.ts
@@ -1,0 +1,23 @@
+import type { RouteRecordRaw } from 'vue-router'
+export const routes = (): RouteRecordRaw[] => {
+  return [
+    {
+      path: 'subscription/:subscription',
+      name: 'subscription-summary-view',
+      redirect: { name: 'subscription-summary-overview-view' },
+      component: () => import('@/app/subscriptions/views/SubscriptionSummaryView.vue'),
+      children: [
+        {
+          path: 'overview',
+          name: 'subscription-summary-overview-view',
+          component: () => import('@/app/subscriptions/views/SubscriptionSummaryOverviewView.vue'),
+        },
+        {
+          path: 'config',
+          name: 'subscription-summary-config-view',
+          component: () => import('@/app/subscriptions/views/SubscriptionSummaryConfigView.vue'),
+        },
+      ],
+    },
+  ]
+}

--- a/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
@@ -1,0 +1,41 @@
+<template>
+  <RouteView
+    name="subscription-summary-config-view"
+    :params="{
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+    }"
+    v-slot="{ route }"
+  >
+    <AppView>
+      <template #title>
+        <h2>
+          Config
+        </h2>
+      </template>
+
+      <KCard>
+        <CodeBlock
+          language="json"
+          :code="props.data.config"
+          is-searchable
+          :query="route.params.codeSearch"
+          :is-filter-mode="route.params.codeFilter"
+          :is-reg-exp-mode="route.params.codeRegExp"
+          @query-change="route.update({ codeSearch: $event })"
+          @filter-mode-change="route.update({ codeFilter: $event })"
+          @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+        />
+      </KCard>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
+import type { KDSSubscription } from '@/app/zones/data'
+const props = defineProps<{
+  data: KDSSubscription
+}>()
+</script>

--- a/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
@@ -6,12 +6,12 @@
       codeFilter: false,
       codeRegExp: false,
     }"
-    v-slot="{ route }"
+    v-slot="{ route, t }"
   >
     <AppView>
       <template #title>
         <h2>
-          Config
+          {{ t('subscriptions.routes.item.headers.config') }}
         </h2>
       </template>
 

--- a/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
@@ -17,8 +17,8 @@
 
       <KCard>
         <CodeBlock
-          language="json"
-          :code="props.data.config"
+          language="yaml"
+          :code="YAML.stringify(props.data)"
           is-searchable
           :query="route.params.codeSearch"
           :is-filter-mode="route.params.codeFilter"
@@ -33,6 +33,7 @@
 </template>
 
 <script lang="ts" setup>
+import { YAML } from '@/app/application'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
 import type { KDSSubscription } from '@/app/zones/data'
 const props = defineProps<{

--- a/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
@@ -1,0 +1,145 @@
+<template>
+  <RouteView
+    name="subscription-summary-overview-view"
+    v-slot="{ t }"
+  >
+    <AppView>
+      <div
+        class="stack-with-borders"
+      >
+        <DefinitionCard
+          layout="horizontal"
+        >
+          <template #title>
+            Version
+          </template>
+
+          <template #body>
+            <template
+              v-for="version in [props.data.version?.kumaCp?.version]"
+            >
+              {{ version ?? '-' }}
+            </template>
+          </template>
+        </DefinitionCard>
+        <DefinitionCard
+          layout="horizontal"
+        >
+          <template #title>
+            Connected
+          </template>
+
+          <template #body>
+            {{ t('common.formats.datetime', { value: Date.parse(props.data.connectTime ?? '') }) }}
+          </template>
+        </DefinitionCard>
+        <DefinitionCard
+          v-if="props.data.disconnectTime"
+          layout="horizontal"
+        >
+          <template #title>
+            Disconnected
+          </template>
+
+          <template #body>
+            {{ t('common.formats.datetime', { value: Date.parse(props.data.disconnectTime) }) }}
+          </template>
+        </DefinitionCard>
+        <DefinitionCard
+          layout="horizontal"
+        >
+          <template #title>
+            Total Responses (sent/ack'ed)
+          </template>
+
+          <template #body>
+            <template
+              v-for="responses in [props.data.status?.total ?? {}]"
+            >
+              {{ responses.responsesSent }}/{{ responses.responsesAcknowledged }}
+            </template>
+          </template>
+        </DefinitionCard>
+        <DefinitionCard
+          v-if="props.data.zoneInstanceId"
+          layout="horizontal"
+        >
+          <template #title>
+            Zone Leader Instance ID
+          </template>
+
+          <template #body>
+            {{ props.data.zoneInstanceId }}
+          </template>
+        </DefinitionCard>
+        <DefinitionCard
+          v-else
+          layout="horizontal"
+        >
+          <template #title>
+            Global Instance ID
+          </template>
+
+          <template #body>
+            {{ props.data.globalInstanceId }}
+          </template>
+        </DefinitionCard>
+        <DefinitionCard
+          layout="horizontal"
+        >
+          <template #title>
+            ID
+          </template>
+
+          <template #body>
+            {{ props.data.id }}
+          </template>
+        </DefinitionCard>
+      </div>
+      <div
+        class="mt-8 stack-with-borders"
+      >
+        <div>
+          <slot name="default" />
+        </div>
+        <DefinitionCard
+          class="mt-4"
+          layout="horizontal"
+        >
+          <template #title>
+            <strong>Type</strong>
+          </template>
+
+          <template #body>
+            Responses sent/ack'ed
+          </template>
+        </DefinitionCard>
+        <template
+          v-for="[key, item] in Object.entries(props.data.status?.stat ?? {})"
+          :key="key"
+        >
+          <DefinitionCard
+            layout="horizontal"
+          >
+            <template #title>
+              {{ key }}
+            </template>
+
+            <template #body>
+              {{ item.responsesSent }}/{{ item.responsesAcknowledged }}
+            </template>
+          </DefinitionCard>
+        </template>
+      </div>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
+import type { KDSSubscription } from '@/app/zones/data'
+
+const props = defineProps<{
+  data: KDSSubscription
+}>()
+</script>

--- a/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
@@ -11,7 +11,7 @@
           layout="horizontal"
         >
           <template #title>
-            Version
+            {{ t('subscriptions.routes.item.headers.version') }}
           </template>
 
           <template #body>
@@ -26,7 +26,7 @@
           layout="horizontal"
         >
           <template #title>
-            Connected
+            {{ t('subscriptions.routes.item.headers.connected') }}
           </template>
 
           <template #body>
@@ -38,7 +38,7 @@
           layout="horizontal"
         >
           <template #title>
-            Disconnected
+            {{ t('subscriptions.routes.item.headers.disconnected') }}
           </template>
 
           <template #body>
@@ -49,7 +49,7 @@
           layout="horizontal"
         >
           <template #title>
-            Total Responses (sent/ack'ed)
+            {{ t('subscriptions.routes.item.headers.responses') }}
           </template>
 
           <template #body>
@@ -65,7 +65,7 @@
           layout="horizontal"
         >
           <template #title>
-            Zone Leader Instance ID
+            {{ t('subscriptions.routes.item.headers.zoneInstanceId') }}
           </template>
 
           <template #body>
@@ -77,7 +77,7 @@
           layout="horizontal"
         >
           <template #title>
-            Global Instance ID
+            {{ t('subscriptions.routes.item.headers.globalInstanceId') }}
           </template>
 
           <template #body>
@@ -88,7 +88,7 @@
           layout="horizontal"
         >
           <template #title>
-            ID
+            {{ t('subscriptions.routes.item.headers.id') }}
           </template>
 
           <template #body>
@@ -107,11 +107,13 @@
           layout="horizontal"
         >
           <template #title>
-            <strong>Type</strong>
+            <strong>
+              {{ t('subscriptions.routes.item.headers.type') }}
+            </strong>
           </template>
 
           <template #body>
-            Responses sent/ack'ed
+            {{ t('subscriptions.routes.item.headers.stat') }}
           </template>
         </DefinitionCard>
         <template

--- a/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
@@ -73,7 +73,7 @@
           </template>
         </DefinitionCard>
         <DefinitionCard
-          v-else
+          v-if="props.data.globalInstanceId"
           layout="horizontal"
         >
           <template #title>

--- a/src/app/subscriptions/views/SubscriptionSummaryView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryView.vue
@@ -1,0 +1,62 @@
+<template>
+  <RouteView
+    name="subscription-summary-view"
+    :params="{
+      subscription: '',
+    }"
+    v-slot="{ route, t }"
+  >
+    <DataCollection
+      :items="props.data"
+      :predicate="item => item.id === route.params.subscription"
+    >
+      <template
+        #item="{ item }"
+      >
+        <AppView>
+          <template #title>
+            <h2>
+              {{ item.zoneInstanceId ?? item.globalInstanceId }}
+            </h2>
+          </template>
+          <XTabs
+            :selected="route.child()?.name"
+          >
+            <template
+              v-for="{ name } in route.children"
+              :key="name"
+              #[`${name}-tab`]
+            >
+              <XAction
+                :to="{
+                  name,
+                }"
+              >
+                {{ t(`subscriptions.routes.item.navigation.${name}`) }}
+              </XAction>
+            </template>
+          </XTabs>
+
+          <RouterView
+            v-slot="{ Component }"
+          >
+            <component
+              :is="Component"
+              :data="item"
+            >
+              <slot name="default" />
+            </component>
+          </RouterView>
+        </AppView>
+      </template>
+    </DataCollection>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import type { KDSSubscription } from '@/app/zones/data/'
+
+const props = defineProps<{
+  data: KDSSubscription[]
+}>()
+</script>

--- a/src/app/zones/index.ts
+++ b/src/app/zones/index.ts
@@ -3,11 +3,11 @@ import { features } from './features'
 import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
 import { sources } from './sources'
+import { services as subscriptions } from '@/app/subscriptions'
 import egressLocales from '@/app/zone-egresses/locales/en-us/index.yaml'
 import ingressLocales from '@/app/zone-ingresses/locales/en-us/index.yaml'
 import type { ServiceDefinition } from '@/services/utils'
 import { token, createInjections } from '@/services/utils'
-import { services as subscriptions } from '@/app/subscriptions'
 
 type Token = ReturnType<typeof token>
 

--- a/src/app/zones/index.ts
+++ b/src/app/zones/index.ts
@@ -7,6 +7,7 @@ import egressLocales from '@/app/zone-egresses/locales/en-us/index.yaml'
 import ingressLocales from '@/app/zone-ingresses/locales/en-us/index.yaml'
 import type { ServiceDefinition } from '@/services/utils'
 import { token, createInjections } from '@/services/utils'
+import { services as subscriptions } from '@/app/subscriptions'
 
 type Token = ReturnType<typeof token>
 
@@ -68,6 +69,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         app.enUs,
       ],
     }],
+    ...subscriptions(app),
   ]
 }
 export const TOKENS = $

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -39,6 +39,12 @@ zone-cps:
       breadcrumbs: Zone Control Planes
       intro: !!text/markdown |
         Zones are a logical grouping that represents a distinct network or infrastructure boundary with a multi-zone deployment. Zone Control Planes are responsible for managing and coordinating the service mesh within a specific zone, handling policies and communication with the Global Control Plane.
+      headers:
+        zoneInstanceId: Zone Leader Instance ID
+        version: Version
+        connected: Connected
+        disconnected: Disconnected
+        responses: Responses (sent/ack'ed)
   list:
     INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS: 'Version mismatch'
     ZONE_STORE_TYPE_MEMORY: 'Uses memory store'

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -43,7 +43,7 @@ zone-cps:
     INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS: 'Version mismatch'
     ZONE_STORE_TYPE_MEMORY: 'Uses memory store'
   detail:
-    subscriptions: 'KDS connections'
+    subscriptions: 'KDS Connections'
     configuration_title: 'Configuration'
     no_subscriptions: 'This zone has no subscriptions'
   empty_state:

--- a/src/app/zones/routes.ts
+++ b/src/app/zones/routes.ts
@@ -1,4 +1,5 @@
 import type { Can } from '@/app/application/services/can'
+import { routes as subscriptions } from '@/app/subscriptions/routes'
 import { routes as egresses } from '@/app/zone-egresses/routes'
 import { routes as ingresses } from '@/app/zone-ingresses/routes'
 import type { RouteRecordRaw } from 'vue-router'
@@ -34,6 +35,7 @@ export const routes = (
                       path: 'overview',
                       name: 'zone-cp-detail-view',
                       component: () => import('@/app/zones/views/ZoneDetailView.vue'),
+                      children: subscriptions(),
                     },
                     {
                       path: 'config',

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -108,11 +108,11 @@
             <h2>{{ t('zone-cps.detail.subscriptions') }}</h2>
             <AppCollection
               :headers="[
-                { ...me.get('headers.zoneInstanceId'), label: 'Zone Leader Instance ID', key: 'zoneInstanceId' },
-                { ...me.get('headers.version'), label: 'Version', key: 'version' },
-                { ...me.get('headers.connected'), label: 'Connected', key: 'connected' },
-                { ...me.get('headers.disconnected'), label: 'Disconnected', key: 'disconnected' },
-                { ...me.get('headers.responses'), label: `Responses (sent/ack'ed)`, key: 'responses' },
+                { ...me.get('headers.zoneInstanceId'), label: t('zone-cps.routes.items.headers.zoneInstanceId'), key: 'zoneInstanceId' },
+                { ...me.get('headers.version'), label: t('zone-cps.routes.items.headers.version'), key: 'version' },
+                { ...me.get('headers.connected'), label: t('zone-cps.routes.items.headers.connected'), key: 'connected' },
+                { ...me.get('headers.disconnected'), label: t('zone-cps.routes.items.headers.disconnected'), key: 'disconnected' },
+                { ...me.get('headers.responses'), label: t('zone-cps.routes.items.headers.responses'), key: 'responses' },
               ]"
               :is-selected-row="item => item.id === route.params.subscription"
               :items="props.data.zoneInsight.subscriptions.map((item, i, arr) => arr[arr.length - (i + 1)])"

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -1,7 +1,11 @@
 <template>
   <RouteView
     name="zone-cp-detail-view"
-    v-slot="{ t, uri }"
+    :params="{
+      zone: '',
+      subscription: '',
+    }"
+    v-slot="{ t, uri, route, me }"
   >
     <DataSource
       :src="uri(sources, '/control-plane/outdated/:version', {
@@ -102,14 +106,79 @@
             v-if="props.data.zoneInsight.subscriptions.length > 0"
           >
             <h2>{{ t('zone-cps.detail.subscriptions') }}</h2>
-
-            <KCard class="mt-4">
-              <SubscriptionList
-                :subscriptions="props.data.zoneInsight.subscriptions"
+            <AppCollection
+              :headers="[
+                { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                { ...me.get('headers.connected'), label: 'Connected', key: 'connected' },
+                { ...me.get('headers.disconnected'), label: 'Disconnected', key: 'disconnected' },
+                { ...me.get('headers.responses'), label: `Responses (sent/ack'ed)`, key: 'responses' },
+              ]"
+              :is-selected-row="item => item.id === route.params.subscription"
+              :items="props.data.zoneInsight.subscriptions.map((item, i, arr) => arr[arr.length - (i + 1)])"
+              @resize="me.set"
+            >
+              <template
+                #name="{ row: item }"
               >
-                <p>{{ t('zone-cps.routes.item.subscription_intro') }}</p>
-              </SubscriptionList>
-            </KCard>
+                <XAction
+                  data-action
+                  :to="{
+                    name: 'subscription-summary-view',
+                    params: {
+                      subscription: item.id,
+                    },
+                  }"
+                >
+                  {{ item.zoneInstanceId }}
+                </XAction>
+              </template>
+              <template
+                #connected="{ row: item }"
+              >
+                {{ t('common.formats.datetime', { value: Date.parse(item.connectTime ?? '') }) }}
+              </template>
+              <template
+                #disconnected="{ row: item }"
+              >
+                <template
+                  v-if="item.disconnectTime"
+                >
+                  {{ t('common.formats.datetime', { value: Date.parse(item.disconnectTime) }) }}
+                </template>
+              </template>
+              <template
+                #responses="{ row: item }"
+              >
+                <template
+                  v-for="responses in [item.status?.total ?? {}]"
+                >
+                  {{ responses.responsesSent }}/{{ responses.responsesAcknowledged }}
+                </template>
+              </template>
+            </AppCollection>
+            <RouterView
+              v-slot="{ Component }"
+            >
+              <SummaryView
+                v-if="route.child()"
+                width="670px"
+                @close="function () {
+                  route.replace({
+                    name: 'zone-cp-detail-view',
+                    params: {
+                      zone: route.params.zone,
+                    },
+                  })
+                }"
+              >
+                <component
+                  :is="Component"
+                  :data="props.data.zoneInsight.subscriptions"
+                >
+                  <p>{{ t('zone-cps.routes.item.subscription_intro') }}</p>
+                </component>
+              </SummaryView>
+            </RouterView>
           </div>
         </div>
       </AppView>
@@ -122,10 +191,11 @@ import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tok
 import { InfoIcon } from '@kong/icons'
 
 import type { ZoneOverview } from '../data'
+import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
+import SummaryView from '@/app/common/SummaryView.vue'
 import { sources } from '@/app/control-planes/sources'
-import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
 
 const props = defineProps<{
   data: ZoneOverview

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -108,7 +108,8 @@
             <h2>{{ t('zone-cps.detail.subscriptions') }}</h2>
             <AppCollection
               :headers="[
-                { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                { ...me.get('headers.zoneInstanceId'), label: 'Zone Leader Instance ID', key: 'zoneInstanceId' },
+                { ...me.get('headers.version'), label: 'Version', key: 'version' },
                 { ...me.get('headers.connected'), label: 'Connected', key: 'connected' },
                 { ...me.get('headers.disconnected'), label: 'Disconnected', key: 'disconnected' },
                 { ...me.get('headers.responses'), label: `Responses (sent/ack'ed)`, key: 'responses' },
@@ -118,7 +119,7 @@
               @resize="me.set"
             >
               <template
-                #name="{ row: item }"
+                #zoneInstanceId="{ row: item }"
               >
                 <XAction
                   data-action
@@ -131,6 +132,11 @@
                 >
                   {{ item.zoneInstanceId }}
                 </XAction>
+              </template>
+              <template
+                #version="{ row: item }"
+              >
+                {{ item.version?.kumaCp?.version ?? '-' }}
               </template>
               <template
                 #connected="{ row: item }"

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -141,7 +141,7 @@ export class KumaModule {
   }
 
   subscriptionConfig(config: any = {}) {
-    return JSON.stringify(deepmerge(subscriptionConfig(), config))
+    return JSON.stringify(deepmerge(subscriptionConfig(), config), null, 4)
   }
 
   /**

--- a/src/test-support/mocks/src/zones/_/_overview.ts
+++ b/src/test-support/mocks/src/zones/_/_overview.ts
@@ -40,7 +40,11 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
             subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
               return {
                 id: fake.string.uuid(),
-                globalInstanceId: `global-${fake.hacker.noun()}`,
+                ...(fake.datatype.boolean()
+                  ? {
+                    globalInstanceId: `global-${fake.hacker.noun()}`,
+                  }
+                  : {}),
                 zoneInstanceId: `zone-${fake.hacker.noun()}`,
                 version: {
                   kumaCp: {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -118,6 +118,7 @@ export interface KDSSubscriptionStatus {
 export interface KDSSubscription {
   config: string
   id: string
+  zoneInstanceId: string
   globalInstanceId: string
   connectTime: string
   disconnectTime?: string

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -118,8 +118,8 @@ export interface KDSSubscriptionStatus {
 export interface KDSSubscription {
   config: string
   id: string
-  zoneInstanceId: string
-  globalInstanceId: string
+  zoneInstanceId?: string
+  globalInstanceId?: string
   connectTime: string
   disconnectTime?: string
   status: KDSSubscriptionStatus


### PR DESCRIPTION
Changes Zone Subscriptions only to use a table/summary view/interaction.

We decided that there would be far more space to show things if we used our common table/summary panel pattern instead of the accordion where there is very little space to show things:

![Screenshot 2024-06-20 at 12 37 34](https://github.com/kumahq/kuma-gui/assets/554604/97ad40ef-9bc9-4d89-bcc8-4ceb89e3e157)

![Screenshot 2024-06-20 at 12 37 44](https://github.com/kumahq/kuma-gui/assets/554604/3dc9d8ed-25ca-40f9-918f-f7ff2f34d39f)

See:

- https://github.com/kumahq/kuma-gui/issues/2623
- https://github.com/kumahq/kuma-gui/issues/2164

---

~Questions:~

~1. Do we want to show the Subscription YAML, the Subscription JSON config, or both?~
~2. If we want to show both, should we add a separate `[YAML]` tab or use the `Structured/YAML` dropdown?~


Note:

I'm guessing we'll want the same layout for DPP subscriptions, I plan to do this as a follow up and there will some changes made on top of here to make the panel work in both places.

Closes https://github.com/kumahq/kuma-gui/issues/2704

