### PR TITLE
chore: support toResourceRules in outbounds summary

### DIFF
--- a/src/app/connections/data/index.spec.ts
+++ b/src/app/connections/data/index.spec.ts
@@ -45,7 +45,12 @@ describe('ConnectionCollection', () => {
         },
         cluster: {
           localhost_9090: {
-            $kind: '',
+            $resourceMeta: {
+              mesh: '',
+              name: '',
+              type: '',
+              zone: '',
+            },
             tcp: {},
             grpc: {
               0: 12,

--- a/src/app/connections/views/ConnectionOutboundSummaryOverviewView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryOverviewView.vue
@@ -6,14 +6,67 @@
       connection: '',
     }"
     name="connection-outbound-summary-overview-view"
-    v-slot="{ t, route }"
+    v-slot="{ t, route, uri }"
   >
     <AppView>
       <template
         v-for="service in [route.params.connection.replace(/-([a-f0-9]){16}$/, '')]"
         :key="service"
       >
-        <div class="stack-with-borders">
+        <div
+          class="stack-with-borders"
+        >
+          <template
+            v-if="props.data.$resourceMeta.type !== ''"
+          >
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template #title>
+                Resource
+              </template>
+
+              <template #body>
+                <KBadge
+                  appearance="info"
+                  max-width="auto"
+                >
+                  <template
+                    v-for="item in [props.data.$resourceMeta]"
+                    :key="typeof item"
+                  >
+                    <XAction
+                      :to="({
+                        MeshService: {
+                          name: 'mesh-service-detail-view',
+                          params: {
+                            mesh: item.mesh,
+                            service: item.name,
+                          },
+                        },
+                        MeshExternalService: {
+                          name: 'mesh-external-service-detail-view',
+                          params: {
+                            mesh: item.mesh,
+                            service: item.name,
+                          },
+                        },
+                        MeshMultiZoneService: {
+                          name: 'mesh-multizone-service-detail-view',
+                          params: {
+                            mesh: item.mesh,
+                            service: item.name,
+                          },
+                        },
+                      } as const)[item.type as 'MeshService' | 'MeshExternalService' | 'MeshMultiZoneService']"
+                    >
+                      {{ item.type }}: {{ item.name }}
+                    </XAction>
+                  </template>
+                </KBadge>
+              </template>
+            </DefinitionCard>
+          </template>
           <DefinitionCard
             layout="horizontal"
           >
@@ -34,131 +87,224 @@
             class="rules"
           >
             <h3>Rules</h3>
-            <DataLoader
-              :src="`/meshes/${route.params.mesh}/rules/for/${route.params.dataPlane}`"
-              v-slot="{ data: rulesData }: RuleCollectionSource"
-            >
-              <DataCollection
-                :predicate="(item) => {
-                  // for to rules we don't have inbound.port, filter out Routes
-                  // then look for the kuma.io/service
-                  return item.ruleType === 'to' && !['MeshHTTPRoute', 'MeshTCPRoute'].includes(item.type) && (
-                    item.matchers.every(item => item.key === 'kuma.io/service' && (item.not ? item.value !== service : item.value === service))
-                  )
-                }"
-                :items="rulesData!.rules"
 
-                v-slot="{ items }"
+            <DataSource
+              :src="`/policy-types`"
+              v-slot="{ data: policyTypes }: PolicyTypeCollectionSource"
+            >
+              <template
+                v-for="types in [Object.groupBy((policyTypes?.policies ?? []), (item) => item.name)]"
+                :key="typeof types"
               >
-                <div class="mt-4">
-                  <AccordionList
-                    :initially-open="0"
-                    multiple-open
-                    class="stack"
+                <DataLoader
+                  :src="uri(sources, `/meshes/:mesh/rules/for/:dataplane`, {
+                    mesh: route.params.mesh,
+                    dataplane: route.params.dataPlane,
+                  })"
+                  v-slot="{ data: rulesData }"
+                >
+                  <template
+                    v-if="props.data.$resourceMeta.type !== ''"
                   >
-                    <template
-                      v-for="(rules, key) in Object.groupBy(items, item => item.type)"
-                      :key="key"
+                    <DataCollection
+                      :predicate="(item) => {
+                        return item.resourceMeta.type === 'Mesh' || props.data.$resourceMeta.name === item.resourceMeta.name
+                      }"
+                      :items="rulesData.toResourceRules"
+                      v-slot="{ items }"
                     >
-                      <KCard>
-                        <AccordionItem>
-                          <template #accordion-header>
+                      <div
+                        class="stack-with-borders mt-4"
+                      >
+                        <template
+                          v-for="(rules, key) in Object.groupBy(items, item => item.type)"
+                          :key="key"
+                        >
+                          <div>
                             <PolicyTypeTag
                               :policy-type="key"
                             >
-                              {{ key }} ({{ rules!.length }})
+                              {{ key }}
                             </PolicyTypeTag>
-                          </template>
-                          <template #accordion-content>
                             <div
