### PR TITLE
chore: merges KTruncate into XLayout

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -136,9 +136,10 @@
                 </template>
 
                 <template #services="{ row }">
-                  <KTruncate
+                  <XLayout
                     v-if="row.services.length > 0"
-                    width="auto"
+                    type="separated"
+                    truncate
                   >
                     <div
                       v-for="(service, index) in row.services"
@@ -174,7 +175,7 @@
                         </template>
                       </TextWithCopyButton>
                     </div>
-                  </KTruncate>
+                  </XLayout>
 
                   <template v-else>
                     {{ t('common.collection.none') }}

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceListView.vue
@@ -72,7 +72,10 @@
                 <template
                   #ports="{ row: item }"
                 >
-                  <KTruncate>
+                  <XLayout
+                    type="separated"
+                    truncate
+                  >
                     <KumaPort
                       v-for="connection in item.spec.ports"
                       :key="connection.port"
@@ -81,12 +84,15 @@
                         targetPort: undefined,
                       }"
                     />
-                  </KTruncate>
+                  </XLayout>
                 </template>
                 <template
                   #labels="{ row: item }"
                 >
-                  <KTruncate>
+                  <XLayout
+                    type="separated"
+                    truncate
+                  >
                     <XBadge
                       v-for="(value, key) in item.spec.selector.meshService.matchLabels"
                       :key="`${key}:${value}`"
@@ -94,7 +100,7 @@
                     >
                       {{ key }}:{{ value }}
                     </XBadge>
-                  </KTruncate>
+                  </XLayout>
                 </template>
                 <template #actions="{ row: item }">
                   <XActionGroup>

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceSummaryView.vue
@@ -54,7 +54,10 @@
                 <template
                   #body
                 >
-                  <KTruncate>
+                  <XLayout
+                    type="separated"
+                    truncate
+                  >
                     <KumaPort
                       v-for="connection in item.spec.ports"
                       :key="connection.port"
@@ -63,7 +66,7 @@
                         targetPort: undefined,
                       }"
                     />
-                  </KTruncate>
+                  </XLayout>
                 </template>
               </DefinitionCard>
               <DefinitionCard
@@ -77,7 +80,10 @@
                 <template
                   #body
                 >
-                  <KTruncate>
+                  <XLayout
+                    type="separated"
+                    truncate
+                  >
                     <XBadge
                       v-for="(value, key) in item.spec.selector.meshService.matchLabels"
                       :key="`${key}:${value}`"
@@ -85,7 +91,7 @@
                     >
                       {{ key }}:{{ value }}
                     </XBadge>
-                  </KTruncate>
+                  </XLayout>
                 </template>
               </DefinitionCard>
             </div>

--- a/packages/kuma-gui/src/app/services/views/MeshServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceListView.vue
@@ -113,7 +113,10 @@
                 <template
                   #ports="{ row: item }"
                 >
-                  <KTruncate>
+                  <XLayout
+                    type="separated"
+                    truncate
+                  >
                     <KumaPort
                       v-for="connection in item.spec.ports"
                       :key="connection.port"
@@ -122,7 +125,7 @@
                         targetPort: undefined,
                       }"
                     />
-                  </KTruncate>
+                  </XLayout>
                 </template>
                 <template #actions="{ row: item }">
                   <XActionGroup>

--- a/packages/kuma-gui/src/app/services/views/MeshServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceSummaryView.vue
@@ -127,7 +127,10 @@
                 <template
                   #body
                 >
-                  <KTruncate>
+                  <XLayout
+                    type="separated"
+                    truncate
+                  >
                     <KumaPort
                       v-for="connection in item.spec.ports"
                       :key="connection.port"
@@ -136,7 +139,7 @@
                         targetPort: undefined,
                       }"
                     />
-                  </KTruncate>
+                  </XLayout>
                 </template>
               </DefinitionCard>
               <DefinitionCard layout="horizontal">
@@ -148,7 +151,10 @@
                 <template
                   #body
                 >
-                  <KTruncate>
+                  <XLayout
+                    type="separated"
+                    truncate
+                  >
                     <XBadge
                       v-for="(value, key) in item.spec.selector.dataplaneTags"
                       :key="`${key}:${value}`"
@@ -156,7 +162,7 @@
                     >
                       {{ key }}:{{ value }}
                     </XBadge>
-                  </KTruncate>
+                  </XLayout>
                 </template>
               </DefinitionCard>
             </div>

--- a/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
+++ b/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
@@ -1,17 +1,22 @@
 <template>
-  <div
+  <component
+    :is="props.type === 'separated' && props.truncate ? KTruncate : 'div'"
     :class="['x-layout', props.type, props.size]"
   >
     <slot name="default" />
-  </div>
+  </component>
 </template>
 <script lang="ts" setup>
+import { KTruncate } from '@kong/kongponents'
 const props = withDefaults(defineProps<{
+  // TODO(jc) :variant
   type?: 'stack' | 'separated' | 'columns'
   size?: 'small' | 'normal'
+  truncate?: boolean
 }>(), {
   type: 'stack',
   size: 'normal',
+  truncate: false,
 })
 </script>
 <style lang="scss" scoped>
@@ -21,7 +26,7 @@ const props = withDefaults(defineProps<{
 .stack.small > * + * {
   margin-block-start: $kui-space-40;
 }
-.separated {
+.separated:not(.k-truncate) {
   display: inline-flex;
   flex-wrap: wrap;
   align-items: center;


### PR DESCRIPTION
We recently found out that `KTruncate` also applies a margin/gap the same as `XLayout` (and we want to keep the same value for gap whether we are using `KTruncate` or not).

Therefore I felt it made sense to combine `KTruncate` with `XLayout` via a `:truncate` property.

Therefore whether you have elements require truncation or not, you use the same component and they will have the same gap spacing