### PR TITLE
fix(ShortcutManager/normalizeKeyCode): code param can be undefined

### DIFF
--- a/src/app/common/filter-bar/ShortcutManager.ts
+++ b/src/app/common/filter-bar/ShortcutManager.ts
@@ -113,7 +113,11 @@ function triggerShortcuts<CommandKeyword extends string>(event: KeyboardEvent, k
   command.trigger(event)
 }
 
-function normalizeKeyCode(code: string): string {
+/**
+ * `code` can sometimes be undefined, e.g. when using input field autocomplete functionalities.
+ * @param {string|undefined} code - Default: empty string `''`
+ */
+function normalizeKeyCode(code: string | undefined = ''): string {
   // Returns relevant modifier keys as the empty string which is going to be filtered out.
   if (MODIFIER_KEY_CODES.includes(code)) {
     return ''


### PR DESCRIPTION
The `code` param for `normalizeKeyCode` can sometimes be `undefined`, e.g. when using browser input autocomplete functionalities.

Closes #2838 