### PR TITLE
chore(deps): add dependabot PR hooks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-# create-gui-pr.yaml is dependant on this name being "Tests"
+# create-gui-pr.yaml is dependent on this name being "Tests"
 name: 'Tests'
 
 # Ensures that only one workflow is run per branch at a time.

--- a/.github/workflows/on-dependabot-pr.yml
+++ b/.github/workflows/on-dependabot-pr.yml
@@ -1,0 +1,26 @@
+name: 'On Dependabot PR'
+
+# Ensures that only one workflow is run per branch at a time.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot-labels:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'kumahq/kuma-gui'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: metadata
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Add a label for all production dependencies
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+        if: steps.metadata.outputs.dependency-type == 'direct:production'
+        run: gh pr edit "$PR_URL" --add-label "production"

--- a/.github/workflows/on-dependabot-pr.yml
+++ b/.github/workflows/on-dependabot-pr.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   dependabot-labels:
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'kumahq/kuma-gui'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: dependabot/fetch-metadata@v2


### PR DESCRIPTION
One of our dependencies is `msw`, which has an [npm post install hook](https://github.com/mswjs/msw/blob/8e173305c143d9281af0010e1dbdb11ca9e62a78/package.json#L88) to amend https://github.com/kumahq/kuma-gui/blob/376ca94362f6342ad52cc561d30ad4e6f013b646/public/mockServiceWorker.js

Generally, the amend is just a bump of this so that the versions match:

https://github.com/kumahq/kuma-gui/blob/376ca94362f6342ad52cc561d30ad4e6f013b646/public/mockServiceWorker.js#L11-L12

As dependabot doesn't perform an install after bumping the version of MSW, the post-install script isn't run and this file isn't amended.

Then, when another user does a local install following the dependabot update, the above file ends up being amended and marked as such in `git`. The user can then either make another PR with only this amend in it (tedious), add the amend to an entirely unrelated PR (not a huge deal but not great either), just reset the file (then the versions don't match up, so not great either)

---

I found that you can amend dependabot PRs after they are made (https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions), so figured we could theoretically amend dependabot `msw` upgrades to run an install then commit the amend on the end of the dependabot PR.

This PR adds a GH workflow, firstly just testing out that we can add a label for to differentiate between prod and dev dependencies on dependabot PRs (taken from https://github.com/dependabot/fetch-metadata?tab=readme-ov-file#labelling) just to test out how this works/looks (its also vaguely useful to have this).

If this works how I'm imagining we can add more actions to run the install and commit the file on the end of msw only upgrade PRs.

Lastly, I've no idea how I can test this properly without merging this to `master` and then waiting/watching, if anyone has any better suggestions please let me know.