### PR TITLE
chore: rollout table column resizing everywhere

### DIFF
--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -1,7 +1,9 @@
 <template>
   <DataSource
-    v-slot="{ data: me }: MeSource"
-    :src="`/me/${props.name}`"
+    v-slot="{ data: me }"
+    :src="uri(sources, '/me/:route', {
+      route: props.name,
+    })"
   >
     <div
       class="route-view"
@@ -19,7 +21,7 @@
       <DataSink
         v-if="me"
         v-slot="{ submit }"
-        :src="`/me/mesh-list-view`"
+        :src="`/me/${props.name}`"
       >
         <slot
           :id="UniqueId"
@@ -58,7 +60,7 @@ import {
   beforePaint,
 } from '../../utilities'
 import { useUri } from '@/app/application/services/data-source'
-import type { MeSource } from '@/app/me/sources'
+import { sources } from '@/app/me/sources'
 import { useEnv } from '@/utilities'
 import { get } from '@/utilities/get'
 import type { RouteRecordRaw } from 'vue-router'

--- a/src/app/application/index.ts
+++ b/src/app/application/index.ts
@@ -18,7 +18,7 @@ import I18n from './services/i18n/I18n'
 import type { Source } from '@/app/application/services/data-source'
 import { create, destroy, getSource, DataSourcePool } from '@/app/application/services/data-source'
 import { services as kuma } from '@/app/kuma'
-import { services as me } from '@/app/me'
+import { TOKENS as ME, services as me } from '@/app/me'
 import { services as x } from '@/app/x'
 import type { ServiceDefinition } from '@/services/utils'
 import { token, createInjections, constant } from '@/services/utils'
@@ -56,6 +56,7 @@ declare module '@vue/runtime-core' {
 }
 
 const $ = {
+  ...ME,
   Env: token<Env>('application.Env'),
   env: token<Env['var']>('application.env'),
   EnvVars: token<EnvVars>('EnvVars'),

--- a/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    v-slot="{ can, t, uri }"
+    v-slot="{ can, t, uri, me }"
     name="home"
   >
     <AppView>
@@ -60,6 +60,7 @@
                 <ZoneControlPlanesList
                   data-testid="zone-control-planes-details"
                   :items="data?.items"
+                  :storage="me"
                 />
               </template>
             </DataLoader>
@@ -92,6 +93,7 @@
                 <MeshInsightsList
                   data-testid="meshes-details"
                   :items="data?.items"
+                  :storage="me"
                 />
               </template>
             </DataLoader>

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -1,285 +1,280 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ can, route, t, me }"
+    name="data-plane-list-view"
+    :params="{
+      page: 1,
+      size: 50,
+      dataplaneType: 'all',
+      s: '',
+      mesh: '',
+      dataPlane: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ can, route, t }"
-      name="data-plane-list-view"
-      :params="{
-        page: 1,
-        size: me.pageSize,
-        dataplaneType: 'all',
-        s: '',
-        mesh: '',
-        dataPlane: '',
-      }"
+    <DataSource
+      v-slot="{ data, error }: DataplaneOverviewCollectionSource"
+      :src="`/meshes/${route.params.mesh}/dataplanes/of/${route.params.dataplaneType}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
     >
-      <DataSource
-        v-slot="{ data, error }: DataplaneOverviewCollectionSource"
-        :src="`/meshes/${route.params.mesh}/dataplanes/of/${route.params.dataplaneType}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
-      >
-        <RouteTitle
-          :render="false"
-          :title="t('data-planes.routes.items.title')"
-        />
-        <AppView>
-          <KCard>
-            <ErrorBlock
-              v-if="error !== undefined"
-              :error="error"
-            />
+      <RouteTitle
+        :render="false"
+        :title="t('data-planes.routes.items.title')"
+      />
+      <AppView>
+        <KCard>
+          <ErrorBlock
+            v-if="error !== undefined"
+            :error="error"
+          />
 
-            <AppCollection
-              v-else
-              class="data-plane-collection"
-              data-testid="data-plane-collection"
-              :page-number="route.params.page"
-              :page-size="route.params.size"
-              :headers="[
-                { label: '&nbsp;', key: 'type' },
-                { label: 'Name', key: 'name' },
-                { label: 'Namespace', key: 'namespace' },
-                ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
-                { label: 'Services', key: 'services' },
-                { label: 'Certificate Info', key: 'certificate' },
-                { label: 'Status', key: 'status' },
-                { label: 'Warnings', key: 'warnings', hideLabel: true },
-                { label: 'Actions', key: 'actions', hideLabel: true },
-              ]"
-              :items="data?.items"
-              :total="data?.total"
-              :error="error"
-              :is-selected-row="(row) => row.name === route.params.dataPlane"
-              summary-route-name="service-data-plane-summary-view"
-              :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
-              :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
-              :empty-state-cta-text="t('common.documentation')"
-              @change="route.update"
-            >
-              <template #toolbar>
-                <FilterBar
-                  class="data-plane-proxy-filter"
-                  :placeholder="`service:backend`"
-                  :query="route.params.s"
-                  :fields="{
-                    name: { description: 'filter by name or parts of a name' },
-                    protocol: { description: 'filter by “kuma.io/protocol” value' },
-                    service: { description: 'filter by “kuma.io/service” value' },
-                    tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                    ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                  }"
-                  @change="(e) => route.update({
-                    ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                  })"
-                />
+          <AppCollection
+            v-else
+            class="data-plane-collection"
+            data-testid="data-plane-collection"
+            :page-number="route.params.page"
+            :page-size="route.params.size"
+            :headers="[
+              { ...me.get('headers.type'), label: '&nbsp;', key: 'type' },
+              { ...me.get('headers.name'), label: 'Name', key: 'name' },
+              { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+              ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+              { ...me.get('headers.services'), label: 'Services', key: 'services' },
+              { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
+              { ...me.get('headers.status'), label: 'Status', key: 'status' },
+              { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+              { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+            ]"
+            :items="data?.items"
+            :total="data?.total"
+            :error="error"
+            :is-selected-row="(row) => row.name === route.params.dataPlane"
+            summary-route-name="service-data-plane-summary-view"
+            :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
+            :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
+            :empty-state-cta-text="t('common.documentation')"
+            @change="route.update"
+            @resize="me.set"
+          >
+            <template #toolbar>
+              <FilterBar
+                class="data-plane-proxy-filter"
+                :placeholder="`service:backend`"
+                :query="route.params.s"
+                :fields="{
+                  name: { description: 'filter by name or parts of a name' },
+                  protocol: { description: 'filter by “kuma.io/protocol” value' },
+                  service: { description: 'filter by “kuma.io/service” value' },
+                  tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                  ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+                }"
+                @change="(e) => route.update({
+                  ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                })"
+              />
 
-                <XSelect
-                  label="Type"
-                  :selected="route.params.dataplaneType"
-                  @change="(value: string) => route.update({ dataplaneType: value })"
-                >
-                  <template #selected="{ item }: { item: 'all' | 'standard' | 'builtin' | 'delegated'}">
-                    <XIcon
-                      v-if="item !== 'all'"
-                      :size="KUI_ICON_SIZE_40"
-                      :name="item"
-                    />
-                    {{ t(`data-planes.type.${item}`) }}
-                  </template>
-                  <template
-                    v-for="item in (['all', 'standard', 'builtin', 'delegated'] as const)"
-                    :key="item"
-                    #[`${item}-option`]
-                  >
-                    <XIcon
-                      v-if="item !== 'all'"
-                      :name="item"
-                    />
-                    {{ t(`data-planes.type.${item}`) }}
-                  </template>
-                </XSelect>
-              </template>
-
-              <template #type="{ row: item }">
-                <XIcon :name="item.dataplaneType">
-                  {{ t(`data-planes.type.${item.dataplaneType}`) }}
-                </XIcon>
-              </template>
-
-              <template #name="{ row: item }">
-                <RouterLink
-                  data-action
-                  class="name-link"
-                  :title="item.name"
-                  :to="{
-                    name: 'data-plane-summary-view',
-                    params: {
-                      mesh: item.mesh,
-                      dataPlane: item.id,
-                    },
-                    query: {
-                      page: route.params.page,
-                      size: route.params.size,
-                      s: route.params.s,
-                      dataplaneType: route.params.dataplaneType,
-                    },
-                  }"
-                >
-                  {{ item.name }}
-                </RouterLink>
-              </template>
-
-              <template #namespace="{ row: item }">
-                {{ item.namespace }}
-              </template>
-
-              <template #services="{ row }">
-                <KTruncate
-                  v-if="row.services.length > 0"
-                  width="auto"
-                >
-                  <div
-                    v-for="(service, index) in row.services"
-                    :key="index"
-                  >
-                    <TextWithCopyButton :text="service">
-                      <RouterLink
-                        v-if="row.dataplaneType === 'standard'"
-                        :to="{
-                          name: 'service-detail-view',
-                          params: {
-                            service,
-                          },
-                        }"
-                      >
-                        {{ service }}
-                      </RouterLink>
-
-                      <RouterLink
-                        v-else-if="row.dataplaneType === 'delegated'"
-                        :to="{
-                          name: 'delegated-gateway-detail-view',
-                          params: {
-                            service,
-                          },
-                        }"
-                      >
-                        {{ service }}
-                      </RouterLink>
-
-                      <template v-else>
-                        {{ service }}
-                      </template>
-                    </TextWithCopyButton>
-                  </div>
-                </KTruncate>
-
-                <template v-else>
-                  {{ t('common.collection.none') }}
+              <XSelect
+                label="Type"
+                :selected="route.params.dataplaneType"
+                @change="(value: string) => route.update({ dataplaneType: value })"
+              >
+                <template #selected="{ item }: { item: 'all' | 'standard' | 'builtin' | 'delegated'}">
+                  <XIcon
+                    v-if="item !== 'all'"
+                    :size="KUI_ICON_SIZE_40"
+                    :name="item"
+                  />
+                  {{ t(`data-planes.type.${item}`) }}
                 </template>
-              </template>
-
-              <template #zone="{ row }">
-                <RouterLink
-                  v-if="row.zone"
-                  :to="{
-                    name: 'zone-cp-detail-view',
-                    params: {
-                      zone: row.zone,
-                    },
-                  }"
+                <template
+                  v-for="item in (['all', 'standard', 'builtin', 'delegated'] as const)"
+                  :key="item"
+                  #[`${item}-option`]
                 >
-                  {{ row.zone }}
-                </RouterLink>
-
-                <template v-else>
-                  {{ t('common.collection.none') }}
+                  <XIcon
+                    v-if="item !== 'all'"
+                    :name="item"
+                  />
+                  {{ t(`data-planes.type.${item}`) }}
                 </template>
-              </template>
+              </XSelect>
+            </template>
 
-              <template #certificate="{ row }">
-                <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                  {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                </template>
+            <template #type="{ row: item }">
+              <XIcon :name="item.dataplaneType">
+                {{ t(`data-planes.type.${item.dataplaneType}`) }}
+              </XIcon>
+            </template>
 
-                <template v-else>
-                  {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                </template>
-              </template>
-
-              <template #status="{ row }">
-                <StatusBadge :status="row.status" />
-              </template>
-
-              <template #warnings="{ row }">
-                <XIcon
-                  v-if="row.isCertExpired || row.warnings.length > 0"
-                  class="mr-1"
-                  name="warning"
-                >
-                  <ul>
-                    <template v-if="row.warnings.length > 0">
-                      <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                    </template>
-
-                    <template v-if="row.isCertExpired">
-                      <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                    </template>
-                  </ul>
-                </XIcon>
-
-                <template v-else>
-                  {{ t('common.collection.none') }}
-                </template>
-              </template>
-
-              <template #actions="{ row: item }">
-                <XActionGroup>
-                  <XAction
-                    :to="{
-                      name: 'data-plane-detail-view',
-                      params: {
-                        dataPlane: item.id,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.actions.view') }}
-                  </XAction>
-                </XActionGroup>
-              </template>
-            </AppCollection>
-
-            <RouterView
-              v-if="route.params.dataPlane"
-              v-slot="child"
-            >
-              <SummaryView
-                @close="route.replace({
-                  name: route.name,
+            <template #name="{ row: item }">
+              <RouterLink
+                data-action
+                class="name-link"
+                :title="item.name"
+                :to="{
+                  name: 'data-plane-summary-view',
                   params: {
-                    mesh: route.params.mesh,
+                    mesh: item.mesh,
+                    dataPlane: item.id,
                   },
                   query: {
                     page: route.params.page,
                     size: route.params.size,
                     s: route.params.s,
+                    dataplaneType: route.params.dataplaneType,
                   },
-                })"
+                }"
               >
-                <component
-                  :is="child.Component"
-                  v-if="typeof data !== 'undefined'"
-                  :items="data.items"
-                />
-              </SummaryView>
-            </RouterView>
-          </KCard>
-        </AppView>
-      </DataSource>
-    </RouteView>
-  </DataSource>
+                {{ item.name }}
+              </RouterLink>
+            </template>
+
+            <template #namespace="{ row: item }">
+              {{ item.namespace }}
+            </template>
+
+            <template #services="{ row }">
+              <KTruncate
+                v-if="row.services.length > 0"
+                width="auto"
+              >
+                <div
+                  v-for="(service, index) in row.services"
+                  :key="index"
+                >
+                  <TextWithCopyButton :text="service">
+                    <RouterLink
+                      v-if="row.dataplaneType === 'standard'"
+                      :to="{
+                        name: 'service-detail-view',
+                        params: {
+                          service,
+                        },
+                      }"
+                    >
+                      {{ service }}
+                    </RouterLink>
+
+                    <RouterLink
+                      v-else-if="row.dataplaneType === 'delegated'"
+                      :to="{
+                        name: 'delegated-gateway-detail-view',
+                        params: {
+                          service,
+                        },
+                      }"
+                    >
+                      {{ service }}
+                    </RouterLink>
+
+                    <template v-else>
+                      {{ service }}
+                    </template>
+                  </TextWithCopyButton>
+                </div>
+              </KTruncate>
+
+              <template v-else>
+                {{ t('common.collection.none') }}
+              </template>
+            </template>
+
+            <template #zone="{ row }">
+              <RouterLink
+                v-if="row.zone"
+                :to="{
+                  name: 'zone-cp-detail-view',
+                  params: {
+                    zone: row.zone,
+                  },
+                }"
+              >
+                {{ row.zone }}
+              </RouterLink>
+
+              <template v-else>
+                {{ t('common.collection.none') }}
+              </template>
+            </template>
+
+            <template #certificate="{ row }">
+              <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+              </template>
+
+              <template v-else>
+                {{ t('data-planes.components.data-plane-list.certificate.none') }}
+              </template>
+            </template>
+
+            <template #status="{ row }">
+              <StatusBadge :status="row.status" />
+            </template>
+
+            <template #warnings="{ row }">
+              <XIcon
+                v-if="row.isCertExpired || row.warnings.length > 0"
+                class="mr-1"
+                name="warning"
+              >
+                <ul>
+                  <template v-if="row.warnings.length > 0">
+                    <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+                  </template>
+
+                  <template v-if="row.isCertExpired">
+                    <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
+                  </template>
+                </ul>
+              </XIcon>
+
+              <template v-else>
+                {{ t('common.collection.none') }}
+              </template>
+            </template>
+
+            <template #actions="{ row: item }">
+              <XActionGroup>
+                <XAction
+                  :to="{
+                    name: 'data-plane-detail-view',
+                    params: {
+                      dataPlane: item.id,
+                    },
+                  }"
+                >
+                  {{ t('common.collection.actions.view') }}
+                </XAction>
+              </XActionGroup>
+            </template>
+          </AppCollection>
+
+          <RouterView
+            v-if="route.params.dataPlane"
+            v-slot="child"
+          >
+            <SummaryView
+              @close="route.replace({
+                name: route.name,
+                params: {
+                  mesh: route.params.mesh,
+                },
+                query: {
+                  page: route.params.page,
+                  size: route.params.size,
+                  s: route.params.s,
+                },
+              })"
+            >
+              <component
+                :is="child.Component"
+                v-if="typeof data !== 'undefined'"
+                :items="data.items"
+              />
+            </SummaryView>
+          </RouterView>
+        </KCard>
+      </AppView>
+    </DataSource>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -292,7 +287,6 @@ import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import type { MeSource } from '@/app/me/sources'
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/external-services/views/ExternalServiceListView.vue
+++ b/src/app/external-services/views/ExternalServiceListView.vue
@@ -1,104 +1,99 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ route, t, me }"
+    name="external-service-list-view"
+    :params="{
+      page: 1,
+      size: 50,
+      mesh: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ route, t }"
-      name="external-service-list-view"
-      :params="{
-        page: 1,
-        size: me.pageSize,
-        mesh: '',
-      }"
+    <DataSource
+      v-slot="{data, error}: ExternalServiceCollectionSource"
+      :src="`/meshes/${route.params.mesh}/external-services?page=${route.params.page}&size=${route.params.size}`"
     >
-      <DataSource
-        v-slot="{data, error}: ExternalServiceCollectionSource"
-        :src="`/meshes/${route.params.mesh}/external-services?page=${route.params.page}&size=${route.params.size}`"
-      >
-        <RouteTitle
-          :render="false"
-          :title="t(`external-services.routes.items.title`)"
-        />
-        <AppView>
-          <KCard>
-            <ErrorBlock
-              v-if="error !== undefined"
-              :error="error"
-            />
+      <RouteTitle
+        :render="false"
+        :title="t(`external-services.routes.items.title`)"
+      />
+      <AppView>
+        <KCard>
+          <ErrorBlock
+            v-if="error !== undefined"
+            :error="error"
+          />
 
-            <AppCollection
-              v-else
-              class="external-service-collection"
-              data-testid="external-service-collection"
-              :empty-state-message="t('common.emptyState.message', { type: 'External Services' })"
-              :empty-state-cta-to="t('external-services.href.docs')"
-              :empty-state-cta-text="t('common.documentation')"
-              :headers="[
-                { label: 'Name', key: 'name' },
-                { label: 'Address', key: 'address' },
-                { label: 'Actions', key: 'actions', hideLabel: true },
-              ]"
-              :page-number="route.params.page"
-              :page-size="route.params.size"
-              :total="data?.total"
-              :items="data?.items"
-              :error="error"
-              @change="route.update"
-            >
-              <template #name="{ row: item }">
-                <TextWithCopyButton :text="item.name">
-                  <RouterLink
-                    :to="{
-                      name: 'external-service-detail-view',
-                      params: {
-                        mesh: item.mesh,
-                        service: item.name,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                      },
-                    }"
-                  >
-                    {{ item.name }}
-                  </RouterLink>
-                </TextWithCopyButton>
+          <AppCollection
+            v-else
+            class="external-service-collection"
+            data-testid="external-service-collection"
+            :empty-state-message="t('common.emptyState.message', { type: 'External Services' })"
+            :empty-state-cta-to="t('external-services.href.docs')"
+            :empty-state-cta-text="t('common.documentation')"
+            :headers="[
+              { ...me.get('headers.name'), label: 'Name', key: 'name' },
+              { ...me.get('headers.address'), label: 'Address', key: 'address' },
+              { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+            ]"
+            :page-number="route.params.page"
+            :page-size="route.params.size"
+            :total="data?.total"
+            :items="data?.items"
+            :error="error"
+            @change="route.update"
+            @resize="me.set"
+          >
+            <template #name="{ row: item }">
+              <TextWithCopyButton :text="item.name">
+                <RouterLink
+                  :to="{
+                    name: 'external-service-detail-view',
+                    params: {
+                      mesh: item.mesh,
+                      service: item.name,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                    },
+                  }"
+                >
+                  {{ item.name }}
+                </RouterLink>
+              </TextWithCopyButton>
+            </template>
+
+            <template #address="{ row }">
+              <TextWithCopyButton
+                v-if="row.networking.address"
+                :text="row.networking.address"
+              />
+
+              <template v-else>
+                {{ t('common.collection.none') }}
               </template>
