### PR TITLE
chore(mk): move accessible targets to the "make main file" i.e. Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,60 @@
+# Please keep this file free of actual scripts
+# It should only be used for adding "non-dot" aliases and documentation
+
 SHELL := /usr/bin/env bash
+MK := ./mk
 
 ## make help: if you're aren't sure use `make help`
 .DEFAULT_GOAL := help
 
-include mk/help.mk
-include mk/run.mk
-include mk/install.mk
-include mk/check.mk
-include mk/test.mk
-include mk/build.mk
+include $(MK)/help.mk
+include $(MK)/run.mk
+include $(MK)/install.mk
+include $(MK)/check.mk
+include $(MK)/test.mk
+include $(MK)/build.mk
+
+## These make targets are only used by CI and is therefore are not exposed in help
+.PHONY: build/sync
+build/sync: .build/sync
+
+.PHONY: install/sync
+install/sync: .install/sync
+### end CI-only scripts
+
+.PHONY: help
+help: .help ## Display this help screen
+
+.PHONY: clean
+clean: .clean ## Dev: Delete all node_modules directories
+
+.PHONY: install
+install: .install ## Dev: install all dependencies (runs before `make run`)
+
+.PHONY: lint
+lint: .lint ## Dev: Run lint checks on all languages
+
+.PHONY: lint/script
+lint/script: .lint/script ## Dev: Run lint checks on both JS/TS
+
+.PHONY: run
+run: .run ## Dev: run local development instance of the GUI. If you are working on the GUI then you are probably looking for this.
+
+.PHONY: run/docs
+run/docs: .run/docs ## Dev: run local instance of the GUI docs, either just for reference or contributing.
+
+.PHONY: run/e2e
+run/e2e: .run/e2e ## Dev: run local instance of production build (used for e2e testing)
+
+.PHONY: test/unit
+test/unit: .test/unit ## Dev: run unit tests and exit
+
+.PHONY: test/unit/watch
+test/unit/watch: .test/unit/watch ## Dev: run unit tests but watch for changes
+
+.PHONY: test/e2e
+test/e2e: .test/e2e ## Run browser-based e2e tests against a running GUI, you may want to set KUMA_BASE_URL=http://localhost:8080/gui and KUMA_TEST_BROWSER=chrome
+
+.PHONY: build ## Dev: build a production artifact in `./dist`
+build: .build
+

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -1,11 +1,11 @@
-.PHONY: build
-build:
+.PHONY: .build
+.build:
 	@npx vite \
 		-c ./vite.config.production.ts \
 		build
 
-.PHONY: build/sync
-build/sync:
+.PHONY: .build/sync
+.build/sync:
 	@$(MAKE) build
 
 .PHONY: build/preview

--- a/mk/check.mk
+++ b/mk/check.mk
@@ -7,11 +7,11 @@ check/node:
 		exit 1; \
 	)
 
-.PHONY: lint
-lint: lint/js lint/ts lint/css lint/lock lint/gherkin ## Dev: Run lint checks on all languages
+.PHONY: .lint
+.lint: lint/js lint/ts lint/css lint/lock lint/gherkin
 
-.PHONY: lint/script
-lint/script: lint/js lint/ts  ## Dev: Run lint checs on both JS/TS
+.PHONY: .lint/script
+.lint/script: lint/js lint/ts  ## Dev: Run lint checs on both JS/TS
 
 .PHONY: lint/js
 lint/js:

--- a/mk/help.mk
+++ b/mk/help.mk
@@ -1,5 +1,6 @@
-.PHONY: help
-help: ## Display this help screen
+.PHONY: .help
+.help: ## Display this help screen
+	@echo "The following targets can be used by running \`make <target>\`"; echo "---"
 	@# Display top-level targets since they are the ones most developers will need.
 	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort -k1 | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 	@# Now show hierarchical targets in separate sections.

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -1,12 +1,12 @@
-.PHONY: install
-install: check/node ## Dev: install all dependencies
+.PHONY: .install
+.install: check/node
 	@npm install
 
