### PR TITLE
feat(policies): add name based search to policy listing

### DIFF
--- a/features/mesh/policies/Data.feature
+++ b/features/mesh/policies/Data.feature
@@ -1,12 +1,13 @@
 Feature: mesh / policies / data
+
   Background:
     Given the CSS selectors
-      | Alias         | Selector                          |
-      | items         | [data-testid='policy-collection'] |
-      | item          | $items tbody tr                   |
-      | state-empty   | [data-testid='empty-block']       |
-      | state-error   | [data-testid='error-block']       |
-      | state-loading | [data-testid='loading-block']     |
+      | Alias         | Selector                       |
+      | items         | [data-testid='app-collection'] |
+      | item          | $items tbody tr                |
+      | state-empty   | [data-testid='empty-block']    |
+      | state-error   | [data-testid='error-block']    |
+      | state-loading | [data-testid='loading-block']  |
     And the URL "/mesh-insights/default" responds with
       """
       body:
@@ -14,6 +15,7 @@ Feature: mesh / policies / data
           CircuitBreaker:
             - total: 2
       """
+
   Scenario: 2 items in the response shows 2 items
     Given the environment
       """
@@ -30,6 +32,7 @@ Feature: mesh / policies / data
     When I visit the "/meshes/default/policies/circuit-breakers" URL
     Then the "$state-loading" element exists
     Then the "$item" element exists 2 times
+
   Scenario: Zero items shows the empty state
     Given the environment
       """

--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -1,9 +1,10 @@
 Feature: mesh / policies / index
+
   Background:
     Given the CSS selectors
       | Alias            | Selector                                  |
       | policy-type-list | [data-testid='policy-type-list']          |
-      | items            | [data-testid='policy-collection']         |
+      | items            | [data-testid='app-collection']            |
       | detail-view      | [data-testid='policy-detail-view']        |
       | items-header     | $items th                                 |
       | item             | $items tbody tr                           |
@@ -24,11 +25,8 @@ Feature: mesh / policies / index
 
   Scenario: Listing has expected content
     When I visit the "/meshes/default/policies/circuit-breakers" URL
-
     Then the "$button-docs" element exists
-
     And the "$items-header" element exists 3 times
-
     And the "[data-testid='policy-list-index-view-tab'].active" element exists
     And the "$item" element exists 2 times
     And the "$item:nth-child(1)" element contains
@@ -37,16 +35,11 @@ Feature: mesh / policies / index
 
   Scenario: Clicking the link goes to the detail page and back again
     When I visit the "/meshes/default/policies/circuit-breakers" URL
-
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "fake-cb-1"
-
     When I click the "$item:nth-child(1) [data-testid='details-link']" element
-
     Then the URL contains "circuit-breakers/fake-cb-1/overview"
     And the "$detail-view" element contains "fake-cb-1"
-
     When I click the "$breadcrumbs > .breadcrumbs-item-container:nth-child(3) > a" element
-
     Then the "$item" element exists 2 times
 
   Scenario: Clicking policy types in the sidebar switches listing
@@ -57,13 +50,9 @@ Feature: mesh / policies / index
           - name: mfi-1
           - name: mfi-2
       """
-
     When I visit the "/meshes/default/policies/circuit-breakers" URL
-
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "fake-cb-1"
-
     When I click the "[data-testid='policy-type-link-MeshFaultInjection']" element
-
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "mfi-1"
 
   Scenario: TargetRef-based policies show Zone and targetRef columns
@@ -80,9 +69,7 @@ Feature: mesh / policies / index
                 kind: MeshService
                 name: service-1
       """
-
     When I visit the "/meshes/default/policies/meshfaultinjections" URL
-
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "mfi-1"
     And the "$item:nth-child(1) td:nth-child(3)" element contains "zone-1"
     And the "$item:nth-child(1) td:nth-child(4)" element contains "MeshService:service-1"
@@ -121,9 +108,7 @@ Feature: mesh / policies / index
           MeshFaultInjection:
             total: 2
       """
-
     When I visit the "/meshes/default/policies/meshfaultinjections" URL
-
     Then the "[data-testid='policy-type-link-MeshFaultInjection']" element exists
     And the "[data-testid='policy-type-link-FaultInjection']" element doesn't exist
 
@@ -135,17 +120,12 @@ Feature: mesh / policies / index
           CircuitBreaker:
             total: 1
       """
-
     When I visit the "/meshes/default/policies/meshfaultinjections" URL
