### PR TITLE
chore: lint package.json versions to only allow caret semvers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2598,6 +2598,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -6627,7 +6638,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
       "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
-      "peer": true,
       "dependencies": {
         "semver": "^7.5.4"
       },
@@ -6642,7 +6652,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6886,6 +6895,67 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-json-schema-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json-schema-validator/-/eslint-plugin-json-schema-validator-5.1.3.tgz",
+      "integrity": "sha512-oD/MFPRihUzzQqw1Q0kiqAarXsWHUkFuKuvuuyPL3i9V/BJV/dTvWH/M735DZTaGxh1iwvCLFREhsW+y56hWmw==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.3.0",
+        "ajv": "^8.0.0",
+        "debug": "^4.3.1",
+        "eslint-compat-utils": "^0.5.0",
+        "json-schema-migrate": "^2.0.0",
+        "jsonc-eslint-parser": "^2.0.0",
+        "minimatch": "^8.0.0",
+        "synckit": "^0.9.0",
+        "toml-eslint-parser": "^0.10.0",
+        "tunnel-agent": "^0.6.0",
+        "yaml-eslint-parser": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-json-schema-validator/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint-plugin-json-schema-validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/eslint-plugin-json-schema-validator/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-plugin-n": {
@@ -9373,6 +9443,34 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
+    "node_modules/json-schema-migrate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      }
+    },
+    "node_modules/json-schema-migrate/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/json-schema-migrate/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9397,6 +9495,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.0.tgz",
+      "integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
       }
     },
     "node_modules/jsonfile": {
@@ -14096,6 +14211,21 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/synckit": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
@@ -14396,6 +14526,20 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toml-eslint-parser": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-0.10.0.tgz",
+      "integrity": "sha512-khrZo4buq4qVmsGzS5yQjKe/WsFvV8fGfOjDQN0q4iy9FjRfPWRgTFrU8u1R2iu/SfWLhY9WnCi4Jhdrcbtg+g==",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
       }
     },
     "node_modules/toposort": {
@@ -16638,6 +16782,22 @@
       "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
       "dev": true
     },
+    "node_modules/yaml-eslint-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.2.3.tgz",
+      "integrity": "sha512-4wZWvE398hCP7O8n3nXKu/vdq1HcH01ixYlCREaJL5NUMwQ0g3MaGFUBNSlmBtKmhbtVG/Cm6lyYmSVTEVil8A==",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.0.0",
+        "lodash": "^4.17.21",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -16770,6 +16930,7 @@
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-import-resolver-typescript": "^3.6.3",
         "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-json-schema-validator": "^5.1.3",
         "eslint-plugin-vue": "^9.32.0",
         "standard": "^17.1.2",
         "stylelint-config-html": "^1.1.0",
@@ -16851,10 +17012,6 @@
         "vitepress": "^1.3.4",
         "vitest": "^2.0.1",
         "vue-tsc": "^2.1.10"
-      },
-      "engines": {
-        "node": ">=20.9",
-        "npm": "^10.0.0"
       }
     }
   }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -22,6 +22,7 @@
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-json-schema-validator": "^5.1.3",
     "eslint-plugin-vue": "^9.32.0",
     "standard": "^17.1.2",
     "stylelint-config-html": "^1.1.0",

