### PR TITLE
fix(meshservice): Encode/Decode DataSource parameters

### DIFF
--- a/features/mesh/services/mesh-services/Item.feature
+++ b/features/mesh/services/mesh-services/Item.feature
@@ -1,0 +1,23 @@
+Feature: mesh / mesh-services / item
+
+  Background:
+    Given the CSS selectors
+      | Alias      | Selector                                       |
+      | dataplanes | [data-testid='data-plane-collection'] tbody tr |
+
+  Scenario: The dataplane table exists
+    Given the environment
+      """
+        KUMA_DATAPLANE_COUNT: 1
+      """
+    And the URL "/meshes/default/meshservices/firewall-1" responds with
+      """
+      body:
+        spec:
+          selector:
+            dataplaneTags:
+              app: firewall-1
+              k8s.kuma.io/namespace: firewall-app
+      """
+    When I visit the "/meshes/default/services/mesh-services/firewall-1/overview" URL
+    Then the "$dataplanes" element exists 1 times

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "deepmerge": "^4.3.1",
         "js-yaml": "^4.1.0",
         "object.groupby": "^1.0.3",
-        "path-to-regexp": "^6.2.2",
+        "path-to-regexp": "^7.0.0",
         "pretty-bytes": "^6.1.1",
         "prismjs": "^1.29.0",
         "semver": "^7.6.2",
@@ -12463,6 +12463,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+      "dev": true
+    },
     "node_modules/msw/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12536,6 +12542,12 @@
         "just-extend": "^6.2.0",
         "path-to-regexp": "^6.2.1"
       }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+      "dev": true
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -12999,9 +13011,12 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-7.0.0.tgz",
+      "integrity": "sha512-58Y94bQqF3zBIASFNiufRPH1NfgZth1qwZ35radL87sg8pgbVqr6uikAhqZtFD+w65MGH6SWnY/ly3GbrM4fbg==",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "npm": "^10.0.0"
   },
   "dependencies": {
-    "@kong-ui-public/i18n": "^2.1.6",
     "@kong-ui-public/app-layout": "^4.2.3",
+    "@kong-ui-public/i18n": "^2.1.6",
     "@kong/icons": "^1.13.0",
     "@kong/kongponents": "^9.0.0-alpha < 9.0.0-beta",
     "@vueuse/core": "^10.10.0",
@@ -47,7 +47,7 @@
     "deepmerge": "^4.3.1",
     "js-yaml": "^4.1.0",
     "object.groupby": "^1.0.3",
-    "path-to-regexp": "^6.2.2",
+    "path-to-regexp": "^7.0.0",
     "pretty-bytes": "^6.1.1",
     "prismjs": "^1.29.0",
     "semver": "^7.6.2",

--- a/src/app/application/services/data-source/Router.ts
+++ b/src/app/application/services/data-source/Router.ts
@@ -25,7 +25,7 @@ export default class Router<T> {
         const args = pattern.exec(_url)
         return {
           route,
-          params: args?.pathname.groups || {},
+          params: Object.fromEntries(Object.entries(args?.pathname.groups || {}).map(([key, value]) => [key, decodeURIComponent(value ?? '')])),
         }
       }
     }


### PR DESCRIPTION
MeshService `dataplaneTags` keys can contain slashes i.e. `{"k8s.kuma.io/namespace":"kuma-demo"}`.

The MeshService detail page has the first occurrence we have something that we pass into DataSource src's that can contain non-URL safe characters, for example here:

https://github.com/kumahq/kuma-gui/blob/ef9410407bb31299b6e581980fb36e63736ec07a/src/app/services/views/MeshServiceDetailView.vue#L122-L125

`/:tags` can end up being `/{"k8s.kuma.io/namespace":"kuma-demo"}`

The slash in `k8s.kuma.io/namespace` is not being encoded correctly.

---

Our `uri` helper uses `path-to-regexp` which previous to version `7` would throw if you used a parameter containing a non-URL safe character (the problem we are fixing). From `7` onwards `path-to-regexp` url encodes all its parameters, which is what we need. Once these are encoded, they also need decoding on the other side.

---

This PR:

- installs a later version of `path-to-regexp` (i.e. `7`) which encodes non URL safe characters (this is already updated on `master`)
- On the other side, decodes the parameters in our `Router` which then get passed these parameters through to our `sources`. Doing the decode here means it works everywhere.

