### PR TITLE
feat: adds XTimespan component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2139,23 +2139,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@kong-ui-public/app-layout": {
-      "version": "4.2.63",
-      "resolved": "https://registry.npmjs.org/@kong-ui-public/app-layout/-/app-layout-4.2.63.tgz",
-      "integrity": "sha512-vhoP3qp8ttJ3k4KyROk3BW5jRXFE+Dr+KsgruOC0QkNkYN7v50UuxjVwsZwrZj16rqt4kzlJHnlZrYzDGAxzoA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@kong/icons": "^1.20.0",
-        "focus-trap": "^7.6.0",
-        "focus-trap-vue": "^4.0.3",
-        "lodash.clonedeep": "^4.5.0"
-      },
-      "peerDependencies": {
-        "@kong/kongponents": "^9.14.16",
-        "vue": ">= 3.3.13 < 4",
-        "vue-router": "^4.4.5"
-      }
-    },
     "node_modules/@kong-ui-public/i18n": {
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/@kong-ui-public/i18n/-/i18n-2.2.9.tgz",
@@ -10157,11 +10140,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -16685,7 +16663,6 @@
       "name": "@kumahq/kuma-gui",
       "version": "2.10.0",
       "dependencies": {
-        "@kong-ui-public/app-layout": "^4.2.63",
         "@kong-ui-public/i18n": "^2.2.9",
         "@kong/icons": "^1.20.0",
         "@kong/kongponents": "^9.14.16",

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@kong-ui-public/i18n": "^2.2.9",
     "@kong/icons": "^1.20.0",
-    "@kong-ui-public/app-layout": "^4.2.63",
     "@kong/kongponents": "^9.14.16",
     "@vueuse/core": "^11.3.0",
     "brandi": "^5.0.0",

--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -53,7 +53,6 @@ data-planes:
       inbounds: 'Inbounds'
       inbound_name: '{service}'
       port: ':{port}'
-      last_updated: 'Last updated'
       namespace: 'Namespace'
       certificate_info: 'Certificate info'
       no_certificate: 'No certificate'

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -42,6 +42,10 @@
             <div
               class="stack"
             >
+              <XTimespan
+                :start="t('common.formats.datetime', { value: Date.parse(props.data.creationTime) })"
+                :end="t('common.formats.datetime', { value: Date.parse(props.data.modificationTime) })"
+              />
               <div
                 class="columns"
               >
@@ -129,41 +133,28 @@
                 </DefinitionCard>
               </div>
               <div
+                v-if="props.data.dataplane.networking.gateway"
                 class="columns"
               >
                 <DefinitionCard>
                   <template #title>
-                    {{ t('data-planes.routes.item.last_updated') }}
+                    {{ t('http.api.property.tags') }}
                   </template>
 
                   <template #body>
-                    {{ t('common.formats.datetime', { value: Date.parse(props.data.modificationTime) }) }}
+                    <TagList :tags="props.data.dataplane.networking.gateway.tags" />
                   </template>
                 </DefinitionCard>
 
-                <template
-                  v-if="props.data.dataplane.networking.gateway"
-                >
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('http.api.property.tags') }}
-                    </template>
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('http.api.property.address') }}
+                  </template>
 
-                    <template #body>
-                      <TagList :tags="props.data.dataplane.networking.gateway.tags" />
-                    </template>
-                  </DefinitionCard>
-
-                  <DefinitionCard>
-                    <template #title>
-                      {{ t('http.api.property.address') }}
-                    </template>
-
-                    <template #body>
-                      <TextWithCopyButton :text="`${props.data.dataplane.networking.address}`" />
-                    </template>
-                  </DefinitionCard>
-                </template>
+                  <template #body>
+                    <TextWithCopyButton :text="`${props.data.dataplane.networking.address}`" />
+                  </template>
+                </DefinitionCard>
               </div>
             </div>
           </KCard>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryOverviewView.vue
@@ -110,7 +110,7 @@
             layout="horizontal"
           >
             <template #title>
-              {{ t('data-planes.routes.item.last_updated') }}
+              {{ t('http.api.property.modificationTime') }}
             </template>
 
             <template #body>

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
@@ -29,13 +29,21 @@
             </XCopyButton>
           </h1>
         </template>