--- a/packages/config/src/eslint.cjs
+++ b/packages/config/src/eslint.cjs
@@ -1,3 +1,6 @@
+const { dirname } = require('path')
+const $config = dirname(require.resolve('@kumahq/config'))
+
 // Taken from https://github.com/vuejs/eslint-plugin-vue/blob/master/lib/utils/inline-non-void-elements.json.
 const INLINE_NON_VOID_ELEMENTS = [
   'a',
@@ -63,7 +66,15 @@ function createEslintConfig(
       'src/types/auto-generated.d.ts',
     ],
     plugins: ['vue', 'import', '@typescript-eslint'],
-    extends: ['eslint:recommended', 'plugin:vue/vue3-recommended', 'standard', '@vue/typescript', 'plugin:import/recommended', 'plugin:import/typescript'],
+    extends: [
+      'eslint:recommended',
+      'plugin:vue/vue3-recommended',
+      'standard',
+      '@vue/typescript',
+      'plugin:import/recommended',
+      'plugin:import/typescript',
+      'plugin:json-schema-validator/recommended'
+    ],
     settings: {
       'import/resolver': {
         typescript: {
@@ -94,6 +105,17 @@ function createEslintConfig(
       'no-console': ['error', { allow: ['info', 'warn', 'error'] }],
       'padded-blocks': 'off',
       'no-unreachable': 'error',
+      'json-schema-validator/no-invalid': ['error', {
+        useSchemastoreCatalog: false,
+        schemas: [
+          {
+            fileMatch: ['package.json'],
+            // our schema allows for ignoring individual dependencies if required
+            // see ./package.schema.json patternProperties examples
+            schema: `${$config}/package.schema.json`
+          }
+        ]
+      }]
     },
     overrides: [
       {

--- a/packages/config/src/package.schema.json
+++ b/packages/config/src/package.schema.json
@@ -7,11 +7,11 @@
     },
     "workspaceOnlyVersion": {
       "type": "string",
-      "pattern": "(^\\*$)|(^file:)"
+      "pattern": "(^\\*$)|(^file:)|(^workspace:)"
     },
     "caretOrWorkspaceOnlyVersion": {
       "type": "string",
-      "pattern": "(^\\^)|(^\\*$)|(^file:)"
+      "pattern": "(^\\^)|(^\\*$)|(^file:)|(^workspace:)"
     },
     "rangeOnlyVersion": {
       "type": "string",

--- a/packages/config/src/package.schema.json
+++ b/packages/config/src/package.schema.json
@@ -5,9 +5,17 @@
       "type": "string",
       "pattern": "^\\^"
     },
-    "workspaceVersion": {
+    "workspaceOnlyVersion": {
       "type": "string",
       "pattern": "(^\\*$)|(^file:)"
+    },
+    "caretOrWorkspaceOnlyVersion": {
+      "type": "string",
+      "pattern": "(^\\^)|(^\\*$)|(^file:)"
+    },
+    "rangeOnlyVersion": {
+      "type": "string",
+      "pattern": "^(?!\\d+\\.\\d+\\.\\d+).*"
     }
   },
   "properties": {
@@ -23,7 +31,7 @@
         }
       },
       "additionalProperties": {
-        "$ref": "#/definitions/caretOnlyVersion"
+        "$ref": "#/definitions/caretOrWorkspaceOnlyVersion"
       }
     },
     "devDependencies": {
@@ -32,13 +40,10 @@
       "patternProperties": {
         "@kumahq/ignored-example": {
           "type": "string"
-        },
-        "@kumahq/config": {
-          "$ref": "#/definitions/workspaceVersion"
         }
       },
       "additionalProperties": {
-        "$ref": "#/definitions/caretOnlyVersion"
+        "$ref": "#/definitions/caretOrWorkspaceOnlyVersion"
       }
     },
     "peerDependencies": {
@@ -50,7 +55,7 @@
         }
       },
       "additionalProperties": {
-        "$ref": "#/definitions/caretOnlyVersion"
+        "$ref": "#/definitions/rangeOnlyVersion"
       }
     }
   }

