### PR TITLE
chore: remove "Go to details" add action dropdown to all rows

### DIFF
--- a/features/application/ListViewNavigation.feature
+++ b/features/application/ListViewNavigation.feature
@@ -1,8 +1,9 @@
 Feature: application / ListViewNavigation
+
   Background:
     Given the CSS selectors
-      | Alias       | Selector                                                                  |
-      | detail-link | [data-testid$='-collection'] tr:nth-child(1) [data-testid='details-link'] |
+      | Alias       | Selector                                                   |
+      | detail-link | [data-testid$='-collection'] tr:nth-child(1) [data-action] |
     And the environment
       """
       KUMA_MODE: global
@@ -12,11 +13,10 @@ Feature: application / ListViewNavigation
   Scenario Outline: The <URL> list view has correct detail view link
     When I visit the "<URL>" URL
     And I click the "$detail-link" element
-
     Then the "<DetailViewSelector>" element exists
 
     Examples:
-      | URL                          | DetailViewSelector                       |
-      | /zones                       | [data-testid='zone-cp-detail-view']      |
-      | /meshes                      | [data-testid='mesh-detail-view']         |
-      | /meshes/default/services     | [data-testid='service-detail-view']      |
+      | URL                      | DetailViewSelector                  |
+      | /zones                   | [data-testid='zone-cp-detail-view'] |
+      | /meshes                  | [data-testid='mesh-detail-view']    |
+      | /meshes/default/services | [data-testid='service-detail-view'] |

--- a/features/mesh/Index.feature
+++ b/features/mesh/Index.feature
@@ -1,4 +1,5 @@
 Feature: mesh / index
+
   Background:
     Given the CSS selectors
       | Alias          | Selector                                     |
@@ -7,7 +8,6 @@ Feature: mesh / index
       | breadcrumbs    | .k-breadcrumbs                               |
       | button-refresh | [data-testid='data-overview-refresh-button'] |
       | navigation     | [data-testid='mesh-tabs'] ul >               |
-
     Given the environment
       """
       KUMA_MESH_COUNT: 2
@@ -23,15 +23,14 @@ Feature: mesh / index
 
   Scenario: Clicking a mesh and back again for <Mesh>
     Then the "$item" element exists 2 times
-    When I click the "<Selector> [data-testid='details-link']" element
+    When I click the "<Selector> [data-testid='x-action-group-control']" element
+    And I click the "<Selector> [data-testid='x-action-group'] li:nth-child(1) [data-testid='x-action']" element
     Then the URL contains "/meshes/<Mesh>"
     And the "$breadcrumbs" element contains "Meshes"
-
     Then I click the "$navigation li:nth-child(2) a" element
     Then I click the "$navigation li:nth-child(3) a" element
     Then I click the "$navigation li:nth-child(4) a" element
     Then I click the "$navigation li:nth-child(1) a" element
-
     And I click the "$breadcrumbs > .breadcrumbs-item-container:nth-child(1) > a" element
     Then the "$item" element exists 2 times
 

--- a/features/mesh/builtin-gateways/Index.feature
+++ b/features/mesh/builtin-gateways/Index.feature
@@ -1,4 +1,5 @@
 Feature: mesh / builtin-gateways / index
+
   Background:
     Given the CSS selectors
       | Alias                   | Selector                                          |
@@ -6,7 +7,6 @@ Feature: mesh / builtin-gateways / index
       | items-header            | $items th                                         |
       | item                    | $items tbody tr                                   |
       | builtin-gateway-sub-tab | [data-testid='builtin-gateway-list-view-sub-tab'] |
-
     And the environment
       """
       KUMA_MESHGATEWAY_COUNT: 1
@@ -23,12 +23,10 @@ Feature: mesh / builtin-gateways / index
 
   Scenario: Sub navigation has expected content
     When I visit the "/meshes/default/gateways/builtin" URL
-
     Then the "$builtin-gateway-sub-tab" element exists
 
   Scenario: The items have the correct columns
     When I visit the "/meshes/default/gateways/builtin" URL
-
     Then the "$items-header" element exists 3 times
     Then the "$items-header" elements contain
       | Value |
@@ -37,7 +35,6 @@ Feature: mesh / builtin-gateways / index
 
   Scenario: The items have the expected content and UI elements
     When I visit the "/meshes/default/gateways/builtin" URL
-
     Then the "[data-testid='gateway-list-tabs-view-tab'].active" element exists
     Then the "$item" element exists 1 times
     Then the "$item:nth-child(1)" element contains
@@ -46,10 +43,7 @@ Feature: mesh / builtin-gateways / index
 
   Scenario: Clicking View details goes to the detail page and back again
     When I visit the "/meshes/default/gateways/builtin" URL
-
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "gateway-1"
-
-    When I click the "$item:nth-child(1) [data-testid='details-link']" element
-
+    When I click the "$item:nth-child(1) [data-action]" element
     Then the URL contains "/gateways/builtin/gateway-1/overview"
     Then the "[data-testid='builtin-gateway-detail-view-tab'].active" element exists

--- a/features/mesh/dataplanes/Navigation.feature
+++ b/features/mesh/dataplanes/Navigation.feature
@@ -1,86 +1,101 @@
 Feature: mesh / dataplanes / navigation
+
   Background:
     Given the CSS selectors
-      | Alias         | Selector                                                                 |
-      | row           | [data-testid$='-collection'] tr:first-child td:first-child               |
-      | summary-title | [data-testid='slideout-title'] a                                         |
-      | detail-link   | [data-testid$='-collection'] tr:first-child [data-testid='details-link'] |
+      | Alias         | Selector                                                                    |
+      | row           | [data-testid$='-collection'] tr:first-child                                 |
+      | summary-title | [data-testid='slideout-title'] a                                            |
+      | action-group  | $row [data-testid='x-action-group-control']                                 |
+      | view          | $row [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | action        | $row [data-action]                                                          |
     And the environment
       """
       KUMA_DATAPLANE_COUNT: 1
       """
 
-    Rule: In a namepaced environment
-      Background:
-        Given the environment
-          """
-          KUMA_ENVIRONMENT: kubernetes
-          """
-        And the URL "/meshes/default/dataplanes/_overview" responds with
-          """
-          body:
-            items:
-            - name: monitor-proxy-0-5064a9c9a-icpsl.kuma-system
-              labels:
-                kuma.io/display-name: monitor-proxy-0-5064a9c9a-icpsl
-                k8s.kuma.io/namespace: kuma-system
-          """
-      Scenario Outline: clicking the detail link
-        When I visit the "<URL>" URL
-        And I click the "$detail-link" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        And the "[data-testid='data-plane-detail-view']" element exists
-        Examples:
-          | URL                                                                             |
-          | /meshes/default/gateways/builtin/alarm-0-6064a9c9a-icpsl.kuma-system/dataplanes |
-          | /meshes/default/services/internal/microchip-0-internal/overview                 |
-          | /meshes/default/data-planes                                                     |
-      Scenario Outline: clicking the row, opening and summary, and clicking the title
-        When I visit the "<URL>" URL
-        And I click the "$row" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system"
-        And the URL doesn't contain "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        Then I click the "$summary-title" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        And the "[data-testid='data-plane-detail-view']" element exists
-        Examples:
-          | URL                                                                             |
-          | /meshes/default/gateways/builtin/alarm-0-6064a9c9a-icpsl.kuma-system/dataplanes |
-          | /meshes/default/services/internal/microchip-0-internal/overview                 |
-          | /meshes/default/data-planes                                                     |
+  Rule: In a namepaced environment
 
-    Rule: In a non-namespaced environment
-      Background:
-        Given the environment
-          """
-          KUMA_ENVIRONMENT: universal
-          """
-        And the URL "/meshes/default/dataplanes/_overview" responds with
-          """
-          body:
-            items:
-            - name: monitor-proxy-0
-          """
-      Scenario Outline: clicking the detail link
-        When I visit the "<URL>" URL
-        And I click the "$detail-link" element
-        Then the URL contains "monitor-proxy-0/overview"
-        And the "[data-testid='data-plane-detail-view']" element exists
-        Examples:
-          | URL                                                                             |
-          | /meshes/default/gateways/builtin/alarm-0-6064a9c9a-icpsl.kuma-system/dataplanes |
-          | /meshes/default/services/internal/microchip-0-internal/overview                 |
-          | /meshes/default/data-planes                                                     |
-      Scenario Outline: clicking the row, opening and summary, and clicking the title
-        When I visit the "<URL>" URL
-        And I click the "$row" element
-        Then the URL contains "monitor-proxy-0"
-        And the URL doesn't contain "monitor-proxy-0/overview"
-        Then I click the "$summary-title" element
-        Then the URL contains "monitor-proxy-0/overview"
-        And the "[data-testid='data-plane-detail-view']" element exists
-        Examples:
-          | URL                                                                             |
-          | /meshes/default/gateways/builtin/alarm-0-6064a9c9a-icpsl.kuma-system/dataplanes |
-          | /meshes/default/services/internal/microchip-0-internal/overview                 |
-          | /meshes/default/data-planes                                                     |
+    Background:
+      Given the environment
+        """
+        KUMA_ENVIRONMENT: kubernetes
+        """
+      And the URL "/meshes/default/dataplanes/_overview" responds with
+        """
+        body:
+          items:
+          - name: monitor-proxy-0-5064a9c9a-icpsl.kuma-system
+            labels:
+              kuma.io/display-name: monitor-proxy-0-5064a9c9a-icpsl
+              k8s.kuma.io/namespace: kuma-system
+        """
+
+    Scenario Outline: clicking the detail link
+      When I visit the "<URL>" URL
+      And I click the "$action-group" element
+      And I click the "$view" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      And the "[data-testid='data-plane-detail-view']" element exists
+
+      Examples:
+        | URL                                                                             |
+        | /meshes/default/gateways/builtin/alarm-0-6064a9c9a-icpsl.kuma-system/dataplanes |
+        | /meshes/default/services/internal/microchip-0-internal/overview                 |
+        | /meshes/default/data-planes                                                     |
+
+    Scenario Outline: clicking the row, opening and summary, and clicking the title
+      When I visit the "<URL>" URL
+      And I click the "$action" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system"
+      And the URL doesn't contain "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      Then I click the "$summary-title" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      And the "[data-testid='data-plane-detail-view']" element exists
+
+      Examples:
+        | URL                                                                             |
+        | /meshes/default/gateways/builtin/alarm-0-6064a9c9a-icpsl.kuma-system/dataplanes |
+        | /meshes/default/services/internal/microchip-0-internal/overview                 |
+        | /meshes/default/data-planes                                                     |
+
+  Rule: In a non-namespaced environment
+
+    Background:
+      Given the environment
+        """
+        KUMA_ENVIRONMENT: universal
+        """
+      And the URL "/meshes/default/dataplanes/_overview" responds with
+        """
+        body:
+          items:
+          - name: monitor-proxy-0
+        """
+
+    Scenario Outline: clicking the detail link
+      When I visit the "<URL>" URL
+      And I click the "$action-group" element
+      And I click the "$view" element
+      Then the URL contains "monitor-proxy-0/overview"
+      And the "[data-testid='data-plane-detail-view']" element exists
+
+      Examples:
+        | URL                                                                             |
+        | /meshes/default/gateways/builtin/alarm-0-6064a9c9a-icpsl.kuma-system/dataplanes |
+        | /meshes/default/services/internal/microchip-0-internal/overview                 |
+        | /meshes/default/data-planes                                                     |
+
+    Scenario Outline: clicking the row, opening and summary, and clicking the title
+      When I visit the "<URL>" URL
+      And I click the "$action" element
+      Then the URL contains "monitor-proxy-0"
+      And the URL doesn't contain "monitor-proxy-0/overview"
+      Then I click the "$summary-title" element
+      Then the URL contains "monitor-proxy-0/overview"
+      And the "[data-testid='data-plane-detail-view']" element exists
+
+      Examples:
+        | URL                                                                             |
+        | /meshes/default/gateways/builtin/alarm-0-6064a9c9a-icpsl.kuma-system/dataplanes |
+        | /meshes/default/services/internal/microchip-0-internal/overview                 |
+        | /meshes/default/data-planes                                                     |

--- a/features/mesh/delegated-gateways/Index.feature
+++ b/features/mesh/delegated-gateways/Index.feature
@@ -1,11 +1,15 @@
 Feature: mesh / delegated-gateways / index
+
   Background:
     Given the CSS selectors
-      | Alias                     | Selector                                            |
-      | items                     | [data-testid='delegated-gateway-collection']        |
-      | items-header              | $items th                                           |
-      | item                      | $items tbody tr                                     |
-      | delegated-gateway-sub-tab | [data-testid='delegated-gateway-list-view-sub-tab'] |
+      | Alias                     | Selector                                                                     |
+      | items                     | [data-testid='delegated-gateway-collection']                                 |
+      | items-header              | $items th                                                                    |
+      | item                      | $items tbody tr                                                              |
+      | action-group              | $item [data-testid='x-action-group-control']                                 |
+      | view                      | $item [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | action                    | $item [data-action]                                                          |
+      | delegated-gateway-sub-tab | [data-testid='delegated-gateway-list-view-sub-tab']                          |
     And the environment
       """
       KUMA_SERVICE_COUNT: 1
