### PR TITLE
chore(meshes): Use `meshServices.mode` w/fallback `meshServices.enabled`

### DIFF
--- a/src/app/application/index.ts
+++ b/src/app/application/index.ts
@@ -25,6 +25,7 @@ import type { ServiceDefinition } from '@/services/utils'
 import { token, createInjections, constant } from '@/services/utils'
 import type { Component } from 'vue'
 export * from './services/can'
+export { runInDebug } from './utilities'
 export { defineSources } from './services/data-source'
 
 // temporary simple "JSON data only" structuredClone polyfill for cloning JSON

--- a/src/app/application/utilities/index.ts
+++ b/src/app/application/utilities/index.ts
@@ -3,6 +3,10 @@ import jsYaml from 'js-yaml'
 type URLParamDefault = string | number | boolean
 type URLParamValue = string | null
 
+export const runInDebug = (func: () => void) => {
+  if (import.meta.env.PROD) return
+  func()
+}
 const difference = <T>(a: T[], b: T[]): T[] => a.filter(item => !b.includes(item))
 
 const includes = <T extends readonly string[]>(arr: T, item: string): item is T[number] => {

--- a/src/app/meshes/data/Mesh.ts
+++ b/src/app/meshes/data/Mesh.ts
@@ -12,6 +12,12 @@ export const Mesh = {
     return {
       ...item,
       config: item,
+      meshServices: ((item = {}) => {
+        return {
+          ...item,
+          mode: typeof item.mode === 'undefined' ? (item.enabled ?? 'Disabled') : item.mode,
+        }
+      })(item.meshServices),
       mtlsBackend,
       metricsBackend,
       routing: ((item = {}) => {

--- a/src/app/meshes/data/index.spec.ts
+++ b/src/app/meshes/data/index.spec.ts
@@ -68,6 +68,9 @@ describe('meshes data transformations', () => {
           type: 'Mesh',
           creationTime: '2020-06-19T12:18:02.097986-04:00',
           modificationTime: '2020-06-19T12:18:02.097986-04:00',
+          meshServices: {
+            mode: 'Disabled',
+          },
           mtlsBackend: {
             name: 'ca-2',
             type: 'BUILTIN',

--- a/src/app/services/features.ts
+++ b/src/app/services/features.ts
@@ -1,4 +1,5 @@
 import type { Features } from '@/app/application'
+import { runInDebug } from '@/app/application'
 import type Env from '@/app/application/services/env/Env'
 import { Mesh } from '@/app/meshes/data'
 export const features = (env: Env['var']): Features => {
@@ -11,7 +12,12 @@ export const features = (env: Env['var']): Features => {
       }
     },
     'use service-insights': (_can, mesh: Mesh) => {
-      return mesh.meshServices?.enabled !== 'Exclusive'
+      runInDebug(() => {
+        if (typeof mesh === 'undefined') {
+          throw new Error('argument `mesh` not provided for can(`use service-insights`)')
+        }
+      })
+      return mesh.meshServices.mode !== 'Exclusive'
     },
   }
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -757,7 +757,8 @@ export interface Mesh extends Entity {
     zoneEgress?: boolean
   }
   meshServices?: {
-    enabled: 'Everywhere' | 'Exclusive'
+    mode?: 'Disabled' | ' Everywhere' | 'ReachableBackends' | 'Exclusive'
+    enabled?: 'Disabled' | ' Everywhere' | 'ReachableBackends' | 'Exclusive'
   }
 }
 


### PR DESCRIPTION
Uses `meshServices.mode` with fallback to `meshServices.enabled` (if neither are set fallback to `meshServices.mode = 'Disabled'`

I also added a `runInDebug` function whose contents is removed at build time. This avoids using something `vite` specific (`import.meta.env.PROD`) and its name is meaningful. I then used this to make sure `mesh` is set in our feature flags (static type checking is loose here right now)

Closes https://github.com/kumahq/kuma-gui/issues/3013