### PR TITLE
chore(deps): removes override for cookie

### DIFF
--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -10,11 +10,6 @@
     "help": "make help",
     "prepare": "husky"
   },
-  "overrides": {
-    "@bundled-es-modules/cookie": {
-      "cookie": "^0.7.1"
-    }
-  },
   "dependencies": {
     "@kong-ui-public/i18n": "^2.2.10",
     "@kong/icons": "^1.20.1",


### PR DESCRIPTION
I remembered to check this thing (see changeset).

Just to note for future-self, this is why we should only use these sorts of things (`resolutions`/`overrides` etc) as an absolute last resort. They are easy to forget about and from what I understand, we could very easily end up being pinned below `0.8.0` for a longer period of time, especially if folks forget why this was ever here in the first place.

---

While triple checking this I also saw some further comment that I'm adding here for future-self, its more recommendation as to using carets should it ever come up again in a hokey cokey type way.

> WHY USING STRICT CONSTRAINT IS BAD?
> Strict constraint (or fully qualified constraint) are those constraints matching only one version. In most case it is a bad idea to use them.
> 
> Moreover, using strict constraint will make the work of some dependency managers harder: if you are depending on a package and have a dependency in common, if both of you require this common dependency strictly, your manager won't be able to choose an appropriate version, satisfying every constraint.
> 
> Unless you know exactly what you are doing and why, you should change to a more flexible one like:
> 
> If the library you are depending on strictly implements Semantic Versioning you should be able to make your constraint even more flexible by allowing your dependency manager to also pull new features:
> 
> `^x.y.z` if your dependency manager supports caret-range constraints
> `>=x.y.z <(x+1).0.0` if your dependency manager support range constraints

https://jubianchi.github.io/semver-check