### PR TITLE
feat(dataplanes): disable linking of new Mesh*Services

### DIFF
--- a/src/app/connections/data/index.spec.ts
+++ b/src/app/connections/data/index.spec.ts
@@ -45,6 +45,7 @@ describe('ConnectionCollection', () => {
         },
         cluster: {
           localhost_9090: {
+            $kind: '',
             tcp: {},
             grpc: {
               0: 12,

--- a/src/app/connections/sources.ts
+++ b/src/app/connections/sources.ts
@@ -37,6 +37,7 @@ export const sources = (source: Source, api: KumaApi) => {
         '_', // most internal names will be prefixed by `_` the rest will become legacy internal names
         'admin',
         'async-client',
+        'kuma_readiness',
         'kuma_envoy_admin',
         'probe_listener',
         'inbound_passthrough_',

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -316,7 +316,7 @@
                                 data-testid="dataplane-outbound"
                                 :protocol="['grpc', 'http', 'tcp'].find(protocol => typeof outbound[protocol] !== 'undefined') ?? 'tcp'"
                                 :traffic="outbound"
-                                :service="name.replace(hash, '')"
+                                :service="outbound.$kind === '' ? name.replace(hash, '') : undefined"
                                 :direction="direction"
                               >
                                 <RouterLink


### PR DESCRIPTION
During parsing of the Envoy stats responses, if we find a clustername with `_msvc_` (or related), we mark that cluster/outbound as having a `kind` of `MeshService`.

Later on in the view, we can decide whether to add a link to the cards service depending on its `kind`.

Currently we only link cards with empty kinds. i.e. if its not a MeshService, MeshMultiZoneService or a MeshExternalService we don't link the card.

See linked issue for more details https://github.com/kumahq/kuma-gui/issues/2848