### PR TITLE
fix(msw): inconsistent package version in generated file

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.3.1'
+const PACKAGE_VERSION = '2.4.12'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()


### PR DESCRIPTION
When running `make install` from outdated or cleaned `node_modules` the `PACKAGE_VERSION` in `public/mockedServiceWorker.js` gets aligned with the version specified in `package.json`, which causes a diff.

