### PR TITLE
fix(search): Always show search bars

### DIFF
--- a/src/app/application/components/app-collection/AppCollection.vue
+++ b/src/app/application/components/app-collection/AppCollection.vue
@@ -31,22 +31,12 @@
       :key="key"
       #[key]="{ row, rowValue }"
     >
-      <template
-        v-if="key === 'toolbar'"
-      >
-        <div class="app-collection-toolbar">
-          <slot name="toolbar" />
-        </div>
-      </template>
-
-      <template v-else>
-        <slot
-          v-if="(props.items ?? []).length > 0"
-          :name="key"
-          :row="row as Row"
-          :row-value="rowValue"
-        />
-      </template>
+      <slot
+        v-if="(props.items ?? []).length > 0"
+        :name="key"
+        :row="row as Row"
+        :row-value="rowValue"
+      />
     </template>
   </KTable>
 </template>
@@ -148,15 +138,6 @@ const click = (e: MouseEvent) => {
 }
 .app-collection :deep(td:first-child li a:hover) {
   text-decoration: underline;
-}
-.app-collection-toolbar {
-  display: flex;
-  justify-content: flex-end;
-  align-items: stretch;
-  flex-wrap: wrap;
-  gap: $kui-space-60;
-  font-size: $kui-font-size-40;
-  width: 100%;
 }
 </style>
 

--- a/src/app/common/filter-bar/FilterBar.vue
+++ b/src/app/common/filter-bar/FilterBar.vue
@@ -4,111 +4,109 @@
     class="filter-bar"
     data-testid="filter-bar"
   >
-    <search>
-      <form
-        ref="$form"
-        @submit.prevent="change"
+    <form
+      ref="$form"
+      @submit.prevent="change"
+    >
+      <button
+        class="focus-filter-input-button"
+        title="Focus filter"
+        type="button"
+        data-testid="filter-bar-focus-filter-input-button"
+        @click="focusFilterInput"
       >
-        <button
-          class="focus-filter-input-button"
-          title="Focus filter"
-          type="button"
-          data-testid="filter-bar-focus-filter-input-button"
-          @click="focusFilterInput"
-        >
-          <span class="visually-hidden">Focus filter</span>
+        <span class="visually-hidden">Focus filter</span>
 
-          <span class="filter-bar-icon">
-            <FilterIcon
-              decorative
-              data-testid="filter-bar-filter-icon"
-              hide-title
-              :size="KUI_ICON_SIZE_30"
-            />
-          </span>
-        </button>
+        <span class="filter-bar-icon">
+          <FilterIcon
+            decorative
+            data-testid="filter-bar-filter-icon"
+            hide-title
+            :size="KUI_ICON_SIZE_30"
+          />
+        </span>
+      </button>
 
-        <label
-          :for="`${props.id}-filter-bar-input`"
-          class="visually-hidden"
-        >
-          <slot>
-            {{ placeholderAndLabelFallback }}
-          </slot>
-        </label>
-        <input
-          :id="`${props.id}-filter-bar-input`"
-          ref="filterInput"
-          v-model="currentQuery"
-          class="filter-bar-input"
-          type="search"
-          :placeholder="currentPlaceholder"
-          data-testid="filter-bar-filter-input"
-          name="s"
-          @focus="isShowingSuggestionBox = true"
-          @input="isShowingSuggestionBox = true"
-          @blur="closeSuggestionBoxIfCondition"
-          @search="(e: InputEvent) => {
-            const $el = e.target as HTMLInputElement
-            if($el.value.length === 0) {
-              clear(e)
-              isShowingSuggestionBox = true
-            }
-          }"
-        >
+      <label
+        :for="`${props.id}-filter-bar-input`"
+        class="visually-hidden"
+      >
+        <slot>
+          {{ placeholderAndLabelFallback }}
+        </slot>
+      </label>
+      <input
+        :id="`${props.id}-filter-bar-input`"
+        ref="filterInput"
+        v-model="currentQuery"
+        class="filter-bar-input"
+        type="search"
+        :placeholder="currentPlaceholder"
+        data-testid="filter-bar-filter-input"
+        name="s"
+        @focus="isShowingSuggestionBox = true"
+        @input="isShowingSuggestionBox = true"
+        @blur="closeSuggestionBoxIfCondition"
+        @search="(e: InputEvent) => {
+          const $el = e.target as HTMLInputElement
+          if($el.value.length === 0) {
+            clear(e)
+            isShowingSuggestionBox = true
+          }
+        }"
+      >
 
