### PR TITLE
chore: lint config package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,9 @@ jobs:
     defaults:
       run:
         working-directory: ./packages/kuma-gui
+    strategy:
+      matrix:
+        package: ['kuma-gui', 'config']
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
@@ -70,7 +73,7 @@ jobs:
             /home/runner/.cache/Cypress
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
       - run: |
-          make lint
+          make -C ./packages/${{ matrix.package }} lint
 
   cli-tests:
     needs: [install-dependencies]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,9 +55,6 @@ jobs:
   lint-tests:
     needs: [install-dependencies]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./packages/kuma-gui
     strategy:
       matrix:
         package: ['kuma-gui', 'config']

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,7 @@ include $(MK)/install.mk
 include $(MK)/check.mk
 
 .PHONY: clean
-clean:
-	@echo "Recursively removing all node_modules/ directories in `pwd`..."; \
-		$(MAKE) .clean
+clean: .clean ## Dev: Remove all `node_modules` recursively
 
 .PHONY: install
 install: .install ## Dev: Install all dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
 SHELL := /usr/bin/env bash
 MK := ./packages/kuma-gui/mk
 
-ROOT := ./mk
-
-include $(ROOT)/index.mk
 include $(MK)/install.mk
 include $(MK)/check.mk
 
 .PHONY: clean
-clean: .install/clean/workspace ## Dev: Delete all node_modules directories
+clean:
+	@echo "Recursively removing all node_modules/ directories in `pwd`..."; \
+		$(MAKE) .clean
 
 .PHONY: install
 install: .install ## Dev: Install all dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+SHELL := /usr/bin/env bash
+MK := ./packages/kuma-gui/mk
+
+ROOT := ./mk
+
+include $(ROOT)/index.mk
+include $(MK)/install.mk
+include $(MK)/check.mk
+
+.PHONY: clean
+clean: .install/clean/workspace ## Dev: Delete all node_modules directories
+
+.PHONY: install
+install: .install ## Dev: Install all dependencies

--- a/mk/index.mk
+++ b/mk/index.mk
@@ -1,0 +1,7 @@
+FILE_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: .install/clean/workspace
+.install/clean/workspace:
+	@cd $(FILE_DIR).. && \
+		echo "Recursively removing all node_modules/ directories in `pwd`..."; \
+		$(MAKE) .clean

--- a/mk/index.mk
+++ b/mk/index.mk
@@ -1,7 +1,0 @@
-FILE_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
-
-.PHONY: .install/clean/workspace
-.install/clean/workspace:
-	@cd $(FILE_DIR).. && \
-		echo "Recursively removing all node_modules/ directories in `pwd`..."; \
-		$(MAKE) .clean

--- a/package-lock.json
+++ b/package-lock.json
@@ -7904,10 +7904,9 @@
       "integrity": "sha512-TV3YgAKda5hPz75n7QXmGCsSzgVya1vvmBieebg3EB5ScmashTZ0FldViG1aU2d4V5rcAGrtQ7k5uAaCo0A4PA=="
     },
     "node_modules/glob": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
-      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
-      "dev": true,
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^4.0.1",
@@ -7941,7 +7940,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
       "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -9133,7 +9131,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
       "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
-      "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -11427,7 +11424,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
       "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
@@ -11443,7 +11439,6 @@
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
       "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
-      "dev": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -16528,6 +16523,7 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-json-schema-validator": "^5.3.1",
         "eslint-plugin-vue": "^9.32.0",
+        "glob": "^11.0.1",
         "globals": "^15.14.0",
         "stylelint-config-html": "^1.1.0",
         "stylelint-config-recommended-scss": "^14.1.0",

--- a/packages/config/.lintstagedrc.json
+++ b/packages/config/.lintstagedrc.json
@@ -1,0 +1,3 @@
+{
+  "*.{cjs,js,ts}": "make lint"
+}

--- a/packages/config/Makefile
+++ b/packages/config/Makefile
@@ -1,0 +1,6 @@
+MK := ../kuma-gui/mk
+
+include $(MK)/check.mk
+
+.PHONY: lint
+lint: .lint/script ## Dev: Run all lint script checks (js,ts)

--- a/packages/config/eslint.config.cjs
+++ b/packages/config/eslint.config.cjs
@@ -1,0 +1,9 @@
+/** @typedef {import('eslint').Linter.Config[]} Config */
+
+const { eslint } = require('./src/index.cjs')
+
+const config = [
+  ...eslint({}),
+]
+
+module.exports = config

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-json-schema-validator": "^5.3.1",
     "eslint-plugin-vue": "^9.32.0",
+    "glob": "^11.0.1",
     "globals": "^15.14.0",
     "stylelint-config-html": "^1.1.0",
     "stylelint-config-recommended-scss": "^14.1.0",

--- a/packages/config/scripts/ci.cjs
+++ b/packages/config/scripts/ci.cjs
@@ -32,5 +32,5 @@ function shuffleArray(array) {
 }
 
 module.exports = {
-  getPartitionedTestFiles
+  getPartitionedTestFiles,
 }

