### PR TITLE
fix: undo closed script node in index.html

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
         // works the same
         name: 'kuma-vitepress-gotemplate',
         transformIndexHtml: (template) => {
-          return template.replace('<div id="app"></div>', `<div id="app"></div><script type="application/json" id="kuma-config" />{{.}}</script>`)
+          return template.replace('<div id="app"></div>', `<div id="app"></div><script type="application/json" id="kuma-config">{{.}}</script>`)
         },
       },
       kumaIndexHtmlVars(),

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
       }
     }
   </style>
-  <script type="application/json" id="kuma-config" />{{.}}</script>
+  <script type="application/json" id="kuma-config">{{.}}</script>
 </head>
 
 <body>


### PR DESCRIPTION
"Damn you auto-complete" 👎 

---

Back in https://github.com/kumahq/kuma-gui/pull/3049 a closed node snuck in, I'm assuming via auto-complete nonsense. I wondered why this didn't break, but its down to browsers being very forgiving in a standard way.

All in all whilst its not broken functionally, its a fix in that its currently incorrect and not intentional.