### PR TITLE
chore: Lint improvements

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -93,6 +93,23 @@ const INLINE_NON_VOID_ELEMENTS = [
     {
       files: ['*.vue'],
       rules: {
+        'vue/attributes-order': ['error', {
+          order: [
+            'DEFINITION',
+            'LIST_RENDERING',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            'UNIQUE',
+            'TWO_WAY_BINDING',
+            'OTHER_DIRECTIVES',
+            'OTHER_ATTR',
+            'EVENTS',
+            'SLOT',
+            'CONTENT',
+          ],
+          alphabetical: false,
+        }],
         'vue/singleline-html-element-content-newline': ['error', {
           ignoreWhenNoAttributes: true,
           ignoreWhenEmpty: true,

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "*.{js,ts,vue}": "make lint/js",
+  "*.{js,ts,vue}": "make -j2 lint/script",
   "*.{css,scss,vue}": "make lint/css",
   "package-lock.json": "make lint/lock"
 }

--- a/features/application/Loading.feature
+++ b/features/application/Loading.feature
@@ -1,5 +1,6 @@
 Feature: application / loading
   # TODO: This test needs fixing it currently console.errors
+
   @skip
   Scenario: Application errors
     Given the environment

--- a/features/application/Titles.feature
+++ b/features/application/Titles.feature
@@ -1,4 +1,5 @@
 Feature: application / titles
+
   Scenario Outline: Visiting the "<Title>" page in "global" Mode
     Given the environment
       """
@@ -8,50 +9,40 @@ Feature: application / titles
     Then the page title contains "<Title>"
 
     Examples:
-      | URL          | Title       |
-      | /            | Overview    |
-      | /diagnostics | Diagnostics |
-
-      | /onboarding                     | Welcome to Kuma!    |
-      | /onboarding/deployment-types    | Deployment Types    |
-      | /onboarding/configuration-types | Configuration Types |
-      | /onboarding/multi-zone          | Multizone           |
-      | /onboarding/create-mesh         | Create the Mesh     |
-      | /onboarding/add-services        | Add new services    |
-      | /onboarding/add-services-code   | Add new services    |
-      | /onboarding/dataplanes-overview | Data plane overview |
-      | /onboarding/completed           | Completed           |
-
-      | /zones/-create                                           | Create & connect Zone |
-      | /zones                                                   | Zone Control Planes   |
-      | /zones/zone-cp-name/overview                             | zone-cp-name          |
-      | /zones/zone-cp-name/ingresses                            | Ingresses             |
-      | /zones/zone-cp-name/ingresses/zone-ingress-name/overview | zone-ingress-name     |
-      | /zones/zone-cp-name/egresses                             | Egresses              |
-      | /zones/zone-cp-name/egresses/zone-egress-name/overview   | zone-egress-name      |
-
-      | /meshes                  | Meshes        |
-      | /meshes/default/overview | Mesh overview |
-
-      | /meshes/default/services/internal                       | Services     |
-      | /meshes/default/services/internal/service-name/overview | service-name |
-
-      | /meshes/default/services/external                       | External Services |
-      | /meshes/default/services/external/service-name/overview | service-name      |
-
-      | /meshes/default/services/mesh-services                  | Mesh Services     |
-
-      | /meshes/default/gateways/builtin                  | Built-in Gateways |
-      | /meshes/default/gateways/builtin/gateway/overview | gateway           |
-
-      | /meshes/default/gateways/delegated                  | Delegated Gateways |
-      | /meshes/default/gateways/delegated/gateway/overview | gateway            |
-
-      | /meshes/default/data-planes                          | Data Plane Proxies |
-      | /meshes/default/data-planes/data-plane-name/overview | data-plane-name    |
-
-      | /meshes/default/policies/circuit-breakers                    | Policies  |
-      | /meshes/default/policies/circuit-breakers/program-0/overview | program-0 |
+      | URL                                                          | Title                 |
+      | /                                                            | Overview              |
+      | /diagnostics                                                 | Diagnostics           |
+      | /onboarding                                                  | Welcome to Kuma!      |
+      | /onboarding/deployment-types                                 | Deployment Types      |
+      | /onboarding/configuration-types                              | Configuration Types   |
+      | /onboarding/multi-zone                                       | Multizone             |
+      | /onboarding/create-mesh                                      | Create the Mesh       |
+      | /onboarding/add-services                                     | Add new services      |
+      | /onboarding/add-services-code                                | Add new services      |
+      | /onboarding/dataplanes-overview                              | Data plane overview   |
+      | /onboarding/completed                                        | Completed             |
+      | /zones/-create                                               | Create & connect Zone |
+      | /zones                                                       | Zone Control Planes   |
+      | /zones/zone-cp-name/overview                                 | zone-cp-name          |
+      | /zones/zone-cp-name/ingresses                                | Ingresses             |
+      | /zones/zone-cp-name/ingresses/zone-ingress-name/overview     | zone-ingress-name     |
+      | /zones/zone-cp-name/egresses                                 | Egresses              |
+      | /zones/zone-cp-name/egresses/zone-egress-name/overview       | zone-egress-name      |
+      | /meshes                                                      | Meshes                |
+      | /meshes/default/overview                                     | Mesh overview         |
+      | /meshes/default/services/internal                            | Services              |
+      | /meshes/default/services/internal/service-name/overview      | service-name          |
+      | /meshes/default/services/external                            | External Services     |
+      | /meshes/default/services/external/service-name/overview      | service-name          |
+      | /meshes/default/services/mesh-services                       | Mesh Services         |
+      | /meshes/default/gateways/builtin                             | Built-in Gateways     |
+      | /meshes/default/gateways/builtin/gateway/overview            | gateway               |
+      | /meshes/default/gateways/delegated                           | Delegated Gateways    |
+      | /meshes/default/gateways/delegated/gateway/overview          | gateway               |
+      | /meshes/default/data-planes                                  | Data Plane Proxies    |
+      | /meshes/default/data-planes/data-plane-name/overview         | data-plane-name       |
+      | /meshes/default/policies/circuit-breakers                    | Policies              |
+      | /meshes/default/policies/circuit-breakers/program-0/overview | program-0             |
 
   Scenario Outline: Visiting the "<Title>" page in "zone" Mode
     Given the environment

--- a/features/application/Upgrade.feature
+++ b/features/application/Upgrade.feature
@@ -1,12 +1,13 @@
 Feature: application / upgrade
+
   Background:
     Given the CSS selectors
       | Alias         | Selector                      |
       | upgrade-check | [data-testid='upgrade-check'] |
     And the environment
-    """
-      KUMA_VERSION: 2.0.0
-    """
+      """
+        KUMA_VERSION: 2.0.0
+      """
 
   Scenario: There is a new version available
     When I visit the "/" URL

--- a/features/application/Warnings.feature
+++ b/features/application/Warnings.feature
@@ -1,4 +1,5 @@
 Feature: application / warnings
+
   Background:
     Given the CSS selectors
       | Alias                     | Selector                                         |
@@ -19,4 +20,3 @@ Feature: application / warnings
       """
     When I visit the "/" URL
     Then the "$memory-store-type-warning" element doesn't exist
-

--- a/features/diagnostics/DetailViewContent.feature
+++ b/features/diagnostics/DetailViewContent.feature
@@ -1,4 +1,5 @@
 Feature: Diagnostics: Detail view content
+
   Background:
     Given the CSS selectors
       | Alias                         | Selector                                |
@@ -12,7 +13,6 @@ Feature: Diagnostics: Detail view content
       """
       KUMA_MODE: global
       """
-
     When I visit the "/diagnostics" URL
     Then the page title contains "Diagnostics"
     Then the "$details" element contains ""mode": "global""
@@ -20,25 +20,17 @@ Feature: Diagnostics: Detail view content
 
   Scenario: Reads code search value from URL
     When I visit the "/diagnostics?codeSearch=(groups%257Cusers)&codeRegExp&codeFilter" URL
-
     Then the "$code-block-search-input" element contains "(groups|users)"
     And the "$code-block-regexp-mode-button[aria-pressed='true']" element exists
     And the "$code-block-filter-mode-button[aria-pressed='true']" element exists
 
   Scenario: Stores code search value in URL
     When I visit the "/diagnostics" URL
-
     Then the "$code-block-regexp-mode-button[aria-pressed='true']" element doesn't exist
     And the "$code-block-filter-mode-button[aria-pressed='true']" element doesn't exist
-
     When I "input" "(groups|users)" into the "$code-block-search-input" element
-
     Then the URL contains "/diagnostics?codeSearch=(groups%257Cusers)"
-
     When I click the "$code-block-regexp-mode-button" element
-
     Then the URL contains "/diagnostics?codeSearch=(groups%257Cusers)&codeRegExp"
-
     When I click the "$code-block-filter-mode-button" element
-
     Then the URL contains "/diagnostics?codeSearch=(groups%257Cusers)&codeRegExp&codeFilter"

--- a/features/docs/Index.feature
+++ b/features/docs/Index.feature
@@ -1,6 +1,7 @@
 # Don't remove this @skip, comment to run the test/screenshotter.
 @skip
 Feature: docs / index
+
   Background:
     Given the environment
       """
@@ -12,13 +13,14 @@ Feature: docs / index
       KUMA_SERVICE_COUNT: 30
       KUMA_DATAPLANE_COUNT: 300
       """
+
   Scenario: Screenshot onboarding
     When I visit the "/onboarding/welcome" URL
     And I wait for 500 ms
     Then screenshot the ".background-image" element to "onboarding"
-
 # Don't remove this comment, uncomment for test.only.
 # @only
+
   Scenario: Screenshot mesh overview
     Given the URL "/mesh-insights" responds with
       """
@@ -67,64 +69,63 @@ Feature: docs / index
     Then screenshot the "#app" element to "dataplane-config"
 
   Scenario: Screenshot dataplane policies
-  Given the environment
-    """
-    KUMA_DATAPLANE_PROXY_RULE_ENABLED: false
-    KUMA_DATAPLANE_RULE_COUNT: 2
-    KUMA_DATAPLANE_TO_RULE_COUNT: 2
-    KUMA_DATAPLANE_FROM_RULE_COUNT: 0
-    """
-  And the URL "/meshes/default/dataplanes/redis-cdccdb4a9b-qjcjs.driver.kuma-system-proxy-0/_rules" responds with
-    """
-    body:
-      rules:
-        - type: MeshHTTPRoute
-          toRules:
-            - matchers:
-                - key: kuma.io/service
-                  not: false
-                  value: other-svc
-              origin:
-                - mesh: default
-                  name: the-other-http-route
-                  type: MeshHTTPRoute
-            - matchers:
-                - key: kuma.io/service
-                  not: false
-                  value: backend_kuma-demo_svc_3001
-              origin:
-                - mesh: default
-                  name: the-http-route
-                  type: MeshHTTPRoute
-        - type: MeshTimeout
-          toRules:
-            - matchers:
-                - key: __rule-matches-hash__
-                  not: false
-                  value: waFsoIISmZDTfFWYqxvY265/GASHYEWvHQTwMh/bpuU=
-                - key: kuma.io/service
-                  not: false
-                  value: backend_kuma-demo_svc_3001
-              origin:
-                - mesh: default
-                  name: on-route
-                  type: MeshTimeout
-                - mesh: default
-                  name: on-service
-                  type: MeshTimeout
-            - matchers:
-                - key: __rule-matches-hash__
-                  not: true
-                  value: waFsoIISmZDTfFWYqxvY265/GASHYEWvHQTwMh/bpuU=
-                - key: kuma.io/service
-                  not: false
-                  value: backend_kuma-demo_svc_3001
-              origin:
-                - mesh: default
-                  name: on-service
-                  type: MeshTimeout
-    """
-
+    Given the environment
+      """
+      KUMA_DATAPLANE_PROXY_RULE_ENABLED: false
+      KUMA_DATAPLANE_RULE_COUNT: 2
+      KUMA_DATAPLANE_TO_RULE_COUNT: 2
+      KUMA_DATAPLANE_FROM_RULE_COUNT: 0
+      """
+    And the URL "/meshes/default/dataplanes/redis-cdccdb4a9b-qjcjs.driver.kuma-system-proxy-0/_rules" responds with
+      """
+      body:
+        rules:
+          - type: MeshHTTPRoute
+            toRules:
+              - matchers:
+                  - key: kuma.io/service
+                    not: false
+                    value: other-svc
+                origin:
+                  - mesh: default
+                    name: the-other-http-route
+                    type: MeshHTTPRoute
+              - matchers:
+                  - key: kuma.io/service
+                    not: false
+                    value: backend_kuma-demo_svc_3001
+                origin:
+                  - mesh: default
+                    name: the-http-route
+                    type: MeshHTTPRoute
+          - type: MeshTimeout
+            toRules:
+              - matchers:
+                  - key: __rule-matches-hash__
+                    not: false
+                    value: waFsoIISmZDTfFWYqxvY265/GASHYEWvHQTwMh/bpuU=
+                  - key: kuma.io/service
+                    not: false
+                    value: backend_kuma-demo_svc_3001
+                origin:
+                  - mesh: default
+                    name: on-route
+                    type: MeshTimeout
+                  - mesh: default
+                    name: on-service
+                    type: MeshTimeout
+              - matchers:
+                  - key: __rule-matches-hash__
+                    not: true
+                    value: waFsoIISmZDTfFWYqxvY265/GASHYEWvHQTwMh/bpuU=
+                  - key: kuma.io/service
+                    not: false
+                    value: backend_kuma-demo_svc_3001
+                origin:
+                  - mesh: default
+                    name: on-service
+                    type: MeshTimeout
+      """
     When I visit the "/meshes/default/data-planes/redis-cdccdb4a9b-qjcjs.driver.kuma-system-proxy-0/policies" URL
     And I click the "[data-testid='to-rule-list'] li:nth-child(1) button" element
     And the ".policy-list" element exists

--- a/features/mesh/Item.feature
+++ b/features/mesh/Item.feature
@@ -1,4 +1,5 @@
 Feature: mesh / item
+
   Background:
     Given the CSS selectors
       | Alias         | Selector                        |

--- a/features/mesh/builtin-gateways/Item.feature
+++ b/features/mesh/builtin-gateways/Item.feature
@@ -1,4 +1,5 @@
 Feature: mesh / builtin-gateways / item
+
   Background:
     Given the CSS selectors
       | Alias         | Selector                                         |
@@ -108,45 +109,36 @@ Feature: mesh / builtin-gateways / item
 
   Scenario: Overview tab has expected content
     When I visit the "/meshes/default/gateways/builtin/gateway-1/overview" URL
-
     Then the URL contains "/builtin/gateway-1/overview?listener=0"
     Then the "$tabs-view" element contains "gateway-1"
     Then the "$listener-card" element exists 2 times
     Then the "$route-card" element exists 2 times
-
     Then the "$listener-card:nth-child(1).active" element exists
     Then the "$listener-card:nth-child(1)" element contains "*:80"
     Then the "$listener-card:nth-child(2)" element contains "bar.com:81"
     Then the "$listener-card:nth-child(2)" element contains "TLS"
     Then the "$listener-card:nth-child(2)" element contains "TERMINATE"
-
     Then the "$route-card:nth-child(1)" element contains "demo-app-1.kuma-system"
     Then the "$route-card:nth-child(1)" element contains "service-1"
     Then the "$route-card:nth-child(2)" element contains "demo-app-3.kuma-system"
     Then the "$route-card:nth-child(2)" element contains "service-2"
-
     When I click the "$listener-card:nth-child(2) [data-action]" element
-
     Then the URL contains "/builtin/gateway-1/overview?listener=1"
     Then the "$route-card" element exists 1 times
-
     Then the "$listener-card:nth-child(2).active" element exists
     Then the "$route-card:nth-child(1)" element contains "demo-app-3.kuma-system"
     Then the "$route-card:nth-child(1)" element contains "service-2"
 
   Scenario: Navigate to overview with non-first selected listener
     When I visit the "/meshes/default/gateways/builtin/gateway-1/overview?listener=1" URL
-
     Then the "$listener-card:nth-child(2).active" element exists
     Then the "$route-card:nth-child(1)" element contains "demo-app-3.kuma-system"
     Then the "$route-card:nth-child(1)" element contains "service-2"
 
   Scenario: Dataplanes tab has expected content
     When I visit the "/meshes/default/gateways/builtin/gateway-1/dataplanes" URL
-
     Then the "$dataplanes" element exists
 
   Scenario: Config tab has expected content
     When I visit the "/meshes/default/gateways/builtin/gateway-1/config" URL
-
     Then the "$config" element exists

--- a/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
@@ -1,4 +1,5 @@
 Feature: Dataplane details for built-in gateway
+
   Background:
     Given the CSS selectors
       | Alias             | Selector                                                           |
@@ -46,15 +47,13 @@ Feature: Dataplane details for built-in gateway
                 envoy:
                   kumaDpCompatible: true
       """
-
     When I visit the "/meshes/default/data-planes/dataplane-gateway_builtin-1/overview" URL
-
     Then the page title contains "dataplane-gateway_builtin-1"
     And the "$detail-view" element contains "dataplane-gateway_builtin-1"
     And the "$details" element contains
       | Value                 |
       | online                |
-      | 193.107.134.106       |
+      |       193.107.134.106 |
       | kuma.io/protocol:http |
       | kuma.io/zone:zone-1   |
     And the "$warnings" element doesn't exist
@@ -82,13 +81,9 @@ Feature: Dataplane details for built-in gateway
           TrafficTrace:
             name: traffic-trace-1
       """
-
     When I visit the "/meshes/default/data-planes/dataplane-gateway_builtin-1/policies" URL
-
     Then the "$policies-view" element contains "traffic-log-1"
     And the "$policies-view" element contains "traffic-trace-1"
-
     When I click the "$route-item-button" element
-
     Then the "$policies-view" element contains "circuit-breaker-1"
     And the "$policies-view" element contains "demo-app_kuma-demo_svc_5000"

--- a/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
@@ -1,4 +1,5 @@
 Feature: Dataplane details for delegated gateway
+
   Background:
     Given the CSS selectors
       | Alias       | Selector                                    |
@@ -43,15 +44,13 @@ Feature: Dataplane details for delegated gateway
                 envoy:
                   kumaDpCompatible: true
       """
-
     When I visit the "/meshes/default/data-planes/dataplane-gateway_delegated-1/overview" URL
-
     Then the page title contains "dataplane-gateway_delegated-1"
     And the "$detail-view" element contains "dataplane-gateway_delegated-1"
     And the "$details" element contains
       | Value                 |
       | online                |
-      | 193.107.134.106       |
+      |       193.107.134.106 |
       | kuma.io/protocol:http |
       | kuma.io/zone:zone-1   |
     And the "$warnings" element doesn't exist

--- a/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
@@ -1,4 +1,5 @@
 Feature: Dataplane details for standard Data Plane Proxy
+
   Background:
     Given the CSS selectors
       | Alias         | Selector                                    |
@@ -77,33 +78,29 @@ Feature: Dataplane details for standard Data Plane Proxy
                 envoy:
                   kumaDpCompatible: true
       """
-
     When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/overview" URL
-
     Then the page title contains "dpp-1-name-of-dataplane"
     And the "$detail-view" element contains "dpp-1-name-of-dataplane"
     And the "$details" element contains "online"
-
     When I click the ".accordion-item:nth-child(1) [data-testid='accordion-item-button']" element
-
     Then the "$status-cds" element contains
       | Value |
       | CDS   |
-      | 1     |
-      | 2     |
+      |     1 |
+      |     2 |
     And the "$status-eds" element contains
       | Value |
       | EDS   |
-      | 3     |
-      | 4     |
+      |     3 |
+      |     4 |
     And the "$status-lds" element contains
       | Value |
       | LDS   |
-      | 6     |
+      |     6 |
     And the "$status-rds" element contains
       | Value |
       | RDS   |
-      | 0     |
+      |     0 |
 
   Scenario: Clusters tab has expected content
     Given the URL "/meshes/default/dataplanes/dpp-1-name-of-dataplane/clusters" responds with
@@ -114,7 +111,5 @@ Feature: Dataplane details for standard Data Plane Proxy
         access_log_sink::default_priority::max_pending_requests::1024
         access_log_sink::default_priority::max_requests::1024
       """
-
     When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/clusters" URL
-
     Then the "$clusters-view" element contains "access_log_sink::observability_name::access_log_sink"

--- a/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
+++ b/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
@@ -1,4 +1,5 @@
 Feature: mesh / dataplanes / DataplaneDetailsTraffic
+
   Background:
     Given the CSS selectors
       | Alias           | Selector                                            |
@@ -20,9 +21,7 @@ Feature: mesh / dataplanes / DataplaneDetailsTraffic
           networking:
             gateway: !!js/undefined
       """
-
     When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/overview" URL
-
     And the "$detail-view" element contains "dpp-1-name-of-dataplane"
     And the "$traffic" element exists
 
@@ -39,7 +38,6 @@ Feature: mesh / dataplanes / DataplaneDetailsTraffic
           networking:
             gateway: !!js/undefined
       """
-
     When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/overview" URL
     Then the "$detail-view" element contains "dpp-1-name-of-dataplane"
     And the "$traffic" element exists

--- a/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/features/mesh/dataplanes/DataplanePolicies.feature
@@ -1,4 +1,5 @@
 Feature: Dataplane policies
+
   Background:
     Given the CSS selectors
       | Alias                              | Selector                                                            |
@@ -18,6 +19,7 @@ Feature: Dataplane policies
       | from-rule-item                     | [data-testid='from-rule-list-0'] .accordion-item                    |
       | from-rule-item-button              | $from-rule-item:nth-child(1) [data-testid='accordion-item-button']  |
       | summary-slideout-container         | [data-testid='summary'] [data-testid='slideout-container']          |
+
   Rule: Any networking type
 
     Scenario: Policies tab has expected content (MeshHTTPRoute with to rules)
@@ -78,19 +80,13 @@ Feature: Dataplane policies
                       name: on-service
                       type: MeshTimeout
         """
-
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
-
       Then the "$policies-view" element contains "MeshHTTPRoute"
       And the "$policies-view" element contains "MeshTimeout"
-
       When I click the "$to-rule-item:nth-child(1) [data-testid='accordion-item-button']" element
-
       Then the "$to-rule-item:nth-child(1)" element contains "kuma.io/service:other-svc"
       And the "$to-rule-item:nth-child(1)" element contains "kuma.io/service:backend_kuma-demo_svc_3001"
-
       When I click the "$to-rule-item:nth-child(2) [data-testid='accordion-item-button']" element
-
       Then the "$to-rule-item:nth-child(2)" element contains "__rule-matches-hash__:waFsoIISmZDTfFWYqxvY265/GASHYEWvHQTwMh/bpuU= and"
       Then the "$to-rule-item:nth-child(2)" element contains "kuma.io/service:backend_kuma-demo_svc_3001"
       And the "$to-rule-item:nth-child(2)" element contains "!__rule-matches-hash__:waFsoIISmZDTfFWYqxvY265/GASHYEWvHQTwMh/bpuU= and"
@@ -184,7 +180,6 @@ Feature: Dataplane policies
                     http:
                       requestTimeout: 10s
         """
-
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
       Then the "$policies-view" element contains "MeshTimeout"
       When I click the "$to-rule-item:nth-child(1) [data-testid='accordion-item-button']" element
@@ -242,7 +237,7 @@ Feature: Dataplane policies
       Then the "$proxy-rule-item:nth-child(1)" element contains "mpp-on-gateway"
       When I click the "$to-rule-item:nth-child(1) [data-testid='accordion-item-button']" element
       Then the "$to-rule-item:nth-child(1)" element contains "!kuma.io/service:bar"
-    
+
     Scenario: The origin policies link in the policies rules' policy list opens the policy summary panel
       Given the environment
         """
@@ -276,8 +271,8 @@ Feature: Dataplane policies
       And the "$summary-slideout-container [data-testid='slideout-title']" element exists
       And the "$summary-slideout-container [data-testid='slideout-title'] h2 a" element contains "the-other-http-route"
 
-
   Rule: Standard proxy
+
     Background:
       Given the environment
         """
@@ -306,6 +301,7 @@ Feature: Dataplane policies
       And the "$legacy-gateway-policies" element doesn't exist
 
   Rule: Delegated gateway
+
     Background:
       Given the environment
         """
@@ -322,16 +318,15 @@ Feature: Dataplane policies
       Then the "$to-rules" element exists
       And the "$legacy-sidecar-policies" element doesn't exist
       And the "$legacy-gateway-policies" element doesn't exist
-
     # We repeat the same test as the one before but with an omitted so we can test
     # an omitted gateway.type. If we ever stop folks accessing gateway.type and rely on the
     # data layer unit test for this instead, we can remove this test.
+
     Scenario: Federated (with a default/delegated type) shows the rules but no legacy content
       Given the environment
         """
         KUMA_MODE: global
         """
-
       And the URL "/meshes/default/dataplanes/dataplane-1/_overview" responds with
         """
         body:
@@ -356,6 +351,7 @@ Feature: Dataplane policies
       And the "$legacy-gateway-policies" element doesn't exist
 
   Rule: Built-in gateway
+
     Background:
       Given the environment
         """

--- a/features/mesh/dataplanes/DataplanePolicySummary.feature
+++ b/features/mesh/dataplanes/DataplanePolicySummary.feature
@@ -1,11 +1,12 @@
 Feature: Dataplane policy summary
+
   Background:
     Given the CSS selectors
       | Alias                      | Selector                                                                   |
       | summary-slideout-container | [data-testid='summary'] [data-testid='slideout-container']                 |
       | summary-title              | $summary-slideout-container [data-testid='slideout-title']                 |
       | summary-content            | $summary-slideout-container [data-testid='data-plane-policy-summary-view'] |
-  
+
   Scenario: Policy Summary View has expected content
     Given the URL "/meshes/default/meshhttproutes/the-other-http-route" responds with
       """
@@ -39,7 +40,6 @@ Feature: Dataplane policy summary
       """
     When I visit the "/meshes/default/data-planes/dataplane-1/policies/meshhttproutes/the-other-http-route" URL
     Then the "[data-testid='data-plane-policies-view']" element exists
-    
     Then the "$summary-slideout-container" element exists
     And the "$summary-title" element contains "the-other-http-route"
     And the "$summary-content" element contains "Target Ref"

--- a/features/mesh/dataplanes/DataplaneSummary.feature
+++ b/features/mesh/dataplanes/DataplaneSummary.feature
@@ -1,4 +1,5 @@
 Feature: Dataplane summary
+
   Background:
     Given the CSS selectors
       | Alias                | Selector                                       |
@@ -22,26 +23,21 @@ Feature: Dataplane summary
       """
       KUMA_DATAPLANE_COUNT: 1
       """
-
     When I visit the "/meshes/default/data-planes" URL
     And I click the "$item:nth-child(1) td:nth-child(2)" element
     Then the "$summary" element exists
     And the "$summary" element contains "test-data-plane-1"
-
     When I click the "$close-summary-button" element
     Then the "$summary" element doesn't exist
-
     When I navigate "back"
     Then the "$summary" element exists
     And the "$summary" element contains "test-data-plane-1"
-
     When I navigate "forward"
     Then the "$summary" element doesn't exist
 
   Scenario: Summary has expected content
     When I visit the "/meshes/default/data-planes" URL
     And I click the "$item:nth-child(1) td:nth-child(2)" element
-
     Then the "$summary" element contains "Feb 18, 2021"
 
   Scenario: Summary URL goes to page with open dataplane summary
@@ -49,6 +45,5 @@ Feature: Dataplane summary
       """
       KUMA_DATAPLANE_COUNT: 51
       """
-
     When I visit the "/meshes/default/data-planes/test-data-plane-1?page=2&size=50" URL
     Then the "$summary" element exists

--- a/features/mesh/dataplanes/Index.feature
+++ b/features/mesh/dataplanes/Index.feature
@@ -1,4 +1,5 @@
 Feature: mesh / dataplanes / index
+
   Background:
     Given the CSS selectors
       | Alias            | Selector                              |
@@ -46,12 +47,10 @@ Feature: mesh / dataplanes / index
 
   Scenario: The Proxy listing table has the correct columns
     When I visit the "/meshes/default/data-planes" URL
-
     Then the "$table-header" element exists 9 times
 
   Scenario: The Proxy listing has the expected content and UI elements
     When I visit the "/meshes/default/data-planes" URL
-
     Then the "$item" element exists 9 times
     Then the "$item:nth-child(1)" element contains
       | Value                |
@@ -90,9 +89,7 @@ Feature: mesh / dataplanes / index
                   disconnectTime: 2021-02-17T07:33:36.412683Z
       """
     When I visit the "/meshes/default/data-planes" URL
-
     Then the "$service-cell" element is empty
-
     Then the "$item:nth-child(1)" element contains
       | Value          |
       | dpp-2          |
@@ -100,6 +97,7 @@ Feature: mesh / dataplanes / index
       | offline        |
 
   Rule: The listing can be filtered by type
+
     Scenario: Filtering by "builtin"
       Given the environment
         """
@@ -118,12 +116,9 @@ Feature: mesh / dataplanes / index
                     tags:
                       kuma.io/service: service-1
         """
-
       When I visit the "/meshes/default/data-planes" URL
       And I click the "$select-type" element
-
       Then the "$select-option" element exists 4 times
-
       When I click the "$select-builtin" element
       Then the URL "/meshes/default/dataplanes/_overview" was requested with
         """
@@ -154,12 +149,9 @@ Feature: mesh / dataplanes / index
                     tags:
                       kuma.io/service: service-1
         """
-
       When I visit the "/meshes/default/data-planes" URL
       And I click the "$select-type" element
-
       Then the "$select-option" element exists 4 times
-
       When I click the "$select-delegated" element
       Then the URL "/meshes/default/dataplanes/_overview" was requested with
         """
@@ -186,12 +178,9 @@ Feature: mesh / dataplanes / index
                 networking:
                   gateway: !!js/undefined
         """
-
       When I visit the "/meshes/default/data-planes" URL
       And I click the "$select-type" element
-
       Then the "$select-option" element exists 4 times
-
       When I click the "$select-standard" element
       Then the URL "/meshes/default/dataplanes/_overview" was requested with
         """

--- a/features/mesh/dataplanes/NoSubscriptions.feature
+++ b/features/mesh/dataplanes/NoSubscriptions.feature
@@ -1,4 +1,5 @@
 Feature: dataplanes / no-subscriptions
+
   Scenario: When there are no subscription I don't get an error
     Given the CSS selectors
       | Alias            | Selector                                    |
@@ -18,7 +19,6 @@ Feature: dataplanes / no-subscriptions
               - health:
                   ready: true
       """
-
     When I visit the "/meshes/default/data-planes/backend/overview" URL
     And the "$detail-view" element contains "backend"
     And the "$overview-content" element contains "offline"

--- a/features/mesh/dataplanes/Warnings.feature
+++ b/features/mesh/dataplanes/Warnings.feature
@@ -1,4 +1,5 @@
 Feature: mesh / dataplanes / warnings
+
   Background:
     Given the CSS selectors
       | Alias                     | Selector                                                          |
@@ -61,7 +62,6 @@ Feature: mesh / dataplanes / warnings
               - tags:
                   kuma.io/zone: zone
       """
-
     When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$unsupported-zone-warning" element exists
 
@@ -81,7 +81,6 @@ Feature: mesh / dataplanes / warnings
                 envoy:
                   kumaDpCompatible: true
       """
-
     When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$unsupported-kuma-warning" element exists
 
@@ -101,6 +100,5 @@ Feature: mesh / dataplanes / warnings
                 envoy:
                   kumaDpCompatible: false
       """
-
     When I visit the "/meshes/default/data-planes/dpp-1/overview" URL
     Then the "$unsupported-envoy-warning" element exists

--- a/features/mesh/dataplanes/overview/Connections.feature
+++ b/features/mesh/dataplanes/overview/Connections.feature
@@ -1,4 +1,5 @@
 Feature: mesh / dataplanes / connections / Connections
+
   Background:
     Given the CSS selectors
       | Alias       | Selector                                    |
@@ -6,7 +7,6 @@ Feature: mesh / dataplanes / connections / Connections
       | traffic     | [data-testid='dataplane-traffic']           |
       | inbound     | [data-testid='dataplane-inbound']           |
       | outbound    | [data-testid='dataplane-outbound']          |
-
   # IMPORTANT: These tests use fixtures rather than random mocks. If they
   # become troublesome to maintain or work with, feel free to replace with
   # something else. They were originally added to give confidence through
@@ -14,11 +14,9 @@ Feature: mesh / dataplanes / connections / Connections
 
   Scenario: Builtin gateway with inbound and outbound stats
     When I visit the "/meshes/default/data-planes/default-gateway-instance-1-86cbb55644-6rxhg.kuma-demo/overview" URL
-
     And the "$detail-view" element contains "default-gateway-instance-1-86cbb55644-6rxhg"
     And the "$inbound" element exists 4 times
     And the "$outbound" element exists 3 times
-
     And the "$inbound:nth-child(1) [data-testid='connections-total'] dd" element contains "1"
     And the "$inbound:nth-child(2) [data-testid='connections-total'] dd" element contains "0"
     And the "$inbound:nth-child(3) [data-testid='rq-2xx'] dd" element contains "691"
@@ -28,7 +26,6 @@ Feature: mesh / dataplanes / connections / Connections
     And the "$inbound:nth-child(4) [data-testid='rq-2xx'] dd" element contains "2"
     And the "$inbound:nth-child(4) [data-testid='rq-4xx'] dd" element contains "0"
     And the "$inbound:nth-child(4) [data-testid='rq-5xx'] dd" element contains "0"
-
     And the "$outbound:nth-child(1) [data-testid='rq-2xx'] dd" element contains "355"
     And the "$outbound:nth-child(1) [data-testid='rq-3xx'] dd" element contains "4"
     And the "$outbound:nth-child(1) [data-testid='rq-4xx'] dd" element contains "0"
@@ -42,50 +39,39 @@ Feature: mesh / dataplanes / connections / Connections
 
   Scenario: Delegated gateway with inbound and outbound stats
     When I visit the "/meshes/default/data-planes/kong-gateway-5bcc776cb4-578gc.kong/overview" URL
-
     And the "$detail-view" element contains "kong-gateway-5bcc776cb4-578gc"
     And the "$inbound" element exists 0 times
     And the "$outbound" element exists 1 times
-
     And the "$outbound:nth-child(1) [data-testid='rq-2xx'] dd" element contains "722"
     And the "$outbound:nth-child(1) [data-testid='rq-4xx'] dd" element contains "1"
     And the "$outbound:nth-child(1) [data-testid='rq-5xx'] dd" element contains "0"
 
   Scenario: HTTP sidecar with inbound and outbound stats
     When I visit the "/meshes/default/data-planes/demo-app-fcc8bc4cb-5xjwd.kuma-demo/overview" URL
-
     And the "$detail-view" element contains "demo-app-fcc8bc4cb-5xjwd"
     And the "$inbound" element exists 1 time
     And the "$outbound" element exists 1 time
-
     And the "$inbound:nth-child(1) [data-testid='rq-2xx'] dd" element contains "4,614"
     And the "$inbound:nth-child(1) [data-testid='rq-3xx'] dd" element contains "17"
     And the "$inbound:nth-child(1) [data-testid='rq-4xx'] dd" element contains "3"
     And the "$inbound:nth-child(1) [data-testid='rq-5xx'] dd" element contains "0"
-
     And the "$outbound:nth-child(1) [data-testid='connections-total'] dd" element contains "4,608"
     And the "$outbound:nth-child(1) [data-testid='bytes-received'] dd" element contains "359"
     And the "$outbound:nth-child(1) [data-testid='bytes-sent'] dd" element contains "24.8"
 
   Scenario: gRPC sidecar with inbound and outbound stats
     When I visit the "/meshes/default/data-planes/grpc-service-75b4ccdfd5-z2jmp.kuma-demo/overview" URL
-
     And the "$detail-view" element contains "grpc-service-75b4ccdfd5-z2jmp"
     And the "$inbound" element exists 1 time
     And the "$outbound" element exists 0 times
-
     And the "$inbound:nth-child(1) [data-testid='grpc-success'] dd" element contains "16"
     And the "$inbound:nth-child(1) [data-testid='grpc-failure'] dd" element contains "0"
 
   Scenario: TCP sidecar with inbound and outbound stats
     When I visit the "/meshes/default/data-planes/redis-54754f5b57-xl2tw.kuma-demo/overview" URL
-
     And the "$detail-view" element contains "redis-54754f5b57-xl2tw"
     And the "$inbound" element exists 1 time
     And the "$outbound" element exists 0 times
-
     And the "$inbound:nth-child(1) [data-testid='connections-total'] dd" element contains "4,953"
     And the "$inbound:nth-child(1) [data-testid='bytes-received'] dd" element contains "26.6"
     And the "$inbound:nth-child(1) [data-testid='bytes-sent'] dd" element contains "390"
-
-

--- a/features/mesh/dataplanes/overview/Inbounds.feature
+++ b/features/mesh/dataplanes/overview/Inbounds.feature
@@ -1,4 +1,5 @@
 Feature: mesh / dataplanes / connections / Inbounds
+
   Background:
     Given the CSS selectors
       | Alias       | Selector                                    |
@@ -22,7 +23,6 @@ Feature: mesh / dataplanes / connections / Inbounds
               - port: 49151
       """
     When I visit the "/meshes/default/data-planes/service-less/overview" URL
-
     And the "$detail-view" element contains "service-less"
     And the "$traffic" element exists
     And the "$inbound" element exists 0 times
@@ -33,8 +33,6 @@ Feature: mesh / dataplanes / connections / Inbounds
       KUMA_DATAPLANE_TYPE: delegated
       """
     When I visit the "/meshes/default/data-planes/delegated/overview" URL
-
     And the "$detail-view" element contains "delegated"
     And the "$traffic" element exists
     And the "$inbound" element exists 0 times
-

--- a/features/mesh/delegated-gateways/Item.feature
+++ b/features/mesh/delegated-gateways/Item.feature
@@ -1,4 +1,5 @@
 Feature: mesh / delegated-gateways / item
+
   Background:
     Given the CSS selectors
       | Alias       | Selector                                           |
@@ -19,10 +20,9 @@ Feature: mesh / delegated-gateways / item
 
   Scenario: Overview tab has expected content
     When I visit the "/meshes/default/gateways/delegated/service-1/overview" URL
-
     Then the "$tabs-view" element contains "service-1"
     Then the "$detail-view" elements contain
       | Value              |
-      | 1.2.3.4:8000       |
-      | 1 / 2              |
+      |       1.2.3.4:8000 |
+      |              1 / 2 |
       | partially degraded |

--- a/features/mesh/external-services/Item.feature
+++ b/features/mesh/external-services/Item.feature
@@ -1,4 +1,5 @@
 Feature: mesh / external-services / item
+
   Background:
     Given the CSS selectors
       | Alias       | Selector                                     |
@@ -14,7 +15,6 @@ Feature: mesh / external-services / item
 
   Scenario: Overview tab has expected content
     When I visit the "/meshes/default/services/external/service-1/overview" URL
-
     Then the "$detail-view" element contains "service-1"
     Then the "$details" element contains "1.2.3.4"
     Then the "$config" element contains "1.2.3.4"

--- a/features/onboarding/Index.feature
+++ b/features/onboarding/Index.feature
@@ -1,4 +1,5 @@
 Feature: onboarding / index
+
   Background:
     Given the CSS selectors
       | Alias                   | Selector                                |
@@ -41,6 +42,7 @@ Feature: onboarding / index
     When I visit the "<URL>" URL
     Then I click the "$skip-button" element
     Then the URL is "/"
+
     Examples:
       | URL                             |
       | /onboarding/welcome             |

--- a/features/onboarding/add-new-services-code/Index.feature
+++ b/features/onboarding/add-new-services-code/Index.feature
@@ -1,4 +1,5 @@
 Feature: onboarding / add-new-services-code / index
+
   Background:
     Given the CSS selectors
       | Alias           | Selector                               |

--- a/features/onboarding/add-new-services/Index.feature
+++ b/features/onboarding/add-new-services/Index.feature
@@ -1,4 +1,5 @@
 Feature: onboarding / add-new-services / index
+
   Background:
     Given the CSS selectors
       | Alias           | Selector                            |

--- a/features/onboarding/configuration-types/Index.feature
+++ b/features/onboarding/configuration-types/Index.feature
@@ -1,8 +1,10 @@
 Feature: onboarding / configuration-types / index
+
   Background:
     Given the CSS selectors
-      | Alias            | Selector                               |
-      | next-button      | [data-testid='onboarding-next-button'] |
+      | Alias       | Selector                               |
+      | next-button | [data-testid='onboarding-next-button'] |
+
   Scenario Outline: With Mode: <Value> the next link is correct
     Given the environment
       """
@@ -11,6 +13,7 @@ Feature: onboarding / configuration-types / index
     When I visit the "/onboarding/configuration-types" URL
     And I click the "$next-button" element
     Then the URL is "<URL>"
+
     Examples:
       | Value      | URL                     |
       | global     | /onboarding/multi-zone  |

--- a/features/onboarding/create-mesh/Index.feature
+++ b/features/onboarding/create-mesh/Index.feature
@@ -1,4 +1,5 @@
 Feature: onboarding / create-mesh / index
+
   Background:
     Given the CSS selectors
       | Alias       | Selector                                   |
@@ -12,8 +13,8 @@ Feature: onboarding / create-mesh / index
     When I visit the "/onboarding/create-mesh" URL
     And I click the "$back-button" element
     Then the URL is "<URL>"
-    Examples:
-      | Value      | URL                     |
-      | global     | /onboarding/multi-zone  |
-      | standalone | /onboarding/configuration-types |
 
+    Examples:
+      | Value      | URL                             |
+      | global     | /onboarding/multi-zone          |
+      | standalone | /onboarding/configuration-types |

--- a/features/onboarding/dataplanes-overview/Index.feature
+++ b/features/onboarding/dataplanes-overview/Index.feature
@@ -1,4 +1,5 @@
 Feature: onboarding / dataplanes-overview / index
+
   Background:
     Given the CSS selectors
       | Alias            | Selector                               |
@@ -12,9 +13,7 @@ Feature: onboarding / dataplanes-overview / index
       """
       KUMA_DATAPLANE_COUNT: 0
       """
-
     When I visit the "/onboarding/dataplanes-overview" URL
-
     Then the "$next-button[disabled]" element exists
 
   Scenario: Next button is enabled if there is at least one Dataplane
@@ -33,9 +32,7 @@ Feature: onboarding / dataplanes-overview / index
                 - connectTime: 2021-02-17T07:33:36.412683Z
                   disconnectTime: !!js/undefined
       """
-
     When I visit the "/onboarding/dataplanes-overview" URL
-
     Then the "$next-button:not([disabled])" element exists
 
   Scenario: UI updates in response to Dataplanes not being offline anymore
@@ -55,13 +52,10 @@ Feature: onboarding / dataplanes-overview / index
                 - connectTime: 2021-02-17T07:33:36.412683Z
                   disconnectTime: 2021-02-17T07:33:36.412683Z
       """
-
     When I visit the "/onboarding/dataplanes-overview" URL
-
     Then the "$state-waiting" element exists
     And the "$dataplanes-table" element contains "dataplane-test"
     And the "$dataplanes-table" element contains "offline"
-
     When the URL "/dataplanes/_overview" responds with
       """
       body:
@@ -77,7 +71,6 @@ Feature: onboarding / dataplanes-overview / index
                 - connectTime: 2021-02-17T07:33:36.412683Z
                   disconnectTime: !!js/undefined
       """
-
     Then the "$state-success" element exists
     And the "$dataplanes-table" element contains "dataplane-test"
     And the "$dataplanes-table" element contains "online"

--- a/features/onboarding/deployment-types/Index.feature
+++ b/features/onboarding/deployment-types/Index.feature
@@ -1,4 +1,5 @@
 Feature: onboarding / deployment-types / index
+
   Background:
     Given the CSS selectors
       | Alias             | Selector                                           |
@@ -9,12 +10,9 @@ Feature: onboarding / deployment-types / index
 
   Scenario: Clicking between standalone and multizone to change the image
     When I visit the "/onboarding/deployment-types" URL
-
     And I click the "$standalone-button" element
     Then the "$standalone-image" element exists
     Then the "$multizone-image" element doesn't exist
-
     And I click the "$multizone-button" element
     Then the "$multizone-image" element exists
     Then the "$standalone-image" element doesn't exist
-

--- a/features/onboarding/multi-zone/Index.feature
+++ b/features/onboarding/multi-zone/Index.feature
@@ -1,4 +1,5 @@
 Feature: onboarding / multi-zone / index
+
   Background:
     Given the CSS selectors
       | Alias       | Selector                                   |

--- a/features/onboarding/welcome/Index.feature
+++ b/features/onboarding/welcome/Index.feature
@@ -1,4 +1,5 @@
 Feature: onboarding / welcome
+
   Background:
     Given the CSS selectors
       | Alias            | Selector                               |
@@ -12,6 +13,7 @@ Feature: onboarding / welcome
       """
     When I visit the "/onboarding/welcome" URL
     Then the "$environment-text" element contains "<Text>"
+
     Examples:
       | Value      | Text       |
       | universal  | Universal  |

--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -1,4 +1,5 @@
 Feature: zones / create
+
   Background:
     Given the CSS selectors
       | Alias                               | Selector                                             |
@@ -23,7 +24,6 @@ Feature: zones / create
       | connected                           | [data-testid='connected']                            |
       | error                               | [data-testid='error']                                |
       | instructions                        | [data-testid='connect-zone-instructions']            |
-
     And the environment
       """
       KUMA_MODE: global
@@ -33,10 +33,8 @@ Feature: zones / create
     Given I visit the "/" URL
     Then the "[data-testid='loading-block']" element doesn't exist
     And I click the "$zones-nav" element
-
     Then the page title contains "Zone Control Planes"
     And the "$create-zone-link" element exists
-
     When I click the "$create-zone-link" element
     Then the page title contains "Create & connect Zone"
 
@@ -44,7 +42,6 @@ Feature: zones / create
     When I visit the "/zones/-create" URL
     Then the "$name-input" element exists
     Then the "$create-zone-button" element is disabled
-
     Then the "$environment-universal-radio-button" element doesn't exist
     Then the "$environment-kubernetes-radio-button" element doesn't exist
     Then the "$ingress-input-switch-label" element doesn't exist
@@ -62,10 +59,8 @@ Feature: zones / create
       """
     When I visit the "/zones/-create" URL
     Then the "$create-zone-button" element is disabled
-
     When I "type" "test" into the "$name-input" element
     Then the "$create-zone-button" element isn't disabled
-
     When I click the "$create-zone-button" element
     Then the URL "/provision-zone" was requested with
       """
@@ -79,15 +74,12 @@ Feature: zones / create
     And the "$egress-input-switch-input" element is checked
     And the "$environment-kubernetes-config" element contains "kdsGlobalAddress: grpcs://<global-kds-address>:5685"
     And the "$waiting" element exists
-
     When I click the "$ingress-input-switch-label" element
     Then the "$ingress-input-switch-input" element isn't checked
     And the "$egress-input-switch-input" element is checked
-
     When I click the "$egress-input-switch-label" element
     Then the "$ingress-input-switch-input" element isn't checked
     And the "$egress-input-switch-input" element isn't checked
-
     When I click the "$environment-universal-radio-button" element
     Then the "$ingress-input-switch-input" element doesn't exist
     And the "$egress-input-switch-input" element doesn't exist
@@ -153,17 +145,13 @@ Feature: zones / create
       headers:
         Status-Code: '409'
       """
-
     When I visit the "/zones/-create" URL
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
-
     Then the "$create-error" element contains "test"
     And the "$instructions" element doesn't exist
-
     When I clear the "$name-input" element
     And I "type" "different-name" into the "$name-input" element
-
     Then the "$create-error" element contains "test"
 
   Scenario: The form shows expected error for 400 response
@@ -180,12 +168,10 @@ Feature: zones / create
           - field: 'name'
             reason: "invalid characters. Valid characters are numbers, lowercase latin letters and '-', '_' symbols."
       """
-
     When I visit the "/zones/-create" URL
     # Note: We're deliberately using a valid name here in order to not trigger client-side validation.
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
-
     Then the "$name-input-invalid-dns-name" element exists
     And the "$instructions" element doesn't exist
 
@@ -193,15 +179,12 @@ Feature: zones / create
     When I visit the "/zones/-create" URL
     And I "type" "zone.eu" into the "$name-input" element
     And I click the "$create-zone-button" element
-
     Then the "$create-error" element doesn't exist
     And the "$name-input-invalid-dns-name" element exists
     And the "$instructions" element doesn't exist
-
     When I clear the "$name-input" element
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
-
     Then the "$create-error" element doesn't exist
     And the "$instructions" element exists
 
@@ -225,16 +208,12 @@ Feature: zones / create
             - connectTime: '2020-07-28T16:18:09.743141Z'
               disconnectTime: !!js/undefined
       """
-
     When I visit the "/zones/-create" URL
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
-
     Then the "$instructions" element exists
     And the "$connected" element exists
-
     When I click the "$exit-button" element
-
     Then the "$confirm-exit-modal" element doesn't exist
     And the page title contains "Zone Control Planes"
 
@@ -248,19 +227,13 @@ Feature: zones / create
       body:
         token: spat_595QOxTSreRmrtdh8ValuoeUAzXMfBmRwYU3V35NQvwgLAWIU
       """
-
     When I visit the "/zones/-create" URL
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
-
     Then the "$instructions" element exists
     And the "$waiting" element exists
-
     When I click the "$exit-button" element
-
     Then the "$confirm-exit-modal" element exists
-
     When I click the "$confirm-exit-button" element
-
     Then the "$confirm-exit-modal" element doesn't exist
     And the page title contains "Zone Control Planes"

--- a/features/zones/zone-cps/Item.feature
+++ b/features/zones/zone-cps/Item.feature
@@ -50,7 +50,7 @@ Feature: zones / item
     And the "$detail-view" element contains
       | Value     |
       | Universal |
-      | 100.0.0   |
+      |   100.0.0 |
       | online    |
       | dpToken   |
     And the "$detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"

--- a/features/zones/zone-cps/egresses/Index.feature
+++ b/features/zones/zone-cps/egresses/Index.feature
@@ -1,4 +1,5 @@
 Feature: zones / egresses / index
+
   Background:
     Given the CSS selectors
       | Alias | Selector                                        |
@@ -24,7 +25,7 @@ Feature: zones / egresses / index
                   disconnectTime: 2020-07-28T16:18:09.743141Z
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: !!js/undefined
-
+      
           - name: zone-egress-2
             zoneEgress:
               zone: zone-cp-1
@@ -34,7 +35,7 @@ Feature: zones / egresses / index
                   disconnectTime: 2020-07-28T16:18:09.743141Z
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-
+      
           - name: zone-egress-3-is-not-part-of-this-zone
             zoneEgress:
               zone: zone-cp-not-zone-cp-1
@@ -45,18 +46,15 @@ Feature: zones / egresses / index
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
       """
-
     When I visit the "<URL>" URL
     Then the page title contains "Egresses"
     And the "$item" element exists <Items> times
-
     Then the "$item:nth-child(1) .status-column" element contains "online"
     Then the "$item:nth-child(1) .name-column" element contains "zone-egress-1"
-
     Then the "$item:nth-child(2) .status-column" element contains "offline"
     Then the "$item:nth-child(2) .name-column" element contains "zone-egress-2"
 
     Examples:
       | Mode   | URL                       | Items |
-      | global | /zones/zone-cp-1/egresses | 2     |
-      | zone   | /zones/egresses           | 3     |
+      | global | /zones/zone-cp-1/egresses |     2 |
+      | zone   | /zones/egresses           |     3 |

--- a/features/zones/zone-cps/egresses/Item.feature
+++ b/features/zones/zone-cps/egresses/Item.feature
@@ -1,4 +1,5 @@
 Feature: zones / egresses / item
+
   Background:
     Given the CSS selectors
       | Alias                   | Selector                                      |
@@ -28,13 +29,10 @@ Feature: zones / egresses / item
             - connectTime: 2020-07-28T16:18:09.743141Z
               disconnectTime: !!js/undefined
       """
-
     When I visit the "/zones/zone-cp-1/egresses/item-1/overview" URL
     Then the page title contains "item-1"
-
     Then the "$egress-detail-tabs-view" element contains "item-1"
     Then the "$egress-detail-view" element contains "166.197.238.26:20555"
     Then the "$egress-detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"
-
     When I click the "$egress-config-tab" element
     Then the "$egress-config-view" element contains "type: ZoneEgress"

--- a/features/zones/zone-cps/egresses/ZoneEgressSummary.feature
+++ b/features/zones/zone-cps/egresses/ZoneEgressSummary.feature
@@ -1,4 +1,5 @@
 Feature: Zone Egress summary
+
   Background:
     Given the CSS selectors
       | Alias                | Selector                                        |
@@ -19,19 +20,15 @@ Feature: Zone Egress summary
       """
       KUMA_ZONEEGRESS_COUNT: 1
       """
-
     When I visit the "/zones/zone-1/egresses" URL
     And I click the "$item:nth-child(1) td:nth-child(2)" element
     Then the "$summary" element exists
     And the "$summary" element contains "zone-egress-1"
-
     When I click the "$close-summary-button" element
     Then the "$summary" element doesn't exist
-
     When I navigate "back"
     Then the "$summary" element exists
     And the "$summary" element contains "zone-egress-1"
-
     When I navigate "forward"
     Then the "$summary" element doesn't exist
 
@@ -40,6 +37,5 @@ Feature: Zone Egress summary
       """
       KUMA_ZONEEGRESS_COUNT: 51
       """
-
     When I visit the "/zones/zone-1/egresses/zone-egress-1?page=2&size=50" URL
     Then the "$summary" element exists

--- a/features/zones/zone-cps/ingresses/Index.feature
+++ b/features/zones/zone-cps/ingresses/Index.feature
@@ -1,4 +1,5 @@
 Feature: zones / ingresses / index
+
   Background:
     Given the CSS selectors
       | Alias | Selector                                         |
@@ -24,7 +25,7 @@ Feature: zones / ingresses / index
                   disconnectTime: 2020-07-28T16:18:09.743141Z
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: !!js/undefined
-
+      
           - name: zone-ingress-2
             zoneIngress:
               zone: zone-cp-1
@@ -34,7 +35,7 @@ Feature: zones / ingresses / index
                   disconnectTime: 2020-07-28T16:18:09.743141Z
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
-
+      
           - name: zone-ingress-3-is-not-part-of-this-zone
             zoneIngress:
               zone: zone-cp-not-zone-cp-1
@@ -45,13 +46,10 @@ Feature: zones / ingresses / index
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: 2020-07-28T16:18:09.743141Z
       """
-
     When I visit the "/zones/zone-cp-1/ingresses" URL
     Then the page title contains "Ingresses"
     And the "$item" element exists 2 times
-
     Then the "$item:nth-child(1) .status-column" element contains "online"
     Then the "$item:nth-child(1) .name-column" element contains "zone-ingress-1"
-
     Then the "$item:nth-child(2) .status-column" element contains "offline"
     Then the "$item:nth-child(2) .name-column" element contains "zone-ingress-2"

--- a/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
+++ b/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
@@ -1,4 +1,5 @@
 Feature: Zone Ingress summary
+
   Background:
     Given the CSS selectors
       | Alias                | Selector                                         |
@@ -19,19 +20,15 @@ Feature: Zone Ingress summary
       """
       KUMA_ZONEINGRESS_COUNT: 1
       """
-
     When I visit the "/zones/zone-1/ingresses" URL
     And I click the "$item:nth-child(1) td:nth-child(2)" element
     Then the "$summary" element exists
     And the "$summary" element contains "zone-ingress-1"
-
     When I click the "$close-summary-button" element
     Then the "$summary" element doesn't exist
-
     When I navigate "back"
     Then the "$summary" element exists
     And the "$summary" element contains "zone-ingress-1"
-
     When I navigate "forward"
     Then the "$summary" element doesn't exist
 
@@ -40,6 +37,5 @@ Feature: Zone Ingress summary
       """
       KUMA_ZONEINGRESS_COUNT: 51
       """
-
     When I visit the "/zones/zone-1/ingresses/zone-ingress-1?page=2&size=50" URL
     Then the "$summary" element exists

--- a/features/zones/zone-cps/ingresses/item/Index.feature
+++ b/features/zones/zone-cps/ingresses/item/Index.feature
@@ -1,4 +1,5 @@
 Feature: zones / ingresses / item
+
   Background:
     Given the CSS selectors
       | Alias            | Selector                                       |
@@ -7,7 +8,6 @@ Feature: zones / ingresses / item
       | detail-tabs-view | [data-testid='zone-ingress-detail-tabs-view']  |
       | navigation       | [data-testid='zone-ingress-tabs'] ul           |
       | config-tab       | [data-testid='zone-ingress-config-view-tab'] a |
-
     And the environment
       """
       KUMA_MODE: global
@@ -40,13 +40,10 @@ Feature: zones / ingresses / item
             - connectTime: 2020-07-28T16:18:09.743141Z
               disconnectTime: !!js/undefined
       """
-
     When I visit the "/zones/zone-cp-1/ingresses/item-1/overview" URL
     Then the page title contains "item-1"
-
     Then the "$detail-tabs-view" element contains "item-1"
     Then the "$detail-view" element contains "166.197.238.26:20555"
     Then the "$detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"
-
     When I click the "$config-tab" element
     Then the "$config-view" element contains "type: ZoneIngress"

--- a/features/zones/zone-cps/ingresses/item/Services.feature
+++ b/features/zones/zone-cps/ingresses/item/Services.feature
@@ -1,10 +1,10 @@
 Feature: zones / ingresses / item / services
+
   Background:
     Given the CSS selectors
       | Alias | Selector                                      |
       | items | [data-testid='available-services-collection'] |
       | item  | $items tbody tr                               |
-
     And the environment
       """
       KUMA_MODE: global

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -8,8 +8,10 @@ check/node:
 	)
 
 .PHONY: lint
-lint: MAKEFLAGS += -j4
-lint: lint/js lint/ts lint/css lint/lock  ## Dev: Run lint checks on all languages
+lint: lint/js lint/ts lint/css lint/lock lint/gherkin ## Dev: Run lint checks on all languages
+
+.PHONY: lint/script
+lint/script: lint/js lint/ts  ## Dev: Run lint checs on both JS/TS
 
 .PHONY: lint/js
 lint/js:
@@ -27,6 +29,12 @@ lint/css:
 	@npx stylelint \
 		$(if $(CI),,--fix) --allow-empty-input \
 		./src/**/*.{css,scss,vue}
+
+.PHONY: lint/gherkin
+lint/gherkin:
+	@find ./features \
+		-name '*.feature' \
+		-exec npx gherkin-utils format '{}' +
 
 .PHONY: lint/lock
 lint/lock:

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "@badeball/cypress-cucumber-preprocessor": "^20.1.0",
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.1",
+        "@cucumber/gherkin-utils": "^9.0.0",
         "@faker-js/faker": "^8.4.1",
         "@kong/design-tokens": "^1.15.2",
         "@modyfi/vite-plugin-yaml": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@badeball/cypress-cucumber-preprocessor": "^20.1.0",
     "@bahmutov/cypress-esbuild-preprocessor": "^2.2.1",
+    "@cucumber/gherkin-utils": "^9.0.0",
     "@faker-js/faker": "^8.4.1",
     "@kong/design-tokens": "^1.15.2",
     "@modyfi/vite-plugin-yaml": "^1.1.0",

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -2,17 +2,17 @@
   <!-- whilst we don't use the addresses here, -->
   <!-- we want to make sure they are retrieved/correctly set -->
   <DataSource
-    v-slot="{data: addresses}: ControlPlaneAddressesSource"
     :src="`/control-plane/addresses`"
+    v-slot="{data: addresses}: ControlPlaneAddressesSource"
   >
     <RouteView
       v-if="typeof addresses !== 'undefined'"
-      v-slot="{ t, can, route }"
       name="app"
       :attrs="{
         class: 'kuma-ready',
       }"
       data-testid-root="mesh-app"
+      v-slot="{ t, can, route }"
     >
       <ApplicationShell
         class="kuma-application"

--- a/src/app/application/components/data-source/DataLoader.vue
+++ b/src/app/application/components/data-source/DataLoader.vue
@@ -1,9 +1,9 @@
 <template>
   <DataSource
-    v-slot="{ refresh }"
     :src="props.src as T"
     @change="(data) => srcData = data"
     @error="(e: Error) => srcError = e"
+    v-slot="{ refresh }"
   >
     <template
       v-if="allData.length > 0 && allData.every(item => typeof item !== 'undefined')"

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -1,9 +1,9 @@
 <template>
   <DataSource
-    v-slot="{ data: me }"
     :src="uri(sources, '/me/:route', {
       route: props.name,
     })"
