### PR TITLE
chore(services): remove mesh-service feature flag

### DIFF
--- a/src/app/services/features.ts
+++ b/src/app/services/features.ts
@@ -1,16 +1,8 @@
 import type { Features } from '@/app/application'
 import { runInDebug } from '@/app/application'
-import type Env from '@/app/application/services/env/Env'
 import { Mesh } from '@/app/meshes/data'
-export const features = (env: Env['var']): Features => {
+export const features = (): Features => {
   return {
-    'use meshservice': () => {
-      try {
-        return !!JSON.parse(env('KUMA_MESHSERVICE_ENABLED', 'true'))
-      } catch (e) {
-        return true
-      }
-    },
     'use service-insights': (_can, mesh: Mesh) => {
       runInDebug(() => {
         if (typeof mesh === 'undefined') {

--- a/src/app/services/routes.ts
+++ b/src/app/services/routes.ts
@@ -39,70 +39,65 @@ export const routes = (can: Can) => {
               },
             ],
           },
-          ...(can('use meshservice')
-            ? [
+          {
+            path: 'mesh-services/:service',
+            name: 'mesh-service-detail-tabs-view',
+            component: () => import('@/app/services/views/MeshServiceDetailTabsView.vue'),
+            children: [
               {
-                path: 'mesh-services/:service',
-                name: 'mesh-service-detail-tabs-view',
-                component: () => import('@/app/services/views/MeshServiceDetailTabsView.vue'),
+                path: 'overview',
+                name: 'mesh-service-detail-view',
+                component: () => import('@/app/services/views/MeshServiceDetailView.vue'),
                 children: [
                   {
-                    path: 'overview',
-                    name: 'mesh-service-detail-view',
-                    component: () => import('@/app/services/views/MeshServiceDetailView.vue'),
-                    children: [
-                      {
-                        path: ':dataPlane',
-                        name: 'mesh-service-data-plane-summary-view',
-                        component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
-                      },
-                    ],
-                  },
-                  {
-                    path: 'config',
-                    name: 'mesh-service-config-view',
-                    component: () => import('@/app/services/views/MeshServiceConfigView.vue'),
+                    path: ':dataPlane',
+                    name: 'mesh-service-data-plane-summary-view',
+                    component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
                   },
                 ],
               },
-              ...(can('use zones')
-                ? [
-                  {
-                    path: 'mesh-multi-zone-services/:service',
-                    name: 'mesh-multi-zone-service-detail-tabs-view',
-                    component: () => import('@/app/services/views/MeshMultiZoneServiceDetailTabsView.vue'),
-                    children: [
-                      {
-                        path: 'overview',
-                        name: 'mesh-multi-zone-service-detail-view',
-                        component: () => import('@/app/services/views/MeshMultiZoneServiceDetailView.vue'),
-                        children: [
-                          {
-                            path: ':dataPlane',
-                            name: 'mesh-multi-zone-service-data-plane-summary-view',
-                            component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ]
-                : []),
               {
-                path: 'mesh-external-services/:service',
-                name: 'mesh-external-service-detail-tabs-view',
-                component: () => import('@/app/services/views/MeshExternalServiceDetailTabsView.vue'),
+                path: 'config',
+                name: 'mesh-service-config-view',
+                component: () => import('@/app/services/views/MeshServiceConfigView.vue'),
+              },
+            ],
+          },
+          ...(can('use zones')
+            ? [
+              {
+                path: 'mesh-multi-zone-services/:service',
+                name: 'mesh-multi-zone-service-detail-tabs-view',
+                component: () => import('@/app/services/views/MeshMultiZoneServiceDetailTabsView.vue'),
                 children: [
                   {
                     path: 'overview',
-                    name: 'mesh-external-service-detail-view',
-                    component: () => import('@/app/services/views/MeshExternalServiceDetailView.vue'),
+                    name: 'mesh-multi-zone-service-detail-view',
+                    component: () => import('@/app/services/views/MeshMultiZoneServiceDetailView.vue'),
+                    children: [
+                      {
+                        path: ':dataPlane',
+                        name: 'mesh-multi-zone-service-data-plane-summary-view',
+                        component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
+                      },
+                    ],
                   },
                 ],
               },
             ]
             : []),
-
+          {
+            path: 'mesh-external-services/:service',
+            name: 'mesh-external-service-detail-tabs-view',
+            component: () => import('@/app/services/views/MeshExternalServiceDetailTabsView.vue'),
+            children: [
+              {
+                path: 'overview',
+                name: 'mesh-external-service-detail-view',
+                component: () => import('@/app/services/views/MeshExternalServiceDetailView.vue'),
+              },
+            ],
+          },
         ],
       },
     ]
@@ -126,50 +121,46 @@ export const routes = (can: Can) => {
               name: 'external-service-list-view',
               component: () => import('@/app/external-services/views/ExternalServiceListView.vue'),
             },
-            ...(can('use meshservice')
+            {
+              path: 'mesh-services',
+              name: 'mesh-service-list-view',
+              component: () => import('@/app/services/views/MeshServiceListView.vue'),
+              children: [
+                {
+                  path: ':service',
+                  name: 'mesh-service-summary-view',
+                  component: () => import('@/app/services/views/MeshServiceSummaryView.vue'),
+                },
+              ],
+            },
+            ...(can('use zones')
               ? [
                 {
-                  path: 'mesh-services',
-                  name: 'mesh-service-list-view',
-                  component: () => import('@/app/services/views/MeshServiceListView.vue'),
+                  path: 'mesh-multi-zone-services',
+                  name: 'mesh-multi-zone-service-list-view',
+                  component: () => import('@/app/services/views/MeshMultiZoneServiceListView.vue'),
                   children: [
                     {
                       path: ':service',
-                      name: 'mesh-service-summary-view',
-                      component: () => import('@/app/services/views/MeshServiceSummaryView.vue'),
-                    },
-                  ],
-                },
-                ...(can('use zones')
-                  ? [
-                    {
-                      path: 'mesh-multi-zone-services',
-                      name: 'mesh-multi-zone-service-list-view',
-                      component: () => import('@/app/services/views/MeshMultiZoneServiceListView.vue'),
-                      children: [
-                        {
-                          path: ':service',
-                          name: 'mesh-multi-zone-service-summary-view',
-                          component: () => import('@/app/services/views/MeshMultiZoneServiceSummaryView.vue'),
-                        },
-                      ],
-                    },
-                  ]
-                  : []),
-                {
-                  path: 'mesh-external-services',
-                  name: 'mesh-external-service-list-view',
-                  component: () => import('@/app/services/views/MeshExternalServiceListView.vue'),
-                  children: [
-                    {
-                      path: ':service',
-                      name: 'mesh-external-service-summary-view',
-                      component: () => import('@/app/services/views/MeshExternalServiceSummaryView.vue'),
+                      name: 'mesh-multi-zone-service-summary-view',
+                      component: () => import('@/app/services/views/MeshMultiZoneServiceSummaryView.vue'),
                     },
                   ],
                 },
               ]
               : []),
+            {
+              path: 'mesh-external-services',
+              name: 'mesh-external-service-list-view',
+              component: () => import('@/app/services/views/MeshExternalServiceListView.vue'),
+              children: [
+                {
+                  path: ':service',
+                  name: 'mesh-external-service-summary-view',
+                  component: () => import('@/app/services/views/MeshExternalServiceSummaryView.vue'),
+                },
+              ],
+            },
           ],
         },
       ]


### PR DESCRIPTION
During the development of our MeshService support we added a feature flag (defaulting to `true`) in case we needed to turn it off in a central place for any reason.

We no longer need this ability as we now always want MeshService support enabled.

This PR removes any usage of the feature flag plus the feature flag itself.

(Make sure you use the GH `Hide whitespace` toggle whilst viewing the diff, otherwise the change look much bigger than they actually are)
