### PR TITLE
refactor(control-planes): use DataCollection for CP detail page

### DIFF
--- a/features/main-overview/DetailViewContent.feature
+++ b/features/main-overview/DetailViewContent.feature
@@ -1,4 +1,5 @@
 Feature: Overview: Detail view content
+
   Background:
     Given the CSS selectors
       | Alias                       | Selector                                    |
@@ -10,13 +11,8 @@ Feature: Overview: Detail view content
         items:
           - name: mesh-1
             services:
-              external:
-                total: 0
-              internal:
-                total: 5
-                online: 3
-                partiallyDegraded: 1
-                offline: 1
+              external: 0
+              internal: 5
             dataplanesByType:
               standard:
                 total: 3
@@ -25,13 +21,8 @@ Feature: Overview: Detail view content
                 offline: 1
           - name: mesh-2
             services:
-              external:
-                total: 0
-              internal:
-                total: 5
-                online: 5
-                partiallyDegraded: 0
-                offline: 0
+              external: 0
+              internal: 5
             dataplanesByType:
               standard:
                 total: 3
@@ -40,13 +31,8 @@ Feature: Overview: Detail view content
                 offline: 0
           - name: mesh-3
             services:
-              external:
-                total: 4
-              internal:
-                total: 5
-                online: 5
-                partiallyDegraded: 0
-                offline: 0
+              external: 4
+              internal: 5
             dataplanesByType:
               standard:
                 total: 3
@@ -55,7 +41,7 @@ Feature: Overview: Detail view content
                 offline: 0
       """
 
-  Scenario: Shows expected content in zone mode
+  Scenario: Shows expected content in non-federated mode
     Given the environment
       """
       KUMA_MESH_COUNT: 3
@@ -85,19 +71,16 @@ Feature: Overview: Detail view content
             total: 1
             online: 1
       """
-
     When I visit the "/" URL
     Then the page title contains "Overview"
-
     And the "[data-testid='zone-control-planes-status']" element doesn't exist
     And the "[data-testid='meshes-status']" element contains "3"
     And the "[data-testid='services-status']" element contains "9/15"
     And the "[data-testid='data-plane-proxies-status']" element contains "7/9"
-
-    And the "$zone-control-planes-details" element doesn't exists
+    And the "$zone-control-planes-details" element doesn't exist
     And the "$meshes-details" element exists
 
-  Scenario: Shows expected content in global mode
+  Scenario: Shows expected content in federated mode
     Given the environment
       """
       KUMA_ZONE_COUNT: 2
