### PR TITLE
fix: remove beforePaint from routeUpdate, its no longer required

### DIFF
--- a/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
+++ b/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
@@ -64,7 +64,6 @@ import {
   cleanQuery,
   createAttrsSetter,
   createTitleSetter,
-  beforePaint,
 } from '../../utilities'
 import DataSink from '../data-source/DataSink.vue'
 import DataSource from '../data-source/DataSource.vue'
@@ -214,13 +213,13 @@ watch(() => props.name, () => {
 
 type RouteParams = Record<string, string | boolean | number | undefined>
 let newParams: RouteParams = {}
-const routerPush = beforePaint((params: RouteParams) => {
+const routerPush = (params: RouteParams) => {
   router.push({
     name: props.name,
     query: cleanQuery(params, route.query),
   })
   newParams = {}
-})
+}
 const routeUpdate = (params: RouteParams): void => {
   newParams = {
     ...newParams,


### PR DESCRIPTION
We had a flake quite a while now that looks something like this:

![Screenshot 2024-10-10 at 13 02 54](https://github.com/user-attachments/assets/66d4feba-a593-4946-9f04-d50ccc7a81d4)

But we've never really seen or heard reports of this with real users.

Lately, I have seen reports of this bug (or one with a similar error) happening with 1 or 2 users. On further investigation the error I've seen here relates to this potentially asynchronous code (using `beforePaint`). "asynchronous code you say?! sounds like it could be the cause of a flake" 😅 

I looked back to try to find out why we needed the `beforePaint` and blamed it back to this PR https://github.com/kumahq/kuma-gui/pull/1493:

> We had/have some strange race-y route/URL interactions that are causing confusing issues during testing where user interactions can happen at a much faster rate than usual. This combined with how paging works in AppCollection, meant that the click on a tab could be immediately "overwritten" by AppCollection, and the navigation would be lost.

As soon as I read "This combined with how paging works in AppCollection" makes me think this `beforePaint` is no longer needed.

A bit of history:

- AppCollection was made as a wrapper around KTable due to its awkward `:fetcher=""` API.
- KTable also does many many things that IMO it shouldn't (data loading, paging, searching, toolbars etc etc etc), this makes KTable rather difficult to work with as things clash and don't work together very well (note: Kongponents is also gradually building out a KTableView which probably reflects this also)
- We had to apply several fixes to KTable to get it to work properly for things like paging see https://github.com/kumahq/kuma-gui/pull/1341 for example.
- Because of all the above, I'd been waiting for a long time to rely on KTable as little as possible, but keep the look and feel, and I finally got the chance to do that in https://github.com/kumahq/kuma-gui/pull/2846, only a month or so back.

Fast forward to today, and we don't even use AppCollection (and therefore KTable) for pagination any more (we use DataCollection and KPagination). This makes things far easier to work with and I believe far less buggy.

Back to this PR, if the `beforePaint` was added because of KTable overloading complications, and we've no stopped using as much as possible from KTable. I'm 99% sure we can now remove this `beforePaint` (which is potentially causing issues due to its async nature).

If I'm right I'm super glad that we are using as little as possible from KTable now, and it looks like this might be one more hack we can remove that we had to add in order to use it. Tests are all green and tests where added in https://github.com/kumahq/kuma-gui/pull/1493, plus I've tried to reproduce the issue described in https://github.com/kumahq/kuma-gui/pull/1493 around history interactions and I can't.