@@ -26,12 +30,10 @@ Feature: mesh / delegated-gateways / index
 
   Scenario: Sub navigation has expected content
     When I visit the "/meshes/default/gateways/delegated" URL
-
     Then the "$delegated-gateway-sub-tab" element exists
 
   Scenario: The items have the correct columns
     When I visit the "/meshes/default/gateways/delegated" URL
-
     Then the "$items-header" element exists 5 times
     Then the "$items-header" elements contain
       | Value                       |
@@ -42,22 +44,19 @@ Feature: mesh / delegated-gateways / index
 
   Scenario: The items have the expected content and UI elements
     When I visit the "/meshes/default/gateways/delegated" URL
-
     Then the "[data-testid='gateway-list-tabs-view-tab'].active" element exists
     Then the "$item" element exists 1 times
     Then the "$item:nth-child(1)" element contains
       | Value              |
       | gateway-1          |
-      | 1.2.3.4:8000       |
-      | 1 / 2              |
+      |       1.2.3.4:8000 |
+      |              1 / 2 |
       | partially degraded |
 
   Scenario: Clicking View details goes to the detail page and back again
     When I visit the "/meshes/default/gateways/delegated" URL
-
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "gateway-1"
-
-    When I click the "$item:nth-child(1) [data-testid='details-link']" element
-
+    When I click the "$action-group" element
+    And I click the "$view" element
     Then the URL contains "/gateways/delegated/gateway-1/overview"
     Then the "[data-testid='delegated-gateway-detail-view-tab'].active" element exists

--- a/features/mesh/external-services/Index.feature
+++ b/features/mesh/external-services/Index.feature
@@ -1,11 +1,15 @@
 Feature: mesh / external-services / index
+
   Background:
     Given the CSS selectors
