### PR TITLE
fix(.vitepress): typescript support

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -8,6 +8,7 @@ import matter from 'gray-matter'
 import { fileURLToPath, URL } from 'node:url'
 import path from 'node:path'
 import { defineConfig as viteConfig } from 'vite'
+// @ts-ignore TS comes with a Object.groupBy declaration but not a polyfill
 import groupBy from 'object.groupby'
 
 import { hoistUseStatements } from '../dev-utilities/hoistUseStatements'
@@ -104,7 +105,7 @@ export default defineConfig({
         return {
           collapsed: key !== 'Overview',
           text: key,
-          items: value.map(item => {
+          items: value?.map(item => {
             const items = get(`${path.dirname(item.path)}/*/**/README.md`)
             return {
               collapsed: true,
@@ -117,7 +118,7 @@ export default defineConfig({
                 }
               })
             }
-          })
+          }) ?? []
         }
       }),
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
   },
   "include": [
     "**/*.ts",
-    "**/*.vue"
+    "**/*.vue",
+    ".**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Adding dot-folders in tsconfig enables full ts support for files like `.vitepress/config.ts`