### PR TITLE
fix(mocks): use generic partitionInto instead of healthStatus

### DIFF
--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -161,6 +161,7 @@ export class KumaModule {
 
   /**
    * Returns a random DPP (or gateway) status object with self-consistent values (i.e. total = online + partiallyDegraded + offline).
+   * @deprecated - please use partitionInto
    */
   healthStatus({ min = 0, max = 30, omitZeroValues = true }: { min?: number, max?: number, omitZeroValues?: boolean } = {}) {
     const total = this.faker.number.int({ min, max })

--- a/src/test-support/mocks/src/global-insight.ts
+++ b/src/test-support/mocks/src/global-insight.ts
@@ -23,9 +23,24 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (_req) =>
     },
     body: {
       dataplanes: {
-        gatewayBuiltin: fake.kuma.healthStatus({ max: gatewayBuiltinTotal, omitZeroValues: false }),
-        gatewayDelegated: fake.kuma.healthStatus({ max: gatewayDelegatedTotal, omitZeroValues: false }),
-        standard: fake.kuma.healthStatus({ max: dataplaneTotal, omitZeroValues: false }),
+        gatewayBuiltin: fake.kuma.partitionInto({
+          online: Number,
+          offline: Number,
+          partiallyDegraded: Number,
+          total: gatewayBuiltinTotal,
+        }, gatewayBuiltinTotal),
+        gatewayDelegated: fake.kuma.partitionInto({
+          online: Number,
+          offline: Number,
+          partiallyDegraded: Number,
+          total: gatewayDelegatedTotal,
+        }, gatewayDelegatedTotal),
+        standard: fake.kuma.partitionInto({
+          online: Number,
+          offline: Number,
+          partiallyDegraded: Number,
+          total: dataplaneTotal,
+        }, dataplaneTotal),
       },
       meshes: {
         total: meshTotal,


### PR DESCRIPTION
I've been looking into some of our test flakes and going through our e2e tests and finding a places that seem strange or are causing or could cause test flakes.

I found an issue here where when setting up a DATAPLANE_COUNT of `1`, you could randomly/occasionally get a value of `0` even though you've said "always give me `1`".

The detail is that the very specific `fake.kuma.healthStatus` method has an optional `min:` argument which defaults to `0`. Meaning if you use `fake.kuma.healthStatus` without setting the `min`, say for example you are trying to guarantee it always returns a total of `1` by using `fake.kuma.healthStatus({max: 1})`, it will actually give you either `0` or `1` because it returns a random between the `min:0` and `max:1`.

I've fixed the issue in the the mock where I found it by using the more generic `fake.kuma.partitionInto` instead. I didn't want to go through and remove all usage of the method right here in order to stay focussed on what I'm doing. But, I've also marked the `fake.kuma.healthStatus` as deprecated as we should always prefer to use the more generic `fake.kuma.partitionInto` instead. I'll make an issue to remove it entirely.


