### PR TITLE
chore(deps): MSW and Sass post upgrade fixes

### DIFF
--- a/vite.config.production.ts
+++ b/vite.config.production.ts
@@ -73,6 +73,7 @@ export const config: UserConfigFn = () => {
           additionalData: hoistUseStatements(`
             @import "@kong/design-tokens/tokens/scss/variables";
           `),
+          api: 'modern-compiler',
         },
       },
     },


### PR DESCRIPTION
~Important: Do not merge until post 2.9. We would like time for the change in Sass setting to "sit in" in the very slim case that it affects something we haven't noticed.~ This is fine to merge now

---

Mainly fixes Sass deprecation warning

![Screenshot 2024-09-26 at 11 57 33](https://github.com/user-attachments/assets/ed31effa-c204-4645-88ef-f12a288bfd54)

~But also bumps the MSW version in mockServiceWorker (vaguely related https://github.com/kumahq/kuma-gui/pull/2918)~ edit: This was eventually done in https://github.com/kumahq/kuma-gui/pull/3095 which was approved and merged first, so I amended this change out