-        <div class="stack">
-          <AppAboutSection
-            :title="t('hostname-generators.routes.item.subtitle', { name: data.name })"
-            :created="t('common.formats.datetime', { value: Date.parse(data.creationTime) })"
-            :modified="t('common.formats.datetime', { value: Date.parse(data.modificationTime) })"
-          >
-            <div class="columns">
+        <XLayout
+          type="stack"
+        >
+          <XCard>
+            <XLayout
+              type="stack"
+            >
+              <XTimespan
+                :start="t('common.formats.datetime', { value: Date.parse(data.creationTime) })"
+                :end="t('common.formats.datetime', { value: Date.parse(data.modificationTime) })"
+              />
+            </XLayout>
+            <div
+              class="columns"
+            >
               <template
                 v-for="labels in [{
                   ...data.spec.selector.meshService.matchLabels,
@@ -64,7 +72,7 @@
                 </DefinitionCard>
               </template>
             </div>
-          </AppAboutSection>
+          </XCard>
 
           <ResourceCodeBlock
             :resource="data.$raw"
@@ -85,22 +93,14 @@
               }"
             />
           </ResourceCodeBlock>
-        </div>
+        </XLayout>
       </AppView>
     </DataLoader>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import { AppAboutSection } from '@kong-ui-public/app-layout'
-
 import { sources } from '../sources'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import ResourceCodeBlock from '@/app/x/components/x-code-block/ResourceCodeBlock.vue'
 </script>
-
-<style lang="scss" scoped>
-:deep(.kong-ui-app-about-section .about-section-content) {
-  display: block;
-}
-</style>

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -91,6 +91,8 @@ common:
 http:
   api:
     property:
+      modificationTime: Modified
+      creationTime: Created
       tls: TLS
       mtls: mTLS
       mTLS: mTLS

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -39,48 +39,54 @@
               />
             </ul>
           </template>
-          <div class="stack">
-            <AppAboutSection
-              :title="t('meshes.routes.item.subtitle', { name: props.mesh.name })"
-              :created="t('common.formats.datetime', { value: Date.parse(props.mesh.creationTime) })"
-              :modified="t('common.formats.datetime', { value: Date.parse(props.mesh.modificationTime) })"
-            >
-              <div class="columns">
-                <template
-                  v-for="policy in ['MeshTrafficPermission', 'MeshMetric', 'MeshAccessLog', 'MeshTrace']"
-                  :key="policy"
-                >
+          <XLayout
+            type="stack"
+          >
+            <XCard>
+              <XLayout
+                type="stack"
+              >
+                <XTimespan
+                  :start="t('common.formats.datetime', { value: Date.parse(props.mesh.creationTime) })"
+                  :end="t('common.formats.datetime', { value: Date.parse(props.mesh.modificationTime) })"
+                />
+                <div class="columns">
                   <template
-                    v-for="enabled in [Object.entries(data?.policies ?? {}).find(([key, value]) => key === policy)]"
-                    :key="enabled"
+                    v-for="policy in ['MeshTrafficPermission', 'MeshMetric', 'MeshAccessLog', 'MeshTrace']"
+                    :key="policy"
                   >
-                    <DefinitionCard>
-                      <template #title>
-                        <XAction
-                          :to="{
-                            name: 'policy-list-view',
-                            params: {
-                              mesh: route.params.mesh,
-                              policyPath: `${policy.toLowerCase()}s`,
-                            },
-                          }"
-                        >
-                          {{ policy }}
-                        </XAction>
-                      </template>
+                    <template
+                      v-for="enabled in [Object.entries(data?.policies ?? {}).find(([key, value]) => key === policy)]"
+                      :key="enabled"
+                    >
+                      <DefinitionCard>
+                        <template #title>
+                          <XAction
+                            :to="{
+                              name: 'policy-list-view',
+                              params: {
+                                mesh: route.params.mesh,
+                                policyPath: `${policy.toLowerCase()}s`,
+                              },
+                            }"
+                          >
+                            {{ policy }}
+                          </XAction>
+                        </template>
 
