### PR TITLE
feat(application): source default URL params from storage

### DIFF
--- a/packages/kuma-gui/src/app/application/index.ts
+++ b/packages/kuma-gui/src/app/application/index.ts
@@ -15,6 +15,7 @@ import type { Can } from './services/can'
 import type { EnvVars } from './services/env/Env'
 import Env from './services/env/Env'
 import I18n from './services/i18n/I18n'
+import storage from './services/storage'
 import type { Source } from '@/app/application/services/data-source'
 import { create, destroy, getSource, DataSourcePool } from '@/app/application/services/data-source'
 import { services as kuma } from '@/app/kuma'
@@ -81,6 +82,9 @@ const $ = {
 
   i18n: token<ReturnType<typeof I18n>>('i18n'),
   enUs: token('i18n.locale.enUs'),
+
+  storage: token<ReturnType<typeof storage>>('application.storage'),
+  storagePrefix: token<string>('application.storage.prefix'),
 }
 
 const addModule = (item: RouteRecordRaw, parent?: RouteRecordRaw) => {
@@ -181,6 +185,13 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
 
     [$.fetch, {
       service: () => fetch,
+    }],
+
+    [$.storage, {
+      service: storage,
+      arguments: [
+        app.storagePrefix,
+      ],
     }],
 
     [$.can, {

--- a/packages/kuma-gui/src/app/application/services/storage/index.ts
+++ b/packages/kuma-gui/src/app/application/services/storage/index.ts
@@ -1,0 +1,21 @@
+export default (prefix: string = 'kumahq-app', storage: Storage = window.localStorage) => {
+  const get = async (key: string): Promise<object> => {
+    try {
+      return JSON.parse(storage.getItem(`${prefix}:${key}`) ?? '{}')
+    } catch (e) {
+      console.error(e)
+    }
+    return {}
+  }
+  const set = async (key: string, value: object): Promise<object> => {
+    try {
+      storage.setItem(`${prefix}:${key}`, JSON.stringify(value))
+      return value
+    } catch (e) {
+      console.error(e)
+    }
+    return {}
+  }
+
+  return { get, set }
+}

--- a/packages/kuma-gui/src/app/me/index.ts
+++ b/packages/kuma-gui/src/app/me/index.ts
@@ -7,14 +7,13 @@ type Sources = ReturnType<typeof sources>
 
 const $ = {
   sources: token<Sources>('me.sources'),
-  storagePrefix: token<string>('me.storage.prefix'),
 }
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
     [$.sources, {
       service: sources,
       arguments: [
-        $.storagePrefix,
+        app.storage,
       ],
       labels: [
         app.sources,


### PR DESCRIPTION
This PR allows us to source certain parameters from localStorage to use for defaults for a page. This functionality isn't used as yet, as in this PR we don't actually save any parameters to localStorage (we will add these later)

For example, if you set your page to `75` on one listing, chances are you probably want that to say as `75` throughout the application for all listings.

There are several interesting things that we backwards and forwards with a bit (even this morning), so I'll try detail a little bit.

### Design constraints

- Preferably, we want to always use declarative `DataSource` to access external data, this includes localStorage data which is external to the main Javascript execution.
- We want it to be as easy as possible to use as a consumer, ie. someone building features for our application.
- Related to the above point, we should continue to use the automatic defaulting that we already have in place that gives us query param defaults, query param normalisation and the engineering focussed type features that we have in `RouteView :params`

### Approach

- We have two types of localStorage "global for the app" and "per route". When you ask for user preferences/storage via `/me/:route` we retrieve both and merge, overwriting anything in app specific storage with route specific storage.
- We wait for the existing `/me/:route` DataSource in RouteView before we do any parameter "fiddling". Previous to this PR we would not render the default slot of the RouteView anyway, ~so from an application standpoint waiting do do this before parameter fiddling before doing anything shouldn't change any functionality here~ 👈 I found this was true with human usage but not in e2e test, so I reused `redirected` an extra guard in the template. Note: Whilst prototyping this, I exposed our storage via a `useStorage` accessor (i.e. I cheated and bypassed DataSource because we weren't sure if we could use this). The final version here, removes the `useStorage` accessor and reverts to using DataSource, which does work with this version. I kept the service injection re-arrangement I did to make the `useStorage` accessor, because I figured we may as well configure it like this, but I removed the `useStorage` accessor entirely as we want folks to always use DataSource to access storage, `useStorage` would make it easy to work around that.
- Whilst prototyping we found we had concurrency issues with the requirement to wait for our storage derived params, mainly around having two side-effect-y Vue `watch`es. I initially chose the second "one time only" `watch` to add the asynchronous code. In the end (for other reasons) I figured I could just merge both watches into one, and use a guard to only run the code in the second one once.
- Furthermore using a second `watch` to pull the storage defaults out of an async storage, and using that by default, meant that things would work fine if you didn't add a certain param to the URL, but if you did add a param to the URL manually (i.e. via a bookmark), this manual param would be overwritten by the one from localStorage. i.e. the defaults were specified in the wrong order. Moving to a single watch meant I could add the storage derived params in the same function along with the merge of URL params and query params, solving this issue.
- We had a bit of fun pairing through this, and figured I'd add some more comments while we were here. I think the code might benefit from some slight organisation, more around grouping related RouteView functionality parts together. i.e. not as much as what AppView probably could do with but _something_

### Manual Testing

Add the following to localStorage:

![Screenshot 2025-01-15 at 12 19 33](https://github.com/user-attachments/assets/657a1922-90fd-4317-95c7-6fe860dc4e74)

With the above settings:

- Visit `http://localhost:8080/gui/zones?page=1`, `&size=75` should be added to the URL (note we hardcode in `size=50` everywhere in the app, so this proves its using the value from localStorage)
- Visit `http://localhost:8080/gui/zones?page=1&size=25`. The URL should remain with `&size=25` proving that we don't overwrite anything in the URL with the localStorage settings.
- Delete your localStorage, visit `http://localhost:8080/gui/zones?page=1`, `&size=50` should be added to the URL, proving that we use the hardcode value of `50` when there is no value in localStorage

I might look to add some tests here either in the PR or after, I wanted to get this up and merged asap so we can continue with the feature this enables (and I think there is still a bit of under-the-hood work to do before we can do that)

I might also add some inline PR comments brb.