-
     Then the "[data-testid='policy-type-link-FaultInjection']" element exists
     And the "[data-testid='policy-type-link-MeshFaultInjection']" element exists
 
   Scenario: Regression test: Zone column is visible when navigating from legacy policy type
     When I visit the "/meshes/default/policies/circuit-breakers" URL
-
     Then the "$items-header" element exists 3 times
-
     When I click the "[data-testid='policy-type-link-MeshFaultInjection']" element
-
     Then the "$items-header" element exists 5 times

--- a/features/mesh/policies/PolicySummary.feature
+++ b/features/mesh/policies/PolicySummary.feature
@@ -1,8 +1,10 @@
 Feature: Policy summary
+
   Background:
     Given the CSS selectors
       | Alias                | Selector                                     |
-      | item                 | [data-testid='policy-collection'] tbody tr   |
+      | items                | [data-testid='app-collection']               |
+      | item                 | $items tbody tr                              |
       | summary              | [data-testid='summary']                      |
       | close-summary-button | $summary [data-testid='slideout-close-icon'] |
     And the URL "/meshes/default/meshfaultinjections" responds with
@@ -17,19 +19,15 @@ Feature: Policy summary
       """
       KUMA_MESHFAULTINJECTION_COUNT: 1
       """
-
     When I visit the "/meshes/default/policies/meshfaultinjections" URL
     And I click the "$item:nth-child(1) td:nth-child(2)" element
     Then the "$summary" element exists
     And the "$summary" element contains "mfi-1"
-
     When I click the "$close-summary-button" element
     Then the "$summary" element doesn't exist
-
     When I navigate "back"
     Then the "$summary" element exists
     And the "$summary" element contains "mfi-1"
-
     When I navigate "forward"
     Then the "$summary" element doesn't exist
 
@@ -38,6 +36,5 @@ Feature: Policy summary
       """
       KUMA_MESHFAULTINJECTION_COUNT: 51
       """
-
     When I visit the "/meshes/default/policies/meshfaultinjections/mfi-1?page=2&size=50" URL
     Then the "$summary" element exists

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -1,6 +1,7 @@
 <template>
   <KTable
     :key="kTableMountKey"
+    data-testid="app-collection"
     class="app-collection"
     :style="`--column-width: ${columnWidth}; --special-column-width: ${SPECIAL_COLUMN_WIDTH}%;`"
     :has-error="(typeof props.error !== 'undefined')"

--- a/src/app/policies/locales/en-us/index.yaml
+++ b/src/app/policies/locales/en-us/index.yaml
@@ -1,4 +1,8 @@
 policies:
+  x-empty-state:
+    title: No data
+    body: !!text/markdown |
+      There are no { type } policies present{ suffix }.
   routes:
     item:
       title: "{name}"

--- a/src/app/policies/sources.ts
+++ b/src/app/policies/sources.ts
@@ -24,7 +24,9 @@ export const sources = (api: KumaApi) => {
       const { mesh, path, size } = params
       const offset = params.size * (params.page - 1)
 
-      return Policy.fromCollection(await api.getAllPolicyEntitiesFromMesh({ mesh, path }, { offset, size }))
+      const name = params.search.length > 0 ? params.search : undefined
+
+      return Policy.fromCollection(await api.getAllPolicyEntitiesFromMesh({ mesh, path }, { offset, size, name }))
     },
 
     '/meshes/:mesh/policy-path/:path/policy/:name': async (params) => {

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -5,7 +5,7 @@
   >
     <RouteView
       v-if="me"
-      v-slot="{ route, t, can }"
+      v-slot="{ route, t, can, uri }"
       name="policy-list-view"
       :params="{
         page: 1,
@@ -13,12 +13,12 @@
         mesh: '',
         policyPath: '',
         policy: '',
+        s: '',
       }"
     >
       <DataCollection
         :predicate="(policyType) => typeof policyType !== 'undefined' && policyType.path === route.params.policyPath"
-        :find="true"
-        :items="props.policyTypes ?? [undefined]"
+        :items="props.policyTypes ?? []"
       >
         <template #empty>
           <EmptyBlock>
@@ -27,158 +27,204 @@
             </template>
           </EmptyBlock>
         </template>
