### PR TITLE
chore: husky pre-commit changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged
+lint-staged


### PR DESCRIPTION
Since https://github.com/kumahq/kuma-gui/pull/2841 we'd started seeing this sort of thing:

![Screenshot 2024-08-29 at 15 18 03](https://github.com/user-attachments/assets/45da750f-7045-4e28-a195-0c3c65c85d42)

Screenshot of changelog relevant to this PR:

![Screenshot 2024-08-29 at 16 37 57](https://github.com/user-attachments/assets/5a03d768-31aa-4e18-87f8-4c6e7a11ba54)

Relevant links:

- https://github.com/typicode/husky/releases/tag/v9.1.2
- https://github.com/typicode/husky/releases/tag/v9.1.1