### PR TITLE
chore(ci): use GITHUB_REF_NAME for dispatch branch

### DIFF
--- a/.github/workflows/dispatch-merged-pr-notification.yml
+++ b/.github/workflows/dispatch-merged-pr-notification.yml
@@ -22,11 +22,12 @@ jobs:
         with:
           github-token: ${{ secrets.NOTIFY_BOT_PAT_TOKEN }}
           script: |
+            const branch = process.env.GITHUB_REF_NAME;
             return github.rest.repos.createDispatchEvent({
               owner: '${{ vars.NOTIFY_REPO_OWNER }}',
               repo: '${{ vars.NOTIFY_REPO_NAME }}',
               event_type: '${{ vars.NOTIFY_EVENT_TYPE }}',
               client_payload: {
-                branch: context.payload.pull_request.base.ref,
+                branch
               },
             })


### PR DESCRIPTION
Follow up of follow up of https://github.com/kumahq/kuma-gui/pull/3355

This is the same approach that kuma uses https://github.com/kumahq/kuma/blob/67912cfb66806a5157bf03122f60e82f8c6dc2fd/.github/workflows/pr-merged.yaml#L22

See:

- https://github.com/kumahq/kuma-gui/pull/3374
- https://github.com/kumahq/kuma-gui/pull/3355