### PR TITLE
fix(ci): add creds to dependabots label editing

### DIFF
--- a/.github/workflows/on-dependabot-pr.yml
+++ b/.github/workflows/on-dependabot-pr.yml
@@ -21,6 +21,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Add a label for all production dependencies
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{github.event.pull_request.html_url}}
         if: steps.metadata.outputs.dependency-type == 'direct:production'
         run: gh pr edit "$PR_URL" --add-label "production"


### PR DESCRIPTION
Continuation of https://github.com/kumahq/kuma-gui/pull/2918

Without this PR we get the below error

![Screenshot 2024-10-22 at 10 01 11](https://github.com/user-attachments/assets/81a7a3f5-249b-4eb2-9ed5-eb87b483fb85)
