### PR TITLE
ci(github): simplify release.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ env.BRANCH }}
+          ref: ${{ env.SHA }}
 
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
@@ -116,18 +116,18 @@ jobs:
           ref: ${{ env.BRANCH }}
           path: ./packages/kuma-gui/main-application
 
-      - run: |
+      - env:
+          GRYPE_JSON_REPORT: steps.sbom.outputs.grype-json-report
+          GRYPE_SARIF_REPORT: steps.sbom.outputs.grype-json-report
+          SBOM_SPDX_REPORT: steps.sbom.outputs.sbom-spdx-report
+          SBOM_CYCLONEDX_REPORT: steps.sbom.outputs.sbom-cyclonedx-report
+        run: |
           cd main-application
 
           echo 'Copying Grype and SBOM reports ...'
           mkdir -p ${{ vars.HOST_REPORTS_DIRECTORY }}
-          rm -f ${{ vars.HOST_REPORTS_DIRECTORY }}/{${{ steps.sbom.outputs.grype-json-report }},${{ steps.sbom.outputs.grype-sarif-report }},${{ steps.sbom.outputs.sbom-spdx-report }},${{ steps.sbom.outputs.sbom-cyclonedx-report }}}
-          mv \
-            ../../../${{ steps.sbom.outputs.grype-json-report }} \
-            ../../../${{ steps.sbom.outputs.grype-sarif-report }} \
-            ../../../${{ steps.sbom.outputs.sbom-spdx-report }} \
-            ../../../${{ steps.sbom.outputs.sbom-cyclonedx-report }} \
-            ${{ vars.HOST_REPORTS_DIRECTORY }}
+          rm -f ${{ vars.HOST_REPORTS_DIRECTORY }}/{"$GRYPE_JSON_REPORT","$GRYPE_SARIF_REPORT","$SBOM_SPDX_REPORT","$SBOM_CYCLONEDX_REPORT"}
+          mv ../../../{"$GRYPE_JSON_REPORT","$GRYPE_SARIF_REPORT","$SBOM_SPDX_REPORT","$SBOM_CYCLONEDX_REPORT"} ${{ vars.HOST_REPORTS_DIRECTORY }}
 
           echo 'Replacing GUI dist files ...'
           rm -rf ${{ vars.HOST_DIST_DIRECTORY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,18 +116,13 @@ jobs:
           ref: ${{ env.BRANCH }}
           path: ./packages/kuma-gui/main-application
 
-      - env:
-          GRYPE_JSON_REPORT: ${{ steps.sbom.outputs.grype-json-report }}
-          GRYPE_SARIF_REPORT: ${{ steps.sbom.outputs.grype-json-report }}
-          SBOM_SPDX_REPORT: ${{ steps.sbom.outputs.sbom-spdx-report }}
-          SBOM_CYCLONEDX_REPORT: ${{ steps.sbom.outputs.sbom-cyclonedx-report }}
-        run: |
+      - run: |
           cd main-application
 
           echo 'Copying Grype and SBOM reports ...'
           mkdir -p ${{ vars.HOST_REPORTS_DIRECTORY }}
-          rm -f ${{ vars.HOST_REPORTS_DIRECTORY }}/{"$GRYPE_JSON_REPORT","$GRYPE_SARIF_REPORT","$SBOM_SPDX_REPORT","$SBOM_CYCLONEDX_REPORT"}
-          mv ../../../{"$GRYPE_JSON_REPORT","$GRYPE_SARIF_REPORT","$SBOM_SPDX_REPORT","$SBOM_CYCLONEDX_REPORT"} ${{ vars.HOST_REPORTS_DIRECTORY }}
+          rm -f ${{ vars.HOST_REPORTS_DIRECTORY }}/kuma-gui*.{json,sarif}
+          mv ../../../kuma-gui*.{json,sarif} ${{ vars.HOST_REPORTS_DIRECTORY }}
 
           echo 'Replacing GUI dist files ...'
           rm -rf ${{ vars.HOST_DIST_DIRECTORY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,10 +117,10 @@ jobs:
           path: ./packages/kuma-gui/main-application
 
       - env:
-          GRYPE_JSON_REPORT: steps.sbom.outputs.grype-json-report
-          GRYPE_SARIF_REPORT: steps.sbom.outputs.grype-json-report
-          SBOM_SPDX_REPORT: steps.sbom.outputs.sbom-spdx-report
-          SBOM_CYCLONEDX_REPORT: steps.sbom.outputs.sbom-cyclonedx-report
+          GRYPE_JSON_REPORT: ${{ steps.sbom.outputs.grype-json-report }}
+          GRYPE_SARIF_REPORT: ${{ steps.sbom.outputs.grype-json-report }}
+          SBOM_SPDX_REPORT: ${{ steps.sbom.outputs.sbom-spdx-report }}
+          SBOM_CYCLONEDX_REPORT: ${{ steps.sbom.outputs.sbom-cyclonedx-report }}
         run: |
           cd main-application
 


### PR DESCRIPTION
Remove some indirections using branches for checkout when we have a SHA and extract params as env vars.

This also makes the workflows more secure