### PR TITLE
fix(meshes): Prevents a double warning for mTLS disabled and no policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kuma-gui",
       "version": "2.6.0",
       "dependencies": {
-        "@kong-ui-public/app-layout": "^4.2.5",
+        "@kong-ui-public/app-layout": "^4.2.3",
         "@kong-ui-public/i18n": "^2.1.6",
         "@kong/icons": "^1.13.0",
         "@kong/kongponents": "^9.0.0-alpha < 9.0.0-beta",
@@ -4469,9 +4469,9 @@
       }
     },
     "node_modules/@kong-ui-public/app-layout": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@kong-ui-public/app-layout/-/app-layout-4.2.5.tgz",
-      "integrity": "sha512-+zMKKm0+B2M3iDSDd723CMKr6G3fv/QBaN3EnQqlRrh9oPMM87XgRq2s9ed20VMK1lFGWtD3LzNN0K1dwSah8g==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@kong-ui-public/app-layout/-/app-layout-4.2.3.tgz",
+      "integrity": "sha512-eo9HKaSBZoldnbBJiGaX9b1OXRRALzE8dcxNqXeFckuKtqA5/PUSPJXf0gU1nRf9EKrD9RnSnB1e0+juGqovrg==",
       "dependencies": {
         "@kong/icons": "^1.13.0",
         "focus-trap": "^7.5.4",
@@ -4479,7 +4479,7 @@
         "lodash.clonedeep": "^4.5.0"
       },
       "peerDependencies": {
-        "@kong/kongponents": "^9.0.0-alpha.169",
+        "@kong/kongponents": "^9.0.0-alpha.162",
         "vue": ">= 3.3.13 < 4",
         "vue-router": "^4.3.2"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@kong-ui-public/i18n": "^2.1.6",
-    "@kong-ui-public/app-layout": "^4.2.5",
+    "@kong-ui-public/app-layout": "^4.2.3",
     "@kong/icons": "^1.13.0",
     "@kong/kongponents": "^9.0.0-alpha < 9.0.0-beta",
     "@vueuse/core": "^10.10.0",

--- a/src/app/meshes/views/MeshDetailView.vue
+++ b/src/app/meshes/views/MeshDetailView.vue
@@ -34,7 +34,7 @@
                 v-html="t('meshes.routes.item.mtls-warning')"
               />
               <li
-                v-if="missingTLSPolicy"
+                v-if="props.mesh.mtlsBackend && missingTLSPolicy"
                 v-html="t('meshes.routes.item.mtp-warning')"
               />
             </ul>


### PR DESCRIPTION
Prevents a double warning showing if you have mTLS disabled and no mTLS related policies.

## Before

![Screenshot 2024-06-21 at 15 49 38](https://github.com/kumahq/kuma-gui/assets/554604/443ea96f-4371-4c34-88fe-1b6cc40bf4c3)

## After

![Screenshot 2024-06-21 at 15 56 15](https://github.com/kumahq/kuma-gui/assets/554604/13372ed2-08e6-4a13-810d-3d545fac456b)



~I've also pinned kongponents version to the same version as release-2.8 to prevent it automatically moving forwards when to the version we have on `master`~

We don't actually need to do the crossed out kongponents pin, its again another consequence of other dependencies unnecessarily bumping kongponents in their package.json file.

What we do need to do is use a version of app-layout that has a minimum kongponents version that has a constraint that includes our version of kongponents in release-2.8, which is why I've chosen 4.2.3

