### PR TITLE
fix: fixes DataPlanePolicyView calling _rules multiple times

### DIFF
--- a/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -21,7 +21,7 @@
         >
           <template
             v-for="policyTypes in [(policyTypesData?.policies ?? []).reduce<Partial<Record<string, PolicyType>>>((obj, policyType) => Object.assign(obj, { [policyType.name]: policyType }), {})]"
-            :key="policyTypes"
+            :key="typeof policyTypes"
           >
             <!-- always try and load and show the rules for everything dataplane type -->
             <DataLoader


### PR DESCRIPTION
This made for a very interesting PR. I wanted to write why this was interesting down somewhere for later reference. But firstly the problem:

We noticed that the DataplanePolicies view was calling the `.../_rules` endpoint multiple times on page load. This PR fixes that so it now only calls the `.../_rules` endpoint once.

---

Why it was interesting?:

I looked into why this HTTP endpoint was being called multiple times and, to cut a long story short, our `<DataSource>` component that calls this HTTP endpoint was being added to the DOM, then immediately removed from the DOM, and then re-added again. The repeated add/remove behaviour was what was causing the multiple HTTP requests because every time the `<DataSource>` gets added to the DOM it makes the HTTP call (this is expected).

Why was it be added/removed in rapid succession? (which wasn't expected)

I tried a few approaches once of which was different to this PR which worked by entirely removing the `<template v-for="">` element on ln:23 in this PR. I had to then repeat the reshape we do there in various other places and amend code elsewhere, which whilst worked, wasn't ideal. It seemed like having the `template` element was causing the DataSource to be removed and re-added, rather than just get added once and stay there.

I then realized that it could be specifically related to the `:key` behaviour of `<template v-for>` tags.

Everywhere you read/hear about `<template v-for>` the recommendation is to add a `:key` so that Vue can keep track and reuse existing elements, but this seems to me to be related to ordering elements correctly based on a range of data coming from the `v-for`. We even have linting errors stopping you from writing `v-for`s without providing a valid `:key` at all. So we _have to_ provide a `:key`.

What I think is then happening is, when `policyTypes` changes, if Vue detects via the `:key` that things have changed regarding order, it will unmount child components and remount them again - and this is the behaviour we don't want.

I wondered if removing simply removing the `:key` instead of the entire `<template v-for>` would also fix the issue, and sure enough when I tried it did 🎉 . The child nodes would still be updated correctly when there was a change to `policyTypes` (i.e. the result of `v-for`).

Re-reading this Vue docs this sounds like:

> When Vue is updating a list of elements rendered with v-for, by default it uses an "in-place patch" strategy. If the order of the data items has changed, instead of moving the DOM elements to match the order of the items, Vue will patch each element in-place and make sure it reflects what should be rendered at that particular index.

> This default mode is efficient, but only suitable when your list render output does not rely on child component state or temporary DOM state (e.g. form input values).

Without `:key`, it sounds like Vue is patching elements in-place (i.e. not remounting child components), _and_ as it says "your list render output does not rely on child component state" it sounds like using `:key` does force the child components to be torn down and re mounted from scratch.

So we don't want to use `:key` in these cases. But now we have the linting problem.

I didn't want to remove the lint rule because there are plenty of instances where we want the nudge to include a `:key`, and there is also a lint rule to stop you from just providing a static non-changing value for a `:key` (i.e. key="`static-value`")

If we use a `:key` that changes when the data changes ( like `policyTypes` as we were using previous to this PR), Vue is gonna think it can't patch in-place and thus unmount and re-mount child components, causing additional unexpected HTTP calls from `<DataSource>`

I then came up with the idea of using `typeof policyTypes`, which satisfies the lint rule making us use a variable from the `v-for` and also doesn't change when the data changes from and empty object to a populated object (i.e. `{}` to `{policies: [...]}`, meaning whilst we are using `:key` the `:key` doesn't change, it is always `[object Object]`. So I hoped that the child component would then not be unmounted and remounted. i.e. pretty much the same behaviour as not using `:key` at all 🤞 

I gave it a try and everything worked as expected 🎉 . The HTTP call was only made once.

I would guess there could be a few other places in our code bases where we should use this `:key="typeof ..."` trick. I suppose the only place where we can't use this is when the data changes from `undefined` to "defined", i.e. the type changes. I'm not totally sure if we have these cases, but if we do we can try something else just for those cases.





