### PR TITLE
fix(app-shell): duplicate slot notifications

### DIFF
--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -147,10 +147,6 @@
       >
         <div class="app-notifications">
           <slot name="notifications" />
-        </div>
-        <slot
-          name="notifications"
-        >
           <XAlert
             v-if="!can('use state')"
             class="mb-4"
@@ -163,7 +159,7 @@
               />
             </ul>
           </XAlert>
-        </slot>
+        </div>
         <slot name="default" />
       </main>
     </div>


### PR DESCRIPTION
This removes a duplicate slot `#notifications` from the `ApplicationShell` component. This caused that when using the slot, the notification would appear twice.
This is probably a leftover from an attempt to resolve conflicts of merge or rebase.