### PR TITLE
chore: prevent a re-render if a change of headers has same value

### DIFF
--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -215,8 +215,10 @@ watch(() => props.pageNumber, function () {
     kTableMountKey.value++
   }
 })
-watch(() => props.headers, function () {
-  kTableMountKey.value++
+watch(() => props.headers, function (val, prev) {
+  if (JSON.stringify(val) !== JSON.stringify(prev)) {
+    kTableMountKey.value++
+  }
 })
 
 function getRowAttributes(row: Row): Record<string, string> {


### PR DESCRIPTION
Prevents a table re-render when the `headers` reference changes but the value doesn't.

This PR also fixes the issue described in https://github.com/kumahq/kuma-gui/pull/2810 but in a different way.

Whilst both separately fix the issue and only one is theoretically needed, both a valuable improvements.