### PR TITLE
fix: amend cluster/rule lookups to use resourceMeta.labels

### DIFF
--- a/src/app/connections/data/index.spec.ts
+++ b/src/app/connections/data/index.spec.ts
@@ -48,6 +48,8 @@ describe('ConnectionCollection', () => {
             $resourceMeta: {
               mesh: '',
               name: '',
+              namespace: '',
+              port: '',
               type: '',
               zone: '',
             },

--- a/src/app/connections/data/index.ts
+++ b/src/app/connections/data/index.ts
@@ -79,7 +79,7 @@ export const ConnectionCollection = {
                 switch (true) {
                   case (str.indexOf('_msvc_') !== -1):
                     return 'MeshService'
-                  case (str.indexOf('_mesvc_') !== -1):
+                  case (str.indexOf('_extsvc_') !== -1):
                     return 'MeshExternalService'
                   case (str.indexOf('_mzsvc_') !== -1):
                     return 'MeshMultiZoneService'

--- a/src/app/connections/data/index.ts
+++ b/src/app/connections/data/index.ts
@@ -56,7 +56,9 @@ export const ConnectionCollection = {
               type: '',
               mesh: '',
               name: '',
+              namespace: '',
               zone: '',
+              port: '',
             },
             tcp,
             ...(typeof http !== 'undefined' ? { http } : {}),
@@ -66,11 +68,13 @@ export const ConnectionCollection = {
           // sniff the name to see if we are a new type of service
           const found = cluster.match(meshServiceRe)
           if (found) {
-            const [mesh, name, namespace, zone, _abbr, _port] = cluster.split('_')
+            const [mesh, name, namespace, zone, _abbr, port] = cluster.split('_')
             stats.$resourceMeta = {
               mesh,
-              name: `${name}.${namespace}`,
+              name,
+              namespace,
               zone,
+              port,
               type: ((str: string) => {
                 switch (true) {
                   case (str.indexOf('_msvc_') !== -1):

--- a/src/app/connections/views/ConnectionOutboundSummaryOverviewView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryOverviewView.vue
@@ -330,10 +330,10 @@ const props = defineProps<{
 }>()
 
 const ruleForCluster = (cluster: any, rule: ResourceRule) => {
-  return cluster.$resourceMeta.name === rule.resourceMeta.labels['kuma.io/display-name'] &&
-  cluster.$resourceMeta.namespace === rule.resourceMeta.labels['k8s.kuma.io/namespace'] &&
-  cluster.$resourceMeta.zone === rule.resourceMeta.labels['kuma.io/zone'] &&
-  (rule.resourceSectionName === '' || cluster.$resourceMeta.port === rule.resourceSectionName)
+  return cluster.$resourceMeta.name === rule.name &&
+  cluster.$resourceMeta.namespace === rule.namespace &&
+  cluster.$resourceMeta.zone === rule.zone &&
+  (rule.resourceSectionName === '' || cluster.$resourceMeta.port === rule.port)
 }
 </script>
 <style lang="scss" scoped>

--- a/src/app/connections/views/ConnectionOutboundSummaryOverviewView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryOverviewView.vue
@@ -108,7 +108,7 @@
                   >
                     <DataCollection
                       :predicate="(item) => {
-                        return item.resourceMeta.type === 'Mesh' || props.data.$resourceMeta.name === item.resourceMeta.name
+                        return item.resourceMeta.type === 'Mesh' || ruleForCluster(props.data, item)
                       }"
                       :items="rulesData.toResourceRules"
                       v-slot="{ items }"
@@ -130,7 +130,7 @@
                               class="stack-with-borders mt-4"
                             >
                               <template
-                                v-for="item in rules!.length > 1 ? rules!.filter((item) => props.data.$resourceMeta.name === item.resourceMeta.name) : rules"
+                                v-for="item in rules!.length > 1 ? rules!.filter(item => ruleForCluster(props.data, item)) : rules"
                                 :key="item"
                               >
                                 <div>
@@ -321,12 +321,20 @@ import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import type { DataplaneOverview } from '@/app/data-planes/data/'
 import type { PolicyTypeCollectionSource } from '@/app/policies/sources'
 import RuleMatchers from '@/app/rules/components/RuleMatchers.vue'
+import { ResourceRule } from '@/app/rules/data/ResourceRule'
 import { sources } from '@/app/rules/sources'
 
 const props = defineProps<{
   data: Record<string, any>
   dataplaneOverview: DataplaneOverview
 }>()
+
+const ruleForCluster = (cluster: any, rule: ResourceRule) => {
+  return cluster.$resourceMeta.name === rule.resourceMeta.labels['kuma.io/display-name'] &&
+  cluster.$resourceMeta.namespace === rule.resourceMeta.labels['k8s.kuma.io/namespace'] &&
+  cluster.$resourceMeta.zone === rule.resourceMeta.labels['kuma.io/zone'] &&
+  (rule.resourceSectionName === '' || cluster.$resourceMeta.port === rule.resourceSectionName)
+}
 </script>
 <style lang="scss" scoped>
 .rules {

--- a/src/app/rules/data/ResourceRule.ts
+++ b/src/app/rules/data/ResourceRule.ts
@@ -4,12 +4,19 @@ type Collection = Entity[]
 
 export const ResourceRule = {
   fromObject(item: Entity) {
+    const labels = typeof item.resourceMeta.labels !== 'undefined' ? item.resourceMeta.labels : {}
     return {
       ...item,
       type: '',
       raw: item.conf[0] ?? {},
       config: item.conf[0] ?? {},
       origins: Array.isArray(item.origin) ? item.origin : [],
+      labels,
+      id: item.resourceMeta.name,
+      name: labels['kuma.io/display-name'] ?? item.resourceMeta.name,
+      namespace: labels['k8s.kuma.io/namespace'] ?? '',
+      zone: labels['kuma.io/zone'] ?? '',
+      port: item.resourceSectionName ?? '',
     }
   },
 


### PR DESCRIPTION
Changes how we lookup/match cluster to rule to use the resourceMeta labels instead of the resourceMeta.name.