+            </template>
 
-              <template #address="{ row }">
-                <TextWithCopyButton
-                  v-if="row.networking.address"
-                  :text="row.networking.address"
-                />
-
-                <template v-else>
-                  {{ t('common.collection.none') }}
-                </template>
-              </template>
-
-              <template #actions="{ row: item }">
-                <XActionGroup>
-                  <XAction
-                    :to="{
-                      name: 'external-service-detail-view',
-                      params: {
-                        mesh: item.mesh,
-                        service: item.name,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.actions.view') }}
-                  </XAction>
-                </XActionGroup>
-              </template>
-            </AppCollection>
-          </KCard>
-        </AppView>
-      </DataSource>
-    </RouteView>
-  </DataSource>
+            <template #actions="{ row: item }">
+              <XActionGroup>
+                <XAction
+                  :to="{
+                    name: 'external-service-detail-view',
+                    params: {
+                      mesh: item.mesh,
+                      service: item.name,
+                    },
+                  }"
+                >
+                  {{ t('common.collection.actions.view') }}
+                </XAction>
+              </XActionGroup>
+            </template>
+          </AppCollection>
+        </KCard>
+      </AppView>
+    </DataSource>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -106,5 +101,4 @@ import type { ExternalServiceCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import type { MeSource } from '@/app/me/sources'
 </script>

--- a/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -1,204 +1,199 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ can, route, t, me }"
+    name="builtin-gateway-dataplanes-view"
+    :params="{
+      mesh: '',
+      gateway: '',
+      listener: '',
+      page: 1,
+      size: 50,
+      s: '',
+      dataPlane: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ can, route, t }"
-      name="builtin-gateway-dataplanes-view"
-      :params="{
-        mesh: '',
-        gateway: '',
-        listener: '',
-        page: 1,
-        size: me.pageSize,
-        s: '',
-        dataPlane: '',
-      }"
-    >
-      <AppView>
-        <DataSource
-          v-slot="{ data: meshGateway, error }: MeshGatewaySource"
-          :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}`"
-        >
-          <div class="stack">
-            <KCard>
-              <DataLoader
-                v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
-                :src="meshGateway === undefined ? '' : `/meshes/${route.params.mesh}/dataplanes/for/service-insight/${meshGateway.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
-                :data="[meshGateway]"
-                :errors="[error]"
-                :loader="false"
+    <AppView>
+      <DataSource
+        v-slot="{ data: meshGateway, error }: MeshGatewaySource"
+        :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}`"
+      >
+        <div class="stack">
+          <KCard>
+            <DataLoader
+              v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
+              :src="meshGateway === undefined ? '' : `/meshes/${route.params.mesh}/dataplanes/for/service-insight/${meshGateway.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
+              :data="[meshGateway]"
+              :errors="[error]"
+              :loader="false"
+            >
+              <AppCollection
+                class="data-plane-collection"
+                data-testid="data-plane-collection"
+                :page-number="route.params.page"
+                :page-size="route.params.size"
+                :headers="[
+                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                  { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
+                  { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                  { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :items="dataplanesData?.items"
+                :total="dataplanesData?.total"
+                :is-selected-row="(row) => row.name === route.params.dataPlane"
+                summary-route-name="builtin-gateway-data-plane-summary-view"
+                :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
+                :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
+                :empty-state-cta-text="t('common.documentation')"
+                @change="route.update"
+                @resize="me.set"
               >
-                <AppCollection
-                  class="data-plane-collection"
-                  data-testid="data-plane-collection"
-                  :page-number="route.params.page"
-                  :page-size="route.params.size"
-                  :headers="[
-                    { label: 'Name', key: 'name' },
-                    { label: 'Namespace', key: 'namespace' },
-                    ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
-                    { label: 'Certificate Info', key: 'certificate' },
-                    { label: 'Status', key: 'status' },
-                    { label: 'Warnings', key: 'warnings', hideLabel: true },
-                    { label: 'Actions', key: 'actions', hideLabel: true },
-                  ]"
-                  :items="dataplanesData?.items"
-                  :total="dataplanesData?.total"
-                  :is-selected-row="(row) => row.name === route.params.dataPlane"
-                  summary-route-name="builtin-gateway-data-plane-summary-view"
-                  :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
-                  :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
-                  :empty-state-cta-text="t('common.documentation')"
-                  @change="route.update"
-                >
-                  <template #toolbar>
-                    <FilterBar
-                      class="data-plane-proxy-filter"
-                      :placeholder="`name:dataplane-name`"
-                      :query="route.params.s"
-                      :fields="{
-                        name: { description: 'filter by name or parts of a name' },
-                        protocol: { description: 'filter by “kuma.io/protocol” value' },
-                        service: { description: 'filter by “kuma.io/service” value' },
-                        tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                        ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                      }"
-                      @change="(e) => route.update({
-                        ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                      })"
-                    />
-                  </template>
+                <template #toolbar>
+                  <FilterBar
+                    class="data-plane-proxy-filter"
+                    :placeholder="`name:dataplane-name`"
+                    :query="route.params.s"
+                    :fields="{
+                      name: { description: 'filter by name or parts of a name' },
+                      protocol: { description: 'filter by “kuma.io/protocol” value' },
+                      service: { description: 'filter by “kuma.io/service” value' },
+                      tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                      ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+                    }"
+                    @change="(e) => route.update({
+                      ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                    })"
+                  />
+                </template>
 
-                  <template #namespace="{ row }">
-                    {{ row.namespace }}
-                  </template>
+                <template #namespace="{ row }">
+                  {{ row.namespace }}
+                </template>
 
-                  <template #name="{ row }">
-                    <XAction
-                      data-action
-                      class="name-link"
-                      :title="row.name"
-                      :to="{
-                        name: 'builtin-gateway-data-plane-summary-view',
-                        params: {
-                          mesh: row.mesh,
-                          dataPlane: row.id,
-                        },
-                        query: {
-                          page: route.params.page,
-                          size: route.params.size,
-                          s: route.params.s,
-                        },
-                      }"
-                    >
-                      {{ row.name }}
-                    </XAction>
-                  </template>
-
-                  <template #zone="{ row }">
-                    <XAction
-                      v-if="row.zone"
-                      :to="{
-                        name: 'zone-cp-detail-view',
-                        params: {
-                          zone: row.zone,
-                        },
-                      }"
-                    >
-                      {{ row.zone }}
-                    </XAction>
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-
-                  <template #certificate="{ row }">
-                    <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                      {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                    </template>
-
-                    <template v-else>
-                      {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                    </template>
-                  </template>
-
-                  <template #status="{ row }">
-                    <StatusBadge :status="row.status" />
-                  </template>
-
-                  <template #warnings="{ row }">
-                    <XIcon
-                      v-if="row.isCertExpired || row.warnings.length > 0"
-                      class="mr-1"
-                      name="warning"
-                    >
-                      <ul>
-                        <template v-if="row.warnings.length > 0">
-                          <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                        </template>
-
-                        <template v-if="row.isCertExpired">
-                          <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                        </template>
-                      </ul>
-                    </XIcon>
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-
-                  <template #actions="{ row: item }">
-                    <XActionGroup>
-                      <XAction
-                        :to="{
-                          name: 'data-plane-detail-view',
-                          params: {
-                            dataPlane: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.actions.view') }}
-                      </XAction>
-                    </XActionGroup>
-                  </template>
-                </AppCollection>
-
-                <RouterView
-                  v-if="route.params.dataPlane"
-                  v-slot="child"
-                >
-                  <SummaryView
-                    @close="route.replace({
-                      name: route.name,
+                <template #name="{ row }">
+                  <XAction
+                    data-action
+                    class="name-link"
+                    :title="row.name"
+                    :to="{
+                      name: 'builtin-gateway-data-plane-summary-view',
                       params: {
-                        mesh: route.params.mesh,
+                        mesh: row.mesh,
+                        dataPlane: row.id,
                       },
                       query: {
                         page: route.params.page,
                         size: route.params.size,
                         s: route.params.s,
                       },
-                    })"
+                    }"
                   >
-                    <component
-                      :is="child.Component"
-                      v-if="typeof dataplanesData !== 'undefined'"
-                      :items="dataplanesData.items"
-                    />
-                  </SummaryView>
-                </RouterView>
-              </DataLoader>
-            </KCard>
-          </div>
-        </DataSource>
-      </AppView>
-    </RouteView>
-  </DataSource>
+                    {{ row.name }}
+                  </XAction>
+                </template>
+
+                <template #zone="{ row }">
+                  <XAction
+                    v-if="row.zone"
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: row.zone,
+                      },
+                    }"
+                  >
+                    {{ row.zone }}
+                  </XAction>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #certificate="{ row }">
+                  <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                    {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                  </template>
+
+                  <template v-else>
+                    {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                  </template>
+                </template>
+
+                <template #status="{ row }">
+                  <StatusBadge :status="row.status" />
+                </template>
+
+                <template #warnings="{ row }">
+                  <XIcon
+                    v-if="row.isCertExpired || row.warnings.length > 0"
+                    class="mr-1"
+                    name="warning"
+                  >
+                    <ul>
+                      <template v-if="row.warnings.length > 0">
+                        <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+                      </template>
+
+                      <template v-if="row.isCertExpired">
+                        <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
+                      </template>
+                    </ul>
+                  </XIcon>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #actions="{ row: item }">
+                  <XActionGroup>
+                    <XAction
+                      :to="{
+                        name: 'data-plane-detail-view',
+                        params: {
+                          dataPlane: item.id,
+                        },
+                      }"
+                    >
+                      {{ t('common.collection.actions.view') }}
+                    </XAction>
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+
+              <RouterView
+                v-if="route.params.dataPlane"
+                v-slot="child"
+              >
+                <SummaryView
+                  @close="route.replace({
+                    name: route.name,
+                    params: {
+                      mesh: route.params.mesh,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                      s: route.params.s,
+                    },
+                  })"
+                >
+                  <component
+                    :is="child.Component"
+                    v-if="typeof dataplanesData !== 'undefined'"
+                    :items="dataplanesData.items"
+                  />
+                </SummaryView>
+              </RouterView>
+            </DataLoader>
+          </KCard>
+        </div>
+      </DataSource>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -208,7 +203,6 @@ import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import type { DataplaneOverviewCollectionSource } from '@/app/data-planes/sources'
-import type { MeSource } from '@/app/me/sources'
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/gateways/views/BuiltinGatewayListView.vue
+++ b/src/app/gateways/views/BuiltinGatewayListView.vue
@@ -1,106 +1,101 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ route, t, can, me }"
+    name="builtin-gateway-list-view"
+    :params="{
+      page: 1,
+      size: 50,
+      mesh: '',
+      gateway: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ route, t, can }"
-      name="builtin-gateway-list-view"
-      :params="{
-        page: 1,
-        size: me.pageSize,
-        mesh: '',
-        gateway: '',
-      }"
+    <DataSource
+      v-slot="{ data, error }: MeshGatewayCollectionSource"
+      :src="`/meshes/${route.params.mesh}/mesh-gateways?page=${route.params.page}&size=${route.params.size}`"
     >
-      <DataSource
-        v-slot="{ data, error }: MeshGatewayCollectionSource"
-        :src="`/meshes/${route.params.mesh}/mesh-gateways?page=${route.params.page}&size=${route.params.size}`"
-      >
-        <AppView>
-          <KCard>
-            <ErrorBlock
-              v-if="error !== undefined"
-              :error="error"
-            />
+      <AppView>
+        <KCard>
+          <ErrorBlock
+            v-if="error !== undefined"
+            :error="error"
+          />
 
-            <AppCollection
-              v-else
-              class="builtin-gateway-collection"
-              data-testid="builtin-gateway-collection"
-              :empty-state-message="t('common.emptyState.message', { type: 'Built-in Gateways' })"
-              :empty-state-cta-to="t('builtin-gateways.href.docs')"
-              :empty-state-cta-text="t('common.documentation')"
-              :headers="[
-                { label: 'Name', key: 'name' },
-                ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
-                { label: 'Actions', key: 'actions', hideLabel: true },
-              ]"
-              :page-number="route.params.page"
-              :page-size="route.params.size"
-              :total="data?.total"
-              :items="data?.items"
-              :error="error"
-              @change="route.update"
-            >
-              <template #name="{ row: item }">
-                <TextWithCopyButton :text="item.name">
-                  <XAction
-                    data-action
-                    :to="{
-                      name: 'builtin-gateway-detail-view',
-                      params: {
-                        mesh: item.mesh,
-                        gateway: item.name,
-                      },
-                    }"
-                  >
-                    {{ item.name }}
-                  </XAction>
-                </TextWithCopyButton>
+          <AppCollection
+            v-else
+            class="builtin-gateway-collection"
+            data-testid="builtin-gateway-collection"
+            :empty-state-message="t('common.emptyState.message', { type: 'Built-in Gateways' })"
+            :empty-state-cta-to="t('builtin-gateways.href.docs')"
+            :empty-state-cta-text="t('common.documentation')"
+            :headers="[
+              { ...me.get('headers.name'), label: 'Name', key: 'name' },
+              ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+              { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+            ]"
+            :page-number="route.params.page"
+            :page-size="route.params.size"
+            :total="data?.total"
+            :items="data?.items"
+            :error="error"
+            @change="route.update"
+            @resize="me.set"
+          >
+            <template #name="{ row: item }">
+              <TextWithCopyButton :text="item.name">
+                <XAction
+                  data-action
+                  :to="{
+                    name: 'builtin-gateway-detail-view',
+                    params: {
+                      mesh: item.mesh,
+                      gateway: item.name,
+                    },
+                  }"
+                >
+                  {{ item.name }}
+                </XAction>
+              </TextWithCopyButton>
+            </template>
+
+            <template #zone="{ row }">
+              <template v-if="row.labels && row.labels['kuma.io/origin'] === 'zone' && row.labels['kuma.io/zone']">
+                <XAction
+                  :to="{
+                    name: 'zone-cp-detail-view',
+                    params: {
+                      zone: row.labels['kuma.io/zone'],
+                    },
+                  }"
+                >
+                  {{ row.labels['kuma.io/zone'] }}
+                </XAction>
               </template>
 
-              <template #zone="{ row }">
-                <template v-if="row.labels && row.labels['kuma.io/origin'] === 'zone' && row.labels['kuma.io/zone']">
-                  <XAction
-                    :to="{
-                      name: 'zone-cp-detail-view',
-                      params: {
-                        zone: row.labels['kuma.io/zone'],
-                      },
-                    }"
-                  >
-                    {{ row.labels['kuma.io/zone'] }}
-                  </XAction>
-                </template>
-
-                <template v-else>
-                  {{ t('common.detail.none') }}
-                </template>
+              <template v-else>
+                {{ t('common.detail.none') }}
               </template>
+            </template>
 
-              <template #actions="{ row: item }">
-                <XActionGroup>
-                  <XAction
-                    :to="{
-                      name: 'builtin-gateway-detail-view',
-                      params: {
-                        mesh: item.mesh,
-                        gateway: item.name,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.actions.view') }}
-                  </XAction>
-                </XActionGroup>
-              </template>
-            </AppCollection>
-          </KCard>
-        </AppView>
-      </DataSource>
-    </RouteView>
-  </DataSource>
+            <template #actions="{ row: item }">
+              <XActionGroup>
+                <XAction
+                  :to="{
+                    name: 'builtin-gateway-detail-view',
+                    params: {
+                      mesh: item.mesh,
+                      gateway: item.name,
+                    },
+                  }"
+                >
+                  {{ t('common.collection.actions.view') }}
+                </XAction>
+              </XActionGroup>
+            </template>
+          </AppCollection>
+        </KCard>
+      </AppView>
+    </DataSource>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -108,5 +103,4 @@ import type { MeshGatewayCollectionSource } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import type { MeSource } from '@/app/me/sources'
 </script>

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -1,242 +1,237 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ can, route, t, me }"
+    name="delegated-gateway-detail-view"
+    :params="{
+      mesh: '',
+      service: '',
+      page: 1,
+      size: 50,
+      s: '',
+      dataPlane: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ can, route, t }"
-      name="delegated-gateway-detail-view"
-      :params="{
-        mesh: '',
-        service: '',
-        page: 1,
-        size: me.pageSize,
-        s: '',
-        dataPlane: '',
-      }"
-    >
-      <AppView>
-        <div class="stack">
-          <DataLoader
-            v-slot="{ data }: ServiceInsightSource"
-            :src="`/meshes/${route.params.mesh}/service-insights/${route.params.service}`"
-          >
-            <KCard v-if="data">
-              <div class="columns">
-                <DefinitionCard>
-                  <template #title>
-                    {{ t('http.api.property.status') }}
+    <AppView>
+      <div class="stack">
+        <DataLoader
+          v-slot="{ data }: ServiceInsightSource"
+          :src="`/meshes/${route.params.mesh}/service-insights/${route.params.service}`"
+        >
+          <KCard v-if="data">
+            <div class="columns">
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.status') }}
+                </template>
+
+                <template #body>
+                  <StatusBadge :status="data.status" />
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.address') }}
+                </template>
+
+                <template #body>
+                  <TextWithCopyButton
+                    v-if="data.addressPort"
+                    :text="data.addressPort"
+                  />
+
+                  <template v-else>
+                    {{ t('common.detail.none') }}
                   </template>
+                </template>
+              </DefinitionCard>
 
-                  <template #body>
-                    <StatusBadge :status="data.status" />
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard>
-                  <template #title>
-                    {{ t('http.api.property.address') }}
-                  </template>
-
-                  <template #body>
-                    <TextWithCopyButton
-                      v-if="data.addressPort"
-                      :text="data.addressPort"
-                    />
-
-                    <template v-else>
-                      {{ t('common.detail.none') }}
-                    </template>
-                  </template>
-                </DefinitionCard>
-
-                <ResourceStatus
-                  :online="data.dataplanes?.online ?? 0"
-                  :total="data.dataplanes?.total ?? 0"
-                >
-                  <template #title>
-                    {{ t('http.api.property.dataPlaneProxies') }}
-                  </template>
-                </ResourceStatus>
-              </div>
-            </KCard>
-          </DataLoader>
-
-          <div>
-            <h3>{{ t('delegated-gateways.detail.data_plane_proxies') }}</h3>
-
-            <KCard class="mt-4">
-              <DataLoader
-                v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
-                :src="`/meshes/${route.params.mesh}/dataplanes/for/service-insight/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
-                :loader="false"
+              <ResourceStatus
+                :online="data.dataplanes?.online ?? 0"
+                :total="data.dataplanes?.total ?? 0"
               >
