### PR TITLE
fix(policies): don't show a card if we don't find a zone

### DIFF
--- a/src/app/policies/views/PolicyDetailView.vue
+++ b/src/app/policies/views/PolicyDetailView.vue
@@ -13,11 +13,11 @@
     v-slot="{ route, t, uri, can, me }"
   >
     <AppView>
-      <KCard>
+      <KCard
+        v-if="can('use zones') && props.data.zone"
+      >
         <div class="columns">
-          <DefinitionCard
-            v-if="can('use zones') && props.data.zone"
-          >
+          <DefinitionCard>
             <template
               #title
             >
@@ -58,14 +58,14 @@
             })"
           >
             <template
-              #loadable="{ data }"
+              #loadable="{ data: dataplanes }"
             >
               <DataCollection
                 type="data-planes"
-                :items="data?.items ?? [undefined]"
+                :items="dataplanes?.items ?? [undefined]"
                 :page="route.params.page"
                 :page-size="route.params.size"
-                :total="data?.total"
+                :total="dataplanes?.total"
                 @change="route.update"
               >
                 <AppCollection
@@ -75,7 +75,7 @@
                     ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
                     { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                   ]"
-                  :items="data?.items"
+                  :items="dataplanes?.items"
                   :is-selected-row="(row) => row.id === route.params.dataPlane"
                   @resize="me.set"
                 >
@@ -130,30 +130,30 @@
                     </XActionGroup>
                   </template>
                 </AppCollection>
-              </DataCollection>
-              <RouterView
-                v-slot="{ Component }"
-              >
-                <SummaryView
-                  v-if="route.child()"
-                  @close="route.replace({
-                    params: {
-                      mesh: route.params.mesh,
-                    },
-                    query: {
-                      page: route.params.page,
-                      size: route.params.size,
-                      s: route.params.s,
-                    },
-                  })"
+                <RouterView
+                  v-slot="{ Component }"
                 >
-                  <component
-                    :is="Component"
-                    v-if="typeof data !== 'undefined'"
-                    :items="data.items"
-                  />
-                </SummaryView>
-              </RouterView>
+                  <SummaryView
+                    v-if="route.child()"
+                    @close="route.replace({
+                      params: {
+                        mesh: route.params.mesh,
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                        s: route.params.s,
+                      },
+                    })"
+                  >
+                    <component
+                      :is="Component"
+                      v-if="typeof dataplanes !== 'undefined'"
+                      :items="dataplanes.items"
+                    />
+                  </SummaryView>
+                </RouterView>
+              </DataCollection>
             </template>
           </DataLoader>
         </KCard>


### PR DESCRIPTION
The top card here can only contain one item - the zone.

We conditionally gate that depending on whether we find a zone or not, but if we don't show it then the card shows as empty.

This PR move the conditional to the entire card rather than just the zone text.

I also fixed a console warning here regarding a shadowed `data` variable (we used `props.data` _and_ `data` previously in this template, and despite them being different `props.data` vs `data` Vue treats tem as the same variable reference hence they are shadowed)

### Before

![Screenshot 2024-09-10 at 11 32 59](https://github.com/user-attachments/assets/ad1c1d74-1965-4a4d-909c-276bbf29a727)

### After

![Screenshot 2024-09-10 at 11 32 24](https://github.com/user-attachments/assets/125fa9ed-8341-4365-a4da-f8b4f8047aee)
