### PR TITLE
feat(zone-egresses/summary-view): add config

### DIFF
--- a/packages/kuma-gui/src/app/zone-egresses/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/data/index.spec.ts
@@ -209,4 +209,34 @@ describe('ZoneEgressOverview', () => {
       },
     )
   })
+
+  describe('zoneIngressOverview.config', () => {
+    test('config is derived from name, timestamps, mesh and zoneIngress of item', async ({ fixture }) => {
+      const expected = {
+        type: 'ZoneEgress',
+        name: 'zone-egress-name.zone-egress-namespace',
+        mesh: 'mesh-0',
+        zone: 'zone-0',
+        creationTime: '2021-07-13T08:40:59Z',
+        modificationTime: '2021-07-13T08:40:59Z',
+        networking: {
+          address: '486f:d1db:efde:c143:94a5:cb9f:271a:c1a7',
+          port: '58936',
+        },
+      }
+      const actual = await fixture.setup((item) => {
+        item.name = expected.name
+        item.mesh = expected.mesh
+        item.creationTime = expected.creationTime
+        item.modificationTime = expected.modificationTime
+        item.zoneEgress = {
+          networking: expected.networking,
+          zone: expected.zone,
+        }
+
+        return item
+      })
+      expect(actual.config).toStrictEqual(expected)
+    })
+  })
 })

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
@@ -3,6 +3,9 @@
     name="zone-egress-summary-view"
     :params="{
       zoneEgress: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
     }"
     v-slot="{ route, t }"
   >
@@ -102,6 +105,36 @@
                 </template>
               </DefinitionCard>
             </div>
+            <div>
+              <h3>
+                {{ t('zone-ingresses.routes.item.config') }}
+              </h3>
+
+              <div class="mt-4">
+                <ResourceCodeBlock
+                  :resource="item.config"
+                  is-searchable
+                  :query="route.params.codeSearch"
+                  :is-filter-mode="route.params.codeFilter"
+                  :is-reg-exp-mode="route.params.codeRegExp"
+                  @query-change="route.update({ codeSearch: $event })"
+                  @filter-mode-change="route.update({ codeFilter: $event })"
+                  @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+                  v-slot="{ copy, copying }"
+                >
+                  <DataSource
+                    v-if="copying"
+                    :src="`/zone-egresses/${route.params.zoneEgress}/as/kubernetes?no-store`"
+                    @change="(data) => {
+                      copy((resolve) => resolve(data))
+                    }"
+                    @error="(e) => {
+                      copy((_resolve, reject) => reject(e))
+                    }"
+                  />
+                </ResourceCodeBlock>
+              </div>
+            </div>
           </AppView>
         </template>
       </template>
@@ -114,6 +147,7 @@ import type { ZoneEgressOverview } from '../data'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+import ResourceCodeBlock from '@/app/x/components/x-code-block/ResourceCodeBlock.vue'
 
 const props = defineProps<{
   items: ZoneEgressOverview[]


### PR DESCRIPTION
Adds the `YAML` config to the `ZoneEgressSummaryView`.
I've also removed some of the custom types that are added in the data layer to move further to the point of inferring the type from the return value.

The `config` is aligned with what was added in #3202:

> The `config` that we add to the data for now represents what is currently applied, including all the stuff that gets added by the backend (and potentially k8s). We might revisit this in the future and add only what the user would apply and exclude everything that is added by the backend (and potentially k8s).

Part of #2922 