### PR TITLE
fix: Use `vue` instead of `@vue/runtime-core` for registering components

### DIFF
--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -199,15 +199,16 @@ watch(() => props.name, () => {
   }
 }, { immediate: true })
 
-let newParams: Record<string, string | boolean | undefined> = {}
-const routerPush = beforePaint((params: Record<string, string | boolean | undefined>) => {
+type RouteParams = Record<string, string | boolean | number | undefined>
+let newParams: RouteParams = {}
+const routerPush = beforePaint((params: RouteParams) => {
   router.push({
     name: props.name,
     query: cleanQuery(params, route.query),
   })
   newParams = {}
 })
-const routeUpdate = (params: Record<string, string | boolean | undefined>) => {
+const routeUpdate = (params: RouteParams): void => {
   newParams = {
     ...newParams,
     ...params,

--- a/src/app/application/index.ts
+++ b/src/app/application/index.ts
@@ -44,7 +44,7 @@ type Sources = ConstructorParameters<typeof DataSourcePool>[0]
 
 type Token = ReturnType<typeof token>
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     AppView: typeof AppView
     DataSource: typeof DataSource

--- a/src/app/application/utilities/index.ts
+++ b/src/app/application/utilities/index.ts
@@ -86,7 +86,7 @@ export const createTitleSetter = ($doc = document) => {
   })
 }
 // when used with router.push, prevents things like `q=` (i.e. key= but with no value)
-export const cleanQuery = <T extends Record<string, unknown>>(params: Record<string, string | boolean | undefined>, originalQuery: T) => {
+export const cleanQuery = <T extends Record<string, unknown>>(params: Record<string, string | boolean | number | undefined>, originalQuery: T) => {
   const query = {
     ...originalQuery as Record<string, string | undefined | null>,
   }

--- a/src/app/x/index.ts
+++ b/src/app/x/index.ts
@@ -19,7 +19,7 @@ import { token } from '@/services/utils'
 
 type Token = ReturnType<typeof token>
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     XIcon: typeof XIcon
     XInput: typeof XInput


### PR DESCRIPTION
Somewhere around vue language tools `2.0.18 - 2.0.21` all of the types for our `slots` suddenly stopped working.

As this seemed to be a pretty big regression, I've been waiting to see if this would be addresses upstream seeing as various other type related bugs have also been fixed since `2.0.18`.

I've waited for quite a while now, and I decided to take look to see if I could figure out exactly what the issue was, which led me to a fix/upgrade from our end.

1. At the beginning it was very much "anything further than 2.0.18 breaks our types (not knowing exactly why), hold off on upgrading for a bit and see what happens"
2. A few weeks back I'd realized that it seemed to be related to objects that DataSource was emitting via slots. DataSource also uses generic properties and some non-simple typescripting.
3. This morning I noticed that types were broken for the majority of our components, not just DataSource.
4. After trying some things out, I realised that if I imported DataSource instead of registering it globally, the types suddenly started to come back 🎉 , which led me to looking at how we register our global components.
5. After a bit of interweb sleuthing, it looks like we should no longer register global components on `@vue/runtime-core` but instead on `vue`.

This PR contains the above change in point 5, plus another slight TS correction that was also causing errors in newer versions of `vue-tsc`.

I've also tried this fix on ~https://github.com/kumahq/kuma-gui/pull/2784~, https://github.com/kumahq/kuma-gui/pull/2805 and it will let us approve and merge that PR 🎉 