### PR TITLE
chore: XAction and XActionGroup improvements

### DIFF
--- a/.vitepress/theme/components/Story.vue
+++ b/.vitepress/theme/components/Story.vue
@@ -2,15 +2,14 @@
   <section
     class="story"
   >
-
     <iframe
+      :height="props.height"
       ref="iframe"
       data-why
       data-why-show-source
     >
       <slot name="default" />
     </iframe>
-
     <details open class="vue-source">
       <summary>View Vue Source</summary>
       <div class="language-vue vp-adaptive-theme">
@@ -35,6 +34,12 @@ import { ref, computed, watch } from 'vue'
 import { getWhyframeSource } from '@whyframe/core/utils'
 import { getHighlighter } from 'shiki'
 
+
+const props = withDefaults(defineProps<{
+  height?: number
+}>(), {
+  height: 300
+})
 const iframe = ref<HTMLIFrameElement>(null)
 const htmlSource = ref<string>('')
 const highlighter = ref<Awaited<ReturnType<typeof getHighlighter>> | undefined>()

--- a/.vitepress/theme/main.md
+++ b/.vitepress/theme/main.md
@@ -5,26 +5,18 @@ layout: false
 import { ref, onMounted } from 'vue'
 import { createApp } from 'whyframe:app'
 import { TOKENS as APP, services as application } from '@/app/application'
-import { TOKENS as DEV, services as development } from '@/services/development'
-import { services as dataplanes } from '@/app/data-planes'
-import { TOKENS as VUE, services as vue } from '@/app/vue'
-import { services as x } from '@/app/x'
-import { services as kuma } from '@/app/kuma'
-import { build, token } from '@/services/utils'
-import Kongponents from '@kong/kongponents'
+import { services as applicationDebug } from '@/app/application/debug'
 import CliEnv from '@/app/application/services/env/CliEnv'
