### PR TITLE
chore(meshes): add warning for when mTLS is enabled but no MTP exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kuma-gui",
       "version": "2.6.0",
       "dependencies": {
+        "@kong-ui-public/app-layout": "^4.2.5",
         "@kong-ui-public/i18n": "^2.1.6",
         "@kong/icons": "^1.13.0",
         "@kong/kongponents": "^9.0.0-alpha < 9.0.0-beta",
@@ -4465,6 +4466,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kong-ui-public/app-layout": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@kong-ui-public/app-layout/-/app-layout-4.2.5.tgz",
+      "integrity": "sha512-+zMKKm0+B2M3iDSDd723CMKr6G3fv/QBaN3EnQqlRrh9oPMM87XgRq2s9ed20VMK1lFGWtD3LzNN0K1dwSah8g==",
+      "dependencies": {
+        "@kong/icons": "^1.13.0",
+        "focus-trap": "^7.5.4",
+        "focus-trap-vue": "^4.0.3",
+        "lodash.clonedeep": "^4.5.0"
+      },
+      "peerDependencies": {
+        "@kong/kongponents": "^9.0.0-alpha.169",
+        "vue": ">= 3.3.13 < 4",
+        "vue-router": "^4.3.2"
       }
     },
     "node_modules/@kong-ui-public/i18n": {
@@ -11766,6 +11783,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@kong-ui-public/i18n": "^2.1.6",
+    "@kong-ui-public/app-layout": "^4.2.5",
     "@kong/icons": "^1.13.0",
     "@kong/kongponents": "^9.0.0-alpha < 9.0.0-beta",
     "@vueuse/core": "^10.10.0",

--- a/src/app/meshes/index.ts
+++ b/src/app/meshes/index.ts
@@ -1,4 +1,3 @@
-import MeshStatus from './components/MeshStatus.vue'
 import { routes } from './routes'
 import type { SplitRouteRecordRaw } from './routes'
 import { sources } from './sources'
@@ -9,13 +8,10 @@ import { services as policies } from '@/app/policies'
 import { services as rules } from '@/app/rules'
 import { services as servicesModule } from '@/app/services'
 import type { ServiceDefinition } from '@/services/utils'
-import { token, createInjections } from '@/services/utils'
+import { token } from '@/services/utils'
 
 type Token = ReturnType<typeof token>
 
-const $ = {
-  MeshStatus: token<typeof MeshStatus>('meshes.components.MeshStatus'),
-}
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   const mesh = {
     ...app,
@@ -42,11 +38,6 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         app.routes,
       ],
     }],
-    [$.MeshStatus, {
-      service: () => {
-        return MeshStatus
-      },
-    }],
     ...servicesModule(mesh),
     ...externalServicesModule(mesh),
     ...gatewaysModule(mesh),
@@ -55,9 +46,3 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     ...rules(mesh),
   ]
 }
-export const TOKENS = $
-export const [
-  useMeshStatus,
-] = createInjections(
-  $.MeshStatus,
-)

--- a/src/app/meshes/locales/en-us/index.yaml
+++ b/src/app/meshes/locales/en-us/index.yaml
@@ -15,6 +15,7 @@ meshes:
   routes:
     item:
       title: "{name}"
+      subtitle: "{name} Mesh"
       breadcrumbs: Meshes
       navigation:
         mesh-detail-view: Overview
@@ -25,6 +26,8 @@ meshes:
       overview: 'Overview'
       mtls-warning: !!text/markdown |
         mTLS is not enabled on this mesh. <a href="{KUMA_DOCS_URL}/policies/mutual-tls/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">Consider enabling mTLS to get the most of out of {KUMA_PRODUCT_NAME}</a>
+      mtp-warning: !!text/markdown |
+        mTLS is enabled but you do not have a <a href="{KUMA_DOCS_URL}/policies/meshtrafficpermission/?{KUMA_UTM_QUERY_PARAMS}">MeshTrafficPermission policy</a> for this mesh.
     items:
       title: Meshes
       breadcrumbs: Meshes

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -1,4 +1,5 @@
 @import '@kong/kongponents/dist/style.css';
+@import '@kong-ui-public/app-layout/dist/style.css';
 
 @import 'mixins';
 @import 'fonts';

--- a/src/test-support/mocks/src/meshes/_.ts
+++ b/src/test-support/mocks/src/meshes/_.ts
@@ -14,36 +14,36 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
       name,
       type: 'Mesh',
       creationTime: '2020-06-19T12:18:02.097986-04:00',
-      modificationTime: '2020-06-19T12:18:02.097986-04:00',
+      modificationTime: '2020-07-19T12:18:02.097986-04:00',
       ...(isMtlsEnabled &&
-         {
-           mtls: {
-             enabledBackend: 'ca-1',
-             backends: [
-               {
-                 name: 'ca-1',
-                 type: 'provided',
-                 dpCert: {
-                   rotation: {
-                     expiration: '1d',
-                   },
-                 },
-                 conf: {
-                   cert: {
-                     secret: 'name-of-secret',
-                   },
-                   key: {
-                     secret: 'name-of-secret',
-                   },
-                 },
-               },
-               {
-                 name: 'ca-2',
-                 type: 'BUILTIN',
-               },
-             ],
-           },
-         }),
+      {
+        mtls: {
+          enabledBackend: 'ca-1',
+          backends: [
+            {
+              name: 'ca-1',
+              type: 'provided',
+              dpCert: {
+                rotation: {
+                  expiration: '1d',
+                },
+              },
+              conf: {
+                cert: {
+                  secret: 'name-of-secret',
+                },
+                key: {
+                  secret: 'name-of-secret',
+                },
+              },
+            },
+            {
+              name: 'ca-2',
+              type: 'BUILTIN',
+            },
+          ],
+        },
+      }),
       ...(fake.datatype.boolean() && {
         logging: {
           backends: [


### PR DESCRIPTION
- Warning for when mTLS is enabled but no MeshTrafficPermission exists
- Added MeshTrafficPermission `[enabled]` column plus link
- Used `@kong-ui-public/app-layout` `AppAboutSection` for wrapping container

We purposefully use `@kong-ui-public/app-layout@4.2.5` here instead of its latest version as `4.2.7` is uninstallable on kuma `release-2.8` even though it would work perfectly fine. Luckily I don't think there are any actual code changes between `4.2.5` and `4.2.7`, the only difference between the two is the tightening of the kongponent constraint (which seeing as I can't install this module at its latest version anymore, is probably the introduction of a bug rather than the fixing of one)

![Screenshot 2024-06-21 at 12 26 41](https://github.com/kumahq/kuma-gui/assets/554604/2c0a1f05-d557-4eaf-870f-f0f380eeebeb)
