### PR TITLE
ci: remove old notification merge guard

### DIFF
--- a/.github/workflows/dispatch-merged-pr-notification.yml
+++ b/.github/workflows/dispatch-merged-pr-notification.yml
@@ -7,13 +7,14 @@ concurrency:
 
 on:
   push:
-    branches: [master, 'release-[0-9]+.[0-9]+']
+    branches:
+      - master
+      - release-[0-9]+.[0-9]+
 
 permissions: {}
 
 jobs:
   dispatch-merged-pr-notififcation:
-    if: github.event.pull_request.merged
     name: Dispatch merged PR notification
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Follow up of https://github.com/kumahq/kuma-gui/pull/3355

I think because we changed the event type, we no longer need the conditional/guard here.