### PR TITLE
fix(zones): fix intro text typo

### DIFF
--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -38,7 +38,7 @@ zone-cps:
       title: Zone Control Planes
       breadcrumbs: Zone Control Planes
       intro: !!text/markdown |
-        Zones are a logical grouping that represents a distinct network or infrastructure boundary with a multi-zone deplyment. Zone Control Planes are responsible for managing and coordinating the service mesh within a specific zone, handling policies and communication with the Global Control Plane.
+        Zones are a logical grouping that represents a distinct network or infrastructure boundary with a multi-zone deployment. Zone Control Planes are responsible for managing and coordinating the service mesh within a specific zone, handling policies and communication with the Global Control Plane.
   list:
     INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS: 'Version mismatch'
     ZONE_STORE_TYPE_MEMORY: 'Uses memory store'


### PR DESCRIPTION
Adds an `o` to `deplyment`