### PR TITLE
chore(ci): rename GUI PR GHA to "release"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,22 @@
-name: 'Create GUI update PR'
-run-name: 'Create GUI update PR (branch: ${{ github.event.workflow_run.head_branch || inputs.branch }})'
+name: 'Build and release to kumahq/kuma'
+run-name: |
+  Build and release to kumahq/kuma (branch: ${{ github.event.workflow_run.head_branch || inputs.branch }})
 
-# **Note 1**: You can merge a pull request into a release branch of the form “release-$MAJOR.$MINOR” (e.g. “release-2.1”) in order to create the GUI update PR in the matching release branch of the host repository. For this to work, the name of this repository’s release branch must match that of the host repository exactly.
-# **Note 2**: Since this workflow can be triggered using the `workflow_run` event type, one needs to pay special attention to the context in which runs will be executed based on this workflow. Most importantly, runs will be using the workflow file found **in the project’s default branch**. This means that context variables like `github.ref` and `github.ref_name` will refer to the default branch **and not the branch that caused the workflow_run event to trigger**. Also, it likely means that to change the behavior of the workflow in a release branch, one will actually have to update the workflow file in the default branch, too.
+# **Note 1**: You can merge a pull request into a release branch of the form
+# “release-$MAJOR.$MINOR” (e.g. “release-2.1”) in order to create the GUI
+# update PR in the matching release branch of the host repository. For this to
+# work, the name of this repository’s release branch must match that of the
+# host repository exactly.
+
+# **Note 2**: Since this workflow can be triggered using the `workflow_run`
+# event type, one needs to pay special attention to the context in which runs
+# will be executed based on this workflow. Most importantly, runs will be using
+# the workflow file found **in the project’s default branch**. This means that
+# context variables like `github.ref` and `github.ref_name` will refer to the
+# default branch **and not the branch that caused the workflow_run event to
+# trigger**. Also, it likely means that to change the behavior of the workflow
+# in a release branch, one will actually have to update the workflow file in
+# the default branch, too.
 
 on:
   # Allows running the workflow manually.
@@ -11,16 +25,19 @@ on:
       branch:
         required: true
         type: string
-        description: The base branch for which to create a GUI PR (default or release branch)
+        description: The base branch for which to create a release PR (default or release branch)
       sha:
         required: true
         type: string
-        description: The commit hash for which to create a GUI PR
+        description: The commit hash for which to create a release PR
   workflow_run:
     workflows: ['Tests']
     types: [completed]
-      # See “Filter pattern cheat sheet” https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-    branches: [master, 'release-[0-9]+.[0-9]+']
+    # See “Filter pattern cheat sheet”
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+    branches:
+      - master
+      - release-[0-9]+.[0-9]+
 
 permissions:
   contents: read # for checking out the repository (e.g. actions/checkout)
@@ -32,12 +49,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || inputs.branch }}
 
 jobs:
-  # Creates a pull request in the main application to update its GUI.
-  create-gui-pr:
+  # Creates a pull request in the main application to update its GUI i.e. a GUI release
+  create-release-pr:
+    # Only runs this job when the triggering workflow run was a success (i.e. the "Tests" workflow passes).
+    if: ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        }}
+    #
     timeout-minutes: 10
-    # Only runs this job when the triggering workflow run was a success (i.e. the “Tests” workflow passes).
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
-    name: Create GUI update PR
     runs-on: ubuntu-latest
     env:
       SHA: ${{ github.event.workflow_run.head_sha || inputs.sha }}


### PR DESCRIPTION
This PR changed our "Create GUI PR" workflow:

1. Naming. I changed the name to `release.yaml` / `Build and release to kumahq/kuma` because we are releasing the GUI to the binary/kuma. "Create GUI PR" sounds like I am creating a PR on `kumahq/kuma-gui`
~2. Added a `repository-data` job that fetches all "topics" from the repository~
~3. Uses the `repository-data` output to look for a `auto-release` "topic" which when present (as it is currently) performs a "release" as before.~

~**I plan on merging this with the `auto-release` "topic" applied to prove it works (validate the PR is made). I will then remove the `auto-release` topic temporarily.**~

~Notes:~

- ~I "think" I can't access the secrets in a run because I'm PRing from a forked PR, hence will currently fail until this is on `master`. I would level a better way to test this out (and GH Actions as a whole really) edit: I confirmed offline that my guess here is right.~
- ~In this PR we have two calls to get the GH token. One during the actual "release" and one to have permissions to access the repo topics. I plan on reusing the one in the `repository-data` job across the entire workflow once this PR is merged and we know it works as expected 🤞~

---

edit: [See comment below](https://github.com/kumahq/kuma-gui/pull/3047#issuecomment-2404660523), but TLDR; this PR now pretty much just renames the workflow action:

1. Naming. I changed the name to `release.yaml` / `Build and release to kumahq/kuma` because we are releasing the GUI to the binary/kuma. "Create GUI PR" sounds like I am creating a PR on `kumahq/kuma-gui`