-                              class="stack-with-borders"
+                              class="stack-with-borders mt-4"
                             >
                               <template
-                                v-for="item in rules"
+                                v-for="item in rules!.length > 1 ? rules!.filter((item) => props.data.$resourceMeta.name === item.resourceMeta.name) : rules"
                                 :key="item"
                               >
-                                <DefinitionCard
-                                  v-if="item.matchers.length > 0"
-                                  layout="horizontal"
-                                >
-                                  <template #title>
-                                    To
-                                  </template>
+                                <div>
+                                  <DefinitionCard
+                                    v-if="item.origins.length > 0"
+                                    layout="horizontal"
+                                  >
+                                    <template #title>
+                                      Origin Policies
+                                    </template>
 
-                                  <template #body>
-                                    <p><RuleMatchers :items="item.matchers" /></p>
-                                  </template>
-                                </DefinitionCard>
-                                <DefinitionCard
-                                  v-if="item.origins.length > 0"
-                                  layout="horizontal"
-                                >
-                                  <template #title>
-                                    Origin Policies
-                                  </template>
-
-                                  <template #body>
-                                    <DataSource
-                                      :src="`/policy-types`"
-                                      v-slot="{ data: policyTypes }: PolicyTypeCollectionSource"
-                                    >
-                                      <template
-                                        v-for="types in [Object.groupBy((policyTypes?.policies ?? []), (item) => item.name)]"
-                                        :key="types"
+                                    <template #body>
+                                      <DataCollection
+                                        :predicate="(item) => {
+                                          return typeof item.resourceMeta !== 'undefined'
+                                        }"
+                                        :items="item.origins"
+                                        :empty="false"
+                                        v-slot="{ items: origins }"
                                       >
                                         <ul>
                                           <li
-                                            v-for="origin in item.origins"
-                                            :key="`${origin.mesh}-${origin.name}`"
+                                            v-for="origin in origins"
+                                            :key="JSON.stringify(origin)"
                                           >
-                                            <RouterLink
-                                              v-if="types[origin.type]"
+                                            <XAction
+                                              v-if="Object.keys(types).length > 0"
                                               :to="{
                                                 name: 'policy-detail-view',
                                                 params: {
-                                                  mesh: origin.mesh,
-                                                  policyPath: types[origin.type]![0].path,
-                                                  policy: origin.name,
+                                                  policyPath: types[key]![0].path,
+                                                  mesh: origin.resourceMeta!.mesh,
+                                                  policy: origin.resourceMeta!.name,
                                                 },
                                               }"
                                             >
-                                              {{ origin.name }}
-                                            </RouterLink>
-                                            <template
-                                              v-else
-                                            >
-                                              {{ origin.name }}
-                                            </template>
+                                              {{ origin.resourceMeta!.name }}
+                                            </XAction>
                                           </li>
                                         </ul>
-                                      </template>
-                                    </DataSource>
-                                  </template>
-                                </DefinitionCard>
-                                <div>
-                                  <dt>
-                                    Config
-                                  </dt>
-                                  <dd class="mt-2">
-                                    <div>
-                                      <CodeBlock
-                                        :code="YAML.stringify(item.raw)"
-                                        language="yaml"
-                                        :show-copy-button="false"
-                                      />
-                                    </div>
-                                  </dd>
+                                      </DataCollection>
+                                    </template>
+                                  </DefinitionCard>
+                                  <CodeBlock
+                                    class="mt-2"
+                                    :code="YAML.stringify(item.raw)"
+                                    language="yaml"
+                                    :show-copy-button="false"
+                                  />
                                 </div>
                               </template>
                             </div>
