### PR TITLE
fix(deps): Fix wrongly nested dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,17 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
+    open-pull-requests-limit: 50
     directory: "/"
     schedule:
       interval: "weekly"
-      open-pull-requests-limit: 50
     labels:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 50
     directory: "/"
     schedule:
       interval: "weekly"
-      open-pull-requests-limit: 50
     labels:
       - "dependencies"


### PR DESCRIPTION
Wrong nesting 🤦 ...

Follow up to https://github.com/kumahq/kuma-gui/pull/3066

---

Could do with a linter here really, but preferably not one thats a JS dependency 🤔 