### PR TITLE
chore(deps): bump nanoid to non-vulnerable versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11028,9 +11028,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.8.tgz",
-      "integrity": "sha512-TcJPw+9RV9dibz1hHUzlLVy8N4X9TnwirAjrU08Juo6BNKggzVfP2ZJ/3ZUSq15Xl5i85i+Z89XBO90pB2PghQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.9.tgz",
+      "integrity": "sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==",
       "funding": [
         {
           "type": "github",
@@ -11965,9 +11965,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
As reported in https://github.com/kumahq/kuma-gui/security/dependabot/103 both `3.3.8` and `5.0.9` are fixed versions. Using `npm update nanoid` bumps `nanoid` to non-vulnerable versions:

_Before_

```shell
kuma-gui
└─┬ @kumahq/kuma-gui@2.10.0 -> ./packages/kuma-gui
  ├─┬ @kong/kongponents@9.14.20
  │ └── nanoid@5.0.8
  └─┬ postcss@8.4.49
    └── nanoid@3.3.7
```

_After_

```shell
kuma-gui
└─┬ @kumahq/kuma-gui@2.10.0 -> ./packages/kuma-gui
  ├─┬ @kong/kongponents@9.14.20
  │ └── nanoid@5.0.9
  └─┬ postcss@8.4.49
    └── nanoid@3.3.8
```