### PR TITLE
fix(zones): use the same version from the DataSource used in the page instead of the env var

### DIFF
--- a/features/zones/zone-cps/Warnings.feature
+++ b/features/zones/zone-cps/Warnings.feature
@@ -1,12 +1,13 @@
 Feature: zones / warnings
+
   Background:
     Given the CSS selectors
-      | Alias                    | Selector                                                             |
-      | warning-no-subscriptions | [data-testid='warning-no-subscriptions']                             |
-      | warning-zone-memory      | [data-testid='warning-ZONE_STORE_TYPE_MEMORY']                       |
-      | zone-cp-table-row        | [data-testid='zone-cp-collection'] tbody tr                          |
-      | warning-trigger          | $zone-cp-table-row:nth-child(1) [data-testid="warning"]              |
-      | warning-memory           | $zone-cp-table-row:nth-child(1) [data-testid="warning-store_memory"] |
+      | Alias                    | Selector                                                                       |
+      | warning-no-subscriptions | [data-testid='warning-no-subscriptions']                                       |
+      | warning-zone-memory      | [data-testid='warning-ZONE_STORE_TYPE_MEMORY']                                 |
+      | zone-cp-table-row        | [data-testid='zone-cp-collection'] tbody tr                                    |
+      | warning-trigger          | $zone-cp-table-row:nth-child(1) [data-testid="warning"]                        |
+      | warning-memory           | $zone-cp-table-row:nth-child(1) [data-testid="warning-ZONE_STORE_TYPE_MEMORY"] |
     And the environment
       """
       KUMA_ZONE_COUNT: 1
@@ -24,6 +25,7 @@ Feature: zones / warnings
     When I visit the "/zones/zone-cp-1/overview" URL
     And I click the "[data-testid='zone-cp-config-view-tab'] a" element
     Then the "$warning-no-subscriptions" element exists
+
   Scenario: When zone store type is memory a warning is shown in listings
     Given the environment
       """
@@ -56,6 +58,7 @@ Feature: zones / warnings
       """
     When I visit the "<URL>" URL
     Then the "$warning-zone-memory" element exists
+
     Examples:
       | URL                       |
       | /zones/zone-cp-1/overview |
@@ -70,6 +73,7 @@ Feature: zones / warnings
       """
     When I visit the "<URL>" URL
     Then the "$warning-zone-memory" element doesn't exist
+
     Examples:
       | URL                       |
       | /zones/zone-cp-1/overview |

--- a/src/app/control-planes/sources.ts
+++ b/src/app/control-planes/sources.ts
@@ -38,9 +38,15 @@ export const sources = (env: Env['var'], api: KumaApi) => {
       // if the current version includes some sort of `-dev` then pretend we
       // are on the latest version and therefore not outdated
       if (!params.version.match('^[0-9]+.[0-9]+.[0-9]+$')) {
-        return false
+        return {
+          version: env('KUMA_VERSION'),
+          outdated: false,
+        }
       }
-      return compare(env('KUMA_VERSION'), params.version) === 1
+      return {
+        version: env('KUMA_VERSION'),
+        outdated: compare(env('KUMA_VERSION'), params.version) === 1,
+      }
     },
 
     // used to figure out if the currently running global control-plane

--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -38,8 +38,8 @@ zone-cps:
       title: Zone Control Planes
       breadcrumbs: Zone Control Planes
   list:
-    version_mismatch: 'Version mismatch'
-    store_memory: 'Uses memory store'
+    ZONE_STORE_TYPE_MEMORY: 'Version mismatch'
+    INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS: 'Uses memory store'
   detail:
     subscriptions: 'KDS connections'
     configuration_title: 'Configuration'

--- a/src/app/zones/views/ZoneDetailTabsView.vue
+++ b/src/app/zones/views/ZoneDetailTabsView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    v-slot="{ can, route }"
+    v-slot="{ can, route, t }"
     name="zone-cp-detail-tabs-view"
     :params="{
       zone: '',
@@ -9,7 +9,6 @@
     <DataLoader
       v-slot="{ data }: ZoneOverviewSource"
       :src="`/zone-cps/${route.params.zone}`"
-      @change="change"
     >
       <AppView
         v-if="data"
@@ -100,7 +99,6 @@
           <component
             :is="child.Component"
             :data="data"
-            :notifications="notifications"
           />
         </RouterView>
       </AppView>
@@ -109,38 +107,13 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue'
 
-import type { ZoneOverview } from '../data'
 import type { ZoneOverviewSource } from '../sources'
 import DeleteResourceModal from '@/app/common/DeleteResourceModal.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import { useI18n, useKumaApi } from '@/utilities'
-import { get } from '@/utilities/get'
+import { useKumaApi } from '@/utilities'
 
 const kumaApi = useKumaApi()