-                <AppCollection
-                  class="data-plane-collection"
-                  data-testid="data-plane-collection"
-                  :page-number="route.params.page"
-                  :page-size="route.params.size"
-                  :headers="[
-                    { label: 'Name', key: 'name' },
-                    { label: 'Namespace', key: 'namespace' },
-                    ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
-                    { label: 'Certificate Info', key: 'certificate' },
-                    { label: 'Status', key: 'status' },
-                    { label: 'Warnings', key: 'warnings', hideLabel: true },
-                    { label: 'Actions', key: 'actions', hideLabel: true },
-                  ]"
-                  :items="dataplanesData?.items"
-                  :total="dataplanesData?.total"
-                  :is-selected-row="(row) => row.name === route.params.dataPlane"
-                  summary-route-name="delegated-gateway-data-plane-summary-view"
-                  :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
-                  :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
-                  :empty-state-cta-text="t('common.documentation')"
-                  @change="route.update"
-                >
-                  <template #toolbar>
-                    <FilterBar
-                      class="data-plane-proxy-filter"
-                      :placeholder="`tag: 'kuma.io/protocol: http'`"
-                      :query="route.params.s"
-                      :fields="{
-                        name: { description: 'filter by name or parts of a name' },
-                        protocol: { description: 'filter by “kuma.io/protocol” value' },
-                        tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                        ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                      }"
-                      @change="(e) => route.update({
-                        ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                      })"
-                    />
-                  </template>
+                <template #title>
+                  {{ t('http.api.property.dataPlaneProxies') }}
+                </template>
+              </ResourceStatus>
+            </div>
+          </KCard>
+        </DataLoader>
 
-                  <template #name="{ row: item }">
-                    <RouterLink
-                      class="name-link"
-                      :to="{
-                        name: 'delegated-gateway-data-plane-summary-view',
-                        params: {
-                          mesh: item.mesh,
-                          dataPlane: item.id,
-                        },
-                        query: {
-                          page: route.params.page,
-                          size: route.params.size,
-                          s: route.params.s,
-                        },
-                      }"
-                    >
-                      {{ item.name }}
-                    </RouterLink>
-                  </template>
+        <div>
+          <h3>{{ t('delegated-gateways.detail.data_plane_proxies') }}</h3>
 
-                  <template #namespace="{ row: item }">
-                    {{ item.namespace }}
-                  </template>
+          <KCard class="mt-4">
+            <DataLoader
+              v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
+              :src="`/meshes/${route.params.mesh}/dataplanes/for/service-insight/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
+              :loader="false"
+            >
+              <AppCollection
+                class="data-plane-collection"
+                data-testid="data-plane-collection"
+                :page-number="route.params.page"
+                :page-size="route.params.size"
+                :headers="[
+                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                  { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
+                  { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                  { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :items="dataplanesData?.items"
+                :total="dataplanesData?.total"
+                :is-selected-row="(row) => row.name === route.params.dataPlane"
+                summary-route-name="delegated-gateway-data-plane-summary-view"
+                :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
+                :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
+                :empty-state-cta-text="t('common.documentation')"
+                @change="route.update"
+                @resize="me.set"
+              >
+                <template #toolbar>
+                  <FilterBar
+                    class="data-plane-proxy-filter"
+                    :placeholder="`tag: 'kuma.io/protocol: http'`"
+                    :query="route.params.s"
+                    :fields="{
+                      name: { description: 'filter by name or parts of a name' },
+                      protocol: { description: 'filter by “kuma.io/protocol” value' },
+                      tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                      ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+                    }"
+                    @change="(e) => route.update({
+                      ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                    })"
+                  />
+                </template>
 
-                  <template #zone="{ row }">
-                    <RouterLink
-                      v-if="row.zone"
-                      :to="{
-                        name: 'zone-cp-detail-view',
-                        params: {
-                          zone: row.zone,
-                        },
-                      }"
-                    >
-                      {{ row.zone }}
-                    </RouterLink>
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-
-                  <template #certificate="{ row }">
-                    <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                      {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                    </template>
-
-                    <template v-else>
-                      {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                    </template>
-                  </template>
-
-                  <template #status="{ row }">
-                    <StatusBadge :status="row.status" />
-                  </template>
-
-                  <template #warnings="{ row }">
-                    <XIcon
-                      v-if="row.isCertExpired || row.warnings.length > 0"
-                      class="mr-1"
-                      name="warning"
-                    >
-                      <ul>
-                        <template v-if="row.warnings.length > 0">
-                          <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                        </template>
-
-                        <template v-if="row.isCertExpired">
-                          <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                        </template>
-                      </ul>
-                    </XIcon>
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-
-                  <template #actions="{ row: item }">
-                    <XActionGroup>
-                      <XAction
-                        :to="{
-                          name: 'data-plane-detail-view',
-                          params: {
-                            dataPlane: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.actions.view') }}
-                      </XAction>
-                    </XActionGroup>
-                  </template>
-                </AppCollection>
-
-                <RouterView
-                  v-if="route.params.dataPlane"
-                  v-slot="child"
-                >
-                  <SummaryView
-                    @close="route.replace({
-                      name: route.name,
+                <template #name="{ row: item }">
+                  <RouterLink
+                    class="name-link"
+                    :to="{
+                      name: 'delegated-gateway-data-plane-summary-view',
                       params: {
-                        mesh: route.params.mesh,
+                        mesh: item.mesh,
+                        dataPlane: item.id,
                       },
                       query: {
                         page: route.params.page,
                         size: route.params.size,
                         s: route.params.s,
                       },
-                    })"
+                    }"
                   >
-                    <component
-                      :is="child.Component"
-                      v-if="typeof dataplanesData !== 'undefined'"
-                      :items="dataplanesData.items"
-                    />
-                  </SummaryView>
-                </RouterView>
-              </DataLoader>
-            </KCard>
-          </div>
+                    {{ item.name }}
+                  </RouterLink>
+                </template>
+
+                <template #namespace="{ row: item }">
+                  {{ item.namespace }}
+                </template>
+
+                <template #zone="{ row }">
+                  <RouterLink
+                    v-if="row.zone"
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: row.zone,
+                      },
+                    }"
+                  >
+                    {{ row.zone }}
+                  </RouterLink>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #certificate="{ row }">
+                  <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                    {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                  </template>
+
+                  <template v-else>
+                    {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                  </template>
+                </template>
+
+                <template #status="{ row }">
+                  <StatusBadge :status="row.status" />
+                </template>
+
+                <template #warnings="{ row }">
+                  <XIcon
+                    v-if="row.isCertExpired || row.warnings.length > 0"
+                    class="mr-1"
+                    name="warning"
+                  >
+                    <ul>
+                      <template v-if="row.warnings.length > 0">
+                        <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+                      </template>
+
+                      <template v-if="row.isCertExpired">
+                        <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
+                      </template>
+                    </ul>
+                  </XIcon>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #actions="{ row: item }">
+                  <XActionGroup>
+                    <XAction
+                      :to="{
+                        name: 'data-plane-detail-view',
+                        params: {
+                          dataPlane: item.id,
+                        },
+                      }"
+                    >
+                      {{ t('common.collection.actions.view') }}
+                    </XAction>
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+
+              <RouterView
+                v-if="route.params.dataPlane"
+                v-slot="child"
+              >
+                <SummaryView
+                  @close="route.replace({
+                    name: route.name,
+                    params: {
+                      mesh: route.params.mesh,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                      s: route.params.s,
+                    },
+                  })"
+                >
+                  <component
+                    :is="child.Component"
+                    v-if="typeof dataplanesData !== 'undefined'"
+                    :items="dataplanesData.items"
+                  />
+                </SummaryView>
+              </RouterView>
+            </DataLoader>
+          </KCard>
         </div>
-      </AppView>
-    </RouteView>
-  </DataSource>
+      </div>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -248,7 +243,6 @@ import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { DataplaneOverviewCollectionSource } from '@/app/data-planes/sources'
-import type { MeSource } from '@/app/me/sources'
 import type { ServiceInsightSource } from '@/app/services/sources'
 </script>
 

--- a/src/app/gateways/views/DelegatedGatewayListView.vue
+++ b/src/app/gateways/views/DelegatedGatewayListView.vue
@@ -1,116 +1,111 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ route, t, me }"
+    name="delegated-gateway-list-view"
+    :params="{
+      page: 1,
+      size: 50,
+      mesh: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ route, t }"
-      name="delegated-gateway-list-view"
-      :params="{
-        page: 1,
-        size: 10,
-        mesh: '',
-      }"
+    <DataSource
+      v-slot="{data, error}: ServiceInsightCollectionSource"
+      :src="`/meshes/${route.params.mesh}/service-insights/of/gateway_delegated?page=${route.params.page}&size=${route.params.size}`"
     >
-      <DataSource
-        v-slot="{data, error}: ServiceInsightCollectionSource"
-        :src="`/meshes/${route.params.mesh}/service-insights/of/gateway_delegated?page=${route.params.page}&size=${route.params.size}`"
-      >
-        <AppView>
-          <KCard>
-            <ErrorBlock
-              v-if="error !== undefined"
-              :error="error"
-            />
+      <AppView>
+        <KCard>
+          <ErrorBlock
+            v-if="error !== undefined"
+            :error="error"
+          />
 
-            <AppCollection
-              v-else
-              class="delegated-gateway-collection"
-              data-testid="delegated-gateway-collection"
-              :empty-state-message="t('common.emptyState.message', { type: 'Delegated Gateways' })"
-              :empty-state-cta-to="t('delegated-gateways.href.docs')"
-              :empty-state-cta-text="t('common.documentation')"
-              :headers="[
-                { label: 'Name', key: 'name' },
-                { label: 'Address', key: 'addressPort' },
-                { label: 'DP proxies (online / total)', key: 'dataplanes' },
-                { label: 'Status', key: 'status' },
-                { label: 'Actions', key: 'actions', hideLabel: true },
-              ]"
-              :page-number="route.params.page"
-              :page-size="route.params.size"
-              :total="data?.total"
-              :items="data?.items"
-              :error="error"
-              @change="route.update"
-            >
-              <template #name="{ row: item }">
-                <TextWithCopyButton :text="item.name">
-                  <RouterLink
-                    :to="{
-                      name: 'delegated-gateway-detail-view',
-                      params: {
-                        mesh: item.mesh,
-                        service: item.name,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                      },
-                    }"
-                  >
-                    {{ item.name }}
-                  </RouterLink>
-                </TextWithCopyButton>
+          <AppCollection
+            v-else
+            class="delegated-gateway-collection"
+            data-testid="delegated-gateway-collection"
+            :empty-state-message="t('common.emptyState.message', { type: 'Delegated Gateways' })"
+            :empty-state-cta-to="t('delegated-gateways.href.docs')"
+            :empty-state-cta-text="t('common.documentation')"
+            :headers="[
+              { ...me.get('headers.name'), label: 'Name', key: 'name' },
+              { ...me.get('headers.addressPort'), label: 'Address', key: 'addressPort' },
+              { ...me.get('headers.dataplanes'), label: 'DP proxies (online / total)', key: 'dataplanes' },
+              { ...me.get('headers.status'), label: 'Status', key: 'status' },
+              { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+            ]"
+            :page-number="route.params.page"
+            :page-size="route.params.size"
+            :total="data?.total"
+            :items="data?.items"
+            :error="error"
+            @change="route.update"
+            @resize="me.set"
+          >
+            <template #name="{ row: item }">
+              <TextWithCopyButton :text="item.name">
+                <RouterLink
+                  :to="{
+                    name: 'delegated-gateway-detail-view',
+                    params: {
+                      mesh: item.mesh,
+                      service: item.name,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                    },
+                  }"
+                >
+                  {{ item.name }}
+                </RouterLink>
+              </TextWithCopyButton>
+            </template>
+
+            <template #addressPort="{ row }">
+              <TextWithCopyButton
+                v-if="row.addressPort"
+                :text="row.addressPort"
+              />
+
+              <template v-else>
+                {{ t('common.collection.none') }}
+              </template>
+            </template>
+
+            <template #dataplanes="{ row }">
+              <template v-if="row.dataplanes">
+                {{ row.dataplanes.online || 0 }} / {{ row.dataplanes.total || 0 }}
               </template>
 
-              <template #addressPort="{ row }">
-                <TextWithCopyButton
-                  v-if="row.addressPort"
-                  :text="row.addressPort"
-                />
-
-                <template v-else>
-                  {{ t('common.collection.none') }}
-                </template>
+              <template v-else>
+                {{ t('common.collection.none') }}
               </template>
+            </template>
 
-              <template #dataplanes="{ row }">
-                <template v-if="row.dataplanes">
-                  {{ row.dataplanes.online || 0 }} / {{ row.dataplanes.total || 0 }}
-                </template>
+            <template #status="{ row }">
+              <StatusBadge :status="row.status" />
+            </template>
 
-                <template v-else>
-                  {{ t('common.collection.none') }}
-                </template>
-              </template>
-
-              <template #status="{ row }">
-                <StatusBadge :status="row.status" />
-              </template>
-
-              <template #actions="{ row: item }">
-                <XActionGroup>
-                  <XAction
-                    :to="{
-                      name: 'delegated-gateway-detail-view',
-                      params: {
-                        mesh: item.mesh,
-                        service: item.name,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.actions.view') }}
-                  </XAction>
-                </XActionGroup>
-              </template>
-            </AppCollection>
-          </KCard>
-        </AppView>
-      </DataSource>
-    </RouteView>
-  </DataSource>
+            <template #actions="{ row: item }">
+              <XActionGroup>
+                <XAction
+                  :to="{
+                    name: 'delegated-gateway-detail-view',
+                    params: {
+                      mesh: item.mesh,
+                      service: item.name,
+                    },
+                  }"
+                >
+                  {{ t('common.collection.actions.view') }}
+                </XAction>
+              </XActionGroup>
+            </template>
+          </AppCollection>
+        </KCard>
+      </AppView>
+    </DataSource>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -118,6 +113,5 @@ import AppCollection from '@/app/application/components/app-collection/AppCollec
 import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import type { MeSource } from '@/app/me/sources'
 import type { ServiceInsightCollectionSource } from '@/app/services/sources'
 </script>

--- a/src/app/kuma/index.ts
+++ b/src/app/kuma/index.ts
@@ -13,6 +13,9 @@ export const TOKENS = {
 }
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
+    [app.storagePrefix, {
+      service: () => 'kumahq.kuma-gui',
+    }],
     [app.EnvVars, {
       constant: {
         KUMA_PRODUCT_NAME: import.meta.env.VITE_NAMESPACE,

--- a/src/app/me/index.ts
+++ b/src/app/me/index.ts
@@ -7,13 +7,14 @@ type Sources = ReturnType<typeof sources>
 
 const $ = {
   sources: token<Sources>('me.sources'),
+  storagePrefix: token<string>('me.storage.prefix'),
 }
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
     [$.sources, {
       service: sources,
       arguments: [
-        app.api,
+        $.storagePrefix,
       ],
       labels: [
         app.sources,

--- a/src/app/me/sources.ts
+++ b/src/app/me/sources.ts
@@ -2,8 +2,7 @@ import merge from 'deepmerge'
 
 import { defineSources } from '../application/services/data-source'
 
-export const sources = (_api: unknown, storage: Storage = window.localStorage) => {
-  const prefix = 'kumahq.kuma-gui'
+export const sources = (prefix: string = 'me', storage: Storage = window.localStorage) => {
   const get = async (key: string): Promise<Object> => {
     try {
       return JSON.parse(storage.getItem(`${prefix}:${key}`) ?? '{}')

--- a/src/app/me/sources.ts
+++ b/src/app/me/sources.ts
@@ -1,12 +1,6 @@
 import merge from 'deepmerge'
 
 import { defineSources } from '../application/services/data-source'
-import type { DataSourceResponse } from '@/app/application'
-
-export type MeSource = DataSourceResponse<{
-  pageSize: number
-  headers: Record<string, { width: number }>
-}>
 
 export const sources = (_api: unknown, storage: Storage = window.localStorage) => {
   const prefix = 'kumahq.kuma-gui'
@@ -28,9 +22,6 @@ export const sources = (_api: unknown, storage: Storage = window.localStorage) =
     return {}
   }
   return defineSources({
-    '/me': async () => {
-      return Promise.resolve({ pageSize: 50 })
-    },
     '/me/:route': async (params) => {
       const json = await get(params.route)
       const res = merge({

--- a/src/app/meshes/components/MeshInsightsList.vue
+++ b/src/app/meshes/components/MeshInsightsList.vue
@@ -6,12 +6,17 @@
     >
       <AppCollection
         :headers="[
-          { label: t('meshes.components.mesh-insights-list.name'), key: 'name'},
-          { label: t('meshes.components.mesh-insights-list.services'), key: 'services'},
-          { label: t('meshes.components.mesh-insights-list.dataplanes'), key: 'dataplanes'},
+          { ...storage.get('mesh.headers.name') ,label: t('meshes.components.mesh-insights-list.name'), key: 'name'},
+          { ...storage.get('mesh.headers.services') ,label: t('meshes.components.mesh-insights-list.services'), key: 'services'},
+          { ...storage.get('mesh.headers.dataplanes') ,label: t('meshes.components.mesh-insights-list.dataplanes'), key: 'dataplanes'},
         ]"
         :items="props.items"
         :total="props.items?.length"
+        @resize="(obj) => {
+          storage.set({
+            mesh: obj,
+          })
+        }"
       >
         <template
           #name="{ row: item }"
@@ -51,7 +56,17 @@ import AppCollection from '@/app/application/components/app-collection/AppCollec
 
 const { t } = useI18n()
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   items?: MeshInsight[]
-}>()
+  storage?: {
+    get: (uri: string) => {}
+    set: (data: any) => void
+  }
+}>(), {
+  items: undefined,
+  storage: () => ({
+    get: () => ({}),
+    set: () => {},
+  }),
+})
 </script>

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -1,58 +1,90 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ route, t, uri, can, me }"
+    name="policy-detail-view"
+    :params="{
+      page: 1,
+      size: 50,
+      s: '',
+      mesh: '',
+      policy: '',
+      policyPath: '',
+      dataPlane: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ route, t, uri, can }"
-      name="policy-detail-view"
-      :params="{
-        mesh: '',
-        policy: '',
-        policyPath: '',
-        dataPlane: '',
-        s: '',
-        page: 1,
-        size: me.pageSize,
-      }"
-    >
-      <AppView>
-        <KCard>
-          <DataLoader
-            :src="uri(sources, '/meshes/:mesh/policy-path/:path/policy/:name/dataplanes', {
-              mesh: route.params.mesh,
-              path: route.params.policyPath,
-              name: route.params.policy,
-            },{
-              page: route.params.page,
-              size: route.params.size,
-            })"
+    <AppView>
+      <KCard>
+        <DataLoader
+          :src="uri(sources, '/meshes/:mesh/policy-path/:path/policy/:name/dataplanes', {
+            mesh: route.params.mesh,
+            path: route.params.policyPath,
+            name: route.params.policy,
+          },{
+            page: route.params.page,
+            size: route.params.size,
+          })"
+        >
+          <template
+            #loadable="{ data }"
           >
-            <template
-              #loadable="{ data }"
+            <DataCollection
+              type="data-planes"
+              :items="data?.items ?? [undefined]"
             >
-              <DataCollection
-                type="data-planes"
-                :items="data?.items ?? [undefined]"
+              <AppCollection
+                :page-number="route.params.page"
+                :page-size="route.params.size"
+                :headers="[
+                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :items="data?.items"
+                :total="data?.total"
+                :is-selected-row="(row) => row.id === route.params.dataPlane"
+                @change="route.update"
+                @resize="me.set"
               >
-                <AppCollection
-                  :page-number="route.params.page"
-                  :page-size="route.params.size"
-                  :headers="[
-                    { label: 'Name', key: 'name' },
-                    { label: 'Namespace', key: 'namespace' },
-                    ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
-                    { label: 'Actions', key: 'actions', hideLabel: true },
-                  ]"
-                  :items="data?.items"
-                  :total="data?.total"
-                  :is-selected-row="(row) => row.id === route.params.dataPlane"
-                  @change="route.update"
-                >
-                  <template #name="{ row: item }">
-                    <RouterLink
-                      data-action
+                <template #name="{ row: item }">
+                  <RouterLink
+                    data-action
+                    :to="{
+                      name: 'data-plane-detail-view',
+                      params: {
+                        dataPlane: item.id,
+                      },
+                    }"
+                  >
+                    {{ item.name }}
+                  </RouterLink>
+                </template>
+
+                <template #namespace="{ row: item }">
+                  {{ item.namespace }}
+                </template>
+
+                <template #zone="{ row }">
+                  <RouterLink
+                    v-if="row.zone"
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: row.zone,
+                      },
+                    }"
+                  >
+                    {{ row.zone }}
+                  </RouterLink>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #actions="{ row: item }">
+                  <XActionGroup>
+                    <XAction
                       :to="{
                         name: 'data-plane-detail-view',
                         params: {
@@ -60,82 +92,44 @@
                         },
                       }"
                     >