-        <div
-          v-if="isShowingSuggestionBox"
-          class="suggestion-box"
-          data-testid="filter-bar-suggestion-box"
-        >
-          <div class="suggestion-list">
-            <p
-              v-if="tokenizerError !== null"
-              class="filter-bar-error"
-            >
-              {{ tokenizerError.message }}
-            </p>
+      <div
+        v-if="isShowingSuggestionBox"
+        class="suggestion-box"
+        data-testid="filter-bar-suggestion-box"
+      >
+        <div class="suggestion-list">
+          <p
+            v-if="tokenizerError !== null"
+            class="filter-bar-error"
+          >
+            {{ tokenizerError.message }}
+          </p>
+
+          <button
+            v-else
+            type="submit"
+            class="submit-query-button"
+            :class="{ 'submit-query-button-is-selected': selectedSuggestionItemIndex === 0 }"
+            data-testid="filter-bar-submit-query-button"
+          >
+            Submit {{ currentQuery }}
+          </button>
+
+          <div
+            v-for="(fieldEntry, index) in fieldEntries"
+            :key="`${props.id}-${index}`"
+            class="suggestion-list-item"
+            :class="{ 'suggestion-list-item-is-selected': selectedSuggestionItemIndex === index + 1 }"
+          >
+            <b>{{ fieldEntry.fieldName }}</b><span v-if="fieldEntry.description !== ''">: {{ fieldEntry.description }}</span>
 
             <button
-              v-else
-              type="submit"
-              class="submit-query-button"
-              :class="{ 'submit-query-button-is-selected': selectedSuggestionItemIndex === 0 }"
-              data-testid="filter-bar-submit-query-button"
+              class="apply-suggestion-button"
+              :title="`Add ${fieldEntry.fieldName}:`"
+              type="button"
+              :data-filter-field="fieldEntry.fieldName"
+              data-testid="filter-bar-apply-suggestion-button"
+              @click="applySuggestion"
             >
-              Submit {{ currentQuery }}
+              <span class="visually-hidden">Add {{ fieldEntry.fieldName }}:</span>
+
+              <ChevronRightIcon
+                decorative
+                hide-title
+                :size="KUI_ICON_SIZE_30"
+              />
             </button>
-
-            <div
-              v-for="(fieldEntry, index) in fieldEntries"
-              :key="`${props.id}-${index}`"
-              class="suggestion-list-item"
-              :class="{ 'suggestion-list-item-is-selected': selectedSuggestionItemIndex === index + 1 }"
-            >
-              <b>{{ fieldEntry.fieldName }}</b><span v-if="fieldEntry.description !== ''">: {{ fieldEntry.description }}</span>
-
-              <button
-                class="apply-suggestion-button"
-                :title="`Add ${fieldEntry.fieldName}:`"
-                type="button"
-                :data-filter-field="fieldEntry.fieldName"
-                data-testid="filter-bar-apply-suggestion-button"
-                @click="applySuggestion"
-              >
-                <span class="visually-hidden">Add {{ fieldEntry.fieldName }}:</span>
-
-                <ChevronRightIcon
-                  decorative
-                  hide-title
-                  :size="KUI_ICON_SIZE_30"
-                />
-              </button>
-            </div>
           </div>
         </div>
-      </form>
-    </search>
+      </div>
+    </form>
   </div>
 </template>
 

--- a/src/app/data-planes/views/DataPlaneListView.vue
+++ b/src/app/data-planes/views/DataPlaneListView.vue
@@ -20,6 +20,49 @@
     >
       <div v-html="t('data-planes.routes.items.intro', {}, { defaultMessage: '' })" />
       <KCard>