-const { t } = useI18n()
-
-const notifications = ref<{kind: string, payload: Record<string, string>}[]>([])
-
-const change = (data: ZoneOverview) => {
-  const warnings = []
-  if (data.zoneInsight.store === 'memory') {
-    warnings.push({
-      kind: 'ZONE_STORE_TYPE_MEMORY',
-      payload: {},
-    })
-  }
-  if (!get(data.zoneInsight, 'version.kumaCp.kumaCpGlobalCompatible', 'true')) {
-    warnings.push({
-      kind: 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS',
-      payload: {
-        zoneCpVersion: get(data.zoneInsight, 'version.kumaCp.version', t('common.collection.none')),
-      },
-    })
-  }
-  notifications.value = warnings
-}
 async function deleteZone(name: string) {
   // Intentionally not wrapped in a try-catch block so that the DeleteResourceModal can discover when the operation failed.
   await kumaApi.deleteZone({ name })

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -3,52 +3,56 @@
     v-slot="{ t, uri }"
     name="zone-cp-detail-view"
   >
-    <AppView>
-      <template
-        v-if="props.notifications.length > 0"
-        #notifications
-      >
-        <ul>
-          <li
-            v-for="warning in props.notifications"
-            :key="warning.kind"
-            :data-testid="`warning-${warning.kind}`"
-
-            v-html="t(`common.warnings.${warning.kind}`, warning.payload)"
-          />
-        </ul>
-      </template>
-      <div
-        data-testid="detail-view-details"
-        class="stack"
-      >
-        <KCard>
-          <div class="columns">
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.status') }}
-              </template>
-
-              <template #body>
-                <StatusBadge :status="props.data.state" />
-              </template>
-            </DefinitionCard>
-            <DataSource
-              v-slot="{ data: outdated }"
-              :src="uri(sources, '/control-plane/outdated/:version', {
-                version: props.data.zoneInsight.version?.kumaCp?.version ?? '-',
+    <DataSource
+      v-slot="{ data: version }"
+      :src="uri(sources, '/control-plane/outdated/:version', {
+        version: props.data.zoneInsight.version?.kumaCp?.version ?? '-',
+      })"
+    >
+      <AppView>
+        <template
+          v-if="props.data.warnings.length > 0"
+          #notifications
+        >
+          <ul>
+            <li
+              v-for="warning in props.data.warnings"
+              :key="warning.kind"
+              :data-testid="`warning-${warning.kind}`"
+              v-html="t(`common.warnings.${warning.kind}`, {
+                ...warning.payload,
+                ...(warning.kind === 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS' ? {
+                  globalCpVersion: version?.version ?? '',
+                } : {}),
               })"
-            >
+            />
+          </ul>
+        </template>
+        <div
+          data-testid="detail-view-details"
+          class="stack"
+        >
+          <KCard>
+            <div class="columns">
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.status') }}
+                </template>
+
+                <template #body>
+                  <StatusBadge :status="props.data.state" />
+                </template>
+              </DefinitionCard>
               <DefinitionCard
                 :class="{
                   version: true,
-                  outdated,
+                  outdated: version?.outdated,
                 }"
               >
                 <template #title>
                   {{ t('zone-cps.routes.item.version') }}
                   <template
-                    v-if="outdated === true"
+                    v-if="version?.outdated === true"
                   >
                     <KTooltip
                       max-width="300"
@@ -70,44 +74,44 @@
                   {{ props.data.zoneInsight.version?.kumaCp?.version ?? '—' }}
                 </template>
               </DefinitionCard>
-            </DataSource>
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.type') }}
-              </template>
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.type') }}
+                </template>
 
-              <template #body>
-                {{ t(`common.product.environment.${props.data.zoneInsight.environment || 'unknown'}`) }}
-              </template>
-            </DefinitionCard>
+                <template #body>
+                  {{ t(`common.product.environment.${props.data.zoneInsight.environment || 'unknown'}`) }}
+                </template>
+              </DefinitionCard>
 
-            <DefinitionCard>
-              <template #title>
-                {{ t('zone-cps.routes.item.authentication_type') }}
-              </template>
+              <DefinitionCard>
+                <template #title>
+                  {{ t('zone-cps.routes.item.authentication_type') }}
+                </template>
 
-              <template #body>
-                {{ props.data.zoneInsight.authenticationType || t('common.not_applicable') }}
-              </template>
-            </DefinitionCard>
-          </div>
-        </KCard>
-
-        <div
-          v-if="props.data.zoneInsight.subscriptions.length > 0"
-        >
-          <h2>{{ t('zone-cps.detail.subscriptions') }}</h2>
-
-          <KCard class="mt-4">
-            <SubscriptionList
-              :subscriptions="props.data.zoneInsight.subscriptions"
-            >
-              <p>{{ t('zone-cps.routes.item.subscription_intro') }}</p>
-            </SubscriptionList>
+                <template #body>
+                  {{ props.data.zoneInsight.authenticationType || t('common.not_applicable') }}
+                </template>
+              </DefinitionCard>
+            </div>
           </KCard>
