### PR TITLE
fix: Disable/replace incorrect eslint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -178,6 +178,15 @@ const INLINE_NON_VOID_ELEMENTS = [
           ignoreRestSiblings: true,
         }],
 
+        /* temporarily allow function, variable and export hoisting */
+        'no-use-before-define': 'off',
+        '@typescript-eslint/no-use-before-define': ['error', {
+          functions: false,
+          classes: true,
+          variables: false,
+          allowNamedExports: true,
+        }],
+
         'no-useless-constructor': 'off',
         '@typescript-eslint/no-useless-constructor': 'error',
 


### PR DESCRIPTION
I was playing around/experimenting with something and eslint was warning me about some incorrect typescript for something that seemed reasonable.

When I looked into it it seems like this eslint rule is incorrect when using with typescript

https://typescript-eslint.io/rules/no-use-before-define/#how-to-use

```js
module.exports = {
  "rules": {
    // Note: you must disable the base rule as it can report incorrect errors
    "no-use-before-define": "off",
    "@typescript-eslint/no-use-before-define": "error"
  }
};
```

While I don't need the experiment I was working on when I found this out, I figured I would PR the eslint correction for the future.

---

The default options for the ts rule would require a fair amount of moving code around just to satisfy the linter, so I've amended the default options along with the addition of a comment.

We should probably do the moving around work so we can just use the default options at some point, but seeing as its just satisfying the linter there's no rush to do that.