### PR TITLE
chore: add extra error handling

### DIFF
--- a/src/app/application/index.ts
+++ b/src/app/application/index.ts
@@ -70,6 +70,7 @@ const $ = {
   sources: token('data.sources'),
   dataSourcePool: token<DataSourcePool>('data.DataSourcePool'),
   getDataSourceCacheKeyPrefix: token<() => string>('data.getDataSourceCacheKeyPrefix'),
+  errorHandler: token<(e: Error) => void>('application.error.handler'),
 
   i18n: token<ReturnType<typeof I18n>>('i18n'),
   enUs: token('i18n.locale.enUs'),
@@ -156,12 +157,17 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
     }],
 
+    [$.errorHandler, {
+      service: () => () => { },
+    }],
+
     [$.dataSourcePool, {
       service: (sources: Sources, getKey: () => string) => {
         return new DataSourcePool(sources, { create, destroy }, getKey)
       },
       arguments: [
         app.sources,
+        $.errorHandler,
         $.getDataSourceCacheKeyPrefix,
       ],
     }],

--- a/src/app/application/services/data-source/DataSourcePool.ts
+++ b/src/app/application/services/data-source/DataSourcePool.ts
@@ -26,7 +26,8 @@ export default class DataSourcePool {
 
   constructor(
     requests: Sources,
-    { create, destroy = () => {}, error = () => {} }: { create: Creator, destroy?: Destroyer, error?: (e: Event) => void },
+    { create, destroy = () => { } }: { create: Creator, destroy?: Destroyer },
+    error: (e: Event) => void = () => { },
     getCacheKeyPrefix: () => string = () => '',
 
     // a currently unbounded cache of previous JSON responses that is used to

--- a/src/app/kuma/index.ts
+++ b/src/app/kuma/index.ts
@@ -1,4 +1,5 @@
 import type { EnvArgs } from '@/app/application/services/env/Env'
+import { ApiError } from '@/app/kuma/services/kuma-api/ApiError'
 import KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
 import { RestClient } from '@/app/kuma/services/kuma-api/RestClient'
 import i18nEnUs from '@/locales/en-us'
@@ -45,6 +46,18 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
     }],
 
+    [app.errorHandler, {
+      service: () => {
+        return (e: Error | ErrorEvent) => {
+          const error = 'error' in e ? e.error : e
+          if (error instanceof ApiError) {
+            return
+          }
+          console.error(error)
+        }
+      },
+    }],
+
     [token('kuma.components.not-found'), {
       service: () => [
         () => import('@/app/kuma/views/KumaNotFoundView.vue'),
@@ -53,6 +66,5 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         app.notFoundView,
       ],
     }],
-
   ]
 }


### PR DESCRIPTION
We found [an error](https://github.com/kumahq/kuma-gui/pull/2697) a few days back which manifested in a user facing scenario, but did not produce a error in the dev console.

This PR adds better error handling to ensure that these sorts of errors are also logged to the dev console.

I did this work against the code previous to #2697 where the bug occurred and with this PR applied it now looks like this:

<img width="1719" alt="Screenshot 2024-06-28 at 13 43 31" src="https://github.com/kumahq/kuma-gui/assets/554604/b6a411b2-e2a4-4f35-8ae2-794763b452d2">