-      | Alias                    | Selector                                           |
-      | items                    | [data-testid='external-service-collection']        |
-      | items-header             | $items th                                          |
-      | item                     | $items tbody tr                                    |
-      | external-service-sub-tab | [data-testid='external-service-list-view-sub-tab'] |
+      | Alias                    | Selector                                                                     |
+      | items                    | [data-testid='external-service-collection']                                  |
+      | items-header             | $items th                                                                    |
+      | item                     | $items tbody tr                                                              |
+      | action-group             | $item [data-testid='x-action-group-control']                                 |
+      | view                     | $item [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | action                   | $item [data-action]                                                          |
+      | external-service-sub-tab | [data-testid='external-service-list-view-sub-tab']                           |
     Given the environment
       """
       KUMA_EXTERNALSERVICE_COUNT: 1
@@ -19,12 +23,10 @@ Feature: mesh / external-services / index
 
   Scenario: Sub navigation has expected content
     When I visit the "/meshes/default/services/external" URL
-
     Then the "$external-service-sub-tab" element exists
 
   Scenario: The items have the correct columns
     When I visit the "/meshes/default/services/external" URL
-
     Then the "$items-header" element exists 3 times
     Then the "$items-header" elements contain
       | Value   |
@@ -33,7 +35,6 @@ Feature: mesh / external-services / index
 
   Scenario: The items have the expected content and UI elements
     When I visit the "/meshes/default/services/external" URL
-
     Then the "[data-testid='service-list-tabs-view-tab'].active" element exists
     Then the "$item" element exists 1 times
     Then the "$item:nth-child(1)" element contains
@@ -42,10 +43,8 @@ Feature: mesh / external-services / index
 
   Scenario: Clicking View details goes to the detail page and back again
     When I visit the "/meshes/default/services/external" URL
-
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "service-1"
-
-    When I click the "$item:nth-child(1) [data-testid='details-link']" element
-
+    When I click the "$action-group" element
+    And I click the "$view" element
     Then the URL contains "/services/external/service-1/overview"
     Then the "[data-testid='external-service-detail-view-tab'].active" element exists

--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -2,14 +2,17 @@ Feature: mesh / policies / index
 
   Background:
     Given the CSS selectors
-      | Alias            | Selector                                  |
-      | policy-type-list | [data-testid='policy-type-list']          |
-      | items            | [data-testid='app-collection']            |
-      | detail-view      | [data-testid='policy-detail-view']        |
-      | items-header     | $items th                                 |
-      | item             | $items tbody tr                           |
-      | button-docs      | [data-testid='policy-documentation-link'] |
-      | breadcrumbs      | .k-breadcrumbs                            |
+      | Alias            | Selector                                                                                 |
+      | policy-type-list | [data-testid='policy-type-list']                                                         |
+      | items            | [data-testid='app-collection']                                                           |
+      | detail-view      | [data-testid='policy-detail-view']                                                       |
+      | items-header     | $items th                                                                                |
+      | item             | $items tbody tr                                                                          |
+      | action-group     | $item:first-child [data-testid='x-action-group-control']                                 |
+      | view             | $item:first-child [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | action           | $item:first-child [data-action]                                                          |
+      | button-docs      | [data-testid='policy-documentation-link']                                                |
+      | breadcrumbs      | .k-breadcrumbs                                                                           |
     And the environment
       """
       KUMA_MODE: global
@@ -36,7 +39,8 @@ Feature: mesh / policies / index
   Scenario: Clicking the link goes to the detail page and back again
     When I visit the "/meshes/default/policies/circuit-breakers" URL
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "fake-cb-1"
-    When I click the "$item:nth-child(1) [data-testid='details-link']" element
+    When I click the "$action-group" element
+    And I click the "$view" element
     Then the URL contains "circuit-breakers/fake-cb-1/overview"
     And the "$detail-view" element contains "fake-cb-1"
     When I click the "$breadcrumbs > .breadcrumbs-item-container:nth-child(3) > a" element

--- a/features/mesh/policies/Navigation.feature
+++ b/features/mesh/policies/Navigation.feature
@@ -1,78 +1,93 @@
 Feature: mesh / policies / navigation
+
   Background:
     Given the CSS selectors
-      | Alias         | Selector                                                                 |
-      | row           | [data-testid$='-collection'] tr:first-child td:first-child               |
-      | summary-title | [data-testid='slideout-title'] a                                         |
-      | detail-link   | [data-testid$='-collection'] tr:first-child [data-testid='details-link'] |
+      | Alias         | Selector                                                                    |
+      | row           | [data-testid$='-collection'] tr:first-child                                 |
+      | summary-title | [data-testid='slideout-title'] a                                            |
+      | action-group  | $row [data-testid='x-action-group-control']                                 |
+      | view          | $row [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | action        | $row [data-action]                                                          |
     And the environment
       """
       KUMA_MESHFAULTINJECTION_COUNT: 1
       """
 
-    Rule: In a namepaced environment
-      Background:
-        Given the environment
-          """
-          KUMA_ENVIRONMENT: kubernetes
-          """
-        And the URL "/meshes/default/meshfaultinjections" responds with
-          """
-          body:
-            items:
-            - name: monitor-proxy-0-5064a9c9a-icpsl.kuma-system
-              labels:
-                kuma.io/display-name: monitor-proxy-0-5064a9c9a-icpsl
-                k8s.kuma.io/namespace: kuma-system
-          """
-      Scenario Outline: clicking the detail link
-        When I visit the "<URL>" URL
-        And I click the "$detail-link" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        And the "[data-testid='policy-detail-view']" element exists
-        Examples:
-          | URL                                          |
-          | /meshes/default/policies/meshfaultinjections |
-      Scenario Outline: clicking the row, opening and summary, and clicking the title
-        When I visit the "<URL>" URL
-        And I click the "$row" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system"
-        And the URL doesn't contain "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        Then I click the "$summary-title" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        And the "[data-testid='policy-detail-view']" element exists
-        Examples:
-          | URL                                          |
-          | /meshes/default/policies/meshfaultinjections |
+  Rule: In a namepaced environment
 
-    Rule: In a non-namespaced environment
-      Background:
-        Given the environment
-          """
-          KUMA_ENVIRONMENT: universal
-          """
-        And the URL "/meshes/default/meshfaultinjections" responds with
-          """
-          body:
-            items:
-            - name: monitor-proxy-0
-          """
-      Scenario Outline: clicking the detail link
-        When I visit the "<URL>" URL
-        And I click the "$detail-link" element
-        Then the URL contains "monitor-proxy-0/overview"
-        And the "[data-testid='policy-detail-view']" element exists
-        Examples:
-          | URL                                          |
-          | /meshes/default/policies/meshfaultinjections |
-      Scenario Outline: clicking the row, opening and summary, and clicking the title
-        When I visit the "<URL>" URL
-        And I click the "$row" element
-        Then the URL contains "monitor-proxy-0"
-        And the URL doesn't contain "monitor-proxy-0/overview"
-        Then I click the "$summary-title" element
-        Then the URL contains "monitor-proxy-0/overview"
-        And the "[data-testid='policy-detail-view']" element exists
-        Examples:
-          | URL                                          |
-          | /meshes/default/policies/meshfaultinjections |
+    Background:
+      Given the environment
+        """
+        KUMA_ENVIRONMENT: kubernetes
+        """
+      And the URL "/meshes/default/meshfaultinjections" responds with
+        """
+        body:
+          items:
+          - name: monitor-proxy-0-5064a9c9a-icpsl.kuma-system
+            labels:
+              kuma.io/display-name: monitor-proxy-0-5064a9c9a-icpsl
+              k8s.kuma.io/namespace: kuma-system
+        """
+
+    Scenario Outline: clicking the detail link
+      When I visit the "<URL>" URL
+      When I click the "$action-group" element
+      And I click the "$view" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      And the "[data-testid='policy-detail-view']" element exists
+
+      Examples:
+        | URL                                          |
+        | /meshes/default/policies/meshfaultinjections |
+
+    Scenario Outline: clicking the row, opening and summary, and clicking the title
+      When I visit the "<URL>" URL
+      And I click the "$action" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system"
+      And the URL doesn't contain "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      Then I click the "$summary-title" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      And the "[data-testid='policy-detail-view']" element exists
+
+      Examples:
+        | URL                                          |
+        | /meshes/default/policies/meshfaultinjections |
+
+  Rule: In a non-namespaced environment
+
+    Background:
+      Given the environment
+        """
+        KUMA_ENVIRONMENT: universal
+        """
+      And the URL "/meshes/default/meshfaultinjections" responds with
+        """
+        body:
+          items:
+          - name: monitor-proxy-0
+        """
+
+    Scenario Outline: clicking the detail link
+      When I visit the "<URL>" URL
+      When I click the "$action-group" element
+      And I click the "$view" element
+      Then the URL contains "monitor-proxy-0/overview"
+      And the "[data-testid='policy-detail-view']" element exists
+
+      Examples:
+        | URL                                          |
+        | /meshes/default/policies/meshfaultinjections |
+
+    Scenario Outline: clicking the row, opening and summary, and clicking the title
+      When I visit the "<URL>" URL
+      And I click the "$action" element
+      Then the URL contains "monitor-proxy-0"
+      And the URL doesn't contain "monitor-proxy-0/overview"
+      Then I click the "$summary-title" element
+      Then the URL contains "monitor-proxy-0/overview"
+      And the "[data-testid='policy-detail-view']" element exists
+
+      Examples:
+        | URL                                          |
+        | /meshes/default/policies/meshfaultinjections |

--- a/features/mesh/services/Index.feature
+++ b/features/mesh/services/Index.feature
@@ -1,12 +1,16 @@
 Feature: mesh / services / index
+
   Background:
     Given the CSS selectors
-      | Alias           | Selector                                  |
-      | items           | [data-testid='service-collection']        |
-      | items-header    | $items th                                 |
-      | item            | $items tbody tr                           |
-      | breadcrumbs     | .k-breadcrumbs                            |
-      | service-sub-tab | [data-testid='service-list-view-sub-tab'] |
+      | Alias           | Selector                                                                                 |
+      | items           | [data-testid='service-collection']                                                       |
+      | items-header    | $items th                                                                                |
+      | item            | $items tbody tr                                                                          |
+      | action-group    | $item:first-child [data-testid='x-action-group-control']                                 |
+      | view            | $item:first-child [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | action          | $item:first-child [data-action]                                                          |
+      | breadcrumbs     | .k-breadcrumbs                                                                           |
+      | service-sub-tab | [data-testid='service-list-view-sub-tab']                                                |
     And the environment
       """
       KUMA_SERVICE_COUNT: 1
@@ -41,11 +45,9 @@ Feature: mesh / services / index
 
   Scenario: Clicking View details goes to the detail page and back again
     Then the "$item:nth-child(1) td:nth-child(1)" element contains "service-1"
-
-    When I click the "$item:nth-child(1) [data-testid='details-link']" element
-
+    When I click the "$action-group" element
+    And I click the "$view" element
     Then the URL contains "/services/internal/service-1/overview"
     Then the "[data-testid='service-detail-view-tab'].active" element exists
-
     When I click the "$breadcrumbs > .breadcrumbs-item-container:nth-child(3) > a" element
     Then the "$item" element exists 1 times

--- a/features/mesh/services/Item.feature
+++ b/features/mesh/services/Item.feature
@@ -1,12 +1,16 @@
 Feature: mesh / services / item
+
   Background:
     Given the CSS selectors
-      | Alias               | Selector                                       |
-      | dataplanes          | [data-testid='data-plane-collection']          |
-      | config              | [data-testid='external-service-config']        |
-      | item                | $dataplanes tbody tr                           |
-      | input-search        | [data-testid='filter-bar-filter-input']        |
-      | button-search       | [data-testid='filter-bar-submit-query-button'] |
+      | Alias         | Selector                                                                                  |
+      | dataplanes    | [data-testid='data-plane-collection']                                                     |
+      | config        | [data-testid='external-service-config']                                                   |
+      | item          | $dataplanes tbody tr                                                                      |
+      | action-group  | $item:nth-child(1) [data-testid='x-action-group-control']                                 |
+      | view          | $item:nth-child(1) [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | action        | $item:nth-child(1) [data-action]                                                          |
+      | input-search  | [data-testid='filter-bar-filter-input']                                                   |
+      | button-search | [data-testid='filter-bar-submit-query-button']                                            |
 
   Scenario Outline: Shows correct tabs for service type <ServiceType>
     Given the URL "/meshes/default/service-insights/firewall-1" responds with
@@ -14,7 +18,6 @@ Feature: mesh / services / item
         body:
           serviceType: <ServiceType>
       """
-
     When I visit the "/meshes/default/services/internal/firewall-1/overview" URL
     Then the "$dataplanes" element exists
     Then the "$config" element doesn't exist
@@ -25,6 +28,7 @@ Feature: mesh / services / item
       | internal       |
 
   Rule: With an internal service
+
     Background:
       Given the URL "/meshes/default/service-insights/system-1" responds with
         """
@@ -50,6 +54,7 @@ Feature: mesh / services / item
           offset: 0
           size: 50
         """
+
     Scenario: Searching by tag doesn't overwrite the existing service tag
       Then the "$input-search" element isn't disabled
       And I wait for 500 ms
@@ -64,6 +69,7 @@ Feature: mesh / services / item
           offset: 0
           size: 50
         """
+
     Scenario: Searching by service tag doesn't overwrite the existing service tag
       Then the "$input-search" element isn't disabled
       And I wait for 500 ms
@@ -75,6 +81,7 @@ Feature: mesh / services / item
           tag:
             - "kuma.io/service:panel-2"
         """
+
     Scenario: The clear search button sends a new request with no search params
       Then the "$input-search" element isn't disabled
       And I wait for 500 ms
@@ -93,6 +100,7 @@ Feature: mesh / services / item
           tag:
             - "kuma.io/service:system-1"
         """
+
     Scenario: The clear search button sends a new request with the correct service tag
       Then the "$input-search" element isn't disabled
       And I wait for 500 ms
@@ -119,6 +127,7 @@ Feature: mesh / services / item
         """
 
     Scenario: Clicking an items view menu takes you to the correct page
-      Then the "$item:nth-child(1) td:nth-child(1) a" element contains "fake-dataplane"
-      And I click the "$item:nth-child(1) [data-testid='details-link']" element
+      Then the "$action" element contains "fake-dataplane"
+      When I click the "$action-group" element
+      And I click the "$view" element
       Then the URL contains "/meshes/default/data-planes/fake-dataplane/overview"

--- a/features/mesh/services/mesh-external-services/Index.feature
+++ b/features/mesh/services/mesh-external-services/Index.feature
@@ -2,12 +2,14 @@ Feature: mesh / services / mesh-external-services / index
 
   Background:
     Given the CSS selectors
-      | Alias         | Selector                                  |
-      | items         | [data-testid='service-collection']        |
-      | item          | $items tbody tr                           |
-      | button-group  | [data-testid='service-list-view-sub-tab'] |
-      | summary-title | [data-testid='slideout-title'] a          |
-      | detail-link   | $item [data-testid='details-link']        |
+      | Alias         | Selector                                                                     |
+      | items         | [data-testid='service-collection']                                           |
+      | item          | $items tbody tr:first-child                                                  |
+      | button-group  | [data-testid='service-list-view-sub-tab']                                    |
+      | summary-title | [data-testid='slideout-title'] a                                             |
+      | action-group  | $item [data-testid='x-action-group-control']                                 |
+      | view          | $item [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | action        | $item [data-action]                                                          |
     And the environment
       """
       KUMA_SERVICE_COUNT: 1
@@ -32,7 +34,8 @@ Feature: mesh / services / mesh-external-services / index
 
     Scenario Outline: clicking the detail link
       When I visit the "<URL>" URL
-      And I click the "$detail-link" element
+      When I click the "$action-group" element
+      And I click the "$view" element
       Then the URL contains "monitor-proxy-0.kuma-demo/overview"
       And the "[data-testid='mesh-external-service-detail-view']" element exists
 
@@ -43,7 +46,7 @@ Feature: mesh / services / mesh-external-services / index
     Scenario Outline: clicking the row, opening the summary, and clicking the title
       When I visit the "<URL>" URL
       Then the "$button-group" element exists
-      And I click the "$item a[data-action]" element
+      And I click the "$action" element
       Then the URL contains "monitor-proxy-0.kuma-demo"
       And the URL doesn't contain "monitor-proxy-0.kuma-demo/overview"
       Then I click the "$summary-title" element

--- a/features/mesh/services/mesh-services/Index.feature
+++ b/features/mesh/services/mesh-services/Index.feature
@@ -1,51 +1,58 @@
 Feature: mesh / services / mesh-services / index
+
   Background:
     Given the CSS selectors
-      | Alias         | Selector                                  |
-      | items         | [data-testid='service-collection']        |
-      | item          | $items tbody tr                           |
-      | button-group  | [data-testid='service-list-view-sub-tab'] |
-      | summary-title | [data-testid='slideout-title'] a          |
-      | detail-link   | $item [data-testid='details-link']        |
+      | Alias         | Selector                                                                     |
+      | items         | [data-testid='service-collection']                                           |
+      | item          | $items tbody tr:first-child                                                  |
+      | button-group  | [data-testid='service-list-view-sub-tab']                                    |
+      | summary-title | [data-testid='slideout-title'] a                                             |
+      | action-group  | $item [data-testid='x-action-group-control']                                 |
+      | view          | $item [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | action        | $item [data-action]                                                          |
     And the environment
       """
       KUMA_SERVICE_COUNT: 1
       """
 
-    Rule: In a namespaced environment
-      Background:
-        Given the environment
-          """
-          KUMA_ENVIRONMENT: kubernetes
-          """
-        And the URL "/meshes/default/meshservices" responds with
-          """
-          body:
-            items:
-            - name: monitor-proxy-0.kuma-demo
-              labels:
-                kuma.io/display-name: monitor-proxy-0
-                k8s.kuma.io/namespace: kuma-demo
-          """
-      Scenario Outline: clicking the detail link
-        When I visit the "<URL>" URL
-        And I click the "$detail-link" element
-        Then the URL contains "monitor-proxy-0.kuma-demo/overview"
-        And the "[data-testid='mesh-service-detail-view']" element exists
-        Examples:
-          | URL                                    |
-          | /meshes/default/services/mesh-services |
+  Rule: In a namespaced environment
 
-      Scenario Outline: clicking the row, opening the summary, and clicking the title
-        When I visit the "<URL>" URL
-        Then the "$button-group" element exists
-        And I click the "$item a[data-action]" element
-        Then the URL contains "monitor-proxy-0.kuma-demo"
-        And the URL doesn't contain "monitor-proxy-0.kuma-demo/overview"
-        Then I click the "$summary-title" element
-        Then the URL contains "monitor-proxy-0.kuma-demo/overview"
-        And the "[data-testid='mesh-service-detail-view']" element exists
-        Examples:
-          | URL                                    |
-          | /meshes/default/services/mesh-services |
+    Background:
+      Given the environment
+        """
+        KUMA_ENVIRONMENT: kubernetes
+        """
+      And the URL "/meshes/default/meshservices" responds with
+        """
+        body:
+          items:
+          - name: monitor-proxy-0.kuma-demo
+            labels:
+              kuma.io/display-name: monitor-proxy-0
+              k8s.kuma.io/namespace: kuma-demo
+        """
 
+    Scenario Outline: clicking the detail link
+      When I visit the "<URL>" URL
+      When I click the "$action-group" element
+      And I click the "$view" element
+      Then the URL contains "monitor-proxy-0.kuma-demo/overview"
+      And the "[data-testid='mesh-service-detail-view']" element exists
+
+      Examples:
+        | URL                                    |
+        | /meshes/default/services/mesh-services |
+
+    Scenario Outline: clicking the row, opening the summary, and clicking the title
+      When I visit the "<URL>" URL
+      Then the "$button-group" element exists
+      And I click the "$action" element
+      Then the URL contains "monitor-proxy-0.kuma-demo"
+      And the URL doesn't contain "monitor-proxy-0.kuma-demo/overview"
+      Then I click the "$summary-title" element
+      Then the URL contains "monitor-proxy-0.kuma-demo/overview"
+      And the "[data-testid='mesh-service-detail-view']" element exists
+
+      Examples:
+        | URL                                    |
+        | /meshes/default/services/mesh-services |

--- a/features/zones/Delete.feature
+++ b/features/zones/Delete.feature
@@ -2,14 +2,14 @@ Feature: zones / delete
 
   Background:
     Given the CSS selectors
-      | Alias          | Selector                                                   |
-      | items          | [data-testid="zone-cp-collection"]                         |
-      | item           | $items tbody tr                                            |
-      | actions-button | $item:nth-child(1) [data-testid='dropdown-trigger'] button |
-      | delete-button  | $item:nth-child(1) [data-testid='dropdown-delete-item']    |
-      | delete-prompt  | [data-testid="delete-zone-modal"]                          |
-      | confirm-button | $delete-prompt [data-testid='modal-action-button']         |
-      | confirm-input  | $delete-prompt [data-testid='confirmation-input']          |
+      | Alias          | Selector                                                                                   |
+      | items          | [data-testid="zone-cp-collection"]                                                         |
+      | item           | $items tbody tr                                                                            |
+      | action-group   | $item:nth-child(1) [data-testid='x-action-group-control']                                  |
+      | delete         | $item:nth-child(1) [data-testid='x-action-group'] li:nth-child(2) [data-testid='x-action'] |
+      | delete-prompt  | [data-testid="delete-zone-modal"]                                                          |
+      | confirm-button | $delete-prompt [data-testid='modal-action-button']                                         |
+      | confirm-input  | $delete-prompt [data-testid='confirmation-input']                                          |
     And the environment
       """
       KUMA_ZONE_COUNT: 3
@@ -25,8 +25,8 @@ Feature: zones / delete
     When I visit the "/zones" URL
 
   Scenario: Clicking delete on an item from the listing page
-    Then I click the "$actions-button" element
-    And I click the "$delete-button" element
+    Then I click the "$action-group" element
+    And I click the "$delete" element
     Then I "type" "zone-1" into the "$confirm-input" element
     And I click the "$confirm-button" element
     Then the URL "/zones/zone-1" was requested with

--- a/features/zones/zone-cps/egresses/Navigation.feature
+++ b/features/zones/zone-cps/egresses/Navigation.feature
@@ -1,10 +1,14 @@
 Feature: zones / egresses / navigation
+
   Background:
     Given the CSS selectors
-      | Alias         | Selector                                                                 |
-      | row           | [data-testid$='-collection'] tr:first-child td:first-child               |
-      | summary-title | [data-testid='slideout-title'] a                                         |
-      | detail-link   | [data-testid$='-collection'] tr:first-child [data-testid='details-link'] |
+      | Alias         | Selector                                                                    |
+      | row           | [data-testid$='-collection'] tr:first-child                                 |
+      | action-group  | $row [data-testid='x-action-group-control']                                 |
+      | view          | $row [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | action        | $row [data-action]                                                          |
+      | summary-title | [data-testid='slideout-title'] a                                            |
+      | detail-link   | [data-testid$='-collection'] tr:first-child [data-testid='details-link']    |
     And the environment
       """
       KUMA_MODE: global
@@ -12,69 +16,81 @@ Feature: zones / egresses / navigation
       KUMA_ZONEEGRESS_COUNT: 1
       """
 
-    Rule: In a namepaced environment
-      Background:
-        Given the environment
-          """
-          KUMA_ENVIRONMENT: kubernetes
-          """
-        And the URL "/zoneegresses/_overview" responds with
-          """
-          body:
-            items:
-            - name: monitor-proxy-0-5064a9c9a-icpsl.kuma-system
-              labels:
-                kuma.io/display-name: monitor-proxy-0-5064a9c9a-icpsl
-                k8s.kuma.io/namespace: kuma-system
-          """
-      Scenario Outline: clicking the detail link
-        When I visit the "<URL>" URL
-        And I click the "$detail-link" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        And the "[data-testid='zone-egress-detail-view']" element exists
-        Examples:
-          | URL                    |
-          | /zones/feed-0/egresses |
-      Scenario Outline: clicking the row, opening and summary, and clicking the title
-        When I visit the "<URL>" URL
-        And I click the "$row" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system"
-        And the URL doesn't contain "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        Then I click the "$summary-title" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        And the "[data-testid='zone-egress-detail-view']" element exists
-        Examples:
-          | URL                    |
-          | /zones/feed-0/egresses |
+  Rule: In a namepaced environment
 
-    Rule: In a non-namespaced environment
-      Background:
-        Given the environment
-          """
-          KUMA_ENVIRONMENT: universal
-          """
-        And the URL "/zoneegresses/_overview" responds with
-          """
-          body:
-            items:
-            - name: monitor-proxy-0
-          """
-      Scenario Outline: clicking the detail link
-        When I visit the "<URL>" URL
-        And I click the "$detail-link" element
-        Then the URL contains "monitor-proxy-0/overview"
-        And the "[data-testid='zone-egress-detail-view']" element exists
-        Examples:
-          | URL                    |
-          | /zones/feed-0/egresses |
-      Scenario Outline: clicking the row, opening and summary, and clicking the title
-        When I visit the "<URL>" URL
-        And I click the "$row" element
-        Then the URL contains "monitor-proxy-0"
-        And the URL doesn't contain "monitor-proxy-0/overview"
-        Then I click the "$summary-title" element
-        Then the URL contains "monitor-proxy-0/overview"
-        And the "[data-testid='zone-egress-detail-view']" element exists
-        Examples:
-          | URL                    |
-          | /zones/feed-0/egresses |
+    Background:
+      Given the environment
+        """
+        KUMA_ENVIRONMENT: kubernetes
+        """
+      And the URL "/zoneegresses/_overview" responds with
+        """
+        body:
+          items:
+          - name: monitor-proxy-0-5064a9c9a-icpsl.kuma-system
+            labels:
+              kuma.io/display-name: monitor-proxy-0-5064a9c9a-icpsl
+              k8s.kuma.io/namespace: kuma-system
+        """
+
+    Scenario Outline: clicking the detail link
+      When I visit the "<URL>" URL
+      When I click the "$action-group" element
+      And I click the "$view" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      And the "[data-testid='zone-egress-detail-view']" element exists
+
+      Examples:
+        | URL                    |
+        | /zones/feed-0/egresses |
+
+    Scenario Outline: clicking the row, opening and summary, and clicking the title
+      When I visit the "<URL>" URL
+      And I click the "$action" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system"
+      And the URL doesn't contain "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      Then I click the "$summary-title" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      And the "[data-testid='zone-egress-detail-view']" element exists
+
+      Examples:
+        | URL                    |
+        | /zones/feed-0/egresses |
+
+  Rule: In a non-namespaced environment
+
+    Background:
+      Given the environment
+        """
+        KUMA_ENVIRONMENT: universal
+        """
+      And the URL "/zoneegresses/_overview" responds with
+        """
+        body:
+          items:
+          - name: monitor-proxy-0
+        """
+
+    Scenario Outline: clicking the detail link
+      When I visit the "<URL>" URL
+      When I click the "$action-group" element
+      And I click the "$view" element
+      Then the URL contains "monitor-proxy-0/overview"
+      And the "[data-testid='zone-egress-detail-view']" element exists
+
+      Examples:
+        | URL                    |
+        | /zones/feed-0/egresses |
+
+    Scenario Outline: clicking the row, opening and summary, and clicking the title
+      When I visit the "<URL>" URL
+      And I click the "$action" element
+      Then the URL contains "monitor-proxy-0"
+      And the URL doesn't contain "monitor-proxy-0/overview"
+      Then I click the "$summary-title" element
+      Then the URL contains "monitor-proxy-0/overview"
+      And the "[data-testid='zone-egress-detail-view']" element exists
+
+      Examples:
+        | URL                    |
+        | /zones/feed-0/egresses |

--- a/features/zones/zone-cps/ingresses/Navigation.feature
+++ b/features/zones/zone-cps/ingresses/Navigation.feature
@@ -1,10 +1,14 @@
 Feature: zones / ingresses / navigation
+
   Background:
     Given the CSS selectors
-      | Alias         | Selector                                                                 |
-      | row           | [data-testid$='-collection'] tr:first-child td:first-child               |
-      | summary-title | [data-testid='slideout-title'] a                                         |
-      | detail-link   | [data-testid$='-collection'] tr:first-child [data-testid='details-link'] |
+      | Alias         | Selector                                                                    |
+      | row           | [data-testid$='-collection'] tr:first-child                                 |
+      | action-group  | $row [data-testid='x-action-group-control']                                 |
+      | view          | $row [data-testid='x-action-group'] li:first-child [data-testid='x-action'] |
+      | action        | $row [data-action]                                                          |
+      | summary-title | [data-testid='slideout-title'] a                                            |
+      | detail-link   | [data-testid$='-collection'] tr:first-child [data-testid='details-link']    |
     And the environment
       """
       KUMA_MODE: global
@@ -12,69 +16,81 @@ Feature: zones / ingresses / navigation
       KUMA_ZONEINGRESS_COUNT: 1
       """
 
-    Rule: In a namepaced environment
-      Background:
-        Given the environment
-          """
-          KUMA_ENVIRONMENT: kubernetes
-          """
-        And the URL "/zone-ingresses/_overview" responds with
-          """
-          body:
-            items:
-            - name: monitor-proxy-0-5064a9c9a-icpsl.kuma-system
-              labels:
-                kuma.io/display-name: monitor-proxy-0-5064a9c9a-icpsl
-                k8s.kuma.io/namespace: kuma-system
-          """
-      Scenario Outline: clicking the detail link
-        When I visit the "<URL>" URL
-        And I click the "$detail-link" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        And the "[data-testid='zone-ingress-detail-view']" element exists
-        Examples:
-          | URL                     |
-          | /zones/feed-0/ingresses |
-      Scenario Outline: clicking the row, opening and summary, and clicking the title
-        When I visit the "<URL>" URL
-        And I click the "$row" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system"
-        And the URL doesn't contain "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        Then I click the "$summary-title" element
-        Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
-        And the "[data-testid='zone-ingress-detail-view']" element exists
-        Examples:
-          | URL                     |
-          | /zones/feed-0/ingresses |
+  Rule: In a namepaced environment
 
-    Rule: In a non-namespaced environment
-      Background:
-        Given the environment
-          """
-          KUMA_ENVIRONMENT: universal
-          """
-        And the URL "/zone-ingresses/_overview" responds with
-          """
-          body:
-            items:
-            - name: monitor-proxy-0
-          """
-      Scenario Outline: clicking the detail link
-        When I visit the "<URL>" URL
-        And I click the "$detail-link" element
-        Then the URL contains "monitor-proxy-0/overview"
-        And the "[data-testid='zone-ingress-detail-view']" element exists
-        Examples:
-          | URL                     |
-          | /zones/feed-0/ingresses |
-      Scenario Outline: clicking the row, opening and summary, and clicking the title
-        When I visit the "<URL>" URL
-        And I click the "$row" element
-        Then the URL contains "monitor-proxy-0"
-        And the URL doesn't contain "monitor-proxy-0/overview"
-        Then I click the "$summary-title" element
-        Then the URL contains "monitor-proxy-0/overview"
-        And the "[data-testid='zone-ingress-detail-view']" element exists
-        Examples:
-          | URL                     |
-          | /zones/feed-0/ingresses |
+    Background:
+      Given the environment
+        """
+        KUMA_ENVIRONMENT: kubernetes
+        """
+      And the URL "/zone-ingresses/_overview" responds with
+        """
+        body:
+          items:
+          - name: monitor-proxy-0-5064a9c9a-icpsl.kuma-system
+            labels:
+              kuma.io/display-name: monitor-proxy-0-5064a9c9a-icpsl
+              k8s.kuma.io/namespace: kuma-system
+        """
+
+    Scenario Outline: clicking the detail link
+      When I visit the "<URL>" URL
+      When I click the "$action-group" element
+      And I click the "$view" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      And the "[data-testid='zone-ingress-detail-view']" element exists
+
+      Examples:
+        | URL                     |
+        | /zones/feed-0/ingresses |
+
+    Scenario Outline: clicking the row, opening and summary, and clicking the title
+      When I visit the "<URL>" URL
+      And I click the "$action" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system"
+      And the URL doesn't contain "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      Then I click the "$summary-title" element
+      Then the URL contains "monitor-proxy-0-5064a9c9a-icpsl.kuma-system/overview"
+      And the "[data-testid='zone-ingress-detail-view']" element exists
+
+      Examples:
+        | URL                     |
+        | /zones/feed-0/ingresses |
+
+  Rule: In a non-namespaced environment
+
+    Background:
+      Given the environment
+        """
+        KUMA_ENVIRONMENT: universal
+        """
+      And the URL "/zone-ingresses/_overview" responds with
+        """
+        body:
+          items:
+          - name: monitor-proxy-0
+        """
+
+    Scenario Outline: clicking the detail link
+      When I visit the "<URL>" URL
+      When I click the "$action-group" element
+      And I click the "$view" element
+      Then the URL contains "monitor-proxy-0/overview"
+      And the "[data-testid='zone-ingress-detail-view']" element exists
+
+      Examples:
+        | URL                     |
+        | /zones/feed-0/ingresses |
+
+    Scenario Outline: clicking the row, opening and summary, and clicking the title
+      When I visit the "<URL>" URL
+      And I click the "$action" element
+      Then the URL contains "monitor-proxy-0"
+      And the URL doesn't contain "monitor-proxy-0/overview"
+      Then I click the "$summary-title" element
+      Then the URL contains "monitor-proxy-0/overview"
+      And the "[data-testid='zone-ingress-detail-view']" element exists
+
+      Examples:
+        | URL                     |
+        | /zones/feed-0/ingresses |

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -262,7 +262,6 @@ const click = (e: MouseEvent) => {
 .app-collection :deep(td:first-child li a:hover) {
   text-decoration: underline;
 }
-
 .app-collection-toolbar {
   display: flex;
   justify-content: flex-end;
@@ -275,6 +274,10 @@ const click = (e: MouseEvent) => {
 </style>
 
 <style lang="scss">
+
+.app-collection .actions-column {
+  width: 48px;
+}
 .app-collection .is-selected {
   background-color: $kui-color-background-neutral-weakest;
 }

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -46,7 +46,7 @@
                 { label: 'Certificate Info', key: 'certificate' },
                 { label: 'Status', key: 'status' },
                 { label: 'Warnings', key: 'warnings', hideLabel: true },
-                { label: 'Details', key: 'details', hideLabel: true },
+                { label: 'Actions', key: 'actions', hideLabel: true },
               ]"
               :items="data?.items"
               :total="data?.total"
@@ -235,24 +235,19 @@
                 </template>
               </template>
 
-              <template #details="{ row }">
-                <RouterLink
-                  class="details-link"
-                  data-testid="details-link"
-                  :to="{
-                    name: 'data-plane-detail-view',
-                    params: {
-                      dataPlane: row.id,
-                    },
-                  }"
-                >
-                  {{ t('common.collection.details_link') }}
-
-                  <ArrowRightIcon
-                    decorative
-                    :size="KUI_ICON_SIZE_30"
-                  />
-                </RouterLink>
+              <template #actions="{ row: item }">
+                <XActionGroup>
+                  <XAction
+                    :to="{
+                      name: 'data-plane-detail-view',
+                      params: {
+                        dataPlane: item.id,
+                      },
+                    }"
+                  >
+                    {{ t('common.collection.actions.view') }}
+                  </XAction>
+                </XActionGroup>
               </template>
             </AppCollection>
 
@@ -288,8 +283,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30, KUI_ICON_SIZE_40 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
+import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
 import type { DataplaneOverviewCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
@@ -326,13 +320,6 @@ import type { MeSource } from '@/app/me/sources'
   white-space: nowrap;
   vertical-align: middle;
 }
-
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-
 .data-plane-collection :deep(.name-column) {
   max-width: 400px;
 }

--- a/src/app/external-services/views/ExternalServiceListView.vue
+++ b/src/app/external-services/views/ExternalServiceListView.vue
@@ -38,7 +38,7 @@
               :headers="[
                 { label: 'Name', key: 'name' },
                 { label: 'Address', key: 'address' },
-                { label: 'Details', key: 'details', hideLabel: true },
+                { label: 'Actions', key: 'actions', hideLabel: true },
               ]"
               :page-number="route.params.page"
               :page-size="route.params.size"
@@ -78,25 +78,20 @@
                 </template>
               </template>
 
-              <template #details="{ row }">
-                <RouterLink
-                  class="details-link"
-                  data-testid="details-link"
-                  :to="{
-                    name: 'external-service-detail-view',
-                    params: {
-                      mesh: row.mesh,
-                      service: row.name,
-                    },
-                  }"
-                >
-                  {{ t('common.collection.details_link') }}
-
-                  <ArrowRightIcon
-                    decorative
-                    :size="KUI_ICON_SIZE_30"
-                  />
-                </RouterLink>
+              <template #actions="{ row: item }">
+                <XActionGroup>
+                  <XAction
+                    :to="{
+                      name: 'external-service-detail-view',
+                      params: {
+                        mesh: item.mesh,
+                        service: item.name,
+                      },
+                    }"
+                  >
+                    {{ t('common.collection.actions.view') }}
+                  </XAction>
+                </XActionGroup>
               </template>
             </AppCollection>
           </KCard>
@@ -107,20 +102,9 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import type { ExternalServiceCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -43,7 +43,7 @@
                     { label: 'Certificate Info', key: 'certificate' },
                     { label: 'Status', key: 'status' },
                     { label: 'Warnings', key: 'warnings', hideLabel: true },
-                    { label: 'Details', key: 'details', hideLabel: true },
+                    { label: 'Actions', key: 'actions', hideLabel: true },
                   ]"
                   :items="dataplanesData?.items"
                   :total="dataplanesData?.total"
@@ -77,7 +77,8 @@
                   </template>
 
                   <template #name="{ row }">
-                    <RouterLink
+                    <XAction
+                      data-action
                       class="name-link"
                       :title="row.name"
                       :to="{
@@ -94,11 +95,11 @@
                       }"
                     >
                       {{ row.name }}
-                    </RouterLink>
+                    </XAction>
                   </template>
 
                   <template #zone="{ row }">
-                    <RouterLink
+                    <XAction
                       v-if="row.zone"
                       :to="{
                         name: 'zone-cp-detail-view',
@@ -108,7 +109,7 @@
                       }"
                     >
                       {{ row.zone }}
