### PR TITLE
feat(zone-ingress-summary-view): use dropdown to select config format

### DIFF
--- a/packages/kuma-gui/cypress/support/step_definitions/index.ts
+++ b/packages/kuma-gui/cypress/support/step_definitions/index.ts
@@ -150,6 +150,11 @@ When(/^I click the "(.*)" element(?: and select "(.*)")?$/, (selector: string, v
   }
 })
 
+When(/^I select "(.*)" from the "(.*)" element$/, (value: string, selector: string) => {
+  $(selector).click()
+  $(`[data-testid="select-item-${value}"] button`).click()
+})
+
 When(/^I (.*) on the "(.*)" element$/, (event: string, selector: string) => {
   switch (event) {
     case 'hover':

--- a/packages/kuma-gui/cypress/support/step_definitions/index.ts
+++ b/packages/kuma-gui/cypress/support/step_definitions/index.ts
@@ -150,11 +150,6 @@ When(/^I click the "(.*)" element(?: and select "(.*)")?$/, (selector: string, v
   }
 })
 
-When(/^I select "(.*)" from the "(.*)" element$/, (value: string, selector: string) => {
-  $(selector).click()
-  $(`[data-testid="select-item-${value}"] button`).click()
-})
-
 When(/^I (.*) on the "(.*)" element$/, (event: string, selector: string) => {
   switch (event) {
     case 'hover':

--- a/packages/kuma-gui/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
@@ -6,6 +6,8 @@ Feature: Zone Ingress summary
       | item                 | [data-testid='zone-ingress-collection'] tbody tr |
       | summary              | [data-testid='summary']                          |
       | close-summary-button | $summary [data-testid='slideout-close-icon']     |
+      | select-preference    | $summary [data-testid='select-input']            |
+      | structured-view      | $summary [data-testid='structured-view']         |
     And the URL "/zone-ingresses/_overview" responds with
       """
       body:
@@ -39,3 +41,18 @@ Feature: Zone Ingress summary
       """
     When I visit the "/zones/zone-1/ingresses/zone-ingress-1?page=2&size=50" URL
     Then the "$summary" element exists
+
+  Scenario: Switching to YAML format and back
+    Given the environment
+      """
+      KUMA_ZONEINGRESS_COUNT: 1
+      """
+    When I visit the "/zones/zone-1/ingresses/zone-ingress-1?page=2&size=50" URL
+    Then the "$select-preference" element exists
+    And the "$structured-view" element exists
+    When I select "yaml" from the "$select-preference" element
+    Then the "[data-testid='k-code-block']" element exists
+    When I select "structured" from the "$select-preference" element
+    Then the "$structured-view" element exists
+
+

--- a/packages/kuma-gui/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
@@ -50,9 +50,12 @@ Feature: Zone Ingress summary
     When I visit the "/zones/zone-1/ingresses/zone-ingress-1?page=2&size=50" URL
     Then the "$select-preference" element exists
     And the "$structured-view" element exists
-    When I select "yaml" from the "$select-preference" element
-    Then the "[data-testid='k-code-block']" element exists
+    When I click the "$select-preference" element
+    When I click the "[data-testid='select-item-yaml'] button" element
+    Then the URL contains "format=yaml"
+    And the "[data-testid='k-code-block']" element exists
     When I select "structured" from the "$select-preference" element
-    Then the "$structured-view" element exists
+    Then the URL contains "format=structured"
+    And the "$structured-view" element exists
 
 

--- a/packages/kuma-gui/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
@@ -47,7 +47,7 @@ Feature: Zone Ingress summary
       """
       KUMA_ZONEINGRESS_COUNT: 1
       """
-    When I visit the "/zones/zone-1/ingresses/zone-ingress-1?page=2&size=50" URL
+    When I visit the "/zones/zone-1/ingresses/zone-ingress-1" URL
     Then the "$select-preference" element exists
     And the "$structured-view" element exists
     When I click the "$select-preference" element

--- a/packages/kuma-gui/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/ingresses/ZoneIngressSummary.feature
@@ -54,7 +54,9 @@ Feature: Zone Ingress summary
     When I click the "[data-testid='select-item-yaml'] button" element
     Then the URL contains "format=yaml"
     And the "[data-testid='k-code-block']" element exists
-    When I select "structured" from the "$select-preference" element
+    And the "$structured-view" element doesn't exists
+    When I click the "$select-preference" element
+    When I click the "[data-testid='select-item-structured'] button" element
     Then the URL contains "format=structured"
     And the "$structured-view" element exists
 

--- a/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
+++ b/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
@@ -11,7 +11,7 @@ import { KTruncate } from '@kong/kongponents'
 const props = withDefaults(defineProps<{
   // TODO(jc) :variant
   type?: 'stack' | 'separated' | 'columns'
-  size?: 'small' | 'normal' | 'max' | 'none'
+  size?: 'small' | 'normal' | 'max'
   truncate?: boolean
 }>(), {
   type: 'stack',

--- a/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
+++ b/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
@@ -11,7 +11,7 @@ import { KTruncate } from '@kong/kongponents'
 const props = withDefaults(defineProps<{
   // TODO(jc) :variant
   type?: 'stack' | 'separated' | 'columns'
-  size?: 'small' | 'normal' | 'max' | 'unset'
+  size?: 'small' | 'normal' | 'max' | 'none'
   truncate?: boolean
 }>(), {
   type: 'stack',

--- a/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
+++ b/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="props.type === 'separated' && props.truncate ? KTruncate : 'div'"
-    :class="['x-layout', props.type, props.size]"
+    :class="['x-layout', props.type, props.size, props.space]"
   >
     <slot name="default" />
   </component>
@@ -12,11 +12,13 @@ const props = withDefaults(defineProps<{
   // TODO(jc) :variant
   type?: 'stack' | 'separated' | 'columns'
   size?: 'small' | 'normal'
+  space?: 'full'
   truncate?: boolean
 }>(), {
   type: 'stack',
   size: 'normal',
   truncate: false,
+  space: undefined,
 })
 </script>
 <style lang="scss" scoped>
@@ -31,6 +33,11 @@ const props = withDefaults(defineProps<{
   flex-wrap: wrap;
   align-items: center;
   gap: $kui-space-40;
+
+  &.full {
+    width: 100%;
+    justify-content: space-between;
+  }
 }
 .columns {
   --threshold: 40rem;

--- a/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
+++ b/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
@@ -11,7 +11,7 @@ import { KTruncate } from '@kong/kongponents'
 const props = withDefaults(defineProps<{
   // TODO(jc) :variant
   type?: 'stack' | 'separated' | 'columns'
-  size?: 'small' | 'normal' | 'max'
+  size?: 'small' | 'normal' | 'max' | 'unset'
   truncate?: boolean
 }>(), {
   type: 'stack',

--- a/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
+++ b/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="props.type === 'separated' && props.truncate ? KTruncate : 'div'"
-    :class="['x-layout', props.type, props.size, props.space]"
+    :class="['x-layout', props.type, props.size]"
   >
     <slot name="default" />
   </component>
@@ -11,14 +11,12 @@ import { KTruncate } from '@kong/kongponents'
 const props = withDefaults(defineProps<{
   // TODO(jc) :variant
   type?: 'stack' | 'separated' | 'columns'
-  size?: 'small' | 'normal'
-  space?: 'full'
+  size?: 'small' | 'normal' | 'max'
   truncate?: boolean
 }>(), {
   type: 'stack',
   size: 'normal',
   truncate: false,
-  space: undefined,
 })
 </script>
 <style lang="scss" scoped>
@@ -28,14 +26,16 @@ const props = withDefaults(defineProps<{
 .stack.small > * + * {
   margin-block-start: $kui-space-40;
 }
+.max {
+  width: 100%;
+}
 .separated:not(.k-truncate) {
   display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
   gap: $kui-space-40;
 
-  &.full {
-    width: 100%;
+  &.max {
     justify-content: space-between;
   }
 }

--- a/packages/kuma-gui/src/app/zone-ingresses/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/zone-ingresses/locales/en-us/index.yaml
@@ -15,7 +15,7 @@ zone-ingresses:
         zone-ingress-clusters-view: 'Clusters'
         zone-ingress-config-view: 'YAML'
       overview: 'Overview'
-      config: 'YAML'
+      config: Configuration
       subscriptions:
         title: 'XDS connections'
       about:
@@ -23,6 +23,10 @@ zone-ingresses:
     items:
       title: Ingresses
       breadcrumbs: Ingresses
+      format: Format
+      formats:
+        yaml: YAML
+        structured: Structured
       intro: !!text/markdown |
         A Zone Ingress is a specialized gateway that facilitates cross-zone communication by securely routing traffic between services in different zones.
   href:

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -84,9 +84,7 @@
                 </XLayout>
               </header>
               <template v-if="route.params.format === 'structured'">
-                <XLayout
-                  type="stack"
-                  size="none"
+                <div
                   class="stack-with-borders"
                   data-testid="structured-view"
                 >
@@ -160,7 +158,7 @@
                       </template>
                     </template>
                   </DefinitionCard>
-                </XLayout>
+                </div>
               </template>
               <template v-else>
                 <div>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -86,7 +86,7 @@
               <template v-if="route.params.format === 'structured'">
                 <XLayout
                   type="stack"
-                  size="unset"
+                  size="none"
                   class="stack-with-borders"
                   data-testid="structured-view"
                 >

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -6,6 +6,7 @@
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
+      format: 'structured',
     }"
     v-slot="{ route, t }"
   >
@@ -52,110 +53,137 @@
               </h2>
             </template>
 
-            <div
-              class="stack-with-borders"
+            <XLayout
+              variant="stack"
             >
-              <DefinitionCard
-                layout="horizontal"
-              >
-                <template #title>
-                  {{ t('http.api.property.status') }}
-                </template>
-
-                <template #body>
-                  <StatusBadge
-                    :status="item.state"
-                  />
-                </template>
-              </DefinitionCard>
-
-              <DefinitionCard
-                v-if="item.namespace.length > 0"
-                layout="horizontal"
-              >
-                <template #title>
-                  {{ t('data-planes.routes.item.namespace') }}
-                </template>
-
-                <template #body>
-                  {{ item.namespace }}
-                </template>
-              </DefinitionCard>
-
-              <DefinitionCard
-                layout="horizontal"
-              >
-                <template #title>
-                  {{ t('http.api.property.address') }}
-                </template>
-
-                <template #body>
-                  <template
-                    v-if="item.zoneIngress.socketAddress.length > 0"
-                  >
-                    <XCopyButton
-                      :text="item.zoneIngress.socketAddress"
-                    />
-                  </template>
-
-                  <template v-else>
-                    {{ t('common.detail.none') }}
-                  </template>
-                </template>
-              </DefinitionCard>
-
-              <DefinitionCard
-                layout="horizontal"
-              >
-                <template #title>
-                  {{ t('http.api.property.advertisedAddress') }}
-                </template>
-
-                <template #body>
-                  <template
-                    v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
-                  >
-                    <XCopyButton
-                      :text="item.zoneIngress.advertisedSocketAddress"
-                    />
-                  </template>
-
-                  <template v-else>
-                    {{ t('common.detail.none') }}
-                  </template>
-                </template>
-              </DefinitionCard>
-            </div>
-            <div>
-              <h3>
-                {{ t('zone-ingresses.routes.item.config') }}
-              </h3>
-
-              <div class="mt-4">
-                <ResourceCodeBlock
-                  :resource="item.config"
-                  is-searchable
-                  :query="route.params.codeSearch"
-                  :is-filter-mode="route.params.codeFilter"
-                  :is-reg-exp-mode="route.params.codeRegExp"
-                  @query-change="route.update({ codeSearch: $event })"
-                  @filter-mode-change="route.update({ codeFilter: $event })"
-                  @reg-exp-mode-change="route.update({ codeRegExp: $event })"
-                  v-slot="{ copy, copying }"
+              <header>
+                <XLayout
+                  type="separated"
+                  space="full"
                 >
-                  <DataSource
-                    v-if="copying"
-                    :src="`/zone-ingresses/${route.params.zoneIngress}/as/kubernetes?no-store`"
-                    @change="(data) => {
-                      copy((resolve) => resolve(data))
-                    }"
-                    @error="(e) => {
-                      copy((_resolve, reject) => reject(e))
-                    }"
-                  />
-                </ResourceCodeBlock>
-              </div>
-            </div>
+                  <h3>
+                    {{ t('zone-ingresses.routes.item.config') }}
+                  </h3>
+                  <div>
+                    <XSelect
+                      :label="t('zone-ingresses.routes.items.format')"
+                      :selected="route.params.format"
+                      @change="(value) => {
+                        route.update({ format: value })
+                      }"
+                    >
+                      <template
+                        v-for="value in ['structured', 'yaml']"
+                        :key="value"
+                        #[`${value}-option`]
+                      >
+                        {{ t(`zone-ingresses.routes.items.formats.${value}`) }}
+                      </template>
+                    </XSelect>
+                  </div>
+                </XLayout>
+              </header>
+              <template v-if="route.params.format === 'structured'">
+                <DefinitionCard
+                  layout="horizontal"
+                >
+                  <template #title>
+                    {{ t('http.api.property.status') }}
+                  </template>
+
+                  <template #body>
+                    <StatusBadge
+                      :status="item.state"
+                    />
+                  </template>
+                </DefinitionCard>
+
+                <DefinitionCard
+                  v-if="item.namespace.length > 0"
+                  layout="horizontal"
+                >
+                  <template #title>
+                    {{ t('data-planes.routes.item.namespace') }}
+                  </template>
+
+                  <template #body>
+                    {{ item.namespace }}
+                  </template>
+                </DefinitionCard>
+
+                <DefinitionCard
+                  layout="horizontal"
+                >
+                  <template #title>
+                    {{ t('http.api.property.address') }}
+                  </template>
+
+                  <template #body>
+                    <template
+                      v-if="item.zoneIngress.socketAddress.length > 0"
+                    >
+                      <XCopyButton
+                        :text="item.zoneIngress.socketAddress"
+                      />
+                    </template>
+
+                    <template v-else>
+                      {{ t('common.detail.none') }}
+                    </template>
+                  </template>
+                </DefinitionCard>
+
+                <DefinitionCard
+                  layout="horizontal"
+                >
+                  <template #title>
+                    {{ t('http.api.property.advertisedAddress') }}
+                  </template>
+
+                  <template #body>
+                    <template
+                      v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
+                    >
+                      <XCopyButton
+                        :text="item.zoneIngress.advertisedSocketAddress"
+                      />
+                    </template>
+
+                    <template v-else>
+                      {{ t('common.detail.none') }}
+                    </template>
+                  </template>
+                </DefinitionCard>
+              </template>
+              <template v-else>
+                <div>
+                  <div class="mt-4">
+                    <ResourceCodeBlock
+                      :resource="item.config"
+                      is-searchable
+                      :query="route.params.codeSearch"
+                      :is-filter-mode="route.params.codeFilter"
+                      :is-reg-exp-mode="route.params.codeRegExp"
+                      @query-change="route.update({ codeSearch: $event })"
+                      @filter-mode-change="route.update({ codeFilter: $event })"
+                      @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+                      v-slot="{ copy, copying }"
+                    >
+                      <DataSource
+                        v-if="copying"
+                        :src="`/zone-ingresses/${route.params.zoneIngress}/as/kubernetes?no-store`"
+                        @change="(data) => {
+                          copy((resolve) => resolve(data))
+                        }"
+                        @error="(e) => {
+                          copy((_resolve, reject) => reject(e))
+                        }"
+                      />
+                    </ResourceCodeBlock>
+                  </div>
+                </div>
+              </template>
+            </XLayout>
           </AppView>
         </template>
       </template>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -86,6 +86,7 @@
               <template v-if="route.params.format === 'structured'">
                 <XLayout
                   type="stack"
+                  size="unset"
                   class="stack-with-borders"
                   data-testid="structured-view"
                 >

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -54,12 +54,12 @@
             </template>
 
             <XLayout
-              variant="stack"
+              type="stack"
             >
               <header>
                 <XLayout
                   type="separated"
-                  space="full"
+                  size="max"
                 >
                   <h3>
                     {{ t('zone-ingresses.routes.item.config') }}
@@ -85,7 +85,7 @@
               </header>
               <template v-if="route.params.format === 'structured'">
                 <XLayout
-                  variant="stack"
+                  type="stack"
                   data-testid="structured-view"
                 >
                   <DefinitionCard

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -86,6 +86,7 @@
               <template v-if="route.params.format === 'structured'">
                 <XLayout
                   type="stack"
+                  class="stack-with-borders"
                   data-testid="structured-view"
                 >
                   <DefinitionCard

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -84,76 +84,81 @@
                 </XLayout>
               </header>
               <template v-if="route.params.format === 'structured'">
-                <DefinitionCard
-                  layout="horizontal"
+                <XLayout
+                  variant="stack"
+                  data-testid="structured-view"
                 >
-                  <template #title>
-                    {{ t('http.api.property.status') }}
-                  </template>
+                  <DefinitionCard
+                    layout="horizontal"
+                  >
+                    <template #title>
+                      {{ t('http.api.property.status') }}
+                    </template>
 
-                  <template #body>
-                    <StatusBadge
-                      :status="item.state"
-                    />
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
-                  v-if="item.namespace.length > 0"
-                  layout="horizontal"
-                >
-                  <template #title>
-                    {{ t('data-planes.routes.item.namespace') }}
-                  </template>
-
-                  <template #body>
-                    {{ item.namespace }}
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template #title>
-                    {{ t('http.api.property.address') }}
-                  </template>
-
-                  <template #body>
-                    <template
-                      v-if="item.zoneIngress.socketAddress.length > 0"
-                    >
-                      <XCopyButton
-                        :text="item.zoneIngress.socketAddress"
+                    <template #body>
+                      <StatusBadge
+                        :status="item.state"
                       />
                     </template>
+                  </DefinitionCard>
 
-                    <template v-else>
-                      {{ t('common.detail.none') }}
-                    </template>
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template #title>
-                    {{ t('http.api.property.advertisedAddress') }}
-                  </template>
-
-                  <template #body>
-                    <template
-                      v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
-                    >
-                      <XCopyButton
-                        :text="item.zoneIngress.advertisedSocketAddress"
-                      />
+                  <DefinitionCard
+                    v-if="item.namespace.length > 0"
+                    layout="horizontal"
+                  >
+                    <template #title>
+                      {{ t('data-planes.routes.item.namespace') }}
                     </template>
 
-                    <template v-else>
-                      {{ t('common.detail.none') }}
+                    <template #body>
+                      {{ item.namespace }}
                     </template>
-                  </template>
-                </DefinitionCard>
+                  </DefinitionCard>
+
+                  <DefinitionCard
+                    layout="horizontal"
+                  >
+                    <template #title>
+                      {{ t('http.api.property.address') }}
+                    </template>
+
+                    <template #body>
+                      <template
+                        v-if="item.zoneIngress.socketAddress.length > 0"
+                      >
+                        <XCopyButton
+                          :text="item.zoneIngress.socketAddress"
+                        />
+                      </template>
+
+                      <template v-else>
+                        {{ t('common.detail.none') }}
+                      </template>
+                    </template>
+                  </DefinitionCard>
+
+                  <DefinitionCard
+                    layout="horizontal"
+                  >
+                    <template #title>
+                      {{ t('http.api.property.advertisedAddress') }}
+                    </template>
+
+                    <template #body>
+                      <template
+                        v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
+                      >
+                        <XCopyButton
+                          :text="item.zoneIngress.advertisedSocketAddress"
+                        />
+                      </template>
+
+                      <template v-else>
+                        {{ t('common.detail.none') }}
+                      </template>
+                    </template>
+                  </DefinitionCard>
+                </XLayout>
               </template>
               <template v-else>
                 <div>


### PR DESCRIPTION
This is part of the efforts to allow the user using the preferred format of showing the config: `structured` vs `yaml` and adds a dropdown menu to select between `structured` and `yaml` in the `ZoneIngressSummaryView`.

![Screenshot 2025-01-17 at 18 31 58](https://github.com/user-attachments/assets/5c31392a-6095-4320-ad6e-6ae4238ac383)

Part of #3283 