@@ -155,15 +138,11 @@ Feature: Overview: Detail view content
                   disconnectTime: 2020-07-28T16:18:09.743141Z
                   config: '{"environment":"kubernetes"}'
       """
-
     When I visit the "/" URL
-
     Then the page title contains "Overview"
-
     And the "[data-testid='zone-control-planes-status']" element contains "1/2"
     And the "[data-testid='meshes-status']" element contains "3"
     And the "[data-testid='services-status']" element contains "9/15"
     And the "[data-testid='data-plane-proxies-status']" element contains "7/9"
-
     And the "$zone-control-planes-details" element exists
     And the "$meshes-details" element exists

--- a/src/app/common/EmptyBlock.vue
+++ b/src/app/common/EmptyBlock.vue
@@ -53,16 +53,20 @@
         </template>
 
         <template
-          v-if="$slots.action || href.length > 0"
           #action
         >
           <slot name="action">
             <XAction
+              v-if="href.length > 0"
               :type="(['docs', 'create'] as const).find((item) => item === actionType)"
               :href="href"
             >
               {{ actionLabel }}
             </XAction>
+            <XTeleportSlot
+              v-else
+              :name="`${props.type}-x-empty-state-actions`"
+            />
           </slot>
         </template>
       </KEmptyState>

--- a/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -50,21 +50,10 @@
                       {{ t('main-overview.detail.health.view_all') }}
                     </XAction>
                   </div>
-                  <!-- Here we check the length of the zones because if the length is zero then -->
-                  <!-- we show a create button in the empty state for the list therefore we don't need -->
-                  <!-- a repeated button here -->
                   <div
-                    v-if="(data?.items.length ?? 0 > 0) && can('create zones')"
                     class="card-actions"
                   >
-                    <KButton
-                      appearance="primary"
-                      :to="{ name: 'zone-create-view' }"
-                    >
-                      <AddIcon />
-
-                      {{ t('zones.index.create') }}
-                    </KButton>
+                    <XTeleportSlot name="control-plane-detail-view-zone-actions" />
                   </div>
                 </div>
 
@@ -114,7 +103,6 @@
 </template>
 
 <script lang="ts" setup>
-import { AddIcon } from '@kong/icons'
 
 import { sources as ControlPlaneSources } from '../sources'
 import { useControlPlaneStatus } from '@/app/control-planes'

--- a/src/app/meshes/components/MeshInsightsList.vue
+++ b/src/app/meshes/components/MeshInsightsList.vue
@@ -1,43 +1,53 @@
 <template>
-  <AppCollection
-    :headers="[
-      { label: t('meshes.components.mesh-insights-list.name'), key: 'name'},
-      { label: t('meshes.components.mesh-insights-list.services'), key: 'services'},
-      { label: t('meshes.components.mesh-insights-list.dataplanes'), key: 'dataplanes'},
-    ]"
-    :items="props.items"
-    :total="props.items?.length"
-    :empty-state-message="t('common.emptyState.message', { type: t('meshes.common.type', {count: 2}) })"
-    :empty-state-cta-to="t('meshes.href.docs')"
-    :empty-state-cta-text="t('common.documentation')"
-  >
-    <template #name="{ row: item }">
-      <RouterLink
-        :to="{
-          name: 'mesh-detail-view',
-          params: {
-            mesh: item.name,
-          },
-        }"
+  <div>
+    <DataCollection
+      :items="props.items ?? [undefined]"
+      type="meshes"
+    >
+      <AppCollection
+        :headers="[
+          { label: t('meshes.components.mesh-insights-list.name'), key: 'name'},
+          { label: t('meshes.components.mesh-insights-list.services'), key: 'services'},
+          { label: t('meshes.components.mesh-insights-list.dataplanes'), key: 'dataplanes'},
+        ]"
+        :items="props.items"
+        :total="props.items?.length"
       >
-        {{ item.name }}
-      </RouterLink>
-    </template>
+        <template
+          #name="{ row: item }"
+        >
+          <XAction
+            :to="{
+              name: 'mesh-detail-view',
+              params: {
+                mesh: item.name,
+              },
+            }"
+          >
+            {{ item.name }}
+          </XAction>
+        </template>
 
-    <template #services="{ row: item }">
-      {{ item.services.internal }}
-    </template>
+        <template
+          #services="{ row: item }"
+        >
+          {{ item.services.internal }}
+        </template>
 
-    <template #dataplanes="{ row: item }">
-      {{ item.dataplanesByType.standard.online }} / {{ item.dataplanesByType.standard.total }}
-    </template>
-  </AppCollection>
+        <template
+          #dataplanes="{ row: item }"
+        >
+          {{ item.dataplanesByType.standard.online }} / {{ item.dataplanesByType.standard.total }}
+        </template>
+      </AppCollection>
+    </DataCollection>
+  </div>
 </template>
 
 <script lang="ts" setup>
 import type { MeshInsight } from '../data'
+import { useI18n } from '@/app/application'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
-import { useI18n } from '@/utilities'
 
 const { t } = useI18n()
 

--- a/src/app/meshes/locales/en-us/index.yaml
+++ b/src/app/meshes/locales/en-us/index.yaml
@@ -1,4 +1,12 @@
 meshes:
+  x-empty-state:
+    title: 'No data'
+    body: !!text/markdown |
+      There are no Meshes present
+    action:
+      type: docs
+      label: Documentation
+      href: '{KUMA_DOCS_URL}/production/mesh?{KUMA_UTM_QUERY_PARAMS}'
   common:
     name: Name
     type: |

--- a/src/app/zones/components/ZoneControlPlanesList.vue
+++ b/src/app/zones/components/ZoneControlPlanesList.vue
@@ -1,38 +1,61 @@
 <template>
-  <AppCollection
-    :headers="[
-      { label: t('zone-cps.components.zone-control-planes-list.name'), key: 'name'},
-      { label: t('zone-cps.components.zone-control-planes-list.status'), key: 'status'},
-    ]"
-    :items="props.items"
-    :total="props.items?.length"
-    :empty-state-title="t('zone-cps.empty_state.title')"
-    :empty-state-message="can('create zones') ? t('zone-cps.empty_state.message') : t('common.emptyState.message', { type: 'Zones' })"
-    :empty-state-cta-to="can('create zones') ? { name: 'zone-create-view' } : undefined"
-    :empty-state-cta-text="t('zones.index.create')"
+  <div
+    v-bind="$attrs"
   >
-    <template #name="{ row: item }">
-      <RouterLink
-        :to="{
-          name: 'zone-cp-detail-view',
-          params: {
-            zone: item.name,
-          },
-        }"
+    <DataCollection
+      :items="props.items ?? [undefined]"
+      :type="can('create zones') ? `zone-cps-crud` : `zone-cps`"
+    >
+      <AppCollection
+        :headers="[
+          { label: t('zone-cps.components.zone-control-planes-list.name'), key: 'name'},
+          { label: t('zone-cps.components.zone-control-planes-list.status'), key: 'status'},
+        ]"
+        :items="props.items"
+        :total="props.items?.length"
       >
-        {{ item.name }}
-      </RouterLink>
-    </template>
+        <template #name="{ row: item }">
+          <XAction
+            :to="{
+              name: 'zone-cp-detail-view',
+              params: {
+                zone: item.name,
+              },
+            }"
+          >
+            {{ item.name }}
+          </XAction>
+        </template>
 
-    <template #status="{ row: item }">
-      <StatusBadge
-        :status="item.state"
-      />
-    </template>
-  </AppCollection>
+        <template #status="{ row: item }">
+          <StatusBadge
+            :status="item.state"
+          />
+        </template>
+      </AppCollection>
+    </DataCollection>
+  </div>
+  <!-- put the create button either in the empty state or above the list -->
+  <!-- depending on whether we are empty or not -->
+  <XTeleportTemplate
+    v-if="can('create zones') && props.items"
+    :to="{
+      name: (props.items.length > 0) ? 'control-plane-detail-view-zone-actions' : 'zone-cps-crud-x-empty-state-actions',
+    }"
+  >
+    <KButton
+      appearance="primary"
+      :to="{ name: 'zone-create-view' }"
+    >
+      <AddIcon />
+      {{ t('zones.index.create') }}
+    </KButton>
+  </XTeleportTemplate>
 </template>
 
 <script lang="ts" setup>
+
+import { AddIcon } from '@kong/icons'
 
 import type { ZoneOverview } from '../data'
 import { useCan, useI18n } from '@/app/application'

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -1,4 +1,14 @@
+zone-cps-crud:
+  x-empty-state:
+    title: No Zones yet...
+    body: !!text/markdown |
+      Create your first Zone to start managing your mesh
+
 zone-cps:
+  x-empty-state:
+    title: No Zones yet...
+    body: !!text/markdown |
+      There are no Zones present
 
   common:
     name: Name

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -4,7 +4,6 @@ import deepmerge from 'deepmerge'
 import type {
   DataplaneNetworking,
   DataPlaneProxyStatus,
-  ServiceStatus,
   ToTargetRefRuleMatch,
 } from '@/types/index.d'
 
@@ -66,6 +65,10 @@ export class KumaModule {
     )
   }
 
+  // TODO(jc): Use `totalName: Number.MAX_VALUE` so we can set a 'total' property automatically
+  /**
+   * Returns an object with the specified properties with the values as a random 'partition' of `total`
+   */
   partitionInto<T extends Record<string, typeof Number | number>>(skeleton: T, total: number): { [K in keyof T]: number } {
     const props = Object.entries(skeleton).filter(([_key, value]) => value === Number || isNaN(Number(value))).map(([key, _value]) => key)
     return {
@@ -158,23 +161,6 @@ export class KumaModule {
     ].filter(([_key, value]) => omitZeroValues ? value !== 0 : true)
 
     return Object.fromEntries(values) as DataPlaneProxyStatus
-  }
-
-  /**
-   * Returns a random service status object with self-consistent values (i.e. total = internal + external).
-   */
-  serviceStatus({ min = 0, max = 30, omitZeroValues = true }: { min?: number, max?: number, omitZeroValues?: boolean } = {}) {
-    const total = this.faker.number.int({ min, max })
-    const internal = this.faker.number.int({ min: 0, max: total })
-    const external = total - internal
-
-    const values = [
-      ['total', total],
-      ['internal', internal],
-      ['external', external],
-    ].filter(([_key, value]) => omitZeroValues ? value !== 0 : true)
-
-    return Object.fromEntries(values) as ServiceStatus
   }
 
   globalInsightServices({ min = 0, max = 30 }: { min?: number, max?: number } = {}) {

--- a/src/test-support/mocks/src/mesh-insights.ts
+++ b/src/test-support/mocks/src/mesh-insights.ts
@@ -119,7 +119,13 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               },
             },
           },
-          services: fake.kuma.serviceStatus({ max: serviceTotal }),
+          services: {
+            total: serviceTotal,
+            ...fake.kuma.partitionInto({
+              internal: Number,
+              external: Number,
+            }, serviceTotal),
+          },
         }
       }),
       next,

--- a/src/test-support/mocks/src/mesh-insights/_.ts
+++ b/src/test-support/mocks/src/mesh-insights/_.ts
@@ -104,7 +104,13 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
           }, {}),
         },
       },
-      services: fake.kuma.serviceStatus({ max: serviceTotal }),
+      services: {
+        total: serviceTotal,
+        ...fake.kuma.partitionInto({
+          internal: Number,
+          external: Number,
+        }, serviceTotal),
+      },
     },
   }
 }


### PR DESCRIPTION
Part of https://github.com/kumahq/kuma-gui/issues/2388

This PR ended up doing several things:

- Uses DataCollection for the lists on the home/ control plane detail page (Zones and Meshes)
- Refactors the way that a `[+ Create Zone]` is conditionally added to the page. We now use a method which means we can decorate the `ZoneControlPlaneList` component from The Outside to add the button if we want to do that eventually. It's also generally nicer as we define the button once and then add to the DOM in the correct place, instead of defining twice and then wrapping both in slightly different conditionals.
- I noticed that the test we use for this mocks the mesh-insights API response incorrectly. So I amended that in the test and used a more generic method we have for mocking 'partitions of totals' in the mocks.

---

To view the different variations you can add the following cookie settings to https://deploy-preview-2699--kuma-gui.netlify.app/gui/:

- Non-empty lists, _without_ zone creation
```
KUMA_ZONE_COUNT=7
KUMA_MESH_COUNT=7
KUMA_ZONE_CREATION_FLOW=disabled
```

- Non-empty lists, _with_ zone creation: 
```
KUMA_ZONE_COUNT=7
KUMA_MESH_COUNT=7
KUMA_ZONE_CREATION_FLOW=enabled
```

- Empty lists, _with_ zone creation
```
KUMA_ZONE_COUNT=0
KUMA_MESH_COUNT=0
KUMA_ZONE_CREATION_FLOW=enabled
```

- Empty lists _without_ zone creation
```
KUMA_ZONE_COUNT=0
KUMA_MESH_COUNT=0
KUMA_ZONE_CREATION_FLOW=disabled
```