-                      {{ item.name }}
-                    </RouterLink>
-                  </template>
-
-                  <template #namespace="{ row: item }">
-                    {{ item.namespace }}
-                  </template>
-
-                  <template #zone="{ row }">
-                    <RouterLink
-                      v-if="row.zone"
-                      :to="{
-                        name: 'zone-cp-detail-view',
-                        params: {
-                          zone: row.zone,
-                        },
-                      }"
-                    >
-                      {{ row.zone }}
-                    </RouterLink>
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-
-                  <template #actions="{ row: item }">
-                    <XActionGroup>
-                      <XAction
-                        :to="{
-                          name: 'data-plane-detail-view',
-                          params: {
-                            dataPlane: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.actions.view') }}
-                      </XAction>
-                    </XActionGroup>
-                  </template>
-                </AppCollection>
-              </DataCollection>
-              <RouterView
-                v-slot="{ Component }"
+                      {{ t('common.collection.actions.view') }}
+                    </XAction>
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+            </DataCollection>
+            <RouterView
+              v-slot="{ Component }"
+            >
+              <SummaryView
+                v-if="route.child()"
+                @close="route.replace({
+                  params: {
+                    mesh: route.params.mesh,
+                  },
+                  query: {
+                    page: route.params.page,
+                    size: route.params.size,
+                    s: route.params.s,
+                  },
+                })"
               >
-                <SummaryView
-                  v-if="route.child()"
-                  @close="route.replace({
-                    params: {
-                      mesh: route.params.mesh,
-                    },
-                    query: {
-                      page: route.params.page,
-                      size: route.params.size,
-                      s: route.params.s,
-                    },
-                  })"
-                >
-                  <component
-                    :is="Component"
-                    v-if="typeof data !== 'undefined'"
-                    :items="data.items"
-                  />
-                </SummaryView>
-              </RouterView>
-            </template>
-          </DataLoader>
-        </KCard>
-      </AppView>
-    </RouteView>
-  </DataSource>
+                <component
+                  :is="Component"
+                  v-if="typeof data !== 'undefined'"
+                  :items="data.items"
+                />
+              </SummaryView>
+            </RouterView>
+          </template>
+        </DataLoader>
+      </KCard>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
-import type { MeSource } from '@/app/me/sources'
 </script>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -1,260 +1,255 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ route, t, can, uri, me }"
+    name="policy-list-view"
+    :params="{
+      page: 1,
+      size: 50,
+      mesh: '',
+      policyPath: '',
+      policy: '',
+      s: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ route, t, can, uri }"
-      name="policy-list-view"
-      :params="{
-        page: 1,
-        size: me.pageSize,
-        mesh: '',
-        policyPath: '',
-        policy: '',
-        s: '',
-      }"
+    <DataCollection
+      :predicate="(policyType) => typeof policyType !== 'undefined' && policyType.path === route.params.policyPath"
+      :items="props.policyTypes ?? []"
     >
-      <DataCollection
-        :predicate="(policyType) => typeof policyType !== 'undefined' && policyType.path === route.params.policyPath"
-        :items="props.policyTypes ?? []"
-      >
-        <template #empty>
-          <EmptyBlock>
-            <template #message>
-              {{ t('policies.routes.items.empty') }}
-            </template>
-          </EmptyBlock>
-        </template>
-        <template #item="{ item: type }">
-          <AppView>
-            <div class="stack">
-              <KCard>
-                <header>
-                  <div>
-                    <KBadge
-                      v-if="type.isExperimental"
-                      appearance="warning"
-                    >
-                      {{ t('policies.collection.beta') }}
-                    </KBadge>
-
-                    <KBadge
-                      v-if="type.isInbound"
-                      appearance="neutral"
-                    >
-                      {{ t('policies.collection.inbound') }}
-                    </KBadge>
-
-                    <KBadge
-                      v-if="type.isOutbound"
-                      appearance="neutral"
-                    >
-                      {{ t('policies.collection.outbound') }}
-                    </KBadge>
-
-                    <XAction
-                      type="docs"
-                      :href="t('policies.href.docs', { name: type.name })"
-                      data-testid="policy-documentation-link"
-                    >
-                      <span class="visually-hidden">{{ t('common.documentation') }}</span>
-                    </XAction>
-                  </div>
-                  <h3>
-                    <PolicyTypeTag
-                      :policy-type="type.name"
-                    >
-                      {{ t('policies.collection.title', { name: type.name }) }}
-                    </PolicyTypeTag>
-                  </h3>
-                </header>
-                <div v-html="t(`policies.type.${type.name}.description`, undefined, { defaultMessage: t('policies.collection.description') })" />
-              </KCard>
-
-              <KCard>
-                <DataLoader
-                  :src="uri(sources, '/meshes/:mesh/policy-path/:path', {
-                    mesh: route.params.mesh,
-                    path: route.params.policyPath,
-                  }, {
-                    page: route.params.page,
-                    size: route.params.size,
-                    search: route.params.s,
-                  })"
-                >
-                  <template
-                    #loadable="{ data }"
+      <template #empty>
+        <EmptyBlock>
+          <template #message>
+            {{ t('policies.routes.items.empty') }}
+          </template>
+        </EmptyBlock>
+      </template>
+      <template #item="{ item: type }">
+        <AppView>
+          <div class="stack">
+            <KCard>
+              <header>
+                <div>
+                  <KBadge
+                    v-if="type.isExperimental"
+                    appearance="warning"
                   >
-                    <search
-                      v-if="(data?.items ?? { length: 0 }).length > 0 || (route.params.s.length > 0)"
+                    {{ t('policies.collection.beta') }}
+                  </KBadge>
+
+                  <KBadge
+                    v-if="type.isInbound"
+                    appearance="neutral"
+                  >
+                    {{ t('policies.collection.inbound') }}
+                  </KBadge>
+
+                  <KBadge
+                    v-if="type.isOutbound"
+                    appearance="neutral"
+                  >
+                    {{ t('policies.collection.outbound') }}
+                  </KBadge>
+
+                  <XAction
+                    type="docs"
+                    :href="t('policies.href.docs', { name: type.name })"
+                    data-testid="policy-documentation-link"
+                  >
+                    <span class="visually-hidden">{{ t('common.documentation') }}</span>
+                  </XAction>
+                </div>
+                <h3>
+                  <PolicyTypeTag
+                    :policy-type="type.name"
+                  >
+                    {{ t('policies.collection.title', { name: type.name }) }}
+                  </PolicyTypeTag>
+                </h3>
+              </header>
+              <div v-html="t(`policies.type.${type.name}.description`, undefined, { defaultMessage: t('policies.collection.description') })" />
+            </KCard>
+
+            <KCard>
+              <DataLoader
+                :src="uri(sources, '/meshes/:mesh/policy-path/:path', {
+                  mesh: route.params.mesh,
+                  path: route.params.policyPath,
+                }, {
+                  page: route.params.page,
+                  size: route.params.size,
+                  search: route.params.s,
+                })"
+              >
+                <template
+                  #loadable="{ data }"
+                >
+                  <search
+                    v-if="(data?.items ?? { length: 0 }).length > 0 || (route.params.s.length > 0)"
+                  >
+                    <form
+                      @submit.prevent
                     >
-                      <form
-                        @submit.prevent
-                      >
-                        <XInput
-                          placeholder="Filter by name..."
-                          type="search"
-                          appearance="search"
-                          :value="route.params.s"
-                          :debounce="1000"
-                          @change="(e) => route.update({
-                            s: e,
-                          })"
+                      <XInput
+                        placeholder="Filter by name..."
+                        type="search"
+                        appearance="search"
+                        :value="route.params.s"
+                        :debounce="1000"
+                        @change="(e) => route.update({
+                          s: e,
+                        })"
+                      />
+                    </form>
+                  </search>
+                  <DataCollection
+                    :items="data?.items ?? [undefined]"
+                  >
+                    <template
+                      #empty
+                    >
+                      <EmptyBlock>
+                        <template #title>
+                          {{ t('policies.x-empty-state.title') }}
+                        </template>
+                        <div
+                          v-html="t('policies.x-empty-state.body', { type: type.name, suffix: route.params.s.length > 0 ? t('common.matchingsearch') : '' })"
                         />
-                      </form>
-                    </search>
-                    <DataCollection
-                      :items="data?.items ?? [undefined]"
-                    >
-                      <template
-                        #empty
-                      >
-                        <EmptyBlock>
-                          <template #title>
-                            {{ t('policies.x-empty-state.title') }}
-                          </template>
-                          <div
-                            v-html="t('policies.x-empty-state.body', { type: type.name, suffix: route.params.s.length > 0 ? t('common.matchingsearch') : '' })"
-                          />
-                          <template
-                            #action
-                          >
-                            <XAction
-                              type="docs"
-                              :href="t('policies.href.docs', { name: type.name })"
-                            >
-                              {{ t('common.documentation') }}
-                            </XAction>
-                          </template>
-                        </EmptyBlock>
-                      </template>
-                      <template
-                        #default
-                      >
-                        <AppCollection
-                          :headers="[
-                            { label: 'Name', key: 'name' },
-                            { label: 'Namespace', key: 'namespace' },
-                            ...(can('use zones') && type.isTargetRefBased ? [{ label: 'Zone', key: 'zone' }] : []),
-                            ...(type.isTargetRefBased ? [{ label: 'Target ref', key: 'targetRef' }] : []),
-                            { label: 'Actions', key: 'actions', hideLabel: true },
-                          ]"
-                          :page-number="route.params.page"
-                          :page-size="route.params.size"
-                          :total="data?.total"
-                          :items="data?.items"
-                          :is-selected-row="(row) => row.id === route.params.policy"
-                          @change="route.update"
+                        <template
+                          #action
                         >
-                          <template #name="{ row }">
+                          <XAction
+                            type="docs"
+                            :href="t('policies.href.docs', { name: type.name })"
+                          >
+                            {{ t('common.documentation') }}
+                          </XAction>
+                        </template>
+                      </EmptyBlock>
+                    </template>
+                    <template
+                      #default
+                    >
+                      <AppCollection
+                        :headers="[
+                          { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                          { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                          ...(can('use zones') && type.isTargetRefBased ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                          ...(type.isTargetRefBased ? [{ ...me.get('headers.targetRef'), label: 'Target ref', key: 'targetRef' }] : []),
+                          { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                        ]"
+                        :page-number="route.params.page"
+                        :page-size="route.params.size"
+                        :total="data?.total"
+                        :items="data?.items"
+                        :is-selected-row="(row) => row.id === route.params.policy"
+                        @change="route.update"
+                        @resize="me.set"
+                      >
+                        <template #name="{ row }">
+                          <XAction
+                            data-action
+                            :to="{
+                              name: 'policy-summary-view',
+                              params: {
+                                mesh: row.mesh,
+                                policyPath: type.path,
+                                policy: row.id,
+                              },
+                              query: {
+                                page: route.params.page,
+                                size: route.params.size,
+                              },
+                            }"
+                          >
+                            {{ row.name }}
+                          </XAction>
+                        </template>
+                        <template #namespace="{ row: item }">
+                          {{ item.namespace.length > 0 ? item.namespace : t('common.detail.none') }}
+                        </template>
+
+                        <template #targetRef="{ row }">
+                          <template v-if="type.isTargetRefBased && typeof row.spec?.targetRef !== 'undefined'">
+                            <KBadge appearance="neutral">
+                              {{ row.spec.targetRef.kind }}<span v-if="row.spec.targetRef.name">:<b>{{ row.spec.targetRef.name }}</b></span>
+                            </KBadge>
+                          </template>
+
+                          <template v-else>
+                            {{ t('common.detail.none') }}
+                          </template>
+                        </template>
+
+                        <template #zone="{ row }">
+                          <template v-if="row.labels && row.labels['kuma.io/origin'] === 'zone' && row.labels['kuma.io/zone']">
                             <XAction
-                              data-action
                               :to="{
-                                name: 'policy-summary-view',
+                                name: 'zone-cp-detail-view',
                                 params: {
-                                  mesh: row.mesh,
-                                  policyPath: type.path,
-                                  policy: row.id,
-                                },
-                                query: {
-                                  page: route.params.page,
-                                  size: route.params.size,
+                                  zone: row.labels['kuma.io/zone'],
                                 },
                               }"
                             >
-                              {{ row.name }}
+                              {{ row.labels['kuma.io/zone'] }}
                             </XAction>
                           </template>
-                          <template #namespace="{ row: item }">
-                            {{ item.namespace.length > 0 ? item.namespace : t('common.detail.none') }}
+
+                          <template v-else>
+                            {{ t('common.detail.none') }}
                           </template>
+                        </template>
 
-                          <template #targetRef="{ row }">
-                            <template v-if="type.isTargetRefBased && typeof row.spec?.targetRef !== 'undefined'">
-                              <KBadge appearance="neutral">
-                                {{ row.spec.targetRef.kind }}<span v-if="row.spec.targetRef.name">:<b>{{ row.spec.targetRef.name }}</b></span>
-                              </KBadge>
-                            </template>
-
-                            <template v-else>
-                              {{ t('common.detail.none') }}
-                            </template>
-                          </template>
-
-                          <template #zone="{ row }">
-                            <template v-if="row.labels && row.labels['kuma.io/origin'] === 'zone' && row.labels['kuma.io/zone']">
-                              <XAction
-                                :to="{
-                                  name: 'zone-cp-detail-view',
-                                  params: {
-                                    zone: row.labels['kuma.io/zone'],
-                                  },
-                                }"
-                              >
-                                {{ row.labels['kuma.io/zone'] }}
-                              </XAction>
-                            </template>
-
-                            <template v-else>
-                              {{ t('common.detail.none') }}
-                            </template>
-                          </template>
-
-                          <template #actions="{ row: item }">
-                            <XActionGroup>
-                              <XAction
-                                :to="{
-                                  name: 'policy-detail-view',
-                                  params: {
-                                    mesh: item.mesh,
-                                    policyPath: type.path,
-                                    policy: item.id,
-                                  },
-                                }"
-                              >
-                                {{ t('common.collection.actions.view') }}
-                              </XAction>
-                            </XActionGroup>
-                          </template>
-                        </AppCollection>
-                      </template>
-                    </DataCollection>
-                    <RouterView
-                      v-if="route.params.policy"
-                      v-slot="{ Component }"
+                        <template #actions="{ row: item }">
+                          <XActionGroup>
+                            <XAction
+                              :to="{
+                                name: 'policy-detail-view',
+                                params: {
+                                  mesh: item.mesh,
+                                  policyPath: type.path,
+                                  policy: item.id,
+                                },
+                              }"
+                            >
+                              {{ t('common.collection.actions.view') }}
+                            </XAction>
+                          </XActionGroup>
+                        </template>
+                      </AppCollection>
+                    </template>
+                  </DataCollection>
+                  <RouterView
+                    v-if="route.params.policy"
+                    v-slot="{ Component }"
+                  >
+                    <SummaryView
+                      @close="route.replace({
+                        name: 'policy-list-view',
+                        params: {
+                          mesh: route.params.mesh,
+                          policyPath: route.params.policyPath,
+                        },
+                        query: {
+                          page: route.params.page,
+                          size: route.params.size,
+                        },
+                      })"
                     >
-                      <SummaryView
-                        @close="route.replace({
-                          name: 'policy-list-view',
-                          params: {
-                            mesh: route.params.mesh,
-                            policyPath: route.params.policyPath,
-                          },
-                          query: {
-                            page: route.params.page,
-                            size: route.params.size,
-                          },
-                        })"
-                      >
-                        <component
-                          :is="Component"
-                          v-if="typeof data !== 'undefined'"
-                          :items="data.items"
-                          :policy-type="type"
-                        />
-                      </SummaryView>
-                    </RouterView>
-                  </template>
-                </DataLoader>
-              </KCard>
-            </div>
-          </AppView>
-        </template>
-      </DataCollection>
-    </RouteView>
-  </DataSource>
+                      <component
+                        :is="Component"
+                        v-if="typeof data !== 'undefined'"
+                        :items="data.items"
+                        :policy-type="type"
+                      />
+                    </SummaryView>
+                  </RouterView>
+                </template>
+              </DataLoader>
+            </KCard>
+          </div>
+        </AppView>
+      </template>
+    </DataCollection>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -264,7 +259,6 @@ import AppCollection from '@/app/application/components/app-collection/AppCollec
 import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
-import type { MeSource } from '@/app/me/sources'
 const props = defineProps<{
   policyTypes?: PolicyType[]
 }>()

--- a/src/app/policies/views/PolicyTypeListView.vue
+++ b/src/app/policies/views/PolicyTypeListView.vue
@@ -1,109 +1,102 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ route, t }"
+    name="policy-list-view"
+    :params="{
+      mesh: '',
+      policyPath: '',
+      policy: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ route, t }"
-      name="policy-list-view"
-      :params="{
-        mesh: '',
-        policyPath: '',
-        policy: '',
-      }"
-    >
-      <RouteTitle
-        :render="false"
-        :title="t('policies.routes.types.title')"
-      />
-      <AppView>
+    <RouteTitle
+      :render="false"
+      :title="t('policies.routes.types.title')"
+    />
+    <AppView>
+      <DataSource
+        v-slot="{ data: meshInsight }: MeshInsightSource"
+        :src="`/mesh-insights/${route.params.mesh}`"
+      >
         <DataSource