--- a/packages/config/src/eslint.cjs
+++ b/packages/config/src/eslint.cjs
@@ -61,19 +61,19 @@ function createEslintConfig(
   {
     tsConfigPath = 'tsconfig.json',
     componentIgnorePatterns = [],
-    versionIgnorePatterns = {}
+    versionIgnorePatterns = {},
   } = {
     tsConfigPath: 'tsconfig.json',
     componentIgnorePatterns: [],
-    versionIgnorePatterns: {}
-  }
+    versionIgnorePatterns: {},
+  },
 ) {
 
   ((properties) => {
     ['dependencies', 'devDependencies', 'peerDependencies'].forEach((item) => {
       properties[item].patternProperties = {
         ...properties[item].patternProperties,
-        ...versionIgnorePatterns[item] ?? {}
+        ...versionIgnorePatterns[item] ?? {},
       }
     })
   })(packageSchema.properties)
@@ -84,31 +84,36 @@ function createEslintConfig(
   )
 
   const importConfig = [
-    importPlugin.flatConfigs.recommended
+    importPlugin.flatConfigs.recommended,
+    {
+      rules: {
+        'import/no-extraneous-dependencies': 'error',
+      },
+    },
   ]
 
   const jsonSchemaValidatorConfig = [
     ...jsonSchemaValidatorPlugin.configs['flat/recommended'],
     {
-    rules: {
-      'json-schema-validator/no-invalid': ['error', {
-        useSchemastoreCatalog: false,
-        mergeSchemas: true,
-        schemas: [
-          {
-            fileMatch: ['package.json'],
-            // our schema allows for ignoring individual dependencies if required
-            // see ./package.schema.json patternProperties examples
-            schema: packageSchema
-          }
-        ]
-      }]}
-    }
+      rules: {
+        'json-schema-validator/no-invalid': ['error', {
+          useSchemastoreCatalog: false,
+          mergeSchemas: true,
+          schemas: [
+            {
+              fileMatch: ['package.json'],
+              // our schema allows for ignoring individual dependencies if required
+              // see ./package.schema.json patternProperties examples
+              schema: packageSchema,
+            },
+          ],
+        }]},
+    },
   ]
 
   const stylisticConfig = {
     plugins: {
-      '@stylistic': stylistic
+      '@stylistic': stylistic,
     },
     rules: {
       // Turns off some non-TypeScript rules in favor of their specific TypeScript rules to avoid false negatives:
@@ -138,7 +143,7 @@ function createEslintConfig(
       '@stylistic/comma-dangle': ['error', 'always-multiline'],
       '@stylistic/quotes': ['error', 'single', { avoidEscape: true }],
       '@stylistic/semi': ['error', 'never'],
-    }
+    },
   }
 
   return [
@@ -153,13 +158,13 @@ function createEslintConfig(
         sourceType: 'module',
         globals: {
           ...globals.browser,
-        }
+        },
       },
       files: [
         '**/*.js',
         '**/*.ts',
         '**/*.vue',
-        '**/*.json'
+        '**/*.json',
       ],
       ignores: [
         'dist/*',
@@ -301,9 +306,9 @@ function createEslintConfig(
         '@typescript-eslint/no-empty-object-type': 'off',
         '@typescript-eslint/no-unused-expressions': ['error', {
           allowTernary: true,
-          allowShortCircuit: true
+          allowShortCircuit: true,
         }],
-      }
+      },
     },
     {
       // temporarily keep supporting commonjs modules (e.g. this file)
@@ -311,15 +316,15 @@ function createEslintConfig(
       languageOptions: {
         globals: {
           ...globals.commonjs,
-        }
+        },
       },
       rules: {
-        '@typescript-eslint/no-require-imports': 'off'
-      }
-    }
+        '@typescript-eslint/no-require-imports': 'off',
+      },
+    },
   ]
 }
 
 module.exports = {
-  createEslintConfig
+  createEslintConfig,
 }

--- a/packages/config/src/stylelint.cjs
+++ b/packages/config/src/stylelint.cjs
@@ -23,4 +23,4 @@ function createStylelintConfig() {
 
 module.exports = {
   createStylelintConfig,
-};
+}

--- a/packages/kuma-gui/mk/check.mk
+++ b/packages/kuma-gui/mk/check.mk
@@ -11,7 +11,7 @@ check/node:
 .lint: lint/js lint/ts lint/css lint/lock lint/gherkin
 
 .PHONY: .lint/script
-.lint/script: lint/js lint/ts  ## Dev: Run lint checs on both JS/TS
+.lint/script: lint/js lint/ts  ## Dev: Run lint checks on both JS/TS
 
 .PHONY: lint/js
 lint/js:

--- a/packages/kuma-gui/mk/install.mk
+++ b/packages/kuma-gui/mk/install.mk
@@ -8,5 +8,6 @@
 
 .PHONY: .clean
 .clean:
-	find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +
+	@echo "Recursively removing all node_modules/ directories in `pwd`..."; \
+		find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +
 


### PR DESCRIPTION
The main goal of this change is to add linting for the `config` package. While doing this I wanted to take the chance and add a few more things:

1. Root `Makefile` for root operations `install` and `clean` for easy cleaning and reinstallation of dependencies
2. Add rule `import/no-extraneous-dependencies` to error in case we make use of a module without installing it beforehand. This caused some issues already and a first fix was added with #3381. But also here I have to install `glob` as it wasn't listed in the config's dependency list, but is imported in [packages/config/scripts/ci.cjs#L1](https://github.com/kumahq/kuma-gui/blob/36911e6e113bdf823e98233d2eac4543acb588b4/packages/config/scripts/ci.cjs#L1).
3. Linting of staged files in `packages/config`
4. Auto-fixing some linting issues that got revealed after adding the linter here
5. A typo I found