### PR TITLE
chore: Bump version numbers to 2.9 (affects dev docs links etc)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 # The following are templating placeholders for the index.html file. They’re going to be replaced using server-side templating when serving the GUI application in production.
 VITE_BASE_GUI_PATH=/gui
-VITE_KUMA_CONFIG='{"baseGuiPath":"/gui","apiUrl":"http://localhost:5681","version":"2.6.0","product":"Kuma","mode":"global","environment":"universal","storeType":"postgres","apiReadOnly":false}'
+VITE_KUMA_CONFIG='{"baseGuiPath":"/gui","apiUrl":"http://localhost:5681","version":"2.9.0","product":"Kuma","mode":"global","environment":"universal","storeType":"postgres","apiReadOnly":false}'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuma-gui",
-  "version": "2.6.0",
+  "version": "2.9.0",
   "private": true,
   "description": "Kuma Manager",
   "author": "Kong",

--- a/src/app/application/services/env/Env.ts
+++ b/src/app/application/services/env/Env.ts
@@ -106,7 +106,7 @@ export function getPathConfigDefault(apiUrlDefault: string = ''): PathConfig {
      * **Example**: `'http://localhost:5681'`
     */
     apiUrl: apiUrlDefault,
-    version: '2.6.0',
+    version: '2.9.0',
     product: 'Kuma',
     mode: 'global',
     environment: 'universal',


### PR DESCRIPTION
For development purposes, we currently hardcode the current Kuma version in 3 separate places.

This version is shown, during development, in the header of the GUI and is used for generating all our documentation links.

In production, the kuma binary feeds a different version in via the `index.html` file.

---

We always forget to bump this for a version and whilst its not super important (we were still on `2.6.0`), its handy for checking links etc.

I vaguely remember suggesting we should set this in one place (the `package.json`) and even better have a way to bump this automatically. Not sure if we made an issue, I'll either link one here if I can find one or make a new one.

edit: I found this https://github.com/kumahq/kuma-gui/issues/2428