### PR TITLE
chore: Slight text/css amends

### DIFF
--- a/src/app/zones/locales/en-us/index.yaml
+++ b/src/app/zones/locales/en-us/index.yaml
@@ -66,5 +66,5 @@ zones:
   index:
     create: 'Create Zone'
   action_menu:
-    toggle_button: 'Zone Actions'
+    toggle_button: 'Actions'
     delete_button: 'Delete'

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -140,7 +140,9 @@ iframe {
   vertical-align: middle;
 }
 
-img {
+// @TODO(jc): We either need a better way to turn this off (maybe :not([height])
+// or it needs removing entirely
+img:not(.no-auto-height) {
   max-width: 100%;
   height: auto;
 }


### PR DESCRIPTION
- Changes `Zone Actions` to just `Actions`
- Allows us to unset `img { height: auto }` without potentially causing damage elsewhere