### PR TITLE
fix(meshservice): Encode/Decode DataSource parameters (#2694)

### DIFF
--- a/features/mesh/services/mesh-services/Item.feature
+++ b/features/mesh/services/mesh-services/Item.feature
@@ -1,0 +1,23 @@
+Feature: mesh / mesh-services / item
+
+  Background:
+    Given the CSS selectors
+      | Alias      | Selector                                       |
+      | dataplanes | [data-testid='data-plane-collection'] tbody tr |
+
+  Scenario: The dataplane table exists
+    Given the environment
+      """
+        KUMA_DATAPLANE_COUNT: 1
+      """
+    And the URL "/meshes/default/meshservices/firewall-1" responds with
+      """
+      body:
+        spec:
+          selector:
+            dataplaneTags:
+              app: firewall-1
+              k8s.kuma.io/namespace: firewall-app
+      """
+    When I visit the "/meshes/default/services/mesh-services/firewall-1/overview" URL
+    Then the "$dataplanes" element exists 1 times

--- a/src/app/application/services/data-source/Router.ts
+++ b/src/app/application/services/data-source/Router.ts
@@ -25,7 +25,7 @@ export default class Router<T> {
         const args = pattern.exec(_url)
         return {
           route,
-          params: args?.pathname.groups || {},
+          params: Object.fromEntries(Object.entries(args?.pathname.groups || {}).map(([key, value]) => [key, decodeURIComponent(value ?? '')])),
         }
       }
     }


### PR DESCRIPTION
Port to `master` of #2694, note the upgraded version of `path-to-regexp` is already installed on `master`

---
From: #2694

MeshService `dataplaneTags` keys can contain slashes i.e. `{"k8s.kuma.io/namespace":"kuma-demo"}`.

The MeshService detail page has the first occurrence we have something that we pass into DataSource src's that can contain non-URL safe characters, for example here:

https://github.com/kumahq/kuma-gui/blob/ef9410407bb31299b6e581980fb36e63736ec07a/src/app/services/views/MeshServiceDetailView.vue#L122-L125

`/:tags` can end up being `/{"k8s.kuma.io/namespace":"kuma-demo"}`

The slash in `k8s.kuma.io/namespace` is not being encoded correctly.

---

Our `uri` helper uses `path-to-regexp` which previous to version `7` would throw if you used a parameter containing a non-URL safe character (the problem we are fixing). From `7` onwards `path-to-regexp` url encodes all its parameters, which is what we need. Once these are encoded, they also need decoding on the other side.

---

This PR:

- installs a later version of `path-to-regexp` (i.e. `7`) which encodes non URL safe characters (this is already updated on `master`)
- On the other side, decodes the parameters in our `Router` which then get passed these parameters through to our `sources`. Doing the decode here means it works everywhere.
