### PR TITLE
fix(kuma-gui/x-prompt): unsupported KPrompt prop type

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-prompt/XPrompt.vue
+++ b/packages/kuma-gui/src/app/x/components/x-prompt/XPrompt.vue
@@ -1,9 +1,9 @@
 <template>
   <KPrompt
     :action-button-text="props.action"
+    :action-button-appearance="props.type === 'danger' ? 'danger' : 'primary'"
     :confirmation-text="props.expected.length > 0 ? props.expected : undefined"
     :visible="true"
-    :type="props.type"
     @cancel="() => emit('cancel')"
     @proceed="() => emit('submit')"
   >


### PR DESCRIPTION
The current version of kongponents dropped the support of the prop `type` on the `KPrompt` component. On the `XPrompt` component we want to continue to abstract away the new props that allow more granular control about the appearance and therefore make it easier to use.
Instead of hardcoding `:action-button-appearance="danger"` or `="props.type"` I thought it's better to keep this separated, so whenever we need to add another option for `type` (that is probably not available in kongponents), this should still work as `:action-button-appearance` has to be aligned with the options of [`KButton.appearance`](https://kongponents.konghq.com/components/button.html#appearance). For now the fallback to everything but `danger` is `primary`.

Closes #3178