--- a/packages/config/src/package.schema.json
+++ b/packages/config/src/package.schema.json
@@ -7,7 +7,7 @@
     },
     "workspaceVersion": {
       "type": "string",
-      "pattern": "^\\*$"
+      "pattern": "(^\\*$)|(^file:)"
     }
   },
   "properties": {

--- a/packages/config/src/package.schema.json
+++ b/packages/config/src/package.schema.json
@@ -1,0 +1,57 @@
+{
+  "type": "object",
+  "definitions": {
+    "caretOnlyVersion": {
+      "type": "string",
+      "pattern": "^\\^"
+    },
+    "workspaceVersion": {
+      "type": "string",
+      "pattern": "^\\*$"
+    }
+  },
+  "properties": {
+    "engines": {
+      "not": {}
+    },
+    "dependencies": {
+      "type": "object",
+      "$comment": "To ignore a dependency to use a non-caret version follow the ignored-example below",
+      "patternProperties": {
+        "@kumahq/ignored-example": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/caretOnlyVersion"
+      }
+    },
+    "devDependencies": {
+      "type": "object",
+      "$comment": "To ignore a dependency to use a non-caret version follow the ignored-example below",
+      "patternProperties": {
+        "@kumahq/ignored-example": {
+          "type": "string"
+        },
+        "@kumahq/config": {
+          "$ref": "#/definitions/workspaceVersion"
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/caretOnlyVersion"
+      }
+    },
+    "peerDependencies": {
+      "type": "object",
+      "$comment": "To ignore a dependency to use a non-caret version follow the ignored-example below",
+      "patternProperties": {
+        "@kumahq/ignored-example": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/caretOnlyVersion"
+      }
+    }
+  }
+}

--- a/packages/kuma-gui/mk/check.mk
+++ b/packages/kuma-gui/mk/check.mk
@@ -16,7 +16,7 @@ check/node:
 .PHONY: lint/js
 lint/js:
 	@npx eslint \
-		$(if $(CI),,--fix) --ext .js,.ts,.vue \
+		$(if $(CI),,--fix) --ext .js,.ts,.vue,.json \
 		.
 
 .PHONY: lint/ts

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -10,10 +10,6 @@
     "help": "make help",
     "prepare": "husky"
   },
-  "engines": {
-    "node": ">=20.9",
-    "npm": "^10.0.0"
-  },
   "overrides": {
     "@bundled-es-modules/cookie": {
       "cookie": "^0.7.1"


### PR DESCRIPTION
Honestly I'm not a huge fan of linting, a lot of rules that people use are either unnecessary or over-zealous. Not only that but it always means depending on lots of things like `eslint`, which you then have to maintain (dependabot PRs etc etc), just for the sake of not caring too much about things like having alphabetically ordered import statements.

Now I've got that off my chest 😅 , I do agree that there are sometimes use cases for specific rules to prevent mistakes that can lead to genuine bugs.

This use case:

Over the past couple of years we've had several issues with duplicate dependencies appearing in our package lock file. They are easy to miss in PR reviews, and a lot of the time people don't realise that hainvg duplicate dependencies can cause very hard to spot issues (in our case having a duplicate install of kongponents has led to CSS issues that are not caught by CI as we don't have CSS regression tests).

The reason we've ended up with a duplicate install of a dependency is because somebody somewhere perhaps mistakenly has used an exact version to specify a package version in their consumable package. This goes for _at least_ `dependencies` and `peerDependencies`, which effect consuming applications.

I think there is no argument/discussion about the need to use range constraints rather than exact constraints in consumable packages (as oppose to consuming applications). In fact we should really go the extra mile even if there is a problem and the temptation to fix a version exactly in a consumable package. (Just so its said, IMO, we should also only use range constraints for consuming applications unless its absolutely necessary - but we are not here to talk about that specific use case today.)

This PR:

- Installs `"eslint-plugin-json-schema-validator"` so we can validate JSON files (I know I know another dependency...)
- Uses a minimal custom json schema to validate our package.json file, only allowing caret versions i.e. `^1.0.0`
- Adds an exception for `@kuma/config` to only allow `*`
- Comments in examples of ignoring our caret rule so we have an escape-hatch/ignore for our rule.
- Includes the rule in our `make lint/js` **for '@kumahq/kuma-gui' only**. We don't yet apply all out linting to our entire workspace, but we will soon.

None of this is an issue in our repository as yet, (we always use `^` versions because as a team we've agreed to so we don't need a linter), but we have flip-flopped in the past. Also in our case we have comparatively little to manage and a small enough team to get away with no hard-defined lint rules, others might not be so lucky.

Kinda unrelated but interesting:

- Also adds a rule to disallow `engines`. Eventually I would like to use this to have a single source of truth for our `engines` values in our workspace `package.json`, whilst we can't include files from `@kumahq/config` into our root package.json file, at least we can lint it to make sure it has specific values using a single source of truth linting rule.

Lastly:

I started with this https://github.com/tclindner/npm-package-json-lint, but decided against it seeing as its a standalone tool (we already need/require eslint so best if we can continue to use that rather than add another tool). I also found it to be fairly rigid, i.e. whilst there is a rule to enforce carets on `devDependencies` and `dependencies` there strangely isn't one for `peerDependencies` and it looks like they don't support adding custom rules. I then thought about looking for a more generic solution where I could define my own rules - a generic JSON schema linter fits that problem, plus you never know as its generic we might find other uses for it.