-                    </RouterLink>
+                    </XAction>
 
                     <template v-else>
                       {{ t('common.collection.none') }}
@@ -151,24 +152,19 @@
                     </template>
                   </template>
 
-                  <template #details="{ row }">
-                    <RouterLink
-                      class="details-link"
-                      data-testid="details-link"
-                      :to="{
-                        name: 'data-plane-detail-view',
-                        params: {
-                          dataPlane: row.id,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.details_link') }}
-
-                      <ArrowRightIcon
-                        decorative
-                        :size="KUI_ICON_SIZE_30"
-                      />
-                    </RouterLink>
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'data-plane-detail-view',
+                          params: {
+                            dataPlane: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
                   </template>
                 </AppCollection>
 
@@ -206,9 +202,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import type { MeshGatewaySource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
@@ -231,12 +224,6 @@ import type { MeSource } from '@/app/me/sources'
   text-overflow: ellipsis;
   white-space: nowrap;
   vertical-align: middle;
-}
-
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
 }
 
 .data-plane-collection :deep(.name-column) {

--- a/src/app/gateways/views/BuiltinGatewayListView.vue
+++ b/src/app/gateways/views/BuiltinGatewayListView.vue
@@ -35,7 +35,7 @@
               :headers="[
                 { label: 'Name', key: 'name' },
                 ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
-                { label: 'Details', key: 'details', hideLabel: true },
+                { label: 'Actions', key: 'actions', hideLabel: true },
               ]"
               :page-number="route.params.page"
               :page-size="route.params.size"
@@ -46,7 +46,8 @@
             >
               <template #name="{ row: item }">
                 <TextWithCopyButton :text="item.name">
-                  <RouterLink
+                  <XAction
+                    data-action
                     :to="{
                       name: 'builtin-gateway-detail-view',
                       params: {
@@ -56,13 +57,13 @@
                     }"
                   >
                     {{ item.name }}
-                  </RouterLink>
+                  </XAction>
                 </TextWithCopyButton>
               </template>
 
               <template #zone="{ row }">
                 <template v-if="row.labels && row.labels['kuma.io/origin'] === 'zone' && row.labels['kuma.io/zone']">
-                  <RouterLink
+                  <XAction
                     :to="{
                       name: 'zone-cp-detail-view',
                       params: {
@@ -71,7 +72,7 @@
                     }"
                   >
                     {{ row.labels['kuma.io/zone'] }}
-                  </RouterLink>
+                  </XAction>
                 </template>
 
                 <template v-else>
@@ -79,25 +80,20 @@
                 </template>
               </template>
 
-              <template #details="{ row }">
-                <RouterLink
-                  class="details-link"
-                  data-testid="details-link"
-                  :to="{
-                    name: 'builtin-gateway-detail-view',
-                    params: {
-                      mesh: row.mesh,
-                      gateway: row.name,
-                    },
-                  }"
-                >
-                  {{ t('common.collection.details_link') }}
-
-                  <ArrowRightIcon
-                    decorative
-                    :size="KUI_ICON_SIZE_30"
-                  />
-                </RouterLink>
+              <template #actions="{ row: item }">
+                <XActionGroup>
+                  <XAction
+                    :to="{
+                      name: 'builtin-gateway-detail-view',
+                      params: {
+                        mesh: item.mesh,
+                        gateway: item.name,
+                      },
+                    }"
+                  >
+                    {{ t('common.collection.actions.view') }}
+                  </XAction>
+                </XActionGroup>
               </template>
             </AppCollection>
           </KCard>
