### PR TITLE
ci(github): [backport/2.7] use push for dispatching new commits (#3355)

### DIFF
--- a/.github/workflows/dispatch-merged-pr-notification.yml
+++ b/.github/workflows/dispatch-merged-pr-notification.yml
@@ -6,8 +6,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
 
 on:
-  pull_request_target:
-    types: [closed]
+  push:
     branches: [master, 'release-[0-9]+.[0-9]+']
 
 permissions: {}


### PR DESCRIPTION
Backport of https://github.com/kumahq/kuma-gui/pull/3355 to release-2.7