### PR TITLE
chore: Refactor AppCollection to not include non-table things

### DIFF
--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -1,36 +1,19 @@
 <template>
   <KTable
-    :key="kTableMountKey"
     data-testid="app-collection"
     class="app-collection"
-    :has-error="(typeof props.error !== 'undefined')"
-    :pagination-total-items="props.total"
-    :initial-fetcher-params="{ page: props.pageNumber, pageSize: props.pageSize }"
     :headers="props.headers"
     :fetcher-cache-key="String(cacheKey)"
-    :fetcher="({ page, pageSize, query: _query }: FetcherParams) => {
-      const value: ChangeValue = {}
-      if(lastPageNumber !== page) {
-        value.page = page;
-      }
-      if(lastPageSize !== pageSize) {
-        value.size = pageSize;
-      }
-      lastPageNumber = page
-      lastPageSize = pageSize
-      if(Object.keys(value).length > 0) {
-        emit('change', value)
-      }
+    :fetcher="() => {
       return { data: props.items }
     }"
     :cell-attrs="({ headerKey }: CellAttrParams) => ({
       class: `${headerKey}-column`,
     })"
     :row-attrs="getRowAttributes"
-    disable-sorting
-    :disable-pagination="props.pageNumber === 0"
-    hide-pagination-when-optional
-    resize-columns
+    :disable-sorting="true"
+    :disable-pagination="true"
+    :resize-columns="true"
     :table-preferences="{
       columnWidths: props.headers.reduce<Record<string, number>>((prev, value) => {
         if(typeof value.width !== 'undefined') {
@@ -43,44 +26,6 @@
     @row:click="click"
     @update:table-preferences="resize"
   >
-    <template
-      v-if="props.items?.length === 0"
-      #empty-state
-    >
-      <EmptyBlock>
-        <template #title>
-          {{ props.emptyStateTitle ?? t('common.emptyState.title') }}
-        </template>
-
-        <template v-if="props.emptyStateMessage">
-          {{ props.emptyStateMessage }}
-        </template>
-
-        <template
-          v-if="props.emptyStateCtaTo"
-          #action
-        >
-          <XAction
-            v-if="typeof props.emptyStateCtaTo === 'string'"
-            action="docs"
-            :href="props.emptyStateCtaTo"
-          >
-            {{ props.emptyStateCtaText }}
-          </XAction>
-
-          <KButton
-            v-else
-            appearance="primary"
-            :to="props.emptyStateCtaTo"
-          >
-            <AddIcon />
-
-            {{ props.emptyStateCtaText }}
-          </KButton>
-        </template>
-      </EmptyBlock>
-    </template>
-
     <template
       v-for="key in Object.keys(slots)"
       :key="key"
@@ -107,65 +52,32 @@
 </template>
 
 <script lang="ts" setup generic="Row extends {}">
-import { AddIcon } from '@kong/icons'
-import { KButton, KTable } from '@kong/kongponents'
+import { KTable } from '@kong/kongponents'
 import { useSlots, ref, watch, Ref } from 'vue'
-import { RouteLocationRaw } from 'vue-router'
 
-import { useI18n } from '@/app/application'
-import EmptyBlock from '@/app/common/EmptyBlock.vue'
 import type { TableHeader as KTableHeader, TablePreferences } from '@kong/kongponents'
-
 type CellAttrParams = {
   headerKey: string
   row: Row
   rowIndex: number
   colIndex: number
 }
-type FetcherParams = {
-  page: number
-  pageSize: number
-  query: string
-}
-type ChangeValue = {
-  page?: number
-  size?: number
-}
 type ResizeValue = {
   headers: Record<string, { width: number }>
 }
-
-const { t } = useI18n()
 
 type TableHeader = KTableHeader & {
   width?: number
 }
 const props = withDefaults(defineProps<{
-  isSelectedRow?: ((row: Row) => boolean) | null
-  total?: number
-  pageNumber?: number
-  pageSize?: number
+  isSelectedRow?: ((row: Row) => boolean)
   items: Row[] | undefined
   headers: TableHeader[]
-  error?: Error | undefined
-  emptyStateTitle?: string
-  emptyStateMessage?: string
-  emptyStateCtaTo?: string | RouteLocationRaw
-  emptyStateCtaText?: string
 }>(), {
-  isSelectedRow: null,
-  total: 0,
-  pageNumber: 0,
-  pageSize: 30,
-  error: undefined,
-  emptyStateTitle: undefined,
-  emptyStateMessage: undefined,
-  emptyStateCtaTo: undefined,
-  emptyStateCtaText: undefined,
+  isSelectedRow: undefined,
 })
 
 const emit = defineEmits<{
-  (e: 'change', value: ChangeValue): void
   (e: 'resize', value: ResizeValue): void
 }>()
 
@@ -173,23 +85,6 @@ const slots = useSlots()
 
 const items = ref(props.items) as Ref<typeof props.items>
 const cacheKey = ref<number>(0)
-/**
- * Used as a means to instruct KTable to re-mount.
- *
- * This is a hack around the fact that there is no other way to tell KTable if
- * the current page of a paginated view has changed. KTable assumes it’s the
- * *sole* owner/maintainer of pagination-related state, but that’s a design
- * flaw that doesn’t account for browser history navigation (e.g. pressing back
- * to go from page 2 to page 1).
- *
- * Is triggered via a watcher whenever `props.pageNumber` changes while the
- * last page number that was emitted by KTable (via calls to its `fetcher`
- * prop) is different (i.e. the page number has changed independently of a
- * KTable mechanism).
- */
-const kTableMountKey = ref(0)
-const lastPageNumber = ref(props.pageNumber)
-const lastPageSize = ref(props.pageSize)
 
 const resize = (args: TablePreferences) => {
   const headers = Object.entries(args.columnWidths ?? {}).reduce<Record<string, { width: number }>>((prev, [key, value]) => {
@@ -211,17 +106,6 @@ watch(() => props.items, (newItems, oldItems) => {
   }
 })
 
-watch(() => props.pageNumber, function () {
-  if (props.pageNumber !== lastPageNumber.value) {
-    kTableMountKey.value++
-  }
-})
-watch(() => props.headers, function (val, prev) {
-  if (JSON.stringify(val) !== JSON.stringify(prev)) {
-    kTableMountKey.value++
-  }
-})
-
 function getRowAttributes(row: Row): Record<string, string> {
   if (!row) {
     return {}
@@ -229,7 +113,7 @@ function getRowAttributes(row: Row): Record<string, string> {
 
   const attributes: Record<string, string> = {}
 
-  if (props.isSelectedRow !== null && props.isSelectedRow(row)) {
+  if (typeof props.isSelectedRow !== 'undefined' && props.isSelectedRow(row)) {
     attributes.class = 'is-selected'
   }
 

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -36,12 +36,14 @@
             <DataCollection
               type="data-planes"
               :items="data?.items ?? [undefined]"
+              :total="data?.total"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              @change="route.update"
             >
               <AppCollection
                 class="data-plane-collection"
                 data-testid="data-plane-collection"
-                :page-number="route.params.page"
-                :page-size="route.params.size"
                 :headers="[
                   { ...me.get('headers.type'), label: '&nbsp;', key: 'type' },
                   { ...me.get('headers.name'), label: 'Name', key: 'name' },
@@ -54,9 +56,7 @@
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
                 :items="data?.items"
-                :total="data?.total"
                 :is-selected-row="(row) => row.name === route.params.dataPlane"
-                @change="route.update"
                 @resize="me.set"
               >
                 <template #toolbar>

--- a/src/app/external-services/views/ExternalServiceListView.vue
+++ b/src/app/external-services/views/ExternalServiceListView.vue
@@ -30,6 +30,10 @@
             <DataCollection
               type="external-services"
               :items="data?.items ?? [undefined]"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="data?.total"
+              @change="route.update"
             >
               <AppCollection
                 class="external-service-collection"
@@ -39,11 +43,7 @@
                   { ...me.get('headers.address'), label: 'Address', key: 'address' },
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
-                :page-number="route.params.page"
-                :page-size="route.params.size"
-                :total="data?.total"
                 :items="data?.items"
-                @change="route.update"
                 @resize="me.set"
               >
                 <template #name="{ row: item }">

--- a/src/app/gateways/views/BuiltinGatewayListView.vue
+++ b/src/app/gateways/views/BuiltinGatewayListView.vue
@@ -27,6 +27,10 @@
             <DataCollection
               type="gateways"
               :items="data?.items ?? [undefined]"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="data?.total"
+              @change="route.update"
             >
               <AppCollection
                 class="builtin-gateway-collection"
@@ -36,11 +40,7 @@
                   ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
-                :page-number="route.params.page"
-                :page-size="route.params.size"
-                :total="data?.total"
                 :items="data?.items"
-                @change="route.update"
                 @resize="me.set"
               >
                 <template #name="{ row: item }">

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -64,168 +64,171 @@
           <KCard class="mt-4">
             <DataLoader
               :src="`/meshes/${route.params.mesh}/dataplanes/for/service-insight/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
-              :loader="false"
-              v-slot="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
             >
-              <AppCollection
-                class="data-plane-collection"
-                data-testid="data-plane-collection"
-                :page-number="route.params.page"
-                :page-size="route.params.size"
-                :headers="[
-                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                  { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
-                  { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                  { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
-                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                ]"
-                :items="dataplanesData?.items"
-                :total="dataplanesData?.total"
-                :is-selected-row="(row) => row.name === route.params.dataPlane"
-                summary-route-name="delegated-gateway-data-plane-summary-view"
-                :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
-                :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
-                :empty-state-cta-text="t('common.documentation')"
-                @change="route.update"
-                @resize="me.set"
+              <template
+                #loadable="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
               >
-                <template #toolbar>
-                  <FilterBar
-                    class="data-plane-proxy-filter"
-                    :placeholder="`tag: 'kuma.io/protocol: http'`"
-                    :query="route.params.s"
-                    :fields="{
-                      name: { description: 'filter by name or parts of a name' },
-                      protocol: { description: 'filter by “kuma.io/protocol” value' },
-                      tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                      ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                    }"
-                    @change="(e) => route.update({
-                      ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                    })"
-                  />
-                </template>
-
-                <template #name="{ row: item }">
-                  <RouterLink
-                    class="name-link"
-                    :to="{
-                      name: 'delegated-gateway-data-plane-summary-view',
-                      params: {
-                        mesh: item.mesh,
-                        dataPlane: item.id,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                        s: route.params.s,
-                      },
-                    }"
-                  >
-                    {{ item.name }}
-                  </RouterLink>
-                </template>
-
-                <template #namespace="{ row: item }">
-                  {{ item.namespace }}
-                </template>
-
-                <template #zone="{ row }">
-                  <RouterLink
-                    v-if="row.zone"
-                    :to="{
-                      name: 'zone-cp-detail-view',
-                      params: {
-                        zone: row.zone,
-                      },
-                    }"
-                  >
-                    {{ row.zone }}
-                  </RouterLink>
-
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-
-                <template #certificate="{ row }">
-                  <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                    {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                  </template>
-
-                  <template v-else>
-                    {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                  </template>
-                </template>
-
-                <template #status="{ row }">
-                  <StatusBadge :status="row.status" />
-                </template>
-
-                <template #warnings="{ row }">
-                  <XIcon
-                    v-if="row.isCertExpired || row.warnings.length > 0"
-                    class="mr-1"
-                    name="warning"
-                  >
-                    <ul>
-                      <template v-if="row.warnings.length > 0">
-                        <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                      </template>
-
-                      <template v-if="row.isCertExpired">
-                        <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                      </template>
-                    </ul>
-                  </XIcon>
-
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-
-                <template #actions="{ row: item }">
-                  <XActionGroup>
-                    <XAction
-                      :to="{
-                        name: 'data-plane-detail-view',
-                        params: {
-                          dataPlane: item.id,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.actions.view') }}
-                    </XAction>
-                  </XActionGroup>
-                </template>
-              </AppCollection>
-
-              <RouterView
-                v-if="route.params.dataPlane"
-                v-slot="child"
-              >
-                <SummaryView
-                  @close="route.replace({
-                    name: route.name,
-                    params: {
-                      mesh: route.params.mesh,
-                    },
-                    query: {
-                      page: route.params.page,
-                      size: route.params.size,
-                      s: route.params.s,
-                    },
-                  })"
+                <DataCollection
+                  type="data-planes"
+                  :items="dataplanesData?.items ?? [undefined]"
+                  :page="route.params.page"
+                  :page-size="route.params.size"
+                  :total="dataplanesData?.total"
+                  @change="route.update"
                 >
-                  <component
-                    :is="child.Component"
-                    v-if="typeof dataplanesData !== 'undefined'"
-                    :items="dataplanesData.items"
-                  />
-                </SummaryView>
-              </RouterView>
+                  <AppCollection
+                    class="data-plane-collection"
+                    data-testid="data-plane-collection"
+                    :headers="[
+                      { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                      { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                      ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                      { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
+                      { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                      { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                      { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                    ]"
+                    :items="dataplanesData?.items"
+                    :is-selected-row="(row) => row.name === route.params.dataPlane"
+                    @resize="me.set"
+                  >
+                    <template #toolbar>
+                      <FilterBar
+                        class="data-plane-proxy-filter"
+                        :placeholder="`tag: 'kuma.io/protocol: http'`"
+                        :query="route.params.s"
+                        :fields="{
+                          name: { description: 'filter by name or parts of a name' },
+                          protocol: { description: 'filter by “kuma.io/protocol” value' },
+                          tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                          ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+                        }"
+                        @change="(e) => route.update({
+                          ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                        })"
+                      />
+                    </template>
+
+                    <template #name="{ row: item }">
+                      <XAction
+                        data-action
+                        class="name-link"
+                        :to="{
+                          name: 'delegated-gateway-data-plane-summary-view',
+                          params: {
+                            mesh: item.mesh,
+                            dataPlane: item.id,
+                          },
+                          query: {
+                            page: route.params.page,
+                            size: route.params.size,
+                            s: route.params.s,
+                          },
+                        }"
+                      >
+                        {{ item.name }}
+                      </XAction>
+                    </template>
+
+                    <template #namespace="{ row: item }">
+                      {{ item.namespace }}
+                    </template>
+
+                    <template #zone="{ row }">
+                      <RouterLink
+                        v-if="row.zone"
+                        :to="{
+                          name: 'zone-cp-detail-view',
+                          params: {
+                            zone: row.zone,
+                          },
+                        }"
+                      >
+                        {{ row.zone }}
+                      </RouterLink>
+
+                      <template v-else>
+                        {{ t('common.collection.none') }}
+                      </template>
+                    </template>
+
+                    <template #certificate="{ row }">
+                      <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                        {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                      </template>
+
+                      <template v-else>
+                        {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                      </template>
+                    </template>
+
+                    <template #status="{ row }">
+                      <StatusBadge :status="row.status" />
+                    </template>
+
+                    <template #warnings="{ row }">
+                      <XIcon
+                        v-if="row.isCertExpired || row.warnings.length > 0"
+                        class="mr-1"
+                        name="warning"
+                      >
+                        <ul>
+                          <template v-if="row.warnings.length > 0">
+                            <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+                          </template>
+
+                          <template v-if="row.isCertExpired">
+                            <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
+                          </template>
+                        </ul>
+                      </XIcon>
+
+                      <template v-else>
+                        {{ t('common.collection.none') }}
+                      </template>
+                    </template>
+
+                    <template #actions="{ row: item }">
+                      <XActionGroup>
+                        <XAction
+                          :to="{
+                            name: 'data-plane-detail-view',
+                            params: {
+                              dataPlane: item.id,
+                            },
+                          }"
+                        >
+                          {{ t('common.collection.actions.view') }}
+                        </XAction>
+                      </XActionGroup>
+                    </template>
+                  </AppCollection>
+                  <RouterView
+                    v-if="route.params.dataPlane"
+                    v-slot="child"
+                  >
+                    <SummaryView
+                      @close="route.replace({
+                        name: route.name,
+                        params: {
+                          mesh: route.params.mesh,
+                        },
+                        query: {
+                          page: route.params.page,
+                          size: route.params.size,
+                          s: route.params.s,
+                        },
+                      })"
+                    >
+                      <component
+                        :is="child.Component"
+                        v-if="typeof dataplanesData !== 'undefined'"
+                        :items="dataplanesData.items"
+                      />
+                    </SummaryView>
+                  </RouterView>
+                </DataCollection>
+              </template>
             </DataLoader>
           </KCard>
         </div>

--- a/src/app/gateways/views/DelegatedGatewayListView.vue
+++ b/src/app/gateways/views/DelegatedGatewayListView.vue
@@ -27,6 +27,10 @@
             <DataCollection
               type="gateways"
               :items="data?.items ?? [undefined]"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="data?.total"
+              @change="route.update"
             >
               <AppCollection
                 class="delegated-gateway-collection"
@@ -38,11 +42,7 @@
                   { ...me.get('headers.status'), label: 'Status', key: 'status' },
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
-                :page-number="route.params.page"
-                :page-size="route.params.size"
-                :total="data?.total"
                 :items="data?.items"
-                @change="route.update"
                 @resize="me.set"
               >
                 <template #name="{ row: item }">

--- a/src/app/meshes/components/MeshInsightsList.vue
+++ b/src/app/meshes/components/MeshInsightsList.vue
@@ -11,7 +11,6 @@
           { ...storage.get('mesh.headers.dataplanes') ,label: t('meshes.components.mesh-insights-list.dataplanes'), key: 'dataplanes'},
         ]"
         :items="props.items"
-        :total="props.items?.length"
         @resize="(obj) => {
           storage.set({
             mesh: obj,

--- a/src/app/meshes/views/MeshListView.vue
+++ b/src/app/meshes/views/MeshListView.vue
@@ -34,6 +34,10 @@
               <DataCollection
                 type="meshes"
                 :items="data?.items ?? [undefined]"
+                :page="route.params.page"
+                :page-size="route.params.size"
+                :total="data?.total"
+                @change="route.update"
               >
                 <AppCollection
                   class="mesh-collection"
@@ -44,12 +48,8 @@
                     { ...me.get('headers.dataplanes'), label: t('meshes.routes.items.collection.dataplanes'), key: 'dataplanes'},
                     { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                   ]"
-                  :page-number="route.params.page"
-                  :page-size="route.params.size"
-                  :total="data?.total"
                   :items="data?.items"
                   :is-selected-row="(row) => row.name === route.params.mesh"
-                  @change="route.update"
                   @resize="me.set"
                 >
                   <template #name="{ row: item }">

--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -63,10 +63,12 @@
               <DataCollection
                 type="data-planes"
                 :items="data?.items ?? [undefined]"
+                :page="route.params.page"
+                :page-size="route.params.size"
+                :total="data?.total"
+                @change="route.update"
               >
                 <AppCollection
-                  :page-number="route.params.page"
-                  :page-size="route.params.size"
                   :headers="[
                     { ...me.get('headers.name'), label: 'Name', key: 'name' },
                     { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
@@ -74,9 +76,7 @@
                     { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                   ]"
                   :items="data?.items"
-                  :total="data?.total"
                   :is-selected-row="(row) => row.id === route.params.dataPlane"
-                  @change="route.update"
                   @resize="me.set"
                 >
                   <template #name="{ row: item }">

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -102,6 +102,10 @@
                   </search>
                   <DataCollection
                     :items="data?.items ?? [undefined]"
+                    :page="route.params.page"
+                    :page-size="route.params.size"
+                    :total="data?.total"
+                    @change="route.update"
                   >
                     <template
                       #empty
@@ -136,12 +140,8 @@
                           ...(type.isTargetRefBased ? [{ ...me.get('headers.targetRef'), label: 'Target ref', key: 'targetRef' }] : []),
                           { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                         ]"
-                        :page-number="route.params.page"
-                        :page-size="route.params.size"
-                        :total="data?.total"
                         :items="data?.items"
                         :is-selected-row="(row) => row.id === route.params.policy"
-                        @change="route.update"
                         @resize="me.set"
                       >
                         <template #name="{ row }">

--- a/src/app/rules/components/RuleList.vue
+++ b/src/app/rules/components/RuleList.vue
@@ -36,7 +36,6 @@
                 :class="{
                   'has-matchers': hasMatchers,
                 }"
-                :total="items.length"
                 :items="items"
                 :headers="[
                   ...(hasMatchers ? [{ label: 'Matchers', key: 'matchers' }] : []),

--- a/src/app/services/views/MeshExternalServiceListView.vue
+++ b/src/app/services/views/MeshExternalServiceListView.vue
@@ -31,6 +31,10 @@
             <DataCollection
               type="services"
               :items="data?.items ?? [undefined]"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="data?.total"
+              @change="route.update"
             >
               <AppCollection
                 data-testid="service-collection"
@@ -43,12 +47,8 @@
                   { ...me.get('headers.port'), label: 'Port', key: 'port' },
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
-                :page-number="route.params.page"
-                :page-size="route.params.size"
-                :total="data?.total"
                 :items="data?.items"
                 :is-selected-row="(item) => item.name === route.params.service"
-                @change="route.update"
                 @resize="me.set"
               >
                 <template #name="{ row: item }">

--- a/src/app/services/views/MeshServiceDetailView.vue
+++ b/src/app/services/views/MeshServiceDetailView.vue
@@ -166,162 +166,163 @@
               <template
                 #loadable="{ data: dataplanes }"
               >
-                <AppCollection
-                  class="data-plane-collection"
-                  data-testid="data-plane-collection"
-                  :page-number="route.params.page"
+                <DataCollection
+                  type="data-planes"
+                  :items="dataplanes?.items ?? [undefined]"
+                  :page="route.params.page"
                   :page-size="route.params.size"
-                  :headers="[
-                    { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                    { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                    { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
-                    { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                    { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
-                    { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                  ]"
-                  :items="dataplanes?.items"
                   :total="dataplanes?.total"
-                  :is-selected-row="(row) => row.name === route.params.dataPlane"
-                  summary-route-name="service-data-plane-summary-view"
-                  :empty-state-message="t('common.emptyState.message', { type: 'Data Plane Proxies' })"
-                  :empty-state-cta-to="t('data-planes.href.docs.data_plane_proxy')"
-                  :empty-state-cta-text="t('common.documentation')"
                   @change="route.update"
-                  @resize="me.set"
                 >
-                  <template #toolbar>
-                    <FilterBar
-                      class="data-plane-proxy-filter"
-                      :placeholder="`name:dataplane-name`"
-                      :query="route.params.s"
-                      :fields="{
-                        name: { description: 'filter by name or parts of a name' },
-                        protocol: { description: 'filter by “kuma.io/protocol” value' },
-                        tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                      }"
-                      @change="(e) => route.update({
-                        ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                      })"
-                    />
-                  </template>
+                  <AppCollection
+                    class="data-plane-collection"
+                    data-testid="data-plane-collection"
+                    :headers="[
+                      { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                      { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                      { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
+                      { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                      { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                      { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                    ]"
+                    :items="dataplanes?.items"
+                    :is-selected-row="(row) => row.name === route.params.dataPlane"
+                    @resize="me.set"
+                  >
+                    <template #toolbar>
+                      <FilterBar
+                        class="data-plane-proxy-filter"
+                        :placeholder="`name:dataplane-name`"
+                        :query="route.params.s"
+                        :fields="{
+                          name: { description: 'filter by name or parts of a name' },
+                          protocol: { description: 'filter by “kuma.io/protocol” value' },
+                          tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                        }"
+                        @change="(e) => route.update({
+                          ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                        })"
+                      />
+                    </template>
 
-                  <template #name="{ row: item }">
-                    <RouterLink
-                      class="name-link"
-                      :to="{
-                        name: 'mesh-service-data-plane-summary-view',
+                    <template #name="{ row: item }">
+                      <RouterLink
+                        class="name-link"
+                        :to="{
+                          name: 'mesh-service-data-plane-summary-view',
+                          params: {
+                            mesh: item.mesh,
+                            dataPlane: item.id,
+                          },
+                          query: {
+                            page: route.params.page,
+                            size: route.params.size,
+                            s: route.params.s,
+                          },
+                        }"
+                      >
+                        {{ item.name }}
+                      </RouterLink>
+                    </template>
+
+                    <template #namespace="{ row: item }">
+                      {{ item.namespace }}
+                    </template>
+
+                    <template #zone="{ row }">
+                      <RouterLink
+                        v-if="row.zone"
+                        :to="{
+                          name: 'zone-cp-detail-view',
+                          params: {
+                            zone: row.zone,
+                          },
+                        }"
+                      >
+                        {{ row.zone }}
+                      </RouterLink>
+
+                      <template v-else>
+                        {{ t('common.collection.none') }}
+                      </template>
+                    </template>
+
+                    <template #certificate="{ row }">
+                      <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                        {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                      </template>
+
+                      <template v-else>
+                        {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                      </template>
+                    </template>
+
+                    <template #status="{ row }">
+                      <StatusBadge :status="row.status" />
+                    </template>
+
+                    <template #warnings="{ row }">
+                      <XIcon
+                        v-if="row.isCertExpired || row.warnings.length > 0"
+                        class="mr-1"
+                        name="warning"
+                      >
+                        <ul>
+                          <template v-if="row.warnings.length > 0">
+                            <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+                          </template>
+
+                          <template v-if="row.isCertExpired">
+                            <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
+                          </template>
+                        </ul>
+                      </XIcon>
+
+                      <template v-else>
+                        {{ t('common.collection.none') }}
+                      </template>
+                    </template>
+
+                    <template #actions="{ row: item }">
+                      <XActionGroup>
+                        <XAction
+                          :to="{
+                            name: 'data-plane-detail-view',
+                            params: {
+                              dataPlane: item.id,
+                            },
+                          }"
+                        >
+                          {{ t('common.collection.actions.view') }}
+                        </XAction>
+                      </XActionGroup>
+                    </template>
+                  </AppCollection>
+                  <RouterView
+                    v-if="route.params.dataPlane"
+                    v-slot="child"
+                  >
+                    <SummaryView
+                      @close="route.replace({
+                        name: route.name,
                         params: {
-                          mesh: item.mesh,
-                          dataPlane: item.id,
+                          mesh: route.params.mesh,
                         },
                         query: {
                           page: route.params.page,
                           size: route.params.size,
                           s: route.params.s,
                         },
-                      }"
+                      })"
                     >
-                      {{ item.name }}
-                    </RouterLink>
-                  </template>
-
-                  <template #namespace="{ row: item }">
-                    {{ item.namespace }}
-                  </template>
-
-                  <template #zone="{ row }">
-                    <RouterLink
-                      v-if="row.zone"
-                      :to="{
-                        name: 'zone-cp-detail-view',
-                        params: {
-                          zone: row.zone,
-                        },
-                      }"
-                    >
-                      {{ row.zone }}
-                    </RouterLink>
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-
-                  <template #certificate="{ row }">
-                    <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                      {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                    </template>
-
-                    <template v-else>
-                      {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                    </template>
-                  </template>
-
-                  <template #status="{ row }">
-                    <StatusBadge :status="row.status" />
-                  </template>
-
-                  <template #warnings="{ row }">
-                    <XIcon
-                      v-if="row.isCertExpired || row.warnings.length > 0"
-                      class="mr-1"
-                      name="warning"
-                    >
-                      <ul>
-                        <template v-if="row.warnings.length > 0">
-                          <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                        </template>
-
-                        <template v-if="row.isCertExpired">
-                          <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                        </template>
-                      </ul>
-                    </XIcon>
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-
-                  <template #actions="{ row: item }">
-                    <XActionGroup>
-                      <XAction
-                        :to="{
-                          name: 'data-plane-detail-view',
-                          params: {
-                            dataPlane: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.actions.view') }}
-                      </XAction>
-                    </XActionGroup>
-                  </template>
-                </AppCollection>
-                <RouterView
-                  v-if="route.params.dataPlane"
-                  v-slot="child"
-                >
-                  <SummaryView
-                    @close="route.replace({
-                      name: route.name,
-                      params: {
-                        mesh: route.params.mesh,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                        s: route.params.s,
-                      },
-                    })"
-                  >
-                    <component
-                      :is="child.Component"
-                      v-if="typeof dataplanes !== 'undefined'"
-                      :items="dataplanes.items"
-                    />
-                  </SummaryView>
-                </RouterView>
+                      <component
+                        :is="child.Component"
+                        v-if="typeof dataplanes !== 'undefined'"
+                        :items="dataplanes.items"
+                      />
+                    </SummaryView>
+                  </RouterView>
+                </DataCollection>
               </template>
             </DataLoader>
           </KCard>

--- a/src/app/services/views/MeshServiceListView.vue
+++ b/src/app/services/views/MeshServiceListView.vue
@@ -31,6 +31,10 @@
             <DataCollection
               type="services"
               :items="data?.items ?? [undefined]"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="data?.total"
+              @change="route.update"
             >
               <AppCollection
                 data-testid="service-collection"
@@ -43,12 +47,8 @@
                   { ...me.get('headers.tags'), label: 'Tags', key: 'tags' },
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
-                :page-number="route.params.page"
-                :page-size="route.params.size"
-                :total="data?.total"
                 :items="data?.items"
                 :is-selected-row="(item) => item.name === route.params.service"
-                @change="route.update"
                 @resize="me.set"
               >
                 <template #name="{ row: item }">

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -90,12 +90,14 @@
                 <DataCollection
                   type="data-planes"
                   :items="data?.items ?? [undefined]"
+                  :page="route.params.page"
+                  :page-size="route.params.size"
+                  :total="data?.total"
+                  @change="route.update"
                 >
                   <AppCollection
                     class="data-plane-collection"
                     data-testid="data-plane-collection"
-                    :page-number="route.params.page"
-                    :page-size="route.params.size"
                     :headers="[
                       { ...me.get('headers.name'), label: 'Name', key: 'name' },
                       { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
@@ -106,10 +108,7 @@
                       { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                     ]"
                     :items="data?.items"
-                    :total="data?.total"
                     :is-selected-row="(row) => row.name === route.params.dataPlane"
-                    summary-route-name="service-data-plane-summary-view"
-                    @change="route.update"
                     @resize="me.set"
                   >
                     <template #toolbar>

--- a/src/app/services/views/ServiceListView.vue
+++ b/src/app/services/views/ServiceListView.vue
@@ -32,6 +32,10 @@
             <DataCollection
               type="services"
               :items="data?.items ?? [undefined]"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="data?.total"
+              @change="route.update"
             >
               <AppCollection
                 class="service-collection"
@@ -43,12 +47,8 @@
                   { ...me.get('headers.status'), label: 'Status', key: 'status' },
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
-                :page-number="route.params.page"
-                :page-size="route.params.size"
-                :total="data?.total"
                 :items="data?.items"
                 :is-selected-row="(row) => row.name === route.params.service"
-                @change="route.update"
                 @resize="me.set"
               >
                 <template #name="{ row: item }">

--- a/src/app/zone-egresses/views/ZoneEgressListView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressListView.vue
@@ -45,6 +45,8 @@
             <DataCollection
               type="zone-egresses"
               :items="egresses?.items ?? [undefined]"
+              :total="egresses?.total"
+              @change="route.update"
             >
               <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
               <AppCollection
@@ -56,12 +58,8 @@
                   { ...me.get('headers.status'), label: 'Status', key: 'status' },
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
-                :page-number="1"
-                :page-size="100"
-                :total="egresses?.total"
                 :items="egresses?.items"
                 :is-selected-row="(row) => row.name === route.params.zoneEgress"
-                @change="route.update"
                 @resize="me.set"
               >
                 <template #name="{ row: item }">

--- a/src/app/zone-ingresses/sources.ts
+++ b/src/app/zone-ingresses/sources.ts
@@ -48,6 +48,7 @@ export const sources = (source: Source, api: KumaApi) => {
       res.items = res.items.filter((item) => {
         return item.zoneIngress.zone === name
       })
+      res.total = res.items.length
       return ZoneIngressOverview.fromCollection(res)
     },
 

--- a/src/app/zone-ingresses/views/ZoneIngressListView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressListView.vue
@@ -34,6 +34,8 @@
             <DataCollection
               type="zone-ingresses"
               :items="ingresses?.items ?? [undefined]"
+              :total="ingresses?.total"
+              @change="route.update"
             >
               <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
               <AppCollection
@@ -46,12 +48,8 @@
                   { ...me.get('headers.status'), label: 'Status', key: 'status' },
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
-                :page-number="1"
-                :page-size="100"
-                :total="ingresses?.total"
                 :items="ingresses?.items"
                 :is-selected-row="(row) => row.name === route.params.zoneIngress"
-                @change="route.update"
                 @resize="me.set"
               >
                 <template #name="{ row: item }">

--- a/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
@@ -9,56 +9,24 @@
     />
     <AppView>
       <KCard>
-        <AppCollection
-          data-testid="available-services-collection"
-          :empty-state-message="t('common.emptyState.message', { type: 'Services' })"
-          :headers="[
-            { label: 'Name', key: 'name' },
-            { label: 'Mesh', key: 'mesh' },
-            { label: 'Protocol', key: 'protocol' },
-            { label: 'No. Instances', key: 'instances' },
-            { label: 'Actions', key: 'actions', hideLabel: true },
-          ]"
+        <DataCollection
+          type="services"
           :items="props.data.zoneIngress.availableServices"
+          :total="props.data.zoneIngress.availableServices.length"
         >
-          <template #name="{ row: item }">
-            <RouterLink
-              :to="{
-                name: 'service-detail-view',
-                params: {
-                  mesh: item.mesh,
-                  service: item.tags['kuma.io/service'],
-                },
-              }"
-            >
-              {{ item.tags['kuma.io/service'] }}
-            </RouterLink>
-          </template>
-
-          <template #mesh="{ row: item }">
-            <RouterLink
-              :to="{
-                name: 'mesh-detail-view',
-                params: {
-                  mesh: item.mesh,
-                },
-              }"
-            >
-              {{ item.mesh }}
-            </RouterLink>
-          </template>
-
-          <template #protocol="{ row: item }">
-            {{ item.tags['kuma.io/protocol'] ?? t('common.collection.none') }}
-          </template>
-
-          <template #instances="{ row: item }">
-            {{ item.instances }}
-          </template>
-
-          <template #actions="{ row: item }">
-            <XActionGroup>
-              <XAction
+          <AppCollection
+            data-testid="available-services-collection"
+            :headers="[
+              { label: 'Name', key: 'name' },
+              { label: 'Mesh', key: 'mesh' },
+              { label: 'Protocol', key: 'protocol' },
+              { label: 'No. Instances', key: 'instances' },
+              { label: 'Actions', key: 'actions', hideLabel: true },
+            ]"
+            :items="props.data.zoneIngress.availableServices"
+          >
+            <template #name="{ row: item }">
+              <RouterLink
                 :to="{
                   name: 'service-detail-view',
                   params: {
@@ -67,11 +35,48 @@
                   },
                 }"
               >
-                {{ t('common.collection.actions.view') }}
-              </XAction>
-            </XActionGroup>
-          </template>
-        </AppCollection>
+                {{ item.tags['kuma.io/service'] }}
+              </RouterLink>
+            </template>
+
+            <template #mesh="{ row: item }">
+              <RouterLink
+                :to="{
+                  name: 'mesh-detail-view',
+                  params: {
+                    mesh: item.mesh,
+                  },
+                }"
+              >
+                {{ item.mesh }}
+              </RouterLink>
+            </template>
+
+            <template #protocol="{ row: item }">
+              {{ item.tags['kuma.io/protocol'] ?? t('common.collection.none') }}
+            </template>
+
+            <template #instances="{ row: item }">
+              {{ item.instances }}
+            </template>
+
+            <template #actions="{ row: item }">
+              <XActionGroup>
+                <XAction
+                  :to="{
+                    name: 'service-detail-view',
+                    params: {
+                      mesh: item.mesh,
+                      service: item.tags['kuma.io/service'],
+                    },
+                  }"
+                >
+                  {{ t('common.collection.actions.view') }}
+                </XAction>
+              </XActionGroup>
+            </template>
+          </AppCollection>
+        </DataCollection>
       </KCard>
     </AppView>
   </RouteView>

--- a/src/app/zones/components/ZoneControlPlanesList.vue
+++ b/src/app/zones/components/ZoneControlPlanesList.vue
@@ -13,7 +13,6 @@
           { ...storage.get('zone.headers.status'),label: t('zone-cps.components.zone-control-planes-list.status'), key: 'status'},
         ]"
         :items="props.items"