+        <search>
+          <FilterBar
+            class="data-plane-proxy-filter"
+            :placeholder="`service:backend`"
+            :query="route.params.s"
+            :fields="{
+              name: { description: 'filter by name or parts of a name' },
+              protocol: { description: 'filter by “kuma.io/protocol” value' },
+              service: { description: 'filter by “kuma.io/service” value' },
+              tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+              ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+            }"
+            @change="(e) => route.update({
+              ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+            })"
+          />
+
+          <XSelect
+            label="Type"
+            :selected="route.params.dataplaneType"
+            @change="(value: string) => route.update({ dataplaneType: value })"
+          >
+            <template #selected="{ item }: { item: 'all' | 'standard' | 'builtin' | 'delegated'}">
+              <XIcon
+                v-if="item !== 'all'"
+                :size="KUI_ICON_SIZE_40"
+                :name="item"
+              />
+              {{ t(`data-planes.type.${item}`) }}
+            </template>
+            <template
+              v-for="item in (['all', 'standard', 'builtin', 'delegated'] as const)"
+              :key="item"
+              #[`${item}-option`]
+            >
+              <XIcon
+                v-if="item !== 'all'"
+                :name="item"
+              />
+              {{ t(`data-planes.type.${item}`) }}
+            </template>
+          </XSelect>
+        </search>
         <DataLoader
           :src="uri(sources, `/meshes/:mesh/dataplanes/of/:type`, {
             mesh: route.params.mesh,
@@ -59,50 +102,6 @@
                 :is-selected-row="(row) => row.name === route.params.dataPlane"
                 @resize="me.set"
               >
-                <template #toolbar>
-                  <FilterBar
-                    class="data-plane-proxy-filter"
-                    :placeholder="`service:backend`"
-                    :query="route.params.s"
-                    :fields="{
-                      name: { description: 'filter by name or parts of a name' },
-                      protocol: { description: 'filter by “kuma.io/protocol” value' },
-                      service: { description: 'filter by “kuma.io/service” value' },
-                      tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                      ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                    }"
-                    @change="(e) => route.update({
-                      ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                    })"
-                  />
-
-                  <XSelect
-                    label="Type"
-                    :selected="route.params.dataplaneType"
-                    @change="(value: string) => route.update({ dataplaneType: value })"
-                  >
-                    <template #selected="{ item }: { item: 'all' | 'standard' | 'builtin' | 'delegated'}">
-                      <XIcon
-                        v-if="item !== 'all'"
-                        :size="KUI_ICON_SIZE_40"
-                        :name="item"
-                      />
-                      {{ t(`data-planes.type.${item}`) }}
-                    </template>
-                    <template
-                      v-for="item in (['all', 'standard', 'builtin', 'delegated'] as const)"
-                      :key="item"
-                      #[`${item}-option`]
-                    >
-                      <XIcon
-                        v-if="item !== 'all'"
-                        :name="item"
-                      />
-                      {{ t(`data-planes.type.${item}`) }}
-                    </template>
-                  </XSelect>
-                </template>
-
                 <template #type="{ row: item }">
                   <XIcon :name="item.dataplaneType">
                     {{ t(`data-planes.type.${item.dataplaneType}`) }}
@@ -311,6 +310,15 @@ const props = defineProps<{
   text-decoration: none;
 }
 
+search {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: $kui-space-60;
+  margin-bottom: $kui-space-60;
+}
 .data-plane-proxy-filter {
   flex-basis: 310px;
   flex-grow: 1;

--- a/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -17,8 +17,27 @@
         :src="`/meshes/${route.params.mesh}/mesh-gateways/${route.params.gateway}`"
         v-slot="{ data: meshGateway, error }: MeshGatewaySource"
       >
-        <div class="stack">
+        <div
+          class="stack"
+        >
           <KCard>
+            <search>
+              <FilterBar
+                class="data-plane-proxy-filter"
+                :placeholder="`name:dataplane-name`"
+                :query="route.params.s"
+                :fields="{
+                  name: { description: 'filter by name or parts of a name' },
+                  protocol: { description: 'filter by “kuma.io/protocol” value' },
+                  service: { description: 'filter by “kuma.io/service” value' },
+                  tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                  ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+                }"
+                @change="(e) => route.update({
+                  ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                })"
+              />
+            </search>
             <DataLoader
               :src="meshGateway === undefined ? '' : `/meshes/${route.params.mesh}/dataplanes/for/service-insight/${meshGateway.selectors[0].match['kuma.io/service']}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
               :data="[meshGateway]"
@@ -51,24 +70,6 @@
                     :is-selected-row="(row) => row.name === route.params.dataPlane"
                     @resize="me.set"
                   >
-                    <template #toolbar>
-                      <FilterBar
-                        class="data-plane-proxy-filter"
-                        :placeholder="`name:dataplane-name`"
-                        :query="route.params.s"
-                        :fields="{
-                          name: { description: 'filter by name or parts of a name' },
-                          protocol: { description: 'filter by “kuma.io/protocol” value' },
-                          service: { description: 'filter by “kuma.io/service” value' },
-                          tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                          ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                        }"
-                        @change="(e) => route.update({
-                          ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                        })"
-                      />
-                    </template>
-
                     <template #namespace="{ row }">
                       {{ row.namespace }}
                     </template>
