### PR TITLE
feat: introduce hostname-generators

### DIFF
--- a/features/hostname-generators/Index.feature
+++ b/features/hostname-generators/Index.feature
@@ -1,0 +1,47 @@
+Feature: hostname-generators / index
+
+  Background:
+    Given the CSS selectors
+      | Alias                      | Selector                                                   |
+      | items                      | [data-testid='hostname-generator-collection']              |
+      | item                       | $items tbody tr                                            |
+      | breadcrumbs                | .k-breadcrumbs                                             |
+      | summary-slideout-container | [data-testid='summary'] [data-testid='slideout-container'] |
+      | summary-title              | $summary-slideout-container [data-testid='slideout-title'] |
+
+  Scenario: Clicking a hostname generator action link and back again for <HostnameGenerator>
+    Given the URL "/hostnamegenerators" responds with
+      """
+      body:
+        items:
+          - name: local-mesh-external-service
+          - name: synced-kube-mesh-service
+      """
+    When I visit the "/hostname-generators" URL
+    When I click the "<Selector> [data-testid='x-action-group-control']" element
+    And I click the "<Selector> [data-testid='x-action-group'] li:nth-child(1) [data-testid='x-action']" element
+    Then the URL contains "/hostname-generators/<HostnameGenerator>/overview"
+    And the "$breadcrumbs" element contains "HostnameGenerators"
+    And I click the "$breadcrumbs > .breadcrumbs-item-container:nth-child(1) > a" element
+
+    Examples:
+      | HostnameGenerator           | Selector           |
+      | local-mesh-external-service | $item:nth-child(1) |
+      | synced-kube-mesh-service    | $item:nth-child(2) |
+
+  Scenario: Clicking a hostname generator
+    Given the URL "/hostnamegenerators" responds with
+      """
+      body:
+        items:
+          - name: local-mesh-external-service
+      """
+    When I visit the "/hostname-generators" URL
+    When I click the "<Selector> td:nth-child(1)" element
+    Then the URL contains "/hostname-generators/<HostnameGenerator>"
+    And the "$summary-slideout-container" element exists
+    And the "$summary-title" element contains "<HostnameGenerator>"
+
+    Examples:
+      | HostnameGenerator           | Selector           |
+      | local-mesh-external-service | $item:nth-child(1) |

--- a/features/hostname-generators/Item.feature
+++ b/features/hostname-generators/Item.feature
@@ -1,0 +1,21 @@
+Feature: hostname-generators / item
+
+  Background:
+    Given the CSS selectors
+      | Alias          | Selector                                                   |
+      | detail-view    | [data-testid='hostname-generator-detail-view']             |
+      | title-bar      | $detail-view .app-view-title-bar                           |
+
+  Scenario: Visiting the detail view of HostnameGenerator <HostnameGenerator>
+    Given the URL "/hostnamegenerators/<HostnameGenerator>" responds with
+      """
+      body:
+        name: <HostnameGenerator>
+      """ 
+    When I visit the "/hostname-generators/<HostnameGenerator>/overview" URL
+    Then the "$detail-view" element exists
+    And the "<Selector>" element contains "<HostnameGenerator>"
+
+    Examples:
+      | HostnameGenerator           | Selector   |
+      | local-mesh-external-service | $title-bar |

--- a/src/app/hostname-generators/data/HostnameGenerator.ts
+++ b/src/app/hostname-generators/data/HostnameGenerator.ts
@@ -1,0 +1,71 @@
+import type { components, paths } from '@/types/auto-generated'
+
+// TODO(schogges): Remove `creationTime` and `modificationTime` once the api specs are complete
+export type HostnameGeneratorList = Omit<components['responses']['HostnameGeneratorList']['content']['application/json'], 'items'> & {
+  items: NonNullable<components['responses']['HostnameGeneratorList']['content']['application/json']['items']>[number] & {
+    creationTime: string
+    modificationTime: string
+  } | undefined
+}
+export type HostnameGeneratorItem = components['responses']['HostnameGeneratorItem']['content']['application/json'] & {
+  creationTime: string
+  modificationTime: string
+}
+export type HostnameGeneratorGetParams = paths['/hostnamegenerators/{name}']['get']['parameters']
+
+export interface HostnameGenerator extends HostnameGeneratorItem {
+  id: string
+  namespace: string
+  zone: string
+  mesh: string
+  selector?: {
+    routeName: string
+    label: string
+  } | undefined
+  $raw: HostnameGeneratorItem
+}
+
+export const HostnameGenerator = {
+  fromObject(item: HostnameGeneratorItem) {
+    const labels = item.labels ?? {}
+    const name = labels['kuma.io/display-name'] ?? item.name
+    const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+    return {
+      ...item,
+      id: item.name,
+      name,
+      namespace,
+      zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
+      mesh: labels['kuma.io/mesh'] || 'default',
+      $raw: item,
+      selector: ((selector: string | undefined) => {
+        if (!selector) return undefined
+
+        let routeName = 'mesh-service-list-view'
+        switch (selector) {
+          case 'meshExternalService': {
+            routeName = 'mesh-external-service-list-view'
+            break
+          }
+          case 'meshMultiZoneService': {
+            routeName = 'mesh-multi-zone-service-list-view'
+          }
+        }
+
+        return {
+          routeName,
+          label: `${selector.charAt(0).toUpperCase()}${selector.slice(1, selector.length)}`,
+        }
+      })(Object.keys(item.spec.selector ?? {})?.[0]),
+    } satisfies HostnameGenerator
+  },
+
+  fromCollection(collection: HostnameGeneratorList) {
+    const items = Array.isArray(collection.items) ? collection.items.map(HostnameGenerator.fromObject) : []
+    return {
+      ...collection,
+      items,
+      total: collection.total ?? items.length,
+    }
+  },
+}

--- a/src/app/hostname-generators/data/HostnameGenerator.ts
+++ b/src/app/hostname-generators/data/HostnameGenerator.ts
@@ -1,26 +1,8 @@
 import type { components, paths } from '@/types/auto-generated'
 
-// TODO(schogges): Remove `creationTime` and `modificationTime` once the api specs are complete
-export type HostnameGeneratorList = Omit<components['responses']['HostnameGeneratorList']['content']['application/json'], 'items'> & {
-  items: NonNullable<components['responses']['HostnameGeneratorList']['content']['application/json']['items']>[number] & {
-    creationTime: string
-    modificationTime: string
-  } | undefined
-}
-export type HostnameGeneratorItem = components['responses']['HostnameGeneratorItem']['content']['application/json'] & {
-  creationTime: string
-  modificationTime: string
-}
+export type HostnameGeneratorList = components['responses']['HostnameGeneratorList']['content']['application/json']
+export type HostnameGeneratorItem = components['responses']['HostnameGeneratorItem']['content']['application/json']
 export type HostnameGeneratorGetParams = paths['/hostnamegenerators/{name}']['get']['parameters']
-
-export interface HostnameGenerator extends HostnameGeneratorItem {
-  id: string
-  namespace: string
-  zone: string
-  mesh: string
-  selector?: keyof NonNullable<HostnameGeneratorItem['spec']['selector']> | undefined
-  $raw: HostnameGeneratorItem
-}
 
 export const HostnameGenerator = {
   fromObject(item: HostnameGeneratorItem) {
@@ -34,10 +16,28 @@ export const HostnameGenerator = {
       name,
       namespace,
       zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
-      mesh: labels['kuma.io/mesh'] || 'default',
+      creationTime: item.creationTime ?? '',
+      modificationTime: item.modificationTime ?? '',
+      spec: ((item = {}) => {
+        return {
+          ...item,
+          selector: ((item = {}) => {
+            return {
+              meshService: {
+                matchLabels: item.meshService?.matchLabels ?? {},
+              },
+              meshExternalService: {
+                matchLabels: item.meshExternalService?.matchLabels ?? {},
+              },
+              meshMultiZoneService: {
+                matchLabels: item.meshMultiZoneService?.matchLabels ?? {},
+              },
+            }
+          })(item.selector),
+        }
+      })(item.spec),
       $raw: item,
-      selector: item.spec.selector ? Object.keys(item.spec.selector)[0] as keyof typeof item.spec.selector : undefined,
-    } satisfies HostnameGenerator
+    }
   },
 
   fromCollection(collection: HostnameGeneratorList) {
@@ -49,3 +49,5 @@ export const HostnameGenerator = {
     }
   },
 }