+    v-slot="{ data: me }"
   >
     <div
       class="route-view"
@@ -20,8 +20,8 @@
       />
       <DataSink
         v-if="me"
-        v-slot="{ submit }"
         :src="`/me/${props.name}`"
+        v-slot="{ submit }"
       >
         <slot
           :id="UniqueId"

--- a/src/app/common/code-block/ResourceCodeBlock.vue
+++ b/src/app/common/code-block/ResourceCodeBlock.vue
@@ -28,8 +28,8 @@
             <XIcon name="copy" />{{ t('common.copyKubernetesShortText') }}
           </KCodeBlockIconButton>
           <XCopyButton
-            v-slot="{ copy }"
             format="hidden"
+            v-slot="{ copy }"
           >
             <slot
               :copy="(cb: CopyCallback) => {

--- a/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
+++ b/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route }"
     :params="{
       codeSearch: '',
       codeFilter: false,
@@ -10,6 +9,7 @@
       connection: '',
     }"
     name="connection-inbound-summary-clusters-view"
+    v-slot="{ route }"
   >
     <RouteTitle
       :render="false"
@@ -17,13 +17,13 @@
     />
     <AppView>
       <DataLoader
-        v-slot="{ data: clusters, refresh }: ClustersDataSource"
         :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/clusters`"
+        v-slot="{ data: clusters, refresh }: ClustersDataSource"
       >
         <DataCollection
-          v-slot="{ items: lines }"
           :items="clusters!.split('\n')"
           :predicate="item => item.startsWith(`${props.data.service}::`)"
+          v-slot="{ items: lines }"
         >
           <CodeBlock
             language="json"

--- a/src/app/connections/views/ConnectionInboundSummaryOverviewView.vue
+++ b/src/app/connections/views/ConnectionInboundSummaryOverviewView.vue
@@ -1,12 +1,12 @@
 <template>
   <RouteView
-    v-slot="{ t, route }"
     :params="{
       mesh: '',
       dataPlane: '',
       connection: '',
     }"
     name="connection-inbound-summary-overview-view"
+    v-slot="{ t, route }"
   >
     <AppView>
       <div
@@ -84,14 +84,14 @@
       >
         <h3>Rules</h3>
         <DataLoader
-          v-slot="{ data: rulesData }: RuleCollectionSource"
           :src="`/meshes/${route.params.mesh}/rules/for/${route.params.dataPlane}`"
+          v-slot="{ data: rulesData }: RuleCollectionSource"
         >
           <DataCollection
-            v-slot="{ items }"
             :predicate="(item) => { return item.ruleType === 'from' && Number(item.inbound!.port) === Number(route.params.connection.split('_')[1])}"
-
             :items="rulesData!.rules"
+
+            v-slot="{ items }"
           >
             <div class="mt-4">
               <AccordionList
@@ -142,8 +142,8 @@
 
                               <template #body>
                                 <DataSource
-                                  v-slot="{ data: policyTypes }: PolicyTypeCollectionSource"
                                   :src="`/policy-types`"
+                                  v-slot="{ data: policyTypes }: PolicyTypeCollectionSource"
                                 >
                                   <template
                                     v-for="types in [Object.groupBy((policyTypes?.policies ?? []), (item) => item.name)]"

--- a/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
+++ b/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route }"
     :params="{
       codeSearch: '',
       codeFilter: false,
@@ -10,6 +9,7 @@
       connection: '',
     }"
     name="connection-inbound-summary-stats-view"
+    v-slot="{ route }"
   >
     <RouteTitle
       :render="false"
@@ -17,11 +17,10 @@
     />
     <AppView>
       <DataLoader
-        v-slot="{ data: stats, refresh }: StatsSource"
         :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${props.dataplaneOverview.dataplane.networking.inboundAddress}`"