-                      <template #body>
-                        <XBadge
-                          appearance="neutral"
-                        >
-                          {{ enabled ? t('meshes.detail.enabled') : t('meshes.detail.disabled') }}
-                        </XBadge>
-                      </template>
-                    </DefinitionCard>
+                        <template #body>
+                          <XBadge
+                            appearance="neutral"
+                          >
+                            {{ enabled ? t('meshes.detail.enabled') : t('meshes.detail.disabled') }}
+                          </XBadge>
+                        </template>
+                      </DefinitionCard>
+                    </template>
                   </template>
-                </template>
-              </div>
-            </AppAboutSection>
+                </div>
+              </XLayout>
+            </XCard>
 
             <KCard>
               <div class="stack">
@@ -152,7 +158,7 @@
                 }"
               />
             </ResourceCodeBlock>
-          </div>
+          </XLayout>
         </AppView>
       </template>
     </DataSource>
@@ -160,8 +166,6 @@
 </template>
 
 <script lang="ts" setup>
-import { AppAboutSection } from '@kong-ui-public/app-layout'
-
 import type { Mesh } from '../data'
 import { sources } from '../sources'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
@@ -172,9 +176,3 @@ const props = defineProps<{
   mesh: Mesh
 }>()
 </script>
-
-<style lang="scss" scoped>
-:deep(.kong-ui-app-about-section .about-section-content) {
-  display: block;
-}
-</style>

--- a/packages/kuma-gui/src/app/x/components/x-timespan/README.md
+++ b/packages/kuma-gui/src/app/x/components/x-timespan/README.md
@@ -1,0 +1,35 @@
+# x-timespan
+
+Presentational component for showing spans of time.
+
+Attributes are purposefully simple strings, please pass in a correctly formatted date using `t('common.formats.datetime', { value: yourDateVariable })`
+
+Both attributes are optional for specifying a single time, and all content of the component is end-aligned. Content will wrap before the values rather than in the middle of the values when space is restricted.
+
+<Story>
+  <XTimespan
+    start="Christmas"
+    end="New Year"
+  />
+  <XTimespan
+    start="Christmas"
+    :end="t('common.formats.datetime', { value: '1' })"
+  />
+  <br />
+  <XTimespan
+    :start="t('common.formats.datetime', { value: '1' })"
+  />
+  <br />
+  <XTimespan
+    :end="t('common.formats.datetime', { value: '1' })"
+  />
+  <br />
+  <figure
+    style="width: 200px;float: right;"
+  >
+    <XTimespan
+      :start="t('common.formats.datetime', { value: '1' })"
+      :end="t('common.formats.datetime', { value: '2' })"
+    />
+  </figure>
+</Story>

--- a/packages/kuma-gui/src/app/x/components/x-timespan/XTimespan.vue
+++ b/packages/kuma-gui/src/app/x/components/x-timespan/XTimespan.vue
@@ -1,0 +1,55 @@
+<template>
+  <dl
+    v-if="props.start.length > 0 || props.end.length > 0"
+    class="x-timespan"
+    data-testid="x-timespan"
+  >
+    <div
+      v-if="props.start.length > 0"
+    >
+      <dt>Created</dt>
+      <dd>{{ props.start }}</dd>
+    </div>
+    <div
+      v-if="props.end.length > 0"
+    >
+      <dt>Modified</dt>
+      <dd>{{ props.end }}</dd>
+    </div>
+  </dl>
+</template>
+<script lang="ts" setup>
+
+const props = withDefaults(defineProps<{
+  start?: string
+  end?: string
+}>(), {
+  start: '',
+  end: '',
+})
+</script>
+<style lang="scss" scoped>
+dl {
+  font-size: $kui-font-size-20;
+  color: $kui-color-text-neutral;
+}
+dl,
+dl div {
+  display: flex;
+  flex-wrap: wrap;
+}
+dl {
+  justify-content: flex-end;
+}
+dd {
+  white-space: nowrap;
+}
+dt::after {
+  content: ':';
+  margin-right: $kui-space-20;
+}
+dl div:nth-child(2)::before {
+  content: '->';
+  margin: 0 $kui-space-40;
+}
+</style>

