### PR TITLE
fix(data-sink): unset error on a subsequent success

### DIFF
--- a/features/zones/Create.feature
+++ b/features/zones/Create.feature
@@ -185,6 +185,7 @@ Feature: zones / create
     When I clear the "$name-input" element
     And I "type" "test" into the "$name-input" element
     And I click the "$create-zone-button" element
+    And the "$name-input-invalid-dns-name" element doesn't exist
     Then the "$create-error" element doesn't exist
     And the "$instructions" element exists
 

--- a/src/app/application/components/data-source/DataSink.vue
+++ b/src/app/application/components/data-source/DataSink.vue
@@ -8,6 +8,7 @@
       @change="(d: TypeOf<T>) => {
         writing = false
         data = d;
+        error = undefined;
         emit('change', d)
         toggle()
       }"


### PR DESCRIPTION
If a DataSink errors, and after another attempt then subsequently succeeds, make sure we unset the error.

e2e test added in Zone Creation for any potential regressions.