### PR TITLE
feature(services): initial support for MeshMultiZoneService

### DIFF
--- a/src/app/services/data/MeshMultizoneService.ts
+++ b/src/app/services/data/MeshMultizoneService.ts
@@ -1,0 +1,38 @@
+import type { components } from '@/types/auto-generated.d'
+type Generated = components['schemas']['MeshMultiZoneServiceItem']
+type GeneratedCollection = components['responses']['MeshMultiZoneServiceList']['content']['application/json']
+
+const Entity = {
+  fromObject(item: Generated) {
+    const labels = item.labels ?? {}
+    const name = labels['kuma.io/display-name'] ?? item.name
+    const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    return {
+      ...item,
+      id: item.name,
+      name,
+      namespace,
+      labels,
+      status: ((item = {}) => {
+        return {
+          vips: Array.isArray(item.vips) ? item.vips : [],
+          meshServices: Array.isArray(item.meshServices) ? item.meshServices : [],
+          ports: Array.isArray(item.ports) ? item.ports : [],
+          addresses: Array.isArray(item.addresses) ? item.addresses : [],
+        }
+      })(item.status),
+      config: item,
+    }
+  },
+
+  fromCollection(collection: GeneratedCollection) {
+    const items = Array.isArray(collection.items) ? collection.items.map(Entity.fromObject) : []
+    return {
+      ...collection,
+      items,
+      total: collection.total ?? items.length,
+    }
+  },
+}
+export const MeshMultizoneService = Entity
+export type MeshMultizoneService = ReturnType<typeof Entity['fromObject']>

--- a/src/app/services/data/index.ts
+++ b/src/app/services/data/index.ts
@@ -4,7 +4,9 @@ import type {
   ServiceInsight as PartialServiceInsight,
   ServiceStatus as ServiceTypeCount,
 } from '@/types/index.d'
+
 export * from './MeshService'
+export * from './MeshMultizoneService'
 export * from './MeshExternalService'
 
 export type ExternalService = PartialExternalService & {

--- a/src/app/services/locales/en-us/index.yaml
+++ b/src/app/services/locales/en-us/index.yaml
@@ -4,6 +4,8 @@ services:
   routes:
     mesh-service-list-view:
       title: Mesh Services
+    mesh-multizone-service-list-view:
+      title: Mesh Multizone Services
     mesh-external-service-list-view:
       title: Mesh External Services
     item:
@@ -13,6 +15,8 @@ services:
         service-detail-view: 'Overview'
         mesh-service-detail-view: 'Overview'
         mesh-service-config-view: 'YAML'
+        mesh-multizone-service-detail-view: 'Overview'
+        mesh-multizone-service-config-view: 'YAML'
         mesh-external-service-detail-view: 'Overview'
         mesh-external-service-config-view: 'YAML'
       overview: 'Overview'
@@ -23,6 +27,7 @@ services:
         A Service represents an application or microservice that is registered with the mesh and can be managed, monitored and secured through the mesh's policies.
       navigation:
         mesh-service-list-view: MeshService
+        mesh-multizone-service-list-view: MeshMultizoneService
         mesh-external-service-list-view: MeshExternalService
         service-list-view: Internal
         external-service-list-view: External
@@ -35,6 +40,9 @@ services:
   mesh-service:
     href:
       docs: '{KUMA_DOCS_URL}/networking/meshservice/?{KUMA_UTM_QUERY_PARAMS}'
+  mesh-multizone-service:
+    href:
+      docs: '{KUMA_DOCS_URL}/networking/meshmultizoneservice/?{KUMA_UTM_QUERY_PARAMS}'
   mesh-external-service:
     href:
       docs: '{KUMA_DOCS_URL}/networking/meshexternalservice/?{KUMA_UTM_QUERY_PARAMS}'

--- a/src/app/services/routes.ts
+++ b/src/app/services/routes.ts
@@ -66,6 +66,30 @@ export const routes = (can: Can) => {
                 ],
               },
               {
+                path: 'mesh-multizone-services/:service',
+                name: 'mesh-multizone-service-detail-tabs-view',
+                component: () => import('@/app/services/views/MeshMultizoneServiceDetailTabsView.vue'),
+                children: [
+                  {
+                    path: 'overview',
+                    name: 'mesh-multizone-service-detail-view',
+                    component: () => import('@/app/services/views/MeshMultizoneServiceDetailView.vue'),
+                    children: [
+                      {
+                        path: ':dataPlane',
+                        name: 'mesh-multizone-service-data-plane-summary-view',
+                        component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
+                      },
+                    ],
+                  },
+                  {
+                    path: 'config',
+                    name: 'mesh-multizone-service-config-view',
+                    component: () => import('@/app/services/views/MeshMultizoneServiceConfigView.vue'),
+                  },
+                ],
+              },
+              {
                 path: 'mesh-external-services/:service',
                 name: 'mesh-external-service-detail-tabs-view',
                 component: () => import('@/app/services/views/MeshExternalServiceDetailTabsView.vue'),
@@ -120,6 +144,18 @@ export const routes = (can: Can) => {
                       path: ':service',
                       name: 'mesh-service-summary-view',
                       component: () => import('@/app/services/views/MeshServiceSummaryView.vue'),
+                    },
+                  ],
+                },
+                {
+                  path: 'mesh-multizone-services',
+                  name: 'mesh-multizone-service-list-view',
+                  component: () => import('@/app/services/views/MeshMultizoneServiceListView.vue'),
+                  children: [
+                    {
+                      path: ':service',
+                      name: 'mesh-multizone-service-summary-view',
+                      component: () => import('@/app/services/views/MeshMultizoneServiceSummaryView.vue'),
                     },
                   ],
                 },

