### PR TITLE
chore: moves font-size declaration to apply everywhere

### DIFF
--- a/src/app/application/components/app-view/AppView.vue
+++ b/src/app/application/components/app-view/AppView.vue
@@ -187,6 +187,9 @@ onBeforeUnmount(() => {
 </style>
 
 <style lang="scss" scoped>
+.app-view {
+  font-size: $kui-font-size-30;
+}
 .app-view-title-bar {
   display: flex;
   align-items: center;

--- a/src/assets/styles/_base.scss
+++ b/src/assets/styles/_base.scss
@@ -24,7 +24,6 @@ body {
   color: $kui-color-text;
   font-family: $kui-font-family-text;
   font-weight: $kui-font-weight-regular;
-  font-size: $kui-font-size-30;
 }
 
 


### PR DESCRIPTION
Moves the declaration of `font-size: 14px` to somewhere in the code that means it will apply everywhere.