+
+export type HostnameGenerator = ReturnType<typeof HostnameGenerator.fromObject>

--- a/src/app/hostname-generators/data/HostnameGenerator.ts
+++ b/src/app/hostname-generators/data/HostnameGenerator.ts
@@ -18,10 +18,7 @@ export interface HostnameGenerator extends HostnameGeneratorItem {
   namespace: string
   zone: string
   mesh: string
-  selector?: {
-    routeName: string
-    label: string
-  } | undefined
+  selector?: keyof NonNullable<HostnameGeneratorItem['spec']['selector']> | undefined
   $raw: HostnameGeneratorItem
 }
 
@@ -30,6 +27,7 @@ export const HostnameGenerator = {
     const labels = item.labels ?? {}
     const name = labels['kuma.io/display-name'] ?? item.name
     const namespace = labels['k8s.kuma.io/namespace'] ?? ''
+
     return {
       ...item,
       id: item.name,
@@ -38,25 +36,7 @@ export const HostnameGenerator = {
       zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
       mesh: labels['kuma.io/mesh'] || 'default',
       $raw: item,
-      selector: ((selector: string | undefined) => {
-        if (!selector) return undefined
-
-        let routeName = 'mesh-service-list-view'
-        switch (selector) {
-          case 'meshExternalService': {
-            routeName = 'mesh-external-service-list-view'
-            break
-          }
-          case 'meshMultiZoneService': {
-            routeName = 'mesh-multi-zone-service-list-view'
-          }
-        }
-
-        return {
-          routeName,
-          label: `${selector.charAt(0).toUpperCase()}${selector.slice(1, selector.length)}`,
-        }
-      })(Object.keys(item.spec.selector ?? {})?.[0]),
+      selector: item.spec.selector ? Object.keys(item.spec.selector)[0] as keyof typeof item.spec.selector : undefined,
     } satisfies HostnameGenerator
   },
 

--- a/src/app/hostname-generators/data/index.spec.ts
+++ b/src/app/hostname-generators/data/index.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test as _test } from 'vitest'
+
+import { HostnameGenerator } from './HostnameGenerator'
+import { plugin, server } from '@/test-support/data'
+import mock from '@/test-support/mocks/src/hostname-generators/_/_overview'
+
+describe('HostnameGenerator', () => {
+  const test = _test.extend(plugin<typeof HostnameGenerator>(
+    HostnameGenerator,
+    server(mock, {
+      params: {
+        name: 'local-mesh-external-service',
+      },
+    }),
+  ))
+
+  describe('hostnameGenerator.$raw', () => {
+    test('$raw is the same as original API response', async ({ fixture }) => {
+      let expected
+      const actual = await fixture.setup((item) => {
+        expected = item
+        return item
+      })
+      expect(actual.$raw).toStrictEqual(expected)
+    })
+  })
+
+  describe('hostnameGenerator.id', () => {
+    test('id is hostnameGenerator.name', async ({ fixture }) => {
+      let expected
+      const actual = await fixture.setup((item) => {
+        expected = item.name
+        return item
+      })
+      expect(actual.id).toStrictEqual(expected)
+    })
+  })
+
+  describe('hostnameGenerator.name', () => {
+    test('name is hostnameGenerator.label.display-name', async ({ fixture }) => {
+      const response = await fixture.setup((item) => {
+        Object.assign(item, { labels: { 'kuma.io/display-name': 'foo' } })
+        return item
+      })
+      expect(response.name).toStrictEqual(response.labels?.['kuma.io/display-name'])
+    })
+    test('name has a fallback to name', async ({ fixture }) => {
+      const response = await fixture.setup((item) => {
+        delete item.labels?.['kuma.io/display-name']
+        return item
+      })
+      expect(response.name).toStrictEqual(response.name)
+    })
+  })
+
+  describe('hostnameGenerator.for', () => {
+    test('for is built from hostnameGenerator.spec.selector', async ({ fixture }) => {
+      const serviceType = 'meshService'
+      const response = await fixture.setup((item) => {
+        delete item.spec?.selector
+        Object.assign(item, { spec: { selector: { [serviceType]: {} } } })
+        return item
+      })
+      expect(response.selector).toStrictEqual({ routeName: 'mesh-service-list-view', label: 'MeshService' })
+    })
+  })
+
+  describe('hostnameGenerator.mesh', () => {
+    test('mesh is taken from labels', async ({ fixture }) => {
+      const mesh = 'foo'
+      const response = await fixture.setup((item) => {
+        Object.assign(item, { labels: { 'kuma.io/mesh': mesh } })
+        return item
+      })
+      expect(response.mesh).toStrictEqual(mesh)
+    })
+    test('mesh has a fallback to `default`', async ({ fixture }) => {
+      const response = await fixture.setup((item) => {
+        Object.assign(item, { labels: { 'kuma.io/mesh': '' } })
+        return item
+      })
+      expect(response.mesh).toStrictEqual('default')
+    })
+  })
+
+  describe('hostnameGenerator.zone', () => {
+    test('zone is set from labels when origin is zone', async ({ fixture }) => {
+      const zone = 'foo'
+      const response = await fixture.setup((item) => {
+        Object.assign(item, {
+          labels: {
+            'kuma.io/origin': 'zone',
+            'kuma.io/zone': zone,
+          },
+        })
+        return item
+      })
+      expect(response.zone).toStrictEqual(zone)
+    })
+  })
+
+  describe('hostnameGenerator.namespace', () => {
+    test('namespace is set from labels', async ({ fixture }) => {
+      const ns = 'foo'
+      const response = await fixture.setup((item) => {
+        Object.assign(item, { labels: { 'k8s.kuma.io/namespace': ns } })
+        return item
+      })
+      expect(response.namespace).toStrictEqual(ns)
+    })
+  })
+})

--- a/src/app/hostname-generators/data/index.spec.ts
+++ b/src/app/hostname-generators/data/index.spec.ts
@@ -53,18 +53,6 @@ describe('HostnameGenerator', () => {
     })
   })
 
-  describe('hostnameGenerator.for', () => {
-    test('for is built from hostnameGenerator.spec.selector', async ({ fixture }) => {
-      const serviceType = 'meshService'
-      const response = await fixture.setup((item) => {
-        delete item.spec?.selector
-        Object.assign(item, { spec: { selector: { [serviceType]: {} } } })
-        return item
-      })
-      expect(response.selector).toStrictEqual({ routeName: 'mesh-service-list-view', label: 'MeshService' })
-    })
-  })
-
   describe('hostnameGenerator.mesh', () => {
     test('mesh is taken from labels', async ({ fixture }) => {
       const mesh = 'foo'
@@ -116,27 +104,21 @@ describe('HostnameGenerator', () => {
         Object.assign(item, { spec: { selector: { meshService: {} } } })
         return item
       })
-      expect(response.selector).toStrictEqual({ routeName: 'mesh-service-list-view', label: 'MeshService' })
+      expect(response.selector).toStrictEqual('meshService')
     })
     test('selector is set from spec.selector meshExternalService key', async ({ fixture }) => {
       const response = await fixture.setup((item) => {
         Object.assign(item, { spec: { selector: { meshExternalService: {} } } })
         return item
       })
-      expect(response.selector).toStrictEqual({
-        routeName: 'mesh-external-service-list-view',
-        label: 'MeshExternalService',
-      })
+      expect(response.selector).toStrictEqual('meshExternalService')
     })
     test('selector is set from spec.selector meshMultiZoneService key', async ({ fixture }) => {
       const response = await fixture.setup((item) => {
         Object.assign(item, { spec: { selector: { meshMultiZoneService: {} } } })
         return item
       })
-      expect(response.selector).toStrictEqual({
-        routeName: 'mesh-multi-zone-service-list-view',
-        label: 'MeshMultiZoneService',
-      })
+      expect(response.selector).toStrictEqual('meshMultiZoneService')
     })
   })
 })

