### PR TITLE
fix(dataplanes): ensure search parameter is passed to HTTP call

### DIFF
--- a/features/mesh/dataplanes/Index.feature
+++ b/features/mesh/dataplanes/Index.feature
@@ -2,16 +2,18 @@ Feature: mesh / dataplanes / index
 
   Background:
     Given the CSS selectors
-      | Alias            | Selector                              |
-      | table            | [data-testid='data-plane-collection'] |
-      | table-header     | $table th                             |
-      | item             | $table tbody tr                       |
-      | service-cell     | $item:nth-child(1) td:nth-child(3)    |
-      | select-type      | [data-testid='select-input']          |
-      | select-option    | .select-item                          |
-      | select-standard  | [data-testid='select-item-standard']  |
-      | select-builtin   | [data-testid='select-item-builtin']   |
-      | select-delegated | [data-testid='select-item-delegated'] |
+      | Alias            | Selector                                       |
+      | table            | [data-testid='data-plane-collection']          |
+      | table-header     | $table th                                      |
+      | item             | $table tbody tr                                |
+      | service-cell     | $item:nth-child(1) td:nth-child(3)             |
+      | select-type      | [data-testid='select-input']                   |
+      | select-option    | .select-item                                   |
+      | select-standard  | [data-testid='select-item-standard']           |
+      | select-builtin   | [data-testid='select-item-builtin']            |
+      | select-delegated | [data-testid='select-item-delegated']          |
+      | input-search     | [data-testid='filter-bar-filter-input']        |
+      | button-search    | [data-testid='filter-bar-submit-query-button'] |
     And the environment
       """
       KUMA_MODE: global
@@ -95,6 +97,21 @@ Feature: mesh / dataplanes / index
       | dpp-2          |
       | No certificate |
       | offline        |
+
+  Scenario: Searching by tag doesn't overwrite the existing service tag
+    When I visit the "/meshes/default/data-planes" URL
+    Then the "$input-search" element isn't disabled
+    And I wait for 500 ms
+    When I "type" "service:system-1" into the "$input-search" element
+    And I click the "$button-search" element
+    Then the URL "/meshes/default/dataplanes/_overview" was requested with
+      """
+      searchParams:
+        tag:
+          - "kuma.io/service:system-1"
+        offset: 0
+        size: 50
+      """
 
   Rule: The listing can be filtered by type
 

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -27,6 +27,7 @@
           }, {
             page: route.params.page,
             size: route.params.size,
+            search: route.params.s,
           })"
         >
           <template


### PR DESCRIPTION
Back in https://github.com/kumahq/kuma-gui/pull/2749 we changed the remaining DataSource's to use DataLoader and `uri` (`uri`s benefit is it carries through all the types for the resource identifier/data).

Unfortunately we mistakenly omitted a `search` parameter (these params are optional). This PR adds it back in.

Double-y unfortunate is that I thought we had e2e tests on our search, which we do, but for another page (dataplane searching within a service detail) 🤦 .

https://github.com/kumahq/kuma-gui/blob/924c7a597ce785fa5d5cfdef48195181fa02f027/features/mesh/services/Item.feature#L58-L71

I copied the above test over to the DataPlane listing page so we now test this in both places. You'll see that new test in this changeset.