+                          </div>
+                        </template>
+                      </div>
+                    </DataCollection>
+                  </template>
+                  <template
+                    v-else
+                  >
+                    <DataCollection
+                      :predicate="(item) => {
+                        // for to rules we don't have inbound.port, filter out Routes
+                        // then look for the kuma.io/service
+                        return item.ruleType === 'to' && !['MeshHTTPRoute', 'MeshTCPRoute'].includes(item.type) && (
+                          item.matchers.every(item => item.key === 'kuma.io/service' && (item.not ? item.value !== service : item.value === service))
+                        )
+                      }"
+                      :items="rulesData!.rules"
+
+                      v-slot="{ items }"
+                    >
+                      <div class="mt-4">
+                        <AccordionList
+                          :initially-open="0"
+                          multiple-open
+                          class="stack"
+                        >
+                          <template
+                            v-for="(rules, key) in Object.groupBy(items, item => item.type)"
+                            :key="key"
+                          >
+                            <KCard>
+                              <AccordionItem>
+                                <template #accordion-header>
+                                  <PolicyTypeTag
+                                    :policy-type="key"
+                                  >
+                                    {{ key }} ({{ rules!.length }})
+                                  </PolicyTypeTag>
+                                </template>
+                                <template #accordion-content>
+                                  <div
+                                    class="stack-with-borders"
+                                  >
+                                    <template
+                                      v-for="item in rules"
+                                      :key="item"
+                                    >
+                                      <DefinitionCard
+                                        v-if="item.matchers.length > 0"
+                                        layout="horizontal"
+                                      >
+                                        <template #title>
+                                          From
+                                        </template>
+
+                                        <template #body>
+                                          <p><RuleMatchers :items="item.matchers" /></p>
+                                        </template>
+                                      </DefinitionCard>
+                                      <DefinitionCard
+                                        v-if="item.origins.length > 0"
+                                        layout="horizontal"
+                                      >
+                                        <template #title>
+                                          Origin Policies
+                                        </template>
+
+                                        <template #body>
+                                          <ul>
+                                            <li
+                                              v-for="origin in item.origins"
+                                              :key="`${origin.mesh}-${origin.name}`"
+                                            >
+                                              <RouterLink
+                                                v-if="types[origin.type]"
+                                                :to="{
+                                                  name: 'policy-detail-view',
+                                                  params: {
+                                                    mesh: origin.mesh,
+                                                    policyPath: types[origin.type]![0].path,
+                                                    policy: origin.name,
+                                                  },
+                                                }"
+                                              >
+                                                {{ origin.name }}
+                                              </RouterLink>
+                                              <template
+                                                v-else
+                                              >
+                                                {{ origin.name }}
+                                              </template>
+                                            </li>
+                                          </ul>
+                                        </template>
+                                      </DefinitionCard>
+                                      <div>
+                                        <dt>
+                                          Config
+                                        </dt>
+                                        <dd class="mt-2">
+                                          <div>
+                                            <CodeBlock
+                                              :code="YAML.stringify(item.raw)"
+                                              language="yaml"
+                                              :show-copy-button="false"
+                                            />
+                                          </div>
+                                        </dd>
+                                      </div>
+                                    </template>
+                                  </div>
+                                </template>
+                              </AccordionItem>
+                            </KCard>
                           </template>
-                        </AccordionItem>
-                      </KCard>
-                    </template>
-                  </AccordionList>
-                </div>
-              </DataCollection>
-            </DataLoader>
+                        </AccordionList>
+                      </div>
+                    </DataCollection>
+                  </template>
+                </DataLoader>
+              </template>
+            </DataSource>
           </div>
         </div>
       </template>
@@ -175,7 +321,8 @@ import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import type { DataplaneOverview } from '@/app/data-planes/data/'
 import type { PolicyTypeCollectionSource } from '@/app/policies/sources'
 import RuleMatchers from '@/app/rules/components/RuleMatchers.vue'
-import type { RuleCollectionSource } from '@/app/rules/sources'
+import { sources } from '@/app/rules/sources'
+
 const props = defineProps<{
   data: Record<string, any>
   dataplaneOverview: DataplaneOverview

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -348,7 +348,7 @@
                                 data-testid="dataplane-outbound"
                                 :protocol="['grpc', 'http', 'tcp'].find(protocol => typeof outbound[protocol] !== 'undefined') ?? 'tcp'"
                                 :traffic="outbound"
-                                :service="outbound.$kind === '' ? name.replace(hash, '') : undefined"
+                                :service="outbound.$resourceMeta.type === '' ? name.replace(hash, '') : undefined"
                                 :direction="direction"
                               >
                                 <RouterLink

--- a/src/app/rules/data/ResourceRule.ts
+++ b/src/app/rules/data/ResourceRule.ts
@@ -1,0 +1,24 @@
+import type { components } from '@/types/auto-generated.d'
+type Entity = components['schemas']['ResourceRule']
+type Collection = Entity[]
+
+export const ResourceRule = {
+  fromObject(item: Entity) {
+    return {
+      ...item,
+      type: '',
+      raw: item.conf[0] ?? {},
+      config: item.conf[0] ?? {},
+      origins: Array.isArray(item.origin) ? item.origin : [],
+    }
+  },
+
+  fromCollection(collection: Collection) {
+    const items = Array.isArray(collection) ? collection.map(ResourceRule.fromObject) : []
+    return {
+      items,
+      total: items.length,
+    }
+  },
+}
+export type ResourceRule = ReturnType<typeof ResourceRule['fromObject']>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,3 +1,5 @@
+import type { components } from '@/types/auto-generated.d'
+type ResourceRule = components['schemas']['ResourceRule']
 /**
  * Creates an “unsaved” variant of a resource type which is missing the fields that are only present on an object once its saved in the database.
  */
@@ -465,6 +467,7 @@ export interface InspectRule {
    */
   type: string
   proxyRule?: InspectProxyRule
+  toResourceRules?: ResourceRule[]
   toRules?: InspectBaseRule[]
   fromRules?: InspectFromRule[]
   warnings?: string[]


### PR DESCRIPTION
Uses `toResourceRules` for rendering Rules/Policies in outbounds drawer.

Please note: Their are no mocks for this yet, until then, please use `KUMA_MOCK_API_ENABLED=false` to point this to a local kuma.

Closes https://github.com/kumahq/kuma-gui/issues/2880