--- a/packages/kuma-gui/src/app/x/components/x-timespan/XTimespan.vue
+++ b/packages/kuma-gui/src/app/x/components/x-timespan/XTimespan.vue
@@ -7,18 +7,21 @@
     <div
       v-if="props.start.length > 0"
     >
-      <dt>Created</dt>
+      <dt>{{ t('http.api.property.creationTime') }}</dt>
       <dd>{{ props.start }}</dd>
     </div>
     <div
       v-if="props.end.length > 0"
     >
-      <dt>Modified</dt>
+      <dt>{{ t('http.api.property.modificationTime') }}</dt>
       <dd>{{ props.end }}</dd>
     </div>
   </dl>
 </template>
 <script lang="ts" setup>
+import { useI18n } from '@/app/application'
+
+const { t } = useI18n()
 
 const props = withDefaults(defineProps<{
   start?: string

--- a/packages/kuma-gui/src/app/x/index.ts
+++ b/packages/kuma-gui/src/app/x/index.ts
@@ -17,6 +17,7 @@ import XSelect from './components/x-select/XSelect.vue'
 import XTabs from './components/x-tabs/XTabs.vue'
 import XTeleportSlot from './components/x-teleport/XTeleportSlot.vue'
 import XTeleportTemplate from './components/x-teleport/XTeleportTemplate.vue'
+import XTimespan from './components/x-timespan/XTimespan.vue'
 import locales from './locales/en-us/index.yaml'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
@@ -47,6 +48,7 @@ declare module 'vue' {
     XTabs: typeof XTabs
     XTeleportTemplate: typeof XTeleportTemplate
     XTeleportSlot: typeof XTeleportSlot
+    XTimespan: typeof XTimespan
     XDisclosure: typeof XDisclosure
   }
 }
@@ -92,6 +94,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
           ['XTabs', XTabs],
           ['XTeleportTemplate', XTeleportTemplate],
           ['XTeleportSlot', XTeleportSlot],
+          ['XTimespan', XTimespan],
           ['XDisclosure', XDisclosure],
         ]
       },

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
@@ -12,47 +12,55 @@
         class="stack"
       >
         <KCard>
-          <div class="columns">
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.status') }}
-              </template>
-
-              <template #body>
-                <StatusBadge :status="props.data.state" />
-              </template>
-            </DefinitionCard>
-
-            <DefinitionCard
-              v-if="props.data.namespace.length > 0"
-            >
-              <template #title>
-                Namespace
-              </template>
-
-              <template #body>
-                {{ props.data.namespace }}
-              </template>
-            </DefinitionCard>
-
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.address') }}
-              </template>
-
-              <template #body>
-                <template v-if="props.data.zoneEgress.socketAddress.length > 0">
-                  <XCopyButton
-                    :text="props.data.zoneEgress.socketAddress"
-                  />
+          <XLayout
+            type="stack"
+          >
+            <XTimespan
+              :start="t('common.formats.datetime', { value: Date.parse(props.data.creationTime) })"
+              :end="t('common.formats.datetime', { value: Date.parse(props.data.modificationTime) })"
+            />
+            <div class="columns">
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.status') }}
                 </template>
 
-                <template v-else>
-                  {{ t('common.detail.none') }}
+                <template #body>
+                  <StatusBadge :status="props.data.state" />
                 </template>
-              </template>
-            </DefinitionCard>
-          </div>
+              </DefinitionCard>
+
+              <DefinitionCard
+                v-if="props.data.namespace.length > 0"
+              >
+                <template #title>
+                  Namespace
+                </template>
+
+                <template #body>
+                  {{ props.data.namespace }}
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.address') }}
+                </template>
+
+                <template #body>
+                  <template v-if="props.data.zoneEgress.socketAddress.length > 0">
+                    <XCopyButton
+                      :text="props.data.zoneEgress.socketAddress"
+                    />
+                  </template>
+
+                  <template v-else>
+                    {{ t('common.detail.none') }}
+                  </template>
+                </template>
+              </DefinitionCard>
+            </div>
+          </XLayout>
         </KCard>
 
         <div

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -12,71 +12,79 @@
         class="stack"
       >
         <KCard>