-.PHONY: install/sync
-install/sync:
+.PHONY: .install/sync
+.install/sync:
 	npm clean-install
 
-.PHONY: clean
-clean: ## Dev: Delete all node_modules directories
+.PHONY: .clean
+.clean:
 	find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +
 

--- a/mk/run.mk
+++ b/mk/run.mk
@@ -1,19 +1,17 @@
 SCRIPT_RUNNER := npm run
 
-run/%: ## Dev: Run any package script using the form `run/name-of-script`.
-	@$(SCRIPT_RUNNER) $*
-
-.PHONY: run
-run: install ## Dev: run local development instance of the GUI. If you are working on the GUI then you are probably looking for this.
+.PHONY: .run
+.run: install
 	@npx vite \
 		-c ./vite.config.development.ts
 
-.PHONY: run/docs
-run/docs: install ## Dev: run local instance of the GUI docs, either just for reference or contributing.
+.PHONY: .run/docs
+.run/docs: install
 	@npx vitepress \
 		dev
 
-run/e2e: ## Dev: run local instance of production build (used for e2e testing)
+.PHONY: .run/e2e
+.run/e2e:
 	@$(MAKE) deploy/e2e
 	@npx vite \
 		-c ./vite.config.preview.ts \

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -1,24 +1,24 @@
 .PHONY: test
 
-.PHONY: test/unit
-test/unit: install ## Dev: run unit tests and exit
+.PHONY: .test/unit
+.test/unit: install
 	@TZ=UTC \
 		FORCE_COLOR=1 \
 		npx vitest \
 			-c vite.config.production.ts \
 			run
 
-.PHONY: test/unit/watch
-test/unit/watch: install ## Dev: run unit tests but watch for changes
+.PHONY: .test/unit/watch
+.test/unit/watch: install
 	@TZ=UTC \
 		FORCE_COLOR=1 \
 		npx vitest \
 			-c vite.config.production.ts \
 
 
-.PHONY: test/e2e
-test/e2e: CYPRESS_SPEC?=**/*.feature
-test/e2e: ## Run browser-based e2e tests against a running GUI, you may want to set KUMA_BASE_URL=http://localhost:8080/gui and KUMA_TEST_BROWSER=chrome
+.PHONY: .test/e2e
+.test/e2e: CYPRESS_SPEC?=**/*.feature
+.test/e2e:
 ifdef KUMA_TEST_BROWSER
 	@TZ=UTC \
 		npx cypress \

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
+    "help": "make help",
     "prepare": "husky"
   },
   "engines": {


### PR DESCRIPTION
Changes our approach to Makefile targets to make them more customisable upstream

---

The biggest problem here is that Make make its troublesome to simply override make targets.

Previously we would 'override' targets by not including the file that had the target we had to override, and then including a different file with our customisations in it for the relevant target. The thing is you would also need to override (or just copy) all targets in a file, rather than just the one you wanted to override.

This approach names all consumable make targets prefixed with a `.` i.e. `.install` vs `install`. We than add references to all these in our base `Makefile` (essentially `make`s `main` file). The `Makefile` is specific to each project so we can add what we want in there and it doesn't affect anything downstream. This also includes adding different documentation if need be.

For example, say in one make file we have:

```make
install: .install ## Docs for this here
```

And we need to add some sort of auth to that we can use 
```make
.install/auth:
  $(AUTH) $(MAKE) .install
install: .install/auth ## Different docs for this here
```

Both of the above examples will run our installation scripts without them being duplicated, but one is decorated with some sort of authentication before doing so.

Moving forwards we should add all "common" user scripts in this file using the same approach. We should avoid mixing the documented aliases in with the rest of the `./mk` files, and avoid mixing long form scripts into the `Makefile` itself. I've added a small comment at the top of the `Makefile` to this effect. 

Lastly, I've only moved previously documented targets into this form as these are the commonly used ones. We can move others later on if necessary/desirable.


