### PR TITLE
chore(mocks): improves mocking for dataplane.networking

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
@@ -63,7 +63,7 @@ Feature: Dataplane details for built-in gateway
       """
       KUMA_MODE: zone
       """
-    And the URL "/meshes/default/dataplanes/dataplane-gateway_builtin-1/policies" responds with
+    And the URL "/meshes/default/dataplanes/dataplane-gateway-builtin-1/policies" responds with
       """
       body:
         listeners:
@@ -81,7 +81,7 @@ Feature: Dataplane details for built-in gateway
           TrafficTrace:
             name: traffic-trace-1
       """
-    When I visit the "/meshes/default/data-planes/dataplane-gateway_builtin-1/policies" URL
+    When I visit the "/meshes/default/data-planes/dataplane-gateway-builtin-1/policies" URL
     Then the "$policies-view" element contains "traffic-log-1"
     And the "$policies-view" element contains "traffic-trace-1"
     When I click the "$route-item-button" element

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
@@ -25,14 +25,14 @@ Feature: Dataplane details for standard Data Plane Proxy
             inbound:
               - health:
                   ready: true
+                  state: Ready
                 address: !!js/undefined
         dataplaneInsight:
           mTLS: !!js/undefined
           subscriptions:
             - connectTime: 2021-02-17T07:33:36.412683Z
               disconnectTime: 2021-02-17T07:33:36.412683Z