+        v-slot="{ data: stats, refresh }: StatsSource"
       >
         <DataCollection
-          v-slot="{ items: lines }"
           :items="stats!.raw.split('\n')"
           :predicate="item => [
             `listener.${props.data.listenerAddress.length > 0 ? props.data.listenerAddress : route.params.connection}`,
@@ -29,6 +28,7 @@
             `http.${props.data.name}.`,
             `tcp.${props.data.name}.`,
           ].some(prefix => item.startsWith(prefix)) && (!item.includes('.rds.') || item.includes(`_${props.data.port}`))"
+          v-slot="{ items: lines }"
         >
           <CodeBlock
             language="json"

--- a/src/app/connections/views/ConnectionInboundSummaryView.vue
+++ b/src/app/connections/views/ConnectionInboundSummaryView.vue
@@ -1,19 +1,19 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="connection-inbound-summary-view"
     :params="{
       connection: '',
       inactive: false,
     }"
+    v-slot="{ route, t }"
   >
     <!-- if its a built in gateway, just take the first one, all the data we use here is the same -->
     <!-- otherwise find the exact inbound -->
     <DataCollection
-      v-slot="{ items }"
       :items="props.data"
       :predicate="props.dataplaneOverview.dataplane.networking.type === 'gateway' ? (item) => true : (item) => item.name === route.params.connection"
       :find="true"
