### PR TITLE
fix(policies): fixes padding for policy type list

### DIFF
--- a/packages/kuma-gui/src/app/application/components/data-collection/DataCollection.vue
+++ b/packages/kuma-gui/src/app/application/components/data-collection/DataCollection.vue
@@ -43,40 +43,44 @@
       class="data-collection"
       type="stack"
     >
-      <slot
-        name="default"
-        :items="paginated"
-      />
-
-      <slot
-        v-if="typeof props.items?.[0] !== 'undefined' && !(props.page === 0 && props.pageSize === 0 && props.total === 0)"
-        name="pagination"
-        :items="paginated"
-      >
-        <KPagination
-          :class="{
-            pagination: true,
-            'with-paging': props.page !== 0 && props.total > 0 && props.total !== props.items.length,
-            'with-sizing': props.pageSize !== 0,
-          }"
-          :total-count="props.total"
-          :current-page="props.page"
-          :initial-page-size="props.pageSize || props.total"
-          :page-sizes="[15, 30, 50, 75, 100]"
-          @page-change="({ page }: PaginationChangeEvent) => {
-            change({
-              page,
-              size: props.pageSize,
-            })
-          }"
-          @page-size-change="({ pageSize }: SizeChangeEvent) => {
-            change({
-              page: props.page,
-              size: pageSize,
-            })
-          }"
+      <div>
+        <slot
+          name="default"
+          :items="paginated"
         />
-      </slot>
+      </div>
+      <div
+        v-if="typeof props.items?.[0] !== 'undefined' && !(props.page === 0 && props.pageSize === 0 && props.total === 0)"
+      >
+        <slot
+          name="pagination"
+          :items="paginated"
+        >
+          <KPagination
+            :class="{
+              pagination: true,
+              'with-paging': props.page !== 0 && props.total > 0 && props.total !== props.items.length,
+              'with-sizing': props.pageSize !== 0,
+            }"
+            :total-count="props.total"
+            :current-page="props.page"
+            :initial-page-size="props.pageSize || props.total"
+            :page-sizes="[15, 30, 50, 75, 100]"
+            @page-change="({ page }: PaginationChangeEvent) => {
+              change({
+                page,
+                size: props.pageSize,
+              })
+            }"
+            @page-size-change="({ pageSize }: SizeChangeEvent) => {
+              change({
+                page: props.page,
+                size: pageSize,
+              })
+            }"
+          />
+        </slot>
+      </div>
     </XLayout>
   </template>
 </template>


### PR DESCRIPTION
This is actually a bug/incorrect configuration/usage of `XLayout` within `DataCollection`.

I made sure the immediate children of `XLayout` are within the `DataCollection`. i.e. I added two divs, the second one isn't necessary as KPagination is a single block level element, but I wanted to keep _both_ immediate children visible within `DataCollection`.

## Before

<img width="667" alt="Screenshot 2025-01-22 at 11 06 31" src="https://github.com/user-attachments/assets/baedfb4f-3eb5-4482-8567-cc1aa5477deb" />

## After

<img width="590" alt="Screenshot 2025-01-22 at 11 06 17" src="https://github.com/user-attachments/assets/29c385d5-a2ae-4146-8dc8-f0493de5d147" />