-          v-slot="{ data: meshInsight }: MeshInsightSource"
-          :src="`/mesh-insights/${route.params.mesh}`"
+          v-slot="{ data, error }: PolicyTypeCollectionSource"
+          :src="`/policy-types`"
         >
-          <DataSource
-            v-slot="{ data, error }: PolicyTypeCollectionSource"
-            :src="`/policy-types`"
+          <div
+            class="policy-list-content"
           >
-            <div
-              class="policy-list-content"
+            <KCard
+              class="policy-type-list"
+              data-testid="policy-type-list"
             >
-              <KCard
-                class="policy-type-list"
-                data-testid="policy-type-list"
+              <!-- block on policy types but not meshInsight -->
+              <DataLoader
+                :data="[data]"
+                :errors="[error]"
               >
-                <!-- block on policy types but not meshInsight -->
-                <DataLoader
-                  :data="[data]"
-                  :errors="[error]"
+                <template
+                  v-for="legacy in [typeof meshInsight?.policies === 'undefined' ? data!.policies : data!.policies.filter(item => {
+                    // legacy policies are those that aren't targetRef and are also in use
+                    return !item.isTargetRefBased && (meshInsight.policies?.[item.name]?.total ?? 0) > 0
+                  })]"
+                  :key="legacy"
                 >
-                  <template
-                    v-for="legacy in [typeof meshInsight?.policies === 'undefined' ? data!.policies : data!.policies.filter(item => {
-                      // legacy policies are those that aren't targetRef and are also in use
-                      return !item.isTargetRefBased && (meshInsight.policies?.[item.name]?.total ?? 0) > 0
-                    })]"
-                    :key="legacy"
+                  <DataCollection
+                    v-slot="{ items }"
+                    :predicate="typeof meshInsight?.policies === 'undefined' ? undefined : (item) => legacy.length > 0 || item.isTargetRefBased"
+                    :items="data!.policies"
                   >
-                    <DataCollection
-                      v-slot="{ items }"
-                      :predicate="typeof meshInsight?.policies === 'undefined' ? undefined : (item) => legacy.length > 0 || item.isTargetRefBased"
-                      :items="data!.policies"
+                    <template
+                      v-for="current in [items.find(policyType => policyType.path === route.params.policyPath)]"
+                      :key="current"
                     >
-                      <template
-                        v-for="current in [items.find(policyType => policyType.path === route.params.policyPath)]"
-                        :key="current"
+                      <div
+                        v-for="(policyType, i) in items"
+                        :key="policyType.path"
+                        class="policy-type-link-wrapper"
+                        :class="{
+                          'policy-type-link-wrapper--is-active': current && current.path === policyType.path,
+                        }"
                       >
-                        <div
-                          v-for="(policyType, i) in items"
-                          :key="policyType.path"
-                          class="policy-type-link-wrapper"
-                          :class="{
-                            'policy-type-link-wrapper--is-active': current && current.path === policyType.path,
+                        <XAction
+                          class="policy-type-link"
+                          :to="{
+                            name: 'policy-list-view',
+                            params: {
+                              mesh: route.params.mesh,
+                              policyPath: policyType.path,
+                            },
                           }"
+                          :mount="route.params.policyPath.length === 0 && i === 0 ? route.replace : undefined"
+                          :data-testid="`policy-type-link-${policyType.name}`"
                         >
-                          <XAction
-                            class="policy-type-link"
-                            :to="{
-                              name: 'policy-list-view',
-                              params: {
-                                mesh: route.params.mesh,
-                                policyPath: policyType.path,
-                              },
-                            }"
-                            :mount="route.params.policyPath.length === 0 && i === 0 ? route.replace : undefined"
-                            :data-testid="`policy-type-link-${policyType.name}`"
-                          >
-                            {{ policyType.name }}
-                          </XAction>
+                          {{ policyType.name }}
+                        </XAction>
 
-                          <div class="policy-count">
-                            {{ meshInsight?.policies?.[policyType.name]?.total ?? 0 }}
-                          </div>
+                        <div class="policy-count">
+                          {{ meshInsight?.policies?.[policyType.name]?.total ?? 0 }}
                         </div>
-                      </template>
-                    </DataCollection>
-                  </template>
-                </DataLoader>
-              </KCard>
-              <div class="policy-list">
-                <RouterView v-slot="{ Component }">
-                  <component
-                    :is="Component"
-                    :policy-types="data?.policies"
-                  />
-                </RouterView>
-              </div>
+                      </div>
+                    </template>
+                  </DataCollection>
+                </template>
+              </DataLoader>
+            </KCard>
+            <div class="policy-list">
+              <RouterView v-slot="{ Component }">
+                <component
+                  :is="Component"
+                  :policy-types="data?.policies"
+                />
+              </RouterView>
             </div>
-          </DataSource>
+          </div>
         </DataSource>
-      </AppView>
-    </RouteView>
-  </DataSource>
+      </DataSource>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
-import type { MeSource } from '@/app/me/sources'
 import type { MeshInsightSource } from '@/app/meshes/sources'
 import type { PolicyTypeCollectionSource } from '@/app/policies/sources'
 </script>

--- a/src/app/services/views/MeshExternalServiceDetailView.vue
+++ b/src/app/services/views/MeshExternalServiceDetailView.vue
@@ -1,117 +1,101 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    name="mesh-external-service-detail-view"
+    :params="{
+    }"
   >
-    <RouteView
-      v-if="me"
-      name="mesh-external-service-detail-view"
-      :params="{
-        mesh: '',
-        service: '',
-        page: 1,
-        size: me.pageSize,
-        s: '',
-        dataPlane: '',
-        codeSearch: '',
-        codeFilter: false,
-        codeRegExp: false,
-      }"
-    >
-      <AppView>
-        <div
-          class="stack"
-        >
-          <KCard>
-            <div class="columns">
-              <DefinitionCard
-                v-if="props.data.status.addresses.length > 0"
+    <AppView>
+      <div
+        class="stack"
+      >
+        <KCard>
+          <div class="columns">
+            <DefinitionCard
+              v-if="props.data.status.addresses.length > 0"
+            >
+              <template
+                #title
               >
-                <template
-                  #title
-                >
-                  Addresses
-                </template>
-                <template
-                  #body
-                >
-                  <KTruncate>
-                    <span
-                      v-for="address in props.data.status.addresses"
-                      :key="address.hostname"
-                    >
-                      {{ address.hostname }}
-                    </span>
-                  </KTruncate>
-                </template>
-              </DefinitionCard>
-              <DefinitionCard
-                v-if="data.spec.match"
-                class="port"
+                Addresses
+              </template>
+              <template
+                #body
               >
-                <template
-                  #title
-                >
-                  Port
-                </template>
-                <template
-                  #body
-                >
-                  <KBadge
-                    v-for="connection in [data.spec.match]"
-                    :key="connection.port"
-                    appearance="info"
+                <KTruncate>
+                  <span
+                    v-for="address in props.data.status.addresses"
+                    :key="address.hostname"
                   >
-                    {{ connection.port }}/{{ connection.protocol }}
-                  </KBadge>
-                </template>
-              </DefinitionCard>
-              <DefinitionCard
-                v-if="data.spec.match"
-                class="tls"
+                    {{ address.hostname }}
+                  </span>
+                </KTruncate>
+              </template>
+            </DefinitionCard>
+            <DefinitionCard
+              v-if="data.spec.match"
+              class="port"
+            >
+              <template
+                #title
               >
-                <template
-                  #title
-                >
-                  TLS
-                </template>
-                <template
-                  #body
-                >
-                  <KBadge
-                    appearance="neutral"
-                  >
-                    {{ data.spec.tls?.enabled ? 'Enabled' : 'Disabled' }}
-                  </KBadge>
-                </template>
-              </DefinitionCard>
-              <DefinitionCard
-                v-if="typeof data.status.vip !== 'undefined'"
-                class="ip"
+                Port
+              </template>
+              <template
+                #body
               >
-                <template
-                  #title
+                <KBadge
+                  v-for="connection in [data.spec.match]"
+                  :key="connection.port"
+                  appearance="info"
                 >
-                  VIP
-                </template>
-                <template
-                  #body
+                  {{ connection.port }}/{{ connection.protocol }}
+                </KBadge>
+              </template>
+            </DefinitionCard>
+            <DefinitionCard
+              v-if="data.spec.match"
+              class="tls"
+            >
+              <template
+                #title
+              >
+                TLS
+              </template>
+              <template
+                #body
+              >
+                <KBadge
+                  appearance="neutral"
                 >
-                  {{ data.status.vip.ip }}
-                </template>
-              </DefinitionCard>
-            </div>
-          </KCard>
-        </div>
-      </AppView>
-    </RouteView>
-  </DataSource>
+                  {{ data.spec.tls?.enabled ? 'Enabled' : 'Disabled' }}
+                </KBadge>
+              </template>
+            </DefinitionCard>
+            <DefinitionCard
+              v-if="typeof data.status.vip !== 'undefined'"
+              class="ip"
+            >
+              <template
+                #title
+              >
+                VIP
+              </template>
+              <template
+                #body
+              >
+                {{ data.status.vip.ip }}
+              </template>
+            </DefinitionCard>
+          </div>
+        </KCard>
+      </div>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
 import type { MeshExternalService } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
-import type { MeSource } from '@/app/me/sources'
 
 const props = defineProps<{
   data: MeshExternalService

--- a/src/app/services/views/MeshExternalServiceListView.vue
+++ b/src/app/services/views/MeshExternalServiceListView.vue
@@ -1,184 +1,179 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ route, t, can, uri, me }"
+    name="mesh-external-service-list-view"
+    :params="{
+      page: 1,
+      size: 50,
+      mesh: '',
+      service: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ route, t, can, uri }"
-      name="mesh-external-service-list-view"
-      :params="{
-        page: 1,
-        size: me.pageSize,
-        mesh: '',
-        service: '',
-      }"
-    >
-      <RouteTitle
-        :render="false"
-        :title="t(`services.routes.mesh-external-service-list-view.title`)"
-      />
-      <AppView>
-        <KCard>
-          <DataLoader
-            :src="uri(sources, '/meshes/:mesh/mesh-external-services', {
-              mesh: route.params.mesh,
-            },{
-              page: route.params.page,
-              size: route.params.size,
-            })"
+    <RouteTitle
+      :render="false"
+      :title="t(`services.routes.mesh-external-service-list-view.title`)"
+    />
+    <AppView>
+      <KCard>
+        <DataLoader
+          :src="uri(sources, '/meshes/:mesh/mesh-external-services', {
+            mesh: route.params.mesh,
+          },{
+            page: route.params.page,
+            size: route.params.size,
+          })"
+        >
+          <template
+            #loadable="{ data }"
           >
-            <template
-              #loadable="{ data }"
+            <DataCollection
+              type="services"
+              :items="data?.items ?? [undefined]"
             >
-              <DataCollection
-                type="services"
-                :items="data?.items ?? [undefined]"
+              <AppCollection
+                data-testid="service-collection"
+                :headers="[
+                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                  { ...me.get('headers.tls'), label: 'TLS', key: 'tls' },
+                  { ...me.get('headers.addresses'), label: 'Addresses', key: 'addresses' },
+                  { ...me.get('headers.port'), label: 'Port', key: 'port' },
+                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :page-number="route.params.page"
+                :page-size="route.params.size"
+                :total="data?.total"
+                :items="data?.items"
+                :is-selected-row="(item) => item.name === route.params.service"
+                @change="route.update"
+                @resize="me.set"
               >
-                <AppCollection
-                  data-testid="service-collection"
-                  :headers="[
-                    { label: 'Name', key: 'name' },
-                    { label: 'Namespace', key: 'namespace' },
-                    ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
-                    { label: 'TLS', key: 'tls' },
-                    { label: 'Addresses', key: 'addresses' },
-                    { label: 'Port', key: 'port' },
-                    { label: 'Actions', key: 'actions', hideLabel: true },
-                  ]"
-                  :page-number="route.params.page"
-                  :page-size="route.params.size"
-                  :total="data?.total"
-                  :items="data?.items"
-                  :is-selected-row="(item) => item.name === route.params.service"
-                  @change="route.update"
-                >
-                  <template #name="{ row: item }">
-                    <TextWithCopyButton
-                      :text="item.name"
-                    >
-                      <XAction
-                        data-action
-                        :to="{
-                          name: 'mesh-external-service-summary-view',
-                          params: {
-                            mesh: item.mesh,
-                            service: item.id,
-                          },
-                          query: {
-                            page: route.params.page,
-                            size: route.params.size,
-                          },
-                        }"
-                      >
-                        {{ item.name }}
-                      </XAction>
-                    </TextWithCopyButton>
-                  </template>
-                  <template
-                    #namespace="{ row: item }"
+                <template #name="{ row: item }">
+                  <TextWithCopyButton
+                    :text="item.name"
                   >
-                    {{ item.namespace }}
-                  </template>
-                  <template #zone="{ row: item }">
-                    <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
-                      <XAction
-                        v-if="item.labels['kuma.io/zone']"
-                        :to="{
-                          name: 'zone-cp-detail-view',
-                          params: {
-                            zone: item.labels['kuma.io/zone'],
-                          },
-                        }"
-                      >
-                        {{ item.labels['kuma.io/zone'] }}
-                      </XAction>
-                    </template>
-
-                    <template v-else>
-                      {{ t('common.detail.none') }}
-                    </template>
-                  </template>
-                  <template #tls="{ row: item }">
-                    <KBadge
-                      appearance="neutral"
+                    <XAction
+                      data-action
+                      :to="{
+                        name: 'mesh-external-service-summary-view',
+                        params: {
+                          mesh: item.mesh,
+                          service: item.id,
+                        },
+                        query: {
+                          page: route.params.page,
+                          size: route.params.size,
+                        },
+                      }"
                     >
-                      {{ item.spec.tls?.enabled ? 'Enabled' : 'Disabled' }}
+                      {{ item.name }}
+                    </XAction>
+                  </TextWithCopyButton>
+                </template>
+                <template
+                  #namespace="{ row: item }"
+                >
+                  {{ item.namespace }}
+                </template>
+                <template #zone="{ row: item }">
+                  <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
+                    <XAction
+                      v-if="item.labels['kuma.io/zone']"
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: item.labels['kuma.io/zone'],
+                        },
+                      }"
+                    >
+                      {{ item.labels['kuma.io/zone'] }}
+                    </XAction>
+                  </template>
+
+                  <template v-else>
+                    {{ t('common.detail.none') }}
+                  </template>
+                </template>
+                <template #tls="{ row: item }">
+                  <KBadge
+                    appearance="neutral"
+                  >
+                    {{ item.spec.tls?.enabled ? 'Enabled' : 'Disabled' }}
+                  </KBadge>
+                </template>
+                <template
+                  #addresses="{ row: item }"
+                >
+                  <KTruncate>
+                    <span
+                      v-for="address in item.status.addresses"
+                      :key="address.hostname"
+                    >
+                      {{ address.hostname }}
+                    </span>
+                  </KTruncate>
+                </template>
+                <template
+                  #port="{ row: item }"
+                >
+                  <template
+                    v-if="item.spec.match"
+                  >
+                    <KBadge
+                      v-for="connection in [item.spec.match]"
+                      :key="connection.port"
+                      appearance="info"
+                    >
+                      {{ connection.port }}/{{ connection.protocol }}
                     </KBadge>
                   </template>
-                  <template
-                    #addresses="{ row: item }"
-                  >
-                    <KTruncate>
-                      <span
-                        v-for="address in item.status.addresses"
-                        :key="address.hostname"
-                      >
-                        {{ address.hostname }}
-                      </span>
-                    </KTruncate>
-                  </template>
-                  <template
-                    #port="{ row: item }"
-                  >
-                    <template
-                      v-if="item.spec.match"
-                    >
-                      <KBadge
-                        v-for="connection in [item.spec.match]"
-                        :key="connection.port"
-                        appearance="info"
-                      >
-                        {{ connection.port }}/{{ connection.protocol }}
-                      </KBadge>
-                    </template>
-                  </template>
+                </template>
 
-                  <template #actions="{ row: item }">
-                    <XActionGroup>
-                      <XAction
-                        :to="{
-                          name: 'mesh-external-service-detail-view',
-                          params: {
-                            mesh: item.mesh,
-                            service: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.actions.view') }}
-                      </XAction>
-                    </XActionGroup>
-                  </template>
-                </AppCollection>
-                <RouterView
-                  v-if="data?.items && route.params.service"
-                  v-slot="child"
+                <template #actions="{ row: item }">
+                  <XActionGroup>
+                    <XAction
+                      :to="{
+                        name: 'mesh-external-service-detail-view',
+                        params: {
+                          mesh: item.mesh,
+                          service: item.id,
+                        },
+                      }"
+                    >
+                      {{ t('common.collection.actions.view') }}
+                    </XAction>
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+              <RouterView
+                v-if="data?.items && route.params.service"
+                v-slot="child"
+              >
+                <SummaryView
+                  @close="route.replace({
+                    name: 'mesh-external-service-list-view',
+                    params: {
+                      mesh: route.params.mesh,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                    },
+                  })"
                 >
-                  <SummaryView
-                    @close="route.replace({
-                      name: 'mesh-external-service-list-view',
-                      params: {
-                        mesh: route.params.mesh,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                      },
-                    })"
-                  >
-                    <component
-                      :is="child.Component"
-                      :items="data?.items"
-                    />
-                  </SummaryView>
-                </RouterView>
-              </DataCollection>
-            </template>
-          </DataLoader>
-        </KCard>
-      </AppView>
-    </RouteView>
-  </DataSource>
+                  <component
+                    :is="child.Component"
+                    :items="data?.items"
+                  />
+                </SummaryView>
+              </RouterView>
+            </DataCollection>
+          </template>
+        </DataLoader>
+      </KCard>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -186,5 +181,4 @@ import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import type { MeSource } from '@/app/me/sources'
 </script>