--- a/src/app/services/sources.ts
+++ b/src/app/services/sources.ts
@@ -1,6 +1,12 @@
 import createClient from 'openapi-fetch'
 
-import { MeshService, MeshExternalService, ExternalService, ServiceInsight } from './data'
+import {
+  MeshService,
+  MeshMultizoneService,
+  MeshExternalService,
+  ExternalService,
+  ServiceInsight,
+} from './data'
 import type { DataSourceResponse } from '@/app/application'
 import { defineSources } from '@/app/application/services/data-source'
 import type KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
@@ -57,6 +63,55 @@ export const sources = (api: KumaApi) => {
     '/meshes/:mesh/mesh-service/:name/as/kubernetes': async (params) => {
       const { mesh, name } = params
       const res = await http.GET('/meshes/{mesh}/meshservices/{name}', {
+        params: {
+          path: {
+            mesh,
+            name,
+          },
+          query: {
+            format: 'kubernetes',
+          },
+        },
+      })
+      return res.data!
+    },
+
+    '/meshes/:mesh/mesh-multizone-services': async (params) => {
+      const { mesh, size } = params
+      const offset = params.size * (params.page - 1)
+
+      const res = await http.GET('/meshes/{mesh}/meshmultizoneservices', {
+        params: {
+          path: {
+            mesh,
+          },
+          query: {
+            offset,
+            size,
+          },
+        },
+      })
+
+      return MeshMultizoneService.fromCollection(res.data!)
+    },
+
+    '/meshes/:mesh/mesh-multizone-service/:name': async (params) => {
+      const { mesh, name } = params
+
+      const res = await http.GET('/meshes/{mesh}/meshmultizoneservices/{name}', {
+        params: {
+          path: {
+            mesh,
+            name,
+          },
+        },
+      })
+      return MeshMultizoneService.fromObject(res.data!)
+    },
+
+    '/meshes/:mesh/mesh-multizone-service/:name/as/kubernetes': async (params) => {
+      const { mesh, name } = params
+      const res = await http.GET('/meshes/{mesh}/meshmultizoneservices/{name}', {
         params: {
           path: {
             mesh,

--- a/src/app/services/views/MeshMultizoneServiceConfigView.vue
+++ b/src/app/services/views/MeshMultizoneServiceConfigView.vue
@@ -1,0 +1,48 @@
+<template>
+  <RouteView
+    name="mesh-service-config-view"
+    :params="{
+      mesh: '',
+      service: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+    }"
+    v-slot="{ route }"
+  >
+    <AppView>
+      <KCard>
+        <ResourceCodeBlock
+          :resource="props.data.config"
+          is-searchable
+          :query="route.params.codeSearch"
+          :is-filter-mode="route.params.codeFilter"
+          :is-reg-exp-mode="route.params.codeRegExp"
+          @query-change="route.update({ codeSearch: $event })"
+          @filter-mode-change="route.update({ codeFilter: $event })"
+          @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          v-slot="{ copy, copying }"
+        >
+          <DataSource
+            v-if="copying"
+            :src="`/meshes/${props.data.mesh}/mesh-service/${props.data.id}/as/kubernetes?no-store`"
+            @change="(data) => {
+              copy((resolve) => resolve(data))
+            }"
+            @error="(e) => {
+              copy((_resolve, reject) => reject(e))
+            }"
+          />
+        </ResourceCodeBlock>
+      </KCard>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import type { MeshService } from '../data'
+import ResourceCodeBlock from '@/app/common/code-block/ResourceCodeBlock.vue'
+const props = defineProps<{
+  data: MeshService
+}>()
+</script>

--- a/src/app/services/views/MeshMultizoneServiceDetailTabsView.vue
+++ b/src/app/services/views/MeshMultizoneServiceDetailTabsView.vue
@@ -1,0 +1,89 @@
+<template>
+  <RouteView
+    name="mesh-multizone-service-detail-tabs-view"
+    :params="{
+      mesh: '',
+      service: '',
+    }"
+    v-slot="{ route, t, uri }"
+  >
+    <DataSource
+      :src="uri(sources, '/meshes/:mesh/mesh-multizone-service/:name', {
+        mesh: route.params.mesh,
+        name: route.params.service,
+      })"
+      v-slot="{ data, error }"
+    >
+      <AppView
+        :docs="t('services.mesh-multizone-service.href.docs')"
+        :breadcrumbs="[
+          {
+            to: {
+              name: 'mesh-detail-view',
+              params: {
+                mesh: route.params.mesh,
+              },
+            },
+            text: route.params.mesh,
+          },
+          {
+            to: {
+              name: 'mesh-multizone-service-list-view',
+              params: {
+                mesh: route.params.mesh,
+              },
+            },
+            text: t('services.routes.mesh-multizone-service-list-view.title'),
+          },
+        ]"
+      >
+        <template #title>
+          <h1
+            v-if="data"
+          >
+            <TextWithCopyButton :text="route.params.service">
+              <RouteTitle
+                :title="t('services.routes.item.title', { name: data.name })"
+              />
+            </TextWithCopyButton>
+          </h1>
+        </template>
+
+        <DataLoader
+          :data="[data]"
+          :errors="[error]"
+        >
+          <XTabs
+            :selected="route.child()?.name"
+          >
+            <template
+              v-for="{ name } in route.children"
+              :key="name"
+              #[`${name}-tab`]
+            >
+              <XAction
+                :to="{ name }"
+              >
+                {{ t(`services.routes.item.navigation.${name}`) }}
+              </XAction>
+            </template>
+          </XTabs>
+
+          <RouterView
+            v-slot="child"
+          >
+            <component
+              :is="child.Component"
+              :data="data"
+            />
+          </RouterView>
+        </DataLoader>
+      </AppView>
+    </DataSource>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import { sources } from '../sources'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+</script>

