### PR TITLE
chore(ci): various makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,23 @@
+# Please keep this file free of actual scripts
+# It should only be used for adding "non-dot" aliases and documentation
+
 SHELL := /usr/bin/env bash
-MK := ./packages/config/src/mk
+
+KUMAHQ_CONFIG := $(shell npm query .workspace | jq -r '.[] | select(.name == "@kumahq/config") | .path')
+MK := $(KUMAHQ_CONFIG)/src/mk
 
 ## make help: if you're aren't sure use `make help`
 .DEFAULT_GOAL := help
+include $(MK)/help.mk
 
 include $(MK)/install.mk
 include $(MK)/check.mk
-include $(MK)/help.mk
+
+.PHONY: help
+help: .help ## Display this help screen
 
 .PHONY: clean
 clean: .clean ## Dev: Remove all `node_modules` recursively
 
 .PHONY: install
 install: .install ## Dev: Install all dependencies
-
-.PHONY: help
-help: .help ## Display this help screen

--- a/packages/config/Makefile
+++ b/packages/config/Makefile
@@ -1,13 +1,26 @@
-MK := ./src/mk
+# Please keep this file free of actual scripts
+# It should only be used for adding "non-dot" aliases and documentation
+
+SHELL := /usr/bin/env bash
+
+KUMAHQ_CONFIG := $(shell npm query .workspace | jq -r '.[] | select(.name == "@kumahq/config") | .path')
+MK := $(KUMAHQ_CONFIG)/src/mk
 
 ## make help: if you're aren't sure use `make help`
 .DEFAULT_GOAL := help
-
-include $(MK)/check.mk
 include $(MK)/help.mk
+
+include $(MK)/install.mk
+include $(MK)/check.mk
 
 .PHONY: help
 help: .help ## Display this help screen
+
+.PHONY: clean
+clean: .clean ## Dev: Remove all `node_modules` recursively
+
+.PHONY: install
+install: .install ## Dev: Install all dependencies
 
 .PHONY: lint
 lint: .lint/script ## Dev: Run all lint script checks (js,ts)

--- a/packages/config/scripts/ci.cjs
+++ b/packages/config/scripts/ci.cjs
@@ -1,5 +1,18 @@
 const { sync: globSync } = require('glob')
+const { readFileSync: read } = require('fs')
 
