### PR TITLE
fix(dataplanes): Remove Resource link from rules drawer

### DIFF
--- a/src/app/connections/data/index.ts
+++ b/src/app/connections/data/index.ts
@@ -4,7 +4,7 @@ const appProtocols = ['http', 'tcp', 'grpc'] as const
 // `_` followed by 1 to 5 digits followed by a `.`
 const trailingPortRe = /_\d{1,5}\./
 const trailingPortRe2 = /_\d{1,5}/
-const meshServiceRe = /_(mz|m|me){1}svc_\d{1,5}$/
+const meshServiceRe = /_(mz|m|ext){1}svc_\d{1,5}$/
 
 export const Stat = {
   fromCollection(items: string) {

--- a/src/app/connections/views/ConnectionOutboundSummaryOverviewView.vue
+++ b/src/app/connections/views/ConnectionOutboundSummaryOverviewView.vue
@@ -16,57 +16,6 @@
         <div
           class="stack-with-borders"
         >
-          <template
-            v-if="props.data.$resourceMeta.type !== ''"
-          >
-            <DefinitionCard
-              layout="horizontal"
-            >
-              <template #title>
-                Resource
-              </template>
-
-              <template #body>
-                <KBadge
-                  appearance="info"
-                  max-width="auto"
-                >
-                  <template
-                    v-for="item in [props.data.$resourceMeta]"
-                    :key="typeof item"
-                  >
-                    <XAction
-                      :to="({
-                        MeshService: {
-                          name: 'mesh-service-detail-view',
-                          params: {
-                            mesh: item.mesh,
-                            service: item.name,
-                          },
-                        },
-                        MeshExternalService: {
-                          name: 'mesh-external-service-detail-view',
-                          params: {
-                            mesh: item.mesh,
-                            service: item.name,
-                          },
-                        },
-                        MeshMultiZoneService: {
-                          name: 'mesh-multizone-service-detail-view',
-                          params: {
-                            mesh: item.mesh,
-                            service: item.name,
-                          },
-                        },
-                      } as const)[item.type as 'MeshService' | 'MeshExternalService' | 'MeshMultiZoneService']"
-                    >
-                      {{ item.type }}: {{ item.name }}
-                    </XAction>
-                  </template>
-                </KBadge>
-              </template>
-            </DefinitionCard>
-          </template>
           <DefinitionCard
             layout="horizontal"
           >


### PR DESCRIPTION
Removes the 'Resources' link form the rules drawer.

We can't quite know the proper type/name of the thing just yet.

I've also added a little fix for detecting `MeshExternalServices` in the same view