### PR TITLE
ci(github): [backport/2.2] use push for dispatching new commits (#3355)

### DIFF
--- a/.github/workflows/dispatch-merged-pr-notification.yml
+++ b/.github/workflows/dispatch-merged-pr-notification.yml
@@ -1,8 +1,7 @@
 name: 'Dispatch merged PR notification'
 
 on:
-  pull_request_target:
-    types: [closed]
+  push:
     branches: [master, 'release-[0-9]+.[0-9]+']
 
 jobs:


### PR DESCRIPTION
Backport of https://github.com/kumahq/kuma-gui/pull/3355 to release-2.2