### PR TITLE
feat(ServiceListTabsView): add explanatory sentences for service type views

### DIFF
--- a/src/app/services/locales/en-us/index.yaml
+++ b/src/app/services/locales/en-us/index.yaml
@@ -27,15 +27,15 @@ services:
         mesh-service-list-view:
           label: MeshService
           description: !!text/markdown |
-            A [MeshService](https://kuma.io/docs/latest/networking/meshservice/#meshservice) represents a destination for traffic from elsewhere in the mesh and can define several networking details. The behaviour of this resource depends on the zone type. 
+            A <a href="https://kuma.io/docs/latest/networking/meshservice/#meshservice" target="_blank">MeshService</a> represents a destination for traffic from elsewhere in the mesh and can define several networking details. The behaviour of this resource depends on the zone type. 
         mesh-multi-zone-service-list-view:
           label: MeshMultiZoneService
           description: !!text/markdown |
-            A [MeshMultiZoneService](https://kuma.io/docs/latest/networking/meshmultizoneservice/#meshmultizoneservice) represents a group of `MeshService` resources in a loadbalanced multizone deployment. `MeshService` resources that are deployed across several clusters can be grouped by a `MeshMultiZoneService`.
+            A <a href="https://kuma.io/docs/latest/networking/meshmultizoneservice/#meshmultizoneservice" target="_blank">MeshMultiZoneService</a> represents a group of `MeshService` resources in a loadbalanced multizone deployment. `MeshService` resources that are deployed across several clusters can be grouped by a `MeshMultiZoneService`.
         mesh-external-service-list-view:
           label: MeshExternalService
           description: !!text/markdown |
-            **Experimental**: A [MeshExternalService](https://kuma.io/docs/latest/networking/meshexternalservice/#meshexternalservice) is a policy that allows an application or microservice to interact with explicit destinations that are not part of the mesh.
+            **Experimental**: A <a href="https://kuma.io/docs/latest/networking/meshexternalservice/#meshexternalservice" target="_blank">MeshExternalService</a> is a policy that allows an application or microservice to interact with explicit destinations that are not part of the mesh.
         service-list-view:
           label: Internal
           description: !!text/markdown |
@@ -43,7 +43,7 @@ services:
         external-service-list-view:
           label: External
           description: !!text/markdown |
-            An [ExternalService](https://kuma.io/docs/latest/policies/external-services/#external-service) is a policy that allows an application or microservice to interact with other services that are not part of the mesh.
+            An <a href="https://kuma.io/docs/latest/policies/external-services/#external-service" target="_blank">ExternalService</a> is a policy that allows an application or microservice to interact with other services that are not part of the mesh.
   detail:
     config: YAML
     data_plane_proxies: Data Plane Proxies

--- a/src/app/services/locales/en-us/index.yaml
+++ b/src/app/services/locales/en-us/index.yaml
@@ -23,14 +23,27 @@ services:
       config: 'YAML'
     items:
       title: Services
-      intro: !!text/markdown |
-        A Service represents an application or microservice that is registered with the mesh and can be managed, monitored and secured through the mesh's policies.
       navigation:
-        mesh-service-list-view: MeshService
-        mesh-multi-zone-service-list-view: MeshMultiZoneService
-        mesh-external-service-list-view: MeshExternalService
-        service-list-view: Internal
-        external-service-list-view: External
+        mesh-service-list-view:
+          label: MeshService
+          description: !!text/markdown |
+            A [MeshService](https://kuma.io/docs/latest/networking/meshservice/#meshservice) represents a destination for traffic from elsewhere in the mesh and can define several networking details. The behaviour of this resource depends on the zone type. 
+        mesh-multi-zone-service-list-view:
+          label: MeshMultiZoneService
+          description: !!text/markdown |
+            A [MeshMultiZoneService](https://kuma.io/docs/latest/networking/meshmultizoneservice/#meshmultizoneservice) represents a group of `MeshService` resources in a loadbalanced multizone deployment. `MeshService` resources that are deployed across several clusters can be grouped by a `MeshMultiZoneService`.
+        mesh-external-service-list-view:
+          label: MeshExternalService
+          description: !!text/markdown |
+            **Experimental**: A [MeshExternalService](https://kuma.io/docs/latest/networking/meshexternalservice/#meshexternalservice) is a policy that allows an application or microservice to interact with explicit destinations that are not part of the mesh.
+        service-list-view:
+          label: Internal
+          description: !!text/markdown |
+            An `Internal` Service represents an application or microservice that is defined and registered with the mesh by using the `DataPlane` tag `kuma.io/service` and can be managed, monitored and secured through the mesh's policies.
+        external-service-list-view:
+          label: External
+          description: !!text/markdown |
+            An [ExternalService](https://kuma.io/docs/latest/policies/external-services/#external-service) is a policy that allows an application or microservice to interact with other services that are not part of the mesh.
   detail:
     config: YAML
     data_plane_proxies: Data Plane Proxies

--- a/src/app/services/locales/en-us/index.yaml
+++ b/src/app/services/locales/en-us/index.yaml
@@ -35,7 +35,7 @@ services:
         mesh-external-service-list-view:
           label: MeshExternalService
           description: !!text/markdown |
-            **Experimental**: A <a href="https://kuma.io/docs/latest/networking/meshexternalservice/#meshexternalservice" target="_blank">MeshExternalService</a> is a policy that allows an application or microservice to interact with explicit destinations that are not part of the mesh.
+            A <a href="https://kuma.io/docs/latest/networking/meshexternalservice/#meshexternalservice" target="_blank">MeshExternalService</a> is a policy that allows an application or microservice to interact with explicit destinations that are not part of the mesh.
         service-list-view:
           label: Internal
           description: !!text/markdown |

--- a/src/app/services/views/ServiceListTabsView.vue
+++ b/src/app/services/views/ServiceListTabsView.vue
@@ -9,33 +9,38 @@
     <div
       class="stack"
     >
-      <div v-html="t('services.routes.items.intro', {}, { defaultMessage: '' })" />
       <AppView>
         <template #actions>
-          <XActionGroup
-            :expanded="true"
-          >
-            <template
-              v-for="{ name } in route.children"
-              :key="name"
+          <div class="service-types-action-group">
+            <XActionGroup
+              :expanded="true"
             >
-              <XAction
-                v-if="!(!can('use service-insights', props.mesh) && ['service-list-view', 'external-service-list-view'].includes(name))"
-                :class="{
-                  'active': route.child()?.name === name,
-                }"
-                :to="{
-                  name,
-                  params: {
-                    mesh: route.params.mesh,
-                  },
-                }"
-                :data-testid="`${name}-sub-tab`"
+              <template
+                v-for="{ name } in route.children"
+                :key="name"
               >
-                {{ t(`services.routes.items.navigation.${name}`) }}
-              </XAction>
-            </template>
-          </XActionGroup>
+                <XAction
+                  v-if="!(!can('use service-insights', props.mesh) && ['service-list-view', 'external-service-list-view'].includes(name))"
+                  :class="{
+                    'active': route.child()?.name === name,
+                  }"
+                  :to="{
+                    name,
+                    params: {
+                      mesh: route.params.mesh,
+                    },
+                  }"
+                  :data-testid="`${name}-sub-tab`"
+                >
+                  {{ t(`services.routes.items.navigation.${name}.label`) }}
+                </XAction>
+              </template>
+            </XActionGroup>
+
+            <p
+              v-html="t(`services.routes.items.navigation.${route.child()?.name}.description`, {}, { defaultMessage: '' })"
+            />
+          </div>
         </template>
 
         <RouterView
@@ -68,3 +73,11 @@ watch(() => router.currentRoute.value.name, (val) => {
   }
 }, { immediate: true })
 </script>
+
+<style lang="scss" scoped>
+.service-types-action-group {
+  display: flex;
+  flex-flow: column nowrap;
+  width: min-content;
+}
+</style>

--- a/src/app/services/views/ServiceListTabsView.vue
+++ b/src/app/services/views/ServiceListTabsView.vue
@@ -11,37 +11,35 @@
     >
       <AppView>
         <template #actions>
-          <div class="service-types-action-group">
-            <XActionGroup
-              :expanded="true"
+          <XActionGroup
+            :expanded="true"
+          >
+            <template
+              v-for="{ name } in route.children"
+              :key="name"
             >
-              <template
-                v-for="{ name } in route.children"
-                :key="name"
+              <XAction
+                v-if="!(!can('use service-insights', props.mesh) && ['service-list-view', 'external-service-list-view'].includes(name))"
+                :class="{
+                  'active': route.child()?.name === name,
+                }"
+                :to="{
+                  name,
+                  params: {
+                    mesh: route.params.mesh,
+                  },
+                }"
+                :data-testid="`${name}-sub-tab`"
               >
-                <XAction
-                  v-if="!(!can('use service-insights', props.mesh) && ['service-list-view', 'external-service-list-view'].includes(name))"
-                  :class="{
-                    'active': route.child()?.name === name,
-                  }"
-                  :to="{
-                    name,
-                    params: {
-                      mesh: route.params.mesh,
-                    },
-                  }"
-                  :data-testid="`${name}-sub-tab`"
-                >
-                  {{ t(`services.routes.items.navigation.${name}.label`) }}
-                </XAction>
-              </template>
-            </XActionGroup>
-
-            <p
-              v-html="t(`services.routes.items.navigation.${route.child()?.name}.description`, {}, { defaultMessage: '' })"
-            />
-          </div>
+                {{ t(`services.routes.items.navigation.${name}.label`) }}
+              </XAction>
+            </template>
+          </XActionGroup>
         </template>
+
+        <div
+          v-html="t(`services.routes.items.navigation.${route.child()?.name}.description`, {}, { defaultMessage: '' })"
+        />
 
         <RouterView
           v-slot="{ Component }"
@@ -73,11 +71,3 @@ watch(() => router.currentRoute.value.name, (val) => {
   }
 }, { immediate: true })
 </script>
-
-<style lang="scss" scoped>
-.service-types-action-group {
-  display: flex;
-  flex-flow: column nowrap;
-  width: min-content;
-}
-</style>


### PR DESCRIPTION
Moved and rephrased the title of the `ServiceListTabView` to separate explanatory sentences for each service type. For most of the services I included a link to the docs.

<img width="1471" alt="Screenshot 2024-10-29 at 11 01 47" src="https://github.com/user-attachments/assets/5ab44f24-cfba-4f3a-ab73-f527338a6cd1">

Closes #2928 