-        <template #default="{ items: types }">
-          <template
-            v-for="policyType in [types[0]!]"
-            :key="policyType"
-          >
-            <AppView>
-              <div class="stack">
-                <KCard>
-                  <header>
-                    <div>
-                      <KBadge
-                        v-if="policyType.isExperimental"
-                        appearance="warning"
-                      >
-                        {{ t('policies.collection.beta') }}
-                      </KBadge>
-
-                      <KBadge
-                        v-if="policyType.isInbound"
-                        appearance="neutral"
-                      >
-                        {{ t('policies.collection.inbound') }}
-                      </KBadge>
-
-                      <KBadge
-                        v-if="policyType.isOutbound"
-                        appearance="neutral"
-                      >
-                        {{ t('policies.collection.outbound') }}
-                      </KBadge>
-
-                      <XAction
-                        type="docs"
-                        :href="t('policies.href.docs', { name: policyType.name })"
-                        data-testid="policy-documentation-link"
-                      >
-                        <span class="visually-hidden">{{ t('common.documentation') }}</span>
-                      </XAction>
-                    </div>
-                    <h3>
-                      <PolicyTypeTag
-                        :policy-type="policyType.name"
-                      >
-                        {{ t('policies.collection.title', { name: policyType.name }) }}
-                      </PolicyTypeTag>
-                    </h3>
-                  </header>
-                  <!-- eslint-disable-next-line vue/no-v-html -->
-                  <div v-html="t(`policies.type.${policyType.name}.description`, undefined, { defaultMessage: t('policies.collection.description') })" />
-                </KCard>
-
-                <KCard>
-                  <DataLoader
-                    v-slot="{ data }: PolicyCollectionSource"
-                    :src="`/meshes/${route.params.mesh}/policy-path/${route.params.policyPath}?page=${route.params.page}&size=${route.params.size}`"
-                    :loader="false"
-                  >
-                    <AppCollection
-                      class="policy-collection"
-                      data-testid="policy-collection"
-                      :empty-state-message="t('common.emptyState.message', { type: `${policyType.name} policies` })"
-                      :empty-state-cta-to="t('policies.href.docs', { name: policyType.name })"
-                      :empty-state-cta-text="t('common.documentation')"
-                      :headers="[
-                        { label: 'Name', key: 'name' },
-                        { label: 'Namespace', key: 'namespace' },
-                        ...(can('use zones') && policyType.isTargetRefBased ? [{ label: 'Zone', key: 'zone' }] : []),
-                        ...(policyType.isTargetRefBased ? [{ label: 'Target ref', key: 'targetRef' }] : []),
-                        { label: 'Details', key: 'details', hideLabel: true },
-                      ]"
-                      :page-number="route.params.page"
-                      :page-size="route.params.size"
-                      :total="data?.total"
-                      :items="data?.items"
-                      :is-selected-row="(row) => row.id === route.params.policy"
-                      @change="route.update"
+        <template #item="{ item: type }">
+          <AppView>
+            <div class="stack">
+              <KCard>
+                <header>
+                  <div>
+                    <KBadge
+                      v-if="type.isExperimental"
+                      appearance="warning"
                     >
-                      <template #name="{ row }">
-                        <XAction
-                          :to="{
-                            name: 'policy-summary-view',
-                            params: {
-                              mesh: row.mesh,
-                              policyPath: policyType.path,
-                              policy: row.id,
-                            },
-                            query: {
-                              page: route.params.page,
-                              size: route.params.size,
-                            },
-                          }"
-                        >
-                          {{ row.name }}
-                        </XAction>
-                      </template>
-                      <template #namespace="{ row: item }">
-                        {{ item.namespace.length > 0 ? item.namespace : t('common.detail.none') }}
-                      </template>
+                      {{ t('policies.collection.beta') }}
+                    </KBadge>
 
-                      <template #targetRef="{ row }">
-                        <template v-if="policyType.isTargetRefBased && typeof row.spec?.targetRef !== 'undefined'">
-                          <KBadge appearance="neutral">
-                            {{ row.spec.targetRef.kind }}<span v-if="row.spec.targetRef.name">:<b>{{ row.spec.targetRef.name }}</b></span>
-                          </KBadge>
-                        </template>
+                    <KBadge
+                      v-if="type.isInbound"
+                      appearance="neutral"
+                    >
+                      {{ t('policies.collection.inbound') }}
+                    </KBadge>
 
-                        <template v-else>
-                          {{ t('common.detail.none') }}
-                        </template>
-                      </template>
+                    <KBadge
+                      v-if="type.isOutbound"
+                      appearance="neutral"
+                    >
+                      {{ t('policies.collection.outbound') }}
+                    </KBadge>
 