-        :total="props.items?.length"
         @resize="(obj) => {
           storage.set({
             zone: obj,

--- a/src/app/zones/views/ZoneListView.vue
+++ b/src/app/zones/views/ZoneListView.vue
@@ -60,6 +60,10 @@
             <DataCollection
               type="zones"
               :items="data?.items ?? [undefined]"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="data?.total"
+              @change="route.update"
             >
               <AppCollection
                 class="zone-cp-collection"
@@ -74,12 +78,8 @@
                   { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
-                :page-number="route.params.page"
-                :page-size="route.params.size"
-                :total="data?.total"
                 :items="data?.items"
                 :is-selected-row="(row) => row.name === route.params.zone"
-                @change="route.update"
                 @resize="me.set"
               >
                 <template


### PR DESCRIPTION
Moves pagination to be contained within DataCollection instead of AppCollection.

---

Lots of reasons for this:

- Pagination could be for something that doesn't look like a table
- We had a few little hacks in AppCollection in order to make sure we would refresh the table when pagination things
- Reduces the amount of code to render a table
- We'd like to eventually use a more slimmed down KTable (the new kongponent KTableView) that doesn't include pagination either

There are also a few more finer details added to make our pagination/total counts a little better i.e. we can now choose to only show the `10 of 100` count without the pagination links.
