### PR TITLE
feature(routing): adds route config walking, plus several walkers

### DIFF
--- a/src/app/application/components/route-view/README.md
+++ b/src/app/application/components/route-view/README.md
@@ -7,8 +7,9 @@ Our `RouteView` component should be used as the top-most component for **every
 routable `*View.vue` component**. Think of it as your `<html>` tag.
 
 ::: danger
-When using this you should specify the name of the route you are creating as
-the RouteView's `name` property. See `name="route-name"` in the below example.
+When using this you should use `$routeName` route component global for the name
+of the route you are creating as the RouteView's `name` property. See
+`:name="$routeName!"` in the below example.
 :::
 
 `RouteView` contains functionality for:
@@ -29,7 +30,7 @@ It generally looks something like this:
 
 ```vue
 <RouteView
-  name="route-name"
+  :name="$routeName!"
   :params="{
     define: ''
     route: ''
@@ -51,7 +52,7 @@ omits some things and adds functionality to others.
 
 ```vue
 <RouteView
-  name="route-name"
+  :name="$routeName!"
   :params="{
     mesh: ''
     service: ''
@@ -107,7 +108,7 @@ the page in-place anywhere in your `*View.vue` component.
 
 ```vue
 <RouteView
-  name="route-name"
+  :name="$routeName!"
 >
   <h1>
     <RouteTitle
@@ -124,7 +125,7 @@ disable this render you can use the `render` attribute:
 
 ```vue
 <RouteView
-  name="route-name"
+  :name="$routeName!"
 >
   <RouteTitle
     title="The title"
@@ -169,7 +170,7 @@ attributes such as `data-*`, you'll need to add that functionality to
 
 ```vue
 <RouteView
-  name="route-name"
+  :name="$routeName!"
   :attrs="{
     class: 'my-html-class',
   }"
@@ -202,7 +203,7 @@ the root HTML node.
 
 ```vue
 <RouteView
-  name="route-name"
+  :name="$routeName!"
   v-slot="{ route, t, env, uri, can, me }"
   ...
 >

--- a/src/app/application/index.ts
+++ b/src/app/application/index.ts
@@ -56,6 +56,9 @@ declare module 'vue' {
     RouteTitle: typeof RouteTitle
     I18nT: ReturnType<typeof i18nTComponent>
   }
+  interface ComponentCustomProperties {
+    $routeName?: string
+  }
 }
 
 const $ = {

--- a/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    name="subscription-summary-config-view"
+    :name="$routeName!"
     :params="{
       codeSearch: '',
       codeFilter: false,

--- a/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    name="subscription-summary-overview-view"
+    :name="$routeName!"
     v-slot="{ t }"
   >
     <AppView>

--- a/src/app/subscriptions/views/SubscriptionSummaryView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    name="subscription-summary-view"
+    :name="$routeName!"
     :params="{
       subscription: '',
     }"

