### PR TITLE
fix(ci): fix release/prune amends

### DIFF
--- a/packages/config/scripts/prune.cjs
+++ b/packages/config/scripts/prune.cjs
@@ -10,6 +10,6 @@ module.exports = {
         ...pkg.dependencies,
         ...pkg.devDependencies,
       },
-    })
+    }, null, 2)
   },
 }

--- a/packages/config/src/mk/release.mk
+++ b/packages/config/src/mk/release.mk
@@ -46,8 +46,9 @@
 		echo "Error: EXCLUDE_PATH does not exist or is not a directory: $(EXCLUDE_PATH)"; \
 		exit 1; \
 	fi
-	@echo '$(shell cd $(KUMAHQ_CONFIG) && node -e "console.log(require('./scripts/prune.cjs').depsToDevDeps('$(EXCLUDE_PATH)/package.json'))")' \
-		> $(EXCLUDE_PATH)/package.json
+	@node -e "console.log(require('$(KUMAHQ_CONFIG)/scripts/prune.cjs').depsToDevDeps('$(EXCLUDE_PATH)/package.json'))" > $(EXCLUDE_PATH)/package-pruned.json
+	@rm $(EXCLUDE_PATH)/package.json
+	@mv $(EXCLUDE_PATH)/package-pruned.json $(EXCLUDE_PATH)/package.json
 
 .PHONY: .release/prune
 .release/prune:


### PR DESCRIPTION
Last two little amends to the pruning we do for release:

- Prettify the JSON
- `rm` and replace package.json instead of using a single command (can cause issues elsewhere)