+const depsToDevDeps = (path) => {
+  const pkg = JSON.parse(read(path, 'utf-8'))
+  return JSON.stringify({
+    ...pkg,
+    dependencies: {},
+    peerDependencies: {},
+    devDependencies: {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    },
+  })
+}
 /**
  * @param {number} length
  * @param {string} prefix
@@ -33,4 +46,5 @@ function shuffleArray(array) {
 
 module.exports = {
   getPartitionedTestFiles,
+  depsToDevDeps,
 }

--- a/packages/config/src/index.cjs
+++ b/packages/config/src/index.cjs
@@ -1,7 +1,9 @@
 const { createEslintConfig } = require('./eslint.cjs')
 const { createStylelintConfig } = require('./stylelint.cjs')
+const ci = require('../scripts/ci.cjs')
 
 module.exports = {
   eslint: createEslintConfig,
   stylelint: createStylelintConfig,
+  ci,
 }

--- a/packages/config/src/mk/help.mk
+++ b/packages/config/src/mk/help.mk
@@ -1,3 +1,7 @@
+NPM_WORKSPACE_ROOT := $(shell npm prefix)
+NODE_VERSION := v$(shell cat $(NPM_WORKSPACE_ROOT)/.nvmrc)
+KUMAHQ_CONFIG := $(shell npm query .workspace | jq -r '.[] | select(.name == "@kumahq/config") | .path')
+
 .PHONY: .help
 .help: ## Display this help screen
 	@echo "The following targets can be used by running \`make <target>\`"; echo "---"
@@ -13,4 +17,18 @@
 		grep -h -E "^$$section/[^:]+:.*?## .*$$" $(MAKEFILE_LIST) | sort -k1 | \
 			awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' ; \
 	done
+
+.PHONY: confirm
+confirm:
+	@if [[ -z "$(CI)" ]]; then \
+		CONFIRM="" ; \
+		read -p "=== Please confirm [y/n]: " -r ; \
+		if [[ ! $$CONFIRM =~ ^[Yy]$$ ]]; then \
+			echo "Aborting" ; \
+			exit 1 ; \
+		else \
+			exit 0; \
+		fi \
+	fi
+
 

--- a/packages/config/src/mk/help.mk
+++ b/packages/config/src/mk/help.mk
@@ -4,7 +4,7 @@ KUMAHQ_CONFIG := $(shell npm query .workspace | jq -r '.[] | select(.name == "@k
 
 .PHONY: .help
 .help: ## Display this help screen
-	@echo "The following targets can be used by running \`make <target>\`"; echo "---"
+	@echo "The following targets can be used by running \`make <target>\` in this directory:"; echo "---"
 	@# Display top-level targets since they are the ones most developers will need.
 	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort -k1 | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 	@# Now show hierarchical targets in separate sections.

--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -8,6 +8,8 @@
 
 .PHONY: .clean
 .clean:
-	@echo "Recursively removing all node_modules/ directories in `pwd`..."; \
-		find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +
-
+	@echo "Recursively removing all node_modules/ directories in $(NPM_WORKSPACE_ROOT)..."
+	@find $(NPM_WORKSPACE_ROOT) -name 'node_modules' -type d -prune
+	@if $(MAKE) -s confirm ; then \
+		find $(NPM_WORKSPACE_ROOT) -name 'node_modules' -type d -prune -exec rm -rf '{}' +; \
+	fi

--- a/packages/config/src/mk/release.mk
+++ b/packages/config/src/mk/release.mk
@@ -37,14 +37,14 @@
 # from 872 to 157 at the time of this change.
 .PHONY: .release/prune
 .release/prune:
-	@if [ -z "$(NPM_WORKFLOW_CONFIG_PATH)" ]; then \
-		echo "Error: NPM_WORKFLOW_CONFIG_PATH is not set or empty."; \
+	@if [ -z "$(KUMAHQ_CONFIG)" ]; then \
+		echo "Error: KUMAHQ_CONFIG is not set or empty."; \
 		exit 1; \
 	fi
-	@if [ ! -d "$(NPM_WORKFLOW_CONFIG_PATH)" ]; then \
-		echo "Error: NPM_WORKFLOW_CONFIG_PATH does not exist or is not a directory: $(NPM_WORKFLOW_CONFIG_PATH)"; \
+	@if [ ! -d "$(KUMAHQ_CONFIG)" ]; then \
+		echo "Error: KUMAHQ_CONFIG does not exist or is not a directory: $(KUMAHQ_CONFIG)"; \
 		exit 1; \
 	fi
-	npm pkg delete devDependencies.@kumahq/config
-	rm -rf $(NPM_WORKFLOW_CONFIG_PATH)
-	npm install --package-lock-only
+	@echo '$(shell node -e "console.log(require('@kumahq/config').ci.depsToDevDeps('$(KUMAHQ_CONFIG)/package.json'))")' \
+		> $(KUMAHQ_CONFIG)/package.json
+	@npm install --package-lock-only

--- a/packages/config/src/mk/test.mk
+++ b/packages/config/src/mk/test.mk
@@ -26,6 +26,7 @@ ifdef KUMA_TEST_BROWSER
 			--e2e \
 			--browser $(KUMA_TEST_BROWSER)
 else
+	@while ! nc -z localhost 5681; do sleep 1; done;
 	@CYPRESS_video=true \
 	TZ=UTC \
 		npx cypress \

--- a/packages/kuma-gui/Makefile
+++ b/packages/kuma-gui/Makefile
@@ -2,14 +2,14 @@
 # It should only be used for adding "non-dot" aliases and documentation
 
 SHELL := /usr/bin/env bash
-MK := ../config/src/mk
-NODE_VERSION:=v$(shell cat ../../.nvmrc)
-NPM_WORKFLOW_CONFIG_PATH ?= $(shell readlink -f ../config)
+
+KUMAHQ_CONFIG := $(shell npm query .workspace | jq -r '.[] | select(.name == "@kumahq/config") | .path')
+MK := $(KUMAHQ_CONFIG)/src/mk
 
 ## make help: if you're aren't sure use `make help`
 .DEFAULT_GOAL := help
-
 include $(MK)/help.mk
+
 include $(MK)/run.mk
 include $(MK)/install.mk
 include $(MK)/check.mk
@@ -27,6 +27,9 @@ install/sync: .install/sync
 
 .PHONY: help
 help: .help ## Display this help screen
+
+.PHONY: clean
+clean: .clean ## Dev: Delete all node_modules directories
 
 .PHONY: install
 install: .install ## Dev: install all dependencies (runs before `make run`)


### PR DESCRIPTION
I stumbled across quite a few things whilst fixing up our `clean` script so:

1. It can be run from any sub-package (like `make install`)
2. It didn't echo the warning message twice in certain environments

I have a longer term goal of making our "wiring root" Makefiles easier to maintain (there might end up being lots of them) and possibly creating them from a template. This goal means that the less path differences etc (`../` over here, `./` over there) the better. This has influenced some decisions here.

In order to run `make clean` from anywhere and it automatically do this from root, we need to know where root is, from wherever we are. This led me to using `npm prefix` for `NPM_WORKSPACE_ROOT`. This led me to realize a `NPM_WORKFLOW_CONFIG_PATH` that I'd not noticed in a previous PR, which led me to our `release` script. Getting here made me realize our `release` script wasn't working since we moved our `mk` files over to `@kumahq/config`.

Hopefully the above explains why this is "various" things rather than just the one.

### `make release/prune` fixes

Since we moved `mk` to `@kumahq/config`, and we also `rm` `@kumahq/config` during SBOM generation, this means we can no longer run any Makefiles after SBOM generation, doh 🤦 

I figured that we only want to delete the dependency configuration for the SBOM generation, not the entire `@kumahq/config` module. Additionally our SBOM generation ignores devDependencies, and `@kumahq/config` is a devDependency but its dependencies are not (ideally our SBOM generator would ignore devDependencies entirely but hey ho).

This PR runs a tiny script before SBOM generation that moves `@kumahq/config`s package config for `dependencies` to `devDependencies` and also deletes its `peerDependencies`. We then run `npm install --package-lock-only` as before. This I believe has the exact same effect as `rm`ing the entire @kumahq/config` module, but without also deleting our Makefile tooling/scripts.

## `make clean`

Can now be run from any repository in the workspace or from the root. I also added a confirmation (if not in CI) so that you have some kind of visibility into what its deleting and a chance to say no.

## make variables

I added some useful variables into `help.mk`, which are necessary for all scripts. I added them to `help.mk` because I would like to make it easy to add the `help` make target and make it hard not to. Adding them to make means you _must_ include `help.mk`

### copypasta ability

I made it so the top ~11 lines of every `Makefile` are exactly the same, this makes it easy to copy/paste them to make multiple ones and keep them in sync i.e. poor mans templating (we may add templating at some point but I doubt it)

### wait for a system/application to test

Lastly I added a wait for our test site to come up, cypress wasn't waiting long enough and even before this it would try 3 times before (sometimes) succeeding. `make` now tales a split second longer due to the new variables, so I added a quick check for our application being served on localhost:5681 before running Cypress.

I may add some inlines.


