### PR TITLE
chore: detect unreachable code

### DIFF
--- a/packages/config/src/eslint.cjs
+++ b/packages/config/src/eslint.cjs
@@ -92,6 +92,7 @@ function createEslintConfig(
       }],
       'no-console': ['error', { allow: ['info', 'warn', 'error'] }],
       'padded-blocks': 'off',
+      'no-unreachable': 'error',
     },
     overrides: [
       {

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/stats.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/stats.ts
@@ -632,8 +632,10 @@ cluster.${service}.upstream_rq_tx_reset: 0
 cluster.${service}.version: 18174995656166257622
 cluster.${service}.warming_state: 0`
       }
+      default: {
+        return ''
+      }
     }
-    return ''
   }).join(`
 `)
 

--- a/packages/kuma-gui/tsconfig.json
+++ b/packages/kuma-gui/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": false,
     "sourceMap": true,
     "types": [
       "vite/client"


### PR DESCRIPTION
Brings back detection of unreachable code. For some reason `no-unreachable` only detects issues in `.js`-files. Probably because with TypeScript this is handed over to the TS compiler.