--- a/src/app/services/views/MeshMultizoneServiceDetailView.vue
+++ b/src/app/services/views/MeshMultizoneServiceDetailView.vue
@@ -1,0 +1,124 @@
+<template>
+  <RouteView
+    name="mesh-multizone-service-detail-view"
+    :params="{
+      mesh: '',
+      service: '',
+      page: 1,
+      size: 50,
+      s: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+    }"
+  >
+    <AppView>
+      <div
+        class="stack"
+      >
+        <KCard>
+          <div class="columns">
+            <DefinitionCard
+              v-if="props.data.status.addresses.length > 0"
+            >
+              <template
+                #title
+              >
+                Addresses
+              </template>
+              <template
+                #body
+              >
+                <KTruncate>
+                  <span
+                    v-for="address in props.data.status.addresses"
+                    :key="address.hostname"
+                  >
+                    {{ address.hostname }}
+                  </span>
+                </KTruncate>
+              </template>
+            </DefinitionCard>
+            <DefinitionCard>
+              <template
+                #title
+              >
+                Ports
+              </template>
+              <template
+                #body
+              >
+                <KTruncate>
+                  <KBadge
+                    v-for="connection in data.status.ports"
+                    :key="connection.port"
+                    appearance="info"
+                  >
+                    {{ connection.port }}:{{ connection.targetPort }}/{{ connection.appProtocol }}
+                  </KBadge>
+                </KTruncate>
+              </template>
+            </DefinitionCard>
+            <DefinitionCard>
+              <template
+                #title
+              >
+                Match Labels
+              </template>
+              <template
+                #body
+              >
+                <KTruncate>
+                  <KBadge
+                    v-for="(value, key) in data.spec.selector.meshService.matchLabels"
+                    :key="`${key}:${value}`"
+                    appearance="info"
+                  >
+                    {{ key }}:{{ value }}
+                  </KBadge>
+                </KTruncate>
+              </template>
+            </DefinitionCard>
+            <DefinitionCard
+              v-if="data.status.vips.length > 0"
+              class="ip"
+            >
+              <template
+                #title
+              >
+                VIPs
+              </template>
+              <template
+                #body
+              >
+                <KTruncate>
+                  <span
+                    v-for="address in data.status.vips"
+                    :key="address.ip"
+                  >
+                    {{ address.ip }}
+                  </span>
+                </KTruncate>
+              </template>
+            </DefinitionCard>
+          </div>
+        </KCard>
+      </div>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import type { MeshMultizoneService } from '../data'
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
+
+const props = defineProps<{
+  data: MeshMultizoneService
+}>()
+</script>
+
+<style lang="scss" scoped>
+.ip span {
+  font-size: $kui-font-size-30;
+}
+</style>