--- a/src/app/services/views/MeshServiceDetailView.vue
+++ b/src/app/services/views/MeshServiceDetailView.vue
@@ -1,302 +1,297 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ can, route, t, uri, me }"
+    name="mesh-service-detail-view"
+    :params="{
+      mesh: '',
+      service: '',
+      page: 1,
+      size: 50,
+      s: '',
+      dataPlane: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ can, route, t, uri }"
-      name="mesh-service-detail-view"
-      :params="{
-        mesh: '',
-        service: '',
-        page: 1,
-        size: me.pageSize,
-        s: '',
-        dataPlane: '',
-        codeSearch: '',
-        codeFilter: false,
-        codeRegExp: false,
-      }"
-    >
-      <AppView>
-        <div
-          class="stack"
-        >
-          <KCard>
-            <div class="columns">
-              <DefinitionCard
-                v-if="props.data.status.addresses.length > 0"
-              >
-                <template
-                  #title
-                >
-                  Addresses
-                </template>
-                <template
-                  #body
-                >
-                  <KTruncate>
-                    <span
-                      v-for="address in props.data.status.addresses"
-                      :key="address.hostname"
-                    >
-                      {{ address.hostname }}
-                    </span>
-                  </KTruncate>
-                </template>
-              </DefinitionCard>
-              <DefinitionCard>
-                <template
-                  #title
-                >
-                  Ports
-                </template>
-                <template
-                  #body
-                >
-                  <KTruncate>
-                    <KBadge
-                      v-for="connection in data.spec.ports"
-                      :key="connection.port"
-                      appearance="info"
-                    >
-                      {{ connection.port }}:{{ connection.targetPort }}/{{ connection.appProtocol }}
-                    </KBadge>
-                  </KTruncate>
-                </template>
-              </DefinitionCard>
-              <DefinitionCard>
-                <template
-                  #title
-                >
-                  Dataplane Tags
-                </template>
-                <template
-                  #body
-                >
-                  <KTruncate>
-                    <KBadge
-                      v-for="(value, key) in data.spec.selector.dataplaneTags"
-                      :key="`${key}:${value}`"
-                      appearance="info"
-                    >
-                      {{ key }}:{{ value }}
-                    </KBadge>
-                  </KTruncate>
-                </template>
-              </DefinitionCard>
-              <DefinitionCard
-                v-if="data.status.vips.length > 0"
-                class="ip"
-              >
-                <template
-                  #title
-                >
-                  VIPs
-                </template>
-                <template
-                  #body
-                >
-                  <KTruncate>
-                    <span
-                      v-for="address in data.status.vips"
-                      :key="address.ip"
-                    >
-                      {{ address.ip }}
-                    </span>
-                  </KTruncate>
-                </template>
-              </DefinitionCard>
-            </div>
-          </KCard>
-
-          <div>
-            <h3>
-              {{ t('services.detail.data_plane_proxies') }}
-            </h3>
-
-            <KCard
-              class="mt-4"
+    <AppView>
+      <div
+        class="stack"
+      >
+        <KCard>
+          <div class="columns">
+            <DefinitionCard
+              v-if="props.data.status.addresses.length > 0"
             >
-              <DataLoader
-                :src="uri(sources, '/meshes/:mesh/dataplanes/for/mesh-service/:tags', {
-                  mesh: route.params.mesh,
-                  tags: JSON.stringify(props.data.spec.selector.dataplaneTags),
-                }, {
-                  page: route.params.page,
-                  size: route.params.size,
-                  search: route.params.s,
-                })"
+              <template
+                #title
               >
-                <template
-                  #loadable="{ data: dataplanes }"
+                Addresses
+              </template>
+              <template
+                #body
+              >
+                <KTruncate>
+                  <span
+                    v-for="address in props.data.status.addresses"
+                    :key="address.hostname"
+                  >
+                    {{ address.hostname }}
+                  </span>
+                </KTruncate>
+              </template>
+            </DefinitionCard>
+            <DefinitionCard>
+              <template
+                #title
+              >
+                Ports
+              </template>
+              <template
+                #body
+              >
+                <KTruncate>
+                  <KBadge
+                    v-for="connection in data.spec.ports"
+                    :key="connection.port"
+                    appearance="info"
+                  >
+                    {{ connection.port }}:{{ connection.targetPort }}/{{ connection.appProtocol }}
+                  </KBadge>
+                </KTruncate>
+              </template>
+            </DefinitionCard>
+            <DefinitionCard>
+              <template
+                #title
+              >
+                Dataplane Tags
+              </template>
+              <template
+                #body
+              >
+                <KTruncate>
+                  <KBadge
+                    v-for="(value, key) in data.spec.selector.dataplaneTags"
+                    :key="`${key}:${value}`"
+                    appearance="info"
+                  >
+                    {{ key }}:{{ value }}
+                  </KBadge>
+                </KTruncate>
+              </template>
+            </DefinitionCard>
+            <DefinitionCard
+              v-if="data.status.vips.length > 0"
+              class="ip"
+            >
+              <template
+                #title
+              >
+                VIPs
+              </template>
+              <template
+                #body
+              >
+                <KTruncate>
+                  <span
+                    v-for="address in data.status.vips"
+                    :key="address.ip"
+                  >
+                    {{ address.ip }}
+                  </span>
+                </KTruncate>
+              </template>
+            </DefinitionCard>
+          </div>
+        </KCard>
+
+        <div>
+          <h3>
+            {{ t('services.detail.data_plane_proxies') }}
+          </h3>
+
+          <KCard
+            class="mt-4"
+          >
+            <DataLoader
+              :src="uri(sources, '/meshes/:mesh/dataplanes/for/mesh-service/:tags', {
+                mesh: route.params.mesh,
+                tags: JSON.stringify(props.data.spec.selector.dataplaneTags),
+              }, {
+                page: route.params.page,
+                size: route.params.size,
+                search: route.params.s,
+              })"
+            >
+              <template
+                #loadable="{ data: dataplanes }"
+              >
+                <AppCollection
+                  class="data-plane-collection"
+                  data-testid="data-plane-collection"
+                  :page-number="route.params.page"
+                  :page-size="route.params.size"
+                  :headers="[
+                    { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                    { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                    { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
+                    { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                    { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                    { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                  ]"
+                  :items="dataplanes?.items"
+                  :total="dataplanes?.total"
+                  :is-selected-row="(row) => row.name === route.params.dataPlane"
+                  summary-route-name="service-data-plane-summary-view"
+                  :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
+                  :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
+                  :empty-state-cta-text="t('common.documentation')"
+                  @change="route.update"
+                  @resize="me.set"
                 >
-                  <AppCollection
-                    class="data-plane-collection"
-                    data-testid="data-plane-collection"
-                    :page-number="route.params.page"
-                    :page-size="route.params.size"
-                    :headers="[
-                      { label: 'Name', key: 'name' },
-                      { label: 'Namespace', key: 'namespace' },
-                      ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
-                      { label: 'Certificate Info', key: 'certificate' },
-                      { label: 'Status', key: 'status' },
-                      { label: 'Warnings', key: 'warnings', hideLabel: true },
-                      { label: 'Actions', key: 'actions', hideLabel: true },
-                    ]"
-                    :items="dataplanes?.items"
-                    :total="dataplanes?.total"
-                    :is-selected-row="(row) => row.name === route.params.dataPlane"
-                    summary-route-name="service-data-plane-summary-view"
-                    :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
-                    :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
-                    :empty-state-cta-text="t('common.documentation')"
-                    @change="route.update"
-                  >
-                    <template #toolbar>
-                      <FilterBar
-                        class="data-plane-proxy-filter"
-                        :placeholder="`name:dataplane-name`"
-                        :query="route.params.s"
-                        :fields="{
-                          name: { description: 'filter by name or parts of a name' },
-                          protocol: { description: 'filter by “kuma.io/protocol” value' },
-                          tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                          ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                        }"
-                        @change="(e) => route.update({
-                          ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                        })"
-                      />
-                    </template>
+                  <template #toolbar>
+                    <FilterBar
+                      class="data-plane-proxy-filter"
+                      :placeholder="`name:dataplane-name`"
+                      :query="route.params.s"
+                      :fields="{
+                        name: { description: 'filter by name or parts of a name' },
+                        protocol: { description: 'filter by “kuma.io/protocol” value' },
+                        tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                        ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+                      }"
+                      @change="(e) => route.update({
+                        ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                      })"
+                    />
+                  </template>
 
-                    <template #name="{ row: item }">
-                      <RouterLink
-                        class="name-link"
-                        :to="{
-                          name: 'mesh-service-data-plane-summary-view',
-                          params: {
-                            mesh: item.mesh,
-                            dataPlane: item.id,
-                          },
-                          query: {
-                            page: route.params.page,
-                            size: route.params.size,
-                            s: route.params.s,
-                          },
-                        }"
-                      >
-                        {{ item.name }}
-                      </RouterLink>
-                    </template>
-
-                    <template #namespace="{ row: item }">
-                      {{ item.namespace }}
-                    </template>
-
-                    <template #zone="{ row }">
-                      <RouterLink
-                        v-if="row.zone"
-                        :to="{
-                          name: 'zone-cp-detail-view',
-                          params: {
-                            zone: row.zone,
-                          },
-                        }"
-                      >
-                        {{ row.zone }}
-                      </RouterLink>
-
-                      <template v-else>
-                        {{ t('common.collection.none') }}
-                      </template>
-                    </template>
-
-                    <template #certificate="{ row }">
-                      <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                        {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                      </template>
-
-                      <template v-else>
-                        {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                      </template>
-                    </template>
-
-                    <template #status="{ row }">
-                      <StatusBadge :status="row.status" />
-                    </template>
-
-                    <template #warnings="{ row }">
-                      <XIcon
-                        v-if="row.isCertExpired || row.warnings.length > 0"
-                        class="mr-1"
-                        name="warning"
-                      >
-                        <ul>
-                          <template v-if="row.warnings.length > 0">
-                            <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                          </template>
-
-                          <template v-if="row.isCertExpired">
-                            <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                          </template>
-                        </ul>
-                      </XIcon>
-
-                      <template v-else>
-                        {{ t('common.collection.none') }}
-                      </template>
-                    </template>
-
-                    <template #actions="{ row: item }">
-                      <XActionGroup>
-                        <XAction
-                          :to="{
-                            name: 'data-plane-detail-view',
-                            params: {
-                              dataPlane: item.id,
-                            },
-                          }"
-                        >
-                          {{ t('common.collection.actions.view') }}
-                        </XAction>
-                      </XActionGroup>
-                    </template>
-                  </AppCollection>
-                  <RouterView
-                    v-if="route.params.dataPlane"
-                    v-slot="child"
-                  >
-                    <SummaryView
-                      @close="route.replace({
-                        name: route.name,
+                  <template #name="{ row: item }">
+                    <RouterLink
+                      class="name-link"
+                      :to="{
+                        name: 'mesh-service-data-plane-summary-view',
                         params: {
-                          mesh: route.params.mesh,
+                          mesh: item.mesh,
+                          dataPlane: item.id,
                         },
                         query: {
                           page: route.params.page,
                           size: route.params.size,
                           s: route.params.s,
                         },
-                      })"
+                      }"
                     >
-                      <component
-                        :is="child.Component"
-                        v-if="typeof dataplanes !== 'undefined'"
-                        :items="dataplanes.items"
-                      />
-                    </SummaryView>
-                  </RouterView>
-                </template>
-              </DataLoader>
-            </KCard>
-          </div>
+                      {{ item.name }}
+                    </RouterLink>
+                  </template>
+
+                  <template #namespace="{ row: item }">
+                    {{ item.namespace }}
+                  </template>
+
+                  <template #zone="{ row }">
+                    <RouterLink
+                      v-if="row.zone"
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: row.zone,
+                        },
+                      }"
+                    >
+                      {{ row.zone }}
+                    </RouterLink>
+
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+
+                  <template #certificate="{ row }">
+                    <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                      {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                    </template>
+
+                    <template v-else>
+                      {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                    </template>
+                  </template>
+
+                  <template #status="{ row }">
+                    <StatusBadge :status="row.status" />
+                  </template>
+
+                  <template #warnings="{ row }">
+                    <XIcon
+                      v-if="row.isCertExpired || row.warnings.length > 0"
+                      class="mr-1"
+                      name="warning"
+                    >
+                      <ul>
+                        <template v-if="row.warnings.length > 0">
+                          <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+                        </template>
+
+                        <template v-if="row.isCertExpired">
+                          <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
+                        </template>
+                      </ul>
+                    </XIcon>
+
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'data-plane-detail-view',
+                          params: {
+                            dataPlane: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
+                  </template>
+                </AppCollection>
+                <RouterView
+                  v-if="route.params.dataPlane"
+                  v-slot="child"
+                >
+                  <SummaryView
+                    @close="route.replace({
+                      name: route.name,
+                      params: {
+                        mesh: route.params.mesh,
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                        s: route.params.s,
+                      },
+                    })"
+                  >
+                    <component
+                      :is="child.Component"
+                      v-if="typeof dataplanes !== 'undefined'"
+                      :items="dataplanes.items"
+                    />
+                  </SummaryView>
+                </RouterView>
+              </template>
+            </DataLoader>
+          </KCard>
         </div>
-      </AppView>
-    </RouteView>
-  </DataSource>
+      </div>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -307,7 +302,6 @@ import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import { sources } from '@/app/data-planes/sources'
-import type { MeSource } from '@/app/me/sources'
 
 const props = defineProps<{
   data: MeshService

--- a/src/app/services/views/MeshServiceListView.vue
+++ b/src/app/services/views/MeshServiceListView.vue
@@ -1,187 +1,182 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ route, t, can, uri, me }"
+    name="mesh-service-list-view"
+    :params="{
+      page: 1,
+      size: 50,
+      mesh: '',
+      service: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ route, t, can, uri }"
-      name="mesh-service-list-view"
-      :params="{
-        page: 1,
-        size: me.pageSize,
-        mesh: '',
-        service: '',
-      }"
-    >
-      <RouteTitle
-        :render="false"
-        :title="t(`services.routes.mesh-service-list-view.title`)"
-      />
-      <AppView>
-        <KCard>
-          <DataLoader
-            :src="uri(sources, '/meshes/:mesh/mesh-services', {
-              mesh: route.params.mesh,
-            },{
-              page: route.params.page,
-              size: route.params.size,
-            })"
+    <RouteTitle
+      :render="false"
+      :title="t(`services.routes.mesh-service-list-view.title`)"
+    />
+    <AppView>
+      <KCard>
+        <DataLoader
+          :src="uri(sources, '/meshes/:mesh/mesh-services', {
+            mesh: route.params.mesh,
+          },{
+            page: route.params.page,
+            size: route.params.size,
+          })"
+        >
+          <template
+            #loadable="{ data }"
           >
-            <template
-              #loadable="{ data }"
+            <DataCollection
+              type="services"
+              :items="data?.items ?? [undefined]"
             >
-              <DataCollection
-                type="services"
-                :items="data?.items ?? [undefined]"
+              <AppCollection
+                data-testid="service-collection"
+                :headers="[
+                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                  { ...me.get('headers.addresses'), label: 'Addresses', key: 'addresses' },
+                  { ...me.get('headers.ports'), label: 'Ports', key: 'ports' },
+                  { ...me.get('headers.tags'), label: 'Tags', key: 'tags' },
+                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :page-number="route.params.page"
+                :page-size="route.params.size"
+                :total="data?.total"
+                :items="data?.items"
+                :is-selected-row="(item) => item.name === route.params.service"
+                @change="route.update"
+                @resize="me.set"
               >
-                <AppCollection
-                  data-testid="service-collection"
-                  :headers="[
-                    { label: 'Name', key: 'name' },
-                    { label: 'Namespace', key: 'namespace' },
-                    ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
-                    { label: 'Addresses', key: 'addresses' },
-                    { label: 'Ports', key: 'ports' },
-                    { label: 'Tags', key: 'tags' },
-                    { label: 'Actions', key: 'actions', hideLabel: true },
-                  ]"
-                  :page-number="route.params.page"
-                  :page-size="route.params.size"
-                  :total="data?.total"
-                  :items="data?.items"
-                  :is-selected-row="(item) => item.name === route.params.service"
-                  @change="route.update"
-                >
-                  <template #name="{ row: item }">
-                    <TextWithCopyButton
-                      :text="item.name"
+                <template #name="{ row: item }">
+                  <TextWithCopyButton
+                    :text="item.name"
+                  >
+                    <XAction
+                      data-action
+                      :to="{
+                        name: 'mesh-service-summary-view',
+                        params: {
+                          mesh: item.mesh,
+                          service: item.id,
+                        },
+                        query: {
+                          page: route.params.page,
+                          size: route.params.size,
+                        },
+                      }"
                     >