-            - controlPlaneInstanceId: 'dpp-1-cp-instance-id'
-              connectTime: 2021-02-17T07:33:37.412683Z
+            - connectTime: 2021-02-17T07:33:37.412683Z
               disconnectTime: !!js/undefined
       """
     When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/overview" URL

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
@@ -374,7 +374,7 @@ Feature: Dataplane policies
         """
         KUMA_MODE: zone
         """
-      When I visit the "/meshes/default/data-planes/dataplane-gateway_builtin-1/policies" URL
+      When I visit the "/meshes/default/data-planes/dataplane-gateway-builtin-1/policies" URL
       Then the "$to-rules" element exists
       And the "$legacy-sidecar-policies" element doesn't exist
       And the "$legacy-gateway-policies" element exists

--- a/packages/kuma-gui/src/test-support/FakeKuma.ts
+++ b/packages/kuma-gui/src/test-support/FakeKuma.ts
@@ -163,8 +163,15 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
     return k8s ? this.k8s.dataplaneSuffix() : ''
   }
 
-  nanodate() {
-    const d = this.faker.date.past()
+  inboundState() {
+    return this.faker.helpers.arrayElement(['Ready', 'NotReady', 'Ignored'])
+  }
+
+  nanodate(options: { refDate?: string | Date } = {}) {
+    if (options.refDate) {
+      options.refDate = new Date(Date.parse(String(options.refDate)))
+    }
+    const d = this.faker.date.past(options)
     // e.g. '2021-07-13T08:41:04.556796688Z'
     return `${d.toISOString().slice(0, -1)}${this.faker.number.int({ min: 1000, max: 999999 })}Z`
   }

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/_overview.ts
@@ -24,10 +24,10 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
   const type = (() => {
     switch (true) {
       case defaultType === 'builtin':
-      case name.includes('-gateway_builtin'):
+      case name.includes('-builtin'):
         return 'BUILTIN'
       case defaultType === 'delegated':
-      case name.includes('-gateway_delegated'):
+      case name.includes('-delegated'):
         return 'DELEGATED'
       default:
         return 'STANDARD'
@@ -78,6 +78,9 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
                   service,
                   zone: isMultizone && fake.datatype.boolean() ? fake.hacker.noun() : undefined,
                 }),
+                ...(fake.datatype.boolean() ? {
+                  state: fake.kuma.inboundState(),
+                } : {}),
               }
             }),
             outbound: Array.from({ length: outboundCount }).map((_, _i) => {

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/policies.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/policies.ts
@@ -3,7 +3,7 @@ import type { EndpointDependencies, MockResponder } from '@/test-support'
 export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const { mesh } = req.params
 
-  if (req.params.name.includes('-gateway_builtin')) {
+  if (req.params.name.includes('-builtin')) {
     return {
       headers: {},
       body: {

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_overview.ts
@@ -8,7 +8,9 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
   const _tags = query.get('tag') ?? ''
 
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
-  const inbounds = parseInt(env('KUMA_DATAPLANEINBOUND_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
+  const defaultType = env('KUMA_DATAPLANE_TYPE', '')
+  const inboundCount = parseInt(env('KUMA_DATAPLANEINBOUND_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
+  const outboundCount = parseInt(env('KUMA_DATAPLANEOUTBOUND_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
   const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
   const isMtlsEnabledOverride = env('KUMA_MTLS_ENABLED', '')
   const { offset, total, next, pageTotal } = pager(
@@ -23,20 +25,23 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       .map(item => { const [key, ...rest] = item.split(':'); return [key, rest.join(':')] }))
     : {}
 
-  let filterType: 'gateway_builtin' | 'gateway_delegated' | 'proxy' | undefined
-  if (_gateway === 'builtin' || _gateway === 'delegated') {
-    filterType = `gateway_${_gateway}`
-  } else if (_gateway === 'false') {
-    filterType = 'proxy'
-  } else if (tags['kuma.io/service']) {
-    if (tags['kuma.io/service'].includes('gateway_builtin')) {
-      filterType = 'gateway_builtin'
-    } else if (tags['kuma.io/service'].includes('gateway_delegated')) {
-      filterType = 'gateway_delegated'
-    } else {
-      filterType = 'proxy'
+  const filterType = (() => {
+    switch (true) {
+      case _gateway === 'false':
+        return 'STANDARD'
+      case defaultType === 'builtin':
+      case _gateway === 'builtin':
+        return 'BUILTIN'
+      case defaultType === 'delegated':
+      case _gateway === 'delegated':
+      case tags['kuma.io/service']?.includes('-delegated'):
+        return 'DELEGATED'
+      case tags['kuma.io/service']?.includes('-builtin'):
+        return 'BUILTIN'
+      default:
+        return ''
     }
-  }
+  })()
 
   return {
     headers: {},
@@ -48,23 +53,68 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const isMultizone = true && fake.datatype.boolean()
         const isMtlsEnabled = isMtlsEnabledOverride !== '' ? isMtlsEnabledOverride === 'true' : fake.datatype.boolean()
 
-        const type = filterType ?? fake.helpers.arrayElement(['gateway_builtin', 'gateway_delegated', 'proxy'])
-
+        const type = filterType || fake.helpers.arrayElement(['BUILTIN', 'DELEGATED', 'STANDARD'])
         // we include the type in the name so when we link using the name
         // we keep the type in the URL so the corresponding item mock knows the type
-        const name = `${fake.hacker.noun()}-${type}`
+        const name = `${fake.hacker.noun()}-${type.toLowerCase()}`
         const displayName = `${_name || name}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
         const nspace = fake.k8s.namespace()
         const service = tags['kuma.io/service']
+        const address = fake.internet.ip()
 
         return {
           type: 'DataplaneOverview',
           mesh,
           name: `${displayName}${k8s ? `.${nspace}` : ''}`,
-          creationTime: '2021-02-17T08:33:36.442044+01:00',
-          modificationTime: '2021-02-17T08:33:36.442044+01:00',
+          ...((modificationTime) => ({
+            creationTime: fake.kuma.date({ refDate: modificationTime }),
+            modificationTime,
+          }))(fake.kuma.date()),
           dataplane: {
-            networking: fake.kuma.dataplaneNetworking({ type, inbounds, isMultizone, service }),
+            networking: {
+              address,
+              ...(fake.datatype.boolean() ? {
+                advertisedAddress: fake.internet.ip(),
+              } : {}),
+              ...(type === 'STANDARD' ? {
+                // normal proxies have inbound and outbound
+                inbound: Array.from({ length: inboundCount }).map((_) => {
+                  return {
+                    address,
+                    port: fake.number.int({ min: 1, max: 65535 }),
+                    ...(fake.datatype.boolean() ? {
+                      serviceAddress: fake.internet.ip(),
+                    } : {}),
+                    ...(fake.datatype.boolean() ? {
+                      servicePort: fake.number.int({ min: 1, max: 65535 }),
+                    } : {}),
+                    tags: fake.kuma.tags({
+                      protocol: fake.kuma.protocol(),
+                      service,
+                      zone: isMultizone && fake.datatype.boolean() ? fake.hacker.noun() : undefined,
+                    }),
+                    ...(fake.datatype.boolean() ? {
+                      state: fake.kuma.inboundState(),
+                    } : {}),
+                  }
+                }),
+                outbound: Array.from({ length: outboundCount }).map((_, _i) => {
+                  return {
+                    port: fake.internet.port(),
+                    tags: fake.kuma.tags({ service }),
+                  }
+                }),
+              } : {
+                // anything but normal proxies are gateways with no inbound/outbound
+                gateway: {
+                  tags: fake.kuma.tags({
+                    service,
+                    zone: isMultizone && fake.datatype.boolean() ? fake.hacker.noun() : undefined,
+                  }),
+                  type,
+                },
+              }),
+            },
           },
           ...(k8s
             ? {
@@ -78,44 +128,57 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             ...(isMtlsEnabled ? { mTLS: fake.kuma.dataplaneMtls() } : {}),
             subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
               return {
-                id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
+                id: fake.string.uuid(),
                 controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
                 ...fake.kuma.connection(item, i, arr),
-                status: {
-                  lastUpdateTime: '2021-02-17T10:48:03.638434Z',
-                  total: {
-                    responsesSent: '5',
-                    responsesAcknowledged: '5',
-                  },
-                  cds: {
-                    responsesSent: '1',
-                    responsesAcknowledged: '1',
-                  },
-                  eds: {
-                    responsesSent: '2',
-                    responsesAcknowledged: '2',
-                  },
-                  lds: {
-                    responsesSent: '2',
-                    responsesAcknowledged: '2',
-                  },
-                  rds: {},
-                },
+                status: (() => {
+                  const xcks = fake.number.int({ min: 100, max: 500 })
+                  const stats = Object.entries(fake.kuma.partitionInto(
+                    {
+                      cds: Number,
+                      eds: Number,
+                      lds: Number,
+                      rds: Number,
+                    }, xcks,
+                  ))
+                  return {
+                    lastUpdateTime: fake.kuma.nanodate(),
+                    total: fake.kuma.partitionInto(
+                      {
+                        responsesSent: xcks,
+                        responsesAcknowledged: Number,
+                        responsesRejected: Number,
+                      }, xcks,
+                    ),
+                    ...stats.reduce(
+                      (prev, [key, value]) => {
+                        prev[key] = fake.kuma.partitionInto(
+                          {
+                            responsesSent: value,
+                            responsesAcknowledged: Number,
+                            responsesRejected: Number,
+                          }, value,
+                        )
+                        return prev
+                      },
+                      {} as Record<string, {}>,
+                    ),
+                  }
+                })(),
                 version: {
                   kumaDp: {
-                    version: '1.0.7',
-                    gitTag: 'unknown',
-                    gitCommit: 'unknown',
-                    buildDate: 'unknown',
+                    version: fake.helpers.arrayElement([fake.system.semver(), 'unknown']),
+                    gitTag: fake.helpers.arrayElement([fake.system.semver(), 'unknown']),
+                    gitCommit: fake.helpers.arrayElement([fake.git.commitSha(), 'unknown']),
+                    buildDate: fake.helpers.arrayElement([fake.kuma.date(), 'unknown']),
                     kumaCpCompatible: fake.datatype.boolean(),
                   },
-                  envoy: {
-                    version: '1.16.2',
-                    build: 'e98e41a8e168af7acae8079fc0cd68155f699aa3/1.16.2/Modified/DEBUG/BoringSSL',
-                    kumaDpCompatible: fake.datatype.boolean(),
-                  },
+                  envoy: ((version) => ({
+                    version,
+                    build: `${fake.git.commitSha()}/${version}/Clean/RELEASE/BoringSSL`,
+                  }))(fake.system.semver()),
                   dependencies: {
-                    coredns: '1.8.3',
+                    coredns: fake.system.semver(),
                   },
                 },
               }


### PR DESCRIPTION
We've had a couple of minor CSS bugs lately that have arisen because the randomized mocks weren't ever giving us certain states (generally we try to make the mocks return all types or data randomly so we see things like these bugs happen during development).

See:

- https://github.com/kumahq/kuma-gui/pull/3298
- https://github.com/kumahq/kuma-gui/pull/3326

This improves the mocks by:

- Further removing usage of the `.dataplaneNetworking()` function, that does too much and hides things away from where you are (i.e. Loss of Locality) This also makes it easier to use synced state across multiple HTTP requests using the faker seed.
- Adds missing variations of data so the variation that caused these issue becomes noticeable.