### PR TITLE
feat: default service hosts to period-delimited

### DIFF
--- a/packages/kuma-gui/src/app/services/data/index.ts
+++ b/packages/kuma-gui/src/app/services/data/index.ts
@@ -31,11 +31,13 @@ export const ServiceInsight = {
   fromObject(partialServiceInsight: PartialServiceInsight): ServiceInsight {
     const serviceType = partialServiceInsight.serviceType ?? 'internal'
     const status = partialServiceInsight.status ?? 'not_available'
+    const addressPort = partialServiceInsight.addressPort?.replaceAll('_', '.')
 
     return {
       ...partialServiceInsight,
       serviceType,
       status,
+      addressPort,
     }
   },
 


### PR DESCRIPTION
DNS is created in the mesh for `_`-delimited and `.`-delimited hostnames. This PR makes the `.`-delimited the default (as it is the only one in conformance with the RFC). This is a QOL improvement for folks copying/pasting from the UI, and both versions should work identically. The API returns `_`-delimited so in the case anyone was using any kind of automation, this shouldn't break them anyway.

fixes #3098 