-                      <XAction
-                        data-action
-                        :to="{
-                          name: 'mesh-service-summary-view',
-                          params: {
-                            mesh: item.mesh,
-                            service: item.id,
-                          },
-                          query: {
-                            page: route.params.page,
-                            size: route.params.size,
-                          },
-                        }"
-                      >
-                        {{ item.name }}
-                      </XAction>
-                    </TextWithCopyButton>
-                  </template>
-                  <template
-                    #namespace="{ row: item }"
-                  >
-                    {{ item.namespace }}
-                  </template>
-                  <template #zone="{ row: item }">
-                    <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
-                      <XAction
-                        v-if="item.labels['kuma.io/zone']"
-                        :to="{
-                          name: 'zone-cp-detail-view',
-                          params: {
-                            zone: item.labels['kuma.io/zone'],
-                          },
-                        }"
-                      >
-                        {{ item.labels['kuma.io/zone'] }}
-                      </XAction>
-                    </template>
-
-                    <template v-else>
-                      {{ t('common.detail.none') }}
-                    </template>
-                  </template>
-                  <template
-                    #addresses="{ row: item }"
-                  >
-                    <KTruncate>
-                      <span
-                        v-for="address in item.status.addresses"
-                        :key="address.hostname"
-                      >
-                        {{ address.hostname }}
-                      </span>
-                    </KTruncate>
-                  </template>
-                  <template
-                    #ports="{ row: item }"
-                  >
-                    <KTruncate>
-                      <KBadge
-                        v-for="connection in item.spec.ports"
-                        :key="connection.port"
-                        appearance="info"
-                      >
-                        {{ connection.port }}:{{ connection.targetPort }}/{{ connection.appProtocol }}
-                      </KBadge>
-                    </KTruncate>
-                  </template>
-                  <template
-                    #tags="{ row: item }"
-                  >
-                    <KTruncate>
-                      <KBadge
-                        v-for="(value, key) in item.spec.selector.dataplaneTags"
-                        :key="`${key}:${value}`"
-                        appearance="info"
-                      >
-                        {{ key }}:{{ value }}
-                      </KBadge>
-                    </KTruncate>
-                  </template>
-                  <template #actions="{ row: item }">
-                    <XActionGroup>
-                      <XAction
-                        :to="{
-                          name: 'mesh-service-detail-view',
-                          params: {
-                            mesh: item.mesh,
-                            service: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.actions.view') }}
-                      </XAction>
-                    </XActionGroup>
-                  </template>
-                </AppCollection>
-                <RouterView
-                  v-if="data?.items && route.params.service"
-                  v-slot="child"
+                      {{ item.name }}
+                    </XAction>
+                  </TextWithCopyButton>
+                </template>
+                <template
+                  #namespace="{ row: item }"
                 >
-                  <SummaryView
-                    @close="route.replace({
-                      name: 'mesh-service-list-view',
-                      params: {
-                        mesh: route.params.mesh,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                      },
-                    })"
-                  >
-                    <component
-                      :is="child.Component"
-                      :items="data?.items"
-                    />
-                  </SummaryView>
-                </RouterView>
-              </DataCollection>
-            </template>
-          </DataLoader>
-        </KCard>
-      </AppView>
-    </RouteView>
-  </DataSource>
+                  {{ item.namespace }}
+                </template>
+                <template #zone="{ row: item }">
+                  <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
+                    <XAction
+                      v-if="item.labels['kuma.io/zone']"
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: item.labels['kuma.io/zone'],
+                        },
+                      }"
+                    >
+                      {{ item.labels['kuma.io/zone'] }}
+                    </XAction>
+                  </template>
+
+                  <template v-else>
+                    {{ t('common.detail.none') }}
+                  </template>
+                </template>
+                <template
+                  #addresses="{ row: item }"
+                >
+                  <KTruncate>
+                    <span
+                      v-for="address in item.status.addresses"
+                      :key="address.hostname"
+                    >
+                      {{ address.hostname }}
+                    </span>
+                  </KTruncate>
+                </template>
+                <template
+                  #ports="{ row: item }"
+                >
+                  <KTruncate>
+                    <KBadge
+                      v-for="connection in item.spec.ports"
+                      :key="connection.port"
+                      appearance="info"
+                    >
+                      {{ connection.port }}:{{ connection.targetPort }}/{{ connection.appProtocol }}
+                    </KBadge>
+                  </KTruncate>
+                </template>
+                <template
+                  #tags="{ row: item }"
+                >
+                  <KTruncate>
+                    <KBadge
+                      v-for="(value, key) in item.spec.selector.dataplaneTags"
+                      :key="`${key}:${value}`"
+                      appearance="info"
+                    >
+                      {{ key }}:{{ value }}
+                    </KBadge>
+                  </KTruncate>
+                </template>
+                <template #actions="{ row: item }">
+                  <XActionGroup>
+                    <XAction
+                      :to="{
+                        name: 'mesh-service-detail-view',
+                        params: {
+                          mesh: item.mesh,
+                          service: item.id,
+                        },
+                      }"
+                    >
+                      {{ t('common.collection.actions.view') }}
+                    </XAction>
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+              <RouterView
+                v-if="data?.items && route.params.service"
+                v-slot="child"
+              >
+                <SummaryView
+                  @close="route.replace({
+                    name: 'mesh-service-list-view',
+                    params: {
+                      mesh: route.params.mesh,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                    },
+                  })"
+                >
+                  <component
+                    :is="child.Component"
+                    :items="data?.items"
+                  />
+                </SummaryView>
+              </RouterView>
+            </DataCollection>
+          </template>
+        </DataLoader>
+      </KCard>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -189,5 +184,4 @@ import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import type { MeSource } from '@/app/me/sources'
 </script>

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -1,262 +1,257 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ can, route, t, me }"
+    name="service-detail-view"
+    :params="{
+      mesh: '',
+      service: '',
+      page: 1,
+      size: 50,
+      s: '',
+      dataPlane: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ can, route, t }"
-      name="service-detail-view"
-      :params="{
-        mesh: '',
-        service: '',
-        page: 1,
-        size: me.pageSize,
-        s: '',
-        dataPlane: '',
-        codeSearch: '',
-        codeFilter: false,
-        codeRegExp: false,
-      }"
-    >
-      <AppView>
-        <DataSource
-          v-slot="{ data, error }: ServiceInsightSource"
-          :src="`/meshes/${route.params.mesh}/service-insights/${route.params.service}`"
+    <AppView>
+      <DataSource
+        v-slot="{ data, error }: ServiceInsightSource"
+        :src="`/meshes/${route.params.mesh}/service-insights/${route.params.service}`"
+      >
+        <ErrorBlock
+          v-if="error"
+          :error="error"
+        />
+
+        <LoadingBlock v-else-if="data === undefined" />
+
+        <div
+          v-else
+          class="stack"
         >
-          <ErrorBlock
-            v-if="error"
-            :error="error"
-          />
+          <KCard>
+            <div class="columns">
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.status') }}
+                </template>
 
-          <LoadingBlock v-else-if="data === undefined" />
+                <template #body>
+                  <StatusBadge :status="data.status" />
+                </template>
+              </DefinitionCard>
 
-          <div
-            v-else
-            class="stack"
-          >
-            <KCard>
-              <div class="columns">
-                <DefinitionCard>
-                  <template #title>
-                    {{ t('http.api.property.status') }}
-                  </template>
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.address') }}
+                </template>
 
-                  <template #body>
-                    <StatusBadge :status="data.status" />
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard>
-                  <template #title>
-                    {{ t('http.api.property.address') }}
-                  </template>
-
-                  <template #body>
-                    <TextWithCopyButton
-                      v-if="data.addressPort"
-                      :text="data.addressPort"
-                    />
-
-                    <template v-else>
-                      {{ t('common.detail.none') }}
-                    </template>
-                  </template>
-                </DefinitionCard>
-
-                <ResourceStatus
-                  :online="data.dataplanes?.online ?? 0"
-                  :total="data.dataplanes?.total ?? 0"
-                >
-                  <template #title>
-                    {{ t('http.api.property.dataPlaneProxies') }}
-                  </template>
-                </ResourceStatus>
-              </div>
-            </KCard>
-
-            <div>
-              <h3>{{ t('services.detail.data_plane_proxies') }}</h3>
-
-              <KCard class="mt-4">
-                <DataSource
-                  v-slot="{ data: dataplanesData, error: dataplanesError }: DataplaneOverviewCollectionSource"
-                  :src="`/meshes/${route.params.mesh}/dataplanes/for/service-insight/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
-                >
-                  <ErrorBlock
-                    v-if="dataplanesError !== undefined"
-                    :error="dataplanesError"
+                <template #body>
+                  <TextWithCopyButton
+                    v-if="data.addressPort"
+                    :text="data.addressPort"
                   />
 
-                  <AppCollection
-                    v-else
-                    class="data-plane-collection"
-                    data-testid="data-plane-collection"
-                    :page-number="route.params.page"
-                    :page-size="route.params.size"
-                    :headers="[
-                      { label: 'Name', key: 'name' },
-                      { label: 'Namespace', key: 'namespace' },
-                      ...(can('use zones') ? [{ label: 'Zone', key: 'zone' }] : []),
-                      { label: 'Certificate Info', key: 'certificate' },
-                      { label: 'Status', key: 'status' },
-                      { label: 'Warnings', key: 'warnings', hideLabel: true },
-                      { label: 'Actions', key: 'actions', hideLabel: true },
-                    ]"
-                    :items="dataplanesData?.items"
-                    :total="dataplanesData?.total"
-                    :error="dataplanesError"
-                    :is-selected-row="(row) => row.name === route.params.dataPlane"
-                    summary-route-name="service-data-plane-summary-view"
-                    :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
-                    :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
-                    :empty-state-cta-text="t('common.documentation')"
-                    @change="route.update"
-                  >
-                    <template #toolbar>
-                      <FilterBar
-                        class="data-plane-proxy-filter"
-                        :placeholder="`name:dataplane-name`"
-                        :query="route.params.s"
-                        :fields="{
-                          name: { description: 'filter by name or parts of a name' },
-                          protocol: { description: 'filter by “kuma.io/protocol” value' },
-                          tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                          ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                        }"
-                        @change="(e) => route.update({
-                          ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                        })"
-                      />
-                    </template>
+                  <template v-else>
+                    {{ t('common.detail.none') }}
+                  </template>
+                </template>
+              </DefinitionCard>
 
-                    <template #name="{ row: item }">
-                      <XAction
-                        data-action
-                        class="name-link"
-                        :to="{
-                          name: 'service-data-plane-summary-view',
-                          params: {
-                            mesh: item.mesh,
-                            dataPlane: item.id,
-                          },
-                          query: {
-                            page: route.params.page,
-                            size: route.params.size,
-                            s: route.params.s,
-                          },
-                        }"
-                      >
-                        {{ item.name }}
-                      </XAction>
-                    </template>
+              <ResourceStatus
+                :online="data.dataplanes?.online ?? 0"
+                :total="data.dataplanes?.total ?? 0"
+              >
+                <template #title>
+                  {{ t('http.api.property.dataPlaneProxies') }}
+                </template>
+              </ResourceStatus>
+            </div>
+          </KCard>
 
-                    <template #namespace="{ row: item }">
-                      {{ item.namespace }}
-                    </template>
+          <div>
+            <h3>{{ t('services.detail.data_plane_proxies') }}</h3>
 
-                    <template #zone="{ row }">
-                      <XAction
-                        v-if="row.zone"
-                        :to="{
-                          name: 'zone-cp-detail-view',
-                          params: {
-                            zone: row.zone,
-                          },
-                        }"
-                      >
-                        {{ row.zone }}
-                      </XAction>
+            <KCard class="mt-4">
+              <DataSource
+                v-slot="{ data: dataplanesData, error: dataplanesError }: DataplaneOverviewCollectionSource"
+                :src="`/meshes/${route.params.mesh}/dataplanes/for/service-insight/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
+              >
+                <ErrorBlock
+                  v-if="dataplanesError !== undefined"
+                  :error="dataplanesError"
+                />
 
-                      <template v-else>
-                        {{ t('common.collection.none') }}
-                      </template>
-                    </template>
+                <AppCollection
+                  v-else
+                  class="data-plane-collection"
+                  data-testid="data-plane-collection"
+                  :page-number="route.params.page"
+                  :page-size="route.params.size"
+                  :headers="[
+                    { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                    { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                    { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
+                    { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                    { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                    { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                  ]"
+                  :items="dataplanesData?.items"
+                  :total="dataplanesData?.total"
+                  :error="dataplanesError"
+                  :is-selected-row="(row) => row.name === route.params.dataPlane"
+                  summary-route-name="service-data-plane-summary-view"
+                  :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
+                  :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
+                  :empty-state-cta-text="t('common.documentation')"
+                  @change="route.update"
+                  @resize="me.set"
+                >
+                  <template #toolbar>
+                    <FilterBar
+                      class="data-plane-proxy-filter"
+                      :placeholder="`name:dataplane-name`"
+                      :query="route.params.s"
+                      :fields="{
+                        name: { description: 'filter by name or parts of a name' },
+                        protocol: { description: 'filter by “kuma.io/protocol” value' },
+                        tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                        ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+                      }"
+                      @change="(e) => route.update({
+                        ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                      })"
+                    />
+                  </template>
 
-                    <template #certificate="{ row }">
-                      <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                        {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                      </template>
-
-                      <template v-else>
-                        {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                      </template>
-                    </template>
-
-                    <template #status="{ row }">
-                      <StatusBadge :status="row.status" />
-                    </template>
-
-                    <template #warnings="{ row }">
-                      <XIcon
-                        v-if="row.isCertExpired || row.warnings.length > 0"
-                        class="mr-1"
-                        name="warning"
-                      >
-                        <ul>
-                          <template v-if="row.warnings.length > 0">
-                            <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                          </template>
-
-                          <template v-if="row.isCertExpired">
-                            <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                          </template>
-                        </ul>
-                      </XIcon>
-
-                      <template v-else>
-                        {{ t('common.collection.none') }}
-                      </template>
-                    </template>
-
-                    <template #actions="{ row: item }">
-                      <XActionGroup>
-                        <XAction
-                          :to="{
-                            name: 'data-plane-detail-view',
-                            params: {
-                              dataPlane: item.id,
-                            },
-                          }"
-                        >
-                          {{ t('common.collection.actions.view') }}
-                        </XAction>
-                      </XActionGroup>
-                    </template>
-                  </AppCollection>
-
-                  <RouterView
-                    v-if="route.params.dataPlane"
-                    v-slot="child"
-                  >
-                    <SummaryView
-                      @close="route.replace({
-                        name: route.name,
+                  <template #name="{ row: item }">
+                    <XAction
+                      data-action
+                      class="name-link"
+                      :to="{
+                        name: 'service-data-plane-summary-view',
                         params: {
-                          mesh: route.params.mesh,
+                          mesh: item.mesh,
+                          dataPlane: item.id,
                         },
                         query: {
                           page: route.params.page,
                           size: route.params.size,
                           s: route.params.s,
                         },
-                      })"
+                      }"
                     >
-                      <component
-                        :is="child.Component"
-                        v-if="typeof dataplanesData !== 'undefined'"
-                        :items="dataplanesData.items"
-                      />
-                    </SummaryView>
-                  </RouterView>
-                </DataSource>
-              </KCard>
-            </div>
+                      {{ item.name }}
+                    </XAction>
+                  </template>
+
+                  <template #namespace="{ row: item }">
+                    {{ item.namespace }}
+                  </template>
+
+                  <template #zone="{ row }">
+                    <XAction
+                      v-if="row.zone"
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: row.zone,
+                        },
+                      }"
+                    >
+                      {{ row.zone }}
+                    </XAction>
+
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+
+                  <template #certificate="{ row }">
+                    <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                      {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                    </template>
+
+                    <template v-else>
+                      {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                    </template>
+                  </template>
+
+                  <template #status="{ row }">
+                    <StatusBadge :status="row.status" />
+                  </template>
+
+                  <template #warnings="{ row }">
+                    <XIcon
+                      v-if="row.isCertExpired || row.warnings.length > 0"
+                      class="mr-1"
+                      name="warning"
+                    >
+                      <ul>
+                        <template v-if="row.warnings.length > 0">
+                          <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+                        </template>
+
+                        <template v-if="row.isCertExpired">
+                          <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
+                        </template>
+                      </ul>
+                    </XIcon>
+
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'data-plane-detail-view',
+                          params: {
+                            dataPlane: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
+                  </template>
+                </AppCollection>
+
+                <RouterView
+                  v-if="route.params.dataPlane"
+                  v-slot="child"
+                >
+                  <SummaryView
+                    @close="route.replace({
+                      name: route.name,
+                      params: {
+                        mesh: route.params.mesh,
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                        s: route.params.s,
+                      },
+                    })"
+                  >
+                    <component
+                      :is="child.Component"
+                      v-if="typeof dataplanesData !== 'undefined'"
+                      :items="dataplanesData.items"
+                    />
+                  </SummaryView>
+                </RouterView>
+              </DataSource>
+            </KCard>
           </div>
-        </DataSource>
-      </AppView>
-    </RouteView>
-  </DataSource>
+        </div>
+      </DataSource>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -271,7 +266,6 @@ import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { DataplaneOverviewCollectionSource } from '@/app/data-planes/sources'
-import type { MeSource } from '@/app/me/sources'
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -1,153 +1,148 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <RouteView
+    v-slot="{ route, t, uri, me }"
+    name="service-list-view"
+    :params="{
+      page: 1,
+      size: 50,
+      mesh: '',
+      service: '',
+    }"
   >
-    <RouteView
-      v-if="me"
-      v-slot="{ route, t, uri }"
-      name="service-list-view"
-      :params="{
-        page: 1,
-        size: me.pageSize,
-        mesh: '',
-        service: '',
-      }"
-    >
-      <RouteTitle
-        :render="false"
-        :title="t(`services.routes.items.title`)"
-      />
-      <AppView>
-        <KCard>
-          <DataLoader
-            :src="uri(sources, '/meshes/:mesh/service-insights/of/:serviceType', {
-              mesh: route.params.mesh,
-              serviceType: 'internal',
-            },{
-              page: route.params.page,
-              size: route.params.size,
-            })"
+    <RouteTitle
+      :render="false"
+      :title="t(`services.routes.items.title`)"
+    />
+    <AppView>
+      <KCard>
+        <DataLoader
+          :src="uri(sources, '/meshes/:mesh/service-insights/of/:serviceType', {
+            mesh: route.params.mesh,
+            serviceType: 'internal',
+          },{
+            page: route.params.page,
+            size: route.params.size,
+          })"
+        >
+          <template
+            #loadable="{ data }"
           >
-            <template
-              #loadable="{ data }"
+            <DataCollection
+              type="services"
+              :items="data?.items ?? [undefined]"
             >
-              <DataCollection
-                type="services"
-                :items="data?.items ?? [undefined]"
+              <AppCollection
+                class="service-collection"
+                data-testid="service-collection"
+                :headers="[
+                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                  { ...me.get('headers.addressPort'), label: 'Address', key: 'addressPort' },
+                  { ...me.get('headers.online'), label: 'DP proxies (online / total)', key: 'online' },
+                  { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :page-number="route.params.page"
+                :page-size="route.params.size"
+                :total="data?.total"
+                :items="data?.items"
+                :is-selected-row="(row) => row.name === route.params.service"
+                @change="route.update"
+                @resize="me.set"
               >
-                <AppCollection
-                  class="service-collection"
-                  data-testid="service-collection"
-                  :headers="[
-                    { label: 'Name', key: 'name' },
-                    { label: 'Address', key: 'addressPort' },
-                    { label: 'DP proxies (online / total)', key: 'online' },
-                    { label: 'Status', key: 'status' },
-                    { label: 'Actions', key: 'actions', hideLabel: true },
-                  ]"
-                  :page-number="route.params.page"
-                  :page-size="route.params.size"
-                  :total="data?.total"
-                  :items="data?.items"
-                  :is-selected-row="(row) => row.name === route.params.service"
-                  @change="route.update"
-                >
-                  <template #name="{ row: item }">
-                    <TextWithCopyButton :text="item.name">
-                      <XAction
-                        data-action
-                        :to="{
-                          name: 'service-detail-view',
-                          params: {
-                            mesh: item.mesh,
-                            service: item.name,
-                          },
-                          query: {
-                            page: route.params.page,
-                            size: route.params.size,
-                          },
-                        }"
-                      >
-                        {{ item.name }}
-                      </XAction>
-                    </TextWithCopyButton>
-                  </template>
-
-                  <template #addressPort="{ row }">
-                    <TextWithCopyButton
-                      v-if="row.addressPort"
-                      :text="row.addressPort"
-                    />
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-
-                  <template #online="{ row: item }">
-                    <template
-                      v-if="item.dataplanes"
+                <template #name="{ row: item }">
+                  <TextWithCopyButton :text="item.name">
+                    <XAction
+                      data-action
+                      :to="{
+                        name: 'service-detail-view',
+                        params: {
+                          mesh: item.mesh,
+                          service: item.name,
+                        },
+                        query: {
+                          page: route.params.page,
+                          size: route.params.size,
+                        },
+                      }"
                     >
-                      {{ item.dataplanes.online || 0 }} / {{ item.dataplanes.total || 0 }}
-                    </template>
-                    <template
-                      v-else
-                    >
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
+                      {{ item.name }}
+                    </XAction>
+                  </TextWithCopyButton>
+                </template>
 
-                  <template #status="{ row: item }">
-                    <StatusBadge :status="item.status" />
-                  </template>
+                <template #addressPort="{ row }">
+                  <TextWithCopyButton
+                    v-if="row.addressPort"
+                    :text="row.addressPort"
+                  />
 
-                  <template #actions="{ row: item }">
-                    <XActionGroup>
-                      <XAction
-                        :to="{
-                          name: 'service-detail-view',
-                          params: {
-                            mesh: item.mesh,
-                            service: item.name,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.actions.view') }}
-                      </XAction>
-                    </XActionGroup>
+                  <template v-else>
+                    {{ t('common.collection.none') }}
                   </template>
-                </AppCollection>
-                <RouterView
-                  v-if="route.params.service"
-                  v-slot="child"
-                >
-                  <SummaryView
-                    @close="route.replace({
-                      name: 'service-list-view',
-                      params: {
-                        mesh: route.params.mesh,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                      },
-                    })"
+                </template>
+
+                <template #online="{ row: item }">
+                  <template
+                    v-if="item.dataplanes"
                   >
