### PR TITLE
feature: enable delayed teleporting

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-teleport/XTeleportSlot.vue
+++ b/packages/kuma-gui/src/app/x/components/x-teleport/XTeleportSlot.vue
@@ -4,8 +4,11 @@
   />
 </template>
 <script lang="ts" setup>
+import { onMounted } from 'vue'
 const props = defineProps<{
   name: string
 }>()
-
+onMounted(() => {
+  window.dispatchEvent(new CustomEvent<{ name: string }>('x-teleport-slot:mounted', { detail: { name: props.name } }))
+})
 </script>

--- a/packages/kuma-gui/src/app/x/components/x-teleport/XTeleportTemplate.vue
+++ b/packages/kuma-gui/src/app/x/components/x-teleport/XTeleportTemplate.vue
@@ -22,8 +22,8 @@ onMounted(() => {
   if (document.querySelector(`[data-x-teleport-id='${props.to.name}']`) !== null) {
     ready.value = true
   } else {
-    window.addEventListener('x-teleport-slot:mounted', (e: Event) => {
-      if (isCustomEvent(e) && e.detail?.name === props.to.name) {
+    window.addEventListener('x-teleport-slot:mounted', (e: CustomEvent<{ name: string }> | Event) => {
+      if ('detail' in e && e.detail?.name === props.to.name) {
         ready.value = true
       }
     }, { signal: controller.signal })

--- a/packages/kuma-gui/src/app/x/components/x-teleport/XTeleportTemplate.vue
+++ b/packages/kuma-gui/src/app/x/components/x-teleport/XTeleportTemplate.vue
@@ -7,19 +7,30 @@
   </Teleport>
 </template>
 <script lang="ts" setup>
-import { onMounted, ref } from 'vue'
+import { onMounted, onBeforeUnmount, ref } from 'vue'
 const props = defineProps<{
   to: {
     name: string
   }
 }>()
-
+const controller = new AbortController()
 const ready = ref<boolean>(false)
+
+const isCustomEvent = (e: Event | CustomEvent): e is CustomEvent => 'detail' in e
+
 onMounted(() => {
   if (document.querySelector(`[data-x-teleport-id='${props.to.name}']`) !== null) {
     ready.value = true
   } else {
-    throw new Error(`The '[data-x-teleport-id='${props.to.name}']' element could not be found to teleport to`)
+    window.addEventListener('x-teleport-slot:mounted', (e: Event) => {
+      if (isCustomEvent(e) && e.detail?.name === props.to.name) {
+        ready.value = true
+      }
+    }, { signal: controller.signal })
   }
+})
+
+onBeforeUnmount(() => {
+  controller.abort()
 })
 </script>

--- a/packages/kuma-gui/src/app/x/components/x-teleport/XTeleportTemplate.vue
+++ b/packages/kuma-gui/src/app/x/components/x-teleport/XTeleportTemplate.vue
@@ -15,9 +15,6 @@ const props = defineProps<{
 }>()
 const controller = new AbortController()
 const ready = ref<boolean>(false)
-
-const isCustomEvent = (e: Event | CustomEvent): e is CustomEvent => 'detail' in e
-
 onMounted(() => {
   if (document.querySelector(`[data-x-teleport-id='${props.to.name}']`) !== null) {
     ready.value = true


### PR DESCRIPTION
Sometimes when you add a teleport to a page, the place where it is supposed to go hasn't quite been rendered yet (the slot) which is just down to Vue/DOM intricacies.

Previously we would just error out if we hit this, but there are some use cases I've found where this is always going to throw. Ideally, it should wait for the corresponding template slot to be available and only then teleport into it, and that is what this PR does.

Just to note: timings wise we are talking milliseconds here.