### PR TITLE
fix(policies): Ensure visits to /policies are redirected

### DIFF
--- a/features/mesh/policies/Index.feature
+++ b/features/mesh/policies/Index.feature
@@ -26,6 +26,10 @@ Feature: mesh / policies / index
         - name: fake-cb-2
       """
 
+  Scenario: Visiting `/policies` redirects
+    When I visit the "/meshes/default/policies" URL
+    Then the URL contains "/meshes/default/policies/circuit-breakers"
+
   Scenario: Listing has expected content
     When I visit the "/meshes/default/policies/circuit-breakers" URL
     Then the "$button-docs" element exists

--- a/src/app/x/components/x-action/XAction.vue
+++ b/src/app/x/components/x-action/XAction.vue
@@ -166,6 +166,7 @@ const props = withDefaults(defineProps<{
   href?: string
   to?: RouteLocationRawWithBooleanQuery
   for?: string
+  mount?: (to: RouteLocationNamedRaw) => void
 }>(), {
   href: '',
   appearance: 'anchor',
@@ -207,6 +208,15 @@ watch(() => props.to, (val) => {
       e.message = `${e.toString()}: ${JSON.stringify(val)}`
     }
     console.error(e)
+  }
+}, { immediate: true })
+
+watch(() => props.mount, (val) => {
+  if (typeof val === 'function') {
+    val({
+      ...props.to,
+      query: query.value,
+    })
   }
 }, { immediate: true })
 </script>


### PR DESCRIPTION
Back in https://github.com/kumahq/kuma-gui/pull/2741/files#diff-f7d102cd28d8503b5974afd6eb10e8d34d072370f7802324da3469ecf3c65b82L142 I removed the `mount` functionality we have in `XAction`, at the time I miss-thought that it was an attrinute/functionality we no longer used/required.

Thing is, we do use it in one place to redirect any visits to `/mesh/:mesh-name/policies` through to `/mesh/:mesh-name/policies/:first-policy-type-that-has-entries`.

This PR puts the functionality back. I also added a test for the redirect to make sure I don't accidentally remove this again.