--- a/src/app/hostname-generators/data/index.spec.ts
+++ b/src/app/hostname-generators/data/index.spec.ts
@@ -53,21 +53,14 @@ describe('HostnameGenerator', () => {
     })
   })
 
-  describe('hostnameGenerator.mesh', () => {
-    test('mesh is taken from labels', async ({ fixture }) => {
-      const mesh = 'foo'
+  describe('hostnameGenerator.namespace', () => {
+    test('namespace is set from labels', async ({ fixture }) => {
+      const ns = 'foo'
       const response = await fixture.setup((item) => {
-        Object.assign(item, { labels: { 'kuma.io/mesh': mesh } })
+        Object.assign(item, { labels: { 'k8s.kuma.io/namespace': ns } })
         return item
       })
-      expect(response.mesh).toStrictEqual(mesh)
-    })
-    test('mesh has a fallback to `default`', async ({ fixture }) => {
-      const response = await fixture.setup((item) => {
-        Object.assign(item, { labels: { 'kuma.io/mesh': '' } })
-        return item
-      })
-      expect(response.mesh).toStrictEqual('default')
+      expect(response.namespace).toStrictEqual(ns)
     })
   })
 
@@ -84,41 +77,6 @@ describe('HostnameGenerator', () => {
         return item
       })
       expect(response.zone).toStrictEqual(zone)
-    })
-  })
-
-  describe('hostnameGenerator.namespace', () => {
-    test('namespace is set from labels', async ({ fixture }) => {
-      const ns = 'foo'
-      const response = await fixture.setup((item) => {
-        Object.assign(item, { labels: { 'k8s.kuma.io/namespace': ns } })
-        return item
-      })
-      expect(response.namespace).toStrictEqual(ns)
-    })
-  })
-
-  describe('hostnameGenerator.selector', () => {
-    test('selector is set from spec.selector meshService key', async ({ fixture }) => {
-      const response = await fixture.setup((item) => {
-        Object.assign(item, { spec: { selector: { meshService: {} } } })
-        return item
-      })
-      expect(response.selector).toStrictEqual('meshService')
-    })
-    test('selector is set from spec.selector meshExternalService key', async ({ fixture }) => {
-      const response = await fixture.setup((item) => {
-        Object.assign(item, { spec: { selector: { meshExternalService: {} } } })
-        return item
-      })
-      expect(response.selector).toStrictEqual('meshExternalService')
-    })
-    test('selector is set from spec.selector meshMultiZoneService key', async ({ fixture }) => {
-      const response = await fixture.setup((item) => {
-        Object.assign(item, { spec: { selector: { meshMultiZoneService: {} } } })
-        return item
-      })
-      expect(response.selector).toStrictEqual('meshMultiZoneService')
     })
   })
 })

--- a/src/app/hostname-generators/data/index.spec.ts
+++ b/src/app/hostname-generators/data/index.spec.ts
@@ -109,4 +109,34 @@ describe('HostnameGenerator', () => {
       expect(response.namespace).toStrictEqual(ns)
     })
   })
+
+  describe('hostnameGenerator.selector', () => {
+    test('selector is set from spec.selector meshService key', async ({ fixture }) => {
+      const response = await fixture.setup((item) => {
+        Object.assign(item, { spec: { selector: { meshService: {} } } })
+        return item
+      })
+      expect(response.selector).toStrictEqual({ routeName: 'mesh-service-list-view', label: 'MeshService' })
+    })
+    test('selector is set from spec.selector meshExternalService key', async ({ fixture }) => {
+      const response = await fixture.setup((item) => {
+        Object.assign(item, { spec: { selector: { meshExternalService: {} } } })
+        return item
+      })
+      expect(response.selector).toStrictEqual({
+        routeName: 'mesh-external-service-list-view',
+        label: 'MeshExternalService',
+      })
+    })
+    test('selector is set from spec.selector meshMultiZoneService key', async ({ fixture }) => {
+      const response = await fixture.setup((item) => {
+        Object.assign(item, { spec: { selector: { meshMultiZoneService: {} } } })
+        return item
+      })
+      expect(response.selector).toStrictEqual({
+        routeName: 'mesh-multi-zone-service-list-view',
+        label: 'MeshMultiZoneService',
+      })
+    })
+  })
 })

--- a/src/app/hostname-generators/data/index.ts
+++ b/src/app/hostname-generators/data/index.ts
@@ -1,0 +1,1 @@
+export * from './HostnameGenerator'

--- a/src/app/hostname-generators/index.ts
+++ b/src/app/hostname-generators/index.ts
@@ -1,0 +1,36 @@
+import locales from './locales/en-us/index.yaml'
+import { routes } from './routes'
+import { sources } from './sources'
+import type { ServiceDefinition } from '@/services/utils'
+import { token } from '@/services/utils'
+
+type Token = ReturnType<typeof token>
+
+export const services = (app: Record<string, Token>): ServiceDefinition[] => {
+  return [
+    [token('hostname-generators.sources'), {
+      service: sources,
+      arguments: [
+        app.api,
+      ],
+      labels: [
+        app.sources,
+      ],
+    }],
+    [token('hostname-generators.routes'), {
+      service: routes,
+      arguments: [
+        app.can,
+      ],
+      labels: [
+        app.routes,
+      ],
+    }],
+    [token('hostname-generators.locales'), {
+      service: () => locales,
+      labels: [
+        app.enUs,
+      ],
+    }],
+  ]
+}

--- a/src/app/hostname-generators/locales/en-us/index.yaml
+++ b/src/app/hostname-generators/locales/en-us/index.yaml
@@ -11,7 +11,6 @@ hostname-generators:
     name: Name
     namespace: Namespace
     zone: Zone
-    selector: Selector
     template: Template
     actions: Actions
   routes:
@@ -25,9 +24,5 @@ hostname-generators:
       breadcrumbs: HostnameGenerators
       intro: !!text/markdown |
         HostnameGenerators provide templates to generate hostnames from properties of different `MeshService` types.
-      collection:
-        services: 'Services'
-        dataplanes: 'Data Plane Proxies (online/total)'
-        
   href:
     docs: '{KUMA_DOCS_URL}/networking/hostnamegenerator?{KUMA_UTM_QUERY_PARAMS}'

