### PR TITLE
chore: Formalize 'route walkers' a little more

### DIFF
--- a/packages/kuma-gui/src/app/application/index.ts
+++ b/packages/kuma-gui/src/app/application/index.ts
@@ -103,22 +103,23 @@ const addPath = (item: RouteRecordRaw, parent?: RouteRecordRaw) => {
   }
 }
 const addRouteName = (item: RouteRecordRaw) => {
-  if (typeof item.name !== 'undefined') {
-    const props = ((props) => {
-      switch (true) {
-        case typeof props === 'function':
-          return props
-        case typeof props === 'undefined':
-          return () => ({})
-        default:
-          return () => props
-      }
-    })(item.props)
-    item.props = (...args) => {
-      return {
-        ...props(...args),
-        routeName: item.name,
-      }
+  if (typeof item.name === 'undefined') {
+    return
+  }
+  const props = ((props) => {
+    switch (true) {
+      case typeof props === 'function':
+        return props
+      case typeof props === 'undefined':
+        return () => ({})
+      default:
+        return () => props
+    }
+  })(item.props)
+  item.props = (...args) => {
+    return {
+      ...props(...args),
+      routeName: item.name,
     }
   }
 }

--- a/packages/kuma-gui/src/app/application/index.ts
+++ b/packages/kuma-gui/src/app/application/index.ts
@@ -102,6 +102,26 @@ const addPath = (item: RouteRecordRaw, parent?: RouteRecordRaw) => {
     item.meta.path = `${path}${path.length > 0 ? '.' : ''}${String(item.name)}`
   }
 }
+const addRouteName = (item: RouteRecordRaw) => {
+  if (typeof item.name !== 'undefined') {
+    const props = ((props) => {
+      switch (true) {
+        case typeof props === 'function':
+          return props
+        case typeof props === 'undefined':
+          return () => ({})
+        default:
+          return () => props
+      }
+    })(item.props)
+    item.props = (...args) => {
+      return {
+        ...props(...args),
+        routeName: item.name,
+      }
+    }
+  }
+}
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
 
@@ -140,6 +160,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         return [
           addModule,
           addPath,
+          addRouteName,
         ]
       },
       labels: [

--- a/packages/kuma-gui/src/app/application/index.ts
+++ b/packages/kuma-gui/src/app/application/index.ts
@@ -24,6 +24,7 @@ import { services as x } from '@/app/x'
 import type { ServiceDefinition } from '@/services/utils'
 import { token, createInjections, constant } from '@/services/utils'
 import type { Component } from 'vue'
+import type { RouteRecordRaw } from 'vue-router'
 export * from './services/can'
 export { runInDebug } from './utilities'
 export { defineSources } from './services/data-source'
@@ -83,6 +84,24 @@ const $ = {
   i18n: token<ReturnType<typeof I18n>>('i18n'),
   enUs: token('i18n.locale.enUs'),
 }
+
+const addModule = (item: RouteRecordRaw, parent?: RouteRecordRaw) => {
+  item.meta = {
+    ...(item.meta ?? {}),
+  }
+  if (typeof parent?.meta?.module !== 'undefined') {
+    item.meta.module = parent.meta.module
+  }
+}
+const addPath = (item: RouteRecordRaw, parent?: RouteRecordRaw) => {
+  item.meta = {
+    ...(item.meta ?? {}),
+  }
+  if (typeof parent?.meta?.path !== 'undefined') {
+    const path = String(parent.meta.path) ?? ''
+    item.meta.path = `${path}${path.length > 0 ? '.' : ''}${String(item.name)}`
+  }
+}
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
 
@@ -114,6 +133,17 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
       labels: [
         app.routes,
+      ],
+    }],
+    [token('application.routes.walkers'), {
+      service: () => {
+        return [
+          addModule,
+          addPath,
+        ]
+      },
+      labels: [
+        app.routeWalkers,
       ],
     }],
     [token('application.locales'), {

--- a/packages/kuma-gui/src/app/data-planes/routes.ts
+++ b/packages/kuma-gui/src/app/data-planes/routes.ts
@@ -63,9 +63,6 @@ export const routes = () => {
       {
         path: ':dataPlane',
         name: `${fullPrefix}data-plane-summary-view`,
-        props: () => ({
-          routeName: `${fullPrefix}data-plane-summary-view`,
-        }),
         component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
       },
     ]

--- a/packages/kuma-gui/src/app/subscriptions/routes.ts
+++ b/packages/kuma-gui/src/app/subscriptions/routes.ts
@@ -5,25 +5,16 @@ export const routes = (prefix: string): RouteRecordRaw[] => {
       path: 'subscription/:subscription',
       name: `${prefix}-subscription-summary-view`,
       redirect: { name: `${prefix}-subscription-summary-overview-view` },
-      props: () => ({
-        routeName: `${prefix}-subscription-summary-view`,
-      }),
       component: () => import('@/app/subscriptions/views/SubscriptionSummaryView.vue'),
       children: [
         {
           path: 'overview',
           name: `${prefix}-subscription-summary-overview-view`,
-          props: () => ({
-            routeName: `${prefix}-subscription-summary-overview-view`,
-          }),
           component: () => import('@/app/subscriptions/views/SubscriptionSummaryOverviewView.vue'),
         },
         {
           path: 'config',
           name: `${prefix}-subscription-summary-config-view`,
-          props: () => ({
-            routeName: `${prefix}-subscription-summary-config-view`,
-          }),
           component: () => import('@/app/subscriptions/views/SubscriptionSummaryConfigView.vue'),
         },
       ],


### PR DESCRIPTION
Back in https://github.com/kumahq/kuma-gui/pull/3151 we introduced the concept of 'route walkers'. These walk over every single route in your entire routing tree, giving you the opportunity to mutate or otherwise tweak a piece of routing config from The Outside.

When we made https://github.com/kumahq/kuma-gui/pull/3151, we noted we'd added the 'route walker' concept plus 2 walkers at our 'vue' level (i.e. in our `vue` module), even though the 2 walkers are specific to our `application` module.

This PR splits the concept and the application level implementations using a `$.routeWalkers` dependency injection label. 

This means we can dynamically add/remove different routeWalkers at the service container level, which will be very useful moving forwards.

---

I also added one more walker than automatically adds a 'props.routeName' property to all route components. You will still need to use `defineProps{ routeName: string}()` in order to access it, but at least you no longer need to manually add repetitive routing configuration to do this.
