### PR TITLE
chore(tests): default CYPRESS_SPEC to all feature files

### DIFF
--- a/mk/test.mk
+++ b/mk/test.mk
@@ -17,6 +17,7 @@ test/unit/watch: install ## Dev: run unit tests but watch for changes
 
 
 .PHONY: test/e2e
+test/e2e: CYPRESS_SPEC?=**/*.feature
 test/e2e: ## Run browser-based e2e tests against a running GUI, you may want to set KUMA_BASE_URL=http://localhost:8080/gui and KUMA_TEST_BROWSER=chrome
 ifdef KUMA_TEST_BROWSER
 	@TZ=UTC \


### PR DESCRIPTION
Personally I use `KUMA_TEST_BROWSER` to always open tests in chrome (its good practice to watch e2e tests run through). Therefore, generally, only CI runs in headless mode, and in CI we _always_ pass in a `CYPRESS_SPEC` env var.

But, just the once I wanted to run the tests in headless mode locally whilst trying to chase down a potential CI bug. So I `unset KUMA_TEST_BROWSER`, and found that I also had to set `CYPRESS_SPEC` otherwise the command errors out.

This PR defaults `CYPRESS_SPEC` to `**/*.feature` so you can just run `make test/e2e` with an empty `CYPRESS_SPEC` and it will run all the tests.