### PR TITLE
fix(dataplanes): correct MeshService regexp based matching

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/overview/ClusterNames.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/ClusterNames.feature
@@ -1,0 +1,25 @@
+Feature: mesh / dataplanes / connections / clusterNames
+  Scenario: MeshServices type clusterNames with hashes are matched correctly
+    Given the CSS selectors
+      | Alias    | Selector                           |
+      | outbound | [data-testid='dataplane-outbound'] |
+    And the URL "/meshes/mesh-name/dataplanes/edge-gateway-546b7bbbc9-mkhx6.kuma-demo/stats" responds with
+      """
+      body: |
+        cluster.default_demo-app_kuma-demo_default_msvc_5000-5d788f7a87b92639.upstream_rq_tx_reset: 0
+      """
+    When I visit the "/meshes/mesh-name/data-planes/edge-gateway-546b7bbbc9-mkhx6.kuma-demo/overview?inactive" URL
+    And the "$outbound" element contains "default_demo-app_kuma-demo_default_msvc_5000-5d788f7a87b92639"
+
+  Scenario: MeshServices type clusterNames without hashes are matched correctly
+    Given the CSS selectors
+      | Alias    | Selector                           |
+      | outbound | [data-testid='dataplane-outbound'] |
+    And the URL "/meshes/mesh-name/dataplanes/edge-gateway-546b7bbbc9-mkhx6.kuma-demo/stats" responds with
+      """
+      body: |
+        cluster.default_demo-app_kuma-demo_default_msvc_5000.upstream_rq_tx_reset: 0
+      """
+    When I visit the "/meshes/mesh-name/data-planes/edge-gateway-546b7bbbc9-mkhx6.kuma-demo/overview?inactive" URL
+    And the "$outbound" element contains "default_demo-app_kuma-demo_default_msvc_5000"
+

--- a/packages/kuma-gui/src/app/connections/data/index.ts
+++ b/packages/kuma-gui/src/app/connections/data/index.ts
@@ -4,7 +4,7 @@ const appProtocols = ['http', 'tcp', 'grpc'] as const
 // `_` followed by 1 to 5 digits followed by a `.`
 const trailingPortRe = /_\d{1,5}\./
 const trailingPortRe2 = /_\d{1,5}/
-const meshServiceRe = /_(mz|m|ext){1}svc_\d{1,5}$/
+const meshServiceRe = /_(mz|m|ext){1}svc_\d{1,5}/
 
 export const Stat = {
   fromCollection(items: string) {

--- a/packages/kuma-gui/src/app/connections/data/index.ts
+++ b/packages/kuma-gui/src/app/connections/data/index.ts
@@ -4,7 +4,7 @@ const appProtocols = ['http', 'tcp', 'grpc'] as const
 // `_` followed by 1 to 5 digits followed by a `.`
 const trailingPortRe = /_\d{1,5}\./
 const trailingPortRe2 = /_\d{1,5}/
-const meshServiceRe = /_(mz|m|ext){1}svc_\d{1,5}/
+const meshServiceRe = /_(mz|m|ext){1}svc_\d{1,5}(-[a-z0-9]+)?$/
 
 export const Stat = {
   fromCollection(items: string) {


### PR DESCRIPTION
Sometimes clusterNames can have hashes after the port. This means some of our clusterName matching is a little too strict.

This PR remove the "end of line" match from our `_msvc_` regexp matching to make sure we also match services with hashes after the port.

Closes https://github.com/kumahq/kuma-gui/issues/3238