### PR TITLE
fix(ci): fix release/prune which runs before make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 
 SHELL := /usr/bin/env bash
 
-KUMAHQ_CONFIG := $(shell npm query .workspace | jq -r '.[] | select(.name == "@kumahq/config") | .path')
+NPM_WORKSPACE_ROOT := $(shell npm prefix)
+KUMAHQ_CONFIG := $(NPM_WORKSPACE_ROOT)/$(shell cat $(NPM_WORKSPACE_ROOT)/package-lock.json | jq -r '.packages | to_entries[] | select(.value.name == "@kumahq/config") | .key')
 MK := $(KUMAHQ_CONFIG)/src/mk
 
 ## make help: if you're aren't sure use `make help`

--- a/packages/config/Makefile
+++ b/packages/config/Makefile
@@ -3,7 +3,8 @@
 
 SHELL := /usr/bin/env bash
 
-KUMAHQ_CONFIG := $(shell npm query .workspace | jq -r '.[] | select(.name == "@kumahq/config") | .path')
+NPM_WORKSPACE_ROOT := $(shell npm prefix)
+KUMAHQ_CONFIG := $(NPM_WORKSPACE_ROOT)/$(shell cat $(NPM_WORKSPACE_ROOT)/package-lock.json | jq -r '.packages | to_entries[] | select(.value.name == "@kumahq/config") | .key')
 MK := $(KUMAHQ_CONFIG)/src/mk
 
 ## make help: if you're aren't sure use `make help`

--- a/packages/config/scripts/ci.cjs
+++ b/packages/config/scripts/ci.cjs
@@ -1,18 +1,5 @@
 const { sync: globSync } = require('glob')
-const { readFileSync: read } = require('fs')
 
-const depsToDevDeps = (path) => {
-  const pkg = JSON.parse(read(path, 'utf-8'))
-  return JSON.stringify({
-    ...pkg,
-    dependencies: {},
-    peerDependencies: {},
-    devDependencies: {
-      ...pkg.dependencies,
-      ...pkg.devDependencies,
-    },
-  })
-}
 /**
  * @param {number} length
  * @param {string} prefix
@@ -46,5 +33,4 @@ function shuffleArray(array) {
 
 module.exports = {
   getPartitionedTestFiles,
-  depsToDevDeps,
 }

--- a/packages/config/scripts/prune.cjs
+++ b/packages/config/scripts/prune.cjs
@@ -1,0 +1,15 @@
+const { readFileSync: read } = require('fs')
+module.exports = {
+  depsToDevDeps: (path) => {
+    const pkg = JSON.parse(read(path, 'utf-8'))
+    return JSON.stringify({
+      ...pkg,
+      dependencies: {},
+      peerDependencies: {},
+      devDependencies: {
+        ...pkg.dependencies,
+        ...pkg.devDependencies,
+      },
+    })
+  },
+}

--- a/packages/config/src/index.cjs
+++ b/packages/config/src/index.cjs
@@ -1,9 +1,7 @@
 const { createEslintConfig } = require('./eslint.cjs')
 const { createStylelintConfig } = require('./stylelint.cjs')
-const ci = require('../scripts/ci.cjs')
 
 module.exports = {
   eslint: createEslintConfig,
   stylelint: createStylelintConfig,
-  ci,
 }

--- a/packages/config/src/mk/help.mk
+++ b/packages/config/src/mk/help.mk
@@ -1,6 +1,6 @@
 NPM_WORKSPACE_ROOT := $(shell npm prefix)
 NODE_VERSION := v$(shell cat $(NPM_WORKSPACE_ROOT)/.nvmrc)
-KUMAHQ_CONFIG := $(shell npm query .workspace | jq -r '.[] | select(.name == "@kumahq/config") | .path')
+KUMAHQ_CONFIG := $(NPM_WORKSPACE_ROOT)/$(shell cat $(NPM_WORKSPACE_ROOT)/package-lock.json | jq -r '.packages | to_entries[] | select(.value.name == "@kumahq/config") | .key')
 
 .PHONY: .help
 .help: ## Display this help screen
@@ -21,10 +21,10 @@ KUMAHQ_CONFIG := $(shell npm query .workspace | jq -r '.[] | select(.name == "@k
 .PHONY: confirm
 confirm:
 	@if [[ -z "$(CI)" ]]; then \
-		CONFIRM="" ; \
+		REPLY="" ; \
 		read -p "=== Please confirm [y/n]: " -r ; \
-		if [[ ! $$CONFIRM =~ ^[Yy]$$ ]]; then \
-			echo "Aborting" ; \
+		if [[ ! $$REPLY =~ ^[Yy]$$ ]]; then \
+			echo $$REPLY ; \
 			exit 1 ; \
 		else \
 			exit 0; \

--- a/packages/config/src/mk/release.mk
+++ b/packages/config/src/mk/release.mk
@@ -46,7 +46,7 @@
 		echo "Error: EXCLUDE_PATH does not exist or is not a directory: $(EXCLUDE_PATH)"; \
 		exit 1; \
 	fi
-	@echo '$(shell node -e "console.log(require('@kumahq/config').ci.depsToDevDeps('$(EXCLUDE_PATH)/package.json'))")' \
+	@echo '$(shell cd $(KUMAHQ_CONFIG) && node -e "console.log(require('./scripts/prune.cjs').depsToDevDeps('$(EXCLUDE_PATH)/package.json'))")' \
 		> $(EXCLUDE_PATH)/package.json
 
 .PHONY: .release/prune

--- a/packages/kuma-gui/Makefile
+++ b/packages/kuma-gui/Makefile
@@ -3,7 +3,8 @@
 
 SHELL := /usr/bin/env bash
 
-KUMAHQ_CONFIG := $(shell npm query .workspace | jq -r '.[] | select(.name == "@kumahq/config") | .path')
+NPM_WORKSPACE_ROOT := $(shell npm prefix)
+KUMAHQ_CONFIG := $(NPM_WORKSPACE_ROOT)/$(shell cat $(NPM_WORKSPACE_ROOT)/package-lock.json | jq -r '.packages | to_entries[] | select(.value.name == "@kumahq/config") | .key')
 MK := $(KUMAHQ_CONFIG)/src/mk
 
 ## make help: if you're aren't sure use `make help`


### PR DESCRIPTION
Follow up of https://github.com/kumahq/kuma-gui/pull/3410

---

Turns out `npm query` requires your `node_modules` to be present, I've no idea why 🤷 , and we have a target that we sometimes run that needs to run before a `make install` (`make release/prune`) 🤦 .

I saw that you can add a `npm --package-lock-file-only query` to get it to use the lock file instead of needing access to `node_modules`. This works when running from workspace root without `node_modules`, but when you run a Makefile from a sub project without `node_modules` adding this arg/flag still fails 🤷 

I've fallen back to just jq-ing the package-lock.json myself at least for the moment so we can unblock the release workflow. If I find a slightly nicer way to do this in the future I'll replace, but I really want to stick to the runtime resolution of things rather than hardcoding paths in several files.

How to test:

- Run `make clean` to remove all your `node_modules` folders
- cd into or use `make -C` to run `make release/prune` from within `packages/kuma-gui`
- Verify that `packages/config` has changes to package.json and package-lock.json also has changes.

I 'think' this will finally unblock the release workflow 🤞 

---

edit: I just checked a this new approach actually works better elsewhere also 🎉 