-import KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
-import { RestClient } from '@/app/kuma/services/kuma-api/RestClient'
-import i18nEnUs from '@/locales/en-us'
+import { TOKENS as VUE, services as vue } from '@/app/vue'
+import { TOKENS } from '@/app/kuma'
+import { build, token } from '@/services/utils'
 import '../../src/assets/styles/main.scss'
 const el = ref()
 const $ = {
   ...VUE,
   ...APP,
-  ...DEV,
+  ...TOKENS,
   globals: token('vue.globals'),
-  httpClient: token('httpClient'),
-  api: token<KumaApi>('KumaApi'),
 }
 
 onMounted(async () => {
@@ -33,10 +25,7 @@ onMounted(async () => {
       const get = build(
         vue($),
         application($),
-        x($),
-        development($),
-        kuma($),
-        dataplanes($),
+        applicationDebug($),
         [
           // temporary $.app replacement
           [$.app, {
@@ -67,25 +56,6 @@ onMounted(async () => {
               $.globals,
             ],
           }],
-          [token('application.routes.navigation.guards'), {
-            service: () => {
-              return []
-            },
-            labels: [
-              $.routesLabel,
-            ],
-          }],
-
-          [token('kong.plugins'), {
-            service: () => {
-              return [
-                [Kongponents],
-              ]
-            },
-            labels: [
-              $.plugins,
-            ],
-          }],
           [token('docs.globals'), {
             service: (i18n) => {
               return [
@@ -105,38 +75,8 @@ onMounted(async () => {
               $.EnvVars,
             ],
           }],
-          [$.httpClient, {
-            service: RestClient,
-            arguments: [
-              $.env,
-            ],
-          }],
-          [$.api, {
-            service: KumaApi,
-            arguments: [
-              $.httpClient,
-              $.env,
-            ],
-          }],
-          [$.EnvVars, {
-            constant: {
-              KUMA_PRODUCT_NAME: '',
-              KUMA_VERSION_URL: '',
-              KUMA_DOCS_URL: '',
-              KUMA_MOCK_API_ENABLED: '',
-              KUMA_API_URL: 'http://localhost:5681',
-              KUMA_ZONE_CREATION_FLOW: '',
-            },
-          }],
-          [token('kuma.i18n.en-us'), {
-            constant: i18nEnUs,
-            labels: [
-              $.enUs,
-            ],
-          }],
         ],
       )
-      get($.msw)
       get($.app)(app)
     }
   })
@@ -146,7 +86,7 @@ onMounted(async () => {
 <div id="sandboxed-component" ref="el"></div>
 
 <style scoped>
-# sandboxed-component {
+#sandboxed-component {
   width: 100%;
   height: 100vh;
   padding: 0.5rem;

--- a/src/app/x/components/x-action-group/README.md
+++ b/src/app/x/components/x-action-group/README.md
@@ -1,1 +1,31 @@
-# x-action-group
+# XActionGroup
+
+XAction group is to render/display groups of actions (i.e. XActions).
+
+You can show the group as 'expanded' or 'not expanded' (i.e. a dropdown). By
+default a not expanded group uses a meatball menu control to allow the user to
+open the group. This can be customized via the `control` slot.
+
+The below shows examples of each layout.
+
+<Story height="340">
+  <div style="display: grid;grid-template-columns: repeat(2, calc(50% -10px));gap: 20px;">
+    <XActionGroup
+      :expanded="false"
+    >
+      <XAction>One</XAction>
+      <XAction>Two</XAction>
+      <XAction>Three</XAction>
+      <XAction appearance="danger">Four</XAction>
+    </XActionGroup>
+    <hr />
+    <XActionGroup
+      :expanded="true"
+    >
+      <XAction>One</XAction>
+      <XAction>Two</XAction>
+      <XAction>Three</XAction>
+      <XAction>Four</XAction>
+    </XActionGroup>
+  </div>
+</Story>

--- a/src/app/x/components/x-action-group/XActionGroup.vue
+++ b/src/app/x/components/x-action-group/XActionGroup.vue
@@ -23,13 +23,20 @@
           <XAction
             v-else
             data-testid="x-action-group-control"
-            type="expand"
+            icon
+            appearance="tertiary"
+            size="small"
           >
             <XIcon name="more" />
           </XAction>
         </template>
         <template #items>
-          <slot name="default" />
+          <XProvider
+            name="x-action-group"
+            :service="props"
+          >
+            <slot name="default" />
+          </XProvider>
         </template>
       </KDropdown>
     </template>
@@ -41,7 +48,6 @@
 </template>
 <script lang="ts" setup>
 import { KDropdown } from '@kong/kongponents'
-import { provide } from 'vue'
 
 const props = withDefaults(defineProps<{
   expanded?: boolean
@@ -49,7 +55,6 @@ const props = withDefaults(defineProps<{
   expanded: false,
 })
 
-provide('x-action-group', props)
 </script>
 <style lang="scss" scoped>
 .x-action-group.expanded {

--- a/src/app/x/components/x-action/README.md
+++ b/src/app/x/components/x-action/README.md
@@ -1,15 +1,50 @@
-# x-action
+# XAction
 
-<Story>
+XAction should be used for all user interactions. **Both** links/anchors and buttons.
+
+The correct semantic HTML element will be used depending on whether you pass
+the `XAction` a `to`/`href` or a `@click` event.
+
+`XAction`s are rendered as `KButton`s by using a KButton `appearance` attribute.
+
+<Story height="320">
   <XAction
     href="http://github.com/kumahq/kuma-gui"
   >
     External link to Github Repo
   </XAction>
-  <hr />
+  <hr style="margin: 20px auto;" />
   <XAction
     @click="() => console.log('Hi')"
   >
-    Button that `console.log`s `Hi` on click
+    Native Button that `console.log`s `Hi` on click
   </XAction>
+  <hr style="margin: 20px auto;" />
+  <div style="display: grid;gap: 20px;grid-template-columns: repeat(2, calc(50% - 10px));">
+    <XAction
+      appearance="primary"
+      @click="() => console.log('Hi')"
+    >
+      Primary KButton
+    </XAction>
+    <XAction
+      appearance="secondary"
+      :to="{ name: '' }"
+    >
+      Secondary KButton
+    </XAction>
+    <XAction
+      appearance="tertiary"
+      @click="() => console.log('Hi')"
+    >
+      Tertiary KButton
+    </XAction>
+    <XAction
+      appearance="danger"
+      @click="() => console.log('Hi')"
+    >
+      Danger KButton
+    </XAction>
+
+  </div>
 </Story>

--- a/src/app/x/components/x-icon/XIcon.vue
+++ b/src/app/x/components/x-icon/XIcon.vue
@@ -41,6 +41,7 @@ import {
   MoreIcon,
   ChevronDownIcon,
   CogIcon,
+  AddIcon,
   HelpIcon,
 } from '@kong/icons'
 import { KTooltip, PopPlacements } from '@kong/kongponents'
@@ -69,6 +70,7 @@ const icons = {
   universal: DeployIcon,
   settings: CogIcon,
   help: HelpIcon,
+  create: AddIcon,
 } as const
 const id = uniqueId('-x-icon-tooltip')
 const slots = useSlots()

--- a/src/app/x/components/x-provider/README.md
+++ b/src/app/x/components/x-provider/README.md
@@ -1,0 +1,3 @@
+# XProvider
+
+A helper for providing Vue's provide/inject functionality around specific slots.

--- a/src/app/x/components/x-provider/XProvider.vue
+++ b/src/app/x/components/x-provider/XProvider.vue
@@ -1,0 +1,13 @@
+<template>
+  <slot name="default" />
+</template>
+<script lang="ts" setup>
+import { provide } from 'vue'
+
+const props = defineProps<{
+  name: string
+  service: Object
+}>()
+provide(props.name, props.service)
+
+</script>

--- a/src/app/x/index.ts
+++ b/src/app/x/index.ts
@@ -1,4 +1,4 @@
-import Kongponents from '@kong/kongponents'
+import Kongponents, { KCard } from '@kong/kongponents'
 
 import XAction from './components/x-action/XAction.vue'
 import XActionGroup from './components/x-action-group/XActionGroup.vue'
@@ -7,6 +7,7 @@ import XCopyButton from './components/x-copy-button/XCopyButton.vue'
 import XDisclosure from './components/x-disclosure/XDisclosure.vue'
 import XIcon from './components/x-icon/XIcon.vue'
 import XInput from './components/x-input/XInput.vue'
+import XProvider from './components/x-provider/XProvider.vue'
 import XSelect from './components/x-select/XSelect.vue'
 import XTabs from './components/x-tabs/XTabs.vue'
 import XTeleportSlot from './components/x-teleport/XTeleportSlot.vue'
@@ -22,8 +23,10 @@ declare module '@vue/runtime-core' {
     XInput: typeof XInput
     XAction: typeof XAction
     XActionGroup: typeof XActionGroup
+    XCard: typeof KCard
     XCopyButton: typeof XCopyButton
     XBreadcrumbs: typeof XBreadcrumbs
+    XProvider: typeof XProvider
     XSelect: typeof XSelect
     XTabs: typeof XTabs
     XTeleportTemplate: typeof XTeleportTemplate
@@ -51,9 +54,11 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
           ['XAction', XAction],
           ['XActionGroup', XActionGroup],
           ['XBreadcrumbs', XBreadcrumbs],
+          ['XCard', KCard],
           ['XCopyButton', XCopyButton],
           ['XIcon', XIcon],
           ['XInput', XInput],
+          ['XProvider', XProvider],
           ['XSelect', XSelect],
           ['XTabs', XTabs],
           ['XTeleportTemplate', XTeleportTemplate],

--- a/src/app/zones-crud/components/ZoneControlPlanesListWithCreate.vue
+++ b/src/app/zones-crud/components/ZoneControlPlanesListWithCreate.vue
@@ -11,26 +11,22 @@
       name: (props.items.length > 0) ? 'control-plane-detail-view-zone-actions' : 'zones-crud-x-empty-state-actions',
     }"
   >
-    <KButton
+    <XAction
+      type="create"
       appearance="primary"
       :to="{ name: 'zone-create-view' }"
     >
-      <AddIcon />
       {{ t('zones-crud.index.create') }}
-    </KButton>
+    </XAction>
   </XTeleportTemplate>
 </template>
 
 <script lang="ts" setup>
-
-import { AddIcon } from '@kong/icons'
-
 import { useI18n } from '@/app/application'
 import ZoneControlPlanesList from '@/app/zones/components/ZoneControlPlanesList.vue'
 import type { ZoneOverview } from '@/app/zones/data'
 
 const { t } = useI18n()
-
 const props = defineProps<{
   items?: ZoneOverview[]
 }>()

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -44,15 +44,14 @@
               v-if="can('create zones') && (data?.items ?? []).length > 0"
               :to="{ name: 'zone-cp-list-view-actions'}"
             >
-              <KButton
+              <XAction
+                type="create"
                 appearance="primary"
                 :to="{ name: 'zone-create-view' }"
                 data-testid="create-zone-link"
               >
-                <AddIcon />
-
                 {{ t('zones.index.create') }}
-              </KButton>
+              </XAction>
             </XTeleportTemplate>
 
             <AppCollection
@@ -235,7 +234,6 @@
 </template>
 
 <script lang="ts" setup>
-import { AddIcon } from '@kong/icons'
 import { ref } from 'vue'
 
 import { sources as zoneSources } from '../sources'


### PR DESCRIPTION
Several improvements to `XAction` and `XActionGroup`

- XActionGroup triggers have a more consistent styling with other applications.
- XAction's have appearance and sizing attributes for customization with KButton's
- I added a new `XProvider` component that lets us add Vue injections in a finer grained way (i.e. around certain slots). We use this to know whether an `XAction` is within a `XActionGroup` or not, but specifically _not_ the trigger/control `XAction`. We only wrap the default slot of `XActionGroup` with `XProvider` so that only buttons within the default slot have access to the injection, the control/trigger slot doesn't.

I used some docs sandboxes for XAction and XAction group to work on these, and I added those in here also.