### PR TITLE
fix: fix loading skeleton for KTable @ kongponents:9.4.1

### DIFF
--- a/features/application/Loading.feature
+++ b/features/application/Loading.feature
@@ -1,18 +1,15 @@
 Feature: application / loading
-  # TODO: This test needs fixing it currently console.errors
 
-  @skip
-  Scenario: Application errors
+  Background:
+    Given the CSS selectors
+      | Alias              | Selector                                                    |
+      | collection-loading | [data-testid$='-collection'] [data-testid='table-skeleton'] |
+
+  Scenario: Collections show a loading view
     Given the environment
       """
-      KUMA_LATENCY: 1000
+      KUMA_LATENCY: 300
       """
-    And the URL "/" responds with
-      """
-      headers:
-        Status-Code: 500
-      """
-    When I visit the "/" URL
-    Then the "$loading" element exists
-    Then the "$loading" element doesn't exist
-    Then the "$error" element exists
+    When I visit the "/meshes" URL
+    Then the "$collection-loading" element exists
+    Then the "$collection-loading" element doesn't exist

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@kong-ui-public/app-layout": "^4.2.25",
         "@kong-ui-public/i18n": "^2.2.2",
         "@kong/icons": "^1.14.1",
-        "@kong/kongponents": "<9.4.1",
+        "@kong/kongponents": "^9.5.1",
         "@vueuse/core": "^11.0.3",
         "brandi": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -3297,9 +3297,9 @@
       }
     },
     "node_modules/@kong/kongponents": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-9.4.0.tgz",
-      "integrity": "sha512-U8DiZWtY3/BTVWKFHhxMdlpyJF/y3ET0IJSsv553KRXCLA/TYat0RH1Coxu2RT0vwIo0NPOu7q8XzdPTvq3PVQ==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-9.5.1.tgz",
+      "integrity": "sha512-JWG+3dxPA9uaMY/V0tw4GTfI5VLQenoMBfv+lPfiFgbBBGsY5KixnJdu0ckajljdEhs/Liw+877P61WOhapeuQ==",
       "dependencies": {
         "@floating-ui/vue": "^1.1.4",
         "@kong/icons": "^1.15.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@kong-ui-public/i18n": "^2.2.2",
     "@kong/icons": "^1.14.1",
     "@kong-ui-public/app-layout": "^4.2.25",
-    "@kong/kongponents": "<9.4.1",
+    "@kong/kongponents": "^9.5.1",
     "@vueuse/core": "^11.0.3",
     "brandi": "^5.0.0",
     "deepmerge": "^4.3.1",

--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -21,7 +21,7 @@
       if(Object.keys(value).length > 0) {
         emit('change', value)
       }
-      return {data: items}
+      return { data: props.items }
     }"
     :cell-attrs="({ headerKey }: CellAttrParams) => ({
       class: `${headerKey}-column`,
@@ -39,6 +39,7 @@
         return prev
       }, {}),
     }"
+    :loading="typeof props.items === 'undefined'"
     @row:click="click"
     @update:table-preferences="resize"
   >


### PR DESCRIPTION
Back in https://github.com/kumahq/kuma-gui/pull/2842 we pinned kongponents due to:

> kongponents 9.4.1 includes a bug somewhere that means the loading skeleton no longer shows for KTables. Therefore I pinned the dependency to anything less than 9.4.1. Guessing dependabot will change that pin anyway. We'll just have to remember not to upgrade when the 9.4.1 dependabot PP comes up

https://github.com/kumahq/kuma-gui/pull/2842#issuecomment-2317217735

I noticed that kongponents' KTable has a manual `:loading` property, so I used that to fix the issue. I also added a new test seeing it was only by chance that I noticed this issue. If it happens again we'll fail.

Following this I could unpin kongponents again.

---

Slight note: https://github.com/kumahq/kuma-gui/pull/2846 <- we are hoping to move away from using KTable entirely and use the newer still-in-progress KTableView. The linked PR still uses KTable, but stops using some of the things in KTable that would prevent us from moving to KTableView.