@@ -208,6 +209,15 @@ import type { DataplaneOverviewCollectionSource } from '@/app/data-planes/source
 </script>
 
 <style lang="scss" scoped>
+search {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: $kui-space-60;
+  margin-bottom: $kui-space-60;
+}
 .data-plane-proxy-filter {
   flex-basis: 350px;
   flex-grow: 1;

--- a/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -61,7 +61,25 @@
         <div>
           <h3>{{ t('delegated-gateways.detail.data_plane_proxies') }}</h3>
 
-          <KCard class="mt-4">
+          <KCard
+            class="mt-4"
+          >
+            <search>
+              <FilterBar
+                class="data-plane-proxy-filter"
+                :placeholder="`tag: 'kuma.io/protocol: http'`"
+                :query="route.params.s"
+                :fields="{
+                  name: { description: 'filter by name or parts of a name' },
+                  protocol: { description: 'filter by “kuma.io/protocol” value' },
+                  tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                  ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+                }"
+                @change="(e) => route.update({
+                  ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                })"
+              />
+            </search>
             <DataLoader
               :src="`/meshes/${route.params.mesh}/dataplanes/for/service-insight/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
             >
@@ -92,23 +110,6 @@
                     :is-selected-row="(row) => row.name === route.params.dataPlane"
                     @resize="me.set"
                   >
-                    <template #toolbar>
-                      <FilterBar
-                        class="data-plane-proxy-filter"
-                        :placeholder="`tag: 'kuma.io/protocol: http'`"
-                        :query="route.params.s"
-                        :fields="{
-                          name: { description: 'filter by name or parts of a name' },
-                          protocol: { description: 'filter by “kuma.io/protocol” value' },
-                          tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                          ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                        }"
-                        @change="(e) => route.update({
-                          ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                        })"
-                      />
-                    </template>
-
                     <template #name="{ row: item }">
                       <XAction
                         data-action
@@ -250,6 +251,15 @@ import type { ServiceInsightSource } from '@/app/services/sources'
 </script>
 
 <style lang="scss" scoped>
+search {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: $kui-space-60;
+  margin-bottom: $kui-space-60;
+}
 .data-plane-proxy-filter {
   flex-basis: 350px;
   flex-grow: 1;

--- a/src/app/policies/views/PolicyListView.vue
+++ b/src/app/policies/views/PolicyListView.vue
@@ -69,6 +69,22 @@
             </KCard>
 
             <KCard>
+              <search>
+                <form
+                  @submit.prevent
+                >
+                  <XInput
+                    placeholder="Filter by name..."
+                    type="search"
+                    appearance="search"
+                    :value="route.params.s"
+                    :debounce="1000"
+                    @change="(e) => route.update({
+                      s: e,
+                    })"
+                  />
+                </form>
+              </search>
               <DataLoader
                 :src="uri(sources, '/meshes/:mesh/policy-path/:path', {
                   mesh: route.params.mesh,
@@ -82,24 +98,6 @@
                 <template
                   #loadable="{ data }"
                 >
-                  <search
-                    v-if="(data?.items ?? { length: 0 }).length > 0 || (route.params.s.length > 0)"
-                  >
-                    <form
-                      @submit.prevent
-                    >
-                      <XInput
-                        placeholder="Filter by name..."
-                        type="search"
-                        appearance="search"
-                        :value="route.params.s"
-                        :debounce="1000"
-                        @change="(e) => route.update({
-                          s: e,
-                        })"
-                      />
-                    </form>
-                  </search>
                   <DataCollection
                     :items="data?.items ?? [undefined]"
                     :page="route.params.page"
