### PR TITLE
fix(zones): remove ZoneConfig subtitle

### DIFF
--- a/src/app/zones/views/ZoneConfigView.vue
+++ b/src/app/zones/views/ZoneConfigView.vue
@@ -39,14 +39,6 @@
           </ul>
         </template>
 
-        <template #title>
-          <h2>
-            <RouteTitle
-              :title="t('zone-cps.routes.item.navigation.zone-cp-config-view')"
-            />
-          </h2>
-        </template>
-
         <KCard>
           <CodeBlock
             v-if="Object.keys(props.data.zoneInsight.config).length > 0"


### PR DESCRIPTION
A teeny while back we removed all our subtitles. I think this one ended up staying in via a rebase.