### PR TITLE
chore(dataplanes): minor amends to dataplane download bundling

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -61,8 +61,8 @@ data-planes:
           eds: Include EDS
           dataplane: Dataplane Configuration
           policies: Policies
-          clusters: Envoy Clusters Logs
-          stats: Envoy Stats Logs
+          clusters: Envoy Clusters
+          stats: Envoy Stats
       about:
         title: About this Data Plane Proxy
       gateway: 'Gateway'

--- a/packages/kuma-gui/src/app/data-planes/sources.ts
+++ b/packages/kuma-gui/src/app/data-planes/sources.ts
@@ -128,7 +128,7 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
                   dppName: name,
                 }, {
                   include_eds: spec.eds,
-                })),
+                }), null, 2),
               }
             })
             break

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -214,11 +214,11 @@ const props = defineProps<{
 
 const specs = ref({
   eds: false,
-  xds: false,
-  clusters: false,
-  stats: false,
-  dataplane: false,
-  policies: false,
+  xds: true,
+  clusters: true,
+  stats: true,
+  dataplane: true,
+  policies: true,
 })
 const downloadBundle = (close: () => void) => async (bundle: { name: string, url: string }) => {
   const a = document.createElement('a')


### PR DESCRIPTION
Adds another few minor amends to bundle downloading:

- Text amends
- Default most options to ticked
- Add JSON whitespace to downloaded XDS config file so you have a chance of reading it when you open it