-          <div class="columns">
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.status') }}
-              </template>
+          <XLayout
+            type="stack"
+          >
+            <XTimespan
+              :start="t('common.formats.datetime', { value: Date.parse(props.data.creationTime) })"
+              :end="t('common.formats.datetime', { value: Date.parse(props.data.modificationTime) })"
+            />
+            <div class="columns">
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.status') }}
+                </template>
 
-              <template #body>
-                <StatusBadge
-                  :status="props.data.state"
-                />
-              </template>
-            </DefinitionCard>
-
-            <DefinitionCard
-              v-if="props.data.namespace.length > 0"
-            >
-              <template #title>
-                Namespace
-              </template>
-
-              <template #body>
-                {{ props.data.namespace }}
-              </template>
-            </DefinitionCard>
-
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.address') }}
-              </template>
-
-              <template #body>
-                <template
-                  v-if="props.data.zoneIngress.socketAddress.length > 0"
-                >
-                  <XCopyButton
-                    :text="props.data.zoneIngress.socketAddress"
+                <template #body>
+                  <StatusBadge
+                    :status="props.data.state"
                   />
                 </template>
+              </DefinitionCard>
 
-                <template v-else>
-                  {{ t('common.detail.none') }}
-                </template>
-              </template>
-            </DefinitionCard>
-
-            <DefinitionCard>
-              <template #title>
-                {{ t('http.api.property.advertisedAddress') }}
-              </template>
-
-              <template #body>
-                <template
-                  v-if="props.data.zoneIngress.advertisedSocketAddress.length > 0"
-                >
-                  <XCopyButton
-                    :text="props.data.zoneIngress.advertisedSocketAddress"
-                  />
+              <DefinitionCard
+                v-if="props.data.namespace.length > 0"
+              >
+                <template #title>
+                  Namespace
                 </template>
 
-                <template v-else>
-                  {{ t('common.detail.none') }}
+                <template #body>
+                  {{ props.data.namespace }}
                 </template>
-              </template>
-            </DefinitionCard>
-          </div>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.address') }}
+                </template>
+
+                <template #body>
+                  <template
+                    v-if="props.data.zoneIngress.socketAddress.length > 0"
+                  >
+                    <XCopyButton
+                      :text="props.data.zoneIngress.socketAddress"
+                    />
+                  </template>
+
+                  <template v-else>
+                    {{ t('common.detail.none') }}
+                  </template>
+                </template>
+              </DefinitionCard>
+
+              <DefinitionCard>
+                <template #title>
+                  {{ t('http.api.property.advertisedAddress') }}
+                </template>
+
+                <template #body>
+                  <template
+                    v-if="props.data.zoneIngress.advertisedSocketAddress.length > 0"
+                  >
+                    <XCopyButton
+                      :text="props.data.zoneIngress.advertisedSocketAddress"
+                    />
+                  </template>
+
+                  <template v-else>
+                    {{ t('common.detail.none') }}
+                  </template>
+                </template>
+              </DefinitionCard>
+            </div>
+          </XLayout>
         </KCard>
 
         <div

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -39,67 +39,75 @@
           class="stack"
         >
           <KCard>
-            <div class="columns">
-              <DefinitionCard>
-                <template #title>
-                  {{ t('http.api.property.status') }}
-                </template>
-
-                <template #body>
-                  <StatusBadge :status="props.data.state" />
-                </template>
-              </DefinitionCard>
-              <DefinitionCard
-                :class="{
-                  version: true,
-                  outdated: version?.outdated,
-                }"
-              >
-                <template #title>
-                  {{ t('zone-cps.routes.item.version') }}
-                  <template
-                    v-if="version?.outdated === true"
-                  >
-                    <KTooltip
-                      max-width="300"
-                    >
-                      <InfoIcon
-                        :color="KUI_COLOR_BACKGROUND_NEUTRAL"
-                        :size="KUI_ICON_SIZE_30"
-                      />
-                      <template #content>
-                        <div
-                          v-html="t('zone-cps.routes.item.version_warning')"
-                        />
-                      </template>
-                    </KTooltip>
+            <XLayout
+              type="stack"
+            >
+              <XTimespan
+                :start="t('common.formats.datetime', { value: Date.parse(props.data.creationTime) })"
+                :end="t('common.formats.datetime', { value: Date.parse(props.data.modificationTime) })"
+              />
+              <div class="columns">
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('http.api.property.status') }}
                   </template>
