### PR TITLE
feat: add include_eds checkbox for XDS config views

### DIFF
--- a/src/app/data-planes/sources.ts
+++ b/src/app/data-planes/sources.ts
@@ -87,6 +87,17 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
         dataPath,
       })
     },
+    '/meshes/:mesh/dataplanes/:name/xds/:endpoints': async (params) => {
+      const { mesh, name, endpoints } = params
+
+      return api.getDataplaneData({
+        mesh,
+        dppName: name,
+        dataPath: 'xds',
+      }, {
+        include_eds: endpoints,
+      })
+    },
 
     '/meshes/:mesh/dataplanes/:name/sidecar-dataplane-policies': async (params) => {
       return SidecarDataplane.fromCollection(await api.getSidecarDataplanePolicies(params))

--- a/src/app/data-planes/views/DataPlaneXdsConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneXdsConfigView.vue
@@ -8,7 +8,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
-    v-slot="{ route, t }"
+    v-slot="{ route, t, uri }"
   >
     <RouteTitle
       :render="false"
@@ -17,7 +17,11 @@
     <AppView>
       <KCard>
         <DataLoader
-          :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/data-path/xds`"
+          :src="uri(sources, '/meshes/:mesh/dataplanes/:name/xds/:endpoints', {
+            mesh: route.params.mesh,
+            name: route.params.dataPlane,
+            endpoints: String(endpoints),
+          })"
           v-slot="{ data, refresh }"
         >
           <CodeBlock
@@ -32,6 +36,10 @@
             @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           >
             <template #primary-actions>
+              <KCheckbox
+                v-model="endpoints"
+                label="Include Endpoints"
+              />
               <XAction
                 action="refresh"
                 appearance="primary"
@@ -48,5 +56,10 @@
 </template>
 
 <script lang="ts" setup>
+import { ref } from 'vue'
+
+import { sources } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
+
+const endpoints = ref<boolean>(false)
 </script>

--- a/src/app/zone-egresses/sources.ts
+++ b/src/app/zone-egresses/sources.ts
@@ -51,6 +51,16 @@ export const sources = (api: KumaApi) => {
 
       return api.getZoneEgressData({ zoneEgressName: name, dataPath })
     },
+    '/zone-egresses/:name/xds/:endpoints': async (params) => {
+      const { name, endpoints } = params
+
+      return api.getZoneEgressData({
+        zoneEgressName: name,
+        dataPath: 'xds',
+      }, {
+        include_eds: endpoints,
+      })
+    },
 
     '/zone-egress-overviews': async (params) => {
       const { size } = params

--- a/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
@@ -7,7 +7,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
-    v-slot="{ route, t }"
+    v-slot="{ route, t, uri }"
   >
     <RouteTitle
       :render="false"
@@ -16,7 +16,10 @@
     <AppView>
       <KCard>
         <DataLoader
-          :src="`/zone-egresses/${route.params.zoneEgress}/data-path/xds`"
+          :src="uri(sources, '/zone-egresses/:name/xds/:endpoints', {
+            name: route.params.zoneEgress,
+            endpoints: String(endpoints),
+          })"
           v-slot="{ data, refresh }"
         >
           <CodeBlock
@@ -31,6 +34,10 @@
             @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           >
             <template #primary-actions>
+              <KCheckbox
+                v-model="endpoints"
+                label="Include Endpoints"
+              />
               <XAction
                 action="refresh"
                 appearance="primary"
@@ -47,5 +54,9 @@
 </template>
 
 <script lang="ts" setup>
+import { ref } from 'vue'
+
+import { sources } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
+const endpoints = ref<boolean>(false)
 </script>

--- a/src/app/zone-ingresses/sources.ts
+++ b/src/app/zone-ingresses/sources.ts
@@ -63,6 +63,16 @@ export const sources = (source: Source, api: KumaApi) => {
       const dataPath = includes(['xds', 'clusters', 'stats'] as const, params.dataPath) ? params.dataPath : 'xds'
       return api.getZoneIngressData({ zoneIngressName: name, dataPath })
     },
+    '/zone-ingresses/:name/xds/:endpoints': async (params) => {
+      const { name, endpoints } = params
+
+      return api.getZoneIngressData({
+        zoneIngressName: name,
+        dataPath: 'xds',
+      }, {
+        include_eds: endpoints,
+      })
+    },
 
     '/zone-ingresses/:name/as/kubernetes': async (params) => {
       const { name } = params

--- a/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
@@ -7,7 +7,7 @@
       codeFilter: false,
       codeRegExp: false,
     }"
-    v-slot="{ route, t }"
+    v-slot="{ route, t, uri }"
   >
     <RouteTitle
       :render="false"
@@ -16,7 +16,10 @@
     <AppView>
       <KCard>
         <DataLoader
-          :src="`/zone-ingresses/${route.params.zoneIngress}/data-path/xds`"
+          :src="uri(sources, '/zone-ingresses/:name/xds/:endpoints', {
+            name: route.params.zoneIngress,
+            endpoints: String(endpoints),
+          })"
           v-slot="{ data, refresh }"
         >
           <CodeBlock
@@ -31,6 +34,10 @@
             @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           >
             <template #primary-actions>
+              <KCheckbox
+                v-model="endpoints"
+                label="Include Endpoints"
+              />
               <XAction
                 action="refresh"
                 appearance="primary"
@@ -47,5 +54,9 @@
 </template>
 
 <script lang="ts" setup>
+import { ref } from 'vue'
+
+import { sources } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
+const endpoints = ref<boolean>(false)
 </script>

--- a/src/test-support/mocks/fs.ts
+++ b/src/test-support/mocks/fs.ts
@@ -82,7 +82,9 @@ import _48 from './src/zone-ingresses/_/_overview'
 import _9 from './src/zone-ingresses/_overview'
 import _127 from './src/zoneegresses/_'
 import _49 from './src/zoneegresses/_/_overview'
+import _149 from './src/zoneegresses/_/xds'
 import _10 from './src/zoneegresses/_overview'
+import _148 from './src/zoneingresses/_/xds'
 import _8 from './src/zones'
 import _50 from './src/zones/_'
 import _12 from './src/zones/_/_overview'
@@ -105,9 +107,11 @@ export const fs: FS = {
   '/zone-ingresses/_overview': _9,
   '/zone-ingresses/:name': _126,
   '/zone-ingresses/:name/_overview': _48,
+  '/zoneingresses/:name/xds': _148,
   '/zoneegresses/_overview': _10,
   '/zoneegresses/:name': _127,
   '/zoneegresses/:name/_overview': _49,
+  '/zoneegresses/:name/xds': _149,
   '/mesh-insights': _13,
   '/mesh-insights/:mesh': _14,
   '/meshes': _15,

--- a/src/test-support/mocks/src/zoneegresses/_/xds.ts
+++ b/src/test-support/mocks/src/zoneegresses/_/xds.ts
@@ -1,0 +1,521 @@
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+export default (_deps: EndpointDependencies): MockResponder => (_req) => {
+  return {
+    headers: {},
+    body: {
+      version_info: '0',
+      resources: [
+        {
+          '@type': 'type.googleapis.com/envoy.api.v2.ClusterLoadAssignment',
+          cluster_name: 'default/snuba-query-tcp',
+          endpoints: [
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  }
+}

--- a/src/test-support/mocks/src/zoneingresses/_/xds.ts
+++ b/src/test-support/mocks/src/zoneingresses/_/xds.ts
@@ -1,0 +1,521 @@
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+export default (_deps: EndpointDependencies): MockResponder => (_req) => {
+  return {
+    headers: {},
+    body: {
+      version_info: '0',
+      resources: [
+        {
+          '@type': 'type.googleapis.com/envoy.api.v2.ClusterLoadAssignment',
+          cluster_name: 'default/snuba-query-tcp',
+          endpoints: [
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              lb_endpoints: [
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.109',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+                {
+                  endpoint: {
+                    address: {
+                      socket_address: {
+                        address: '192.168.208.139',
+                        port_value: 9000,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  }
+}


### PR DESCRIPTION
Adds a checkbox to all XDS configuraiton pages that controls whether to show eds/endpoints in the XDS config or not.

**I wanted to double check the API URLs for this. I'm pretty sure the API endpoints here are correct, inside `/zoneegresses` and `/zoneingresses`. Just we have API endpoints for Zone Ingresses under `/zone-ingresses` also (note the hypen)**

You can also check this with a local cluster by using `KUMA_MOCK_API_ENABLED=false` so that the we use a local running instance of Kuma.

Closes https://github.com/kumahq/kuma-gui/issues/3031