### PR TITLE
chore(zones): add k8s/universal icons to zone rows instead of type

### DIFF
--- a/features/zones/zone-cps/Index.feature
+++ b/features/zones/zone-cps/Index.feature
@@ -1,4 +1,5 @@
 Feature: zones / index
+
   Background:
     Given the CSS selectors
       | Alias             | Selector                                    |
@@ -22,13 +23,13 @@ Feature: zones / index
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  config: '{"environment":"universal", "store": {"type": "memory"}}'
+                  config: '{"store": {"type": "memory"}}'
                   version:
                     kumaCp:
                       version: 1.0.0-rc2-211-g823fe8ce
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: !!js/undefined
-                  config: '{"environment":"kubernetes", "store": {"type": "memory"}}'
+                  config: '{"store": {"type": "memory"}}'
                   version:
                     kumaCp:
                       version: 1.0.0-rc2-211-not-the-version-i-want
@@ -39,7 +40,7 @@ Feature: zones / index
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-                  config: '{"environment":"kubernetes", "store": {"type": "memory"}}'
+                  config: '{"store": {"type": "memory"}}'
                   version:
                     kumaCp:
                       version: 1.0.0-rc2-211-g823fe8ce
@@ -56,19 +57,13 @@ Feature: zones / index
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
       """
-
     When I visit the "/zones" URL
     Then the page title contains "Zone Control Planes"
-
     Then the "$zone-cp-table-row:nth-child(1) .state-column" element contains "online"
     Then the "$zone-cp-table-row:nth-child(1) .name-column" element contains "zone-cp-1"
     Then the "$zone-cp-table-row:nth-child(1) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
-    Then the "$zone-cp-table-row:nth-child(1) .type-column" element contains "universal"
-
     Then the "$zone-cp-table-row:nth-child(2) .state-column" element contains "offline"
     Then the "$zone-cp-table-row:nth-child(2) .name-column" element contains "zone-cp-2"
     Then the "$zone-cp-table-row:nth-child(2) .zoneCpVersion-column" element contains "1.0.0-rc2-211-g823fe8ce"
-    Then the "$zone-cp-table-row:nth-child(2) .type-column" element contains "kubernetes"
-
     Then the "$zone-cp-table-row:nth-child(3) .state-column" element contains "disabled"
     Then the "$zone-cp-table-row:nth-child(3) .name-column" element contains "zone-cp-3"

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -3,7 +3,6 @@
     :key="kTableMountKey"
     data-testid="app-collection"
     class="app-collection"
-    :style="`--column-width: ${columnWidth}; --special-column-width: ${SPECIAL_COLUMN_WIDTH}%;`"
     :has-error="(typeof props.error !== 'undefined')"
     :pagination-total-items="props.total"
     :initial-fetcher-params="{ page: props.pageNumber, pageSize: props.pageSize }"
@@ -99,7 +98,7 @@
 <script lang="ts" setup generic="Row extends {}">
 import { AddIcon } from '@kong/icons'
 import { KButton, KTable, TableHeader } from '@kong/kongponents'
-import { useSlots, ref, watch, Ref, computed } from 'vue'
+import { useSlots, ref, watch, Ref } from 'vue'
 import { RouteLocationRaw } from 'vue-router'
 
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
@@ -122,8 +121,6 @@ type ChangeValue = {
 }
 
 const { t } = useI18n()
-
-const SPECIAL_COLUMN_WIDTH = 5
 
 const props = withDefaults(defineProps<{
   isSelectedRow?: ((row: Row) => boolean) | null
@@ -174,18 +171,6 @@ const cacheKey = ref<number>(0)
 const kTableMountKey = ref(0)
 const lastPageNumber = ref(props.pageNumber)
 const lastPageSize = ref(props.pageSize)
-
-const columnWidth = computed(() => {
-  const specialColumns = props.headers.filter((header) => ['details', 'warnings', 'actions'].includes(header.key))
-
-  if (specialColumns.length > 4) {
-    return 'initial'
-  }
-
-  const percentage = 100 - specialColumns.length * SPECIAL_COLUMN_WIDTH
-  const numberOfCommonColumns = props.headers.length - specialColumns.length
-  return `calc(${percentage}% / ${numberOfCommonColumns})`
-})
 
 watch(() => props.items, (newItems, oldItems) => {
   if (newItems !== oldItems) {
@@ -259,18 +244,6 @@ const click = (e: MouseEvent) => {
 </style>
 
 <style lang="scss">
-.app-collection td {
-  width: var(--column-width, initial);
-}
-
-.app-collection .details-column,
-.app-collection .warnings-column,
-.app-collection .actions-column {
-  width: var(--special-column-width, initial);
-  min-width: 80px;
-  text-align: end;
-}
-
 .app-collection .is-selected {
   background-color: $kui-color-background-neutral-weakest;
 }

--- a/src/app/x/components/x-icon/XIcon.vue
+++ b/src/app/x/components/x-icon/XIcon.vue
@@ -36,6 +36,8 @@ import {
   BookIcon,
   FilterIcon,
   CopyIcon,
+  RuntimeKicIcon,
+  DeployIcon,
 } from '@kong/icons'
 import { KTooltip, PopPlacements } from '@kong/kongponents'
 import { useSlots, useAttrs } from 'vue'
@@ -57,6 +59,8 @@ const icons = {
   docs: BookIcon,
   search: FilterIcon,
   copy: CopyIcon,
+  kubernetes: RuntimeKicIcon,
+  universal: DeployIcon,
 } as const
 const id = uniqueId('-x-icon-tooltip')
 const slots = useSlots()

--- a/src/app/zones/components/ZoneControlPlanesList.vue
+++ b/src/app/zones/components/ZoneControlPlanesList.vue
@@ -8,12 +8,27 @@
     >
       <AppCollection
         :headers="[
+          { label: '&nbsp;', key: 'type' },
           { label: t('zone-cps.components.zone-control-planes-list.name'), key: 'name'},
           { label: t('zone-cps.components.zone-control-planes-list.status'), key: 'status'},
         ]"
         :items="props.items"
         :total="props.items?.length"
       >
+        <template
+          #type="{ row: item }"
+        >
+          <template
+            v-for="env in [(['kubernetes', 'universal'] as const).find(env => env === item.zoneInsight.environment) ?? 'kubernetes']"
+            :key="env"
+          >
+            <XIcon
+              :name="env"
+            >
+              {{ t(`common.product.environment.${env}`) }}
+            </XIcon>
+          </template>
+        </template>
         <template #name="{ row: item }">
           <XAction
             :to="{
@@ -69,3 +84,10 @@ const props = defineProps<{
   items?: ZoneOverview[]
 }>()
 </script>
+<style lang="scss" scoped>
+.app-collection:deep(:is(th, td):nth-child(1)) {
+  padding-left: 8px !important;
+  padding-right: 0 !important;
+  width: 16px !important;
+}
+</style>

--- a/src/app/zones/components/ZoneControlPlanesList.vue
+++ b/src/app/zones/components/ZoneControlPlanesList.vue
@@ -31,6 +31,7 @@
         </template>
         <template #name="{ row: item }">
           <XAction
+            data-action
             :to="{
               name: 'zone-cp-detail-view',
               params: {
@@ -89,5 +90,10 @@ const props = defineProps<{
   padding-left: 8px !important;
   padding-right: 0 !important;
   width: 16px !important;
+}
+.app-collection :deep(td:nth-child(2) a) {
+  color: inherit;
+  font-weight: $kui-font-weight-semibold;
+  text-decoration: none;
 }
 </style>

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -102,6 +102,7 @@
                 </template>
                 <template #name="{ row: item }">
                   <RouterLink
+                    data-action
                     :to="{
                       name: 'zone-cp-detail-view',
                       params: {
@@ -347,6 +348,11 @@ async function deleteZone(name: string) {
   padding-left: 8px !important;
   padding-right: 0 !important;
   width: 16px !important;
+}
+.app-collection :deep(td:nth-child(2) a) {
+  color: inherit;
+  font-weight: $kui-font-weight-semibold;
+  text-decoration: none;
 }
 
 .details-link {


### PR DESCRIPTION
Uses icons/tooltips to show zoneCP type instead of an additional column.

I added them both on the zone listing on the global control plane overview page and the zone listing page.

---

![Screenshot 2024-06-21 at 13 45 26](https://github.com/kumahq/kuma-gui/assets/554604/e57a6d20-03b8-43f9-9282-cd8b70d23595)

---

![Screenshot 2024-06-21 at 13 45 40](https://github.com/kumahq/kuma-gui/assets/554604/73a833d5-926a-4115-ac6f-0f296f0c2bec)