+      v-slot="{ items }"
     >
       <AppView>
         <template #title>

--- a/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route }"
     :params="{
       codeSearch: '',
       codeFilter: false,
@@ -10,6 +9,7 @@
       connection: '',
     }"
     name="connection-outbound-summary-clusters-view"
+    v-slot="{ route }"
   >
     <RouteTitle
       :render="false"
@@ -17,13 +17,13 @@
     />
     <AppView>
       <DataLoader
-        v-slot="{ data, refresh }: ClustersDataSource"
         :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/clusters`"
+        v-slot="{ data, refresh }: ClustersDataSource"
       >
         <DataCollection
-          v-slot="{ items: lines }"
           :items="data!.split('\n')"
           :predicate="item => item.startsWith(`${route.params.connection}::`)"
+          v-slot="{ items: lines }"
         >
           <CodeBlock
             language="json"

--- a/src/app/connections/views/ConnectionOutboundSummaryOverviewView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryOverviewView.vue
@@ -1,12 +1,12 @@
 <template>
   <RouteView
-    v-slot="{ t, route }"
     :params="{
       mesh: '',
       dataPlane: '',
       connection: '',
     }"
     name="connection-outbound-summary-overview-view"
+    v-slot="{ t, route }"
   >
     <AppView>
       <template
@@ -35,11 +35,10 @@
           >
             <h3>Rules</h3>
             <DataLoader
-              v-slot="{ data: rulesData }: RuleCollectionSource"
               :src="`/meshes/${route.params.mesh}/rules/for/${route.params.dataPlane}`"
+              v-slot="{ data: rulesData }: RuleCollectionSource"
             >
               <DataCollection
-                v-slot="{ items }"
                 :predicate="(item) => {
                   // for to rules we don't have inbound.port, filter out Routes
                   // then look for the kuma.io/service
@@ -47,8 +46,9 @@
                     item.matchers.every(item => item.key === 'kuma.io/service' && (item.not ? item.value !== service : item.value === service))
                   )
                 }"
-
                 :items="rulesData!.rules"
+
+                v-slot="{ items }"
               >
                 <div class="mt-4">
                   <AccordionList
@@ -99,8 +99,8 @@
 
                                   <template #body>
                                     <DataSource
-                                      v-slot="{ data: policyTypes }: PolicyTypeCollectionSource"
                                       :src="`/policy-types`"
+                                      v-slot="{ data: policyTypes }: PolicyTypeCollectionSource"
                                     >
                                       <template
                                         v-for="types in [Object.groupBy((policyTypes?.policies ?? []), (item) => item.name)]"

--- a/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route }"
     :params="{
       codeSearch: '',
       codeFilter: false,
@@ -10,6 +9,7 @@
       connection: '',
     }"
     name="connection-outbound-summary-stats-view"
+    v-slot="{ route }"
   >
     <RouteTitle
       :render="false"
@@ -17,13 +17,13 @@
     />
     <AppView>
       <DataLoader
-        v-slot="{ data, refresh }: StatsSource"
         :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${props.dataplaneOverview.dataplane.networking.inboundAddress}`"
