### PR TITLE
chore: Reorders RouteView to have a root node

### DIFF
--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -1,37 +1,36 @@
 <template>
-  <DataSource
-    :src="uri(sources, '/me/:route', {
-      route: props.name,
-    })"
-    v-slot="{ data: me }"
+  <div
+    class="route-view"
+    v-bind="htmlAttrs"
+    :data-testid="name"
   >
     <div
-      class="route-view"
-      v-bind="htmlAttrs"
-      :data-testid="name"
+      v-if="!hasParent"
+      id="application-route-announcer"
+      ref="title"
+      class="route-view-title visually-hidden"
+      aria-live="assertive"
+      aria-atomic="true"
+    />
+    <DataSink
+      :src="`/me/${props.name}`"
+      v-slot="{ submit: _submit }"
     >
-      <div
-        v-if="!hasParent"
-        id="application-route-announcer"
-        ref="title"
-        class="route-view-title visually-hidden"
-        aria-live="assertive"
-        aria-atomic="true"
+      <!-- eslint-disable vue/no-lone-template -->
+      <template
+        :ref="() => {
+          submit = _submit
+        }"
       />
-      <DataSink
-        v-if="me"
-        :src="`/me/${props.name}`"
-        v-slot="{ submit: _submit }"
-      >
-        <!-- eslint-disable vue/no-lone-template -->
-        <template
-          :ref="() => {
-            submit = _submit
-          }"
-        />
-      </DataSink>
+    </DataSink>
+    <DataSource
+      :src="uri(sources, '/me/:route', {
+        route: props.name,
+      })"
+      v-slot="{ data: me }"
+    >
       <slot
-        v-if="submit"
+        v-if="me && submit"
         :id="UniqueId"
         name="default"
         :t="t"
@@ -49,8 +48,8 @@
           child,
         }"
       />
-    </div>
-  </DataSource>
+    </DataSource>
+  </div>
 </template>
 <script lang="ts" setup generic="T extends Record<string, string | number | boolean> = {}">
 import { computed, provide, inject, ref, watch, onBeforeUnmount, reactive, useAttrs } from 'vue'


### PR DESCRIPTION
Shuffles around the components in `RouteView` to ensure we have a proper DOM node as root for if we ever add attributes to the component (`<RouteView data-testid="">`)

Whilst previously `DataSource` was the single root node, `DataSource` itself does not have a wrapping root DOM component. This PR moves the root node here to be a `div` i.e. a proper DOM node.