--- a/src/app/services/views/MeshMultizoneServiceDetailView.vue
+++ b/src/app/services/views/MeshMultizoneServiceDetailView.vue
@@ -11,6 +11,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
+    v-slot="{ t, me }"
   >
     <AppView>
       <div
@@ -103,6 +104,57 @@
             </DefinitionCard>
           </div>
         </KCard>
+
+        <div>
+          <h3>
+            Mesh Services
+          </h3>
+
+          <KCard
+            class="mt-4"
+          >
+            <AppCollection
+              :headers="[
+                { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+              ]"
+              :items="data.status.meshServices"
+              :total="data.status.meshServices.length"
+              @resize="me.set"
+            >
+              <template #name="{ row: item }">
+                <XAction
+                  class="name-link"
+                  :to="{
+                    name: 'mesh-service-detail-view',
+                    params: {
+                      mesh: data.mesh,
+                      service: item.name,
+                    },
+                  }"
+                >
+                  {{ item.name }}
+                </XAction>
+              </template>
+
+              <template #actions="{ row: item }">
+                <XActionGroup>
+                  <XAction
+                    :to="{
+                      name: 'mesh-service-detail-view',
+                      params: {
+                        mesh: data.mesh,
+                        service: item.name,
+                      },
+                    }"
+                  >
+                    {{ t('common.collection.actions.view') }}
+                  </XAction>
+                </XActionGroup>
+              </template>
+            </AppCollection>
+          </KCard>
+        </div>
       </div>
     </AppView>
   </RouteView>
@@ -110,6 +162,7 @@
 
 <script lang="ts" setup>
 import type { MeshMultizoneService } from '../data'
