### PR TITLE
chore: prevents unwanted click events firing

### DIFF
--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -119,7 +119,6 @@ function getRowAttributes(row: Row): Record<string, string> {
 
   return attributes
 }
-
 const click = (e: MouseEvent) => {
   const $tr = (e.target as HTMLElement).closest('tr')
   if ($tr) {
@@ -129,7 +128,8 @@ const click = (e: MouseEvent) => {
       }
       return prev
     }, null)
-    if ($a !== null && $a.closest('tr, li') === $tr) {
+    if ((window.getSelection()?.isCollapsed ?? true) && $a !== null && $a.closest('tr, li') === $tr) {
+      e.preventDefault()
       $a.click()
     }
   }

--- a/src/app/common/SummaryView.vue
+++ b/src/app/common/SummaryView.vue
@@ -32,7 +32,7 @@ onClickOutside(
   slideOutRef,
   useThrottleFn((event: PointerEvent) => {
     const $el = event.target as HTMLElement
-    if (event.isTrusted && $el.nodeName.toLowerCase() !== 'a') {
+    if ((window.getSelection()?.isCollapsed ?? true) && !event.defaultPrevented && event.isTrusted && $el.nodeName.toLowerCase() !== 'a') {
       emit('close')
     }
   }, 1, true, false),


### PR DESCRIPTION
This PR does two things related to unwanted "synthetic" click events happening in our table rows. Our table rows use a synthetic click event to simulate a HTML anchor click because we use tables for navigation lists and we are unable to wrap anchors around table rows (`<a />`s around `<tr />`s)

The fixes:

1. Our summary drawer has an `onClickOutside` event so that if its open and you click outside the drawer, it then closes. Thing is, if you click outside the drawer on a different table row, we don't want the drawer to close, but instead change to the summary of the row you have clicked. The `.preventDefault()` related code here prevents the drawer from closing if you click a different row.
2. Currently if you select a piece of text that is in a table row (probably in order to copy it to your clipboard), when you let go of your mouse to finish the selection, it immediately fires the mouseup of a click event, meaning you are then navigated elsewhere, which is incredibly frustrating and has probably led to people wanting more and more copy buttons. The `window.getSelection()` code here prevents the navigation happening if you are selecting text.