-                </template>
 
-                <template #body>
-                  {{ props.data.zoneInsight.version?.kumaCp?.version ?? '—' }}
-                </template>
-              </DefinitionCard>
-              <DefinitionCard>
-                <template #title>
-                  {{ t('http.api.property.type') }}
-                </template>
+                  <template #body>
+                    <StatusBadge :status="props.data.state" />
+                  </template>
+                </DefinitionCard>
+                <DefinitionCard
+                  :class="{
+                    version: true,
+                    outdated: version?.outdated,
+                  }"
+                >
+                  <template #title>
+                    {{ t('zone-cps.routes.item.version') }}
+                    <template
+                      v-if="version?.outdated === true"
+                    >
+                      <KTooltip
+                        max-width="300"
+                      >
+                        <InfoIcon
+                          :color="KUI_COLOR_BACKGROUND_NEUTRAL"
+                          :size="KUI_ICON_SIZE_30"
+                        />
+                        <template #content>
+                          <div
+                            v-html="t('zone-cps.routes.item.version_warning')"
+                          />
+                        </template>
+                      </KTooltip>
+                    </template>
+                  </template>
 
-                <template #body>
-                  {{ t(`common.product.environment.${props.data.zoneInsight.environment || 'unknown'}`) }}
-                </template>
-              </DefinitionCard>
+                  <template #body>
+                    {{ props.data.zoneInsight.version?.kumaCp?.version ?? '—' }}
+                  </template>
+                </DefinitionCard>
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('http.api.property.type') }}
+                  </template>
 
-              <DefinitionCard>
-                <template #title>
-                  {{ t('zone-cps.routes.item.authentication_type') }}
-                </template>
+                  <template #body>
+                    {{ t(`common.product.environment.${props.data.zoneInsight.environment || 'unknown'}`) }}
+                  </template>
+                </DefinitionCard>
 
-                <template #body>
-                  {{ props.data.zoneInsight.authenticationType || t('common.not_applicable') }}
-                </template>
-              </DefinitionCard>
-            </div>
+                <DefinitionCard>
+                  <template #title>
+                    {{ t('zone-cps.routes.item.authentication_type') }}
+                  </template>
+
+                  <template #body>
+                    {{ props.data.zoneInsight.authenticationType || t('common.not_applicable') }}
+                  </template>
+                </DefinitionCard>
+              </div>
+            </XLayout>
           </KCard>
 
           <div

--- a/packages/kuma-gui/src/assets/styles/main.scss
+++ b/packages/kuma-gui/src/assets/styles/main.scss
@@ -7,6 +7,4 @@
 @use 'utilities';
 
 @import '@kong/kongponents/dist/style.css';
-@import '@kong-ui-public/app-layout/dist/style.css';
-
 


### PR DESCRIPTION
Adds `<XTimespan />` component.

See docs (`make run/docs` - see screengrab at the bottom of this description)

We have several areas where we want to consistently show a timespan (or possible a single time value if only a `start` or `end` is set. Importantly we would like to have a single easy-to-use component in order to do this. 

This PR adds this new component, replaces AppAboutSection usage with XTimespan (and removes the repetitive "fix-up" CSS related to that). Additionally, XTimespan copes better in smaller areas (i.e. wrapping) and avoids tangental dependency issues related to `app-layout` (we remove `app-layout` as a dependency here). I also added it in Zones and Zone*gress.

Lastly, there are probably a few other areas where we can now use his, but seeing as we weren't showing dates there already these can be added in a follow up PR.

<img width="1273" alt="Screenshot 2024-11-27 at 10 52 17" src="https://github.com/user-attachments/assets/ecf44011-8d80-438a-8a43-db02b26f6de5">

