### PR TITLE
fix(ci): correct paths for SBOM moving

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,10 +111,10 @@ jobs:
           mkdir -p ${{ vars.HOST_REPORTS_DIRECTORY }}
           rm -f ${{ vars.HOST_REPORTS_DIRECTORY }}/{${{ steps.sbom.outputs.grype-json-report }},${{ steps.sbom.outputs.grype-sarif-report }},${{ steps.sbom.outputs.sbom-spdx-report }},${{ steps.sbom.outputs.sbom-cyclonedx-report }}}
           mv \
-            ../${{ steps.sbom.outputs.grype-json-report }} \
-            ../${{ steps.sbom.outputs.grype-sarif-report }} \
-            ../${{ steps.sbom.outputs.sbom-spdx-report }} \
-            ../${{ steps.sbom.outputs.sbom-cyclonedx-report }} \
+            ../../../${{ steps.sbom.outputs.grype-json-report }} \
+            ../../../${{ steps.sbom.outputs.grype-sarif-report }} \
+            ../../../${{ steps.sbom.outputs.sbom-spdx-report }} \
+            ../../../${{ steps.sbom.outputs.sbom-cyclonedx-report }} \
             ${{ vars.HOST_REPORTS_DIRECTORY }}
 
           echo 'Replacing GUI dist files ...'


### PR DESCRIPTION
Follow up of https://github.com/kumahq/kuma-gui/pull/3176

---

The above PR moved files around quite a bit, and in doing so we didn't update the paths correctly for the SBOM moving around when we do a "release" to `kuma`.

GH Actions still run in root, but I changed all of the `run:` GHActions to have a different working directory in order to be able to run our `make` targets easier. Re-looking at the script in this PR, this means the SBOM reports are in root, but we checkout `kuma` into `/packages/kuma-gui/main-application` instead of what it used to be `/main-application`, this means we need to go 2 directories extra up (`kuma-gui` and `packages`) to get to root.

Unfortunately this is a bit hard to test as its not _yet_ in the `Makefile` (I moved most of the CI scripts to our Makefile a while back so we could test them easier), just I was unfamiliar with this bit so unfortunately left it as is 😬 . Pretty sure this is good, but we'll only know on merge 🤞 😅  . I think my thinking is correct (see above explanation)

2 improvements I'd like to make in the future at somepoint:

1. Checkout `kuma` at `/` - thats cleaner now we have workspaces
2. Move this `mv`-y `cp`-y stuff into our Makefile so its easier to test outside of GH actions, and probably refine it a little.

