### PR TITLE
chore: adds Progress icon to XIcon/XAction

### DIFF
--- a/src/app/x/components/x-action/XAction.vue
+++ b/src/app/x/components/x-action/XAction.vue
@@ -34,10 +34,10 @@
       }"
     >
       <template
-        v-if="['create'].includes(props.action)"
+        v-if="['create', 'refresh', 'progress'].includes(props.action)"
       >
         <XIcon
-          :name="props.action as 'create'"
+          :name="props.action as ('create' | 'refresh' | 'progress')"
         />
       </template>
       <slot name="default" />
@@ -116,10 +116,10 @@
       @click="emit('click')"
     >
       <template
-        v-if="['create', 'refresh'].includes(props.action)"
+        v-if="['create', 'refresh', 'progress'].includes(props.action)"
       >
         <XIcon
-          :name="props.action as ('create' | 'refresh')"
+          :name="props.action as ('create' | 'refresh' | 'progress')"
         />
       </template>
       <slot name="default" />
@@ -159,7 +159,7 @@ const emit = defineEmits<{
   (event: 'click'): Event
 }>()
 const props = withDefaults(defineProps<{
-  action?: 'default' | 'docs' | 'create' | 'copy' | 'action' | 'expand' | 'refresh'
+  action?: 'default' | 'docs' | 'create' | 'copy' | 'action' | 'expand' | 'refresh' | 'progress'
   appearance?: 'primary' | 'secondary' | 'tertiary' | 'danger' | 'anchor'
   size?: 'small' | 'medium' | 'large'
   href?: string

--- a/src/app/x/components/x-icon/XIcon.vue
+++ b/src/app/x/components/x-icon/XIcon.vue
@@ -44,6 +44,7 @@ import {
   AddIcon,
   HelpIcon,
   RefreshIcon,
+  ProgressIcon,
 } from '@kong/icons'
 import { KTooltip, PopPlacements } from '@kong/kongponents'
 import { useSlots, useAttrs } from 'vue'
@@ -74,6 +75,7 @@ const icons = {
   help: HelpIcon,
   create: AddIcon,
   refresh: RefreshIcon,
+  progress: ProgressIcon,
 } as const
 const id = uniqueId('-x-icon-tooltip')
 const slots = useSlots()


### PR DESCRIPTION
Adds ProgressIcon to XIcon and XButton, which means we can use conditionals like:

```vue
:action="writing ? 'progress' : 'create'"
```

instead of 

```vue
<ProgressIcon v-if="writing" />
<AddIcon v-else />
```