### PR TITLE
chore(meshservice): removes Services from DDP listing in exclusive

### DIFF
--- a/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -69,6 +69,7 @@
             <component
               :is="child.Component"
               :data="data"
+              :mesh="props.mesh"
             />
           </RouterView>
         </DataLoader>
@@ -80,4 +81,8 @@
 <script lang="ts" setup>
 import { DataplaneOverviewSource } from '../sources'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+import type { Mesh } from '@/app/meshes/data'
+const props = defineProps<{
+  mesh: Mesh
+}>()
 </script>

--- a/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -237,7 +237,7 @@
                             <ConnectionCard
                               data-testid="dataplane-inbound"
                               :protocol="item.protocol"
-                              :service="item.tags['kuma.io/service']"
+                              :service="can('use service-insights', props.mesh) ? item.tags['kuma.io/service'] : ''"
                               :traffic="typeof error === 'undefined' ?
                                 stats :
                                 {
@@ -531,6 +531,7 @@ import ConnectionCard from '@/app/connections/components/connection-traffic/Conn
 import ConnectionGroup from '@/app/connections/components/connection-traffic/ConnectionGroup.vue'
 import ConnectionTraffic from '@/app/connections/components/connection-traffic/ConnectionTraffic.vue'
 import type { StatsSource } from '@/app/connections/sources'
+import type { Mesh } from '@/app/meshes/data'
 import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
 import { useRoute } from '@/app/vue'
 
@@ -538,6 +539,7 @@ const _route = useRoute()
 
 const props = defineProps<{
   data: DataplaneOverview
+  mesh: Mesh
 }>()
 
 const warnings = computed(() => props.data.warnings.concat(...(props.data.isCertExpired ? [{ kind: 'CERT_EXPIRED' }] : [])))

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -49,7 +49,7 @@
                   { ...me.get('headers.name'), label: 'Name', key: 'name' },
                   { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
                   ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                  { ...me.get('headers.services'), label: 'Services', key: 'services' },
+                  ...(can('use service-insights', props.mesh) ? [{ ...me.get('headers.services'), label: 'Services', key: 'services' }] : []),
                   { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
                   { ...me.get('headers.status'), label: 'Status', key: 'status' },
                   { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
@@ -293,6 +293,10 @@ import FilterBar from '@/app/common/filter-bar/FilterBar.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+import type { Mesh } from '@/app/meshes/data'
+const props = defineProps<{
+  mesh: Mesh
+}>()
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/meshes/routes.ts
+++ b/src/app/meshes/routes.ts
@@ -27,6 +27,7 @@ export const routes = (
           path: ':mesh',
           name: 'mesh',
           redirect: { name: 'mesh-detail-view' },
+          component: () => import('@/app/meshes/views/MeshView.vue'),
           children: [
             {
               path: '',

--- a/src/app/meshes/views/MeshDetailTabsView.vue
+++ b/src/app/meshes/views/MeshDetailTabsView.vue
@@ -4,7 +4,7 @@
     :params="{
       mesh: '',
     }"
-    v-slot="{ route, t, uri }"
+    v-slot="{ route, t }"
   >
     <AppView>
       <template #title>
@@ -19,46 +19,38 @@
         </h1>
       </template>
 
-      <DataLoader
-        :src="uri(
-          sources,
-          '/meshes/:name',
-          {
-            name: route.params.mesh,
-          },
-        )"
-        v-slot="{ data: mesh }"
+      <XTabs
+        :selected="route.child()?.name"
+        data-testid="mesh-tabs"
       >
-        <XTabs
-          :selected="route.child()?.name"
-          data-testid="mesh-tabs"
+        <template
+          v-for="{ name } in route.children.filter(({ name }) => name !== 'external-service-list-view')"
+          :key="name"
+          #[`${name}-tab`]
         >
-          <template
-            v-for="{ name } in route.children.filter(({ name }) => name !== 'external-service-list-view')"
-            :key="name"
-            #[`${name}-tab`]
+          <XAction
+            :to="{ name }"
           >
-            <XAction
-              :to="{ name }"
-            >
-              {{ t(`meshes.routes.item.navigation.${name}`) }}
-            </XAction>
-          </template>
-        </XTabs>
+            {{ t(`meshes.routes.item.navigation.${name}`) }}
+          </XAction>
+        </template>
+      </XTabs>
 
-        <RouterView
-          v-slot="{ Component }"
-        >
-          <component
-            :is="Component"
-            :mesh="mesh"
-          />
-        </RouterView>
-      </DataLoader>
+      <RouterView
+        v-slot="{ Component }"
+      >
+        <component
+          :is="Component"
+          :mesh="props.mesh"
+        />
+      </RouterView>
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import { sources } from '../sources'
+import type { Mesh } from '@/app/meshes/data'
+const props = defineProps<{
+  mesh: Mesh
+}>()
 </script>

--- a/src/app/meshes/views/MeshView.vue
+++ b/src/app/meshes/views/MeshView.vue
@@ -1,0 +1,34 @@
+<template>
+  <RouteView
+    name="mesh-view"
+    :params="{
+      mesh: '',
+    }"
+    v-slot="{ route, uri }"
+  >
+    <DataLoader
+      :src="uri(
+        sources,
+        '/meshes/:name',
+        {
+          name: route.params.mesh,
+        },
+      )"
+      v-slot="{ data: mesh }"
+    >
+      <AppView>
+        <RouterView
+          v-slot="{ Component }"
+        >
+          <component
+            :is="Component"
+            :mesh="mesh"
+          />
+        </RouterView>
+      </AppView>
+    </DataLoader>
+  </RouteView>
+</template>
+<script lang="ts" setup>
+import { sources } from '../sources'
+</script>

--- a/src/app/services/features.ts
+++ b/src/app/services/features.ts
@@ -1,5 +1,6 @@
 import type { Features } from '@/app/application'
 import type Env from '@/app/application/services/env/Env'
+import { Mesh } from '@/app/meshes/data'
 export const features = (env: Env['var']): Features => {
   return {
     'use meshservice': () => {
@@ -8,6 +9,9 @@ export const features = (env: Env['var']): Features => {
       } catch (e) {
         return true
       }
+    },
+    'use service-insights': (_can, mesh: Mesh) => {
+      return mesh.meshServices?.enabled !== 'Exclusive'
     },
   }
 }

--- a/src/app/services/views/ServiceListTabsView.vue
+++ b/src/app/services/views/ServiceListTabsView.vue
@@ -20,7 +20,7 @@
               :key="name"
             >
               <XAction
-                v-if="!(props.mesh.meshServices?.enabled === 'Exclusive' && ['service-list-view', 'external-service-list-view'].includes(name))"
+                v-if="!(!can('use service-insights', props.mesh) && ['service-list-view', 'external-service-list-view'].includes(name))"
                 :class="{
                   'active': route.child()?.name === name,
                 }"
@@ -54,14 +54,17 @@
 import { watch } from 'vue'
 import { useRouter } from 'vue-router'
 
+import { useCan } from '@/app/application'
 import type { Mesh } from '@/app/meshes/data'
-const router = useRouter()
 const props = defineProps<{
   mesh: Mesh
 }>()
+
+const router = useRouter()
+const can = useCan()
 watch(() => router.currentRoute.value.name, (val) => {
   if (val === 'service-list-tabs-view') {
-    router.replace(props.mesh.meshServices?.enabled === 'Exclusive' ? { name: 'mesh-service-list-view' } : { name: 'service-list-view' })
+    router.replace(can('use service-insights', props.mesh) ? { name: 'service-list-view' } : { name: 'mesh-service-list-view' })
   }
 }, { immediate: true })
 </script>


### PR DESCRIPTION
Removes the `Services` column from the Dataplane listing, and the DataPlane Inbound card links, only when the Mesh is in meshServices Exclusive mode.