### PR TITLE
chore: Amend default font-size to be slightly smaller

### DIFF
--- a/src/app/application/components/app-view/AppView.vue
+++ b/src/app/application/components/app-view/AppView.vue
@@ -160,7 +160,9 @@ onBeforeUnmount(() => {
 
 <style lang="scss">
 .k-breadcrumbs {
-  margin-bottom: 0 !important
+  margin-bottom: 0 !important;
+  position: relative;
+  left: -3px;
 }
 .is-fullscreen {
   .app-view-title-bar {

--- a/src/app/kuma/components/ApplicationShell.vue
+++ b/src/app/kuma/components/ApplicationShell.vue
@@ -269,6 +269,7 @@ nav :deep(.app-navigator) > a {
   border-radius: 5px;
   text-decoration: none;
   color: currentColor;
+  font-size: $kui-font-size-40;
   &:hover,
   &:is(.is-active) {
     background-color: $kui-color-background-neutral-weaker;

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -24,8 +24,9 @@ body {
   color: $kui-color-text;
   font-family: $kui-font-family-text;
   font-weight: $kui-font-weight-regular;
-  font-size: $kui-font-size-40;
+  font-size: $kui-font-size-30;
 }
+
 
 blockquote,
 dl,


### PR DESCRIPTION
Decreases default body text ever so slightly to bring it in line with other areas.

I re-upped the size for our side menu to keep the side nav links the same size as previous. Otherwise the only things affected are the new introductory intro sentences and the service type button group, both can be seen in the below screengrabs.

### Before

![Screenshot 2024-07-17 at 09 24 22](https://github.com/user-attachments/assets/ec2d9784-c953-484f-ae97-7aedeebea9d8)

### After

![Screenshot 2024-07-17 at 09 31 05](https://github.com/user-attachments/assets/a54098ca-627e-4973-9a16-dbac6ce14b88)