@@ -302,6 +300,15 @@ header > div {
 header > h3 {
   margin-top: 0;
   float: left;
+}
+search form {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: $kui-space-60;
+  margin-bottom: $kui-space-60;
 }
 .app-collection:deep(:is(th, td):nth-child(1)) {
   padding-right: 0 !important;

--- a/src/app/services/views/MeshServiceDetailView.vue
+++ b/src/app/services/views/MeshServiceDetailView.vue
@@ -119,6 +119,21 @@
           <KCard
             class="mt-4"
           >
+            <search>
+              <FilterBar
+                class="data-plane-proxy-filter"
+                :placeholder="`name:dataplane-name`"
+                :query="route.params.s"
+                :fields="{
+                  name: { description: 'filter by name or parts of a name' },
+                  protocol: { description: 'filter by “kuma.io/protocol” value' },
+                  tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                }"
+                @change="(e) => route.update({
+                  ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                })"
+              />
+            </search>
             <DataLoader
               :src="uri(sources, '/meshes/:mesh/dataplanes/for/mesh-service/:tags', {
                 mesh: route.params.mesh,
@@ -161,22 +176,6 @@
                     :is-selected-row="(row) => row.name === route.params.dataPlane"
                     @resize="me.set"
                   >
-                    <template #toolbar>
-                      <FilterBar
-                        class="data-plane-proxy-filter"
-                        :placeholder="`name:dataplane-name`"
-                        :query="route.params.s"
-                        :fields="{
-                          name: { description: 'filter by name or parts of a name' },
-                          protocol: { description: 'filter by “kuma.io/protocol” value' },
-                          tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                        }"
-                        @change="(e) => route.update({
-                          ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                        })"
-                      />
-                    </template>
-
                     <template #name="{ row: item }">
                       <RouterLink
                         class="name-link"
@@ -321,6 +320,15 @@ const props = defineProps<{
 <style lang="scss" scoped>
 .ip span {
   font-size: $kui-font-size-30;
+}
+search {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: $kui-space-60;
+  margin-bottom: $kui-space-60;
 }
 .data-plane-proxy-filter {
   flex-basis: 350px;

--- a/src/app/services/views/ServiceDetailView.vue
+++ b/src/app/services/views/ServiceDetailView.vue
@@ -74,6 +74,22 @@
           <KCard
             class="mt-4"
           >
+            <search>
+              <FilterBar
+                class="data-plane-proxy-filter"
+                :placeholder="`name:dataplane-name`"
+                :query="route.params.s"
+                :fields="{
+                  name: { description: 'filter by name or parts of a name' },
+                  protocol: { description: 'filter by “kuma.io/protocol” value' },
+                  tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                  ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+                }"
+                @change="(e) => route.update({
+                  ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+                })"
+              />
+            </search>
             <DataLoader
               :src="uri(dataplaneSources, `/meshes/:mesh/dataplanes/for/service-insight/:service`, {
                 mesh: route.params.mesh,
@@ -111,23 +127,6 @@
                     :is-selected-row="(row) => row.name === route.params.dataPlane"
                     @resize="me.set"
                   >
-                    <template #toolbar>
-                      <FilterBar
-                        class="data-plane-proxy-filter"
-                        :placeholder="`name:dataplane-name`"
-                        :query="route.params.s"
-                        :fields="{
-                          name: { description: 'filter by name or parts of a name' },
-                          protocol: { description: 'filter by “kuma.io/protocol” value' },
-                          tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                          ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                        }"
-                        @change="(e) => route.update({
-                          ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                        })"
-                      />
-                    </template>
-
                     <template #name="{ row: item }">
                       <XAction
                         data-action
@@ -270,6 +269,15 @@ import { sources as dataplaneSources } from '@/app/data-planes/sources'
 </script>
 
 <style lang="scss" scoped>
+search {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: $kui-space-60;
+  margin-bottom: $kui-space-60;
+}
 .data-plane-proxy-filter {
   flex-basis: 350px;
   flex-grow: 1;

--- a/src/app/x/components/x-input/XInput.vue
+++ b/src/app/x/components/x-input/XInput.vue
@@ -1,7 +1,7 @@
 <template>
   <KInput
     :model-value="props.value"
-    @input="(e: string) => e.length === 0 ? emit('change', e) : change(e)"
+    @input="(e: string) => change(e)"
   >
     <template
       v-if="[


### PR DESCRIPTION
This PR hoists all search/toolbars out of AppCollection and the DataLoader/Collections to its own "standalone component". Meaning it is always visible, throughout loading/erroneous and empty states.

---

There is a little CSS repetition here, but I hope to add a XLayout component pretty soon which I hope will cover this at some point.

Note I also took the `<search>` out of `FilterBar` and used it at the "call site" instead, in some places the `search` should contains the `select` also.

Closes https://github.com/kumahq/kuma-gui/issues/2981