+import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 
 const props = defineProps<{
@@ -120,5 +173,14 @@ const props = defineProps<{
 <style lang="scss" scoped>
 .ip span {
   font-size: $kui-font-size-30;
+}
+
+.name-link {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
 }
 </style>

--- a/src/app/services/views/MeshMultizoneServiceListView.vue
+++ b/src/app/services/views/MeshMultizoneServiceListView.vue
@@ -1,0 +1,188 @@
+<template>
+  <RouteView
+    name="mesh-multizone-service-list-view"
+    :params="{
+      page: 1,
+      size: 50,
+      mesh: '',
+      service: '',
+    }"
+    v-slot="{ route, t, can, uri, me }"
+  >
+    <RouteTitle
+      :render="false"
+      :title="t(`services.routes.mesh-multizone-service-list-view.title`)"
+    />
+    <AppView
+      :docs="t('services.mesh-multizone-service.href.docs')"
+    >
+      <KCard>
+        <DataLoader
+          :src="uri(sources, '/meshes/:mesh/mesh-multizone-services', {
+            mesh: route.params.mesh,
+          },{
+            page: route.params.page,
+            size: route.params.size,
+          })"
+        >
+          <template
+            #loadable="{ data }"
+          >
+            <DataCollection
+              type="services"
+              :items="data?.items ?? [undefined]"
+            >
+              <AppCollection
+                :headers="[
+                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                  { ...me.get('headers.addresses'), label: 'Addresses', key: 'addresses' },
+                  { ...me.get('headers.ports'), label: 'Ports', key: 'ports' },
+                  { ...me.get('headers.labels'), label: 'Match Labels', key: 'labels' },
+                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :page-number="route.params.page"
+                :page-size="route.params.size"
+                :total="data?.total"
+                :items="data?.items"
+                :is-selected-row="(item) => item.name === route.params.service"
+                @change="route.update"
+                @resize="me.set"
+              >
+                <template #name="{ row: item }">
+                  <TextWithCopyButton
+                    :text="item.name"
+                  >
+                    <XAction
+                      data-action
+                      :to="{
+                        name: 'mesh-multizone-service-summary-view',
+                        params: {
+                          mesh: item.mesh,
+                          service: item.id,
+                        },
+                        query: {
+                          page: route.params.page,
+                          size: route.params.size,
+                        },
+                      }"
+                    >
+                      {{ item.name }}
+                    </XAction>
+                  </TextWithCopyButton>
+                </template>
+                <template
+                  #namespace="{ row: item }"
+                >
+                  {{ item.namespace }}
+                </template>
+                <template #zone="{ row: item }">
+                  <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
+                    <XAction
+                      v-if="item.labels['kuma.io/zone']"
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: item.labels['kuma.io/zone'],
+                        },
+                      }"
+                    >
+                      {{ item.labels['kuma.io/zone'] }}
+                    </XAction>
+                  </template>
+
+                  <template v-else>
+                    {{ t('common.detail.none') }}
+                  </template>
+                </template>
+                <template
+                  #addresses="{ row: item }"
+                >
+                  <KTruncate>
+                    <span
+                      v-for="address in item.status.addresses"
+                      :key="address.hostname"
+                    >
+                      {{ address.hostname }}
+                    </span>
+                  </KTruncate>
+                </template>
+                <template
+                  #ports="{ row: item }"
+                >
+                  <KTruncate>
+                    <KBadge
+                      v-for="connection in item.status.ports"
+                      :key="connection.port"
+                      appearance="info"
+                    >
+                      {{ connection.port }}:{{ connection.targetPort }}/{{ connection.appProtocol }}
+                    </KBadge>
+                  </KTruncate>
+                </template>
+                <template
+                  #labels="{ row: item }"
+                >
+                  <KTruncate>
+                    <KBadge
+                      v-for="(value, key) in item.spec.selector.meshService.matchLabels"
+                      :key="`${key}:${value}`"
+                      appearance="info"
+                    >
+                      {{ key }}:{{ value }}
+                    </KBadge>
+                  </KTruncate>
+                </template>
+                <template #actions="{ row: item }">
+                  <XActionGroup>
+                    <XAction
+                      :to="{
+                        name: 'mesh-multizone-service-detail-view',
+                        params: {
+                          mesh: item.mesh,
+                          service: item.id,
+                        },
+                      }"
+                    >
+                      {{ t('common.collection.actions.view') }}
+                    </XAction>
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+              <RouterView
+                v-if="data?.items && route.params.service"
+                v-slot="child"
+              >
+                <SummaryView
+                  @close="route.replace({
+                    name: 'mesh-multizone-service-list-view',
+                    params: {
+                      mesh: route.params.mesh,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                    },
+                  })"
+                >
+                  <component
+                    :is="child.Component"
+                    :items="data?.items"
+                  />
+                </SummaryView>
+              </RouterView>
+            </DataCollection>
+          </template>
+        </DataLoader>
+      </KCard>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import { sources } from '../sources'
+import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
+import SummaryView from '@/app/common/SummaryView.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+</script>