-                      <template #zone="{ row }">
-                        <template v-if="row.labels && row.labels['kuma.io/origin'] === 'zone' && row.labels['kuma.io/zone']">
-                          <RouterLink
-                            :to="{
-                              name: 'zone-cp-detail-view',
-                              params: {
-                                zone: row.labels['kuma.io/zone'],
-                              },
-                            }"
-                          >
-                            {{ row.labels['kuma.io/zone'] }}
-                          </RouterLink>
-                        </template>
+                    <XAction
+                      type="docs"
+                      :href="t('policies.href.docs', { name: type.name })"
+                      data-testid="policy-documentation-link"
+                    >
+                      <span class="visually-hidden">{{ t('common.documentation') }}</span>
+                    </XAction>
+                  </div>
+                  <h3>
+                    <PolicyTypeTag
+                      :policy-type="type.name"
+                    >
+                      {{ t('policies.collection.title', { name: type.name }) }}
+                    </PolicyTypeTag>
+                  </h3>
+                </header>
+                <div v-html="t(`policies.type.${type.name}.description`, undefined, { defaultMessage: t('policies.collection.description') })" />
+              </KCard>
 
-                        <template v-else>
-                          {{ t('common.detail.none') }}
-                        </template>
-                      </template>
-
-                      <template #details="{ row }">
-                        <XAction
-                          class="details-link"
-                          data-testid="details-link"
-                          :to="{
-                            name: 'policy-detail-view',
-                            params: {
-                              mesh: row.mesh,
-                              policyPath: policyType.path,
-                              policy: row.id,
-                            },
-                          }"
-                        >
-                          {{ t('common.collection.details_link') }}
-
-                          <ArrowRightIcon
-                            decorative
-                            :size="KUI_ICON_SIZE_30"
+              <KCard>
+                <DataLoader
+                  :src="uri(sources, '/meshes/:mesh/policy-path/:path', {
+                    mesh: route.params.mesh,
+                    path: route.params.policyPath,
+                  }, {
+                    page: route.params.page,
+                    size: route.params.size,
+                    search: route.params.s,
+                  })"
+                >
+                  <template
+                    #loadable="{ data }"
+                  >
+                    <search
+                      v-if="(data?.items ?? { length: 0 }).length > 0 || (route.params.s.length > 0)"
+                    >
+                      <form
+                        @submit.prevent
+                      >
+                        <XInput
+                          placeholder="Filter by name..."
+                          type="search"
+                          appearance="search"
+                          :value="route.params.s"
+                          :debounce="1000"
+                          @change="(e) => route.update({
+                            s: e,
+                          })"
+                        />
+                      </form>
+                    </search>
+                    <DataCollection
+                      :items="data?.items ?? [undefined]"
+                    >
+                      <template
+                        #empty
+                      >
+                        <EmptyBlock>
+                          <template #title>
+                            {{ t('policies.x-empty-state.title') }}
+                          </template>
+                          <div
+                            v-html="t('policies.x-empty-state.body', { type: type.name, suffix: route.params.s.length > 0 ? t('common.matchingsearch') : '' })"
                           />
-                        </XAction>
+                          <template
+                            #action
+                          >
+                            <XAction
+                              type="docs"
+                              :href="t('policies.href.docs', { name: type.name })"
+                            >
+                              {{ t('common.documentation') }}
+                            </XAction>
+                          </template>
+                        </EmptyBlock>
                       </template>
