### PR TITLE
fix(dataplanes): Fix margins on inbound cards in dataplane overview

### DIFF
--- a/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionGroup.vue
+++ b/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionGroup.vue
@@ -14,11 +14,6 @@ const props = defineProps<{
 }>()
 </script>
 <style lang="scss" scoped>
-.service-traffic-group .body {
-  display: flex;
-  flex-direction: column;
-  gap: $kui-space-40;
-}
 .type-passthrough,
 .type-outbound {
   padding: $kui-space-40;

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -227,46 +227,51 @@
                         </XEmptyState>
                       </template>
                       <template #default="{ items: _inbounds }">
-                        <template
-                          v-for="item in _inbounds"
-                          :key="`${item.name}`"
+                        <XLayout
+                          type="stack"
+                          size="small"
                         >
                           <template
-                            v-for="stats in [
-                              traffic?.inbounds[item.name],
-                            ]"
-                            :key="stats"
+                            v-for="item in _inbounds"
+                            :key="`${item.name}`"
                           >
-                            <ConnectionCard
-                              data-testid="dataplane-inbound"
-                              :protocol="item.protocol"
-                              :service="can('use service-insights', props.mesh) ? item.tags['kuma.io/service'] : ''"
-                              :traffic="typeof error === 'undefined' ?
-                                stats :
-                                {
-                                  name: '',
-                                  protocol: item.protocol,
-                                  port: `${item.port}`,
-                                }
-                              "
+                            <template
+                              v-for="stats in [
+                                traffic?.inbounds[item.name],
+                              ]"
+                              :key="stats"
                             >
-                              <XAction
-                                data-action
-                                :to="{
-                                  name: ((name) => name.includes('bound') ? name.replace('-outbound-', '-inbound-') : 'connection-inbound-summary-overview-view')(String(_route.name)),
-                                  params: {
-                                    connection: item.name,
-                                  },
-                                  query: {
-                                    inactive: route.params.inactive,
-                                  },
-                                }"
+                              <ConnectionCard
+                                data-testid="dataplane-inbound"
+                                :protocol="item.protocol"
+                                :service="can('use service-insights', props.mesh) ? item.tags['kuma.io/service'] : ''"
+                                :traffic="typeof error === 'undefined' ?
+                                  stats :
+                                  {
+                                    name: '',
+                                    protocol: item.protocol,
+                                    port: `${item.port}`,
+                                  }
+                                "
                               >
-                                {{ item.name.replace('localhost', '').replace('_', ':') }}
-                              </XAction>
-                            </ConnectionCard>
+                                <XAction
+                                  data-action
+                                  :to="{
+                                    name: ((name) => name.includes('bound') ? name.replace('-outbound-', '-inbound-') : 'connection-inbound-summary-overview-view')(String(_route.name)),
+                                    params: {
+                                      connection: item.name,
+                                    },
+                                    query: {
+                                      inactive: route.params.inactive,
+                                    },
+                                  }"
+                                >
+                                  {{ item.name.replace('localhost', '').replace('_', ':') }}
+                                </XAction>
+                              </ConnectionCard>
+                            </template>
                           </template>
-                        </template>
+                        </XLayout>
                       </template>
                     </DataCollection>
                   </template>
@@ -342,33 +347,38 @@
                             v-for="hash in [/-([a-f0-9]){16}$/]"
                             :key="hash"
                           >
-                            <template
-                              v-for="[name, outbound] in outbounds"
-                              :key="`${name}`"
+                            <XLayout
+                              type="stack"
+                              size="small"
                             >
-                              <ConnectionCard
-                                data-testid="dataplane-outbound"
-                                :protocol="['grpc', 'http', 'tcp'].find(protocol => typeof outbound[protocol] !== 'undefined') ?? 'tcp'"
-                                :traffic="outbound"
-                                :service="outbound.$resourceMeta.type === '' ? name.replace(hash, '') : undefined"
-                                :direction="direction"
+                              <template
+                                v-for="[name, outbound] in outbounds"
+                                :key="`${name}`"
                               >
-                                <XAction
-                                  data-action
-                                  :to="{
-                                    name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'connection-outbound-summary-overview-view')(String(_route.name)),
-                                    params: {
-                                      connection: name,
-                                    },
-                                    query: {
-                                      inactive: route.params.inactive,
-                                    },
-                                  }"
+                                <ConnectionCard
+                                  data-testid="dataplane-outbound"
+                                  :protocol="['grpc', 'http', 'tcp'].find(protocol => typeof outbound[protocol] !== 'undefined') ?? 'tcp'"
+                                  :traffic="outbound"
+                                  :service="outbound.$resourceMeta.type === '' ? name.replace(hash, '') : undefined"
+                                  :direction="direction"
                                 >
-                                  {{ name }}
-                                </XAction>
-                              </ConnectionCard>
-                            </template>
+                                  <XAction
+                                    data-action
+                                    :to="{
+                                      name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'connection-outbound-summary-overview-view')(String(_route.name)),
+                                      params: {
+                                        connection: name,
+                                      },
+                                      query: {
+                                        inactive: route.params.inactive,
+                                      },
+                                    }"
+                                  >
+                                    {{ name }}
+                                  </XAction>
+                                </ConnectionCard>
+                              </template>
+                            </XLayout>
                           </template>
                         </ConnectionGroup>
                       </DataCollection>
@@ -634,7 +644,8 @@ const warnings = computed(() => props.data.warnings.concat(...(props.data.isCert
   align-items: center;
 }
 
-.inbound-list>*+* {
+.inbound-list > * + * {
+  border: 1px solid red;
   margin-block-start: $kui-space-60;
   border-top: $kui-border-width-10 solid $kui-color-border;
   padding-block-start: $kui-space-60;

--- a/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
+++ b/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="['x-layout', props.type]"
+    :class="['x-layout', props.type, props.size]"
   >
     <slot name="default" />
   </div>
@@ -8,13 +8,18 @@
 <script lang="ts" setup>
 const props = withDefaults(defineProps<{
   type?: 'stack' | 'separated'
+  size?: 'small' | 'normal'
 }>(), {
   type: 'stack',
+  size: 'normal',
 })
 </script>
 <style lang="scss" scoped>
-.stack > * + * {
+.stack.normal > * + * {
   margin-block-start: $kui-space-70;
+}
+.stack.small > * + * {
+  margin-block-start: $kui-space-40;
 }
 .separated {
   display: inline-flex;


### PR DESCRIPTION
I've used `XLayout` to do this and added a `small` variant, (fyi: we also have/had a `.stack-small` previously) Wanted to note I'm still ever so slightly cautious about `XLayout` (and the component first approach) https://github.com/kumahq/kuma-gui/pull/3092#issuecomment-2450324907, happy enough with it to use it to fix this though:

See left-hand inbound top/bottom margins:

### Before 

![Screenshot 2024-11-18 at 09 12 08](https://github.com/user-attachments/assets/1c39a1cf-dfd2-4d70-9c5e-c25cb926dd19)

### After

![Screenshot 2024-11-18 at 09 11 55](https://github.com/user-attachments/assets/a5668126-7f7e-41a7-800e-4f903e3e6e87)


**P.S. Be sure to use GHs hide whitespace option when reviewing:**

![Screenshot 2024-11-18 at 09 31 33](https://github.com/user-attachments/assets/14f47f84-4fae-48ce-99d7-32fdd65ced3b)

