### PR TITLE
fix: pr previews

### DIFF
--- a/vite.plugins.ts
+++ b/vite.plugins.ts
@@ -75,9 +75,19 @@ const server = (template: string = './index.html', vars: Partial<KumaHtmlVars> =
 
 }
 export const replicateKumaServer = (...args: Parameters<typeof server>): Plugin => {
-  return {
+  const plugin = {
     name: 'replicateKumaServer',
+    config: (_: unknown, { mode }: { mode: string }) => {
+      switch (mode) {
+        case 'preview': {
+          const { name, ...rest } = kumaIndexHtmlVars()
+          Object.assign(plugin, rest)
+          break
+        }
+      }
+    },
     configureServer: server(...args),
     configurePreviewServer: server(...args),
   }
+  return plugin
 }


### PR DESCRIPTION
Following https://github.com/kumahq/kuma-gui/pull/3049 I forgot that our PRs are ever so slightly different.

This PR applies a similar template interpolation to out index.html for a build **but only if build is called with `--mode preview`**

At some point I'd like to add some sort of browser runner test to just ping one page of the GUI on the PR preview to make sure its there and work to prevent this happening again. I'll make an issue - https://github.com/kumahq/kuma-gui/issues/3156