### PR TITLE
fix: bump/override cookie dependency to ^0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1050,6 +1050,15 @@
         "cookie": "^0.5.0"
       }
     },
+    "node_modules/@bundled-es-modules/cookie/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@bundled-es-modules/statuses": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
@@ -6164,15 +6173,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
-    },
-    "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/copy-anything": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "node": ">=20.9",
     "npm": "^10.0.0"
   },
+  "overrides": {
+    "@bundled-es-modules/cookie": {
+      "cookie": "^0.7.1"
+    }
+  },
   "dependencies": {
     "@kong-ui-public/i18n": "^2.2.6",
     "@kong/icons": "^1.14.1",


### PR DESCRIPTION
`cookie` less than `0.7.0` has a low dev time security issue.

I've waited a few days in the hope that this would be resolved upstream, but its seems like the package that includes the dependency have bumped the version (3 weeks ago) but not actually made a release 😭 

Not sure when the release will happen and filter down to us, so I've used an override for now to mirror the version they have used (but not released) in the upstream repo.

Hopefully this should resolve the notification we have about this.