### PR TITLE
chore: uses new subscriptions table/drawer layout for zoneIngress

### DIFF
--- a/features/zones/zone-cps/ingresses/item/Index.feature
+++ b/features/zones/zone-cps/ingresses/item/Index.feature
@@ -2,12 +2,15 @@ Feature: zones / ingresses / item
 
   Background:
     Given the CSS selectors
-      | Alias            | Selector                                       |
-      | detail-view      | [data-testid='zone-ingress-detail-view']       |
-      | config-view      | [data-testid='zone-ingress-config-view']       |
-      | detail-tabs-view | [data-testid='zone-ingress-detail-tabs-view']  |
-      | navigation       | [data-testid='zone-ingress-tabs'] ul           |
-      | config-tab       | [data-testid='zone-ingress-config-view-tab'] a |
+      | Alias         | Selector                                       |
+      | page          | [data-testid='zone-ingress-detail-tabs-view']  |
+      | header        | $page .app-view-title-bar                      |
+      | overview-view | [data-testid='zone-ingress-detail-view']       |
+      | config-view   | [data-testid='zone-ingress-config-view']       |
+      | subscriptions | [data-testid='app-collection'] tbody tr        |
+      | subscription  | $subscriptions:nth-child(1)                    |
+      | navigation    | [data-testid='zone-ingress-tabs'] ul           |
+      | config-tab    | [data-testid='zone-ingress-config-view-tab'] a |
     And the environment
       """
       KUMA_MODE: global
@@ -41,9 +44,8 @@ Feature: zones / ingresses / item
               disconnectTime: !!js/undefined
       """
     When I visit the "/zones/zone-cp-1/ingresses/item-1/overview" URL
-    Then the page title contains "item-1"
-    Then the "$detail-tabs-view" element contains "item-1"
-    Then the "$detail-view" element contains "166.197.238.26:20555"
-    Then the "$detail-view" element contains "Connected: Jul 28, 2020, 4:18 PM"
+    Then the "$header" element contains "item-1"
+    Then the "$overview-view" element contains "166.197.238.26:20555"
+    Then the "$subscription" element contains "Jul 28, 2020, 4:18 PM"
     When I click the "$config-tab" element
     Then the "$config-view" element contains "type: ZoneIngress"

--- a/src/app/application/components/route-view/README.md
+++ b/src/app/application/components/route-view/README.md
@@ -7,9 +7,8 @@ Our `RouteView` component should be used as the top-most component for **every
 routable `*View.vue` component**. Think of it as your `<html>` tag.
 
 ::: danger
-When using this you should use `$routeName` route component global for the name
-of the route you are creating as the RouteView's `name` property. See
-`:name="$routeName!"` in the below example.
+When using this you should specify the name of the route you are creating as
+the RouteView's `name` property. See `name="route-name"` in the below example.
 :::
 
 `RouteView` contains functionality for:
@@ -30,7 +29,7 @@ It generally looks something like this:
 
 ```vue
 <RouteView
-  :name="$routeName!"
+  name="route-name"
   :params="{
     define: ''
     route: ''
@@ -52,7 +51,7 @@ omits some things and adds functionality to others.
 
 ```vue
 <RouteView
-  :name="$routeName!"
+  name="route-name"
   :params="{
     mesh: ''
     service: ''
@@ -108,7 +107,7 @@ the page in-place anywhere in your `*View.vue` component.
 
 ```vue
 <RouteView
-  :name="$routeName!"
+  name="route-name"
 >
   <h1>
     <RouteTitle
@@ -125,7 +124,7 @@ disable this render you can use the `render` attribute:
 
 ```vue
 <RouteView
-  :name="$routeName!"
+  name="route-name"
 >
   <RouteTitle
     title="The title"
@@ -170,7 +169,7 @@ attributes such as `data-*`, you'll need to add that functionality to
 
 ```vue
 <RouteView
-  :name="$routeName!"
+  name="route-name"
   :attrs="{
     class: 'my-html-class',
   }"
@@ -203,7 +202,7 @@ the root HTML node.
 
 ```vue
 <RouteView
