### PR TITLE
fix: remove underline from KTabs

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-tabs/XTabs.vue
+++ b/packages/kuma-gui/src/app/x/components/x-tabs/XTabs.vue
@@ -87,6 +87,8 @@ watch(() => slots, () => {
   border-radius: inherit;
   color: inherit;
   outline: inherit;
+  /* TODO(jc): This can be removed if we ever get rid of the global link styling  */
+  text-decoration: none !important;
 }
 :deep(.tab-link) > *:focus-visible {
   background-color: $kui-color-background-neutral-weaker;


### PR DESCRIPTION
See PR preview in https://github.com/kumahq/kuma-gui/pull/3289

The above PR added a little underline on hover/focus to our tabs, this removes it.

---

Ideally we wouldn't have to do this but our "global" stylesheet is a little too "catch all". The fix here fixes the issue without leading to a tonne of churn, but I commented in a note so that if/when we make our global styling different, we can remove this.