### PR TITLE
fix: check for closed source on retry

### DIFF
--- a/src/app/application/services/data-source/index.ts
+++ b/src/app/application/services/data-source/index.ts
@@ -1,6 +1,6 @@
 import { compile } from 'path-to-regexp'
 
-import CallableEventSource from './CallableEventSource'
+import CallableEventSource, { isClosed } from './CallableEventSource'
 import type { Creator, Destroyer } from './DataSourcePool'
 export { default as DataSourcePool } from './DataSourcePool'
 // reusable Type Utility for easy to use Types within Vue templates
@@ -78,7 +78,7 @@ export const getSource = (doc: Hideable) => {
       const self = this
       let attempts = 0
       let iterations = 0
-      while (true) {
+      while (!isClosed(self)) {
         // if this isn't the first call then we should wait before calling again
         if (iterations > 0) {
           await new Promise((resolve) => setTimeout(resolve, self.configuration.interval ?? 1000))

--- a/src/app/zones/sources.ts
+++ b/src/app/zones/sources.ts
@@ -44,25 +44,6 @@ export const sources = (source: Source, api: KumaApi) => {
         },
       })
     },
-    '/zone-cps/online/:name': (params) => {
-      const ZoneOfflineError = class extends Error { }
-      const { name } = params
-      return source(async () => {
-        const res = ZoneOverview.fromObject(await api.getZoneOverview({ name }))
-        // anything but online, retry
-        if (res.state === 'online') {
-          return res
-        } else {
-          throw new ZoneOfflineError()
-        }
-      }, {
-        retry: (e) => {
-          if (e instanceof ZoneOfflineError) {
-            return new Promise((resolve) => setTimeout(resolve, 2000))
-          }
-        },
-      })
-    },
     '/zone-cps/:name': async (params) => {
       const { name } = params
       return ZoneOverview.fromObject(await api.getZoneOverview({ name }))

--- a/src/test-support/mocks/src/zones/_/_overview.ts
+++ b/src/test-support/mocks/src/zones/_/_overview.ts
@@ -4,19 +4,8 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
   const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
 
   // To test the error handling of the zone creation flow’s polling mechanism
-  /* return {
-    headers: {
-      'Status-Code': '401',
-    },
-    body: {
-      type: '/std-errors',
-      status: 401,
-      title: 'Authorization error',
-      detail: '401 Unauthorized',
-      instance: '0123456789abcdefghijkl',
-      invalid_parameters: [],
-    },
-  } */
+  // use KUMA_SUBSCRIPTION_COUNT=0 in your cookies, set to
+  // KUMA_SUBSCRIPTION_COUNT=1 to make it connect
 
   return {
     headers: {


### PR DESCRIPTION
Whilst finishing yo cleaning up the removal of our `zone-crud` module, I spotted that there could be a case where a erroneous-retrying DataSource will not be closed correctly.

This PR:

- Removes a now unused source (checking the online-ness of a zone) that we used to use in the zone creation flow.
- Checks our retry loop to see if the DataSource is closed, and if it is finish the loop
- Removes a comment suggesting to use a 401 error for checking the creation flows polling mechanism. In some instances 401s are dealt with by other sorts of retries, therefore a 401 can be misleading. If its ever needed, you can mock this just by setting a subscription count to zero, so I switched up the comment to explain that.
