### PR TITLE
chore(deps): adds .dedupe Makefile target

### DIFF
--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -6,6 +6,10 @@
 .install/sync:
 	npm clean-install
 
+.PHONY: .dedupe
+.dedupe:
+	@npm dedupe
+
 .PHONY: .clean
 .clean:
 	@echo "Recursively removing all node_modules/ directories in $(NPM_WORKSPACE_ROOT)..."


### PR DESCRIPTION
Adds `.dedupe` Makefile target that calls `npm dedupe`.

Note: this isn't something we do often here, so I haven't made a corresponding "dotless" and documented/exposed `dedupe` here.