+        v-slot="{ data, refresh }: StatsSource"
       >
         <DataCollection
-          v-slot="{ items: lines }"
           :items="data!.raw.split('\n')"
           :predicate="item => item.includes(`.${route.params.connection}.`)"
+          v-slot="{ items: lines }"
         >
           <CodeBlock
             language="json"

--- a/src/app/connections/views/ConnectionOutboundSummaryView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryView.vue
@@ -1,11 +1,11 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="connection-outbound-summary-view"
     :params="{
       connection: '',
       inactive: false,
     }"
+    v-slot="{ route, t }"
   >
     <AppView>
       <template #title>
@@ -35,10 +35,10 @@
       </XTabs>
       <RouterView v-slot="{ Component }">
         <DataCollection
-          v-slot="{ items }"
           :items="Object.entries(props.data)"
           :predicate="([key, _value]) => key === route.params.connection"
           :find="true"
+          v-slot="{ items }"
         >
           <component
             :is="Component"

--- a/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ can, t, uri, me }"
     name="home"
+    v-slot="{ can, t, uri, me }"
   >
     <AppView>
       <template #title>
@@ -16,8 +16,8 @@
         class="stack"
       >
         <DataLoader
-          v-slot="{ data }"
           :src="uri(ControlPlaneSources, '/global-insight', {})"
+          v-slot="{ data }"
         >
           <ControlPlaneStatus
             :can-use-zones="can('use zones')"

--- a/src/app/data-planes/views/DataPlaneClustersView.vue
+++ b/src/app/data-planes/views/DataPlaneClustersView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="data-plane-clusters-view"
     :params="{
       mesh: '',
@@ -9,6 +8,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <AppView>
       <RouteTitle
@@ -17,8 +17,8 @@
       />
       <KCard>
         <DataLoader
-          v-slot="{ data, refresh }"
           :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/clusters`"
+          v-slot="{ data, refresh }"
         >
           <CodeBlock
             language="json"

--- a/src/app/data-planes/views/DataPlaneConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri }"
     name="data-plane-config-view"
     :params="{
       mesh: '',
@@ -9,6 +8,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t, uri }"
   >
     <RouteTitle
       :render="false"
@@ -17,14 +17,13 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data }"
           :src="uri(sources, `/meshes/:mesh/dataplanes/:name`, {
             mesh: route.params.mesh,
             name: route.params.dataPlane,
           })"
+          v-slot="{ data }"
         >
           <ResourceCodeBlock
-            v-slot="{ copy, copying }"
             :resource="data.config"
             is-searchable
             :query="route.params.codeSearch"
@@ -33,6 +32,7 @@
             @query-change="route.update({ codeSearch: $event })"
             @filter-mode-change="route.update({ codeFilter: $event })"
             @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            v-slot="{ copy, copying }"
           >
             <DataSource
               v-if="copying"

--- a/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -1,15 +1,15 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="data-plane-detail-tabs-view"
     :params="{
       mesh: '',
       dataPlane: '',
     }"
+    v-slot="{ route, t }"
   >
     <DataSource
-      v-slot="{ data, error }: DataplaneOverviewSource"
       :src="`/meshes/${route.params.mesh}/dataplane-overviews/${route.params.dataPlane}`"
+      v-slot="{ data, error }: DataplaneOverviewSource"
     >
       <AppView
         :breadcrumbs="[

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -1,16 +1,16 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     :params="{
       mesh: '',
       dataPlane: '',
       inactive: false,
     }"
     name="data-plane-detail-view"
+    v-slot="{ route, t }"
   >
     <DataSource
-      v-slot="{ data: traffic, error, refresh }: StatsSource"
       :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${props.data.dataplane.networking.inboundAddress}`"
+      v-slot="{ data: traffic, error, refresh }: StatsSource"
     >
       <AppView>
         <template
@@ -49,10 +49,10 @@
                     <StatusBadge :status="props.data.status" />
                     <DataCollection
                       v-if="props.data.dataplaneType === 'standard'"
-                      v-slot="{ items : unhealthyInbounds }"
                       :items="props.data.dataplane.networking.inbounds"
                       :predicate="item => !item.health.ready"
                       :empty="false"
+                      v-slot="{ items : unhealthyInbounds }"
                     >
                       <KTooltip
                         class="reason-tooltip"
@@ -292,9 +292,9 @@
                         </ConnectionCard>
                       </ConnectionGroup>
                       <DataCollection
-                        v-slot="{ items: outbounds }"
                         :predicate="route.params.inactive ? undefined : ([key, item]) => ((typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) as (number | undefined) ?? 0) > 0"
                         :items="Object.entries<any>(traffic.outbounds)"
+                        v-slot="{ items: outbounds }"
                       >
                         <ConnectionGroup
                           v-if="outbounds.length > 0"

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ can, route, t, me, uri }"
     name="data-plane-list-view"
     :params="{
       page: 1,
@@ -10,6 +9,7 @@
       mesh: '',
       dataPlane: '',
     }"
+    v-slot="{ can, route, t, me, uri }"
   >
     <RouteTitle
       :render="false"

--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -1,11 +1,11 @@
 <template>
   <RouteView
-    v-slot="{ can, route, t }"
     name="data-plane-policies-view"
     :params="{
       mesh: '',
       dataPlane: '',
     }"
+    v-slot="{ can, route, t }"
   >
     <RouteTitle
       :render="false"
@@ -16,8 +16,8 @@
         <!-- we load in policyTypes for everything so we can use `path` for links/URLs/API requests -->
         <!-- we ask for the policyTypes here and always share the errors/data with all the DataLoaders below -->
         <DataSource
-          v-slot="{ data: policyTypesData, error: policyTypesError }: PolicyTypeCollectionSource"
           :src="`/policy-types`"
+          v-slot="{ data: policyTypesData, error: policyTypesError }: PolicyTypeCollectionSource"
         >
           <template
             v-for="policyTypes in [(policyTypesData?.policies ?? []).reduce<Partial<Record<string, PolicyType>>>((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})]"
@@ -25,10 +25,10 @@
           >
             <!-- always try and load and show the rules for everything dataplane type -->
             <DataLoader
-              v-slot="{ data: rulesData }: RuleCollectionSource"
               :src="`/meshes/${route.params.mesh}/rules/for/${route.params.dataPlane}`"
               :data="[policyTypesData]"
               :errors="[policyTypesError]"
+              v-slot="{ data: rulesData }: RuleCollectionSource"
             >
               <!-- show an empty state if we have no rules at all -->
               <DataCollection
@@ -40,11 +40,11 @@
                   :key="ruleType"
                 >
                   <DataCollection
-                    v-slot="{ items }"
                     :items="rulesData!.rules"
                     :predicate="(item) => item.ruleType === ruleType"
                     :comparator="(a, b) => a.type.localeCompare(b.type)"
                     :empty="false"
+                    v-slot="{ items }"
                   >
                     <KCard>
                       <h3>
@@ -63,11 +63,11 @@
 
                 <!-- otherwise, for from rules, group by inbound port and display if we have any -->
                 <DataCollection
-                  v-slot="{ items }"
                   :items="rulesData!.rules"
                   :predicate="(item) => item.ruleType === 'from'"
                   :comparator="(a, b) => a.type.localeCompare(b.type)"
                   :empty="false"
+                  v-slot="{ items }"
                 >
                   <KCard>
                     <h3 class="mb-2">
@@ -102,10 +102,10 @@
                 <!-- builtin gateways have different data/visuals than other types of dataplanes -->
                 <template v-if="props.data.dataplaneType === 'builtin'">
                   <DataLoader