@@ -108,20 +104,9 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import type { MeshGatewayCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -84,7 +84,7 @@
                     { label: 'Certificate Info', key: 'certificate' },
                     { label: 'Status', key: 'status' },
                     { label: 'Warnings', key: 'warnings', hideLabel: true },
-                    { label: 'Details', key: 'details', hideLabel: true },
+                    { label: 'Actions', key: 'actions', hideLabel: true },
                   ]"
                   :items="dataplanesData?.items"
                   :total="dataplanesData?.total"
@@ -190,24 +190,19 @@
                     </template>
                   </template>
 
-                  <template #details="{ row: item }">
-                    <RouterLink
-                      class="details-link"
-                      data-testid="details-link"
-                      :to="{
-                        name: 'data-plane-detail-view',
-                        params: {
-                          dataPlane: item.id,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.details_link') }}
-
-                      <ArrowRightIcon
-                        decorative
-                        :size="KUI_ICON_SIZE_30"
-                      />
-                    </RouterLink>
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'data-plane-detail-view',
+                          params: {
+                            dataPlane: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
                   </template>
                 </AppCollection>
 
@@ -245,9 +240,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
@@ -273,12 +265,6 @@ import type { ServiceInsightSource } from '@/app/services/sources'
   text-overflow: ellipsis;
   white-space: nowrap;
   vertical-align: middle;
-}
-
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
 }
 
 .data-plane-collection :deep(.name-column) {

--- a/src/app/gateways/views/DelegatedGatewayListView.vue
+++ b/src/app/gateways/views/DelegatedGatewayListView.vue
@@ -36,7 +36,7 @@
                 { label: 'Address', key: 'addressPort' },
                 { label: 'DP proxies (online / total)', key: 'dataplanes' },
                 { label: 'Status', key: 'status' },
-                { label: 'Details', key: 'details', hideLabel: true },
+                { label: 'Actions', key: 'actions', hideLabel: true },
               ]"
               :page-number="route.params.page"
               :page-size="route.params.size"
@@ -90,25 +90,20 @@
                 <StatusBadge :status="row.status" />
               </template>
 
-              <template #details="{ row }">
-                <RouterLink
-                  class="details-link"
-                  data-testid="details-link"
-                  :to="{
-                    name: 'delegated-gateway-detail-view',
-                    params: {
-                      mesh: row.mesh,
-                      service: row.name,
-                    },
-                  }"
-                >
-                  {{ t('common.collection.details_link') }}
-
-                  <ArrowRightIcon
-                    decorative
-                    :size="KUI_ICON_SIZE_30"
-                  />
-                </RouterLink>
+              <template #actions="{ row: item }">
+                <XActionGroup>
+                  <XAction
+                    :to="{
+                      name: 'delegated-gateway-detail-view',
+                      params: {
+                        mesh: item.mesh,
+                        service: item.name,
+                      },
+                    }"
+                  >
+                    {{ t('common.collection.actions.view') }}
+                  </XAction>
+                </XActionGroup>
               </template>
             </AppCollection>
           </KCard>
@@ -119,9 +114,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
@@ -129,11 +121,3 @@ import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeSource } from '@/app/me/sources'
 import type { ServiceInsightCollectionSource } from '@/app/services/sources'
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/gateways/views/GatewayListTabsView.vue
+++ b/src/app/gateways/views/GatewayListTabsView.vue
@@ -17,7 +17,9 @@
           :items="route.children"
           :empty="false"
         >
-          <XActionGroup>
+          <XActionGroup
+            :expanded="true"
+          >
             <XAction
               v-for="{ name } in items"
               :key="`${name}`"

--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -81,59 +81,53 @@
             {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
           </p>
 
-          <KDropdown
-            :kpop-attributes="{ placement: 'bottomEnd' }"
-          >
-            <KButton
-              icon
-              appearance="tertiary"
+          <XActionGroup>
+            <template
+              #control
             >
-              <HelpIcon />
-
-              <span class="visually-hidden">Help</span>
-            </KButton>
-
-            <template #items>
-              <KDropdownItem
-                :item="{
-                  to: t('common.product.href.docs.index'),
-                  label: '',
-                }"
-                target="_blank"
-                rel="noopener noreferrer"
+              <XAction
+                appearance="tertiary"
               >