--- a/src/app/services/views/MeshMultizoneServiceSummaryView.vue
+++ b/src/app/services/views/MeshMultizoneServiceSummaryView.vue
@@ -1,0 +1,157 @@
+<template>
+  <RouteView
+    name="mesh-multizone-service-summary-view"
+    :params="{
+      mesh: '',
+      service: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+    }"
+    v-slot="{ route, t }"
+  >
+    <DataCollection
+      :items="props.items"
+      :predicate="item => item.id === route.params.service"
+    >
+      <template
+        #item="{ item }"
+      >
+        <AppView>
+          <template #title>
+            <h2>
+              <XAction
+                :to="{
+                  name: 'mesh-multizone-service-detail-view',
+                  params: {
+                    mesh: route.params.mesh,
+                    service: route.params.service,
+                  },
+
+                }"
+              >
+                <RouteTitle
+                  :title="t('services.routes.item.title', { name: item.name })"
+                />
+              </XAction>
+            </h2>
+          </template>
+
+          <div
+            class="stack"
+          >
+            <div
+              class="stack-with-borders"
+            >
+              <DefinitionCard
+                v-if="item.status.addresses.length > 0"
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
+                  Addresses
+                </template>
+                <template
+                  #body
+                >
+                  <KTruncate>
+                    <span
+                      v-for="address in item.status.addresses"
+                      :key="address.hostname"
+                    >
+                      {{ address.hostname }}
+                    </span>
+                  </KTruncate>
+                </template>
+              </DefinitionCard>
+              <DefinitionCard
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
+                  Ports
+                </template>
+                <template
+                  #body
+                >
+                  <KTruncate>
+                    <KBadge
+                      v-for="connection in item.status.ports"
+                      :key="connection.port"
+                      appearance="info"
+                    >
+                      {{ connection.port }}{{ connection.targetPort ? `:${connection.targetPort}` : '' }}{{ connection.appProtocol ? `/${connection.appProtocol}` : '' }}
+                    </KBadge>
+                  </KTruncate>
+                </template>
+              </DefinitionCard>
+              <DefinitionCard
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
+                  Match Labels
+                </template>
+                <template
+                  #body
+                >
+                  <KTruncate>
+                    <KBadge
+                      v-for="(value, key) in item.spec.selector.meshService.matchLabels"
+                      :key="`${key}:${value}`"
+                      appearance="info"
+                    >
+                      {{ key }}:{{ value }}
+                    </KBadge>
+                  </KTruncate>
+                </template>
+              </DefinitionCard>
+            </div>
+            <div>
+              <h3>
+                {{ t('services.routes.item.config') }}
+              </h3>
+
+              <div class="mt-4">
+                <ResourceCodeBlock
+                  :resource="item.config"
+                  is-searchable
+                  :query="route.params.codeSearch"
+                  :is-filter-mode="route.params.codeFilter"
+                  :is-reg-exp-mode="route.params.codeRegExp"
+                  @query-change="route.update({ codeSearch: $event })"
+                  @filter-mode-change="route.update({ codeFilter: $event })"
+                  @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+                  v-slot="{ copy, copying }"
+                >
+                  <DataSource
+                    v-if="copying"
+                    :src="`/meshes/${route.params.mesh}/mesh-multizone-service/${route.params.service}/as/kubernetes?no-store`"
+                    @change="(data) => {
+                      copy((resolve) => resolve(data))
+                    }"
+                    @error="(e) => {
+                      copy((_resolve, reject) => reject(e))
+                    }"
+                  />
+                </ResourceCodeBlock>
+              </div>
+            </div>
+          </div>
+        </AppView>
+      </template>
+    </DataCollection>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import ResourceCodeBlock from '@/app/common/code-block/ResourceCodeBlock.vue'
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
+import type { MeshMultizoneService } from '@/app/services/data'
+const props = defineProps<{
+  items: MeshMultizoneService[]
+}>()
+</script>