-                    v-slot="{ data: gatewayDataplane }: MeshGatewayDataplaneSource"
                     :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/gateway-dataplane-policies`"
                     :data="[policyTypesData]"
                     :errors="[policyTypesError]"
+                    v-slot="{ data: gatewayDataplane }: MeshGatewayDataplaneSource"
                   >
                     <DataCollection
                       v-if="gatewayDataplane"
@@ -131,16 +131,16 @@
                 <!-- anything but builtin gateways -->
                 <template v-else>
                   <DataLoader
-                    v-slot="{ data: sidecarDataplaneData }: SidecarDataplaneCollectionSource"
                     :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/sidecar-dataplane-policies`"
                     :data="[policyTypesData]"
                     :errors="[policyTypesError]"
+                    v-slot="{ data: sidecarDataplaneData }: SidecarDataplaneCollectionSource"
                   >
                     <DataCollection
-                      v-slot="{ items }"
                       :predicate="(item) => policyTypes[item.type]?.isTargetRefBased === false"
                       :items="sidecarDataplaneData!.policyTypeEntries"
                       :empty="false"
+                      v-slot="{ items }"
                     >
                       <h3>
                         {{ t('data-planes.routes.item.legacy_policies') }}

--- a/src/app/data-planes/views/DataPlanePolicySummaryView.vue
+++ b/src/app/data-planes/views/DataPlanePolicySummaryView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="data-plane-policy-summary-view"
     :params="{
       mesh: '',
@@ -10,10 +9,11 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <DataSource
-      v-slot="{ data, error }: PolicySource"
       :src="`/meshes/${route.params.mesh}/policy-path/${route.params.policyPath}/policy/${route.params.policy}`"
+      v-slot="{ data, error }: PolicySource"
     >
       <AppView>
         <template #title>
@@ -43,7 +43,6 @@
             :policy="data"
           >
             <ResourceCodeBlock
-              v-slot="{ copy, copying }"
               :resource="data.config"
               is-searchable
               :query="route.params.codeSearch"
@@ -52,6 +51,7 @@
               @query-change="route.update({ codeSearch: $event })"
               @filter-mode-change="route.update({ codeFilter: $event })"
               @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+              v-slot="{ copy, copying }"
             >
               <DataSource
                 v-if="copying"

--- a/src/app/data-planes/views/DataPlaneStatsView.vue
+++ b/src/app/data-planes/views/DataPlaneStatsView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="data-plane-stats-view"
     :params="{
       mesh: '',
@@ -9,6 +8,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <RouteTitle
       :render="false"
@@ -17,8 +17,8 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data: statsData, refresh }: StatsSource"
           :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${props.data.dataplane.networking.inboundAddress}`"
+          v-slot="{ data: statsData, refresh }: StatsSource"
         >
           <CodeBlock
             language="json"

--- a/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -1,10 +1,10 @@
 <template>
   <RouteView
-    v-slot="{ t, route }"
     name="data-plane-summary-view"
     :params="{
       dataPlane: '',
     }"
+    v-slot="{ t, route }"
   >
     <DataCollection
       :items="props.items"
@@ -69,10 +69,10 @@
                       />
                       <DataCollection
                         v-if="item.dataplaneType === 'standard'"
-                        v-slot="{ items : inbounds }"
                         :items="item.dataplane.networking.inbounds"
                         :predicate="item => !item.health.ready"
                         :empty="false"
+                        v-slot="{ items : inbounds }"
                       >
                         <KTooltip
                           class="reason-tooltip"
@@ -180,8 +180,8 @@
 
               <DataCollection
                 v-if="item.dataplaneType === 'standard'"
-                v-slot="{ items : inbounds }"
                 :items="item.dataplane.networking.inbounds"
+                v-slot="{ items : inbounds }"
               >
                 <div>
                   <h3>{{ t('data-planes.routes.item.inbounds') }}</h3>

--- a/src/app/data-planes/views/DataPlaneXdsConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneXdsConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="data-plane-xds-config-view"
     :params="{
       mesh: '',
@@ -9,6 +8,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <RouteTitle
       :render="false"
@@ -17,8 +17,8 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data, refresh }"
           :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/xds`"
+          v-slot="{ data, refresh }"
         >
           <CodeBlock
             language="json"

--- a/src/app/diagnostics/views/DiagnosticsDetailView.vue
+++ b/src/app/diagnostics/views/DiagnosticsDetailView.vue
@@ -1,12 +1,12 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri }"
     name="diagnostics"
     :params="{
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t, uri }"
   >
     <AppView
       :breadcrumbs="[
@@ -28,8 +28,8 @@
 
       <KCard>
         <DataLoader
-          v-slot="{ data }"
           :src="uri(sources, `/config`, {})"
+          v-slot="{ data }"
         >
           <CodeBlock
             data-testid="code-block-diagnostics"

--- a/src/app/external-services/views/ExternalServiceDetailTabsView.vue
+++ b/src/app/external-services/views/ExternalServiceDetailTabsView.vue
@@ -1,11 +1,11 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="external-service-detail-tabs-view"
     :params="{
       mesh: '',
       service: '',
     }"
+    v-slot="{ route, t }"
   >
     <AppView
       :docs="t('external-services.href.docs')"

--- a/src/app/external-services/views/ExternalServiceDetailView.vue
+++ b/src/app/external-services/views/ExternalServiceDetailView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri }"
     name="external-service-detail-view"
     :params="{
       mesh: '',
@@ -9,17 +8,18 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t, uri }"
   >
     <AppView>
       <div
         class="stack"
       >
         <DataLoader
-          v-slot="{ data }"
           :src="uri(sources, `/meshes/:mesh/external-services/:name`, {
             mesh: route.params.mesh,
             name: route.params.service,
           })"
+          v-slot="{ data }"
         >
           <KCard
             data-testid="external-service-details"
@@ -51,7 +51,6 @@
             <h3>{{ t('external-services.detail.config') }}</h3>
 
             <ResourceCodeBlock
-              v-slot="{ copy, copying }"
               class="mt-4"
               data-testid="external-service-config"
               :resource="data.config"
@@ -62,6 +61,7 @@
               @query-change="route.update({ codeSearch: $event })"
               @filter-mode-change="route.update({ codeFilter: $event })"
               @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+              v-slot="{ copy, copying }"
             >
               <DataSource
                 v-if="copying"

--- a/src/app/external-services/views/ExternalServiceListView.vue
+++ b/src/app/external-services/views/ExternalServiceListView.vue
@@ -1,12 +1,12 @@
 <template>
   <RouteView
-    v-slot="{ route, t, me, uri }"
     name="external-service-list-view"
     :params="{
       page: 1,
       size: 50,
       mesh: '',
     }"
+    v-slot="{ route, t, me, uri }"
   >
     <RouteTitle
       :render="false"

--- a/src/app/gateways/views/BuiltinGatewayConfigView.vue
+++ b/src/app/gateways/views/BuiltinGatewayConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri }"
     name="builtin-gateway-config-view"
     :params="{
       mesh: '',
@@ -9,6 +8,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t, uri }"
   >
     <RouteTitle
       :render="false"
@@ -17,14 +17,13 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data }"
           :src="uri(sources, `/meshes/:mesh/mesh-gateways/:name`, {
             mesh: route.params.mesh,
             name: route.params.gateway,
           })"
+          v-slot="{ data }"
         >
           <ResourceCodeBlock
-            v-slot="{ copy, copying }"
             data-testid="config"
             :resource="data.config"
             is-searchable
@@ -34,6 +33,7 @@
             @query-change="route.update({ codeSearch: $event })"
             @filter-mode-change="route.update({ codeFilter: $event })"
             @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            v-slot="{ copy, copying }"
           >
             <DataSource
               v-if="copying"

--- a/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ can, route, t, me }"
     name="builtin-gateway-dataplanes-view"
     :params="{
       mesh: '',
@@ -11,20 +10,21 @@
       s: '',
       dataPlane: '',
     }"
+    v-slot="{ can, route, t, me }"
   >
     <AppView>
       <DataSource
-        v-slot="{ data: meshGateway, error }: MeshGatewaySource"
         :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}`"
+        v-slot="{ data: meshGateway, error }: MeshGatewaySource"
       >
         <div class="stack">
           <KCard>
             <DataLoader
-              v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
               :src="meshGateway === undefined ? '' : `/meshes/${route.params.mesh}/dataplanes/for/service-insight/${meshGateway.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
               :data="[meshGateway]"
               :errors="[error]"
               :loader="false"
+              v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
             >
               <AppCollection
                 class="data-plane-collection"

--- a/src/app/gateways/views/BuiltinGatewayDetailTabsView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailTabsView.vue
@@ -1,11 +1,11 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="builtin-gateway-detail-tabs-view"
     :params="{
       mesh: '',
       gateway: '',
     }"
+    v-slot="{ route, t }"
   >
     <AppView
       :docs="t('builtin-gateways.href.docs')"

--- a/src/app/gateways/views/BuiltinGatewayDetailView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDetailView.vue
@@ -1,27 +1,27 @@
 <template>
   <RouteView
-    v-slot="{ route }"
     name="builtin-gateway-detail-view"
     :params="{
       mesh: '',
       gateway: '',
       listener: '0',
     }"
+    v-slot="{ route }"
   >
     <AppView>
       <DataSource
-        v-slot="{ data: meshGateway, error: meshGatewayError }: MeshGatewaySource"
         :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}`"
+        v-slot="{ data: meshGateway, error: meshGatewayError }: MeshGatewaySource"
       >
         <DataSource
-          v-slot="{ data: policyTypesData, error: policyTypesError }: PolicyTypeCollectionSource"
           :src="`/policy-types`"
+          v-slot="{ data: policyTypesData, error: policyTypesError }: PolicyTypeCollectionSource"
         >
           <DataLoader
-            v-slot="{ data: rulesData }: GatewayRulesSource"
             :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}/rules`"
             :data="[meshGateway, policyTypesData]"
             :errors="[meshGatewayError, policyTypesError]"
+            v-slot="{ data: rulesData }: GatewayRulesSource"
           >
             <template v-if="meshGateway && rulesData && policyTypesData">
               <ListenerRoutes

--- a/src/app/gateways/views/BuiltinGatewayListView.vue
+++ b/src/app/gateways/views/BuiltinGatewayListView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, can, me, uri }"
     name="builtin-gateway-list-view"
     :params="{
       page: 1,
@@ -8,6 +7,7 @@
       mesh: '',
       gateway: '',
     }"
+    v-slot="{ route, t, can, me, uri }"
   >
     <AppView
       :docs="t('builtin-gateways.href.docs')"

--- a/src/app/gateways/views/DelegatedGatewayDetailTabsView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailTabsView.vue
@@ -1,11 +1,11 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="delegated-gateway-detail-tabs-view"
     :params="{
       mesh: '',
       service: '',
     }"
+    v-slot="{ route, t }"
   >
     <AppView
       :docs="t('delegated-gateways.href.docs')"

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ can, route, t, me }"
     name="delegated-gateway-detail-view"
     :params="{
       mesh: '',
@@ -10,12 +9,13 @@
       s: '',
       dataPlane: '',
     }"
+    v-slot="{ can, route, t, me }"
   >
     <AppView>
       <div class="stack">
         <DataLoader
-          v-slot="{ data }: ServiceInsightSource"
           :src="`/meshes/${route.params.mesh}/service-insights/${route.params.service}`"
+          v-slot="{ data }: ServiceInsightSource"
         >
           <KCard v-if="data">
             <div class="columns">
@@ -63,9 +63,9 @@
 
           <KCard class="mt-4">
             <DataLoader
-              v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
               :src="`/meshes/${route.params.mesh}/dataplanes/for/service-insight/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
               :loader="false"
+              v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
             >
               <AppCollection
                 class="data-plane-collection"

--- a/src/app/gateways/views/DelegatedGatewayListView.vue
+++ b/src/app/gateways/views/DelegatedGatewayListView.vue
@@ -1,12 +1,12 @@
 <template>
   <RouteView
-    v-slot="{ route, t, me, uri }"
     name="delegated-gateway-list-view"
     :params="{
       page: 1,
       size: 50,
       mesh: '',
     }"
+    v-slot="{ route, t, me, uri }"
   >
     <AppView
       :docs="t('delegated-gateways.href.docs')"

--- a/src/app/gateways/views/GatewayListTabsView.vue
+++ b/src/app/gateways/views/GatewayListTabsView.vue
@@ -1,10 +1,10 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="gateway-list-tabs-view"
     :params="{
       mesh: '',
     }"
+    v-slot="{ route, t }"
   >
     <RouteTitle
       :render="false"
@@ -15,9 +15,9 @@
       <AppView>
         <template #actions>
           <DataCollection
-            v-slot="{ items }"
             :items="route.children"
             :empty="false"
+            v-slot="{ items }"
           >
             <XActionGroup
               :expanded="true"

--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -26,8 +26,8 @@
 
           <div class="upgrade-check-wrapper">
             <DataSource
-              v-slot="{ data }"
               :src="`/control-plane/version/latest`"
+              v-slot="{ data }"
             >
               <!-- make sure we have data but don't show errors or loaders -->
               <KAlert

--- a/src/app/meshes/views/MeshDetailTabsView.vue
+++ b/src/app/meshes/views/MeshDetailTabsView.vue
@@ -1,10 +1,10 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="mesh-detail-tabs-view"
     :params="{
       mesh: '',
     }"
+    v-slot="{ route, t }"
   >
     <AppView>
       <template #title>
@@ -20,8 +20,8 @@
       </template>
 
       <DataLoader
-        v-slot="{ data: mesh }: MeshSource"
         :src="`/meshes/${route.params.mesh}`"
+        v-slot="{ data: mesh }: MeshSource"
       >
         <XTabs
           :selected="route.child()?.name"

--- a/src/app/meshes/views/MeshDetailView.vue
+++ b/src/app/meshes/views/MeshDetailView.vue
@@ -1,10 +1,10 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri }"
     name="mesh-detail-view"
     :params="{
       mesh: '',
     }"
+    v-slot="{ route, t, uri }"
   >
     <RouteTitle
       :title="t('meshes.routes.overview.title')"
@@ -12,10 +12,10 @@
     />
 
     <DataSource
-      v-slot="{ data }"
       :src="uri(sources, '/mesh-insights/:name', {
         name: route.params.mesh,
       })"
+      v-slot="{ data }"
     >
       <template
         v-for="missingTLSPolicy in [
@@ -138,8 +138,8 @@
               </div>
             </KCard>
             <ResourceCodeBlock
-              v-slot="{ copy, copying }"
               :resource="mesh.config"
+              v-slot="{ copy, copying }"
             >
               <DataSource
                 v-if="copying"

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -1,12 +1,12 @@
 <template>
   <RouteView
-    v-slot="{ route, t, me }"
     name="mesh-list-view"
     :params="{
       page: 1,
       size: 50,
       mesh: '',
     }"
+    v-slot="{ route, t, me }"
   >
     <AppView
       :docs="t('meshes.href.docs')"
@@ -23,9 +23,9 @@
         <div v-html="t('meshes.routes.items.intro', {}, { defaultMessage: '' })" />
         <KCard>
           <DataLoader
-            v-slot="{ data, error }: MeshInsightCollectionSource"
             :src="`/mesh-insights?page=${route.params.page}&size=${route.params.size}`"
             :loader="false"
+            v-slot="{ data, error }: MeshInsightCollectionSource"
           >
             <AppCollection
               class="mesh-collection"

--- a/src/app/meshes/views/MeshRootView.vue
+++ b/src/app/meshes/views/MeshRootView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ t }"
     name="mesh-index-view"
