### PR TITLE
chore(ci): installs cypress-terminal-report for surfacing console.warns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5277,6 +5277,11 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5571,6 +5576,37 @@
         "sinon": "^17.0.0",
         "sinon-chai": "^3.7.0",
         "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/cypress-terminal-report": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-7.0.4.tgz",
+      "integrity": "sha512-atP8It2IwcgzJ3YsQcwYFbnuCC/KSGPEUaorJsJi3E9JE93IdFf21LuwuApOfbEMmqVu6mPtlxmxqutBFZNxhg==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "compare-versions": "^6.1.1",
+        "fs-extra": "^10.1.0",
+        "process": "^0.11.10",
+        "superstruct": "0.14.2"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "cypress": ">=10.0.0"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/cypress/node_modules/commander": {
@@ -13792,6 +13828,11 @@
         "node": ">=16"
       }
     },
+    "node_modules/superstruct": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
+      "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -16501,6 +16542,7 @@
         "@badeball/cypress-cucumber-preprocessor": "^21.0.2",
         "cypress": "^13.15.2",
         "cypress-fail-fast": "^7.1.1",
+        "cypress-terminal-report": "^7.0.4",
         "eslint": "^8.57.1",
         "stylelint": "^16.10.0"
       }
@@ -16548,6 +16590,7 @@
         "cypress": "^13.15.2",
         "cypress-fail-fast": "^7.1.1",
         "cypress-fail-on-console-error": "^5.1.1",
+        "cypress-terminal-report": "^7.0.4",
         "dotenv": "^16.4.5",
         "eslint": "^8.57.1",
         "glob": "^11.0.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -32,6 +32,7 @@
     "@badeball/cypress-cucumber-preprocessor": "^21.0.2",
     "cypress": "^13.15.2",
     "cypress-fail-fast": "^7.1.1",
+    "cypress-terminal-report": "^7.0.4",
     "eslint": "^8.57.1",
     "stylelint": "^16.10.0"
   }

--- a/packages/config/src/cypress.ts
+++ b/packages/config/src/cypress.ts
@@ -2,6 +2,7 @@ import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-prepro
 import { createEsbuildPlugin } from '@badeball/cypress-cucumber-preprocessor/esbuild'
 import createBundler from '@bahmutov/cypress-esbuild-preprocessor'
 import cypressFailFast from 'cypress-fail-fast/plugin'
+import installLogsPrinter from 'cypress-terminal-report/src/installLogsPrinter'
 import esbuild from 'esbuild'
 import fs from 'node:fs'
 
@@ -31,6 +32,7 @@ export const cypress = (env: Record<string, string>) => {
       // Can be turned on via CLI using `CYPRESS_video=true npm run test:browser`
       video: false,
       async setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) {
+
         // propagate env to Cypress.env
         Object.entries(env).forEach(([prop, value]) => {
           config.env[prop] = value
@@ -79,6 +81,10 @@ export const cypress = (env: Record<string, string>) => {
           }
         })
 
+        installLogsPrinter(on, {
+          logToFilesOnAfterRun: true,
+          printLogsToConsole: 'always',
+        })
         cypressFailFast(on, config)
 
         // Make sure to return the config object as it might have been modified by the plugin.

--- a/packages/kuma-gui/cypress/support/e2e.ts
+++ b/packages/kuma-gui/cypress/support/e2e.ts
@@ -1,4 +1,8 @@
 import 'cypress-fail-fast'
 import failOnConsoleError from 'cypress-fail-on-console-error'
+import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector'
+installLogsCollector({
+  collectTypes: ['cons:warn'],
+})
 
 failOnConsoleError()

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -59,6 +59,7 @@
     "cypress": "^13.15.2",
     "cypress-fail-fast": "^7.1.1",
     "cypress-fail-on-console-error": "^5.1.1",
+    "cypress-terminal-report": "^7.0.4",
     "dotenv": "^16.4.5",
     "eslint": "^8.57.1",
     "glob": "^11.0.0",


### PR DESCRIPTION
There are places where we can sometimes have certain HTTP errors swallowed and converted to `console.warn`, currently its up in the air whether we leave them alone or convert them to console.errors (so they fail our tests using `cypress-fail-on-console-error` that we already have installed).

This PR install a further dependency that allows us to log `console.warn`s.

Note there are other things that it allows us to log, but for the moment I'm looking for low noise and just output `console.warn`s. Also, we can't fail on console.warn because we have 3rd party dependencies that use `warn` correctly and for good reason.

---

I confirmed we are seeing console.warns in the tests in GH logs. You can apparently get the plugin to output a txt file so you can make an artifact, but I plan on adding this later if this plugin proves useful. For now it will be good to merge this as is so we can start watching for console.warn.

<img width="978" alt="Screenshot 2024-11-20 at 12 45 38" src="https://github.com/user-attachments/assets/a318ec8a-8015-4fdf-9fcb-df8686babf64">