--- a/src/app/x/components/x-breadcrumbs/XBreadcrumbs.vue
+++ b/src/app/x/components/x-breadcrumbs/XBreadcrumbs.vue
@@ -1,7 +1,7 @@
 <template>
   <KBreadcrumbs
     :items="props.items"
-    :item-max-width="'150px'"
+    :item-max-width="'500px'"
   >
     <template
       v-for="(slot, key) in slots"

--- a/src/test-support/mocks/fs.ts
+++ b/src/test-support/mocks/fs.ts
@@ -55,6 +55,8 @@ import _134 from './src/meshes/_/meshgateways/test-meshgateway/_'
 import _135 from './src/meshes/_/meshgateways/test-meshgateway/_rules'
 import _132 from './src/meshes/_/meshhttproutes'
 import _133 from './src/meshes/_/meshhttproutes/_'
+import _140 from './src/meshes/_/meshmultizoneservices'
+import _141 from './src/meshes/_/meshmultizoneservices/_'
 import _136 from './src/meshes/_/meshservices'
 import _137 from './src/meshes/_/meshservices/_'
 import _35 from './src/meshes/_/proxytemplates'
@@ -158,6 +160,8 @@ export const fs: FS = {
   '/meshes/:mesh/meshgateways/:name/_rules': _131,
   '/meshes/:mesh/meshservices': _136,
   '/meshes/:mesh/meshservices/:name': _137,
+  '/meshes/:mesh/meshmultizoneservices': _140,
+  '/meshes/:mesh/meshmultizoneservices/:name': _141,
   '/meshes/:mesh/meshexternalservices': _138,
   '/meshes/:mesh/meshexternalservices/:name': _139,
   '/meshes/:mesh/meshhttproutes': _132,

--- a/src/test-support/mocks/src/meshes/_/meshmultizoneservices.ts
+++ b/src/test-support/mocks/src/meshes/_/meshmultizoneservices.ts
@@ -1,6 +1,6 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
 import type { components } from '@/types/auto-generated.d'
-type Entity = components['schemas']['MeshServiceItem']
+type Entity = components['schemas']['MeshMultiZoneServiceItem']
 
 export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (req) => {
   const query = req.url.searchParams
@@ -27,7 +27,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const nspace = fake.k8s.namespace()
 
         return {
-          type: 'MeshService',
+          type: 'MeshMultiZoneService',
           mesh,
           name: `${displayName}${k8s ? `.${nspace}` : ''}`,
           creationTime: '2021-02-19T08:06:15.14624+01:00',
@@ -43,6 +43,13 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             }
             : {}),
           spec: {
+            selector: {
+              meshService: {
+                matchLabels: fake.kuma.tags({}),
+              },
+            },
+          },
+          status: {
             ports: Array.from({ length: 5 }).map(_ => (
               {
                 port: fake.internet.port(),
@@ -50,20 +57,15 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 appProtocol: fake.kuma.protocol(),
               }
             )),
-            selector: {
-              dataplaneTags: fake.kuma.tags({}),
-            },
-          },
-          status: {
+            meshServices: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
+              name: fake.hacker.noun(),
+            })),
             addresses: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
               hostname: fake.internet.domainName(),
             })),
             vips: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
               ip: fake.internet.ip(),
             })),
