### PR TITLE
chore: clean up some .env file vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,3 @@
 VITE_VERSION_URL=https://kuma.io/latest_version
-VITE_NAMESPACE=Kuma
 VITE_KUMA_API_SERVER_URL=http://localhost:5681
 VITE_DOCS_BASE_URL=https://kuma.io/docs

--- a/cypress/services.ts
+++ b/cypress/services.ts
@@ -28,7 +28,6 @@ export const services = <T extends Record<string, Token>>(app: T): ServiceDefini
   [$.EnvVars, {
     constant: {
       KUMA_API_URL: Cypress.env('VITE_KUMA_API_SERVER_URL'),
-      KUMA_PRODUCT_NAME: Cypress.env('VITE_NAMESPACE'),
       KUMA_VERSION_URL: Cypress.env('VITE_VERSION_URL'),
       KUMA_DOCS_URL: Cypress.env('VITE_DOCS_BASE_URL'),
       KUMA_MOCK_API_ENABLED: Cypress.env('VITE_MOCK_API_ENABLED'),

--- a/src/app/application/services/env/Env.ts
+++ b/src/app/application/services/env/Env.ts
@@ -11,13 +11,9 @@ export type KumaHtmlVars = {
 }
 
 export type EnvArgs = {
-  KUMA_PRODUCT_NAME: string
   KUMA_VERSION_URL: string
   KUMA_DOCS_URL: string
   KUMA_MOCK_API_ENABLED: string
-  KUMA_MESHSERVICE_ENABLED: string
-  // @TODO(jc) pretty sure this can be removed now, along with its reference in env.spec
-  KUMA_ZONE_CREATION_FLOW: 'disabled' | 'enabled' | undefined
 }
 type EnvProps = {
   KUMA_VERSION: string

--- a/src/app/application/services/env/env.spec.ts
+++ b/src/app/application/services/env/env.spec.ts
@@ -29,19 +29,15 @@ describe('env', () => {
     }
     const env = new MockEnv(
       {
-        KUMA_PRODUCT_NAME: 'product',
         KUMA_VERSION_URL: 'http://version.fake',
         KUMA_DOCS_URL: 'http://docs.fake',
         KUMA_MOCK_API_ENABLED: 'false',
-        KUMA_ZONE_CREATION_FLOW: 'enabled',
-        KUMA_MESHSERVICE_ENABLED: 'true',
       },
     )
     expect(env.var('KUMA_DOCS_URL')).toBe('http://docs.fake/110.127.x')
     expect(env.var('KUMA_VERSION')).toBe('110.127.30')
     expect(env.var('KUMA_API_URL')).toBe('/somewhere/else')
     expect(env.var('KUMA_BASE_PATH')).toBe('/not/gui')
-    expect(env.var('KUMA_PRODUCT_NAME')).toBe('product')
   })
 
   test.each([

--- a/src/app/kuma/index.ts
+++ b/src/app/kuma/index.ts
@@ -25,7 +25,6 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [app.EnvVars, {
       constant: {
-        KUMA_PRODUCT_NAME: import.meta.env.VITE_NAMESPACE,
         KUMA_VERSION_URL: import.meta.env.VITE_VERSION_URL,
         KUMA_DOCS_URL: import.meta.env.VITE_DOCS_BASE_URL,
         KUMA_MOCK_API_ENABLED: import.meta.env.VITE_MOCK_API_ENABLED,

--- a/src/app/kuma/locales/en-us/index.yaml
+++ b/src/app/kuma/locales/en-us/index.yaml
@@ -1,6 +1,22 @@
 common:
-  not_applicable: N/A
-  matchingsearch: " matching that search"
+  product:
+    name: Kuma
+    utm_query_params: utm_source=Kuma&utm_medium=Kuma
+    href:
+      # version: https://kuma.io/latest_version
+      feedback: 'https://github.com/kumahq/kuma/issues/new/choose'
+      install: 'https://kuma.io/install/latest/?{KUMA_UTM_QUERY_PARAMS}'
+      docs:
+        # base: https://kuma.io/docs
+        index: '{KUMA_DOCS_URL}/?{KUMA_UTM_QUERY_PARAMS}'
+    environment:
+      universal: Universal
+      kubernetes: Kubernetes
+      unknown: '—'
+    mode:
+      standalone: Standalone
+      global: Multi-Zone
+      zone: Zone
   formats:
     integer: |
       { value, select,
@@ -13,22 +29,8 @@ common:
         undefined { Invalid Date }
         other { { value, date, datetime } }
       }
-  product:
-    name: Kuma
-    utm_query_params: utm_source=Kuma&utm_medium=Kuma
-    href:
-      docs:
-        index: '{KUMA_DOCS_URL}/?{KUMA_UTM_QUERY_PARAMS}'
-      feedback: 'https://github.com/kumahq/kuma/issues/new/choose'
-      install: 'https://kuma.io/install/latest/?{KUMA_UTM_QUERY_PARAMS}'
-    environment:
-      universal: Universal
-      kubernetes: Kubernetes
-      unknown: '—'
-    mode:
-      standalone: Standalone
-      global: Multi-Zone
-      zone: Zone
+  not_applicable: N/A
+  matchingsearch: " matching that search"
   warnings:
     CERT_EXPIRED: !!text/markdown |
       The certificate for this dataplane has expired

--- a/src/shims-env.d.ts
+++ b/src/shims-env.d.ts
@@ -1,6 +1,5 @@
 interface ImportMetaEnv {
   readonly VITE_VERSION_URL: string
-  readonly VITE_NAMESPACE: string
   readonly VITE_KUMA_API_SERVER_URL: string
   readonly VITE_DOCS_BASE_URL: string
 }


### PR DESCRIPTION
Since a long time ago we've had `.env` file support. The `.env` file used to be used for 2 things:

1. Changing several `env` vars at build-time (previous to having support for changing `env` vars at runtime via dev-time browser cookies)
2. Storing strings (sometimes test/copy, sometimes URLs) used throughout the application that we may need to change at build time (previous to having i18n support)

Since then, we added both support for setting env vars at runtime via cookies (removing the need to restart the dev server), and i18n support for storing maps of strings in a KV store mainly for localizing from "machine to human".

Both these additions completely remove the need for storing most of these values in an `.env` file so I've slowly been moving things to not use the `.env` file and then removing the env vars from `.env`.

This PR:

- Removes reference to `VITE_NAMESPACE`, we've used `t('common.product.name')` for quite a while now instead of this.
- Removes `KUMA_MESHSERVICE_ENABLED` we no longer use this.
- Removes `KUMA_ZONE_CREATION_FLOW` we no longer use this.

I also made some small amends to our `common.product` strings:

- I commented in `version` and `docs.base`. At some point I will uncomment and make the changes to also remove these from the env file.
- Moved the structure around slightly to put the `product` things at the very top of the file so they are visible at the top as soon as you open the file up.

