### PR TITLE
chore(deps): removes dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
     labels:
       - "dependencies"
 
@@ -12,6 +11,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
Removes dependbot PR limits.

---

If there are 100 dependabot PRs, I don't just want to know about the first 10 and then wait for a week. I want to know about all 100 and then choose which ones to merge first (probably ones that are most important)

I really don't mind leaving dependabot upgrade PRs outstanding for a while if they are not important, but I do mind not knowing about dependabot upgrades which might be important.