--- a/src/app/vue/index.ts
+++ b/src/app/vue/index.ts
@@ -31,25 +31,26 @@ const $ = {
 // similar to navigationGuards. We'd then do this specific functionality in
 // `@app/application` as it relates to RouteView
 const addRouteName = (item: RouteRecordRaw, _parent?: RouteRecordRaw) => {
-  if (typeof item.component !== 'undefined' && typeof item.component === 'function') {
-    // @ts-ignore at this point item.component has to be a function because we checked it above
-    const component = item.component.bind(item)
-    item.component = async () => {
-      // we need to create a new instance of the component as import is
-      // natively cached we could re-cache this in a WeakMap if it becomes
-      // necessary (I don't think it will)
-      const cached = (await component()).default
-      const route = {
-        default: {
-          ...cached,
-          render: (...args: Record<string, unknown>[]) => {
-            args[0].$routeName = item.name
-            return cached.render(...args)
-          },
+  if (typeof item.component !== 'function') {
+    return
+  }
+  // @ts-ignore at this point item.component has to be a function because we checked it above
+  const component = item.component.bind(item)
+  item.component = async () => {
+    // we need to create a new instance of the component as import is
+    // natively cached we could re-cache this in a WeakMap if it becomes
+    // necessary (I don't think it will)
+    const cached = (await component()).default
+    const route = {
+      default: {
+        ...cached,
+        render: (...args: Record<string, unknown>[]) => {
+          args[0].$routeName = item.name
+          return cached.render(...args)
         },
-      }
-      return route
+      },
     }
+    return route
   }
 }
 const addModule = (item: RouteRecordRaw, parent?: RouteRecordRaw) => {

--- a/src/app/vue/index.ts
+++ b/src/app/vue/index.ts
@@ -26,6 +26,62 @@ const $ = {
   routesLabel: token<RouteRecordRaw[]>('vue.routes.label'),
   navigationGuards: token<NavigationGuard[]>('vue.routes.navigation.guards'),
 }
+
+// @TODO at some point we should expose this as an extendable thing
+// similar to navigationGuards. We'd then do this specific functionality in
+// `@app/application` as it relates to RouteView
+const addRouteName = (item: RouteRecordRaw, _parent?: RouteRecordRaw) => {
+  if (typeof item.component !== 'undefined' && typeof item.component === 'function') {
+    // @ts-ignore at this point item.component has to be a function because we checked it above
+    const component = item.component.bind(item)
+    item.component = async () => {
+      // we need to create a new instance of the component as import is
+      // natively cached we could re-cache this in a WeakMap if it becomes
+      // necessary (I don't think it will)
+      const cached = (await component()).default
+      const route = {
+        default: {
+          ...cached,
+          render: (...args: Record<string, unknown>[]) => {
+            args[0].$routeName = item.name
+            return cached.render(...args)
+          },
+        },
+      }
+      return route
+    }
+  }
+}
+const addModule = (item: RouteRecordRaw, parent?: RouteRecordRaw) => {
+  item.meta = {
+    ...(item.meta ?? {}),
+  }
+  if (typeof parent?.meta?.module !== 'undefined') {
+    item.meta.module = parent.meta.module
+  }
+}
+const addPath = (item: RouteRecordRaw, parent?: RouteRecordRaw) => {
+  item.meta = {
+    ...(item.meta ?? {}),
+  }
+  if (typeof parent?.meta?.path !== 'undefined') {
+    const path = String(parent.meta.path) ?? ''
+    item.meta.path = `${path}${path.length > 0 ? '.' : ''}${String(item.name)}`
+  }
+}
+function walkRoutes(routes: RouteRecordRaw[], parent?: RouteRecordRaw) {
+  routes.forEach((item) => {
+    // this is very specific to app/application
+    addModule(item, parent)
+    addPath(item, parent)
+    addRouteName(item, parent)
+    //
+    if (typeof item.children !== 'undefined') {
+      walkRoutes(item.children, item)
+    }
+  })
+  return routes
+}
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
     [$.app, {
@@ -60,11 +116,16 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ) => {
         const router = createRouter({
           history: createWebHistory(env('KUMA_BASE_PATH')),
-          routes: [{
-            path: '/',
-            name: 'app',
-            children: routes,
-          }],
+          routes: walkRoutes([
+            {
+              path: '/',
+              name: 'app',
+              meta: {
+                path: '',
+              },
+              children: routes,
+            },
+          ]),
         })
 
         guards.forEach((item) => {


### PR DESCRIPTION
This PR introduces the concept of "route config walkers" to our application.

These walkers allow us to decorate individual route configs in a centralized place. They purposefully mutate the config rather than return the a copy of the config. I've kept the code for this in one place for now, but once I'm totally sure of the API I'll probably re-shuffle things slightly to use our service container labels. I've added code comments/TODOs to this effect in the PR.

---

The walkers/decorators I added here:

### `$routeName`

Currently we have/use `<RouteView name="the-name-of-the-route">` i.e. we hard code the name of the route associated with this file into the RouteView's name. This means we can't then reuse, or 'mount', the same route component file at another URL and at the very least its error/typo prone having to write the thing in two places. I actually wanted to do something like this when I added `RouteView` orignally but my Vue chops weren't good enough to think of a way to do it 😅  

For example, in relation to https://github.com/kumahq/kuma-gui/issues/2921, I'd like to 'mount' the `subscription/` module in various places: `zones/`, `zone-ingresses/`, `zone-egresses/` and `data-planes/`. I can't hardcode in `zone-cps-subscription-summary-view` as the name for the route when its under zones, because that will be incorrect when I re-use it for say `zone-ingress-subscription-summary-view`. We need to know the name of the route dynamically.

`addRouteName` adds a dynamically assigned `$routeName` global var to every single route component template rendering context:

- whilst following vue pseudo-standard `$` prefixing for global vars
- whilst avoiding the need for the template author to configure a prop all the time (by using the global)
- I don't think there is a way via typescript to say "this var exists in a route component, but not in any other types of components" so even though this is always set for route components, I set it to possibly undefined so that its correct if someone accidentally thinks its available in non-route components. This also explains why I'm ok using `$routeName!` (with `!`) here. I want to make sure `:name` is required, but I'm totally sure that in a route component `$routeName` is set.

### meta.module

For quite a while now our application is split into several microservices/micro-frontends/modules (or whatever we want to call them). It would be handy sometimes to know the module that a route belongs to. For example in relation to https://github.com/kumahq/kuma-gui/issues/2430. We would eventually like to avoid having to type `t('name-of-the-module.name-of-the-route.title')` and just write `t('title')` from within route components. If `RouteView::t` knows which module and route it is in, we can avoid having to repeat the prefix/namespace 10s of times throughout the route component, hopefully making it less of a chore to use i18n for anything not super essential.

I would guess there might be other places where we would use this.

`addMeta` lets you add a `meta.module` to the very top route in a modules route configuration. This then flows down to every single child route in that module so we don't have to hardcode that ourselves. We add it once, and it flows down. Note: I haven't added any top-level `meta.module` for this to use as yet.

### meta.path

I also think it will be useful at some point to have a full path for a routing configuration as well as just the name.

`addPath` automatically compiles a `meta.path` on every single route config containing the full path of a route. For example a route called `zone-ingress-subscription-summary-view` would have a `meta.path` similar to `zone-cp-detail-view.zone-ingress-detail-view.zone-ingress-subscription-summary-view`.

I hope at some point we'll be able to reduce some more redundant namespacing in the future and expand on the concept of 'mounting' modules at several different places.

For example, instead of a name of `zone-ingress-subscription-summary-view` I could have a route path of `zone-cp.zone-ingress.subscription.summary`. I might also want to link to simply `.summary.config` (the `config` of whereever I'm mounted) instead of `zone-cp.zone-ingress.subscription.summary.config`

---

Lastly I only need `$routeName` right now for https://github.com/kumahq/kuma-gui/issues/2921. Both `meta.module` and `meta.path` are features for other further work, but it was useful to add several functions to check the API (for example I didn't realise at first I might need access to `parent: RouteRecordRaw`)