--- a/src/app/hostname-generators/locales/en-us/index.yaml
+++ b/src/app/hostname-generators/locales/en-us/index.yaml
@@ -1,0 +1,33 @@
+hostname-generators:
+  x-empty-state:
+    title: 'No data'
+    body: !!text/markdown |
+      There are no HostnameGenerators present
+    action:
+      type: docs
+      label: Documentation
+      href: '{KUMA_DOCS_URL}/networking/hostnamegenerator?{KUMA_UTM_QUERY_PARAMS}'
+  common:
+    name: Name
+    namespace: Namespace
+    zone: Zone
+    selector: Selector
+    template: Template
+    actions: Actions
+  routes:
+    item:
+      title: "{name}"
+      subtitle: "{name} HostnameGenerator"
+      breadcrumbs: HostnameGenerators
+      config: YAML
+    items:
+      title: HostnameGenerators
+      breadcrumbs: HostnameGenerators
+      intro: !!text/markdown |
+        HostnameGenerators provide templates to generate hostnames from properties of different `MeshService` types.
+      collection:
+        services: 'Services'
+        dataplanes: 'Data Plane Proxies (online/total)'
+        
+  href:
+    docs: '{KUMA_DOCS_URL}/networking/hostnamegenerator?{KUMA_UTM_QUERY_PARAMS}'

--- a/src/app/hostname-generators/routes.ts
+++ b/src/app/hostname-generators/routes.ts
@@ -1,0 +1,37 @@
+import type { RouteRecordRaw } from 'vue-router'
+
+export type SplitRouteRecordRaw = {
+  items: () => RouteRecordRaw[]
+  item: () => RouteRecordRaw[]
+}
+
+export const routes = (
+): RouteRecordRaw[] => {
+  return [
+    {
+      path: '/hostname-generators',
+      name: 'hostname-generator-root-view',
+      redirect: { name: 'hostname-generator-list-view' },
+      component: () => import('@/app/hostname-generators/views/HostnameGeneratorRootView.vue'),
+      children: [
+        {
+          path: '',
+          name: 'hostname-generator-list-view',
+          component: () => import('@/app/hostname-generators/views/HostnameGeneratorListView.vue'),
+          children: [
+            {
+              path: ':name',
+              name: 'hostname-generator-summary-view',
+              component: () => import('@/app/hostname-generators/views/HostnameGeneratorSummaryView.vue'),
+            },
+          ],
+        },
+        {
+          path: ':name/overview',
+          name: 'hostname-generator-detail-view',
+          component: () => import('@/app/hostname-generators/views/HostnameGeneratorDetailView.vue'),
+        },
+      ],
+    },
+  ]
+}

--- a/src/app/hostname-generators/sources.ts
+++ b/src/app/hostname-generators/sources.ts
@@ -1,0 +1,23 @@
+import { HostnameGenerator } from './data/HostnameGenerator'
+import { defineSources } from '../application/services/data-source'
+import type KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
+
+export const sources = (api: KumaApi) => {
+  return defineSources({
+    '/hostnamegenerators': async (params) => {
+      return HostnameGenerator.fromCollection(await api.getHostnameGenerators(params))
+    },
+
+    '/hostnamegenerators/:name': async (params) => {
+      const { name } = params
+
+      return HostnameGenerator.fromObject(await api.getHostnameGenerator({ name }))
+    },
+
+    '/hostnamegenerators/:name/as/kubernetes': async (params) => {
+      const { name } = params
+
+      return api.getHostnameGenerator({ name }, { format: 'kubernetes' })
+    },
+  })
+}

--- a/src/app/hostname-generators/sources.ts
+++ b/src/app/hostname-generators/sources.ts
@@ -12,7 +12,7 @@ export const sources = (api: KumaApi) => {
   })
 
   return defineSources({
-    '/hostnamegenerators': async (params) => {
+    '/hostname-generators': async (params) => {
       const { size } = params
       const offset = params.size * (params.page - 1)
 
@@ -29,7 +29,7 @@ export const sources = (api: KumaApi) => {
       return HostnameGenerator.fromCollection(res.data!)
     },
 
-    '/hostnamegenerators/:name': async (params) => {
+    '/hostname-generators/:name': async (params) => {
       const { name } = params
 
       const res = await http.GET('/hostnamegenerators/{name}', {
@@ -43,7 +43,7 @@ export const sources = (api: KumaApi) => {
       return HostnameGenerator.fromObject(res.data!)
     },
 
-    '/hostnamegenerators/:name/as/kubernetes': async (params) => {
+    '/hostname-generators/:name/as/kubernetes': async (params) => {
       const { name } = params
 
       const res = await http.GET('/hostnamegenerators/{name}', {

--- a/src/app/hostname-generators/sources.ts
+++ b/src/app/hostname-generators/sources.ts
@@ -1,23 +1,64 @@
+import createClient from 'openapi-fetch'
+
 import { HostnameGenerator } from './data/HostnameGenerator'
 import { defineSources } from '../application/services/data-source'
 import type KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
+import { paths } from '@/types/auto-generated'
 
 export const sources = (api: KumaApi) => {
+  const http = createClient<paths>({
+    baseUrl: '',
+    fetch: api.client.fetch,
+  })
+
   return defineSources({
     '/hostnamegenerators': async (params) => {
-      return HostnameGenerator.fromCollection(await api.getHostnameGenerators(params))
+      const { size } = params
+      const offset = params.size * (params.page - 1)
+
+      const res = await http.GET('/hostnamegenerators', {
+        params: {
+          // @ts-ignore TODO(schogges): remove ts-ignore once https://github.com/kumahq/kuma/issues/11339 is done
+          query: {
+            offset,
+            size,
+          },
+        },
+      })
+
+      return HostnameGenerator.fromCollection(res.data!)
     },
 
     '/hostnamegenerators/:name': async (params) => {
       const { name } = params
 
-      return HostnameGenerator.fromObject(await api.getHostnameGenerator({ name }))
+      const res = await http.GET('/hostnamegenerators/{name}', {
+        params: {
+          path: {
+            name,
+          },
+        },
+      })
+
+      return HostnameGenerator.fromObject(res.data!)
     },
 
     '/hostnamegenerators/:name/as/kubernetes': async (params) => {
       const { name } = params
 
-      return api.getHostnameGenerator({ name }, { format: 'kubernetes' })
+      const res = await http.GET('/hostnamegenerators/{name}', {
+        params: {
+          path: {
+            name,
+          },
+          // @ts-ignore
+          query: {
+            format: 'kubernetes',
+          },
+        },
+      })
+
+      return res.data!
     },
   })
 }

--- a/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
+++ b/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
@@ -18,10 +18,7 @@
       v-slot="{ data }"
     >
       <AppView :docs="t('hostname-generators.href.docs')">
-        <template
-          v-if="data"
-          #title
-        >
+        <template #title>
           <h1>
             <XCopyButton
               :text="data.name"
@@ -64,7 +61,6 @@
           </AppAboutSection>
 
           <ResourceCodeBlock
-            v-if="data"
             :resource="data.$raw"
             v-slot="{ copy, copying }"
           >

--- a/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
+++ b/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
@@ -36,27 +36,33 @@
             :modified="t('common.formats.datetime', { value: Date.parse(data.modificationTime) })"
           >
             <div class="columns">
-              <DefinitionCard>
-                <template #title>
-                  {{ t('hostname-generators.common.selector') }}
-                </template>
+              <template
+                v-for="labels in [{
+                  ...data.spec.selector.meshService.matchLabels,
+                  ...data.spec.selector.meshExternalService.matchLabels,
+                  ...data.spec.selector.meshMultiZoneService.matchLabels,
+                }]"
+                :key="typeof labels"
+              >
+                <DefinitionCard v-if="Object.keys(labels).length">
+                  <template #title>
+                    Tags
+                  </template>
 
-                <template
-                  v-if="data.selector"
-                  #body
-                >
-                  <XAction
-                    :to="{
-                      name: routeMap.get(data.selector),
-                      params: {
-                        mesh: data.mesh,
-                      },
-                    }"
-                  >
-                    {{ `${data.selector.charAt(0).toUpperCase()}${data.selector.slice(1, data.selector.length)}` }}
-                  </XAction>
-                </template>
-              </DefinitionCard>
+                  <template #body>
+                    <XLayout type="separated">
+                      <template
+                        v-for="(value, key) in labels"
+                        :key="key"
+                      >
+                        <XBadge>
+                          {{ key }}:{{ value }}
+                        </XBadge>
+                      </template>
+                    </XLayout>
+                  </template>
+                </DefinitionCard>
+              </template>
             </div>
           </AppAboutSection>
 
@@ -88,16 +94,9 @@
 <script lang="ts" setup>
 import { AppAboutSection } from '@kong-ui-public/app-layout'
 
-import { HostnameGenerator } from '../data'
 import { sources } from '../sources'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import ResourceCodeBlock from '@/app/x/components/x-code-block/ResourceCodeBlock.vue'
-
-const routeMap = new Map<HostnameGenerator['selector'], string>([
-  ['meshService', 'mesh-service-list-view'],
-  ['meshExternalService', 'mesh-external-service-list-view'],
-  ['meshMultiZoneService', 'mesh-multi-zone-service-list-view'],
-])
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
+++ b/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
@@ -1,0 +1,104 @@
+<template>
+  <RouteView
+    name="hostname-generator-detail-view"
+    :params="{
+      name: '',
+    }"
+    v-slot="{ route, t, uri }"
+  >
+    <RouteTitle
+      :title="t('hostname-generators.routes.items.title')"
+      :render="false"
+    />
+
+    <DataLoader
+      :src="uri(sources, '/hostnamegenerators/:name', {
+        name: route.params.name,
+      })"
+      v-slot="{ data }"
+    >
+      <AppView :docs="t('hostname-generators.href.docs')">
+        <template
+          v-if="data"
+          #title
+        >
+          <h1>
+            <XCopyButton
+              :text="data.name"
+            >
+              <RouteTitle
+                :title="t('hostname-generators.routes.item.title', { name: data.name })"
+              />
+            </XCopyButton>
+          </h1>
+        </template>
+        <div class="stack">
+          <AppAboutSection
+            :title="t('hostname-generators.routes.item.subtitle', { name: data.name })"
+            :created="t('common.formats.datetime', { value: Date.parse(data.creationTime) })"
+            :modified="t('common.formats.datetime', { value: Date.parse(data.modificationTime) })"
+          >
+            <div class="columns">
+              <DefinitionCard>
+                <template #title>
+                  {{ t('hostname-generators.common.selector') }}
+                </template>
+
+                <template
+                  v-if="data.selector"
+                  #body
+                >
+                  <XAction
+                    :to="{
+                      name: data.selector?.routeName,
+                      params: {
+                        mesh: data.mesh,
+                      },
+                    }"
+                  >
+                    {{ data.selector?.label }}
+                  </XAction>
+                </template>
+              </DefinitionCard>
+            </div>
+          </AppAboutSection>
+
+          <ResourceCodeBlock
+            v-if="data"
+            :resource="data.$raw"
+            v-slot="{ copy, copying }"
+          >
+            <DataSource
+              v-if="copying"
+              :src="uri(sources, '/hostnamegenerators/:name/as/kubernetes', {
+                name: route.params.name,
+              }, {
+                cacheControl: 'no-store',
+              })"
+              @change="(data) => {
+                copy((resolve) => resolve(data))
+              }"
+              @error="(e) => {
+                copy((_resolve, reject) => reject(e))
+              }"
+            />
+          </ResourceCodeBlock>
+        </div>
+      </AppView>
+    </DataLoader>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import { AppAboutSection } from '@kong-ui-public/app-layout'
+
+import { sources } from '../sources'
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
+import ResourceCodeBlock from '@/app/x/components/x-code-block/ResourceCodeBlock.vue'
+</script>
+
+<style lang="scss" scoped>
+:deep(.kong-ui-app-about-section .about-section-content) {
+  display: block;
+}
+</style>

--- a/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
+++ b/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
@@ -47,13 +47,13 @@
                 >
                   <XAction
                     :to="{
-                      name: data.selector?.routeName,
+                      name: routeMap.get(data.selector),
                       params: {
                         mesh: data.mesh,
                       },
                     }"
                   >