-            tls: {
-              status: fake.helpers.arrayElement([undefined, 'Ready', 'NotReady']),
-            },
           },
         } satisfies Entity & {
           creationTime: string

--- a/src/test-support/mocks/src/meshes/_/meshmultizoneservices.ts
+++ b/src/test-support/mocks/src/meshes/_/meshmultizoneservices.ts
@@ -58,7 +58,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               }
             )),
             meshServices: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
-              name: fake.hacker.noun(),
+              name: `${fake.hacker.noun()}-${i}${k8s ? `.${fake.k8s.namespace()}` : ''}`,
             })),
             addresses: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
               hostname: fake.internet.domainName(),

--- a/src/test-support/mocks/src/meshes/_/meshmultizoneservices/_.ts
+++ b/src/test-support/mocks/src/meshes/_/meshmultizoneservices/_.ts
@@ -1,0 +1,65 @@
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+import type { components } from '@/types/auto-generated.d'
+type Entity = components['schemas']['MeshMultiZoneServiceItem']
+
+export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => {
+  const query = req.url.searchParams
+
+  const mesh = req.params.mesh as string
+  const name = req.params.name as string
+
+  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
+  const parts = String(name).split('.')
+  const displayName = parts.slice(0, -1).join('.')
+  const nspace = parts.pop()!
+
+  return {
+    headers: {},
+    body: {
+      ...(query.get('format') === 'kubernetes' && {
+        apiVersion: 'kuma.io/v1alpha1',
+      }),
+      type: 'MeshMultiZoneService',
+      mesh,
+      name,
+      creationTime: '2021-02-19T08:06:15.14624+01:00',
+      modificationTime: '2021-02-19T08:07:37.539229+01:00',
+      ...(k8s
+        ? {
+          labels: {
+            'kuma.io/display-name': displayName,
+            'k8s.kuma.io/namespace': nspace,
+          },
+        }
+        : {}),
+      spec: {
+        selector: {
+          meshService: {
+            matchLabels: fake.kuma.tags({}),
+          },
+        },
+      },
+      status: {
+        ports: Array.from({ length: 5 }).map(_ => (
+          {
+            port: fake.internet.port(),
+            targetPort: fake.internet.port(),
+            appProtocol: fake.kuma.protocol(),
+          }
+        )),
+        meshServices: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
+          name: fake.hacker.noun(),
+        })),
+        addresses: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
+          hostname: fake.internet.domainName(),
+        })),
+        vips: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
+          ip: fake.internet.ip(),
+        })),
+      },
+    } satisfies Entity & {
+      creationTime: string
+      modificationTime: string
+    },
+  }
+}

--- a/src/test-support/mocks/src/meshes/_/meshservices/_.ts
+++ b/src/test-support/mocks/src/meshes/_/meshservices/_.ts
@@ -1,16 +1,14 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
 import type { MeshService } from '@/types/index.d'
 
-export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => {
+export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const query = req.url.searchParams
 
   const mesh = req.params.mesh as string
   const name = req.params.name as string
 
-  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
   const parts = String(name).split('.')
-  const displayName = parts.slice(0, -1).join('.')
-  const nspace = parts.pop()
+  const k8s = parts.length > 1
 
   return {
     headers: {},
@@ -26,8 +24,8 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
       ...(k8s
         ? {
           labels: {
-            'kuma.io/display-name': displayName,
-            'k8s.kuma.io/namespace': nspace,
+            'kuma.io/display-name': parts.slice(0, -1).join('.'),
+            'k8s.kuma.io/namespace': parts.pop()!,
           },
         }
         : {}),


### PR DESCRIPTION
Initial support for `MeshMultiZoneService`.

This is pretty much a copy/pasta of `MeshService` with some slight tweaks.

The detail page specifically is quite bare as we don't need a listing of `Dataplane`s here.

~We probably do need a listing of `MeshService` here though, although I'd be happy to PR that separately once I find out for definite.~

I added a simple listing of MeshServices / `meshServices` which is just a table with a single name column whose rows link to the MeshService detail page.

Closes https://github.com/kumahq/kuma-gui/issues/2768