-                Documentation
-              </KDropdownItem>
-              <KDropdownItem
-                :item="{
-                  to: t('common.product.href.feedback'),
-                  label: '',
-                }"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Feedback
-              </KDropdownItem>
-              <KDropdownItem
-                :item="{
-                  to: { name: 'onboarding-welcome-view' },
-                  label: '',
-                }"
-              >
-                Onboarding
-              </KDropdownItem>
+                <XIcon
+                  name="help"
+                >
+                  Help
+                </XIcon>
+              </XAction>
             </template>
-          </KDropdown>
-
+            <XAction
+              :href="t('common.product.href.docs.index')"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Documentation
+            </XAction>
+            <XAction
+              :href="t('common.product.href.feedback')"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Feedback
+            </XAction>
+            <XAction
+              :to="{ name: 'onboarding-welcome-view' }"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Onboarding
+            </XAction>
+          </XActionGroup>
           <KButton
             :to="{ name: 'diagnostics' }"
             appearance="tertiary"
             icon
             data-testid="nav-item-diagnostics"
           >
-            <CogIcon />
-
-            <span class="visually-hidden">Diagnostics</span>
+            <XIcon
+              name="settings"
+            >
+              Diagnostics
+            </XIcon>
           </KButton>
         </slot>
       </div>
@@ -178,7 +172,6 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { CogIcon, HelpIcon } from '@kong/icons'
 import GithubButton from 'vue-github-button'
 
 import { useEnv, useI18n, useCan } from '@/app/application'

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -31,7 +31,7 @@
                 { ...me.get('headers.name'), label: t('meshes.common.name'), key: 'name' },
                 { ...me.get('headers.services'), label: t('meshes.routes.items.collection.services'), key: 'services'},
                 { ...me.get('headers.dataplanes'), label: t('meshes.routes.items.collection.dataplanes'), key: 'dataplanes'},
-                { ...me.get('headers.details'), label: 'Details', key: 'details', hideLabel: true },
+                { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
               ]"
               :page-number="route.params.page"
               :page-size="route.params.size"
@@ -46,7 +46,8 @@
               @resize="me.set"
             >
               <template #name="{ row: item }">
-                <RouterLink
+                <XAction
+                  data-action
                   :to="{
                     name: 'mesh-detail-view',
                     params: {
@@ -59,7 +60,7 @@
                   }"
                 >
                   {{ item.name }}
-                </RouterLink>
+                </XAction>
               </template>
 
               <template #services="{ row: item }">
@@ -69,25 +70,19 @@
               <template #dataplanes="{ row: item }">
                 {{ item.dataplanesByType.standard.online }} / {{ item.dataplanesByType.standard.total }}
               </template>
-
-              <template #details="{ row }">
-                <RouterLink
-                  class="details-link"
-                  data-testid="details-link"
-                  :to="{
-                    name: 'mesh-detail-view',
-                    params: {
-                      mesh: row.name,
-                    },
-                  }"
-                >
-                  {{ t('common.collection.details_link') }}
-
-                  <ArrowRightIcon
-                    decorative
-                    :size="KUI_ICON_SIZE_30"
-                  />
-                </RouterLink>
+              <template #actions="{ row: item }">
+                <XActionGroup>
+                  <XAction
+                    :to="{
+                      name: 'mesh-detail-view',
+                      params: {
+                        mesh: item.name,
+                      },
+                    }"
+                  >
+                    {{ t('common.collection.actions.view') }}
+                  </XAction>
+                </XActionGroup>
               </template>
             </AppCollection>
           </DataLoader>
@@ -98,17 +93,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import type { MeshInsightCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -43,7 +43,7 @@
                     { label: 'Name', key: 'name' },
                     { label: 'Namespace', key: 'namespace' },
                     ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
-                    { label: 'Details', key: 'details', hideLabel: true },
+                    { label: 'Actions', key: 'actions', hideLabel: true },
                   ]"
                   :items="data?.items"
                   :total="data?.total"
@@ -86,24 +86,19 @@
                     </template>
                   </template>
 
-                  <template #details="{ row: item }">
-                    <RouterLink
-                      class="details-link"
-                      data-testid="details-link"
-                      :to="{
-                        name: 'data-plane-detail-view',
-                        params: {
-                          dataPlane: item.id,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.details_link') }}
-
-                      <ArrowRightIcon
-                        decorative
-                        :size="KUI_ICON_SIZE_30"
-                      />
-                    </RouterLink>
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'data-plane-detail-view',
+                          params: {
+                            dataPlane: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
                   </template>
                 </AppCollection>
               </DataCollection>
@@ -139,18 +134,8 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -139,7 +139,7 @@
                             { label: 'Namespace', key: 'namespace' },
                             ...(can('use zones') && type.isTargetRefBased ? [{ label: 'Zone', key: 'zone' }] : []),
                             ...(type.isTargetRefBased ? [{ label: 'Target ref', key: 'targetRef' }] : []),
-                            { label: 'Details', key: 'details', hideLabel: true },
+                            { label: 'Actions', key: 'actions', hideLabel: true },
                           ]"
                           :page-number="route.params.page"
                           :page-size="route.params.size"
@@ -150,6 +150,7 @@
                         >
                           <template #name="{ row }">
                             <XAction
+                              data-action
                               :to="{
                                 name: 'policy-summary-view',
                                 params: {
@@ -184,7 +185,7 @@
 
                           <template #zone="{ row }">
                             <template v-if="row.labels && row.labels['kuma.io/origin'] === 'zone' && row.labels['kuma.io/zone']">
-                              <RouterLink
+                              <XAction
                                 :to="{
                                   name: 'zone-cp-detail-view',
                                   params: {
@@ -193,7 +194,7 @@
                                 }"
                               >
                                 {{ row.labels['kuma.io/zone'] }}
-                              </RouterLink>
+                              </XAction>
                             </template>
 
                             <template v-else>
@@ -201,26 +202,21 @@
                             </template>
                           </template>
 
-                          <template #details="{ row }">
-                            <XAction
-                              class="details-link"
-                              data-testid="details-link"
-                              :to="{
-                                name: 'policy-detail-view',
-                                params: {
-                                  mesh: row.mesh,
-                                  policyPath: type.path,
-                                  policy: row.id,
-                                },
-                              }"
-                            >
-                              {{ t('common.collection.details_link') }}
-
-                              <ArrowRightIcon
-                                decorative
-                                :size="KUI_ICON_SIZE_30"
-                              />
-                            </XAction>
+                          <template #actions="{ row: item }">
+                            <XActionGroup>
+                              <XAction
+                                :to="{
+                                  name: 'policy-detail-view',
+                                  params: {
+                                    mesh: item.mesh,
+                                    policyPath: type.path,
+                                    policy: item.id,
+                                  },
+                                }"
+                              >
+                                {{ t('common.collection.actions.view') }}
+                              </XAction>
+                            </XActionGroup>
                           </template>
                         </AppCollection>
                       </template>
@@ -262,9 +258,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import type { PolicyType } from '../data'
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
@@ -292,10 +285,5 @@ header > div {
 header > h3 {
   margin-top: 0;
   float: left;
-}
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
 }
 </style>

--- a/src/app/policies/views/PolicyTypeListView.vue
+++ b/src/app/policies/views/PolicyTypeListView.vue
@@ -107,6 +107,14 @@ import type { MeSource } from '@/app/me/sources'
 import type { MeshInsightSource } from '@/app/meshes/sources'
 import type { PolicyTypeCollectionSource } from '@/app/policies/sources'
 </script>
+<style lang="scss">
+.policy-type-link {
+  color: currentColor;
+  flex-grow: 1;
+  padding: $kui-space-40 $kui-space-60;
+}
+
+</style>
 <style lang="scss" scoped>
 .policy-list-content {
   display: flex;
@@ -134,12 +142,6 @@ import type { PolicyTypeCollectionSource } from '@/app/policies/sources'
 
 .policy-type-link-wrapper:not(.policy-type-link-wrapper--is-active) {
   color: $kui-color-text-neutral;
-}
-
-.policy-type-link {
-  color: currentColor;
-  flex-grow: 1;
-  padding: $kui-space-40 $kui-space-60;
 }
 
 .policy-count {

--- a/src/app/services/views/MeshExternalServiceListView.vue
+++ b/src/app/services/views/MeshExternalServiceListView.vue
@@ -44,7 +44,7 @@
                     { label: 'TLS', key: 'tls' },
                     { label: 'Addresses', key: 'addresses' },
                     { label: 'Port', key: 'port' },
-                    { label: 'Details', key: 'details', hideLabel: true },
+                    { label: 'Actions', key: 'actions', hideLabel: true },
                   ]"
                   :page-number="route.params.page"
                   :page-size="route.params.size"
@@ -82,7 +82,7 @@
                   </template>
                   <template #zone="{ row: item }">
                     <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
-                      <RouterLink
+                      <XAction
                         v-if="item.labels['kuma.io/zone']"
                         :to="{
                           name: 'zone-cp-detail-view',
@@ -92,7 +92,7 @@
                         }"
                       >
                         {{ item.labels['kuma.io/zone'] }}
-                      </RouterLink>
+                      </XAction>
                     </template>
 
                     <template v-else>
@@ -134,25 +134,20 @@
                     </template>
                   </template>
 
-                  <template #details="{ row: item }">
-                    <XAction
-                      class="details-link"
-                      data-testid="details-link"
-                      :to="{
-                        name: 'mesh-external-service-detail-view',
-                        params: {
-                          mesh: item.mesh,
-                          service: item.id,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.details_link') }}
-
-                      <ArrowRightIcon
-                        decorative
-                        :size="KUI_ICON_SIZE_30"
-                      />
-                    </XAction>
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'mesh-external-service-detail-view',
+                          params: {
+                            mesh: item.mesh,
+                            service: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
                   </template>
                 </AppCollection>
                 <RouterView
@@ -187,19 +182,9 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/services/views/MeshServiceDetailView.vue
+++ b/src/app/services/views/MeshServiceDetailView.vue
@@ -144,7 +144,7 @@
                       { label: 'Certificate Info', key: 'certificate' },
                       { label: 'Status', key: 'status' },
                       { label: 'Warnings', key: 'warnings', hideLabel: true },
-                      { label: 'Details', key: 'details', hideLabel: true },
+                      { label: 'Actions', key: 'actions', hideLabel: true },
                     ]"
                     :items="dataplanes?.items"
                     :total="dataplanes?.total"
@@ -250,24 +250,19 @@
                       </template>
                     </template>
 
-                    <template #details="{ row: item }">
-                      <RouterLink
-                        class="details-link"
-                        data-testid="details-link"
-                        :to="{
-                          name: 'data-plane-detail-view',
-                          params: {
-                            dataPlane: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.details_link') }}
-
-                        <ArrowRightIcon
-                          decorative
-                          :size="KUI_ICON_SIZE_30"
-                        />
-                      </RouterLink>
+                    <template #actions="{ row: item }">
+                      <XActionGroup>
+                        <XAction
+                          :to="{
+                            name: 'data-plane-detail-view',
+                            params: {
+                              dataPlane: item.id,
+                            },
+                          }"
+                        >
+                          {{ t('common.collection.actions.view') }}
+                        </XAction>
+                      </XActionGroup>
                     </template>
                   </AppCollection>
                   <RouterView
@@ -305,9 +300,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import type { MeshService } from '../data'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
@@ -338,12 +330,6 @@ const props = defineProps<{
   text-overflow: ellipsis;
   white-space: nowrap;
   vertical-align: middle;
-}
-
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
 }
 
 .data-plane-collection :deep(.name-column) {

--- a/src/app/services/views/MeshServiceListView.vue
+++ b/src/app/services/views/MeshServiceListView.vue
@@ -44,7 +44,7 @@
                     { label: 'Addresses', key: 'addresses' },
                     { label: 'Ports', key: 'ports' },
                     { label: 'Tags', key: 'tags' },
-                    { label: 'Details', key: 'details', hideLabel: true },
+                    { label: 'Actions', key: 'actions', hideLabel: true },
                   ]"
                   :page-number="route.params.page"
                   :page-size="route.params.size"
