### PR TITLE
feat(data-planes/data-plane-summary-view): add config

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneSummary.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneSummary.feature
@@ -47,3 +47,12 @@ Feature: Dataplane summary
       """
     When I visit the "/meshes/default/data-planes/test-data-plane-1?page=2&size=50" URL
     Then the "$summary" element exists
+
+  Scenario: Summary URL offers tabs
+    When I visit the "/meshes/default/data-planes/test-data-plane-1?page=2&size=50" URL
+    Then the URL contains "/summary-overview"
+    And the "[data-testid='data-plane-summary-overview-view']" element exists
+    Then I click the "[data-testid='data-plane-summary-config-view-tab'] a" element
+    Then the URL contains "/config"
+    And the "[data-testid='data-plane-summary-config-view']" element exists
+    And the "[data-testid='k-code-block']" element exists

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneOverview.ts
@@ -1,3 +1,4 @@
+import { Dataplane } from './Dataplane'
 import { DataplaneInsight } from './DataplaneInsight'
 import { DataplaneNetworking } from './DataplaneNetworking'
 import type { PaginatedApiListResponse } from '@/types/api.d'
@@ -6,21 +7,6 @@ import type {
   DataplaneWarning,
   LabelValue,
 } from '@/types/index.d'
-export type DataplaneOverview = PartialDataplaneOverview & {
-  dataplane: {
-    networking: DataplaneNetworking
-  }
-  id: string
-  namespace: string
-  labels: Exclude<PartialDataplaneOverview['labels'], undefined>
-  dataplaneInsight: DataplaneInsight
-  dataplaneType: 'standard' | 'builtin' | 'delegated'
-  status: 'online' | 'offline' | 'partially_degraded'
-  warnings: DataplaneWarning[]
-  isCertExpired: boolean
-  zone: string | undefined
-  services: string[]
-}
 
 // any collection of non-spaces followed by a `:` or `: ` followed by a
 // collection of non-spaces
@@ -39,6 +25,17 @@ const searchShortcuts: Record<string, string> = {
   zone: 'kuma.io/zone',
   protocol: 'kuma.io/protocol',
 }
+const states = {
+  online: 'online',
+  offline: 'offline',
+  partiallyDegraded: 'partially_degraded',
+} as const
+const dpTypes = {
+  builtin: 'builtin',
+  delegated: 'delegated',
+  standard: 'standard',
+} as const
+
 export const DataplaneOverview = {
   search(search: string) {
     const terms = [...search.matchAll(searchRe)].filter(item => item[0].length > 0).map(item => item[0].trim())
@@ -61,7 +58,7 @@ export const DataplaneOverview = {
       })(prev, item)
     }, { tag: [] }) || {}
   },
-  fromObject(item: PartialDataplaneOverview, canUseZones: boolean): DataplaneOverview {
+  fromObject(item: PartialDataplaneOverview, canUseZones: boolean) {
     const dataplaneInsight = DataplaneInsight.fromObject(item.dataplaneInsight)
 
     const networking = DataplaneNetworking.fromObject(item.dataplane.networking)
@@ -73,6 +70,15 @@ export const DataplaneOverview = {
     const zone = tags.find((tag) => tag.label === 'kuma.io/zone')?.value
     const labels = typeof item.labels !== 'undefined' ? item.labels : {}
 
+    const { config } = Dataplane.fromObject({
+      type: 'Dataplane',
+      name: item.name,
+      mesh: item.mesh,
+      creationTime: item.creationTime,
+      modificationTime: item.modificationTime,
+      networking,
+    })
+
     return {
       ...item,
       id: item.name,
@@ -83,9 +89,9 @@ export const DataplaneOverview = {
       },
       labels,
       dataplaneInsight,
-      dataplaneType: networking.type === 'gateway' ? 'builtin' : typeof networking.gateway !== 'undefined' ? 'delegated' : 'standard',
+      dataplaneType: networking.type === 'gateway' ? dpTypes.builtin : typeof networking.gateway !== 'undefined' ? dpTypes.delegated : dpTypes.standard,
       status: (() => {
-        const state = typeof dataplaneInsight.connectedSubscription !== 'undefined' ? 'online' : 'offline'
+        const state = typeof dataplaneInsight.connectedSubscription !== 'undefined' ? states.online : states.offline
         if (networking.gateway) {
           return state
         }
@@ -94,10 +100,10 @@ export const DataplaneOverview = {
         switch (true) {
           case unhealthyInbounds.length === networking.inbounds.length:
             // All inbounds being unhealthy means the Dataplane is offline.
-            return 'offline'
+            return states.offline
           case unhealthyInbounds.length > 0:
             // Some inbounds being unhealthy means the Dataplane is partially degraded.
-            return 'partially_degraded'
+            return states.partiallyDegraded
           default:
             // All inbounds being healthy means the Dataplane’s status is determined by whether it’s connected to a control plane.
             return state
@@ -107,10 +113,11 @@ export const DataplaneOverview = {
       isCertExpired,
       services,
       zone,
+      config,
     }
   },
 
-  fromCollection(partialDataplaneOverviews: PaginatedApiListResponse<PartialDataplaneOverview>, canUseZones: boolean): PaginatedApiListResponse<DataplaneOverview> {
+  fromCollection(partialDataplaneOverviews: PaginatedApiListResponse<PartialDataplaneOverview>, canUseZones: boolean) {
     return {
       ...partialDataplaneOverviews,
       items: Array.isArray(partialDataplaneOverviews.items)
@@ -191,3 +198,5 @@ function getWarnings({ version }: DataplaneInsight, tags: LabelValue[], canUseZo
 
   return warnings
 }
+
+export type DataplaneOverview = ReturnType<typeof DataplaneOverview.fromObject>

--- a/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
@@ -375,4 +375,36 @@ describe('DataplaneOverview', () => {
       },
     )
   })
+  describe('dataplane.config', () => {
+    test(
+      'config is derived from Dataplane and based on DataplaneOverview data',
+      async ({ fixture }) => {
+        const expected = {
+          type: 'Dataplane',
+          name: 'dp-name',
+          mesh: 'dp-mesh',
+          creationTime: '2021-02-19T07:06:16.384057Z',
+          modificationTime: '2021-02-29T07:06:00.00Z',
+          networking: {
+            address: '167.61.18.108',
+            type: 'sidecar',
+            inboundAddress: 'localhost',
+            inbounds: [],
+            outbounds: [],
+          },
+        }
+
+        const actual = await fixture.setup((item) => {
+          item.name = expected.name
+          item.mesh = expected.mesh
+          item.creationTime = expected.creationTime
+          item.modificationTime = expected.modificationTime
+          item.dataplane.networking = expected.networking
+
+          return item
+        })
+
+        expect(actual.config).toStrictEqual(expected)
+      })
+  })
 })

--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -37,6 +37,8 @@ data-planes:
         data-plane-outbound-summary-overview-view: 'Overview'
         data-plane-outbound-summary-stats-view: 'Stats'
         data-plane-outbound-summary-clusters-view: 'Clusters'
+        data-plane-summary-overview-view: Overview
+        data-plane-summary-config-view: Config
       gateway: 'Gateway'
       inbounds: 'Inbounds'
       inbound_name: '{service}'

--- a/packages/kuma-gui/src/app/data-planes/routes.ts
+++ b/packages/kuma-gui/src/app/data-planes/routes.ts
@@ -67,7 +67,29 @@ export const routes = () => {
             {
               path: ':dataPlane',
               name: 'data-plane-summary-view',
+              props: () => ({
+                routeName: 'data-plane-summary-view',
+              }),
+              redirect: { name: 'data-plane-summary-overview-view' },
               component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
+              children: [
+                {
+                  path: 'summary-overview',
+                  name: 'data-plane-summary-overview-view',
+                  props: () => ({
+                    routeName: 'data-plane-summary-overview-view',
+                  }),
+                  component: () => import('@/app/data-planes/views/DataPlaneSummaryOverviewView.vue'),
+                },
+                {
+                  path: 'config',
+                  name: 'data-plane-summary-config-view',
+                  props: () => ({
+                    routeName: 'data-plane-summary-config-view',
+                  }),
+                  component: () => import('@/app/data-planes/views/DataPlaneSummaryConfigView.vue'),
+                },
+              ],
             },
           ],
         },

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryConfigView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryConfigView.vue
@@ -1,0 +1,55 @@
+<template>
+  <RouteView
+    :name="props.routeName"
+    :params="{
+      mesh: '',
+      dataPlane: '',
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+    }"
+    v-slot="{ route, uri }"
+  >
+    <AppView>
+      <ResourceCodeBlock
+        :resource="props.data.config"
+        language="yaml"
+        is-searchable
+        :query="route.params.codeSearch"
+        :is-filter-mode="route.params.codeFilter"
+        :is-reg-exp-mode="route.params.codeRegExp"
+        @query-change="route.update({ codeSearch: $event })"
+        @filter-mode-change="route.update({ codeFilter: $event })"
+        @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+        v-slot="{ copy, copying }"
+      >
+        <DataSource
+          v-if="copying"
+          :src="uri(sources, `/meshes/:mesh/dataplanes/:name/as/kubernetes`, {
+            mesh: route.params.mesh,
+            name: route.params.dataPlane,
+          }, {
+            cacheControl: 'no-store',
+          })"
+          @change="(data) => {
+            copy((resolve) => resolve(data))
+          }"
+          @error="(e) => {
+            copy((_resolve, reject) => reject(e))
+          }"
+        />
+      </ResourceCodeBlock>
+    </AppView>
+  </RouteView>
+</template>
+
+<script setup lang="ts">
+import type { DataplaneOverview } from '../data'
+import { sources } from '../sources'
+import ResourceCodeBlock from '@/app/x/components/x-code-block/ResourceCodeBlock.vue'
+
+const props = defineProps<{
+  data: DataplaneOverview
+  routeName: string
+}>()
+</script>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryOverviewView.vue
@@ -1,0 +1,286 @@
+<template>
+  <RouteView
+    :name="props.routeName"
+    :params="{
+      dataPlane: '',
+    }"
+    v-slot="{ t, can }"
+  >
+    <AppView>
+      <div
+        class="stack"
+      >
+        <div
+          class="stack-with-borders"
+        >
+          <DefinitionCard
+            layout="horizontal"
+          >
+            <template #title>
+              {{ t('http.api.property.status') }}
+            </template>
+
+            <template #body>
+              <div
+                class="status-with-reason"
+              >
+                <StatusBadge
+                  :status="props.data.status"
+                />
+                <DataCollection
+                  v-if="props.data.dataplaneType === 'standard'"
+                  :items="props.data.dataplane.networking.inbounds"
+                  :predicate="item => item.state !== 'Ready'"
+                  :empty="false"
+                  v-slot="{ items : inbounds }"
+                >
+                  <KTooltip
+                    class="reason-tooltip"
+                  >
+                    <InfoIcon
+                      :color="KUI_COLOR_BACKGROUND_NEUTRAL"
+                      :size="KUI_ICON_SIZE_30"
+                    />
+                    <template #content>
+                      <ul>
+                        <li
+                          v-for="inbound in inbounds"
+                          :key="`${inbound.service}:${inbound.port}`"
+                        >
+                          {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
+                        </li>
+                      </ul>
+                    </template>
+                  </KTooltip>
+                </DataCollection>
+              </div>
+            </template>
+          </DefinitionCard>
+
+          <DefinitionCard
+            layout="horizontal"
+          >
+            <template #title>
+              Type
+            </template>
+
+            <template #body>
+              {{ t(`data-planes.type.${props.data.dataplaneType}`) }}
+            </template>
+          </DefinitionCard>
+
+          <DefinitionCard
+            v-if="props.data.namespace.length > 0"
+            layout="horizontal"
+          >
+            <template #title>
+              {{ t('data-planes.routes.item.namespace') }}
+            </template>
+
+            <template #body>
+              {{ props.data.namespace }}
+            </template>
+          </DefinitionCard>
+
+          <DefinitionCard
+            v-if="can('use zones') && props.data.zone"
+            layout="horizontal"
+          >
+            <template
+              #title
+            >
+              Zone
+            </template>
+            <template
+              #body
+            >
+              <XAction
+                :to="{
+                  name: 'zone-cp-detail-view',
+                  params: {
+                    zone: props.data.zone,
+                  },
+                }"
+              >
+                {{ props.data.zone }}
+              </XAction>
+            </template>
+          </DefinitionCard>
+          <DefinitionCard
+            layout="horizontal"
+          >
+            <template #title>
+              {{ t('data-planes.routes.item.last_updated') }}
+            </template>
+
+            <template #body>
+              {{ t('common.formats.datetime', { value: Date.parse(props.data.modificationTime) }) }}
+            </template>
+          </DefinitionCard>
+        </div>
+
+        <div
+          v-if="props.data.dataplane.networking.gateway"
+        >
+          <h3>{{ t('data-planes.routes.item.gateway') }}</h3>
+
+          <div
+            class="mt-4"
+          >
+            <div
+              class="stack-with-borders"
+            >
+              <DefinitionCard
+                layout="horizontal"
+              >
+                <template #title>
+                  {{ t('http.api.property.tags') }}
+                </template>
+
+                <template #body>
+                  <TagList
+                    alignment="right"
+                    :tags="props.data.dataplane.networking.gateway.tags"
+                  />
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard
+                layout="horizontal"
+              >
+                <template #title>
+                  {{ t('http.api.property.address') }}
+                </template>
+
+                <template #body>
+                  <TextWithCopyButton
+                    :text="`${props.data.dataplane.networking.address}`"
+                  />
+                </template>
+              </DefinitionCard>
+            </div>
+          </div>
+        </div>
+
+        <DataCollection
+          v-if="props.data.dataplaneType === 'standard'"
+          :items="props.data.dataplane.networking.inbounds"
+          v-slot="{ items : inbounds }"
+        >
+          <div>
+            <h3>{{ t('data-planes.routes.item.inbounds') }}</h3>
+
+            <div
+              class="mt-4 stack"
+            >
+              <div
+                v-for="(inbound, index) in inbounds"
+                :key="index"
+                class="inbound"
+              >
+                <h4>
+                  <TextWithCopyButton
+                    :text="inbound.tags['kuma.io/service']"
+                  >
+                    {{ t('data-planes.routes.item.inbound_name', { service: inbound.tags['kuma.io/service'] }) }}
+                  </TextWithCopyButton>
+                </h4>
+
+                <div
+                  class="mt-2 stack-with-borders"
+                >
+                  <DefinitionCard
+                    layout="horizontal"
+                  >
+                    <template #title>
+                      {{ t('http.api.property.state') }}
+                    </template>
+
+                    <template #body>
+                      <XBadge
+                        v-if="inbound.state === 'Ready'"
+                        appearance="success"
+                      >
+                        {{ t(`http.api.value.${inbound.state}`) }}
+                      </XBadge>
+
+                      <XBadge
+                        v-else
+                        appearance="danger"
+                      >
+                        {{ t(`http.api.value.${inbound.state}`) }}
+                      </XBadge>
+                    </template>
+                  </DefinitionCard>
+
+                  <DefinitionCard
+                    layout="horizontal"
+                  >
+                    <template #title>
+                      {{ t('http.api.property.tags') }}
+                    </template>
+
+                    <template #body>
+                      <TagList
+                        alignment="right"
+                        :tags="inbound.tags"
+                      />
+                    </template>
+                  </DefinitionCard>
+
+                  <DefinitionCard
+                    layout="horizontal"
+                  >
+                    <template #title>
+                      {{ t('http.api.property.address') }}
+                    </template>
+
+                    <template #body>
+                      <TextWithCopyButton :text="inbound.addressPort" />
+                    </template>
+                  </DefinitionCard>
+                </div>
+              </div>
+            </div>
+          </div>
+        </DataCollection>
+      </div>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
+import { InfoIcon } from '@kong/icons'
+
+import type { DataplaneOverview } from '../data'
+import DefinitionCard from '@/app/common/DefinitionCard.vue'
+import StatusBadge from '@/app/common/StatusBadge.vue'
+import TagList from '@/app/common/TagList.vue'
+import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+
+const props = defineProps<{
+  data: DataplaneOverview
+  routeName: string
+}>()
+</script>
+<style lang="scss" scoped>
+h2.type-standard {
+  --icon-before: url('@/assets/images/east-west.svg') !important;
+}
+h2.type-builtin,
+h2.type-delegated {
+  --icon-before: url('@/assets/images/portal.svg') !important;
+}
+
+.status-with-reason {
+  display: flex;
+  align-items: center;
+  gap: $kui-space-50;
+}
+
+.reason-tooltip :deep(.kong-icon) {
+  display: flex;
+  align-items: center;
+}
+</style>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -1,15 +1,14 @@
 <template>
   <RouteView
-    name="data-plane-summary-view"
+    :name="props.routeName"
     :params="{
       dataPlane: '',
     }"
-    v-slot="{ t, route, can }"
+    v-slot="{ route, t }"
   >
     <DataCollection
       :items="props.items"
       :predicate="item => item.id === route.params.dataPlane"
-      :find="true"
     >
       <template #empty>
         <XEmptyState>
@@ -49,245 +48,34 @@
                 </XAction>
               </h2>
             </template>
-
-            <div
-              class="stack"
+            <XTabs
+              :selected="route.child()?.name"
             >
-              <div
-                class="stack-with-borders"
+              <template
+                v-for="{ name } in route.children"
+                :key="name"
+                #[`${name}-tab`]
               >
-                <DefinitionCard
-                  layout="horizontal"
+                <XAction
+                  :to="{
+                    name,
+                  }"
                 >
-                  <template #title>
-                    {{ t('http.api.property.status') }}
-                  </template>
+                  {{ t(`data-planes.routes.item.navigation.${name}`) }}
+                </XAction>
+              </template>
+            </XTabs>
 
-                  <template #body>
-                    <div
-                      class="status-with-reason"
-                    >
-                      <StatusBadge
-                        :status="item.status"
-                      />
-                      <DataCollection
-                        v-if="item.dataplaneType === 'standard'"
-                        :items="item.dataplane.networking.inbounds"
-                        :predicate="item => item.state !== 'Ready'"
-                        :empty="false"
-                        v-slot="{ items : inbounds }"
-                      >
-                        <KTooltip
-                          class="reason-tooltip"
-                        >
-                          <InfoIcon
-                            :color="KUI_COLOR_BACKGROUND_NEUTRAL"
-                            :size="KUI_ICON_SIZE_30"
-                          />
-                          <template #content>
-                            <ul>
-                              <li
-                                v-for="inbound in inbounds"
-                                :key="`${inbound.service}:${inbound.port}`"
-                              >
-                                {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
-                              </li>
-                            </ul>
-                          </template>
-                        </KTooltip>
-                      </DataCollection>
-                    </div>
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template #title>
-                    Type
-                  </template>
-
-                  <template #body>
-                    {{ t(`data-planes.type.${item.dataplaneType}`) }}
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
-                  v-if="item.namespace.length > 0"
-                  layout="horizontal"
-                >
-                  <template #title>
-                    {{ t('data-planes.routes.item.namespace') }}
-                  </template>
-
-                  <template #body>
-                    {{ item.namespace }}
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
-                  v-if="can('use zones') && item.zone"
-                  layout="horizontal"
-                >
-                  <template
-                    #title
-                  >
-                    Zone
-                  </template>
-                  <template
-                    #body
-                  >
-                    <XAction
-                      :to="{
-                        name: 'zone-cp-detail-view',
-                        params: {
-                          zone: item.zone,
-                        },
-                      }"
-                    >
-                      {{ item.zone }}
-                    </XAction>
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template #title>
-                    {{ t('data-planes.routes.item.last_updated') }}
-                  </template>
-
-                  <template #body>
-                    {{ t('common.formats.datetime', { value: Date.parse(item.modificationTime) }) }}
-                  </template>
-                </DefinitionCard>
-              </div>
-
-              <div
-                v-if="item.dataplane.networking.gateway"
+            <RouterView
+              v-slot="{ Component }"
+            >
+              <component
+                :is="Component"
+                :data="item"
               >
-                <h3>{{ t('data-planes.routes.item.gateway') }}</h3>
-
-                <div
-                  class="mt-4"
-                >
-                  <div
-                    class="stack-with-borders"
-                  >
-                    <DefinitionCard
-                      layout="horizontal"
-                    >
-                      <template #title>
-                        {{ t('http.api.property.tags') }}
-                      </template>
-
-                      <template #body>
-                        <TagList
-                          alignment="right"
-                          :tags="item.dataplane.networking.gateway.tags"
-                        />
-                      </template>
-                    </DefinitionCard>
-
-                    <DefinitionCard
-                      layout="horizontal"
-                    >
-                      <template #title>
-                        {{ t('http.api.property.address') }}
-                      </template>
-
-                      <template #body>
-                        <TextWithCopyButton
-                          :text="`${item.dataplane.networking.address}`"
-                        />
-                      </template>
-                    </DefinitionCard>
-                  </div>
-                </div>
-              </div>
-
-              <DataCollection
-                v-if="item.dataplaneType === 'standard'"
-                :items="item.dataplane.networking.inbounds"
-                v-slot="{ items : inbounds }"
-              >
-                <div>
-                  <h3>{{ t('data-planes.routes.item.inbounds') }}</h3>
-
-                  <div
-                    class="mt-4 stack"
-                  >
-                    <div
-                      v-for="(inbound, index) in inbounds"
-                      :key="index"
-                      class="inbound"
-                    >
-                      <h4>
-                        <TextWithCopyButton
-                          :text="inbound.tags['kuma.io/service']"
-                        >
-                          {{ t('data-planes.routes.item.inbound_name', { service: inbound.tags['kuma.io/service'] }) }}
-                        </TextWithCopyButton>
-                      </h4>
-
-                      <div
-                        class="mt-2 stack-with-borders"
-                      >
-                        <DefinitionCard
-                          layout="horizontal"
-                        >
-                          <template #title>
-                            {{ t('http.api.property.state') }}
-                          </template>
-
-                          <template #body>
-                            <XBadge
-                              v-if="inbound.state === 'Ready'"
-                              appearance="success"
-                            >
-                              {{ t(`http.api.value.${inbound.state}`) }}
-                            </XBadge>
-
-                            <XBadge
-                              v-else
-                              appearance="danger"
-                            >
-                              {{ t(`http.api.value.${inbound.state}`) }}
-                            </XBadge>
-                          </template>
-                        </DefinitionCard>
-
-                        <DefinitionCard
-                          layout="horizontal"
-                        >
-                          <template #title>
-                            {{ t('http.api.property.tags') }}
-                          </template>
-
-                          <template #body>
-                            <TagList
-                              alignment="right"
-                              :tags="inbound.tags"
-                            />
-                          </template>
-                        </DefinitionCard>
-
-                        <DefinitionCard
-                          layout="horizontal"
-                        >
-                          <template #title>
-                            {{ t('http.api.property.address') }}
-                          </template>
-
-                          <template #body>
-                            <TextWithCopyButton :text="inbound.addressPort" />
-                          </template>
-                        </DefinitionCard>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </DataCollection>
-            </div>
+                <slot name="default" />
+              </component>
+            </RouterView>
           </AppView>
         </template>
       </template>
@@ -296,36 +84,10 @@
 </template>
 
 <script lang="ts" setup>
-import { KUI_COLOR_BACKGROUND_NEUTRAL, KUI_ICON_SIZE_30 } from '@kong/design-tokens'
-import { InfoIcon } from '@kong/icons'
-
-import type { DataplaneOverview } from '../data'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
-import StatusBadge from '@/app/common/StatusBadge.vue'
-import TagList from '@/app/common/TagList.vue'
-import TextWithCopyButton from '@/app/common/TextWithCopyButton.vue'
+import { DataplaneOverview } from '../data'
 
 const props = defineProps<{
   items: DataplaneOverview[]
+  routeName: string
 }>()
 </script>
-<style lang="scss" scoped>
-h2.type-standard {
-  --icon-before: url('@/assets/images/east-west.svg') !important;
-}
-h2.type-builtin,
-h2.type-delegated {
-  --icon-before: url('@/assets/images/portal.svg') !important;
-}
-
-.status-with-reason {
-  display: flex;
-  align-items: center;
-  gap: $kui-space-50;
-}
-
-.reason-tooltip :deep(.kong-icon) {
-  display: flex;
-  align-items: center;
-}
-</style>


### PR DESCRIPTION
This change introduces a tab navigation to the `DataPlaneSummaryView` offering an `Overview` and `Config` tab. The reason for the separation into tabs was because the summary view could get very crowded already. The `Overview` tab shows everything that was previously shown on the summary view. The `Config` tab shows the config, which is based on some metadata and `dataplane.network` data of a `DataPlaneOverview` item (similar to what was done in #3202 and #3203).
