### PR TITLE
fix(deps): Tell dependabot to open more PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      open-pull-requests-limit: 50
     labels:
       - "dependencies"
 
@@ -11,5 +12,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      open-pull-requests-limit: 50
     labels:
       - "dependencies"


### PR DESCRIPTION
As this property is called a `-limit`, back in https://github.com/kumahq/kuma-gui/pull/2910 I removed this property, thinking it would that open infinite amounts of PRs (i.e. no limit).

Turns out this property has a default value of `5` meaning I actually reduced the amount of PRs dependabot could open, which is the opposite of what I wanted 😆 

This PR lets dependabot open up to 50 PRs for JS deps, seeing as its JS, we probably need a large figure here 😅 . I bumped the GH actions limit to use the same figure just for consistency really (we only use about 5 actions)