-                    </AppCollection>
+                      <template
+                        #default
+                      >
+                        <AppCollection
+                          :headers="[
+                            { label: 'Name', key: 'name' },
+                            { label: 'Namespace', key: 'namespace' },
+                            ...(can('use zones') && type.isTargetRefBased ? [{ label: 'Zone', key: 'zone' }] : []),
+                            ...(type.isTargetRefBased ? [{ label: 'Target ref', key: 'targetRef' }] : []),
+                            { label: 'Details', key: 'details', hideLabel: true },
+                          ]"
+                          :page-number="route.params.page"
+                          :page-size="route.params.size"
+                          :total="data?.total"
+                          :items="data?.items"
+                          :is-selected-row="(row) => row.id === route.params.policy"
+                          @change="route.update"
+                        >
+                          <template #name="{ row }">
+                            <XAction
+                              :to="{
+                                name: 'policy-summary-view',
+                                params: {
+                                  mesh: row.mesh,
+                                  policyPath: type.path,
+                                  policy: row.id,
+                                },
+                                query: {
+                                  page: route.params.page,
+                                  size: route.params.size,
+                                },
+                              }"
+                            >
+                              {{ row.name }}
+                            </XAction>
+                          </template>
+                          <template #namespace="{ row: item }">
+                            {{ item.namespace.length > 0 ? item.namespace : t('common.detail.none') }}
+                          </template>
+
+                          <template #targetRef="{ row }">
+                            <template v-if="type.isTargetRefBased && typeof row.spec?.targetRef !== 'undefined'">
+                              <KBadge appearance="neutral">
+                                {{ row.spec.targetRef.kind }}<span v-if="row.spec.targetRef.name">:<b>{{ row.spec.targetRef.name }}</b></span>
+                              </KBadge>
+                            </template>
+
+                            <template v-else>
+                              {{ t('common.detail.none') }}
+                            </template>
+                          </template>
+
+                          <template #zone="{ row }">
+                            <template v-if="row.labels && row.labels['kuma.io/origin'] === 'zone' && row.labels['kuma.io/zone']">
+                              <RouterLink
+                                :to="{
+                                  name: 'zone-cp-detail-view',
+                                  params: {
+                                    zone: row.labels['kuma.io/zone'],
+                                  },
+                                }"
+                              >
+                                {{ row.labels['kuma.io/zone'] }}
+                              </RouterLink>
+                            </template>
+
+                            <template v-else>
+                              {{ t('common.detail.none') }}
+                            </template>
+                          </template>
+
+                          <template #details="{ row }">
+                            <XAction
+                              class="details-link"
+                              data-testid="details-link"
+                              :to="{
+                                name: 'policy-detail-view',
+                                params: {
+                                  mesh: row.mesh,
+                                  policyPath: type.path,
+                                  policy: row.id,
+                                },
+                              }"
+                            >
+                              {{ t('common.collection.details_link') }}
+
+                              <ArrowRightIcon
+                                decorative
+                                :size="KUI_ICON_SIZE_30"
+                              />
+                            </XAction>
+                          </template>
+                        </AppCollection>
+                      </template>
+                    </DataCollection>
                     <RouterView
                       v-if="route.params.policy"
                       v-slot="{ Component }"
@@ -200,15 +246,15 @@
                           :is="Component"
                           v-if="typeof data !== 'undefined'"
                           :items="data.items"
-                          :policy-type="policyType"
+                          :policy-type="type"
                         />
                       </SummaryView>
                     </RouterView>
-                  </DataLoader>
-                </KCard>
-              </div>
-            </AppView>
-          </template>
+                  </template>
+                </DataLoader>
+              </KCard>
+            </div>
+          </AppView>
         </template>
       </DataCollection>
     </RouteView>
@@ -220,12 +266,12 @@ import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
 import { ArrowRightIcon } from '@kong/icons'
 
 import type { PolicyType } from '../data'
+import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import type { MeSource } from '@/app/me/sources'
-import type { PolicyCollectionSource } from '@/app/policies/sources'
 const props = defineProps<{
   policyTypes?: PolicyType[]
 }>()
@@ -244,7 +290,6 @@ header > div {
   align-items: flex-start;
 }
 header > h3 {
-  /* TODO: remove :not(:first-child)s */
   margin-top: 0;
   float: left;
 }

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -1,5 +1,6 @@
 common:
   not_applicable: N/A
+  matchingsearch: " matching that search"
   formats:
     integer: |
       { value, select,

--- a/src/services/kuma-api/KumaApi.ts
+++ b/src/services/kuma-api/KumaApi.ts
@@ -219,7 +219,7 @@ export default class KumaApi extends Api {
     return this.client.get(`/meshes/${mesh}/${path}/${name}/_resources/dataplanes`, { params })
   }
 
-  getAllPolicyEntitiesFromMesh({ mesh, path }: { mesh: string, path: string }, params?: PaginationParameters): Promise<PaginatedApiListResponse<PolicyEntity>> {
+  getAllPolicyEntitiesFromMesh({ mesh, path }: { mesh: string, path: string }, params?: PaginationParameters & { name?: string }): Promise<PaginatedApiListResponse<PolicyEntity>> {
     return this.client.get(`/meshes/${mesh}/${path}`, { params })
   }
 


### PR DESCRIPTION
See https://github.com/kumahq/kuma-gui/issues/1639 (not clear whether we should close that seeing as it mentions doing search elsewhere other than policies)

Adds name based searching to the policy listings. Follows exactly the same approach we use for simple searching as elsewhere.

### Searching with result: 

![Screenshot 2024-06-20 at 15 13 01](https://github.com/kumahq/kuma-gui/assets/554604/2038aa18-1ea6-4676-883b-d95622859378)

### Searching with no result: 

![Screenshot 2024-06-20 at 15 13 08](https://github.com/kumahq/kuma-gui/assets/554604/f52cd5dd-a6a5-4522-8244-daf38a69327f)