+    v-slot="{ t }"
   >
     <AppView
       :breadcrumbs="[

--- a/src/app/onboarding/components/OnboardingAlert.vue
+++ b/src/app/onboarding/components/OnboardingAlert.vue
@@ -1,11 +1,11 @@
 <template>
   <DataSource
-    v-slot="{ data, refresh }"
     :src="`/me/-onboarding-alert`"
+    v-slot="{ data, refresh }"
   >
     <DataSink
-      v-slot="{ submit }"
       :src="`/me/-onboarding-alert`"
+      v-slot="{ submit }"
     >
       <KAlert
         v-if="data?.closed !== true"

--- a/src/app/onboarding/views/OnboardingAddNewServicesCodeView.vue
+++ b/src/app/onboarding/views/OnboardingAddNewServicesCodeView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ can, t }"
     name="onboarding-add-new-services"
+    v-slot="{ can, t }"
   >
     <RouteTitle
       :title="t('onboarding.routes.add-services-code.title')"
@@ -9,8 +9,8 @@
     />
     <AppView>
       <DataSource
-        v-slot="{ data, error }: DataplaneOverviewCollectionSource"
         :src="`/dataplanes/online?page=1&size=10`"
+        v-slot="{ data, error }: DataplaneOverviewCollectionSource"
       >
         <OnboardingPage>
           <template #header>

--- a/src/app/onboarding/views/OnboardingAddNewServicesView.vue
+++ b/src/app/onboarding/views/OnboardingAddNewServicesView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ t }"
     name="onboarding-add-new-services-view"
+    v-slot="{ t }"
   >
     <RouteTitle
       :title="t('onboarding.routes.add-services.title')"

--- a/src/app/onboarding/views/OnboardingCompletedView.vue
+++ b/src/app/onboarding/views/OnboardingCompletedView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ t }"
     name="onboarding-completed-view"
+    v-slot="{ t }"
   >
     <RouteTitle
       :title="t('onboarding.routes.completed.title')"

--- a/src/app/onboarding/views/OnboardingConfigurationTypesView.vue
+++ b/src/app/onboarding/views/OnboardingConfigurationTypesView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ can, t }"
     name="onboarding-configuration-types-view"
+    v-slot="{ can, t }"
   >
     <RouteTitle
       :title="t('onboarding.routes.configuration-types.title')"

--- a/src/app/onboarding/views/OnboardingCreateMeshView.vue
+++ b/src/app/onboarding/views/OnboardingCreateMeshView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ can, t }"
     name="onboarding-create-mesh-view"
+    v-slot="{ can, t }"
   >
     <RouteTitle
       :title="t('onboarding.routes.create-mesh.title')"

--- a/src/app/onboarding/views/OnboardingDataplanesView.vue
+++ b/src/app/onboarding/views/OnboardingDataplanesView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ t }"
     name="onboarding-dataplanes-view"
+    v-slot="{ t }"
   >
     <RouteTitle
       :title="t('onboarding.routes.dataplanes-overview.title')"
@@ -9,8 +9,8 @@
     />
     <AppView>
       <DataSource
-        v-slot="{ data, error }: DataplaneOverviewCollectionSource"
         :src="`/dataplanes/poll?page=1&size=10`"
+        v-slot="{ data, error }: DataplaneOverviewCollectionSource"
       >
         <template
           v-for="offline in [(data?.items ?? []).some(item => item.status !== 'online')]"

--- a/src/app/onboarding/views/OnboardingDeploymentTypesView.vue
+++ b/src/app/onboarding/views/OnboardingDeploymentTypesView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ t }"
     name="onboarding-deployment-types-view"
+    v-slot="{ t }"
   >
     <RouteTitle
       :title="t('onboarding.routes.deployment-types.title')"

--- a/src/app/onboarding/views/OnboardingMultiZoneView.vue
+++ b/src/app/onboarding/views/OnboardingMultiZoneView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ t }"
     name="onboarding-multi-zone-view"
+    v-slot="{ t }"
   >
     <RouteTitle
       :title="t('onboarding.routes.multizone.title')"
@@ -9,12 +9,12 @@
     />
     <AppView>
       <DataSource
-        v-slot="{ data, error }: ZoneOverviewCollectionSource"
         :src="`/zone-cps/~online?page=1&size=10`"
+        v-slot="{ data, error }: ZoneOverviewCollectionSource"
       >
         <DataSource
-          v-slot="{ data: ingresses, error: ingressesError }: ZoneIngressOverviewCollectionSource"
           :src="`/zone-ingress-overviews/~online?page=1&size=10`"
+          v-slot="{ data: ingresses, error: ingressesError }: ZoneIngressOverviewCollectionSource"
         >
           <OnboardingPage>
             <template #header>

--- a/src/app/onboarding/views/OnboardingWelcomeView.vue
+++ b/src/app/onboarding/views/OnboardingWelcomeView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ env, t, can }"
     name="onboarding-welcome-view"
+    v-slot="{ env, t, can }"
   >
     <RouteTitle
       :title="t('onboarding.routes.welcome.title', {name: t('common.product.name')})"

--- a/src/app/policies/views/PolicyDetailConfigView.vue
+++ b/src/app/policies/views/PolicyDetailConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, uri }"
     name="policy-detail-config-view"
     :params="{
       mesh: '',
@@ -10,11 +9,11 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, uri }"
   >
     <AppView>
       <KCard>
         <ResourceCodeBlock
-          v-slot="{ copy, copying }"
           :resource="props.data.config"
           is-searchable
           :query="route.params.codeSearch"
@@ -23,6 +22,7 @@
           @query-change="route.update({ codeSearch: $event })"
           @filter-mode-change="route.update({ codeFilter: $event })"
           @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          v-slot="{ copy, copying }"
         >
           <DataSource
             v-if="copying"

--- a/src/app/policies/views/PolicyDetailTabsView.vue
+++ b/src/app/policies/views/PolicyDetailTabsView.vue
@@ -1,20 +1,20 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri }"
     name="policy-detail-tabs-view"
     :params="{
       mesh: '',
       policy: '',
       policyPath: '',
     }"
+    v-slot="{ route, t, uri }"
   >
     <DataSource
-      v-slot="{ data, error }"
       :src="uri(sources, '/meshes/:mesh/policy-path/:path/policy/:name', {
         mesh: route.params.mesh,
         path: route.params.policyPath,
         name: route.params.policy,
       })"
+      v-slot="{ data, error }"
     >
       <AppView
         :breadcrumbs="[

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri, can, me }"
     name="policy-detail-view"
     :params="{
       page: 1,
@@ -11,6 +10,7 @@
       policyPath: '',
       dataPlane: '',
     }"
+    v-slot="{ route, t, uri, can, me }"
   >
     <AppView>
       <KCard>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, can, uri, me }"
     name="policy-list-view"
     :params="{
       page: 1,
@@ -10,6 +9,7 @@
       policy: '',
       s: '',
     }"
+    v-slot="{ route, t, can, uri, me }"
   >
     <DataCollection
       :predicate="(policyType) => typeof policyType !== 'undefined' && policyType.path === route.params.policyPath"

--- a/src/app/policies/views/PolicySummaryView.vue
+++ b/src/app/policies/views/PolicySummaryView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="policy-summary-view"
     :params="{
       mesh: '',
@@ -10,6 +9,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <DataCollection
       :items="props.items"
@@ -56,7 +56,6 @@
               :policy="item"
             >
               <ResourceCodeBlock
-                v-slot="{ copy, copying }"
                 :resource="item.config"
                 is-searchable
                 :query="route.params.codeSearch"
@@ -65,6 +64,7 @@
                 @query-change="route.update({ codeSearch: $event })"
                 @filter-mode-change="route.update({ codeFilter: $event })"
                 @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+                v-slot="{ copy, copying }"
               >
                 <DataSource
                   v-if="copying"

--- a/src/app/policies/views/PolicyTypeListView.vue
+++ b/src/app/policies/views/PolicyTypeListView.vue
@@ -1,12 +1,12 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="policy-list-view"
     :params="{
       mesh: '',
       policyPath: '',
       policy: '',
     }"
+    v-slot="{ route, t }"
   >
     <RouteTitle
       :render="false"
@@ -14,12 +14,12 @@
     />
     <AppView>
       <DataSource
-        v-slot="{ data: meshInsight }: MeshInsightSource"
         :src="`/mesh-insights/${route.params.mesh}`"
+        v-slot="{ data: meshInsight }: MeshInsightSource"
       >
         <DataSource
-          v-slot="{ data, error }: PolicyTypeCollectionSource"
           :src="`/policy-types`"
+          v-slot="{ data, error }: PolicyTypeCollectionSource"
         >
           <div
             class="policy-list-content"
@@ -41,9 +41,9 @@
                   :key="legacy"
                 >
                   <DataCollection
-                    v-slot="{ items }"
                     :predicate="typeof meshInsight?.policies === 'undefined' ? undefined : (item) => legacy.length > 0 || item.isTargetRefBased"
                     :items="data!.policies"
+                    v-slot="{ items }"
                   >
                     <template
                       v-for="current in [items.find(policyType => policyType.path === route.params.policyPath)]"

--- a/src/app/services/views/MeshExternalServiceConfigView.vue
+++ b/src/app/services/views/MeshExternalServiceConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route }"
     name="mesh-external-service-config-view"
     :params="{
       mesh: '',
@@ -9,11 +8,11 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route }"
   >
     <AppView>
       <KCard>
         <ResourceCodeBlock
-          v-slot="{ copy, copying }"
           :resource="props.data.config"
           is-searchable
           :query="route.params.codeSearch"
@@ -22,6 +21,7 @@
           @query-change="route.update({ codeSearch: $event })"
           @filter-mode-change="route.update({ codeFilter: $event })"
           @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          v-slot="{ copy, copying }"
         >
           <DataSource
             v-if="copying"

--- a/src/app/services/views/MeshExternalServiceDetailTabsView.vue
+++ b/src/app/services/views/MeshExternalServiceDetailTabsView.vue
@@ -1,18 +1,18 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri }"
     name="mesh-external-service-detail-tabs-view"
     :params="{
       mesh: '',
       service: '',
     }"
+    v-slot="{ route, t, uri }"
   >
     <DataSource
-      v-slot="{ data, error }"
       :src="uri(sources, '/meshes/:mesh/mesh-external-service/:name', {
         mesh: route.params.mesh,
         name: route.params.service,
       })"
+      v-slot="{ data, error }"
     >
       <AppView
         :docs="t('services.mesh-external-service.href.docs')"

--- a/src/app/services/views/MeshExternalServiceListView.vue
+++ b/src/app/services/views/MeshExternalServiceListView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, can, uri, me }"
     name="mesh-external-service-list-view"
     :params="{
       page: 1,
@@ -8,6 +7,7 @@
       mesh: '',
       service: '',
     }"
+    v-slot="{ route, t, can, uri, me }"
   >
     <RouteTitle
       :render="false"

--- a/src/app/services/views/MeshExternalServiceSummaryView.vue
+++ b/src/app/services/views/MeshExternalServiceSummaryView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="mesh-external-service-summary-view"
     :params="{
       mesh: '',
@@ -9,6 +8,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <DataCollection
       :items="props.items"
@@ -112,7 +112,6 @@
 
               <div class="mt-4">
                 <ResourceCodeBlock
-                  v-slot="{ copy, copying }"
                   :resource="item.config"
                   is-searchable
                   :query="route.params.codeSearch"
@@ -121,6 +120,7 @@
                   @query-change="route.update({ codeSearch: $event })"
                   @filter-mode-change="route.update({ codeFilter: $event })"
                   @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+                  v-slot="{ copy, copying }"
                 >
                   <DataSource
                     v-if="copying"

--- a/src/app/services/views/MeshServiceConfigView.vue
+++ b/src/app/services/views/MeshServiceConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route }"
     name="mesh-service-config-view"
     :params="{
       mesh: '',
@@ -9,11 +8,11 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route }"
   >
     <AppView>
       <KCard>
         <ResourceCodeBlock
-          v-slot="{ copy, copying }"
           :resource="props.data.config"
           is-searchable
           :query="route.params.codeSearch"
@@ -22,6 +21,7 @@
           @query-change="route.update({ codeSearch: $event })"
           @filter-mode-change="route.update({ codeFilter: $event })"
           @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          v-slot="{ copy, copying }"
         >
           <DataSource
             v-if="copying"

--- a/src/app/services/views/MeshServiceDetailTabsView.vue
+++ b/src/app/services/views/MeshServiceDetailTabsView.vue
@@ -1,18 +1,18 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri }"
     name="mesh-service-detail-tabs-view"
     :params="{
       mesh: '',
       service: '',
     }"
+    v-slot="{ route, t, uri }"
   >
     <DataSource
-      v-slot="{ data, error }"
       :src="uri(sources, '/meshes/:mesh/mesh-service/:name', {
         mesh: route.params.mesh,
         name: route.params.service,
       })"
+      v-slot="{ data, error }"
     >
       <AppView
         :docs="t('services.mesh-service.href.docs')"

--- a/src/app/services/views/MeshServiceDetailView.vue
+++ b/src/app/services/views/MeshServiceDetailView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ can, route, t, uri, me }"
     name="mesh-service-detail-view"
     :params="{
       mesh: '',
@@ -13,6 +12,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ can, route, t, uri, me }"
   >
     <AppView>
       <div

--- a/src/app/services/views/MeshServiceListView.vue
+++ b/src/app/services/views/MeshServiceListView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, can, uri, me }"
     name="mesh-service-list-view"
     :params="{
       page: 1,
@@ -8,6 +7,7 @@
       mesh: '',
       service: '',
     }"
+    v-slot="{ route, t, can, uri, me }"
   >
     <RouteTitle
       :render="false"

--- a/src/app/services/views/MeshServiceSummaryView.vue
+++ b/src/app/services/views/MeshServiceSummaryView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="mesh-service-summary-view"
     :params="{
       mesh: '',
@@ -9,6 +8,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <DataCollection
       :items="props.items"
@@ -117,7 +117,6 @@
 
               <div class="mt-4">
                 <ResourceCodeBlock
-                  v-slot="{ copy, copying }"
                   :resource="item.config"
                   is-searchable
                   :query="route.params.codeSearch"
@@ -126,6 +125,7 @@
                   @query-change="route.update({ codeSearch: $event })"
                   @filter-mode-change="route.update({ codeFilter: $event })"
                   @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+                  v-slot="{ copy, copying }"
                 >
                   <DataSource
                     v-if="copying"

--- a/src/app/services/views/ServiceConfigView.vue
+++ b/src/app/services/views/ServiceConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="service-config-view"
     :params="{
       mesh: '',
@@ -9,6 +8,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <AppView>
       <template #title>
@@ -22,8 +22,8 @@
       <KCard>
         <div>
           <DataSource
-            v-slot="{ data: externalService, error: externalServiceError }: ExternalServiceSource"
             :src="`/meshes/${route.params.mesh}/external-services/for/${route.params.service}`"
+            v-slot="{ data: externalService, error: externalServiceError }: ExternalServiceSource"
           >
             <ErrorBlock
               v-if="externalServiceError"
@@ -43,7 +43,6 @@
 
             <ResourceCodeBlock
               v-else
-              v-slot="{ copy, copying }"
               :resource="externalService.config"
               is-searchable
               :query="route.params.codeSearch"