+
+          <div
+            v-if="props.data.zoneInsight.subscriptions.length > 0"
+          >
+            <h2>{{ t('zone-cps.detail.subscriptions') }}</h2>
+
+            <KCard class="mt-4">
+              <SubscriptionList
+                :subscriptions="props.data.zoneInsight.subscriptions"
+              >
+                <p>{{ t('zone-cps.routes.item.subscription_intro') }}</p>
+              </SubscriptionList>
+            </KCard>
+          </div>
         </div>
-      </div>
-    </AppView>
+      </AppView>
+    </DataSource>
   </RouteView>
 </template>
 
@@ -121,12 +125,9 @@ import StatusBadge from '@/app/common/StatusBadge.vue'
 import { sources } from '@/app/control-planes/sources'
 import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
 
-const props = withDefaults(defineProps<{
+const props = defineProps<{
   data: ZoneOverview
-  notifications: { kind: string, payload: Record<string, string> }[]
-}>(), {
-  notifications: () => [],
-})
+}>()
 </script>
 <style lang="scss" scoped>
 .version.outdated :deep(.definition-card-container) {

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -61,7 +61,7 @@
               :headers="[
                 { ...me.get('headers.type'), label: '&nbsp;', key: 'type' },
                 { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                { ...me.get('headers.zoneCpVersion'), label: 'Zone CP Version', key: 'zoneCpVersion' },
+                { ...me.get('headers.zoneCpVersion'), label: 'Zone Leader CP Version', key: 'zoneCpVersion' },
                 { ...me.get('headers.ingress'), label: 'Ingresses (online / total)', key: 'ingress' },
                 { ...me.get('headers.egress'), label: 'Egresses (online / total)', key: 'egress' },
                 { ...me.get('headers.state'), label: 'Status', key: 'state' },
@@ -140,40 +140,27 @@
               </template>
 
               <template #warnings="{ row: item }">
-                <template
-                  v-for="warnings in [{
-                    version_mismatch: !get(item.zoneInsight, 'version.kumaCp.kumaCpGlobalCompatible', 'true'),
-                    store_memory: item.zoneInsight.store === 'memory',
-                  }]"
-                  :key="`${warnings.version_mismatch}-${warnings.store_memory}`"
+                <XIcon
+                  v-if="item.warnings.length > 0"
+                  name="warning"
+                  data-testid="warning"
                 >
-                  <XIcon
-                    v-if="Object.values(warnings).some((item) => item)"
-                    name="warning"
-                    data-testid="warning"
-                  >
-                    <ul>
-                      <template
-                        v-for="(warning, i) in warnings"
-                        :key="i"
-                      >
-                        <li
-                          v-if="warning"
-                          :data-testid="`warning-${i}`"
-                        >
-                          {{ t(`zone-cps.list.${i}`) }}
-                        </li>
-                      </template>
-                    </ul>
-                  </XIcon>
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
+                  <ul>
+                    <li
+                      v-for="warning in item.warnings"
+                      :key="warning.kind"
+                      :data-testid="`warning-${warning.kind}`"
+                    >
+                      {{ t(`zone-cps.list.${warning.kind}`) }}
+                    </li>
+                  </ul>
+                </XIcon>
+                <template v-else>
+                  {{ t('common.collection.none') }}
                 </template>
               </template>
 
               <template
-                v-if="can('create zones')"
                 #actions="{ row }"
               >
                 <XActionGroup>
@@ -191,6 +178,7 @@
                       {{ t('common.collection.actions.view') }}
                     </XAction>
                     <XAction
+                      v-if="can('create zones')"
                       appearance="danger"
                       @click="toggle"
                     >
@@ -318,10 +306,5 @@ async function deleteZone(name: string) {
   color: inherit;
   font-weight: $kui-font-weight-semibold;
   text-decoration: none;
-}
-
-.warning-type-memory {
-  margin-top: $kui-space-60;
-  margin-bottom: $kui-space-60;
 }
 </style>

--- a/src/locales/en-us/common/index.yaml
+++ b/src/locales/en-us/common/index.yaml
@@ -43,7 +43,7 @@ common:
     INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS: !!text/markdown |
       There is a mismatch between versions of Kuma DP (**{ kumaDp }**) and the Zone Control Plane.
     INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS: !!text/markdown |
-      There is mismatch between versions of Zone Control Plane (**{ zoneCpVersion }**) and the Global Control Plane (**{ KUMA_VERSION }**)
+      There is mismatch between versions of Zone Control Plane (**{ zoneCpVersion }**) and the Global Control Plane (**{ globalCpVersion }**)
   copyText: 'Copy'
   copySuccessText: 'Copied!'
   copyKubernetesText: 'Copy as Kubernetes'


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/2621 we added an async DataSource that compares the version of the ZoneCP and the GlobalCP.

We usually just compare using the sync `env('KUMA_VERSION')` (as we do here) but sometimes we need an async interaction.

Previously, we only used the comparison for one warning/tooltip in the page. This PR changes it so we emit whether the relationship between zone and global is outdated, _plus the latest version_. This means we can also use this latest version in other places.

When we need to use an async interaction for this, doing this PR means we can.

---

As I worked on this it made sense to also move the Zone warnings data reshaping into our data layer, so I did that here also.