### PR TITLE
fix: remove decorative attribute from all icons to fix tooltipping

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
+++ b/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
@@ -3,12 +3,13 @@
     :is="slots.default ? KTooltip : AnonymousComponent"
     :placement="props.placement"
   >
+    <!-- we hardcode decorative to false for the moment due to an issue with kong/icons -->
     <component
       v-bind="attrs"
       :is="icons[props.name]"
       :aria-described-by="slots.default ? id : undefined"
       :tabindex="slots.default ? 0 : undefined"
-      :decorative="!!slots.default"
+      :decorative="false"
       :color="props.color ? props.color : `var(--${props.name}IconColor, 'currentColor')`"
       :size="props.size"
       display="inline-block"


### PR DESCRIPTION
Hardcodes `decorative="false"` in order to guarantee that `@kong/icons` show (`kong/icons` PR that introduced the issue)

---

Not totally sure how to go about resolving the issue as yet, ideally I'd like to use CSS for all our icons as all icons by their very nature are "decorative". Once we've decided exactly what to do we can revisit this. In the meantime this fix resolves things for our users whilst dodging/avoiding any issues over implementation.

 