@@ -52,6 +51,7 @@
               @query-change="route.update({ codeSearch: $event })"
               @filter-mode-change="route.update({ codeFilter: $event })"
               @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+              v-slot="{ copy, copying }"
             >
               <DataSource
                 v-if="copying"

--- a/src/app/services/views/ServiceDetailTabsView.vue
+++ b/src/app/services/views/ServiceDetailTabsView.vue
@@ -1,11 +1,11 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="service-detail-tabs-view"
     :params="{
       mesh: '',
       service: '',
     }"
+    v-slot="{ route, t }"
   >
     <AppView
       :docs="t('services.href.docs')"

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ can, route, t, me, uri }"
     name="service-detail-view"
     :params="{
       mesh: '',
@@ -13,6 +12,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ can, route, t, me, uri }"
   >
     <AppView>
       <div
@@ -20,11 +20,11 @@
       >
         <KCard>
           <DataLoader
-            v-slot="{ data }"
             :src="uri(sources, `/meshes/:mesh/service-insights/:name`, {
               mesh: route.params.mesh,
               name: route.params.service,
             })"
+            v-slot="{ data }"
           >
             <div class="columns">
               <DefinitionCard>

--- a/src/app/services/views/ServiceListTabsView.vue
+++ b/src/app/services/views/ServiceListTabsView.vue
@@ -1,10 +1,10 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="service-list-tabs-view"
     :params="{
       mesh: '',
     }"
+    v-slot="{ route, t }"
   >
     <div class="stack">
       <div v-html="t('services.routes.items.intro', {}, { defaultMessage: '' })" />

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri, me }"
     name="service-list-view"
     :params="{
       page: 1,
@@ -8,6 +7,7 @@
       mesh: '',
       service: '',
     }"
+    v-slot="{ route, t, uri, me }"
   >
     <RouteTitle
       :render="false"

--- a/src/app/zone-egresses/views/ZoneEgressClustersView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressClustersView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="zone-egress-clusters-view"
     :params="{
       zoneEgress: '',
@@ -8,6 +7,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <RouteTitle
       :render="false"
@@ -16,8 +16,8 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data, refresh }"
           :src="`/zone-egresses/${route.params.zoneEgress}/data-path/clusters`"
+          v-slot="{ data, refresh }"
         >
           <CodeBlock
             language="json"

--- a/src/app/zone-egresses/views/ZoneEgressConfigView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri }"
     name="zone-egress-config-view"
     :params="{
       zoneEgress: '',
@@ -8,6 +7,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t, uri }"
   >
     <RouteTitle
       :render="false"
@@ -16,13 +16,12 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data }"
           :src="uri(sources, `/zone-egresses/:name`, {
             name: route.params.zoneEgress,
           })"
+          v-slot="{ data }"
         >
           <ResourceCodeBlock
-            v-slot="{ copy, copying }"
             :resource="data.config"
             is-searchable
             :query="route.params.codeSearch"
@@ -31,6 +30,7 @@
             @query-change="route.update({ codeSearch: $event })"
             @filter-mode-change="route.update({ codeFilter: $event })"
             @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            v-slot="{ copy, copying }"
           >
             <DataSource
               v-if="copying"

--- a/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
@@ -1,15 +1,15 @@
 <template>
   <RouteView
-    v-slot="{ route, can, t }"
     name="zone-egress-detail-tabs-view"
     :params="{
       zone: '',
       zoneEgress: '',
     }"
+    v-slot="{ route, can, t }"
   >
     <DataSource
-      v-slot="{ data, error }: ZoneEgressOverviewSource"
       :src="`/zone-egress-overviews/${route.params.zoneEgress}`"
+      v-slot="{ data, error }: ZoneEgressOverviewSource"
     >
       <AppView
         :docs="t('zone-ingresses.href.docs')"

--- a/src/app/zone-egresses/views/ZoneEgressDetailView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressDetailView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ t }"
     name="zone-egress-detail-view"
+    v-slot="{ t }"
   >
     <AppView>
       <div

--- a/src/app/zone-egresses/views/ZoneEgressListView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressListView.vue
@@ -1,7 +1,6 @@
 <template>
   <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
   <RouteView
-    v-slot="{ route, t, me, uri, can }"
     name="zone-egress-list-view"
     :params="{
       /* page: 1, */
@@ -9,6 +8,7 @@
       zone: '',
       zoneEgress: '',
     }"
+    v-slot="{ route, t, me, uri, can }"
   >
     <RouteTitle
       v-if="can('use zones')"

--- a/src/app/zone-egresses/views/ZoneEgressStatsView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressStatsView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="zone-egress-stats-view"
     :params="{
       zoneEgress: '',
@@ -8,6 +7,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <RouteTitle
       :render="false"
@@ -16,8 +16,8 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data, refresh }"
           :src="`/zone-egresses/${route.params.zoneEgress}/data-path/stats`"
+          v-slot="{ data, refresh }"
         >
           <CodeBlock
             language="json"

--- a/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
@@ -1,10 +1,10 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="zone-egress-summary-view"
     :params="{
       zoneEgress: '',
     }"
+    v-slot="{ route, t }"
   >
     <DataCollection
       :items="props.items"

--- a/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="zone-egress-xds-config-view"
     :params="{
       zoneEgress: '',
@@ -8,6 +7,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <RouteTitle
       :render="false"
@@ -16,8 +16,8 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data, refresh }"
           :src="`/zone-egresses/${route.params.zoneEgress}/data-path/xds`"
+          v-slot="{ data, refresh }"
         >
           <CodeBlock
             language="json"

--- a/src/app/zone-ingresses/views/ZoneIngressClustersView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressClustersView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="zone-ingress-clusters-view"
     :params="{
       zoneIngress: '',
@@ -8,6 +7,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <RouteTitle
       :render="false"
@@ -16,8 +16,8 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data, refresh }"
           :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/clusters`"
+          v-slot="{ data, refresh }"
         >
           <CodeBlock
             language="json"

--- a/src/app/zone-ingresses/views/ZoneIngressConfigView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri }"
     name="zone-ingress-config-view"
     :params="{
       zoneIngress: '',
@@ -8,6 +7,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t, uri }"
   >
     <RouteTitle
       :render="false"
@@ -16,13 +16,12 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data }"
           :src="uri(sources, `/zone-ingresses/:name`, {
             name: route.params.zoneIngress,
           })"
+          v-slot="{ data }"
         >
           <ResourceCodeBlock
-            v-slot="{ copy, copying }"
             :resource="data.config"
             is-searchable
             :query="route.params.codeSearch"
@@ -31,6 +30,7 @@
             @query-change="route.update({ codeSearch: $event })"
             @filter-mode-change="route.update({ codeFilter: $event })"
             @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            v-slot="{ copy, copying }"
           >
             <DataSource
               v-if="copying"

--- a/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
@@ -1,15 +1,15 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="zone-ingress-detail-tabs-view"
     :params="{
       zone: '',
       zoneIngress: '',
     }"
+    v-slot="{ route, t }"
   >
     <DataSource
-      v-slot="{ data, error }: ZoneIngressOverviewSource"
       :src="`/zone-ingress-overviews/${route.params.zoneIngress}`"
+      v-slot="{ data, error }: ZoneIngressOverviewSource"
     >
       <AppView
         :docs="t('zone-ingresses.href.docs')"

--- a/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ t }"
     name="zone-ingress-detail-view"
+    v-slot="{ t }"
   >
     <AppView>
       <div

--- a/src/app/zone-ingresses/views/ZoneIngressListView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressListView.vue
@@ -1,7 +1,6 @@
 <template>
   <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
   <RouteView
-    v-slot="{ route, t, me, uri }"
     name="zone-ingress-list-view"
     :params="{
       /* page: 1, */
@@ -9,6 +8,7 @@
       zone: '',
       zoneIngress: '',
     }"
+    v-slot="{ route, t, me, uri }"
   >
     <RouteTitle
       :render="false"

--- a/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    v-slot="{ t }"
     name="zone-ingress-services-view"
+    v-slot="{ t }"
   >
     <RouteTitle
       :render="false"

--- a/src/app/zone-ingresses/views/ZoneIngressStatsView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressStatsView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="zone-ingress-stats-view"
     :params="{
       zoneIngress: '',
@@ -8,6 +7,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <RouteTitle
       :render="false"
@@ -16,8 +16,8 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data, refresh }"
           :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/stats`"
+          v-slot="{ data, refresh }"
         >
           <CodeBlock
             language="json"

--- a/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -1,10 +1,10 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="zone-ingress-summary-view"
     :params="{
       zoneIngress: '',
     }"
+    v-slot="{ route, t }"
   >
     <DataCollection
       :items="props.items"

--- a/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t }"
     name="zone-ingress-xds-config-view"
     :params="{
       zoneIngress: '',
@@ -8,6 +7,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t }"
   >
     <RouteTitle
       :render="false"
@@ -16,8 +16,8 @@
     <AppView>
       <KCard>
         <DataLoader
-          v-slot="{ data, refresh }"
           :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/xds`"
+          v-slot="{ data, refresh }"
         >
           <CodeBlock
             language="json"

--- a/src/app/zones-crud/views/ZoneCreateView.vue
+++ b/src/app/zones-crud/views/ZoneCreateView.vue
@@ -1,14 +1,14 @@
 <template>
   <RouteView
-    v-slot="{ route, id, uri, t }"
     name="zone-create-view"
     :attrs="{
       class: 'is-fullscreen',
     }"
+    v-slot="{ route, id, uri, t }"
   >
     <DataSink
-      v-slot="{ submit, payload, data: zone, error, writing }"
       :src="`/zone-cps/~/create`"
+      v-slot="{ submit, payload, data: zone, error, writing }"
     >
       <AppView
         :fullscreen="true"
@@ -150,12 +150,12 @@
                       v-slot="{ expanded, toggle }"
                     >
                       <DataSource
-                        v-slot="{ error: validateError }"
                         :src="expanded ? uri(sources, `/zone-cps/:name/validate`, {
                           name,
                         }) : ''"
                         @change="toggle"
                         @error="toggle"
+                        v-slot="{ error: validateError }"
                       >
                         <template
                           v-for="invalid in [
@@ -300,8 +300,8 @@
 
                   <div class="form-section__content">
                     <DataSource
-                      v-slot="{ data }"
                       :src="uri(cpSources, '/control-plane/addresses', {})"
+                      v-slot="{ data }"
                     >
                       <template
                         v-if="(typeof data !== 'undefined')"
@@ -329,13 +329,13 @@
 
                 <div class="form-section">
                   <DataSource
-                    v-slot="{ data, error: scanError }"
                     :src="uri(sources, '/zone-cps/online/:name', {
                       name,
                     }, {
                       cacheControl: 'no-cache',
                     })"
                     @change="success"
+                    v-slot="{ data, error: scanError }"
                   >
                     <div class="form-section__header">
                       <h2 class="form-section-title">

--- a/src/app/zones/views/ZoneConfigView.vue
+++ b/src/app/zones/views/ZoneConfigView.vue
@@ -1,6 +1,5 @@
 <template>
   <RouteView
-    v-slot="{ route, t, uri }"
     name="zone-cp-config-view"
     :params="{
       zone: '',
@@ -8,16 +7,17 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ route, t, uri }"
   >
     <RouteTitle
       :render="false"
       :title="t('zone-cps.routes.item.navigation.zone-cp-config-view')"
     />
     <DataSource
-      v-slot="{ data: version }"
       :src="uri(sources, '/control-plane/outdated/:version', {
         version: props.data.zoneInsight.version?.kumaCp?.version ?? '-',
       })"
+      v-slot="{ data: version }"
     >
       <AppView>
         <template

--- a/src/app/zones/views/ZoneDetailTabsView.vue
+++ b/src/app/zones/views/ZoneDetailTabsView.vue
@@ -1,14 +1,14 @@
 <template>
   <RouteView
-    v-slot="{ can, route, t }"
     name="zone-cp-detail-tabs-view"
     :params="{
       zone: '',
     }"
+    v-slot="{ can, route, t }"
   >
     <DataLoader
-      v-slot="{ data }: ZoneOverviewSource"
       :src="`/zone-cps/${route.params.zone}`"
+      v-slot="{ data }: ZoneOverviewSource"
     >
       <AppView
         v-if="data"
@@ -61,9 +61,9 @@
               >
                 <DataSink
                   v-if="expanded"
-                  v-slot="{ submit, error }"
                   :src="`/zone-cps/${data.name}/delete`"
                   @change="() => route.replace({ name: 'zone-cp-list-view' })"
+                  v-slot="{ submit, error }"
                 >
                   <XPrompt
                     :action="t('common.delete_modal.proceed_button')"

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -1,13 +1,13 @@
 <template>
   <RouteView
-    v-slot="{ t, uri }"
     name="zone-cp-detail-view"
+    v-slot="{ t, uri }"
   >
     <DataSource
-      v-slot="{ data: version }"
       :src="uri(sources, '/control-plane/outdated/:version', {
         version: props.data.zoneInsight.version?.kumaCp?.version ?? '-',
       })"
+      v-slot="{ data: version }"
     >
       <AppView
         :docs="t('zones.href.docs.cta')"

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -1,12 +1,12 @@
 <template>
   <RouteView
-    v-slot="{ route, t, can, uri, me }"
     name="zone-cp-list-view"
     :params="{
       page: 1,
       size: 50,
       zone: '',
     }"
+    v-slot="{ route, t, can, uri, me }"
   >
     <AppView
       :docs="t('zones.href.docs.cta')"
@@ -20,11 +20,11 @@
       </template>
 
       <DataSource
-        v-slot="{ data, error, refresh }"
         :src="uri(zoneSources, '/zone-cps', {}, {
           page: route.params.page,
           size: route.params.size,
         })"
+        v-slot="{ data, error, refresh }"
       >
         <DataSource
           :src="`/zone-ingress-overviews?page=1&size=100`"
@@ -191,9 +191,9 @@
                     >
                       <DataSink
                         v-if="expanded"
-                        v-slot="{ submit, error: deleteError }"
                         :src="`/zone-cps/${row.name}/delete`"
                         @change="() => { toggle(); refresh() }"
+                        v-slot="{ submit, error: deleteError }"
                       >
                         <XPrompt
                           :action="t('common.delete_modal.proceed_button')"


### PR DESCRIPTION
I've always found it weird that with the ordering we have we write components like this:

```vue
<DataSource
  v-slot="{ essentiallyTheReturnValueOfTheComponent }"
  src="/essentially/the/argument/for/the/component"
/>
```

^ The above ordering seems the wrong way around to me, the return (`v-slot`) is specified first and the arguments last 🤯 

```vue
<DataSource
  src="/essentially/the/argument/for/the/component"
  v-slot="{ essentiallyTheReturnValueOfTheComponent }"
/>
```

^ This to me seems better and for folks that haven't noticed the pure-like "pass the component some arguments and get something in return", this order makes it easier to read things through.

---

I also added:

- a `make lint/scripts` mainly for our pre-commit hook. This just runs `lint/js` and `lint/js`, the pre-commit hook additionally uses `-j2` to run them at the same time.
- a `make lint/gherkin` to lint our `.feature` file tests. Ideally this would also be on a pre-commit hook, but for some reason when using it in the hook I got a `SIGPIPE` error, so I can follow up at a later date once I figure out why it does that. At least we have a shared linter now instead of relying on IDE settings and potential differences. Kinda annoyed by some of the changes the linter has made but 🤷 , at least I can be annoyed consistently 😆 

I split the commits into the config changes, and the changes that are as a result of the new config, hopefully that helps with review.