-                    {{ data.selector?.label }}
+                    {{ `${data.selector.charAt(0).toUpperCase()}${data.selector.slice(1, data.selector.length)}` }}
                   </XAction>
                 </template>
               </DefinitionCard>
@@ -88,9 +88,16 @@
 <script lang="ts" setup>
 import { AppAboutSection } from '@kong-ui-public/app-layout'
 
+import { HostnameGenerator } from '../data'
 import { sources } from '../sources'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import ResourceCodeBlock from '@/app/x/components/x-code-block/ResourceCodeBlock.vue'
+
+const routeMap = new Map<HostnameGenerator['selector'], string>([
+  ['meshService', 'mesh-service-list-view'],
+  ['meshExternalService', 'mesh-external-service-list-view'],
+  ['meshMultiZoneService', 'mesh-multi-zone-service-list-view'],
+])
 </script>
 
 <style lang="scss" scoped>

--- a/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
+++ b/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
@@ -12,7 +12,7 @@
     />
 
     <DataLoader
-      :src="uri(sources, '/hostnamegenerators/:name', {
+      :src="uri(sources, '/hostname-generators/:name', {
         name: route.params.name,
       })"
       v-slot="{ data }"
@@ -72,7 +72,7 @@
           >
             <DataSource
               v-if="copying"
-              :src="uri(sources, '/hostnamegenerators/:name/as/kubernetes', {
+              :src="uri(sources, '/hostname-generators/:name/as/kubernetes', {
                 name: route.params.name,
               }, {
                 cacheControl: 'no-store',

--- a/src/app/hostname-generators/views/HostnameGeneratorListView.vue
+++ b/src/app/hostname-generators/views/HostnameGeneratorListView.vue
@@ -51,7 +51,7 @@
                   @resize="me.set"
                 >
                   <template #name="{ row: item }">
-                    <TextWithCopyButton
+                    <XCopyButton
                       :text="item.name"
                     >
                       <XAction
@@ -69,7 +69,7 @@
                       >
                         {{ item.name }}
                       </XAction>
-                    </TextWithCopyButton>
+                    </XCopyButton>
                   </template>
 
                   <template #actions="{ row: item }">
@@ -122,5 +122,5 @@
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
-import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+import XCopyButton from '@/app/x/components/x-copy-button/XCopyButton.vue'
 </script>

--- a/src/app/hostname-generators/views/HostnameGeneratorListView.vue
+++ b/src/app/hostname-generators/views/HostnameGeneratorListView.vue
@@ -1,0 +1,126 @@
+<template>
+  <RouteView
+    name="hostname-generator-list-view"
+    :params="{
+      name: '',
+      page: 1,
+      size: 15,
+    }"
+    v-slot="{ route, t, can, uri, me }"
+  >
+    <AppView
+      :docs="t('hostname-generators.href.docs')"
+    >
+      <template #title>
+        <h1>
+          <RouteTitle
+            :title="t('hostname-generators.routes.items.title')"
+          />
+        </h1>
+      </template>
+      <div class="stack">
+        <div v-html="t('hostname-generators.routes.items.intro', {}, { defaultMessage: '' })" />
+        <KCard>
+          <DataLoader
+            :src="uri(sources, '/hostnamegenerators', {}, {
+              page: route.params.page,
+              size: route.params.size,
+            })"
+          >
+            <template
+              #loadable="{ data }"
+            >
+              <DataCollection
+                type="hostname-generators"
+                :items="data?.items ?? [undefined]"
+                :page="route.params.page"
+                :page-size="route.params.size"
+                :total="data?.total"
+                @change="route.update"
+              >
+                <AppCollection
+                  data-testid="hostname-generator-collection"
+                  :headers="[
+                    { ...me.get('headers.name'), label: t('hostname-generators.common.name'), key: 'name' },
+                    { ...me.get('headers.namespace'), label: t('hostname-generators.common.namespace'), key: 'namespace' },
+                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: t('hostname-generators.common.zone'), key: 'zone' }] : []),
+                    { ...me.get('headers.actions'), label: t('hostname-generators.common.actions'), key: 'actions', hideLabel: true },
+                  ]"
+                  :items="data?.items"
+                  :is-selected-row="(item) => item.name === route.params.name"
+                  @resize="me.set"
+                >
+                  <template #name="{ row: item }">
+                    <TextWithCopyButton
+                      :text="item.name"
+                    >
+                      <XAction
+                        data-action
+                        :to="{
+                          name: 'hostname-generator-summary-view',
+                          params: {
+                            name: item.id,
+                          },
+                          query: {
+                            page: route.params.page,
+                            size: route.params.size,
+                          },
+                        }"
+                      >
+                        {{ item.name }}
+                      </XAction>
+                    </TextWithCopyButton>
+                  </template>
+
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'hostname-generator-detail-view',
+                          params: {
+                            name: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
+                  </template>
+                </AppCollection>
+                <RouterView
+                  v-if="data?.items && route.params.name"
+                  v-slot="child"
+                >
+                  <SummaryView
+                    @close="route.replace({
+                      name: 'hostname-generator-list-view',
+                      params: {
+                        name: '',
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                      },
+                    })"
+                  >
+                    <component
+                      :is="child.Component"
+                      :items="data?.items"
+                    />
+                  </SummaryView>
+                </RouterView>
+              </DataCollection>
+            </template>
+          </DataLoader>
+        </KCard>
+      </div>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import { sources } from '../sources'
+import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
+import SummaryView from '@/app/common/SummaryView.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+</script>

