### PR TITLE
chore: Remove old uniqueId from @/utilities

### DIFF
--- a/src/app/common/filter-bar/FilterBar.vue
+++ b/src/app/common/filter-bar/FilterBar.vue
@@ -118,7 +118,7 @@ import { ChevronRightIcon, FilterIcon } from '@kong/icons'
 import { computed, onBeforeUnmount, onMounted, watch, ref } from 'vue'
 
 import { Command, ShortcutManager } from './ShortcutManager'
-import uniqueId from '@/utilities/uniqueId'
+import { uniqueId } from '@/app/application'
 
 type FilterFieldDefinition = {
   description: string

--- a/src/utilities/uniqueId.ts
+++ b/src/utilities/uniqueId.ts
@@ -1,5 +1,0 @@
-let i = 0
-export default (prefix = 'unique') => {
-  i++
-  return `${prefix}-${i}`
-}


### PR DESCRIPTION
Back in the mists of time, we added a `uniqueId` to out `@/utilities` folder.

We've since moved to use a much more modular approach and we have a `application` module that contains things that are generally needed by the entire application (i.e. any module in the application). This `application` module includes a `uniqueId` function that we now use almost everywhere.

https://github.com/kumahq/kuma-gui/blob/73077f131ff5f22e0801873ead4172130fe010fa/src/app/application/utilities/index.ts#L10-L18

I found one instance of where we were still using the old one, so I removed that and deleted the old file.

Note: There are a few places where we use `uniqueId` where its not really necessary (for legacy reasons), I guess these will be removed also in time.


