### PR TITLE
fix(zones): Unmix zone warning texts

### DIFF
--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -40,8 +40,8 @@ zone-cps:
       intro: !!text/markdown |
         Zones are a logical grouping that represents a distinct network or infrastructure boundary with a multi-zone deplyment. Zone Control Planes are responsible for managing and coordinating the service mesh within a specific zone, handling policies and communication with the Global Control Plane.
   list:
-    ZONE_STORE_TYPE_MEMORY: 'Version mismatch'
-    INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS: 'Uses memory store'
+    INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS: 'Version mismatch'
+    ZONE_STORE_TYPE_MEMORY: 'Uses memory store'
   detail:
     subscriptions: 'KDS connections'
     configuration_title: 'Configuration'


### PR DESCRIPTION
See title

---

A couple of weeks back I moved the warnings inspection over to our data layer, but unfortunately whilst doing so I mixed up the warning messages 🤦 https://github.com/kumahq/kuma-gui/pull/2712/files#diff-b74e52e340de40ac28d9f03911b3150dd6e2a60629b55351d4d160735bda2fcb