--- a/src/app/hostname-generators/views/HostnameGeneratorListView.vue
+++ b/src/app/hostname-generators/views/HostnameGeneratorListView.vue
@@ -22,7 +22,7 @@
         <div v-html="t('hostname-generators.routes.items.intro', {}, { defaultMessage: '' })" />
         <KCard>
           <DataLoader
-            :src="uri(sources, '/hostnamegenerators', {}, {
+            :src="uri(sources, '/hostname-generators', {}, {
               page: route.params.page,
               size: route.params.size,
             })"

--- a/src/app/hostname-generators/views/HostnameGeneratorRootView.vue
+++ b/src/app/hostname-generators/views/HostnameGeneratorRootView.vue
@@ -1,0 +1,19 @@
+<template>
+  <RouteView
+    name="hostname-generator-root-view"
+    v-slot="{ t }"
+  >
+    <AppView
+      :breadcrumbs="[
+        {
+          to: {
+            name: 'hostname-generator-list-view',
+          },
+          text: t('hostname-generators.routes.item.breadcrumbs'),
+        },
+      ]"
+    >
+      <RouterView />
+    </AppView>
+  </RouteView>
+</template>

--- a/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
+++ b/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
@@ -1,0 +1,144 @@
+<template>
+  <RouteView
+    name="hostname-generator-summary-view"
+    :params="{
+      name: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+    }"
+    v-slot="{ route, t, can }"
+  >
+    <DataCollection
+      :items="props.items"
+      :predicate="item => item.id === route.params.name"
+    >
+      <template
+        #item="{ item }"
+      >
+        <AppView>
+          <template #title>
+            <h2>
+              <XAction
+                :to="{
+                  name: 'hostname-generator-detail-view',
+                  params: {
+                    name: route.params.name,
+                  },
+
+                }"
+              >
+                <RouteTitle
+                  :title="t('hostname-generators.routes.item.title', { name: item.name })"
+                />
+              </XAction>
+            </h2>
+          </template>
+
+          <div
+            class="stack"
+          >
+            <div
+              class="stack-with-borders"
+            >
+              <DefinitionCard
+                v-if="item.namespace.length > 0"
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
+                  {{ t('hostname-generators.common.namespace') }}
+                </template>
+
+                <template
+                  #body
+                >
+                  {{ item.namespace }}
+                </template>
+              </DefinitionCard>
+              <DefinitionCard
+                v-if="can('use zones') && item.zone"
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
+                  {{ t('hostname-generators.common.zone') }}
+                </template>
+                <template
+                  #body
+                >
+                  <XAction
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: item.zone,
+                      },
+                    }"
+                  >
+                    {{ item.zone }}
+                  </XAction>
+                </template>
+              </DefinitionCard>
+              <DefinitionCard
+                v-if="item.spec.template"
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
+                  {{ t('hostname-generators.common.template') }}
+                </template>
+                <template
+                  #body
+                >
+                  {{ item.spec.template }}
+                </template>
+              </DefinitionCard>
+            </div>
+            <div>
+              <h3>
+                {{ t('hostname-generators.routes.item.config') }}
+              </h3>
+
+              <div class="mt-4">
+                <ResourceCodeBlock
+                  :resource="item.$raw"
+                  is-searchable
+                  :query="route.params.codeSearch"
+                  :is-filter-mode="route.params.codeFilter"
+                  :is-reg-exp-mode="route.params.codeRegExp"
+                  @query-change="route.update({ codeSearch: $event })"
+                  @filter-mode-change="route.update({ codeFilter: $event })"
+                  @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+                  v-slot="{ copy, copying }"
+                >
+                  <DataSource
+                    v-if="copying"
+                    :src="`/hostnamegenerators/${route.params.name}/as/kubernetes?no-store`"
+                    @change="(data) => {
+                      copy((resolve) => resolve(data))
+                    }"
+                    @error="(e) => {
+                      copy((_resolve, reject) => reject(e))
+                    }"
+                  />
+                </ResourceCodeBlock>
+              </div>
+            </div>
+          </div>
+        </AppView>
+      </template>
+    </DataCollection>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
+import type { HostnameGenerator } from '@/app/hostname-generators/data'
+import ResourceCodeBlock from '@/app/x/components/x-code-block/ResourceCodeBlock.vue'
+const props = defineProps<{
+  items: HostnameGenerator[]
+}>()
+</script>

--- a/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
+++ b/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
@@ -116,7 +116,7 @@
                 >
                   <DataSource
                     v-if="copying"
-                    :src="`/hostnamegenerators/${route.params.name}/as/kubernetes?no-store`"
+                    :src="`/hostname-generators/${route.params.name}/as/kubernetes?no-store`"
                     @change="(data) => {
                       copy((resolve) => resolve(data))
                     }"