@@ -82,7 +82,7 @@
                   </template>
                   <template #zone="{ row: item }">
                     <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
-                      <RouterLink
+                      <XAction
                         v-if="item.labels['kuma.io/zone']"
                         :to="{
                           name: 'zone-cp-detail-view',
@@ -92,7 +92,7 @@
                         }"
                       >
                         {{ item.labels['kuma.io/zone'] }}
-                      </RouterLink>
+                      </XAction>
                     </template>
 
                     <template v-else>
@@ -137,25 +137,20 @@
                       </KBadge>
                     </KTruncate>
                   </template>
-                  <template #details="{ row: item }">
-                    <XAction
-                      class="details-link"
-                      data-testid="details-link"
-                      :to="{
-                        name: 'mesh-service-detail-view',
-                        params: {
-                          mesh: item.mesh,
-                          service: item.id,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.details_link') }}
-
-                      <ArrowRightIcon
-                        decorative
-                        :size="KUI_ICON_SIZE_30"
-                      />
-                    </XAction>
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'mesh-service-detail-view',
+                          params: {
+                            mesh: item.mesh,
+                            service: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
                   </template>
                 </AppCollection>
                 <RouterView
@@ -190,19 +185,9 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -101,7 +101,7 @@
                       { label: 'Certificate Info', key: 'certificate' },
                       { label: 'Status', key: 'status' },
                       { label: 'Warnings', key: 'warnings', hideLabel: true },
-                      { label: 'Details', key: 'details', hideLabel: true },
+                      { label: 'Actions', key: 'actions', hideLabel: true },
                     ]"
                     :items="dataplanesData?.items"
                     :total="dataplanesData?.total"
@@ -131,7 +131,8 @@
                     </template>
 
                     <template #name="{ row: item }">
-                      <RouterLink
+                      <XAction
+                        data-action
                         class="name-link"
                         :to="{
                           name: 'service-data-plane-summary-view',
@@ -147,7 +148,7 @@
                         }"
                       >
                         {{ item.name }}
-                      </RouterLink>
+                      </XAction>
                     </template>
 
                     <template #namespace="{ row: item }">
@@ -155,7 +156,7 @@
                     </template>
 
                     <template #zone="{ row }">
-                      <RouterLink
+                      <XAction
                         v-if="row.zone"
                         :to="{
                           name: 'zone-cp-detail-view',
@@ -165,7 +166,7 @@
                         }"
                       >
                         {{ row.zone }}
-                      </RouterLink>
+                      </XAction>
 
                       <template v-else>
                         {{ t('common.collection.none') }}
@@ -208,24 +209,19 @@
                       </template>
                     </template>
 
-                    <template #details="{ row: item }">
-                      <RouterLink
-                        class="details-link"
-                        data-testid="details-link"
-                        :to="{
-                          name: 'data-plane-detail-view',
-                          params: {
-                            dataPlane: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.details_link') }}
-
-                        <ArrowRightIcon
-                          decorative
-                          :size="KUI_ICON_SIZE_30"
-                        />
-                      </RouterLink>
+                    <template #actions="{ row: item }">
+                      <XActionGroup>
+                        <XAction
+                          :to="{
+                            name: 'data-plane-detail-view',
+                            params: {
+                              dataPlane: item.id,
+                            },
+                          }"
+                        >
+                          {{ t('common.collection.actions.view') }}
+                        </XAction>
+                      </XActionGroup>
                     </template>
                   </AppCollection>
 
@@ -264,9 +260,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import type { ServiceInsightSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
@@ -294,12 +287,6 @@ import type { MeSource } from '@/app/me/sources'
   text-overflow: ellipsis;
   white-space: nowrap;
   vertical-align: middle;
-}
-
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
 }
 
 .data-plane-collection :deep(.name-column) {

--- a/src/app/services/views/ServiceListTabsView.vue
+++ b/src/app/services/views/ServiceListTabsView.vue
@@ -8,7 +8,9 @@
   >
     <AppView>
       <template #actions>
-        <XActionGroup>
+        <XActionGroup
+          :expanded="true"
+        >
           <XAction
             v-for="{ name } in route.children"
             :key="name"

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -44,7 +44,7 @@
                     { label: 'Address', key: 'addressPort' },
                     { label: 'DP proxies (online / total)', key: 'online' },
                     { label: 'Status', key: 'status' },
-                    { label: 'Details', key: 'details', hideLabel: true },
+                    { label: 'Actions', key: 'actions', hideLabel: true },
                   ]"
                   :page-number="route.params.page"
                   :page-size="route.params.size"
@@ -56,6 +56,7 @@
                   <template #name="{ row: item }">
                     <TextWithCopyButton :text="item.name">
                       <XAction
+                        data-action
                         :to="{
                           name: 'service-detail-view',
                           params: {
@@ -101,25 +102,20 @@
                     <StatusBadge :status="item.status" />
                   </template>
 
-                  <template #details="{ row }">
-                    <XAction
-                      class="details-link"
-                      data-testid="details-link"
-                      :to="{
-                        name: 'service-detail-view',
-                        params: {
-                          mesh: row.mesh,
-                          service: row.name,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.details_link') }}
-
-                      <ArrowRightIcon
-                        decorative
-                        :size="KUI_ICON_SIZE_30"
-                      />
-                    </XAction>
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'service-detail-view',
+                          params: {
+                            mesh: item.mesh,
+                            service: item.name,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
                   </template>
                 </AppCollection>
                 <RouterView
@@ -155,9 +151,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
@@ -165,11 +158,3 @@ import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/x/components/x-action-group/XActionGroup.vue
+++ b/src/app/x/components/x-action-group/XActionGroup.vue
@@ -1,18 +1,63 @@
 <template>
   <div
-    class="x-action-group"
+    data-testid="x-action-group"
+    :class="{
+      'x-action-group': true,
+      'expanded': props.expanded,
+    }"
   >
-    <slot />
+    <template
+      v-if="!props.expanded"
+    >
+      <KDropdown
+        :kpop-attributes="{
+          placement: 'bottomEnd',
+        }"
+        width="150"
+      >
+        <template #default>
+          <slot
+            v-if="$slots.control"
+            name="control"
+          />
+          <XAction
+            v-else
+            data-testid="x-action-group-control"
+            type="expand"
+          >
+            <XIcon name="more" />
+          </XAction>
+        </template>
+        <template #items>
+          <slot name="default" />
+        </template>
+      </KDropdown>
+    </template>
+    <slot
+      v-else
+      name="default"
+    />
   </div>
 </template>
+<script lang="ts" setup>
+import { KDropdown } from '@kong/kongponents'
+import { provide } from 'vue'
 
+const props = withDefaults(defineProps<{
+  expanded?: boolean
+}>(), {
+  expanded: false,
+})
+
+provide('x-action-group', props)
+</script>
 <style lang="scss" scoped>
-.x-action-group {
+.x-action-group.expanded {
   display: flex;
   align-items: center;
 }
 
-.x-action-group :deep(> *) {
+.x-action-group.expanded :deep(> *) {
   border-color: $kui-color-border-primary-weak;
   border-top: $kui-border-width-10 solid;
   border-bottom: $kui-border-width-10 solid;
@@ -21,22 +66,22 @@
   text-decoration: none;
 }
 
-.x-action-group :deep(> .active) {
+.x-action-group.expanded :deep(> .active) {
   border-color: $kui-color-border-primary-strong;
   background-color: $kui-color-background-primary-weakest;
 }
 
-.x-action-group :deep(> * + *) {
+.x-action-group.expanded :deep(> * + *) {
   border-left: $kui-border-width-10 solid;
 }
 
-.x-action-group :deep(> *:first-child) {
+.x-action-group.expanded :deep(> *:first-child) {
   border-left: $kui-border-width-10 solid;
   border-top-left-radius: $kui-border-radius-30;
   border-bottom-left-radius: $kui-border-radius-30;
 }
 
-.x-action-group :deep(> *:last-child) {
+.x-action-group.expanded :deep(> *:last-child) {
   border-right: $kui-border-width-10 solid;
   border-top-right-radius: $kui-border-radius-30;
   border-bottom-right-radius: $kui-border-radius-30;

--- a/src/app/x/components/x-icon/XIcon.vue
+++ b/src/app/x/components/x-icon/XIcon.vue
@@ -38,6 +38,10 @@ import {
   CopyIcon,
   RuntimeKicIcon,
   DeployIcon,
+  MoreIcon,
+  ChevronDownIcon,
+  CogIcon,
+  HelpIcon,
 } from '@kong/icons'
 import { KTooltip, PopPlacements } from '@kong/kongponents'
 import { useSlots, useAttrs } from 'vue'
@@ -59,8 +63,12 @@ const icons = {
   docs: BookIcon,
   search: FilterIcon,
   copy: CopyIcon,
+  more: MoreIcon,
+  expand: ChevronDownIcon,
   kubernetes: RuntimeKicIcon,
   universal: DeployIcon,
+  settings: CogIcon,
+  help: HelpIcon,
 } as const
 const id = uniqueId('-x-icon-tooltip')
 const slots = useSlots()

--- a/src/app/zone-egresses/views/ZoneEgressListView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressListView.vue
@@ -40,7 +40,7 @@
                 { label: 'Name', key: 'name' },
                 { label: 'Address', key: 'socketAddress' },
                 { label: 'Status', key: 'status' },
-                { label: 'Details', key: 'details', hideLabel: true },
+                { label: 'Actions', key: 'actions', hideLabel: true },
               ]"
               :page-number="1"
               :page-size="100"
@@ -54,7 +54,8 @@
               @change="route.update"
             >
               <template #name="{ row: item }">
-                <RouterLink
+                <XAction
+                  data-action
                   :to="{
                     name: 'zone-egress-summary-view',
                     params: {
@@ -69,7 +70,7 @@
                   }"
                 >
                   {{ item.name }}
-                </RouterLink>
+                </XAction>
               </template>
 
               <template #socketAddress="{ row: item }">
@@ -88,24 +89,19 @@
                 />
               </template>
 
-              <template #details="{ row: item }">
-                <RouterLink
-                  class="details-link"
-                  data-testid="details-link"
-                  :to="{
-                    name: 'zone-egress-detail-view',
-                    params: {
-                      zoneEgress: item.id,
-                    },
-                  }"
-                >
-                  {{ t('common.collection.details_link') }}
-
-                  <ArrowRightIcon
-                    decorative
-                    :size="KUI_ICON_SIZE_30"
-                  />
-                </RouterLink>
+              <template #actions="{ row: item }">
+                <XActionGroup>
+                  <XAction
+                    :to="{
+                      name: 'zone-egress-detail-view',
+                      params: {
+                        zoneEgress: item.id,
+                      },
+                    }"
+                  >
+                    {{ t('common.collection.actions.view') }}
+                  </XAction>
+                </XActionGroup>
               </template>
             </AppCollection>
           </KCard>
@@ -141,9 +137,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import type { ZoneEgressOverviewCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
@@ -152,11 +145,3 @@ import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/zone-ingresses/views/ZoneIngressListView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressListView.vue
@@ -41,7 +41,7 @@
                 { label: 'Address', key: 'socketAddress' },
                 { label: 'Advertised address', key: 'advertisedSocketAddress' },
                 { label: 'Status', key: 'status' },
-                { label: 'Details', key: 'details', hideLabel: true },
+                { label: 'Actions', key: 'actions', hideLabel: true },
               ]"
               :page-number="1"
               :page-size="100"
@@ -55,7 +55,8 @@
               @change="route.update"
             >
               <template #name="{ row: item }">
-                <RouterLink
+                <XAction
+                  data-action
                   :to="{
                     name: 'zone-ingress-summary-view',
                     params: {
@@ -70,7 +71,7 @@
                   }"
                 >
                   {{ item.name }}
-                </RouterLink>
+                </XAction>
               </template>
 
               <template #socketAddress="{ row: item }">
@@ -99,24 +100,19 @@
                 />
               </template>
 
-              <template #details="{ row: item }">
-                <RouterLink
-                  class="details-link"
-                  data-testid="details-link"
-                  :to="{
-                    name: 'zone-ingress-detail-view',
-                    params: {
-                      zoneIngress: item.id,
-                    },
-                  }"
-                >
-                  {{ t('common.collection.details_link') }}
-
-                  <ArrowRightIcon
-                    decorative
-                    :size="KUI_ICON_SIZE_30"
-                  />
-                </RouterLink>
+              <template #actions="{ row: item }">
+                <XActionGroup>
+                  <XAction
+                    :to="{
+                      name: 'zone-ingress-detail-view',
+                      params: {
+                        zoneIngress: item.id,
+                      },
+                    }"
+                  >
+                    {{ t('common.collection.actions.view') }}
+                  </XAction>
+                </XActionGroup>
               </template>
             </AppCollection>
           </KCard>
@@ -152,9 +148,6 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { ArrowRightIcon } from '@kong/icons'
-
 import type { ZoneIngressOverviewCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
@@ -163,11 +156,3 @@ import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeSource } from '@/app/me/sources'
 </script>
-
-<style lang="scss" scoped>
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-</style>

--- a/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
@@ -21,7 +21,7 @@
           ]"
           :items="props.data.zoneIngress.availableServices"
         >
-          <template #name="{ row: item }: {row: AvailableService}">
+          <template #name="{ row: item }">
             <RouterLink
               :to="{
                 name: 'service-detail-view',
@@ -35,7 +35,7 @@
             </RouterLink>
           </template>
 
-          <template #mesh="{ row: item }: {row: AvailableService}">
+          <template #mesh="{ row: item }">
             <RouterLink
               :to="{
                 name: 'mesh-detail-view',
@@ -48,7 +48,7 @@
             </RouterLink>
           </template>
 
-          <template #protocol="{ row: item }: {row: AvailableService}">
+          <template #protocol="{ row: item }">
             {{ item.tags['kuma.io/protocol'] ?? t('common.collection.none') }}
           </template>
 
@@ -56,36 +56,20 @@
             {{ item.instances }}
           </template>
 
-          <template #actions="{ row: item }: {row: AvailableService}">
-            <KDropdown
-              class="actions-dropdown"
-              :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
-              width="150"
-            >
-              <template #default>
-                <KButton
-                  class="non-visual-button"
-                  appearance="secondary"
-                  icon
-                >
-                  <MoreIcon />
-                </KButton>
-              </template>
-              <template #items>
-                <KDropdownItem
-                  :item="{
-                    to: {
-                      name: 'service-detail-view',
-                      params: {
-                        mesh: item.mesh,
-                        service: item.tags['kuma.io/service'],
-                      },
-                    },
-                    label: t('common.collection.actions.view'),
-                  }"
-                />
-              </template>
-            </KDropdown>
+          <template #actions="{ row: item }">
+            <XActionGroup>
+              <XAction
+                :to="{
+                  name: 'service-detail-view',
+                  params: {
+                    mesh: item.mesh,
+                    service: item.tags['kuma.io/service'],
+                  },
+                }"
+              >
+                {{ t('common.collection.actions.view') }}
+              </XAction>
+            </XActionGroup>
           </template>
         </AppCollection>
       </KCard>
