### PR TITLE
chore(i18n): add a 'count=1' overwritable global variable

### DIFF
--- a/packages/kuma-gui/src/app/application/services/i18n/I18n.ts
+++ b/packages/kuma-gui/src/app/application/services/i18n/I18n.ts
@@ -41,6 +41,7 @@ export default <T extends I18nRecord>(strs: T, env: Env['var']) => {
     KUMA_DOCS_URL: env('KUMA_DOCS_URL'),
     KUMA_UTM_QUERY_PARAMS: i18n.t('common.product.utm_query_params' as Parameters<typeof i18n['t']>[0]),
     KUMA_PRODUCT_NAME: i18n.t('common.product.name' as Parameters<typeof i18n['t']>[0]),
+    count: 1,
   }
   return {
     ...i18n,

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -92,6 +92,12 @@ common:
 http:
   api:
     property:
+      name: |
+        { count, plural,
+          =0 { Names }
+          =1 { Name }
+          other { Names }
+        }
       modificationTime: Modified
       creationTime: Created
       tls: TLS


### PR DESCRIPTION
It would be nice to use pluralization via our i18n more (instead of hardcoding both singular and plural forms as separate keys)

I've kinda experimented with this before, so this more of sharing that thinking and therefore this PR might not eventually be merged.

---

This PR adds a default `count` "global" variable.

We already have an idea of global variables but they are almost like environment variables and cased so.

Why do we need a `count` global variable?

I've included a `name` example in this PR. Almost every resource in our application has a http `name` property and we use that term everywhere in our UI. Sometimes we want `names` and sometimes we want `name`. 

Instead of having two keys:

```yaml
name: Name
names:  |
      { count, plural,
          =0 { Names }
          =1 { Name }
          other { Names }
        }
```

or worse

```yaml
name: Name
names: Names
```

we could just have one:

```yaml
name:  |
      { count, plural,
          =0 { Names }
          =1 { Name }
          other { Names }
        }
```

The thing is that would mean you always have to pass a `count` which is annoying.

I tried some other ideas first (such as checking the error returned when count was missing) but seemed too over-complicated.


