### PR TITLE
chore(deps): upgrade/dedupe shiki and related

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3770,31 +3770,21 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.10.3.tgz",
-      "integrity": "sha512-D45PMaBaeDHxww+EkcDQtDAtzv00Gcsp72ukBtaLSmqRvh0WgGMq3Al0rl1QQBZfuneO75NXMIzEZGFitThWbg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-VbEhDAhT/2ozO0TPr5/ZQBO/NWLqtk4ZiBf6NplYpF38mKjNfMMied5fNEfIfYfN+cdKvhDB4VMcKvG/g9c3zg==",
       "dev": true,
       "dependencies": {
         "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.10.3.tgz",
-      "integrity": "sha512-MNjsyye2WHVdxfZUSr5frS97sLGe6G1T+1P41QjyBFJehZphMcr4aBlRLmq6OSPBslYe9byQPVvt/LJCOfxw8Q==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.11.0.tgz",
+      "integrity": "sha512-RNEUyOxF1cPYVG2EvBv0CZeDU1Tp4fSxmsVD2Ofv+8h9hBqqgpq+l+7uyouyqV1JHNlqwRmUwAqrQU3GQQ3csQ==",
       "dev": true,
       "dependencies": {
-        "shiki": "1.10.3"
-      }
-    },
-    "node_modules/@shikijs/transformers/node_modules/shiki": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.10.3.tgz",
-      "integrity": "sha512-eneCLncGuvPdTutJuLyUGS8QNPAVFO5Trvld2wgEq1e002mwctAhJKeMGWtWVXOIEzmlcLRqcgPSorR6AVzOmQ==",
-      "dev": true,
-      "dependencies": {
-        "@shikijs/core": "1.10.3",
-        "@types/hast": "^3.0.4"
+        "shiki": "1.11.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -13523,15 +13513,6 @@
       "dev": true,
       "dependencies": {
         "@shikijs/core": "1.11.0",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/shiki/node_modules/@shikijs/core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.11.0.tgz",
-      "integrity": "sha512-VbEhDAhT/2ozO0TPr5/ZQBO/NWLqtk4ZiBf6NplYpF38mKjNfMMied5fNEfIfYfN+cdKvhDB4VMcKvG/g9c3zg==",
-      "dev": true,
-      "dependencies": {
         "@types/hast": "^3.0.4"
       }
     },


### PR DESCRIPTION
Wanted to do an experiment/put a PR up to illustrate some less ideal behaviour of our upgrading prompted by https://github.com/kumahq/kuma-gui/pull/2783

Previous to this PR we have 2 versions each of `shiki` and `@shikijs/core`

This PR was created by using a mix of `npm upgrade`, `npm why` and `npm prune` and is what we would want to happen ideally.

Note: `shiki` is only used for syntax highlighting within our vitepress engineering documentation.