@@ -94,9 +78,7 @@
 </template>
 
 <script lang="ts" setup>
-import { MoreIcon } from '@kong/icons'
-
-import type { AvailableService, ZoneIngressOverview } from '../data'
+import type { ZoneIngressOverview } from '../data'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 const props = defineProps<{
   data: ZoneIngressOverview

--- a/src/app/zones/views/ZoneDetailTabsView.vue
+++ b/src/app/zones/views/ZoneDetailTabsView.vue
@@ -36,45 +36,48 @@
           v-if="can('create zones')"
           #actions
         >
-          <KDropdown
-            :kpop-attributes="{ placement: 'bottomEnd' }"
-            :trigger-text="t('zones.action_menu.toggle_button')"
-            show-caret
-            width="280"
-          >
-            <template #items>
-              <XDisclosure
-                v-slot="{ expanded, toggle }"
+          <XActionGroup>
+            <template
+              #control
+            >
+              <XAction
+                type="expand"
+                appearance="primary"
               >
-                <KDropdownItem
-                  danger
-                  data-testid="delete-button"
-                  @click.prevent="toggle"
-                >
-                  {{ t('zones.action_menu.delete_button') }}
-                </KDropdownItem>
-                <XTeleportTemplate
-                  :to="{ name: 'modal-layer' }"
-                >
-                  <DeleteResourceModal
-                    v-if="expanded"
-                    :confirmation-text="data.name"
-                    :delete-function="() => deleteZone(data.name)"
-                    is-visible
-                    :action-button-text="t('common.delete_modal.proceed_button')"
-                    :title="t('common.delete_modal.title', { type: 'Zone' })"
-                    data-testid="delete-zone-modal"
-                    @cancel="toggle"
-                    @delete="() => route.replace({ name: 'zone-cp-list-view' })"
-                  >
-                    <p>{{ t('common.delete_modal.text1', { type: 'Zone', name: data.name }) }}</p>
-
-                    <p>{{ t('common.delete_modal.text2') }}</p>
-                  </DeleteResourceModal>
-                </XTeleportTemplate>
-              </XDisclosure>
+                {{ t('zones.action_menu.toggle_button') }}
+              </XAction>
             </template>
-          </KDropdown>
+            <XDisclosure
+              v-slot="{ expanded, toggle }"
+            >
+              <XAction
+                appearance="danger"
+                data-testid="delete-button"
+                @click="toggle"
+              >
+                {{ t('zones.action_menu.delete_button') }}
+              </XAction>
+              <XTeleportTemplate
+                :to="{ name: 'modal-layer' }"
+              >
+                <DeleteResourceModal
+                  v-if="expanded"
+                  :confirmation-text="data.name"
+                  :delete-function="() => deleteZone(data.name)"
+                  is-visible
+                  :action-button-text="t('common.delete_modal.proceed_button')"
+                  :title="t('common.delete_modal.title', { type: 'Zone' })"
+                  data-testid="delete-zone-modal"
+                  @cancel="toggle"
+                  @delete="() => route.replace({ name: 'zone-cp-list-view' })"
+                >
+                  <p>{{ t('common.delete_modal.text1', { type: 'Zone', name: data.name }) }}</p>
+
+                  <p>{{ t('common.delete_modal.text2') }}</p>
+                </DeleteResourceModal>
+              </XTeleportTemplate>
+            </XDisclosure>
+          </XActionGroup>
         </template>
 
         <XTabs

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -71,7 +71,6 @@
                   { label: 'Egresses (online / total)', key: 'egress' },
                   { label: 'Status', key: 'state' },
                   { label: 'Warnings', key: 'warnings', hideLabel: true },
-                  { label: 'Details', key: 'details', hideLabel: true },
                   { label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
                 :page-number="route.params.page"
@@ -101,7 +100,7 @@
                   </template>
                 </template>
                 <template #name="{ row: item }">
-                  <RouterLink
+                  <XAction
                     data-action
                     :to="{
                       name: 'zone-cp-detail-view',
@@ -115,7 +114,7 @@
                     }"
                   >
                     {{ item.name }}
-                  </RouterLink>
+                  </XAction>
                 </template>
 
                 <template #zoneCpVersion="{ row: item }">
@@ -177,78 +176,51 @@
                   </template>
                 </template>
 
-                <template #details="{ row }">
-                  <RouterLink
-                    class="details-link"
-                    data-testid="details-link"
-                    :to="{
-                      name: 'zone-cp-detail-view',
-                      params: {
-                        zone: row.name,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.details_link') }}
-
-                    <ArrowRightIcon
-                      decorative
-                      :size="KUI_ICON_SIZE_30"
-                    />
-                  </RouterLink>
-                </template>
-
                 <template
                   v-if="can('create zones')"
                   #actions="{ row }"
                 >
-                  <KDropdown
-                    class="actions-dropdown"
-                    :kpop-attributes="{ placement: 'bottomEnd', popoverClasses: 'mt-5 more-actions-popover' }"
-                    width="150"
-                  >
-                    <template #default>
-                      <KButton
-                        class="non-visual-button"
-                        appearance="secondary"
-                        icon
+                  <XActionGroup>
+                    <XDisclosure
+                      v-slot="{ expanded, toggle }"
+                    >
+                      <XAction
+                        :to="{
+                          name: 'zone-cp-detail-view',
+                          params: {
+                            zone: row.name,
+                          },
+                        }"
                       >
-                        <MoreIcon />
-                      </KButton>
-                    </template>
-
-                    <template #items>
-                      <XDisclosure
-                        v-slot="{ expanded, toggle }"
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                      <XAction
+                        appearance="danger"
+                        @click="toggle"
                       >
-                        <KDropdownItem
-                          danger
-                          data-testid="dropdown-delete-item"
-                          @click="toggle"
+                        {{ t('common.collection.actions.delete') }}
+                      </XAction>
+                      <XTeleportTemplate
+                        :to="{ name: 'modal-layer' }"
+                      >
+                        <DeleteResourceModal
+                          v-if="expanded"
+                          :confirmation-text="row.name"
+                          :delete-function="() => deleteZone(row.name)"
+                          is-visible
+                          :action-button-text="t('common.delete_modal.proceed_button')"
+                          :title="t('common.delete_modal.title', { type: 'Zone' })"
+                          data-testid="delete-zone-modal"
+                          @cancel="toggle"
+                          @delete="() => { toggle(); refresh() }"
                         >
-                          {{ t('common.collection.actions.delete') }}
-                        </KDropdownItem>
-                        <XTeleportTemplate
-                          :to="{ name: 'modal-layer' }"
-                        >
-                          <DeleteResourceModal
-                            v-if="expanded"
-                            :confirmation-text="row.name"
-                            :delete-function="() => deleteZone(row.name)"
-                            is-visible
-                            :action-button-text="t('common.delete_modal.proceed_button')"
-                            :title="t('common.delete_modal.title', { type: 'Zone' })"
-                            data-testid="delete-zone-modal"
-                            @cancel="toggle"
-                            @delete="() => { toggle(); refresh() }"
-                          >
-                            <p>{{ t('common.delete_modal.text1', { type: 'Zone', name: row.name }) }}</p>
+                          <p>{{ t('common.delete_modal.text1', { type: 'Zone', name: row.name }) }}</p>
 
-                            <p>{{ t('common.delete_modal.text2') }}</p>
-                          </DeleteResourceModal>
-                        </XTeleportTemplate>
-                      </XDisclosure>
-                    </template>
-                  </KDropdown>
+                          <p>{{ t('common.delete_modal.text2') }}</p>
+                        </DeleteResourceModal>
+                      </XTeleportTemplate>
+                    </XDisclosure>
+                  </XActionGroup>
                 </template>
               </AppCollection>
             </template>
@@ -280,8 +252,7 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { AddIcon, ArrowRightIcon, MoreIcon } from '@kong/icons'
+import { AddIcon } from '@kong/icons'
 import { ref } from 'vue'
 
 import { sources as zoneSources } from '../sources'
@@ -353,16 +324,6 @@ async function deleteZone(name: string) {
   color: inherit;
   font-weight: $kui-font-weight-semibold;
   text-decoration: none;
-}
-
-.details-link {
-  display: inline-flex;
-  align-items: center;
-  gap: $kui-space-20;
-}
-
-.actions-dropdown {
-  display: inline-block;
 }
 
 .warning-type-memory {


### PR DESCRIPTION
- Removes "Go to details" links from all tables
- Adds end of row dropdown with "View details" item in it

This PR resolves several issues with the "Go to details" links such as when they were shown _as well as_ a dropdown, wrapping issues, and alignment issues.

I made some amends and reused `XActionGroup` for the dropdown menu as what we are building here is a "group of actions", it just so happens this group of actions is shown as a dropdown menu. If you add `expanded="true"` to the `XActionGroup` it will be shown as a row of buttons instead of a dropdown i.e. same component for showing groups of actions with an attribute to allow you to configure these actions are shown.

I made quite a few changes that meant some `data-testid` attributes where removed, so there were some changes to tests here to reflect that (plus having to open up the new dropdown), unfortunately it also meant a tonne of formatting changes 😬 

I made a few other changes while I was there such as converting some `RouterLinks` to `XActions` (there is a long running task to do this and eventually remove `RouterLink` entirely)

---


Closes some of https://github.com/kumahq/kuma-gui/issues/2668