--- a/src/app/kuma/services/kuma-api/KumaApi.ts
+++ b/src/app/kuma/services/kuma-api/KumaApi.ts
@@ -1,5 +1,10 @@
 import { Api } from './Api'
 import type {
+  HostnameGeneratorGetParams,
+  HostnameGeneratorItem,
+  HostnameGeneratorList,
+} from '@/app/hostname-generators/data'
+import type {
   ApiKindListResponse,
   DataPlaneOverviewParameters,
   ExternalServicesParameters,
@@ -237,5 +242,13 @@ export default class KumaApi extends Api {
 
   getMeshGatewayRules({ mesh, name }: { mesh: string, name: string }, params?: any): Promise<InspectRulesForDataplane> {
     return this.client.get(`/meshes/${mesh}/meshgateways/${name}/_rules`, { params })
+  }
+
+  getHostnameGenerators(params?: any): Promise<HostnameGeneratorList> {
+    return this.client.get('/hostnamegenerators', { params })
+  }
+
+  getHostnameGenerator({ name }: HostnameGeneratorGetParams['path'], params?: any): Promise<HostnameGeneratorItem> {
+    return this.client.get(`/hostnamegenerators/${name}`, params)
   }
 }

--- a/src/app/kuma/services/kuma-api/KumaApi.ts
+++ b/src/app/kuma/services/kuma-api/KumaApi.ts
@@ -1,10 +1,5 @@
 import { Api } from './Api'
 import type {
-  HostnameGeneratorGetParams,
-  HostnameGeneratorItem,
-  HostnameGeneratorList,
-} from '@/app/hostname-generators/data'
-import type {
   ApiKindListResponse,
   DataPlaneOverviewParameters,
   ExternalServicesParameters,
@@ -242,13 +237,5 @@ export default class KumaApi extends Api {
 
   getMeshGatewayRules({ mesh, name }: { mesh: string, name: string }, params?: any): Promise<InspectRulesForDataplane> {
     return this.client.get(`/meshes/${mesh}/meshgateways/${name}/_rules`, { params })
-  }
-
-  getHostnameGenerators(params?: any): Promise<HostnameGeneratorList> {
-    return this.client.get('/hostnamegenerators', { params })
-  }
-
-  getHostnameGenerator({ name }: HostnameGeneratorGetParams['path'], params?: any): Promise<HostnameGeneratorItem> {
-    return this.client.get(`/hostnamegenerators/${name}`, params)
   }
 }

--- a/src/app/service-mesh/index.ts
+++ b/src/app/service-mesh/index.ts
@@ -1,4 +1,5 @@
 import { services as controlPlanes } from '@/app/control-planes'
+import { services as hostnameGenerators } from '@/app/hostname-generators'
 import { services as meshes } from '@/app/meshes'
 import { services as zones } from '@/app/zones'
 import type { ServiceConfigurator, Token } from '@/services/utils'
@@ -10,4 +11,5 @@ export const services: ServiceConfigurator<SupportedTokens> = ($) => [
   ...controlPlanes($),
   ...zones($),
   ...meshes($),
+  ...hostnameGenerators($),
 ]

--- a/src/test-support/FakeKuma.ts
+++ b/src/test-support/FakeKuma.ts
@@ -365,7 +365,35 @@ export class KumaModule {
       }),
     }
   }
+
+  env() {
+    const environments = ['kubernetes', 'universal'] as const
+    return this.faker.helpers.arrayElement<typeof environments[number]>(environments)
+  }
+
+  hostnameTemplate({ external, multizone, withNamespace, withZone }: Record<string, boolean | undefined> = {}) {
+    const service = external ? 'extsvc' : multizone ? 'mzsvc' : 'svc'
+
+    return [
+      '{{ .DisplayName }}',
+      withNamespace ? '{{ .Namespace }}' : [],
+      service,
+      withZone ? '{{ .Zone }}' : [],
+      'mesh',
+      'local',
+    ].flat().join('.')
+  }
+
+  meshServiceTypeSelector() {
+    const items = [
+      'meshExternalService',
+      'meshMultiZoneService',
+      'meshService',
+    ] as const
+    return this.faker.helpers.arrayElement<typeof items[number]>(items)
+  }
 }
