### PR TITLE
fix: flaky tests due to mismatch of payload type

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
@@ -23,10 +23,8 @@ Feature: Dataplane details for standard Data Plane Proxy
             advertisedAddress: !!js/undefined
             gateway: !!js/undefined
             inbound:
-              - health:
-                  ready: true
-                  state: Ready
-                address: !!js/undefined
+              - address: !!js/undefined
+                state: Ready
         dataplaneInsight:
           mTLS: !!js/undefined
           subscriptions:

--- a/packages/kuma-gui/features/mesh/dataplanes/Index.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Index.feature
@@ -80,7 +80,6 @@ Feature: mesh / dataplanes / index
                 inbound:
                   - tags:
                       kuma.io/service: !!js/undefined
-                    state: NotReady
             dataplaneInsight:
               mTLS:
                 certificateExpirationTime: !!js/undefined

--- a/packages/kuma-gui/features/mesh/dataplanes/Index.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Index.feature
@@ -31,11 +31,10 @@ Feature: mesh / dataplanes / index
             networking:
               gateway: !!js/undefined
               inbound:
-                - health:
-                    ready: true
-                  tags:
+                - tags:
                     kuma.io/service: service-1
                     kuma.io/zone: zone-1
+                  state: Ready
           dataplaneInsight:
             mTLS:
               certificateExpirationTime: 2023-11-03T09:10:17Z
@@ -79,10 +78,9 @@ Feature: mesh / dataplanes / index
               networking:
                 gateway: !!js/undefined
                 inbound:
-                  - health:
-                      ready: true
-                    tags:
+                  - tags:
                       kuma.io/service: !!js/undefined
+                    state: NotReady
             dataplaneInsight:
               mTLS:
                 certificateExpirationTime: !!js/undefined

--- a/packages/kuma-gui/features/mesh/dataplanes/Index.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Index.feature
@@ -80,6 +80,7 @@ Feature: mesh / dataplanes / index
                 inbound:
                   - tags:
                       kuma.io/service: !!js/undefined
+                    state: Ready
             dataplaneInsight:
               mTLS:
                 certificateExpirationTime: !!js/undefined

--- a/packages/kuma-gui/features/mesh/dataplanes/NoSubscriptions.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/NoSubscriptions.feature
@@ -10,6 +10,14 @@ Feature: dataplanes / no-subscriptions
       KUMA_SUBSCRIPTION_COUNT: 0
       KUMA_DATAPLANEINBOUND_COUNT: 1
       """
+    And the URL "/meshes/default/dataplanes/backend/_overview" responds with
+      """
+      body:
+        dataplane:
+          networking:
+            inbound:
+              - state: Ready
+      """
     When I visit the "/meshes/default/data-planes/backend/overview" URL
     And the "$detail-view" element contains "backend"
     And the "$overview-content" element contains "offline"

--- a/packages/kuma-gui/features/mesh/dataplanes/NoSubscriptions.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/NoSubscriptions.feature
@@ -10,9 +10,6 @@ Feature: dataplanes / no-subscriptions
       KUMA_SUBSCRIPTION_COUNT: 0
       KUMA_DATAPLANEINBOUND_COUNT: 1
       """
-    And the URL "/meshes/default/dataplanes/backend/_overview" responds with
-      """
-      """
     When I visit the "/meshes/default/data-planes/backend/overview" URL
     And the "$detail-view" element contains "backend"
     And the "$overview-content" element contains "offline"

--- a/packages/kuma-gui/features/mesh/dataplanes/NoSubscriptions.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/NoSubscriptions.feature
@@ -16,8 +16,7 @@ Feature: dataplanes / no-subscriptions
         dataplane:
           networking:
             inbound:
-              - health:
-                  ready: true
+              - state: NotReady
       """
     When I visit the "/meshes/default/data-planes/backend/overview" URL
     And the "$detail-view" element contains "backend"

--- a/packages/kuma-gui/features/mesh/dataplanes/NoSubscriptions.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/NoSubscriptions.feature
@@ -12,11 +12,6 @@ Feature: dataplanes / no-subscriptions
       """
     And the URL "/meshes/default/dataplanes/backend/_overview" responds with
       """
-      body:
-        dataplane:
-          networking:
-            inbound:
-              - state: NotReady
       """
     When I visit the "/meshes/default/data-planes/backend/overview" URL
     And the "$detail-view" element contains "backend"

--- a/packages/kuma-gui/features/onboarding/dataplanes-overview/Index.feature
+++ b/packages/kuma-gui/features/onboarding/dataplanes-overview/Index.feature
@@ -69,8 +69,7 @@ Feature: onboarding / dataplanes-overview / index
             dataplane:
               networking:
                 inbounds:
-                  - health:
-                      ready: true
+                  - state: Ready
             dataplaneInsight:
               subscriptions:
                 - connectTime: 2021-02-17T07:33:36.412683Z


### PR DESCRIPTION
Over the past weeks we have noticed some flakes of our browser tests where the assertion was mainly about a state being `online`. I have traced it down to a mismatch of our payload type. In our tests we always set the state that we want to assert for in `dataplane.inbound.health.state`, but according to our type in [data-planes](https://github.com/kumahq/kuma-gui/blob/26976933fb563768d5f09099f2d7d28c11545bcd/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts#L13) there is no entry `health`. The `state` can be found in `dataplane.inbound.state`.

Example:
![Screenshot 2025-01-20 at 11 11 05](https://github.com/user-attachments/assets/0df626fb-d6d2-4efa-889d-fe0a84c8a83f)

Closes #3376