### PR TITLE
chore(zones): add zones to all summary and detail pages

### DIFF
--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -127,6 +127,8 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
       if (typeof filterParams.tag === 'undefined') {
         filterParams.tag = []
       }
+      // MeshService dataplanes should always be filtered by the zone for the MeshService via dataplaneTags
+      filterParams.tag = filterParams.tag.filter((item) => !item.startsWith('kuma.io/zone:'))
       filterParams.tag = filterParams.tag.concat(Object.entries(JSON.parse(params.tags)).map(([key, value]) => `${key}:${value}`))
 
       return DataplaneOverview.fromCollection(await api.getAllDataplaneOverviewsFromMesh({ mesh }, {

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -6,7 +6,7 @@
       inactive: false,
     }"
     name="data-plane-detail-view"
-    v-slot="{ route, t }"
+    v-slot="{ route, t, can }"
   >
     <DataSource
       :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/stats/${props.data.dataplane.networking.inboundAddress}`"
@@ -38,100 +38,132 @@
           data-testid="dataplane-details"
         >
           <KCard>
-            <div class="columns">
-              <DefinitionCard>
-                <template #title>
-                  {{ t('http.api.property.status') }}
-                </template>
+            <div
+              class="stack"
+            >
+              <div
+                class="columns"
+              >
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('http.api.property.status') }}
+                  </template>
 
-                <template #body>
-                  <div class="status-with-reason">
-                    <StatusBadge :status="props.data.status" />
-                    <DataCollection
-                      v-if="props.data.dataplaneType === 'standard'"
-                      :items="props.data.dataplane.networking.inbounds"
-                      :predicate="item => !item.health.ready"
-                      :empty="false"
-                      v-slot="{ items : unhealthyInbounds }"
-                    >
-                      <KTooltip
-                        class="reason-tooltip"
+                  <template #body>
+                    <div class="status-with-reason">
+                      <StatusBadge :status="props.data.status" />
+                      <DataCollection
+                        v-if="props.data.dataplaneType === 'standard'"
+                        :items="props.data.dataplane.networking.inbounds"
+                        :predicate="item => !item.health.ready"
+                        :empty="false"
+                        v-slot="{ items : unhealthyInbounds }"
                       >
-                        <InfoIcon
-                          :color="KUI_COLOR_BACKGROUND_NEUTRAL"
-                          :size="KUI_ICON_SIZE_30"
-                        />
-                        <template #content>
-                          <ul>
-                            <li
-                              v-for="inbound in unhealthyInbounds"
-                              :key="`${inbound.service}:${inbound.port}`"
-                            >
-                              {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
-                            </li>
-                          </ul>
-                        </template>
-                      </KTooltip>
-                    </DataCollection>
-                  </div>
-                </template>
-              </DefinitionCard>
-
-              <DefinitionCard>
-                <template #title>
-                  Type
-                </template>
-
-                <template #body>
-                  {{ t(`data-planes.type.${props.data.dataplaneType}`) }}
-                </template>
-              </DefinitionCard>
-
-              <DefinitionCard
-                v-if="props.data.namespace.length > 0"
-              >
-                <template #title>
-                  Namespace
-                </template>
-
-                <template #body>
-                  {{ props.data.namespace }}
-                </template>
-              </DefinitionCard>
-
-              <DefinitionCard>
-                <template #title>
-                  {{ t('data-planes.routes.item.last_updated') }}
-                </template>
-
-                <template #body>
-                  {{ t('common.formats.datetime', { value: Date.parse(props.data.modificationTime) }) }}
-                </template>
-              </DefinitionCard>
-
-              <template
-                v-if="props.data.dataplane.networking.gateway"
-              >
-                <DefinitionCard>
-                  <template #title>
-                    {{ t('http.api.property.tags') }}
-                  </template>
-
-                  <template #body>
-                    <TagList :tags="props.data.dataplane.networking.gateway.tags" />
+                        <KTooltip
+                          class="reason-tooltip"
+                        >
+                          <InfoIcon
+                            :color="KUI_COLOR_BACKGROUND_NEUTRAL"
+                            :size="KUI_ICON_SIZE_30"
+                          />
+                          <template #content>
+                            <ul>
+                              <li
+                                v-for="inbound in unhealthyInbounds"
+                                :key="`${inbound.service}:${inbound.port}`"
+                              >
+                                {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
+                              </li>
+                            </ul>
+                          </template>
+                        </KTooltip>
+                      </DataCollection>
+                    </div>
                   </template>
                 </DefinitionCard>
 
+                <DefinitionCard
+                  v-if="can('use zones') && props.data.zone"
+                >
+                  <template
+                    #title
+                  >
+                    Zone
+                  </template>
+                  <template
+                    #body
+                  >
+                    <XAction
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: props.data.zone,
+                        },
+                      }"
+                    >
+                      {{ props.data.zone }}
+                    </XAction>
+                  </template>
+                </DefinitionCard>
                 <DefinitionCard>
                   <template #title>
-                    {{ t('http.api.property.address') }}
+                    Type
                   </template>
 
                   <template #body>
-                    <TextWithCopyButton :text="`${props.data.dataplane.networking.address}`" />
+                    {{ t(`data-planes.type.${props.data.dataplaneType}`) }}
                   </template>
                 </DefinitionCard>
-              </template>
+
+                <DefinitionCard
+                  v-if="props.data.namespace.length > 0"
+                >
+                  <template #title>
+                    Namespace
+                  </template>
+
+                  <template #body>
+                    {{ props.data.namespace }}
+                  </template>
+                </DefinitionCard>
+              </div>
+              <div
+                class="columns"
+              >
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('data-planes.routes.item.last_updated') }}
+                  </template>
+
+                  <template #body>
+                    {{ t('common.formats.datetime', { value: Date.parse(props.data.modificationTime) }) }}
+                  </template>
+                </DefinitionCard>
+
+                <template
+                  v-if="props.data.dataplane.networking.gateway"
+                >
+                  <DefinitionCard>
+                    <template #title>
+                      {{ t('http.api.property.tags') }}
+                    </template>
+
+                    <template #body>
+                      <TagList :tags="props.data.dataplane.networking.gateway.tags" />
+                    </template>
+                  </DefinitionCard>
+
+                  <DefinitionCard>
+                    <template #title>
+                      {{ t('http.api.property.address') }}
+                    </template>
+
+                    <template #body>
+                      <TextWithCopyButton :text="`${props.data.dataplane.networking.address}`" />
+                    </template>
+                  </DefinitionCard>
+                </template>
+              </div>
             </div>
           </KCard>
 

--- a/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -4,7 +4,7 @@
     :params="{
       dataPlane: '',
     }"
-    v-slot="{ t, route }"
+    v-slot="{ t, route, can }"
   >
     <DataCollection
       :items="props.items"
@@ -122,6 +122,30 @@
                   </template>
                 </DefinitionCard>
 
+                <DefinitionCard
+                  v-if="can('use zones') && item.zone"
+                  layout="horizontal"
+                >
+                  <template
+                    #title
+                  >
+                    Zone
+                  </template>
+                  <template
+                    #body
+                  >
+                    <XAction
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: item.zone,
+                        },
+                      }"
+                    >
+                      {{ item.zone }}
+                    </XAction>
+                  </template>
+                </DefinitionCard>
                 <DefinitionCard
                   layout="horizontal"
                 >

--- a/src/app/policies/components/PolicySummary.vue
+++ b/src/app/policies/components/PolicySummary.vue
@@ -7,7 +7,7 @@
         {{ t('policies.routes.item.overview') }}
       </h3>
 
-      <div class="mt-4 stack">
+      <div class="mt-4 stack-with-borders">
         <DefinitionCard
           layout="horizontal"
         >
@@ -37,6 +37,30 @@
 
           <template #body>
             {{ props.policy.namespace }}
+          </template>
+        </DefinitionCard>
+        <DefinitionCard
+          v-if="props.policy.zone"
+          layout="horizontal"
+        >
+          <template
+            #title
+          >
+            Zone
+          </template>
+          <template
+            #body
+          >
+            <XAction
+              :to="{
+                name: 'zone-cp-detail-view',
+                params: {
+                  zone: props.policy.zone,
+                },
+              }"
+            >
+              {{ props.policy.zone }}
+            </XAction>
           </template>
         </DefinitionCard>
       </div>

--- a/src/app/policies/data/index.ts
+++ b/src/app/policies/data/index.ts
@@ -13,12 +13,6 @@ export type PolicyDataplane = PartialPolicyDataplane & {
   labels: Exclude<PartialPolicyDataplane['labels'], undefined>
 }
 
-export type Policy = PartialPolicy & {
-  config: PartialPolicy
-  id: string
-  namespace: string
-}
-
 export const PolicyDataplane = {
   fromObject(item: PartialPolicyDataplane): PolicyDataplane {
     const labels = typeof item.labels !== 'undefined' ? item.labels : {}
@@ -43,19 +37,21 @@ export const PolicyDataplane = {
 }
 
 export const Policy = {
-  fromObject(item: PartialPolicy): Policy {
+  fromObject(item: PartialPolicy) {
     const labels = typeof item.labels !== 'undefined' ? item.labels : {}
     return {
       ...item,
-      config: item,
+      labels,
       id: item.name,
       name: labels['kuma.io/display-name'] ?? item.name,
       namespace: labels['k8s.kuma.io/namespace'] ?? '',
+      zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
+      config: item,
 
     }
   },
 
-  fromCollection(partialPolicies: PaginatedApiListResponse<PartialPolicy>): PaginatedApiListResponse<Policy> {
+  fromCollection(partialPolicies: PaginatedApiListResponse<PartialPolicy>) {
     return {
       ...partialPolicies,
       items: Array.isArray(partialPolicies.items)
@@ -64,3 +60,4 @@ export const Policy = {
     }
   },
 }
+export type Policy = ReturnType<typeof Policy['fromObject']>

--- a/src/app/policies/locales/en-us/index.yaml
+++ b/src/app/policies/locales/en-us/index.yaml
@@ -10,7 +10,7 @@ policies:
       overview: 'Overview'
       config: 'YAML'
       navigation:
-        policy-detail-view: Affected Data Plane Policies
+        policy-detail-view: Overview
         policy-detail-config-view: YAML
     items:
       empty: "This policy type does not exist."

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -14,77 +14,74 @@
   >
     <AppView>
       <KCard>
-        <DataLoader
-          :src="uri(sources, '/meshes/:mesh/policy-path/:path/policy/:name/dataplanes', {
-            mesh: route.params.mesh,
-            path: route.params.policyPath,
-            name: route.params.policy,
-          },{
-            page: route.params.page,
-            size: route.params.size,
-          })"
-        >
-          <template
-            #loadable="{ data }"
+        <div class="columns">
+          <DefinitionCard
+            v-if="can('use zones') && props.data.zone"
           >
-            <DataCollection
-              type="data-planes"
-              :items="data?.items ?? [undefined]"
+            <template
+              #title
             >
-              <AppCollection
-                :page-number="route.params.page"
-                :page-size="route.params.size"
-                :headers="[
-                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                ]"
-                :items="data?.items"
-                :total="data?.total"
-                :is-selected-row="(row) => row.id === route.params.dataPlane"
-                @change="route.update"
-                @resize="me.set"
+              Zone
+            </template>
+            <template
+              #body
+            >
+              <XAction
+                :to="{
+                  name: 'zone-cp-detail-view',
+                  params: {
+                    zone: props.data.zone,
+                  },
+                }"
               >
-                <template #name="{ row: item }">
-                  <RouterLink
-                    data-action
-                    :to="{
-                      name: 'data-plane-detail-view',
-                      params: {
-                        dataPlane: item.id,
-                      },
-                    }"
-                  >
-                    {{ item.name }}
-                  </RouterLink>
-                </template>
-
-                <template #namespace="{ row: item }">
-                  {{ item.namespace }}
-                </template>
-
-                <template #zone="{ row }">
-                  <RouterLink
-                    v-if="row.zone"
-                    :to="{
-                      name: 'zone-cp-detail-view',
-                      params: {
-                        zone: row.zone,
-                      },
-                    }"
-                  >
-                    {{ row.zone }}
-                  </RouterLink>
-
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-
-                <template #actions="{ row: item }">
-                  <XActionGroup>
-                    <XAction
+                {{ props.data.zone }}
+              </XAction>
+            </template>
+          </DefinitionCard>
+        </div>
+      </KCard>
+      <div>
+        <h3>
+          Affected Data Plane Proxies
+        </h3>
+        <KCard
+          class="mt-4"
+        >
+          <DataLoader
+            :src="uri(sources, '/meshes/:mesh/policy-path/:path/policy/:name/dataplanes', {
+              mesh: route.params.mesh,
+              path: route.params.policyPath,
+              name: route.params.policy,
+            },{
+              page: route.params.page,
+              size: route.params.size,
+            })"
+          >
+            <template
+              #loadable="{ data }"
+            >
+              <DataCollection
+                type="data-planes"
+                :items="data?.items ?? [undefined]"
+              >
+                <AppCollection
+                  :page-number="route.params.page"
+                  :page-size="route.params.size"
+                  :headers="[
+                    { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                    { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                    { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                  ]"
+                  :items="data?.items"
+                  :total="data?.total"
+                  :is-selected-row="(row) => row.id === route.params.dataPlane"
+                  @change="route.update"
+                  @resize="me.set"
+                >
+                  <template #name="{ row: item }">
+                    <RouterLink
+                      data-action
                       :to="{
                         name: 'data-plane-detail-view',
                         params: {
@@ -92,44 +89,87 @@
                         },
                       }"
                     >
-                      {{ t('common.collection.actions.view') }}
-                    </XAction>
-                  </XActionGroup>
-                </template>
-              </AppCollection>
-            </DataCollection>
-            <RouterView
-              v-slot="{ Component }"
-            >
-              <SummaryView
-                v-if="route.child()"
-                @close="route.replace({
-                  params: {
-                    mesh: route.params.mesh,
-                  },
-                  query: {
-                    page: route.params.page,
-                    size: route.params.size,
-                    s: route.params.s,
-                  },
-                })"
+                      {{ item.name }}
+                    </RouterLink>
+                  </template>
+
+                  <template #namespace="{ row: item }">
+                    {{ item.namespace }}
+                  </template>
+
+                  <template #zone="{ row }">
+                    <RouterLink
+                      v-if="row.zone"
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: row.zone,
+                        },
+                      }"
+                    >
+                      {{ row.zone }}
+                    </RouterLink>
+
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'data-plane-detail-view',
+                          params: {
+                            dataPlane: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
+                  </template>
+                </AppCollection>
+              </DataCollection>
+              <RouterView
+                v-slot="{ Component }"
               >
-                <component
-                  :is="Component"
-                  v-if="typeof data !== 'undefined'"
-                  :items="data.items"
-                />
-              </SummaryView>
-            </RouterView>
-          </template>
-        </DataLoader>
-      </KCard>
+                <SummaryView
+                  v-if="route.child()"
+                  @close="route.replace({
+                    params: {
+                      mesh: route.params.mesh,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                      s: route.params.s,
+                    },
+                  })"
+                >
+                  <component
+                    :is="Component"
+                    v-if="typeof data !== 'undefined'"
+                    :items="data.items"
+                  />
+                </SummaryView>
+              </RouterView>
+            </template>
+          </DataLoader>
+        </KCard>
+      </div>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
+import type { Policy } from '../data'
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
+
+const props = defineProps<{
+  data: Policy
+}>()
 </script>

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -180,16 +180,16 @@
                         </template>
 
                         <template #zone="{ row }">
-                          <template v-if="row.labels && row.labels['kuma.io/origin'] === 'zone' && row.labels['kuma.io/zone']">
+                          <template v-if="row.zone">
                             <XAction
                               :to="{
                                 name: 'zone-cp-detail-view',
                                 params: {
-                                  zone: row.labels['kuma.io/zone'],
+                                  zone: row.zone,
                                 },
                               }"
                             >
-                              {{ row.labels['kuma.io/zone'] }}
+                              {{ row.zone }}
                             </XAction>
                           </template>
 

--- a/src/app/services/data/MeshExternalService.ts
+++ b/src/app/services/data/MeshExternalService.ts
@@ -9,17 +9,18 @@ export const MeshExternalService = {
     const namespace = labels['k8s.kuma.io/namespace'] ?? ''
     return {
       ...item,
-      config: item,
       id: item.name,
       name,
       namespace,
       labels,
+      zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
       status: ((item = {}) => {
         return {
           ...item,
           addresses: Array.isArray(item.addresses) ? item.addresses : [],
         }
       })(item.status),
+      config: item,
 
     }
   },

--- a/src/app/services/data/MeshService.ts
+++ b/src/app/services/data/MeshService.ts
@@ -13,8 +13,10 @@ export const MeshService = {
       name,
       namespace,
       labels,
+      zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
       spec: ((item = {}) => {
         return {
+          ...item,
           ports: Array.isArray(item.ports) ? item.ports : [],
           selector: ((item = {}) => {
             return {
@@ -25,6 +27,7 @@ export const MeshService = {
       })(item.spec),
       status: ((item = {}) => {
         return {
+          ...item,
           tls: typeof item.tls !== 'undefined' ? item.tls : { status: 'NotReady' },
           vips: Array.isArray(item.vips) ? item.vips : [],
           addresses: Array.isArray(item.addresses) ? item.addresses : [],

--- a/src/app/services/views/MeshExternalServiceDetailView.vue
+++ b/src/app/services/views/MeshExternalServiceDetailView.vue
@@ -1,8 +1,7 @@
 <template>
   <RouteView
     name="mesh-external-service-detail-view"
-    :params="{
-    }"
+    v-slot="{ can }"
   >
     <AppView>
       <div
@@ -10,6 +9,29 @@
       >
         <KCard>
           <div class="columns">
+            <DefinitionCard
+              v-if="can('use zones') && props.data.zone"
+            >
+              <template
+                #title
+              >
+                Zone
+              </template>
+              <template
+                #body
+              >
+                <XAction
+                  :to="{
+                    name: 'zone-cp-detail-view',
+                    params: {
+                      zone: props.data.zone,
+                    },
+                  }"
+                >
+                  {{ props.data.zone }}
+                </XAction>
+              </template>
+            </DefinitionCard>
             <DefinitionCard
               v-if="props.data.status.addresses.length > 0"
             >

--- a/src/app/services/views/MeshExternalServiceSummaryView.vue
+++ b/src/app/services/views/MeshExternalServiceSummaryView.vue
@@ -8,7 +8,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
-    v-slot="{ route, t }"
+    v-slot="{ route, t, can }"
   >
     <DataCollection
       :items="props.items"
@@ -43,6 +43,30 @@
             <div
               class="stack-with-borders"
             >
+              <DefinitionCard
+                v-if="can('use zones') && item.zone"
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
+                  Zone
+                </template>
+                <template
+                  #body
+                >
+                  <XAction
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: item.zone,
+                      },
+                    }"
+                  >
+                    {{ item.zone }}
+                  </XAction>
+                </template>
+              </DefinitionCard>
               <DefinitionCard
                 v-if="item.status.addresses.length > 0"
                 layout="horizontal"

--- a/src/app/services/views/MeshServiceDetailView.vue
+++ b/src/app/services/views/MeshServiceDetailView.vue
@@ -21,6 +21,29 @@
         <KCard>
           <div class="columns">
             <DefinitionCard
+              v-if="can('use zones') && props.data.zone"
+            >
+              <template
+                #title
+              >
+                Zone
+              </template>
+              <template
+                #body
+              >
+                <XAction
+                  :to="{
+                    name: 'zone-cp-detail-view',
+                    params: {
+                      zone: props.data.zone,
+                    },
+                  }"
+                >
+                  {{ props.data.zone }}
+                </XAction>
+              </template>
+            </DefinitionCard>
+            <DefinitionCard
               v-if="props.data.status.addresses.length > 0"
             >
               <template
@@ -117,7 +140,12 @@
             <DataLoader
               :src="uri(sources, '/meshes/:mesh/dataplanes/for/mesh-service/:tags', {
                 mesh: route.params.mesh,
-                tags: JSON.stringify(props.data.spec.selector.dataplaneTags),
+                tags: JSON.stringify({
+                  ...(can('use zones') && props.data.zone ? {
+                    'kuma.io/zone': props.data.zone,
+                  } : {}),
+                  ...props.data.spec.selector.dataplaneTags,
+                }),
               }, {
                 page: route.params.page,
                 size: route.params.size,
@@ -135,7 +163,6 @@
                   :headers="[
                     { ...me.get('headers.name'), label: 'Name', key: 'name' },
                     { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
                     { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
                     { ...me.get('headers.status'), label: 'Status', key: 'status' },
                     { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
@@ -160,7 +187,6 @@
                         name: { description: 'filter by name or parts of a name' },
                         protocol: { description: 'filter by “kuma.io/protocol” value' },
                         tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                        ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
                       }"
                       @change="(e) => route.update({
                         ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,

--- a/src/app/services/views/MeshServiceListView.vue
+++ b/src/app/services/views/MeshServiceListView.vue
@@ -79,17 +79,16 @@
                   {{ item.namespace }}
                 </template>
                 <template #zone="{ row: item }">
-                  <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
+                  <template v-if="item.zone">
                     <XAction
-                      v-if="item.labels['kuma.io/zone']"
                       :to="{
                         name: 'zone-cp-detail-view',
                         params: {
-                          zone: item.labels['kuma.io/zone'],
+                          zone: item.zone,
                         },
                       }"
                     >
-                      {{ item.labels['kuma.io/zone'] }}
+                      {{ item.zone }}
                     </XAction>
                   </template>
 

--- a/src/app/services/views/MeshServiceSummaryView.vue
+++ b/src/app/services/views/MeshServiceSummaryView.vue
@@ -8,7 +8,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
-    v-slot="{ route, t }"
+    v-slot="{ route, t, can }"
   >
     <DataCollection
       :items="props.items"
@@ -43,6 +43,30 @@
             <div
               class="stack-with-borders"
             >
+              <DefinitionCard
+                v-if="can('use zones') && item.zone"
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
+                  Zone
+                </template>
+                <template
+                  #body
+                >
+                  <XAction
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: item.zone,
+                      },
+                    }"
+                  >
+                    {{ item.zone }}
+                  </XAction>
+                </template>
+              </DefinitionCard>
               <DefinitionCard
                 v-if="item.status.addresses.length > 0"
                 layout="horizontal"

--- a/src/test-support/mocks/src/meshes/_/meshexternalservices/_.ts
+++ b/src/test-support/mocks/src/meshes/_/meshexternalservices/_.ts
@@ -28,6 +28,8 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
           labels: {
             'kuma.io/display-name': displayName,
             'k8s.kuma.io/namespace': nspace,
+            'kuma.io/origin': 'zone',
+            'kuma.io/zone': fake.hacker.noun(),
           },
         }
         : {}),


### PR DESCRIPTION
Whilst doing this I noticed that lots of our top detail boxes are very overloaded now. For instance DDP detail pages have a possible 7 columns (I split this one into 2 rows here).

Data can often overlap and become unreadable, so at least at a technical level its time to take a look at our `class="columns"` layout to provide something that is more responsive.

There is also possibly an opportunity to say we should look at this from a design perspective as looking at the data in the summary panels often provides a more readable display.

Closes https://github.com/kumahq/kuma-gui/issues/2670