### PR TITLE
chore(deps): remove semver from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "path-to-regexp": "^7.0.0",
         "pretty-bytes": "^6.1.1",
         "prismjs": "^1.29.0",
-        "semver": "^7.6.2",
         "vue": "^3.4.31",
         "vue-github-button": "^3.1.0",
         "vue-router": "^4.4.0"
@@ -13045,6 +13044,7 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "path-to-regexp": "^7.0.0",
     "pretty-bytes": "^6.1.1",
     "prismjs": "^1.29.0",
-    "semver": "^7.6.2",
     "vue": "^3.4.31",
     "vue-github-button": "^3.1.0",
     "vue-router": "^4.4.0"


### PR DESCRIPTION
I while ago we removed `semver` from our package.json, and then added it back in again when we realized we were using it in our Vuex `store`.

https://github.com/kumahq/kuma-gui/pull/936

We removed our Vuex `store` entirely a while ago, which means we can remove `semver` from our package.json again and should reduce our dependabot PRs ever so slightly (the one that made me look into this is here https://github.com/kumahq/kuma-gui/pull/2780)

Note: `semver` is still a transitive dev dependency.
