### PR TITLE
chore(mesh-service): add copy button to address when there is only one

### DIFF
--- a/src/app/services/data/MeshExternalService.ts
+++ b/src/app/services/data/MeshExternalService.ts
@@ -17,7 +17,14 @@ export const MeshExternalService = {
       status: ((item = {}) => {
         return {
           ...item,
-          addresses: Array.isArray(item.addresses) ? item.addresses : [],
+          addresses: Array.isArray(item.addresses)
+            ? item.addresses.map(item => {
+              return {
+                ...item,
+                hostname: typeof item.hostname === 'string' ? item.hostname : '',
+              }
+            })
+            : [],
         }
       })(item.status),
 

--- a/src/app/services/data/MeshService.ts
+++ b/src/app/services/data/MeshService.ts
@@ -27,7 +27,14 @@ export const MeshService = {
         return {
           tls: typeof item.tls !== 'undefined' ? item.tls : { status: 'NotReady' },
           vips: Array.isArray(item.vips) ? item.vips : [],
-          addresses: Array.isArray(item.addresses) ? item.addresses : [],
+          addresses: Array.isArray(item.addresses)
+            ? item.addresses.map(item => {
+              return {
+                ...item,
+                hostname: typeof item.hostname === 'string' ? item.hostname : '',
+              }
+            })
+            : [],
         }
       })(item.status),
       config: item,

--- a/src/app/services/views/MeshExternalServiceDetailView.vue
+++ b/src/app/services/views/MeshExternalServiceDetailView.vue
@@ -21,7 +21,18 @@
               <template
                 #body
               >
-                <KTruncate>
+                <template
+                  v-if="props.data.status.addresses.length === 1"
+                >
+                  <TextWithCopyButton
+                    :text="props.data.status.addresses[0].hostname"
+                  >
+                    {{ props.data.status.addresses[0].hostname }}
+                  </TextWithCopyButton>
+                </template>
+                <KTruncate
+                  v-else
+                >
                   <span
                     v-for="address in props.data.status.addresses"
                     :key="address.hostname"
@@ -96,6 +107,7 @@
 <script lang="ts" setup>
 import type { MeshExternalService } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 
 const props = defineProps<{
   data: MeshExternalService

--- a/src/app/services/views/MeshExternalServiceListView.vue
+++ b/src/app/services/views/MeshExternalServiceListView.vue
@@ -107,7 +107,18 @@
                 <template
                   #addresses="{ row: item }"
                 >
-                  <KTruncate>
+                  <template
+                    v-if="item.status.addresses.length === 1"
+                  >
+                    <TextWithCopyButton
+                      :text="item.status.addresses[0].hostname"
+                    >
+                      {{ item.status.addresses[0].hostname }}
+                    </TextWithCopyButton>
+                  </template>
+                  <KTruncate
+                    v-else
+                  >
                     <span
                       v-for="address in item.status.addresses"
                       :key="address.hostname"

--- a/src/app/services/views/MeshExternalServiceSummaryView.vue
+++ b/src/app/services/views/MeshExternalServiceSummaryView.vue
@@ -55,7 +55,18 @@
                 <template
                   #body
                 >
-                  <KTruncate>
+                  <template
+                    v-if="item.status.addresses.length === 1"
+                  >
+                    <TextWithCopyButton
+                      :text="item.status.addresses[0].hostname"
+                    >
+                      {{ item.status.addresses[0].hostname }}
+                    </TextWithCopyButton>
+                  </template>
+                  <KTruncate
+                    v-else
+                  >
                     <span
                       v-for="address in item.status.addresses"
                       :key="address.hostname"
@@ -145,6 +156,7 @@
 <script lang="ts" setup>
 import ResourceCodeBlock from '@/app/common/code-block/ResourceCodeBlock.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeshExternalService } from '@/app/services/data'
 const props = defineProps<{
   items: MeshExternalService[]

--- a/src/app/services/views/MeshServiceDetailView.vue
+++ b/src/app/services/views/MeshServiceDetailView.vue
@@ -31,7 +31,18 @@
               <template
                 #body
               >
-                <KTruncate>
+                <template
+                  v-if="props.data.status.addresses.length === 1"
+                >
+                  <TextWithCopyButton
+                    :text="props.data.status.addresses[0].hostname"
+                  >
+                    {{ props.data.status.addresses[0].hostname }}
+                  </TextWithCopyButton>
+                </template>
+                <KTruncate
+                  v-else
+                >
                   <span
                     v-for="address in props.data.status.addresses"
                     :key="address.hostname"
@@ -301,6 +312,7 @@ import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import { sources } from '@/app/data-planes/sources'
 
 const props = defineProps<{

--- a/src/app/services/views/MeshServiceListView.vue
+++ b/src/app/services/views/MeshServiceListView.vue
@@ -100,7 +100,18 @@
                 <template
                   #addresses="{ row: item }"
                 >
-                  <KTruncate>
+                  <template
+                    v-if="item.status.addresses.length === 1"
+                  >
+                    <TextWithCopyButton
+                      :text="item.status.addresses[0].hostname"
+                    >
+                      {{ item.status.addresses[0].hostname }}
+                    </TextWithCopyButton>
+                  </template>
+                  <KTruncate
+                    v-else
+                  >
                     <span
                       v-for="address in item.status.addresses"
                       :key="address.hostname"

--- a/src/app/services/views/MeshServiceSummaryView.vue
+++ b/src/app/services/views/MeshServiceSummaryView.vue
@@ -55,7 +55,18 @@
                 <template
                   #body
                 >
-                  <KTruncate>
+                  <template
+                    v-if="item.status.addresses.length === 1"
+                  >
+                    <TextWithCopyButton
+                      :text="item.status.addresses[0].hostname"
+                    >
+                      {{ item.status.addresses[0].hostname }}
+                    </TextWithCopyButton>
+                  </template>
+                  <KTruncate
+                    v-else
+                  >
                     <span
                       v-for="address in item.status.addresses"
                       :key="address.hostname"
@@ -150,6 +161,7 @@
 <script lang="ts" setup>
 import ResourceCodeBlock from '@/app/common/code-block/ResourceCodeBlock.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
 import type { MeshService } from '@/app/services/data'
 const props = defineProps<{
   items: MeshService[]

--- a/src/test-support/mocks/src/meshes/_/meshexternalservices.ts
+++ b/src/test-support/mocks/src/meshes/_/meshexternalservices.ts
@@ -58,7 +58,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             },
           },
           status: {
-            addresses: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
+            addresses: Array.from({ length: fake.number.int({ min: 0, max: 5 }) }).map(_ => ({
               hostname: fake.internet.domainName(),
             })),
             vip: {

--- a/src/test-support/mocks/src/meshes/_/meshservices.ts
+++ b/src/test-support/mocks/src/meshes/_/meshservices.ts
@@ -54,7 +54,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             },
           },
           status: {
-            addresses: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
+            addresses: Array.from({ length: fake.number.int({ min: 0, max: 5 }) }).map(_ => ({
               hostname: fake.internet.domainName(),
             })),
             vips: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({


### PR DESCRIPTION
Closes https://github.com/kumahq/kuma-gui/issues/2791

Adds a copy button to all MeshService/MeshExternalService `addresses` in lists, summaries and details....but only when there is a single address (`addresses` is an array, but I'm guessing its most commonly single length)

Personally I'm not super keen on copy buttons, I want to see what I'm copying, but I get why people like them. I am a little cautious though about having a glut of copy buttons in every page of the GUI, mentioning here as I'd like to find a good balance and wanted to note somewhere whilst its at the forefront of my mind.
