### PR TITLE
fix(mocks): re-add zone HTTP endpoint

### DIFF
--- a/src/test-support/mocks/fs.ts
+++ b/src/test-support/mocks/fs.ts
@@ -87,6 +87,7 @@ import _151 from './src/zoneingresses/_/clusters'
 import _150 from './src/zoneingresses/_/stats'
 import _148 from './src/zoneingresses/_/xds'
 import _8 from './src/zones'
+import _50 from './src/zones/_'
 import _12 from './src/zones/_/_overview'
 import _11 from './src/zones/_overview'
 import type { FS } from '@/test-support'
@@ -122,6 +123,7 @@ export const fs: FS = {
   // zones
   '/zones': _8,
   '/zones/_overview': _11,
+  '/zones/:name': _50,
   '/zones/:name/_overview': _12,
   '/zone-ingresses/_overview': _9,
   '/zone-ingresses/:name/_overview': _48,

--- a/src/test-support/mocks/src/zones/_.ts
+++ b/src/test-support/mocks/src/zones/_.ts
@@ -1,0 +1,22 @@
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+
+export default (_deps: EndpointDependencies): MockResponder => (req) => {
+  switch (req.method.toUpperCase()) {
+    case 'DELETE':
+      return {
+        headers: {},
+        body: {},
+      }
+    default:
+      return {
+        headers: {},
+        body: {
+          type: 'Zone',
+          name: req.params.name,
+          creationTime: '2021-02-19T08:06:15.380674+01:00',
+          modificationTime: '2021-02-19T08:06:15.380674+01:00',
+          enabled: true,
+        },
+      }
+  }
+}


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/3034 we cleaned up a few mock endpoints we don't use. We mistakenly removed the zone deletion endpoint, which we use elsewhere but the backend code for it is in the kuma binary and as such this mock belongs here.