### PR TITLE
chore: replace sass @import with @use to reduce console warnings

### DIFF
--- a/vite.config.production.ts
+++ b/vite.config.production.ts
@@ -71,7 +71,7 @@ export const config: UserConfigFn = () => {
       preprocessorOptions: {
         scss: {
           additionalData: hoistUseStatements(`
-            @import "@kong/design-tokens/tokens/scss/variables";
+            @use "@kong/design-tokens/tokens/scss/variables" as *;
           `),
           api: 'modern-compiler',
         },


### PR DESCRIPTION
We use sass for our `@kong/design-tokens` support.

This applies another fix for a recent sass upgrade to prevent `@kong/design-tokens` related console warnings:

## Previous:

![Screenshot 2024-10-29 at 10 24 09](https://github.com/user-attachments/assets/c8fbe9b3-6250-48c3-a8a7-cf287293b555)

Note there are still some deprecation warnings due to our own usage of sass, but this gets rid of the majority of noise:

![Screenshot 2024-10-29 at 10 28 05](https://github.com/user-attachments/assets/895ba023-7733-4581-8d3a-3af5770a8a91)

Whilst we have to use sass in order to consume `@kong/design-tokens`, a the better fix for our own code is to get rid of sass usage entirely. So I hope/plan on doing that in a follow up PR relatively soon. (edit: I made a follow up issue https://github.com/kumahq/kuma-gui/issues/3123)
