### PR TITLE
fix(onboarding): fixes empty state text and flakey onboarding test

### DIFF
--- a/features/onboarding/dataplanes-overview/Index.feature
+++ b/features/onboarding/dataplanes-overview/Index.feature
@@ -38,8 +38,15 @@ Feature: onboarding / dataplanes-overview / index
   Scenario: UI updates in response to Dataplanes not being offline anymore
     Given the environment
       """
-      KUMA_DATAPLANE_COUNT: 1
+      KUMA_DATAPLANE_COUNT: 0
       KUMA_DATAPLANEINBOUND_COUNT: 0
+      KUMA_SUBSCRIPTION_COUNT: 0
+      """
+    When I visit the "/onboarding/dataplanes-overview" URL
+    Then the "$state-waiting" element exists
+    Then the environment
+      """
+      KUMA_DATAPLANE_COUNT: 1
       KUMA_SUBSCRIPTION_COUNT: 1
       """
     And the URL "/dataplanes/_overview" responds with
@@ -52,8 +59,6 @@ Feature: onboarding / dataplanes-overview / index
                 - connectTime: 2021-02-17T07:33:36.412683Z
                   disconnectTime: 2021-02-17T07:33:36.412683Z
       """
-    When I visit the "/onboarding/dataplanes-overview" URL
-    Then the "$state-waiting" element exists
     And the "$dataplanes-table" element contains "dataplane-test"
     And the "$dataplanes-table" element contains "offline"
     When the URL "/dataplanes/_overview" responds with

--- a/src/app/onboarding/views/OnboardingDataplanesView.vue
+++ b/src/app/onboarding/views/OnboardingDataplanesView.vue
@@ -13,7 +13,7 @@
         v-slot="{ data, error }: DataplaneOverviewCollectionSource"
       >
         <template
-          v-for="offline in [(data?.items ?? []).some(item => item.status !== 'online')]"
+          v-for="offline in [data?.items.length === 0 || data?.items.some(item => item.status !== 'online')]"
           :key="offline"
         >
           <OnboardingPage>


### PR DESCRIPTION
We had a flakey onboarding e2e test, and when I started looking into it I saw another little issue, I fixed that in the end didn't seem related to the flake:

- I noticed that the even when the response was empty, the GUI would say `The following data plane proxies (DPPs) are connected to the control plane:` and show `0` instead of saying `Waiting for DPPs`. This was down to `.some` doing the opposite of what you expect when the array its acting on is empty. There is a small fix in the application code for this.
- I believe the flake was due to the test checking for the `$state-waiting` potentially after the initial request has responded/loaded, meaning it will never exist. As the request could respond either before or after the `$state-waiting` assertion, this causes the test to be flakey. I've changed the test to first always respond with zero dataplanes until we assert that `$state-waiting` exists, and then carry out the rest of the tests as we did before.