### PR TITLE
feat(zone-ingress/summary-view): add config

### DIFF
--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.spec.ts
@@ -281,4 +281,14 @@ describe('ZoneIngressOverview', () => {
       },
     )
   })
+  describe('zoneIngressOverview.$raw', () => {
+    test('$raw is the same as original API response', async ({ fixture }) => {
+      let expected
+      const actual = await fixture.setup((item) => {
+        expected = item
+        return item
+      })
+      expect(actual.$raw).toStrictEqual(expected)
+    })
+  })
 })

--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.spec.ts
@@ -281,14 +281,45 @@ describe('ZoneIngressOverview', () => {
       },
     )
   })
-  describe('zoneIngressOverview.$raw', () => {
-    test('$raw is the same as original API response', async ({ fixture }) => {
-      let expected
+  describe('zoneIngressOverview.config', () => {
+    test('config is derived from name, timestamps, mesh and zoneIngress of item', async ({ fixture }) => {
+      const expected = {
+        type: 'ZoneIngress',
+        name: 'zone-ingress-name.zone-ingress-namespace',
+        mesh: 'mesh-0',
+        zone: 'zone-0',
+        creationTime: '2021-07-13T08:40:59Z',
+        modificationTime: '2021-07-13T08:40:59Z',
+        availableServices: [{
+          instances: 50,
+          mesh: 'mesh-0',
+          tags: {
+            app: 'programm-app',
+            'kuma.io/zone': 'zone-0',
+            'kuma.io/service': 'program-app_alarm_svc_36676',
+          },
+        }],
+        networking: {
+          address: '486f:d1db:efde:c143:94a5:cb9f:271a:c1a7',
+          advertisedAddress: '190.26.201.59',
+          advertisedPort: '58329',
+          port: '58936',
+        },
+      }
       const actual = await fixture.setup((item) => {
-        expected = item
+        item.name = expected.name
+        item.mesh = expected.mesh
+        item.creationTime = expected.creationTime
+        item.modificationTime = expected.modificationTime
+        item.zoneIngress = {
+          availableServices: expected.availableServices,
+          networking: expected.networking,
+          zone: expected.zone,
+        }
+
         return item
       })
-      expect(actual.$raw).toStrictEqual(expected)
+      expect(actual.config).toStrictEqual(expected)
     })
   })
 })

--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
@@ -60,17 +60,25 @@ export const ZoneIngressOverview = {
   fromObject: (item: PartialZoneIngressOverview) => {
     const zoneIngressInsight = ZoneIngressInsight.fromObject(item.zoneIngressInsight)
     const zoneIngress = InternalZoneIngress.fromObject(item.zoneIngress)
+    const zoneIngressConfig = ZoneIngress.fromObject({
+      type: 'ZoneIngress',
+      name: item.name,
+      creationTime: item.creationTime,
+      modificationTime: item.modificationTime,
+      mesh: item.mesh,
+      ...item.zoneIngress,
+    }).config
     const labels = typeof item.labels !== 'undefined' ? item.labels : {}
 
     return {
       ...item,
-      $raw: item,
       id: item.name,
       name: labels['kuma.io/display-name'] ?? item.name,
       namespace: labels['k8s.kuma.io/namespace'] ?? '',
       labels,
       zoneIngressInsight,
       zoneIngress,
+      config: zoneIngressConfig,
       // it is possible to have zoneIngresses on a 'disabled' zone but we don't
       // want to do anything special about that just now at least
       state: typeof zoneIngressInsight.connectedSubscription !== 'undefined' ? 'online' as const : 'offline' as const,

--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
@@ -24,14 +24,6 @@ export type ZoneIngress = {
 
 export type ZoneIngressInsight = PartialZoneIngressInsight & DiscoverySubscriptionCollection & {}
 
-export type ZoneIngressOverview = PartialZoneIngressOverview & {
-  id: string
-  namespace: string
-  labels: Exclude<PartialZoneIngressOverview['labels'], undefined>
-  zoneIngress: InternalZoneIngress
-  zoneIngressInsight: ZoneIngressInsight
-  state: 'online' | 'offline'
-}
 // TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
 const InternalZoneIngress = {
   fromObject: (item: PartialInternalZoneIngress): InternalZoneIngress => {
@@ -65,13 +57,14 @@ export const ZoneIngressInsight = {
   },
 }
 export const ZoneIngressOverview = {
-  fromObject: (item: PartialZoneIngressOverview): ZoneIngressOverview => {
+  fromObject: (item: PartialZoneIngressOverview) => {
     const zoneIngressInsight = ZoneIngressInsight.fromObject(item.zoneIngressInsight)
     const zoneIngress = InternalZoneIngress.fromObject(item.zoneIngress)
     const labels = typeof item.labels !== 'undefined' ? item.labels : {}
 
     return {
       ...item,
+      $raw: item,
       id: item.name,
       name: labels['kuma.io/display-name'] ?? item.name,
       namespace: labels['k8s.kuma.io/namespace'] ?? '',
@@ -80,13 +73,15 @@ export const ZoneIngressOverview = {
       zoneIngress,
       // it is possible to have zoneIngresses on a 'disabled' zone but we don't
       // want to do anything special about that just now at least
-      state: typeof zoneIngressInsight.connectedSubscription !== 'undefined' ? 'online' : 'offline',
+      state: typeof zoneIngressInsight.connectedSubscription !== 'undefined' ? 'online' as const : 'offline' as const,
     }
   },
-  fromCollection: (collection: CollectionResponse<PartialZoneIngressOverview>): CollectionResponse<ZoneIngressOverview> => {
+  fromCollection: (collection: CollectionResponse<PartialZoneIngressOverview>) => {
     return {
       ...collection,
       items: Array.isArray(collection.items) ? collection.items.map(ZoneIngressOverview.fromObject) : [],
     }
   },
 }
+
+export type ZoneIngressOverview = ReturnType<typeof ZoneIngressOverview.fromObject>

--- a/packages/kuma-gui/src/app/zone-ingresses/sources.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/sources.ts
@@ -37,7 +37,7 @@ export const sources = (source: Source, api: KumaApi) => {
         },
       })
     },
-    '/zone-cps/:name/ingresses': async (params): Promise<ZoneIngressOverviewCollection> => {
+    '/zone-cps/:name/ingresses': async (params) => {
       const { name, size, page } = params
       const offset = size * (page - 1)
 

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -3,6 +3,9 @@
     name="zone-ingress-summary-view"
     :params="{
       zoneIngress: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
     v-slot="{ route, t }"
   >
@@ -123,6 +126,36 @@
                 </template>
               </DefinitionCard>
             </div>
+            <div>
+              <h3>
+                {{ t('zone-ingresses.routes.item.config') }}
+              </h3>
+
+              <div class="mt-4">
+                <ResourceCodeBlock
+                  :resource="item.$raw"
+                  is-searchable
+                  :query="route.params.codeSearch"
+                  :is-filter-mode="route.params.codeFilter"
+                  :is-reg-exp-mode="route.params.codeRegExp"
+                  @query-change="route.update({ codeSearch: $event })"
+                  @filter-mode-change="route.update({ codeFilter: $event })"
+                  @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+                  v-slot="{ copy, copying }"
+                >
+                  <DataSource
+                    v-if="copying"
+                    :src="`/zone-ingresses/${route.params.zoneIngress}/as/kubernetes?no-store`"
+                    @change="(data) => {
+                      copy((resolve) => resolve(data))
+                    }"
+                    @error="(e) => {
+                      copy((_resolve, reject) => reject(e))
+                    }"
+                  />
+                </ResourceCodeBlock>
+              </div>
+            </div>
           </AppView>
         </template>
       </template>
@@ -135,6 +168,7 @@ import type { ZoneIngressOverview } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+import ResourceCodeBlock from '@/app/x/components/x-code-block/ResourceCodeBlock.vue'
 
 const props = defineProps<{
   items: ZoneIngressOverview[]

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -133,7 +133,7 @@
 
               <div class="mt-4">
                 <ResourceCodeBlock
-                  :resource="item.$raw"
+                  :resource="item.config"
                   is-searchable
                   :query="route.params.codeSearch"
                   :is-filter-mode="route.params.codeFilter"


### PR DESCRIPTION
Adds the `YAML` config to the `ZoneIngressSummaryView`.
I've also removed some of the custom types that are added in the data layer to move further to the point of inferring the type from the return value.

Part of #2922 