### PR TITLE
chore(tests): allow relative mocks, allow passthrough via mocks

### DIFF
--- a/src/test-support/fake.ts
+++ b/src/test-support/fake.ts
@@ -80,9 +80,9 @@ export type EndpointDependencies = {
   env: Env
 }
 export type MockResponse = {
-  headers: Record<string, string>
+  headers?: Record<string, string>
   body: string | Record<string, unknown>
-}
+} | undefined
 export type MockResponder = (req: RestRequest) => MockResponse
 export type FakeEndpoint = (deps: EndpointDependencies) => MockResponder
 

--- a/src/test-support/intercept.ts
+++ b/src/test-support/intercept.ts
@@ -87,8 +87,12 @@ export const mocker = (env: (key: AppEnvKeys, d?: string) => string, cy: Server,
             url,
             request,
           })
+          if (typeof response === 'undefined') {
+            req.continue()
+            return
+          }
           req.reply({
-            statusCode: parseInt(response.headers['Status-Code'] ?? '200'),
+            statusCode: parseInt(response.headers?.['Status-Code'] ?? '200'),
             delay: parseInt(mockEnv('KUMA_LATENCY', '0')),
             body: response.body,
           })

--- a/src/test-support/vite.ts
+++ b/src/test-support/vite.ts
@@ -78,6 +78,9 @@ export default (opts: PluginOptions): Plugin => {
       body: options.body ?? {},
       params,
     })
+    if (typeof response === 'undefined') {
+      throw new Error('not found')
+    }
     await new Promise(resolve => setTimeout(resolve, parseInt(env('KUMA_LATENCY', '0'))))
     return {
       json: async () => {
@@ -86,7 +89,7 @@ export default (opts: PluginOptions): Plugin => {
       text: async () => {
         return response.body.toString()
       },
-      headers: new Map(Object.entries(response.headers)),
+      headers: new Map(Object.entries(response.headers ?? {})),
     }
   }
 


### PR DESCRIPTION
This PR does two things related to our mocks:

---

Up until now we've only ever really needed to mock out our HTTP API at `http://localhost:5681` or occasionally a full absolute URL such as `https://kuma.io/latest_version`.

There are times when we want to mock out "whereever we are" i.e. `http://localhost:8080` (or :8081, :8082 etc for our local dev server) or maybe our GH PR preview at say `https://deploy-preview-2918--kuma-gui.netlify.app/`.

Usually we would just use `/` to say this, but for ease we've used `/` to say/mean "our HTTP API at `http://localhost:5681`" (as we can set `http://localhost:5681` to be something different we don't want to/can't hardcode that either)

This PR uses `://` instead of `/` to say "use the same protocol and the same host" i.e. "whereever we are". Anything using this will use the host of the local dev server, or the host of the PR preview (or the host of any other environment we may need to use)

Therefore:

- `/mesh/`: mock `$KUMA_API_URL/mesh` (generally `$KUMA_API_URL` is `http://localhost:5681`, but maybe not)
- `http://kuma.io/mesh/`: mock `http://kuma.io/mesh/`
- `:///mesh/`: mock `/mesh/` i.e. "whereever we are" (generally `http://localhost:8080`, sometimes `https://deploy-preview-*--kuma-gui.netlify.app/`, but maybe not)
---

We hit upon a usecase for our mocks where we might want to almost all of the time get an actual HTTP response from a live URL that we don't control. Therefore we don't want to mock it out always as we'll never see/notice any updates to the response that we get from that URL. Therefore it would be nice to be able to say _within the mock file_, only mock this if a certain environment variable is set, otherwise just passthrough to the live response and respond with that.

This PR lets us our mock functions return `undefined` instead of `{header, body}`. If we get `undefined` from a mock file, this means "just passthrough to the live request".

We might expand on this later so, from within the mock file, say "take the live response, and then overwrite just a part of it" meaning we will still see/be aware of updates to the live responses that we don't own but still control the bits we need to control from our codebase. We'll see how we go with the solution in this PR first.

---

Just to note incase: our `fake-api`/mocks stuff is still the result of some "guerrilla coding"/"just get it working" from when we started pulling the application into shape. Ideally, I'll get a bit of time to refactor it a bit at some point (One day! 😅 ), but for now I'm still a bit 🤷 about being too concerned about the code here. Most important thing is it still works fine for mocking our tests across a pretty large matrix of environments and applications. 