-                    <component
-                      :is="child.Component"
-                      :name="route.params.service"
-                      :service="data?.items.find((item) => item.name === route.params.service)"
-                    />
-                  </SummaryView>
-                </RouterView>
-              </DataCollection>
-            </template>
-          </DataLoader>
-        </KCard>
-      </AppView>
-    </RouteView>
-  </DataSource>
+                    {{ item.dataplanes.online || 0 }} / {{ item.dataplanes.total || 0 }}
+                  </template>
+                  <template
+                    v-else
+                  >
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #status="{ row: item }">
+                  <StatusBadge :status="item.status" />
+                </template>
+
+                <template #actions="{ row: item }">
+                  <XActionGroup>
+                    <XAction
+                      :to="{
+                        name: 'service-detail-view',
+                        params: {
+                          mesh: item.mesh,
+                          service: item.name,
+                        },
+                      }"
+                    >
+                      {{ t('common.collection.actions.view') }}
+                    </XAction>
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+              <RouterView
+                v-if="route.params.service"
+                v-slot="child"
+              >
+                <SummaryView
+                  @close="route.replace({
+                    name: 'service-list-view',
+                    params: {
+                      mesh: route.params.mesh,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                    },
+                  })"
+                >
+                  <component
+                    :is="child.Component"
+                    :name="route.params.service"
+                    :service="data?.items.find((item) => item.name === route.params.service)"
+                  />
+                </SummaryView>
+              </RouterView>
+            </DataCollection>
+          </template>
+        </DataLoader>
+      </KCard>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -156,5 +151,4 @@ import AppCollection from '@/app/application/components/app-collection/AppCollec
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import type { MeSource } from '@/app/me/sources'
 </script>

--- a/src/app/zone-egresses/views/ZoneEgressListView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressListView.vue
@@ -1,139 +1,134 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
+  <RouteView
+    v-slot="{ route, t, me }"
+    name="zone-egress-list-view"
+    :params="{
+      /* page: 1, */
+      /* size: me.pageSize, */
+      zone: '',
+      zoneEgress: '',
+    }"
   >
-    <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
-    <RouteView
-      v-if="me"
-      v-slot="{ route, t }"
-      name="zone-egress-list-view"
-      :params="{
-        /* page: 1, */
-        /* size: me.pageSize, */
-        zone: '',
-        zoneEgress: '',
-      }"
-    >
-      <RouteTitle
-        :render="false"
-        :title="t('zone-egresses.routes.items.title')"
-      />
-      <AppView>
-        <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
-        <DataSource
-          v-slot="{ data, error }: ZoneEgressOverviewCollectionSource"
-          :src="`/zone-cps/${route.params.zone || '*'}/egresses?page=${'1'}&size=${'100'}`"
-        >
-          <KCard>
-            <ErrorBlock
-              v-if="error !== undefined"
-              :error="error"
-            />
+    <RouteTitle
+      :render="false"
+      :title="t('zone-egresses.routes.items.title')"
+    />
+    <AppView>
+      <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
+      <DataSource
+        v-slot="{ data, error }: ZoneEgressOverviewCollectionSource"
+        :src="`/zone-cps/${route.params.zone || '*'}/egresses?page=${'1'}&size=${'100'}`"
+      >
+        <KCard>
+          <ErrorBlock
+            v-if="error !== undefined"
+            :error="error"
+          />
 
-            <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
-            <AppCollection
-              v-else
-              class="zone-egress-collection"
-              data-testid="zone-egress-collection"
-              :headers="[
-                { label: 'Name', key: 'name' },
-                { label: 'Address', key: 'socketAddress' },
-                { label: 'Status', key: 'status' },
-                { label: 'Actions', key: 'actions', hideLabel: true },
-              ]"
-              :page-number="1"
-              :page-size="100"
-              :total="data?.total"
-              :items="data?.items"
-              :error="error"
-              :empty-state-message="t('common.emptyState.message', { type: 'Zone Egresses' })"
-              :empty-state-cta-to="t('zone-egresses.href.docs')"
-              :empty-state-cta-text="t('common.documentation')"
-              :is-selected-row="(row) => row.name === route.params.zoneEgress"
-              @change="route.update"
-            >
-              <template #name="{ row: item }">
+          <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
+          <AppCollection
+            v-else
+            class="zone-egress-collection"
+            data-testid="zone-egress-collection"
+            :headers="[
+              { ...me.get('headers.name'), label: 'Name', key: 'name' },
+              { ...me.get('headers.socketAddress'), label: 'Address', key: 'socketAddress' },
+              { ...me.get('headers.status'), label: 'Status', key: 'status' },
+              { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+            ]"
+            :page-number="1"
+            :page-size="100"
+            :total="data?.total"
+            :items="data?.items"
+            :error="error"
+            :empty-state-message="t('common.emptyState.message', { type: 'Zone Egresses' })"
+            :empty-state-cta-to="t('zone-egresses.href.docs')"
+            :empty-state-cta-text="t('common.documentation')"
+            :is-selected-row="(row) => row.name === route.params.zoneEgress"
+            @change="route.update"
+            @resize="me.set"
+          >
+            <template #name="{ row: item }">
+              <XAction
+                data-action
+                :to="{
+                  name: 'zone-egress-summary-view',
+                  params: {
+                    zone: route.params.zone,
+                    zoneEgress: item.id,
+                  },
+                  query: {
+                    // TODO: Update page & size once the list endpoint is being filtered by zone
+                    page: 1,
+                    size: 100,
+                  },
+                }"
+              >
+                {{ item.name }}
+              </XAction>
+            </template>
+
+            <template #socketAddress="{ row: item }">
+              <TextWithCopyButton
+                v-if="item.zoneEgress.socketAddress.length > 0"
+                :text="item.zoneEgress.socketAddress"
+              />
+              <template v-else>
+                {{ t('common.collection.none') }}
+              </template>
+            </template>
+
+            <template #status="{ row: item }">
+              <StatusBadge
+                :status="item.state"
+              />
+            </template>
+
+            <template #actions="{ row: item }">
+              <XActionGroup>
                 <XAction
-                  data-action
                   :to="{
-                    name: 'zone-egress-summary-view',
+                    name: 'zone-egress-detail-view',
                     params: {
-                      zone: route.params.zone,
                       zoneEgress: item.id,
-                    },
-                    query: {
-                      // TODO: Update page & size once the list endpoint is being filtered by zone
-                      page: 1,
-                      size: 100,
                     },
                   }"
                 >
-                  {{ item.name }}
+                  {{ t('common.collection.actions.view') }}
                 </XAction>
-              </template>
+              </XActionGroup>
+            </template>
+          </AppCollection>
+        </KCard>
 
-              <template #socketAddress="{ row: item }">
-                <TextWithCopyButton
-                  v-if="item.zoneEgress.socketAddress.length > 0"
-                  :text="item.zoneEgress.socketAddress"
-                />
-                <template v-else>
-                  {{ t('common.collection.none') }}
-                </template>
-              </template>
-
-              <template #status="{ row: item }">
-                <StatusBadge
-                  :status="item.state"
-                />
-              </template>
-
-              <template #actions="{ row: item }">
-                <XActionGroup>
-                  <XAction
-                    :to="{
-                      name: 'zone-egress-detail-view',
-                      params: {
-                        zoneEgress: item.id,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.actions.view') }}
-                  </XAction>
-                </XActionGroup>
-              </template>
-            </AppCollection>
-          </KCard>
-
-          <RouterView
-            v-if="route.params.zoneEgress"
-            v-slot="child"
+        <RouterView
+          v-if="route.params.zoneEgress"
+          v-slot="child"
+        >
+          <SummaryView
+            @close="route.replace({
+              name: 'zone-egress-list-view',
+              params: {
+                zone: route.params.zone,
+              },
+              query: {
+                // TODO: Update page & size once the list endpoint is being filtered by zone
+                page: 1,
+                size: 100,
+              },
+            })"
           >
-            <SummaryView
-              @close="route.replace({
-                name: 'zone-egress-list-view',
-                params: {
-                  zone: route.params.zone,
-                },
-                query: {
-                  // TODO: Update page & size once the list endpoint is being filtered by zone
-                  page: 1,
-                  size: 100,
-                },
-              })"
-            >
-              <component
-                :is="child.Component"
-                v-if="typeof data !== 'undefined'"
-                :items="data.items"
-              />
-            </SummaryView>
-          </RouterView>
-        </DataSource>
-      </AppView>
-    </RouteView>
-  </DataSource>
+            <component
+              :is="child.Component"
+              v-if="typeof data !== 'undefined'"
+              :items="data.items"
+            />
+          </SummaryView>
+        </RouterView>
+      </DataSource>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -143,5 +138,4 @@ import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import type { MeSource } from '@/app/me/sources'
 </script>

--- a/src/app/zone-ingresses/views/ZoneIngressListView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressListView.vue
@@ -1,150 +1,145 @@
 <template>
-  <DataSource
-    v-slot="{ data: me }: MeSource"
-    src="/me"
+  <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
+  <RouteView
+    v-slot="{ route, t, me }"
+    name="zone-ingress-list-view"
+    :params="{
+      /* page: 1, */
+      /* size: me.pageSize, */
+      zone: '',
+      zoneIngress: '',
+    }"
   >
-    <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
-    <RouteView
-      v-if="me"
-      v-slot="{ route, t }"
-      name="zone-ingress-list-view"
-      :params="{
-        /* page: 1, */
-        /* size: me.pageSize, */
-        zone: '',
-        zoneIngress: '',
-      }"
-    >
-      <RouteTitle
-        :render="false"
-        :title="t('zone-ingresses.routes.items.title')"
-      />
-      <AppView>
-        <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
-        <DataSource
-          v-slot="{ data, error }: ZoneIngressOverviewCollectionSource"
-          :src="`/zone-cps/${route.params.zone}/ingresses?page=${'1'}&size=${'100'}`"
-        >
-          <KCard>
-            <ErrorBlock
-              v-if="error !== undefined"
-              :error="error"
-            />
+    <RouteTitle
+      :render="false"
+      :title="t('zone-ingresses.routes.items.title')"
+    />
+    <AppView>
+      <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
+      <DataSource
+        v-slot="{ data, error }: ZoneIngressOverviewCollectionSource"
+        :src="`/zone-cps/${route.params.zone}/ingresses?page=${'1'}&size=${'100'}`"
+      >
+        <KCard>
+          <ErrorBlock
+            v-if="error !== undefined"
+            :error="error"
+          />
 
-            <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
-            <AppCollection
-              v-else
-              class="zone-ingress-collection"
-              data-testid="zone-ingress-collection"
-              :headers="[
-                { label: 'Name', key: 'name' },
-                { label: 'Address', key: 'socketAddress' },
-                { label: 'Advertised address', key: 'advertisedSocketAddress' },
-                { label: 'Status', key: 'status' },
-                { label: 'Actions', key: 'actions', hideLabel: true },
-              ]"
-              :page-number="1"
-              :page-size="100"
-              :total="data?.total"
-              :items="data?.items"
-              :error="error"
-              :empty-state-message="t('common.emptyState.message', { type: 'Zone Ingresses' })"
-              :empty-state-cta-to="t('zone-ingresses.href.docs')"
-              :empty-state-cta-text="t('common.documentation')"
-              :is-selected-row="(row) => row.name === route.params.zoneIngress"
-              @change="route.update"
-            >
-              <template #name="{ row: item }">
+          <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
+          <AppCollection
+            v-else
+            class="zone-ingress-collection"
+            data-testid="zone-ingress-collection"
+            :headers="[
+              { ...me.get('headers.name'), label: 'Name', key: 'name' },
+              { ...me.get('headers.socketAddress'), label: 'Address', key: 'socketAddress' },
+              { ...me.get('headers.advertisedSocketAddress'), label: 'Advertised address', key: 'advertisedSocketAddress' },
+              { ...me.get('headers.status'), label: 'Status', key: 'status' },
+              { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+            ]"
+            :page-number="1"
+            :page-size="100"
+            :total="data?.total"
+            :items="data?.items"
+            :error="error"
+            :empty-state-message="t('common.emptyState.message', { type: 'Zone Ingresses' })"
+            :empty-state-cta-to="t('zone-ingresses.href.docs')"
+            :empty-state-cta-text="t('common.documentation')"
+            :is-selected-row="(row) => row.name === route.params.zoneIngress"
+            @change="route.update"
+            @resize="me.set"
+          >
+            <template #name="{ row: item }">
+              <XAction
+                data-action
+                :to="{
+                  name: 'zone-ingress-summary-view',
+                  params: {
+                    zone: route.params.zone,
+                    zoneIngress: item.id,
+                  },
+                  query: {
+                    // TODO: Update page & size once the list endpoint is being filtered by zone
+                    page: 1,
+                    size: 100,
+                  },
+                }"
+              >
+                {{ item.name }}
+              </XAction>
+            </template>
+
+            <template #socketAddress="{ row: item }">
+              <TextWithCopyButton
+                v-if="item.zoneIngress.socketAddress.length > 0"
+                :text="item.zoneIngress.socketAddress"
+              />
+              <template v-else>
+                {{ t('common.collection.none') }}
+              </template>
+            </template>
+
+            <template #advertisedSocketAddress="{ row: item }">
+              <TextWithCopyButton
+                v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
+                :text="item.zoneIngress.advertisedSocketAddress"
+              />
+              <template v-else>
+                {{ t('common.collection.none') }}
+              </template>
+            </template>
+
+            <template #status="{ row: item }">
+              <StatusBadge
+                :status="item.state"
+              />
+            </template>
+
+            <template #actions="{ row: item }">
+              <XActionGroup>
                 <XAction
-                  data-action
                   :to="{
-                    name: 'zone-ingress-summary-view',
+                    name: 'zone-ingress-detail-view',
                     params: {
-                      zone: route.params.zone,
                       zoneIngress: item.id,
-                    },
-                    query: {
-                      // TODO: Update page & size once the list endpoint is being filtered by zone
-                      page: 1,
-                      size: 100,
                     },
                   }"
                 >
-                  {{ item.name }}
+                  {{ t('common.collection.actions.view') }}
                 </XAction>
-              </template>
+              </XActionGroup>
+            </template>
+          </AppCollection>
+        </KCard>
 
-              <template #socketAddress="{ row: item }">
-                <TextWithCopyButton
-                  v-if="item.zoneIngress.socketAddress.length > 0"
-                  :text="item.zoneIngress.socketAddress"
-                />
-                <template v-else>
-                  {{ t('common.collection.none') }}
-                </template>
-              </template>
-
-              <template #advertisedSocketAddress="{ row: item }">
-                <TextWithCopyButton
-                  v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
-                  :text="item.zoneIngress.advertisedSocketAddress"
-                />
-                <template v-else>
-                  {{ t('common.collection.none') }}
-                </template>
-              </template>
-
-              <template #status="{ row: item }">
-                <StatusBadge
-                  :status="item.state"
-                />
-              </template>
-
-              <template #actions="{ row: item }">
-                <XActionGroup>
-                  <XAction
-                    :to="{
-                      name: 'zone-ingress-detail-view',
-                      params: {
-                        zoneIngress: item.id,
-                      },
-                    }"
-                  >
-                    {{ t('common.collection.actions.view') }}
-                  </XAction>
-                </XActionGroup>
-              </template>
-            </AppCollection>
-          </KCard>
-
-          <RouterView
-            v-if="route.params.zoneIngress"
-            v-slot="child"
+        <RouterView
+          v-if="route.params.zoneIngress"
+          v-slot="child"
+        >
+          <SummaryView
+            @close="route.replace({
+              name: 'zone-ingress-list-view',
+              params: {
+                zone: route.params.zone,
+              },
+              query: {
+                // TODO: Update page & size once the list endpoint is being filtered by zone
+                page: 1,
+                size: 100,
+              },
+            })"
           >
-            <SummaryView
-              @close="route.replace({
-                name: 'zone-ingress-list-view',
-                params: {
-                  zone: route.params.zone,
-                },
-                query: {
-                  // TODO: Update page & size once the list endpoint is being filtered by zone
-                  page: 1,
-                  size: 100,
-                },
-              })"
-            >
-              <component
-                :is="child.Component"
-                v-if="typeof data !== 'undefined'"
-                :items="data.items"
-              />
-            </SummaryView>
-          </RouterView>
-        </DataSource>
-      </AppView>
-    </RouteView>
-  </DataSource>
+            <component
+              :is="child.Component"
+              v-if="typeof data !== 'undefined'"
+              :items="data.items"
+            />
+          </SummaryView>
+        </RouterView>
+      </DataSource>
+    </AppView>
+  </RouteView>
 </template>
 
 <script lang="ts" setup>
@@ -154,5 +149,4 @@ import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import type { MeSource } from '@/app/me/sources'
 </script>

--- a/src/app/zones/components/ZoneControlPlanesList.vue
+++ b/src/app/zones/components/ZoneControlPlanesList.vue
@@ -8,12 +8,17 @@
     >
       <AppCollection
         :headers="[
-          { label: '&nbsp;', key: 'type' },
-          { label: t('zone-cps.components.zone-control-planes-list.name'), key: 'name'},
-          { label: t('zone-cps.components.zone-control-planes-list.status'), key: 'status'},
+          { ...storage.get('zone.headers.type'), label: '&nbsp;', key: 'type' },
+          { ...storage.get('zone.headers.name'),label: t('zone-cps.components.zone-control-planes-list.name'), key: 'name'},
+          { ...storage.get('zone.headers.status'),label: t('zone-cps.components.zone-control-planes-list.status'), key: 'status'},
         ]"
         :items="props.items"
         :total="props.items?.length"
+        @resize="(obj) => {
+          storage.set({
+            zone: obj,
+          })
+        }"
       >
         <template
           #type="{ row: item }"
@@ -62,9 +67,19 @@ import StatusBadge from '@/app/common/StatusBadge.vue'
 const { t } = useI18n()
 const can = useCan()
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   items?: ZoneOverview[]
-}>()
+  storage?: {
+    get: (uri: string) => {}
+    set: (data: any) => void
+  }
+}>(), {
+  items: undefined,
+  storage: () => ({
+    get: () => ({}),
+    set: () => {},
+  }),
+})
 </script>
 <style lang="scss" scoped>
 .app-collection:deep(:is(th, td):nth-child(1)) {


### PR DESCRIPTION
Roll out of the code in https://github.com/kumahq/kuma-gui/pull/2625 to all our tables.

All tables should now have resizable columns that remember the sizes through browser refreshes (via `localStorage`)

Whilst the changeset looks big due to the amount of tables we have, the work is basically:

- Remove the `me` `DataSource` in favour of `RouteView::me`
- Add a `@resize` event listener to`AppCollection`
- Splat down the values from `me` i.e. `headers.headerName` onto the header JSON for the table/AppCollection.

There is a lot of green in the changeset due to the removal of the top-level `DataSource` component the the re-nesting that then occurs. I made some inline comments in the place that weren't specifically just rollout of the same thing again and again.

Part of https://github.com/kumahq/kuma-gui/issues/2468