-  :name="$routeName!"
+  name="route-name"
   v-slot="{ route, t, env, uri, can, me }"
   ...
 >

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -198,9 +198,9 @@ watch(() => {
 }, { immediate: true })
 
 watch(() => props.name, () => {
-  if (props.name.startsWith('$routeName')) {
-    throw new Error('`$routeName` has been used for a name, please use `:name` not `name`')
-  }
+  // if (props.name.startsWith('$routeName')) {
+  //   throw new Error('`$routeName` has been used for a name, please use `:name` not `name`')
+  // }
   // we only want query params here
   const params = Object.entries(routeParams || {}).reduce((prev, [key, value]) => {
     if (typeof route.params[key] === 'undefined') {

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -198,9 +198,6 @@ watch(() => {
 }, { immediate: true })
 
 watch(() => props.name, () => {
-  if (typeof props.name === 'undefined' || props.name.startsWith('$routeName')) {
-    throw new Error('`$routeName` has been used for a name, please use `:name` not `name`')
-  }
   // we only want query params here
   const params = Object.entries(routeParams || {}).reduce((prev, [key, value]) => {
     if (typeof route.params[key] === 'undefined') {

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -198,9 +198,9 @@ watch(() => {
 }, { immediate: true })
 
 watch(() => props.name, () => {
-  // if (props.name.startsWith('$routeName')) {
-  //   throw new Error('`$routeName` has been used for a name, please use `:name` not `name`')
-  // }
+  if (typeof props.name === 'undefined' || props.name.startsWith('$routeName')) {
+    throw new Error('`$routeName` has been used for a name, please use `:name` not `name`')
+  }
   // we only want query params here
   const params = Object.entries(routeParams || {}).reduce((prev, [key, value]) => {
     if (typeof route.params[key] === 'undefined') {

--- a/src/app/application/components/route-view/RouteView.vue
+++ b/src/app/application/components/route-view/RouteView.vue
@@ -198,6 +198,9 @@ watch(() => {
 }, { immediate: true })
 
 watch(() => props.name, () => {
+  if (props.name.startsWith('$routeName')) {
+    throw new Error('`$routeName` has been used for a name, please use `:name` not `name`')
+  }
   // we only want query params here
   const params = Object.entries(routeParams || {}).reduce((prev, [key, value]) => {
     if (typeof route.params[key] === 'undefined') {

--- a/src/app/kuma/locales/en-us/index.yaml
+++ b/src/app/kuma/locales/en-us/index.yaml
@@ -94,10 +94,13 @@ http:
       tls: TLS
       mtls: mTLS
       mTLS: mTLS
+      id: ID
       globalInstanceId: Global instance ID
       controlPlaneInstanceId: CP instance ID
+      zoneInstanceId: Zone Leader Instance ID
       connectTime: Connected
       disconnectTime: Disconnected
+      version: Version
       cds: CDS
       eds: EDS
       lds: LDS

--- a/src/app/subscriptions/components/SubscriptionDetails.vue
+++ b/src/app/subscriptions/components/SubscriptionDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="stack">
     <XAlert
-      v-if="statuses.length === 0"
+      v-if="Object.keys(props.subscription.status.acknowledgements).length === 0"
       appearance="info"
     >
       <template #icon>
@@ -30,13 +30,13 @@
         </div>
 
         <div
-          v-for="(row, index) in statuses"
-          :key="index"
+          v-for="(row, prop) in props.subscription.status.acknowledgements"
+          :key="prop"
           class="row"
-          :data-testid="`subscription-status-${row.type}`"
+          :data-testid="`subscription-status-${prop}`"
         >
           <div class="type">
-            {{ t(`http.api.property.${row.type}`) }}
+            {{ t(`http.api.property.${prop}`) }}
           </div>
 
           <div>
@@ -50,16 +50,16 @@
 
 <script lang="ts" setup>
 import { PortalIcon } from '@kong/icons'
-import { PropType, computed } from 'vue'
+import { PropType } from 'vue'
 
+import type { Subscription } from '../data'
 import { useI18n } from '@/app/application'
-import type { DiscoveryServiceStats, DiscoverySubscription, KDSSubscription } from '@/types/index.d'
 
 const { t } = useI18n()
 
 const props = defineProps({
   subscription: {
-    type: Object as PropType<KDSSubscription | DiscoverySubscription>,
+    type: Object as PropType<Subscription>,
     required: true,
   },
 
@@ -67,39 +67,6 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-})
-
-type StatusRow = {
-  type: string
-  responsesSent: string
-  responsesAcknowledged: string
-  responsesRejected: string
-}
-
-const statuses = computed<StatusRow[]>(() => {
-  let status: Record<string, DiscoveryServiceStats>
-
-  if ('controlPlaneInstanceId' in props.subscription) {
-    const { lastUpdateTime, total, ...discoverySubscriptionStatus } = props.subscription.status
-    status = discoverySubscriptionStatus
-  } else {
-    status = props.subscription.status?.stat ?? {}
-  }
-
-  if (!status) {
-    return []
-  }
-
-  return Object.entries(status).map(([type, stat]) => {
-    const { responsesSent = '0', responsesAcknowledged = '0', responsesRejected = '0' } = stat
-
-    return {
-      type,
-      responsesSent,
-      responsesAcknowledged,
-      responsesRejected,
-    }
-  })
 })
 </script>
 

--- a/src/app/subscriptions/components/SubscriptionHeader.vue
+++ b/src/app/subscriptions/components/SubscriptionHeader.vue
@@ -39,14 +39,13 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 
+import type { Subscription } from '../data'
 import { useI18n } from '@/app/application'
-import type { DiscoverySubscription } from '@/app/subscriptions/data'
-import type { KDSSubscription } from '@/app/zones/data'
 
 const { t } = useI18n()
 
 const props = defineProps<{
-  subscription: KDSSubscription | DiscoverySubscription
+  subscription: Subscription
 }>()
 
 const zoneInstanceId = computed(() => 'zoneInstanceId' in props.subscription ? props.subscription.zoneInstanceId : null)

--- a/src/app/subscriptions/components/SubscriptionList.vue
+++ b/src/app/subscriptions/components/SubscriptionList.vue
@@ -28,12 +28,12 @@ import { computed } from 'vue'
 
 import SubscriptionDetails from './SubscriptionDetails.vue'
 import SubscriptionHeader from './SubscriptionHeader.vue'
+import type { Subscription } from '../data'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
-import type { DiscoverySubscription, KDSSubscription } from '@/types/index.d'
 
 const props = defineProps<{
-  subscriptions: Array<KDSSubscription | DiscoverySubscription>
+  subscriptions: Subscription[]
 }>()
 
 const reversedSubscriptions = computed(() => {

--- a/src/app/subscriptions/data/index.ts
+++ b/src/app/subscriptions/data/index.ts
@@ -36,17 +36,17 @@ export const Subscription = {
             ...acknowledgements.reduce((prev, prop) => {
               prev[prop] = prev[prop] ?? 0
               return prev
-            }, item.total as {
+            }, {} as {
               [key in (typeof acknowledgements)[number]]: number
             }),
           },
           acknowledgements: {
             ...Object.fromEntries(
-              Object.entries(stats).map(([key, value]) => {
+              Object.entries(stats).map(([key, _value]) => {
                 return [key, acknowledgements.reduce((prev, prop) => {
                   prev[prop] = prev[prop] ?? 0
                   return prev
-                }, value as {
+                }, {} as {
                   [key in (typeof acknowledgements)[number]]: number
                 })]
               }),

--- a/src/app/subscriptions/data/index.ts
+++ b/src/app/subscriptions/data/index.ts
@@ -26,15 +26,15 @@ export const Subscription = {
       $raw: item,
       ...item,
       status: ((item) => {
-        const { total, lastUpdateTime, stat, ...rest } = { stat: {}, ...item }
-        const stats = Object.keys(stat).length > 0 ? stat : rest
+        const { total = {}, lastUpdateTime, stat = {}, ...rest } = { stat: {}, ...item }
+        const stats: Record<string, Record<string, number>> = Object.keys(stat).length > 0 ? stat : rest
         return {
           ...item,
           // make sure we default to zero for all acknowledgement properties
           total: {
             ...total,
             ...acknowledgements.reduce((prev, prop) => {
-              prev[prop] = prev[prop] ?? 0
+              prev[prop] = total[prop] ?? 0
               return prev
             }, {} as {
               [key in (typeof acknowledgements)[number]]: number
@@ -42,9 +42,9 @@ export const Subscription = {
           },
           acknowledgements: {
             ...Object.fromEntries(
-              Object.entries(stats).map(([key, _value]) => {
+              Object.entries(stats).map(([key, value]) => {
                 return [key, acknowledgements.reduce((prev, prop) => {
-                  prev[prop] = prev[prop] ?? 0
+                  prev[prop] = value[prop] ?? 0
                   return prev
                 }, {} as {
                   [key in (typeof acknowledgements)[number]]: number

--- a/src/app/subscriptions/data/index.ts
+++ b/src/app/subscriptions/data/index.ts
@@ -10,6 +10,9 @@ const acknowledgements = [
   'responsesAcknowledged',
   'responsesRejected',
 ] as const
+type Acknowledgements = {
+  [key in (typeof acknowledgements)[number]]: number
+}
 
 export type Version = PartialVersion
 
@@ -36,9 +39,7 @@ export const Subscription = {
             ...acknowledgements.reduce((prev, prop) => {
               prev[prop] = total[prop] ?? 0
               return prev
-            }, {} as {
-              [key in (typeof acknowledgements)[number]]: number
-            }),
+            }, {} as Acknowledgements),
           },
           acknowledgements: {
             ...Object.fromEntries(
@@ -46,9 +47,7 @@ export const Subscription = {
                 return [key, acknowledgements.reduce((prev, prop) => {
                   prev[prop] = value[prop] ?? 0
                   return prev
-                }, {} as {
-                  [key in (typeof acknowledgements)[number]]: number
-                })]
+                }, {} as Acknowledgements)]
               }),
             ),
           },

--- a/src/app/subscriptions/locales/en-us/index.yaml
+++ b/src/app/subscriptions/locales/en-us/index.yaml
@@ -2,16 +2,12 @@ subscriptions:
   routes:
     item:
       navigation:
-        subscription-summary-overview-view: Overview
-        subscription-summary-config-view: YAML
+        zone-cp-subscription-summary-overview-view: Overview
+        zone-cp-subscription-summary-config-view: YAML
+        zone-ingress-subscription-summary-overview-view: Overview
+        zone-ingress-subscription-summary-config-view: YAML
       headers:
         config: Config
-        version: Version
-        connected: Connected
-        disconnected: Disconnected
         responses: Total Responses (sent/ack'ed)
-        zoneInstanceId: Zone Leader Instance ID
-        globalInstanceId: Global Instance ID
-        id: ID
         type: Type
         stat: Responses sent/ack'ed

--- a/src/app/subscriptions/routes.ts
+++ b/src/app/subscriptions/routes.ts
@@ -1,20 +1,20 @@
 import type { RouteRecordRaw } from 'vue-router'
-export const routes = (): RouteRecordRaw[] => {
+export const routes = (prefix: string): RouteRecordRaw[] => {
   return [
     {
       path: 'subscription/:subscription',
-      name: 'subscription-summary-view',
-      redirect: { name: 'subscription-summary-overview-view' },
+      name: `${prefix}-subscription-summary-view`,
+      redirect: { name: `${prefix}-subscription-summary-overview-view` },
       component: () => import('@/app/subscriptions/views/SubscriptionSummaryView.vue'),
       children: [
         {
           path: 'overview',
-          name: 'subscription-summary-overview-view',
+          name: `${prefix}-subscription-summary-overview-view`,
           component: () => import('@/app/subscriptions/views/SubscriptionSummaryOverviewView.vue'),
         },
         {
           path: 'config',
-          name: 'subscription-summary-config-view',
+          name: `${prefix}-subscription-summary-config-view`,
           component: () => import('@/app/subscriptions/views/SubscriptionSummaryConfigView.vue'),
         },
       ],

--- a/src/app/subscriptions/routes.ts
+++ b/src/app/subscriptions/routes.ts
@@ -5,16 +5,25 @@ export const routes = (prefix: string): RouteRecordRaw[] => {
       path: 'subscription/:subscription',
       name: `${prefix}-subscription-summary-view`,
       redirect: { name: `${prefix}-subscription-summary-overview-view` },
+      props: () => ({
+        routeName: `${prefix}-subscription-summary-view`,
+      }),
       component: () => import('@/app/subscriptions/views/SubscriptionSummaryView.vue'),
       children: [
         {
           path: 'overview',
           name: `${prefix}-subscription-summary-overview-view`,
+          props: () => ({
+            routeName: `${prefix}-subscription-summary-overview-view`,
+          }),
           component: () => import('@/app/subscriptions/views/SubscriptionSummaryOverviewView.vue'),
         },
         {
           path: 'config',
           name: `${prefix}-subscription-summary-config-view`,
+          props: () => ({
+            routeName: `${prefix}-subscription-summary-config-view`,
+          }),
           component: () => import('@/app/subscriptions/views/SubscriptionSummaryConfigView.vue'),
         },
       ],

--- a/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    :name="$routeName!"
+    :name="props.routeName"
     :params="{
       codeSearch: '',
       codeFilter: false,
@@ -29,5 +29,6 @@ import type { Subscription } from '../data'
 import { YAML } from '@/app/application'
 const props = defineProps<{
   data: Subscription
+  routeName: string
 }>()
 </script>

--- a/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryConfigView.vue
@@ -6,36 +6,28 @@
       codeFilter: false,
       codeRegExp: false,
     }"
-    v-slot="{ route, t }"
+    v-slot="{ route }"
   >
     <AppView>
-      <template #title>
-        <h2>
-          {{ t('subscriptions.routes.item.headers.config') }}
-        </h2>
-      </template>
-
-      <KCard>
-        <XCodeBlock
-          language="yaml"
-          :code="YAML.stringify(props.data)"
-          is-searchable
-          :query="route.params.codeSearch"
-          :is-filter-mode="route.params.codeFilter"
-          :is-reg-exp-mode="route.params.codeRegExp"
-          @query-change="route.update({ codeSearch: $event })"
-          @filter-mode-change="route.update({ codeFilter: $event })"
-          @reg-exp-mode-change="route.update({ codeRegExp: $event })"
-        />
-      </KCard>
+      <XCodeBlock
+        language="yaml"
+        :code="YAML.stringify(props.data.$raw)"
+        is-searchable
+        :query="route.params.codeSearch"
+        :is-filter-mode="route.params.codeFilter"
+        :is-reg-exp-mode="route.params.codeRegExp"
+        @query-change="route.update({ codeSearch: $event })"
+        @filter-mode-change="route.update({ codeFilter: $event })"
+        @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+      />
     </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
+import type { Subscription } from '../data'
 import { YAML } from '@/app/application'
-import type { KDSSubscription } from '@/app/zones/data'
 const props = defineProps<{
-  data: KDSSubscription
+  data: Subscription
 }>()
 </script>

--- a/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
@@ -11,7 +11,7 @@
           layout="horizontal"
         >
           <template #title>
-            {{ t('subscriptions.routes.item.headers.version') }}
+            {{ t('http.api.property.version') }}
           </template>
 
           <template #body>
@@ -26,7 +26,7 @@
           layout="horizontal"
         >
           <template #title>
-            {{ t('subscriptions.routes.item.headers.connected') }}
+            {{ t('http.api.property.connectTime') }}
           </template>
 
           <template #body>
@@ -38,7 +38,7 @@
           layout="horizontal"
         >
           <template #title>
-            {{ t('subscriptions.routes.item.headers.disconnected') }}
+            {{ t('http.api.property.disconnectTime') }}
           </template>
 
           <template #body>
@@ -60,35 +60,28 @@
             </template>
           </template>
         </DefinitionCard>
-        <DefinitionCard
-          v-if="props.data.zoneInstanceId"
-          layout="horizontal"
+        <template
+          v-for="prop in (['zoneInstanceId', 'globalInstanceId', 'controlPlaneInstanceId'] as const)"
+          :key="typeof prop"
         >
-          <template #title>
-            {{ t('subscriptions.routes.item.headers.zoneInstanceId') }}
-          </template>
+          <DefinitionCard
+            v-if="props.data[prop]"
+            layout="horizontal"
+          >
+            <template #title>
+              {{ t(`http.api.property.${prop}`) }}
+            </template>
 
-          <template #body>
-            {{ props.data.zoneInstanceId }}
-          </template>
-        </DefinitionCard>
-        <DefinitionCard
-          v-if="props.data.globalInstanceId"
-          layout="horizontal"
-        >
-          <template #title>
-            {{ t('subscriptions.routes.item.headers.globalInstanceId') }}
-          </template>
-
-          <template #body>
-            {{ props.data.globalInstanceId }}
-          </template>
-        </DefinitionCard>
+            <template #body>
+              {{ props.data[prop] }}
+            </template>
+          </DefinitionCard>
+        </template>
         <DefinitionCard
           layout="horizontal"
         >
           <template #title>
-            {{ t('subscriptions.routes.item.headers.id') }}
+            {{ t('http.api.property.id') }}
           </template>
 
           <template #body>
@@ -96,7 +89,18 @@
           </template>
         </DefinitionCard>
       </div>
+      <XAlert
+        v-if="Object.keys(props.data.status.acknowledgements).length === 0"
+        appearance="info"
+      >
+        <template #icon>
+          <PortalIcon />
+        </template>
+
+        {{ t('common.detail.subscriptions.no_stats', { id: props.data.id }) }}
+      </XAlert>
       <div
+        v-else
         class="mt-8 stack-with-borders"
       >
         <div>
@@ -117,14 +121,14 @@
           </template>
         </DefinitionCard>
         <template
-          v-for="[key, item] in Object.entries(props.data.status?.stat ?? {})"
+          v-for="[key, item] in Object.entries(props.data.status.acknowledgements ?? {})"
           :key="key"
         >
           <DefinitionCard
             layout="horizontal"
           >
             <template #title>
-              {{ key }}
+              {{ t(`http.api.property.${key}`) }}
             </template>
 
             <template #body>
@@ -138,10 +142,12 @@
 </template>
 
 <script lang="ts" setup>
+import { PortalIcon } from '@kong/icons'
+
+import type { Subscription } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
-import type { KDSSubscription } from '@/app/zones/data'
 
 const props = defineProps<{
-  data: KDSSubscription
+  data: Subscription
 }>()
 </script>

--- a/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryOverviewView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    :name="$routeName!"
+    :name="props.routeName"
     v-slot="{ t }"
   >
     <AppView>
@@ -149,5 +149,6 @@ import DefinitionCard from '@/app/common/DefinitionCard.vue'
 
 const props = defineProps<{
   data: Subscription
+  routeName: string
 }>()
 </script>

--- a/src/app/subscriptions/views/SubscriptionSummaryView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryView.vue
@@ -16,7 +16,7 @@
         <AppView>
           <template #title>
             <h2>
-              {{ item.zoneInstanceId ?? item.globalInstanceId }}
+              {{ item.zoneInstanceId ?? item.globalInstanceId ?? item.controlPlaneInstanceId }}
             </h2>
           </template>
           <XTabs
@@ -54,9 +54,9 @@
 </template>
 
 <script lang="ts" setup>
-import type { KDSSubscription } from '@/app/zones/data/'
+import type { Subscription } from '../data/'
 
 const props = defineProps<{
-  data: KDSSubscription[]
+  data: Subscription[]
 }>()
 </script>

--- a/src/app/subscriptions/views/SubscriptionSummaryView.vue
+++ b/src/app/subscriptions/views/SubscriptionSummaryView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    :name="$routeName!"
+    :name="props.routeName"
     :params="{
       subscription: '',
     }"
@@ -58,5 +58,6 @@ import type { Subscription } from '../data/'
 
 const props = defineProps<{
   data: Subscription[]
+  routeName: string
 }>()
 </script>

--- a/src/app/vue/index.ts
+++ b/src/app/vue/index.ts
@@ -30,45 +30,6 @@ const $ = {
 // @TODO at some point we should expose this as an extendable thing
 // similar to navigationGuards. We'd then do this specific functionality in
 // `@app/application` as it relates to RouteView
-const addRouteName = (item: RouteRecordRaw, _parent?: RouteRecordRaw) => {
-  if (typeof item.component !== 'function') {
-    return
-  }
-  // @ts-ignore at this point item.component has to be a function because we checked it above
-  const component = item.component.bind(item)
-  item.component = async () => {
-    // we need to create a new instance of the component as import is
-    // natively cached we could re-cache this in a WeakMap if it becomes
-    // necessary (I don't think it will)
-    const cached = (await component()).default
-    if (typeof cached.render === 'function') {
-      return {
-        default: {
-          ...cached,
-          render: (...args: Record<string, unknown>[]) => {
-            args[0].$routeName = item.name
-            return cached.render(...args)
-          },
-        },
-      }
-    } else if (typeof cached.setup === 'function') {
-      return {
-        default: {
-          ...cached,
-          setup: (...args: any[]) => {
-            const func = cached.setup(...args)
-            return (...args: Record<string, unknown>[]) => {
-              args[0].$routeName = item.name
-              return func(...args)
-            }
-          },
-        },
-      }
-
-    }
-    return cached
-  }
-}
 const addModule = (item: RouteRecordRaw, parent?: RouteRecordRaw) => {
   item.meta = {
     ...(item.meta ?? {}),
@@ -91,7 +52,6 @@ function walkRoutes(routes: RouteRecordRaw[], parent?: RouteRecordRaw) {
     // this is very specific to app/application
     addModule(item, parent)
     addPath(item, parent)
-    addRouteName(item, parent)
     //
     if (typeof item.children !== 'undefined') {
       walkRoutes(item.children, item)

--- a/src/app/zone-ingresses/routes.ts
+++ b/src/app/zone-ingresses/routes.ts
@@ -1,3 +1,4 @@
+import { routes as subscriptions } from '@/app/subscriptions/routes'
 import type { RouteRecordRaw } from 'vue-router'
 
 export const routes = (prefix = 'ingresses') => {
@@ -13,6 +14,7 @@ export const routes = (prefix = 'ingresses') => {
             path: 'overview',
             name: 'zone-ingress-detail-view',
             component: () => import('@/app/zone-ingresses/views/ZoneIngressDetailView.vue'),
+            children: subscriptions('zone-ingress'),
           },
           {
             path: 'services',

--- a/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    :name="$routeName!"
+    name="zone-ingress-detail-view"
     :params="{
       subscription: '',
       zoneIngress: '',

--- a/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -1,7 +1,11 @@
 <template>
   <RouteView
-    name="zone-ingress-detail-view"
-    v-slot="{ t }"
+    :name="$routeName!"
+    :params="{
+      subscription: '',
+      zoneIngress: '',
+    }"
+    v-slot="{ t, me, route }"
   >
     <AppView>
       <div
@@ -42,7 +46,7 @@
                 <template
                   v-if="props.data.zoneIngress.socketAddress.length > 0"
                 >
-                  <TextWithCopyButton
+                  <XCopyButton
                     :text="props.data.zoneIngress.socketAddress"
                   />
                 </template>
@@ -62,7 +66,7 @@
                 <template
                   v-if="props.data.zoneIngress.advertisedSocketAddress.length > 0"
                 >
-                  <TextWithCopyButton
+                  <XCopyButton
                     :text="props.data.zoneIngress.advertisedSocketAddress"
                   />
                 </template>
@@ -77,15 +81,85 @@
 
         <div
           v-if="props.data.zoneIngressInsight.subscriptions.length > 0"
-          data-testid="zone-ingress-subscriptions"
         >
           <h2>{{ t('zone-ingresses.routes.item.subscriptions.title') }}</h2>
-
-          <KCard class="mt-4">
-            <SubscriptionList
-              :subscriptions="props.data.zoneIngressInsight.subscriptions"
-            />
-          </KCard>
+          <AppCollection
+            :headers="[
+              { ...me.get('headers.instanceId'), label: t('http.api.property.instanceId'), key: 'instanceId' },
+              { ...me.get('headers.version'), label: t('http.api.property.version'), key: 'version' },
+              { ...me.get('headers.connected'), label: t('http.api.property.connected'), key: 'connected' },
+              { ...me.get('headers.disconnected'), label: t('http.api.property.disconnected'), key: 'disconnected' },
+              { ...me.get('headers.responses'), label: t('http.api.property.responses'), key: 'responses' },
+            ]"
+            :is-selected-row="item => item.id === route.params.subscription"
+            :items="props.data.zoneIngressInsight.subscriptions.map((_, i, arr) => arr[arr.length - (i + 1)])"
+            @resize="me.set"
+          >
+            <template
+              #instanceId="{ row: item }"
+            >
+              <XAction
+                data-action
+                :to="{
+                  name: 'zone-ingress-subscription-summary-view',
+                  params: {
+                    subscription: item.id,
+                  },
+                }"
+              >
+                {{ item.controlPlaneInstanceId }}
+              </XAction>
+            </template>
+            <template
+              #version="{ row: item }"
+            >
+              {{ item.version?.kumaDp?.version ?? '-' }}
+            </template>
+            <template
+              #connected="{ row: item }"
+            >
+              {{ t('common.formats.datetime', { value: Date.parse(item.connectTime ?? '') }) }}
+            </template>
+            <template
+              #disconnected="{ row: item }"
+            >
+              <template
+                v-if="item.disconnectTime"
+              >
+                {{ t('common.formats.datetime', { value: Date.parse(item.disconnectTime) }) }}
+              </template>
+            </template>
+            <template
+              #responses="{ row: item }"
+            >
+              <template
+                v-for="responses in [item.status?.total ?? {}]"
+              >
+                {{ responses.responsesSent }}/{{ responses.responsesAcknowledged }}
+              </template>
+            </template>
+          </AppCollection>
+          <RouterView
+            v-slot="{ Component }"
+          >
+            <SummaryView
+              v-if="route.child()"
+              width="670px"
+              @close="function () {
+                route.replace({
+                  name: 'zone-ingress-detail-view',
+                  params: {
+                    zoneIngress: route.params.zoneIngress,
+                  },
+                })
+              }"
+            >
+              <component
+                :is="Component"
+                :data="props.data.zoneIngressInsight.subscriptions"
+              />
+            </SummaryView>
+          </RouterView>
         </div>
       </div>
     </AppView>
@@ -94,10 +168,10 @@
 
 <script lang="ts" setup>
 import type { ZoneIngressOverview } from '../data'
+import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
-import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
-import SubscriptionList from '@/app/subscriptions/components/SubscriptionList.vue'
+import SummaryView from '@/app/common/SummaryView.vue'
 
 const props = defineProps<{
   data: ZoneIngressOverview

--- a/src/app/zones/routes.ts
+++ b/src/app/zones/routes.ts
@@ -35,7 +35,7 @@ export const routes = (
                       path: 'overview',
                       name: 'zone-cp-detail-view',
                       component: () => import('@/app/zones/views/ZoneDetailView.vue'),
-                      children: subscriptions(),
+                      children: subscriptions('zone-cp'),
                     },
                     {
                       path: 'config',

--- a/src/app/zones/views/ZoneDetailView.vue
+++ b/src/app/zones/views/ZoneDetailView.vue
@@ -124,7 +124,7 @@
                 <XAction
                   data-action
                   :to="{
-                    name: 'subscription-summary-view',
+                    name: 'zone-cp-subscription-summary-view',
                     params: {
                       subscription: item.id,
                     },

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -66,6 +66,7 @@ export class KumaModule {
   }
 
   // TODO(jc): Use `totalName: Number.MAX_VALUE` so we can set a 'total' property automatically
+  // TODO(jc): Would be good to make this work deeply `{cds: { responses: Number }}` etc
   /**
    * Returns an object with the specified properties with the values as a random 'partition' of `total`
    */

--- a/src/test-support/mocks/src/zone-ingresses/_/_overview.ts
+++ b/src/test-support/mocks/src/zone-ingresses/_/_overview.ts
@@ -4,8 +4,13 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
 
   const parts = String(name).split('.')
-  const displayName = parts.slice(0, -1).join('.')
-  const nspace = parts.pop()
+  let displayName = parts.slice(0, -1).join('.')
+  let nspace = parts.pop()
+
+  if (displayName.length === 0) {
+    displayName = String(nspace)
+    nspace = ''
+  }
 
   const zoneName = fake.hacker.noun()
 

--- a/src/test-support/mocks/src/zone-ingresses/_/_overview.ts
+++ b/src/test-support/mocks/src/zone-ingresses/_/_overview.ts
@@ -57,27 +57,41 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
                 id: fake.string.uuid(),
                 controlPlaneInstanceId: fake.hacker.noun(),
                 ...fake.kuma.connection(item, i, arr),
-                generation: 409,
-                status: {
-                  lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-                  total: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  cds: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  eds: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  lds: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  rds: {},
-                },
+                generation: fake.number.int({ min: 1, max: 500 }),
+                status: (() => {
+                  const xcks = fake.number.int({ min: 100, max: 500 })
+                  const stats = Object.entries(fake.kuma.partitionInto(
+                    {
+                      cds: Number,
+                      eds: Number,
+                      lds: Number,
+                      rds: Number,
+                    }, xcks,
+                  ))
+                  return {
+                    lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                    total: fake.kuma.partitionInto(
+                      {
+                        responsesSent: xcks,
+                        responsesAcknowledged: Number,
+                        responsesRejected: Number,
+                      }, xcks,
+                    ),
+                    ...stats.reduce(
+                      (prev, [key, value]) => {
+                        prev[key] = fake.kuma.partitionInto(
+                          {
+                            responsesSent: value,
+                            responsesAcknowledged: Number,
+                            responsesRejected: Number,
+                          }, value,
+                        )
+                        return prev
+                      },
+                      {} as Record<string, {}>,
+                    ),
+                  }
+                })(),
                 version: {
                   kumaDp: {
                     version: '1.2.1',

--- a/src/test-support/mocks/src/zone-ingresses/_overview.ts
+++ b/src/test-support/mocks/src/zone-ingresses/_overview.ts
@@ -66,27 +66,41 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                     id: fake.string.uuid(),
                     controlPlaneInstanceId: fake.hacker.noun(),
                     ...fake.kuma.connection(item, i, arr),
-                    generation: 409,
-                    status: {
-                      lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
-                      total: {
-                        responsesSent: `${fake.number.int(30)}`,
-                        responsesAcknowledged: `${fake.number.int(30)}`,
-                      },
-                      cds: {
-                        responsesSent: `${fake.number.int(30)}`,
-                        responsesAcknowledged: `${fake.number.int(30)}`,
-                      },
-                      eds: {
-                        responsesSent: `${fake.number.int(30)}`,
-                        responsesAcknowledged: `${fake.number.int(30)}`,
-                      },
-                      lds: {
-                        responsesSent: `${fake.number.int(30)}`,
-                        responsesAcknowledged: `${fake.number.int(30)}`,
-                      },
-                      rds: {},
-                    },
+                    generation: fake.number.int({ min: 1, max: 500 }),
+                    status: (() => {
+                      const xcks = fake.number.int({ min: 100, max: 500 })
+                      const stats = Object.entries(fake.kuma.partitionInto(
+                        {
+                          cds: Number,
+                          eds: Number,
+                          lds: Number,
+                          rds: Number,
+                        }, xcks,
+                      ))
+                      return {
+                        lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                        total: fake.kuma.partitionInto(
+                          {
+                            responsesSent: xcks,
+                            responsesAcknowledged: Number,
+                            responsesRejected: Number,
+                          }, xcks,
+                        ),
+                        ...stats.reduce(
+                          (prev, [key, value]) => {
+                            prev[key] = fake.kuma.partitionInto(
+                              {
+                                responsesSent: value,
+                                responsesAcknowledged: Number,
+                                responsesRejected: Number,
+                              }, value,
+                            )
+                            return prev
+                          },
+                          {} as Record<string, {}>,
+                        ),
+                      }
+                    })(),
                     version: {
                       kumaDp: {
                         version: '1.2.1',

--- a/src/test-support/mocks/src/zones/_/_overview.ts
+++ b/src/test-support/mocks/src/zones/_/_overview.ts
@@ -46,71 +46,52 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
                 },
                 config: fake.kuma.subscriptionConfig(),
                 ...fake.kuma.connection(item, i, arr),
-                status: {
-                  lastUpdateTime: '2021-02-19T07:06:16.384057Z',
-                  total: {
-                    responsesSent: `${fake.number.int(30)}`,
-                    responsesAcknowledged: `${fake.number.int(30)}`,
-                  },
-                  stat: {
-                    CircuitBreaker: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
+                status: (() => {
+                  const xcks = fake.number.int({ min: 100, max: 500 })
+                  const stats = Object.entries(fake.kuma.partitionInto(
+                    {
+                      CircuitBreaker: Number,
+                      Config: Number,
+                      Mesh: Number,
+                      Secret: Number,
+                      Dataplane: Number,
+                      ExternalService: Number,
+                      FaultInjection: Number,
+                      HealthCheck: Number,
+                      ProxyTemplate: Number,
+                      Retry: Number,
+                      TrafficLog: Number,
+                      TrafficPermission: Number,
+                      TrafficRoute: Number,
+                      TrafficTrace: Number,
+                    }, xcks,
+                  ))
+                  return {
+                    lastUpdateTime: '2021-07-13T09:03:11.614941842Z',
+                    total: fake.kuma.partitionInto(
+                      {
+                        responsesSent: xcks,
+                        responsesAcknowledged: Number,
+                        responsesRejected: Number,
+                      }, xcks,
+                    ),
+                    stat: {
+                      ...stats.reduce(
+                        (prev, [key, value]) => {
+                          prev[key] = fake.kuma.partitionInto(
+                            {
+                              responsesSent: value,
+                              responsesAcknowledged: Number,
+                              responsesRejected: Number,
+                            }, value,
+                          )
+                          return prev
+                        },
+                        {} as Record<string, {}>,
+                      ),
                     },
-                    Config: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    Dataplane: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    ExternalService: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    FaultInjection: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    HealthCheck: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    Mesh: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    ProxyTemplate: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    Retry: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    Secret: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    TrafficLog: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    TrafficPermission: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    TrafficRoute: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                    TrafficTrace: {
-                      responsesSent: `${fake.number.int(30)}`,
-                      responsesAcknowledged: `${fake.number.int(30)}`,
-                    },
-                  },
-                },
+                  }
+                })(),
               }
             }),
           }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -105,29 +105,6 @@ export interface ToTargetRef<T extends string = string> {
   rules: ToTargetRefRule[]
 }
 
-export interface DiscoveryServiceStats {
-  responsesSent?: string
-  responsesAcknowledged?: string
-  responsesRejected?: string
-}
-
-export interface KDSSubscriptionStatus {
-  lastUpdateTime: string
-  total: DiscoveryServiceStats
-  stat: Record<string, DiscoveryServiceStats>
-}
-
-export interface KDSSubscription {
-  config: string
-  id: string
-  zoneInstanceId?: string
-  globalInstanceId?: string
-  connectTime: string
-  disconnectTime?: string
-  status: KDSSubscriptionStatus
-  version: any
-}
-
 export interface ZoneInsight {
   subscriptions: KDSSubscription[]
 }
@@ -238,33 +215,59 @@ export interface EnvoyVersion {
   build: string
   kumaDpCompatible?: boolean
 }
-
-export interface DiscoverySubscriptionStatus {
-  lastUpdateTime: string
-  total: DiscoveryServiceStats
-  cds: DiscoveryServiceStats
-  eds: DiscoveryServiceStats
-  lds: DiscoveryServiceStats
-  rds: DiscoveryServiceStats
-}
-
 export interface Version {
   kumaDp: KumaDpVersion
+  kumaCp?: KumaCpVersion
 
   envoy: EnvoyVersion
 
   dependencies: Record<string, string>
 }
 
-export interface DiscoverySubscription {
+export interface DiscoveryServiceStats {
+  responsesSent?: number
+  responsesAcknowledged?: number
+  responsesRejected?: number
+}
+
+export type SubscriptionStatus = {
+  lastUpdateTime: string
+  total: DiscoveryServiceStats
+}
+
+export type KDSSubscriptionStatus = {
+  stat: Record<string, DiscoveryServiceStats>
+} & SubscriptionStatus
+
+export type DiscoverySubscriptionStatus = {
+  cds: DiscoveryServiceStats
+  eds: DiscoveryServiceStats
+  lds: DiscoveryServiceStats
+  rds: DiscoveryServiceStats
+} & SubscriptionStatus
+
+export type Subscription = {
   id: string
-  controlPlaneInstanceId: string
   connectTime?: string
   disconnectTime?: string
-  status: DiscoverySubscriptionStatus
-  generation?: number
-  version?: Version
 }
+
+export type KDSSubscription = {
+  version: any
+
+  config: string
+  zoneInstanceId?: string
+  globalInstanceId?: string
+  status: KDSSubscriptionStatus
+} & Subscription
+
+export type DiscoverySubscription = {
+  version?: Version
+
+  controlPlaneInstanceId: string
+  generation?: number
+  status: DiscoverySubscriptionStatus
+} & Subscription
 
 export interface DataPlaneInsight {
   mTLS?: {


### PR DESCRIPTION
Adds new Subscription Table/Drawer UI to ZoneIngresses (whilst maintaining old-style for Egress and Dataplanes until we change those also)

Part of: https://github.com/kumahq/kuma-gui/issues/2921

---

~Lots of failing tests here, so keeping in draft until I've sorted that. I would guess it's probably chore-like updating of tests but we'll see!~

Turns out we can't use `addRouteName` from https://github.com/kumahq/kuma-gui/pull/3151 due to things being slightly different and weird between dev source and compiled/built source.

Instead I reverted to use route config `props` here, which was second favourite option. I plan to improve on this a little more, and if I ever figure out a more reliable way to add a dynamic global like `$routeName` I can add it at a later date. In the meantime I'd rather keep this table/drawers feature on track. Apologies for the noisy PR!

