### PR TITLE
fix: include include_eds option in the URL

### DIFF
--- a/src/app/data-planes/views/DataPlaneXdsConfigView.vue
+++ b/src/app/data-planes/views/DataPlaneXdsConfigView.vue
@@ -7,6 +7,7 @@
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
+      includeEds: false,
     }"
     v-slot="{ route, t, uri }"
   >
@@ -20,7 +21,7 @@
           :src="uri(sources, '/meshes/:mesh/dataplanes/:name/xds/:endpoints', {
             mesh: route.params.mesh,
             name: route.params.dataPlane,
-            endpoints: String(endpoints),
+            endpoints: String(route.params.includeEds),
           })"
           v-slot="{ data, refresh }"
         >
@@ -37,7 +38,7 @@
           >
             <template #primary-actions>
               <KCheckbox
-                v-model="endpoints"
+                v-model="route.params.includeEds"
                 label="Include Endpoints"
               />
               <XAction
@@ -56,10 +57,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue'
-
 import { sources } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
 
-const endpoints = ref<boolean>(false)
 </script>

--- a/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
+++ b/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
@@ -6,6 +6,7 @@
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
+      includeEds: false,
     }"
     v-slot="{ route, t, uri }"
   >
@@ -18,7 +19,7 @@
         <DataLoader
           :src="uri(sources, '/zone-egresses/:name/xds/:endpoints', {
             name: route.params.zoneEgress,
-            endpoints: String(endpoints),
+            endpoints: String(route.params.includeEds),
           })"
           v-slot="{ data, refresh }"
         >
@@ -35,7 +36,7 @@
           >
             <template #primary-actions>
               <KCheckbox
-                v-model="endpoints"
+                v-model="route.params.includeEds"
                 label="Include Endpoints"
               />
               <XAction
@@ -54,9 +55,6 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue'
-
 import { sources } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
-const endpoints = ref<boolean>(false)
 </script>

--- a/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
@@ -6,6 +6,7 @@
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
+      includeEds: false,
     }"
     v-slot="{ route, t, uri }"
   >
@@ -18,7 +19,7 @@
         <DataLoader
           :src="uri(sources, '/zone-ingresses/:name/xds/:endpoints', {
             name: route.params.zoneIngress,
-            endpoints: String(endpoints),
+            endpoints: String(route.params.includeEds),
           })"
           v-slot="{ data, refresh }"
         >
@@ -35,7 +36,7 @@
           >
             <template #primary-actions>
               <KCheckbox
-                v-model="endpoints"
+                v-model="route.params.includeEds"
                 label="Include Endpoints"
               />
               <XAction
@@ -54,9 +55,6 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue'
-
 import { sources } from '../sources'
 import CodeBlock from '@/app/common/code-block/CodeBlock.vue'
-const endpoints = ref<boolean>(false)
 </script>


### PR DESCRIPTION
I wasn't thinking straight for https://github.com/kumahq/kuma-gui/pull/3032 and used Vue refs for the checkbox v-model for the include endpoints option instead of using the URL via our `RouteView::params` 🤦 .

This PR changes that so now your selection of "Include Endpoints" yes/no is included in the URL of your browser.