### PR TITLE
chore(config/eslint): add vue/no-console

### DIFF
--- a/packages/config/src/eslint.cjs
+++ b/packages/config/src/eslint.cjs
@@ -143,6 +143,7 @@ function createEslintConfig(
       {
         files: ['*.vue'],
         rules: {
+          'vue/no-console': 'error',
           'vue/attributes-order': ['error', {
             order: [
               'DEFINITION',

--- a/packages/kuma-gui/src/app/x/components/x-code-block/ResourceCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/ResourceCodeBlock.vue
@@ -36,7 +36,7 @@
                 if (expanded) {
                   toggle()
                 }
-                cb((text: Object) => copy(toYamlRepresentation(text)), (e: unknown) => console.error(e))
+                cb((text: Object) => copy(toYamlRepresentation(text)), onCopyReject)
               }"
               :copying="expanded"
             />
@@ -88,4 +88,6 @@ function toYamlRepresentation(resource: Object): string {
   }
   return YAML.stringify(resource)
 }
+
+const onCopyReject: Parameters<CopyCallback>[1] = (e: unknown) => console.error(e)
 </script>


### PR DESCRIPTION
We recently noticed that `console` statements are not catched in `.vue` files inside the `template` (although catched in `script`) (xref: https://github.com/kumahq/kuma-gui/pull/3300#discussion_r1887136806).