### PR TITLE
feat(gateways/GatewayListTabsView): add explanatory sentences to gateway types

### DIFF
--- a/src/app/gateways/locales/en-us/index.yaml
+++ b/src/app/gateways/locales/en-us/index.yaml
@@ -5,8 +5,14 @@ gateways:
       intro: !!text/markdown |
         Gateways are specialized proxies that manage incoming and outgoing traffic between the service mesh and external clients or other networks, enabling secure and controlled access to services with the mesh.
       navigation:
-        builtin-gateway-list-view: Built-in
-        delegated-gateway-list-view: Delegated
+        builtin-gateway-list-view:
+          label: Built-in
+          description: !!text/markdown |
+            With a <a href="{KUMA_DOCS_URL}/guides/gateway-builtin/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">Built-in Gateway</a> it is possible to route external traffic into the service mesh (North/South). Further <a href="{KUMA_DOCS_URL}/using-mesh/managing-ingress-traffic/builtin/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">configuration</a> enables secure and controlled access to the mesh internal services.
+        delegated-gateway-list-view:
+          label: Delegated
+          description: !!text/markdown |
+            A <a href="{KUMA_DOCS_URL}/using-mesh/managing-ingress-traffic/delegated/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">Delegated Gateway</a> allows the integration of existing API gateway solutions into the mesh by adding an Envoy sidecar proxy to an existing Gateway. It then manages the traffic between the services inside the mesh and external clients (North/South).
 
 builtin-gateways:
   routes:

--- a/src/app/gateways/views/GatewayListTabsView.vue
+++ b/src/app/gateways/views/GatewayListTabsView.vue
@@ -11,7 +11,6 @@
       :title="t(`${route.child()?.name === 'builtin-gateway-list-view' ? 'builtin' : 'delegated'}-gateways.routes.items.title`)"
     />
     <div class="stack">
-      <div v-html="t('gateways.routes.items.intro', {}, { defaultMessage: '' })" />
       <AppView>
         <template #actions>
           <DataCollection
@@ -36,11 +35,15 @@
                 }"
                 :data-testid="`${name}-sub-tab`"
               >
-                {{ t(`gateways.routes.items.navigation.${name}`) }}
+                {{ t(`gateways.routes.items.navigation.${name}.label`) }}
               </XAction>
             </XActionGroup>
           </DataCollection>
         </template>
+
+        <div
+          v-html="t(`gateways.routes.items.navigation.${route.child()?.name}.description`, {}, { defaultMessage: '' })"
+        />
 
         <RouterView
           v-slot="{ Component}"


### PR DESCRIPTION
Follow up to #3119 

Brings back consistency between services and gateways by adding explanatory sentences to the gateway types and moving everything below the action group.

<img width="1470" alt="Screenshot 2024-10-29 at 15 49 05" src="https://github.com/user-attachments/assets/4e373c99-6f1e-4f76-87d8-7b6828679280">

