### PR TITLE
refactor: for route state prefer events over v-model

### DIFF
--- a/packages/kuma-gui/src/app/application/components/route-view/README.md
+++ b/packages/kuma-gui/src/app/application/components/route-view/README.md
@@ -93,12 +93,10 @@ Defining these "dependencies" here has several advantages:
 4. Boolean route params are transformed correctly for the URL. In the above
    example the resulting query parameter will be the existence of `?checked`
    not `?checked=true` and `?checked=false`
-5. Route params can be used as `v-model` values. Ideally we usually use events
-   to change route properties, but for components that only support `v-model`
-   you can use the route.param as the v-model. For example `<KCheckBox
-   v-model="route.params.checked" />` will automatically sync the checkbox state
-   to the `?checked` query parameter. This aims to make it easier to maintain
-   state in the browser URL and harder not to
+5. Route params can be used as a state for input elements. In order to retrieve and update the route properties
+   we can use events. For example `<KCheckBox :model-value="route.params.checked" @change="(value) => route.update({ checked: value })" />`
+   will automatically sync the checkbox state to the `?checked` query parameter. This aims to make it easier to maintain
+   state in the browser URL and harder not to. Note that this does not work when using the bi-directional `v-model` attribute.
 
 ## Setting the `<title>` of the page
 

--- a/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
+++ b/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
@@ -174,18 +174,6 @@ const routeView = {
 }
 const routeParams = reactive<Params>(structuredClone(props.params) as Params)
 
-// Updates the URL for route params if used as a modelValue (for boolean props only)
-watch(routeParams, (val) => {
-  if (route.name === props.name) {
-    const booleans = Object.fromEntries(Object.entries(val).filter(([key, _value]) => {
-      return typeof props.params[key] === 'boolean'
-    }))
-    if (Object.keys(booleans).length > 0) {
-      routeUpdate(booleans)
-    }
-  }
-})
-
 // when any URL params change, normalize/validate/default and reset our actual application params
 const redirected = ref<boolean>(false)
 watch(() => {

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryXdsConfigView.vue
@@ -39,8 +39,9 @@
         >
           <template #primary-actions>
             <XCheckbox
-              v-model="route.params.includeEds"
+              :model-value="route.params.includeEds"
               :label="t('connections.include_endpoints')"
+              @change="(value) => route.update({ includeEds: value})"
             />
             <XAction
               action="refresh"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
@@ -38,8 +38,9 @@
           >
             <template #primary-actions>
               <XCheckbox
-                v-model="route.params.includeEds"
+                :model-value="route.params.includeEds"
                 label="Include Endpoints"
+                @change="(value) => route.update({ includeEds: value})"
               />
               <XAction
                 action="refresh"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -288,8 +288,9 @@
                   #actions
                 >
                   <XInputSwitch
-                    v-model="route.params.inactive"
+                    :model-value="route.params.inactive"
                     data-testid="dataplane-outbounds-inactive-toggle"
+                    @change="(value) => route.update({ inactive: value})"
                   >
                     <template #label>
                       Show inactive

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
@@ -100,8 +100,9 @@
                   #actions
                 >
                   <XInputSwitch
-                    v-model="route.params.inactive"
+                    :model-value="route.params.inactive"
                     data-testid="dataplane-outbounds-inactive-toggle"
+                    @change="(value) => route.update({ inactive: value})"
                   >
                     <template #label>
                       Show inactive

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressXdsConfigView.vue
@@ -36,8 +36,9 @@
           >
             <template #primary-actions>
               <XCheckbox
-                v-model="route.params.includeEds"
+                :model-value="route.params.includeEds"
                 label="Include Endpoints"
+                @change="(value) => route.update({ includeEds: value})"
               />
               <XAction
                 action="refresh"

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -125,8 +125,9 @@
                 #actions
               >
                 <XInputSwitch
-                  v-model="route.params.inactive"
+                  :model-value="route.params.inactive"
                   data-testid="dataplane-outbounds-inactive-toggle"
+                  @change="(value) => route.update({ inactive: value})"
                 >
                   <template #label>
                     Show inactive

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressXdsConfigView.vue
@@ -36,8 +36,9 @@
           >
             <template #primary-actions>
               <XCheckbox
-                v-model="route.params.includeEds"
+                :model-value="route.params.includeEds"
                 label="Include Endpoints"
+                @change="(value) => route.update({ includeEds: value})"
               />
               <XAction
                 action="refresh"


### PR DESCRIPTION
In #1966 a watcher has been added to sync boolean query search params. This watcher caused some issues in nested routes due to a race condition.

The reason for the watcher (from #1966)
>Whilst I'd prefer not use two way binding models we have some components that we use that uses these as required values, such as KInputSwitch

Turns out that the components `KSelect` and `KCheckBox` now support the `@change` events. When used alongside the `:model-value` we have our getter and setter separated. This means that we can remove the additional watcher.

From #3409 
> 4. I had to keep the watcher with the booleans only for the case of KInputSwitch.