+
 export default class FakeKuma extends Faker {
   k8s = new K8sModule(this)
   kuma = new KumaModule(this, this.k8s)

--- a/src/test-support/mocks/fs.ts
+++ b/src/test-support/mocks/fs.ts
@@ -2,6 +2,8 @@ import _124 from './kuma.io/latest_version'
 import _1 from './src/config'
 import _4 from './src/dataplanes/_overview'
 import _5 from './src/global-insight'
+import _201 from './src/hostname-generators/_/_overview'
+import _200 from './src/hostname-generators/_overview'
 import _13 from './src/mesh-insights'
 import _14 from './src/mesh-insights/_'
 import _15 from './src/meshes'
@@ -194,5 +196,7 @@ export const fs: FS = {
   '/meshes/:mesh/traffic-traces': _45,
   '/meshes/:mesh/traffic-traces/:name': _46,
   '/meshes/:mesh/virtual-outbounds': _47,
-
+  // hostname-generators
+  '/hostnamegenerators': _200,
+  '/hostnamegenerators/:name': _201,
 }

--- a/src/test-support/mocks/src/hostname-generators/_/_overview.ts
+++ b/src/test-support/mocks/src/hostname-generators/_/_overview.ts
@@ -1,0 +1,49 @@
+import type { HostnameGeneratorItem } from '@/app/hostname-generators/data'
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+
+export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => {
+  const { params } = req
+  const name = params.name as string
+  const [displayName = '', namespace = ''] = name.split('.')
+  const meshServiceTypeSelector = fake.kuma.meshServiceTypeSelector()
+  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
+  const creationTime = fake.date.past()
+
+  const body = {
+    type: 'HostnameGenerator',
+    name,
+    labels: k8s
+      ? {
+        'kuma.io/display-name': displayName,
+        'k8s.kuma.io/namespace': namespace,
+        'kuma.io/env': fake.kuma.env(),
+        'kuma.io/mesh': 'default',
+        'kuma.io/origin': fake.kuma.origin(),
+        'kuma.io/zone': fake.hacker.noun(),
+      }
+      : {},
+    spec: {
+      selector: {
+        [meshServiceTypeSelector]: {
+          matchLabels: {
+            'kuma.io/origin': fake.kuma.origin(),
+            'kuma.io/env': fake.kuma.env(),
+          },
+        },
+      },
+      template: fake.kuma.hostnameTemplate({
+        external: meshServiceTypeSelector === 'meshExternalService',
+        multizone: meshServiceTypeSelector === 'meshMultiZoneService',
+        withNamespace: fake.datatype.boolean(),
+        withZone: fake.datatype.boolean(),
+      }),
+    },
+    creationTime: creationTime.toISOString(),
+    modificationTime: fake.date.between({ from: creationTime, to: Date.now() }).toISOString(),
+  } satisfies HostnameGeneratorItem
+
+  return {
+    headers: {},
+    body,
+  }
+}

--- a/src/test-support/mocks/src/hostname-generators/_overview.ts
+++ b/src/test-support/mocks/src/hostname-generators/_overview.ts
@@ -14,11 +14,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i): HostnameGeneratorItem => {
-        const meshServiceType = fake.kuma.meshServiceTypeSelector()
-        const matchLabels = {
-          'kuma.io/origin': fake.kuma.origin(),
-          'kuma.io/env': fake.kuma.env(),
-        }
+        const meshServiceTypeSelector = fake.kuma.meshServiceTypeSelector()
         const namespace = fake.hacker.noun()
         const displayName = `${fake.science.chemicalElement().name.toLowerCase()}-${offset + i}-service`
         const creationTime = fake.date.past()
@@ -38,11 +34,16 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             : {},
           spec: {
             selector: {
-              [meshServiceType]: { matchLabels },
+              [meshServiceTypeSelector]: {
+                matchLabels: {
+                  'kuma.io/origin': fake.kuma.origin(),
+                  'kuma.io/env': fake.kuma.env(),
+                },
+              },
             },
             template: fake.kuma.hostnameTemplate({
-              external: meshServiceType === 'meshExternalService',
-              multizone: meshServiceType === 'meshMultiZoneService',
+              external: meshServiceTypeSelector === 'meshExternalService',
+              multizone: meshServiceTypeSelector === 'meshMultiZoneService',
               withNamespace: fake.datatype.boolean(),
               withZone: fake.datatype.boolean(),
             }),

--- a/src/test-support/mocks/src/hostname-generators/_overview.ts
+++ b/src/test-support/mocks/src/hostname-generators/_overview.ts
@@ -1,0 +1,57 @@
+import type { HostnameGeneratorItem } from '@/app/hostname-generators/data'
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (req) => {
+  const { offset, total, next, pageTotal } = pager(
+    `${fake.number.int({ min: 1, max: 100 })}`,
+    req,
+    '/hostname-generators/_overview',
+  )
+
+  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
+
+  return {
+    headers: {},
+    body: {
+      total,
+      items: Array.from({ length: pageTotal }).map((_, i): HostnameGeneratorItem => {
+        const meshServiceType = fake.kuma.meshServiceTypeSelector()
+        const matchLabels = {
+          'kuma.io/origin': fake.kuma.origin(),
+          'kuma.io/env': fake.kuma.env(),
+        }
+        const namespace = fake.hacker.noun()
+        const displayName = `${fake.science.chemicalElement().name.toLowerCase()}-${offset + i}-service`
+        const creationTime = fake.date.past()
+
+        return {
+          type: 'HostnameGenerator',
+          name: `${displayName}${k8s ? `.${namespace}` : ''}`,
+          labels: k8s
+            ? {
+              'kuma.io/display-name': displayName,
+              'k8s.kuma.io/namespace': namespace,
+              'kuma.io/env': fake.kuma.env(),
+              'kuma.io/mesh': 'default',
+              'kuma.io/origin': fake.kuma.origin(),
+              'kuma.io/zone': fake.hacker.noun(),
+            }
+            : {},
+          spec: {
+            selector: {
+              [meshServiceType]: { matchLabels },
+            },
+            template: fake.kuma.hostnameTemplate({
+              external: meshServiceType === 'meshExternalService',
+              multizone: meshServiceType === 'meshMultiZoneService',
+              withNamespace: fake.datatype.boolean(),
+              withZone: fake.datatype.boolean(),
+            }),
+          },
+          creationTime: creationTime.toISOString(),
+          modificationTime: fake.date.between({ from: creationTime, to: Date.now() }).toISOString(),
+        } satisfies HostnameGeneratorItem
+      }),
+      next,
+    },
+  }
+}

--- a/src/types/auto-generated.d.ts
+++ b/src/types/auto-generated.d.ts
@@ -2988,9 +2988,9 @@ export interface components {
             type: string;
             /** @description a rule that affects the entire proxy */
             proxyRule?: components["schemas"]["ProxyRule"];
-            /** @description a set of rules for the outbounds of this proxy */
+            /** @description a set of rules for the outbounds of this proxy. The field is not set when 'meshService.mode' on Mesh is set to 'Exclusive'. */
             toRules?: components["schemas"]["Rule"][];
-            /** @description a set of rules for the resources targeted by this proxy */
+            /** @description a set of rules for the outbounds produced by real resources (i.e MeshService, MeshExternalService, MeshMultiZoneService). */
             toResourceRules?: components["schemas"]["ResourceRule"][];
             /** @description a set of rules for each inbound of this proxy */
             fromRules?: components["schemas"]["FromRule"][];
@@ -3368,6 +3368,18 @@ export interface components {
                     };
                 }[];
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshAccessLogCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -3918,6 +3930,18 @@ export interface components {
                     };
                 }[];
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshCircuitBreakerCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -4127,6 +4151,18 @@ export interface components {
                     };
                 }[];
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshFaultInjectionCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -4343,6 +4379,18 @@ export interface components {
                     };
                 }[];
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshHealthCheckCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -4649,6 +4697,18 @@ export interface components {
                     };
                 }[];
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshHTTPRouteCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -4953,6 +5013,18 @@ export interface components {
                     };
                 }[];
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshLoadBalancingStrategyCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -5117,6 +5189,18 @@ export interface components {
                     };
                 };
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshMetricCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -5206,6 +5290,18 @@ export interface components {
                     };
                 };
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshPassthroughCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -5519,6 +5615,18 @@ export interface components {
                     };
                 };
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshProxyPatchCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -5774,6 +5882,18 @@ export interface components {
                     };
                 }[];
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshRateLimitCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -6082,6 +6202,18 @@ export interface components {
                     };
                 }[];
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshRetryCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -6226,6 +6358,18 @@ export interface components {
                     };
                 }[];
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshTCPRouteCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -6427,6 +6571,18 @@ export interface components {
                     };
                 }[];
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshTimeoutCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -6550,6 +6706,18 @@ export interface components {
                     };
                 };
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshTLSCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -6643,20 +6811,20 @@ export interface components {
                          *     'x-client-trace-id' header is set. Mirror of client_sampling in Envoy
                          *     https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
                          *     Either int or decimal represented as string.
-                         * @default 100%
+                         * @default 100
                          */
                         client: number | string;
                         /**
                          * @description Target percentage of requests will be traced
                          *     after all other sampling checks have been applied (client, force tracing,
                          *     random sampling). This field functions as an upper limit on the total
-                         *     configured sampling rate. For instance, setting client_sampling to 100%
-                         *     but overall_sampling to 1% will result in only 1% of client requests with
+                         *     configured sampling rate. For instance, setting client to 100
+                         *     but overall to 1 will result in only 1% of client requests with
                          *     the appropriate headers to be force traced. Mirror of
                          *     overall_sampling in Envoy
                          *     https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
                          *     Either int or decimal represented as string.
-                         * @default 100%
+                         * @default 100
                          */
                         overall: number | string;
                         /**
@@ -6665,7 +6833,7 @@ export interface components {
                          *     Mirror of random_sampling in Envoy
                          *     https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
                          *     Either int or decimal represented as string.
-                         * @default 100%
+                         * @default 100
                          */
                         random: number | string;
                     };
@@ -6722,6 +6890,18 @@ export interface components {
                     };
                 };
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshTraceCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -6828,6 +7008,18 @@ export interface components {
                     };
                 };
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         MeshTrafficPermissionCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -6868,6 +7060,18 @@ export interface components {
                 };
                 template?: string;
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
         };
         HostnameGeneratorCreateOrUpdateSuccessResponse: {
             /** @description warnings is a list of warning messages to return to the requesting Kuma API clients.
@@ -7016,6 +7220,18 @@ export interface components {
                     };
                 };
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
             /** @description Status is the current status of the Kuma MeshExternalService resource. */
             status?: {
                 /** @description Addresses section for generated domains */
@@ -7104,6 +7320,18 @@ export interface components {
                     };
                 };
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
             /** @description Status is the current status of the Kuma MeshMultiZoneService resource. */
             status?: {
                 /** @description Addresses is a list of addresses generated by HostnameGenerator */
@@ -7209,6 +7437,18 @@ export interface components {
                  */
                 state?: "Available" | "Unavailable";
             };
+            /**
+             * Format: date-time
+             * @description Time at which the resource was created
+             * @example 0001-01-01T00:00:00Z
+             */
+            creationTime?: string;
+            /**
+             * Format: date-time
+             * @description Time at which the resource was updated
+             * @example 0001-01-01T00:00:00Z
+             */
+            modificationTime?: string;
             /** @description Status is the current status of the Kuma MeshService resource. */
             status?: {
                 addresses?: {


### PR DESCRIPTION
This change introduces the views for `HostnameGenerator`s, including `ListView`, `SummaryView` and `DetailView`. With the next iterations we will add more information to the views.
Currently there is no navigation element on the home page that brings the user to the views. For now the path `/hostname-generators` has to be entered manually.

**ListView**
![Screenshot 2024-11-08 at 19 13 40](https://github.com/user-attachments/assets/3103f0ac-475a-40ea-97dc-d7e03635c4a5)

**SummaryView**
![Screenshot 2024-11-08 at 19 13 56](https://github.com/user-attachments/assets/c22ab1a3-bc6b-4408-b604-1c2017e9359b)

**DetailView**
![Screenshot 2024-11-12 at 10 10 33](https://github.com/user-attachments/assets/ad138004-fe53-4055-b036-64bcf40205b9)


Closes #2956