### PR TITLE
chore: uses XI18n component pt1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7426,6 +7426,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint-plugin-no-unsanitized": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.2.tgz",
+      "integrity": "sha512-ydF3PMFKEIkP71ZbLHFvu6/FW8SvRv6VV/gECfrQkqyD5+5oCAtPz8ZHy0GRuMDtNe2jsNdPCQXX4LSbkapAVQ==",
+      "peerDependencies": {
+        "eslint": "^8 || ^9"
+      }
+    },
     "node_modules/eslint-plugin-vue": {
       "version": "9.32.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.32.0.tgz",
@@ -16560,6 +16568,7 @@
         "eslint-import-resolver-typescript": "^3.7.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-json-schema-validator": "^5.3.1",
+        "eslint-plugin-no-unsanitized": "^4.1.2",
         "eslint-plugin-vue": "^9.32.0",
         "glob": "^11.0.1",
         "globals": "^15.14.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -24,6 +24,7 @@
     "esbuild": "^0.24.2",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-typescript": "^3.7.0",
+    "eslint-plugin-no-unsanitized": "^4.1.2",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-json-schema-validator": "^5.3.1",
     "eslint-plugin-vue": "^9.32.0",

--- a/packages/config/src/eslint.cjs
+++ b/packages/config/src/eslint.cjs
@@ -5,6 +5,7 @@ const { defineConfig, createConfig: vueTsEslintConfig } = require('@vue/eslint-c
 const importPlugin = require('eslint-plugin-import')
 const stylistic = require('@stylistic/eslint-plugin')
 const eslint = require('@eslint/js')
+const nounsanitized = require('eslint-plugin-no-unsanitized')
 const jsonSchemaValidatorPlugin = require('eslint-plugin-json-schema-validator')
 const globals = require('globals')
 const $config = dirname(require.resolve('@kumahq/config'))
@@ -107,7 +108,8 @@ function createEslintConfig(
               schema: packageSchema,
             },
           ],
-        }]},
+        }],
+      },
     },
   ]
 
@@ -148,6 +150,7 @@ function createEslintConfig(
 
   return [
     eslint.configs.recommended,
+    nounsanitized.configs.recommended,
     ...vueTsConfig,
     ...importConfig,
     ...jsonSchemaValidatorConfig,
@@ -228,7 +231,7 @@ function createEslintConfig(
           ignoreWhenEmpty: true,
           ignores: ['router-link', 'pre', ...INLINE_NON_VOID_ELEMENTS],
         }],
-        'vue/no-v-html': 'off',
+        'vue/no-v-html': 'error',
         // Reason: https://github.com/vuejs/eslint-plugin-vue/issues/2259
         'vue/no-setup-props-destructure': 'off',
         'vue/comma-dangle': ['error', 'always-multiline'],

--- a/packages/kuma-gui/.vitepress/theme/components/Story.vue
+++ b/packages/kuma-gui/.vitepress/theme/components/Story.vue
@@ -15,7 +15,9 @@
       <div class="language-vue vp-adaptive-theme">
         <button title="Copy Code" class="copy"></button>
         <span class="lang">vue</span>
+        <!-- eslint-disable vue/no-v-html -->
         <div v-html="vueSource"></div>
+        <!-- eslint-enable -->
       </div>
     </details>
 
@@ -40,7 +42,7 @@ const props = withDefaults(defineProps<{
 }>(), {
   height: 300
 })
-const iframe = ref<HTMLIFrameElement>(null)
+const iframe = ref<HTMLIFrameElement | null>(null)
 const htmlSource = ref<string>('')
 const highlighter = ref<Awaited<ReturnType<typeof getHighlighter>> | undefined>()
 

--- a/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
+++ b/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
@@ -153,7 +153,7 @@ const routeView = {
   addTitle: (item: string, sym: symbol) => {
     const $title = title.value
     if ($title) {
-      $title.innerHTML = t('components.route-view.route-announcer', { title: item })
+      $title.textContent = t('components.route-view.route-announcer', { title: item })
     }
 
     titles.set(sym, item)

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -27,8 +27,12 @@
               v-for="warning in warnings"
               :key="warning.kind"
               :data-testid="`warning-${warning.kind}`"
-              v-html="t(`common.warnings.${warning.kind}`, warning.payload)"
-            />
+            >
+              <XI18n
+                :path="`common.warnings.${warning.kind}`"
+                :params="warning.payload"
+              />
+            </li>
             <li
               v-if="error"
               :data-testid="`warning-stats-loading`"
@@ -505,8 +509,8 @@
                 class="mt-4"
                 variant="warning"
               >
-                <div
-                  v-html="t('data-planes.routes.item.mtls.disabled')"
+                <XI18n
+                  path="data-planes.routes.item.mtls.disabled"
                 />
               </XAlert>
             </template>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -18,7 +18,10 @@
     <AppView
       :docs="t('data-planes.href.docs.data_plane_proxy')"
     >
-      <div v-html="t('data-planes.routes.items.intro', {}, { defaultMessage: '' })" />
+      <XI18n
+        path="data-planes.routes.items.intro"
+        default-message=""
+      />
       <XCard>
         <search>
           <FilterBar

--- a/packages/kuma-gui/src/app/gateways/views/GatewayListTabsView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/GatewayListTabsView.vue
@@ -41,8 +41,9 @@
           </DataCollection>
         </template>
 
-        <div
-          v-html="t(`gateways.routes.items.navigation.${route.child()?.name}.description`, {}, { defaultMessage: '' })"
+        <XI18n
+          :path="`gateways.routes.items.navigation.${route.child()?.name}.description`"
+          default-message=""
         />
 
         <RouterView

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
@@ -18,102 +18,103 @@
           />
         </h1>
       </template>
-      <div class="stack">
-        <div v-html="t('hostname-generators.routes.items.intro', {}, { defaultMessage: '' })" />
-        <XCard>
-          <DataLoader
-            :src="uri(sources, '/hostname-generators', {}, {
-              page: route.params.page,
-              size: route.params.size,
-            })"
+      <XI18n
+        path="hostname-generators.routes.items.intro"
+        default-message=""
+      />
+      <XCard>
+        <DataLoader
+          :src="uri(sources, '/hostname-generators', {}, {
+            page: route.params.page,
+            size: route.params.size,
+          })"
+        >
+          <template
+            #loadable="{ data }"
           >
-            <template
-              #loadable="{ data }"
+            <DataCollection
+              type="hostname-generators"
+              :items="data?.items ?? [undefined]"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="data?.total"
+              @change="route.update"
             >
-              <DataCollection
-                type="hostname-generators"
-                :items="data?.items ?? [undefined]"
-                :page="route.params.page"
-                :page-size="route.params.size"
-                :total="data?.total"
-                @change="route.update"
+              <AppCollection
+                data-testid="hostname-generator-collection"
+                :headers="[
+                  { ...me.get('headers.name'), label: t('hostname-generators.common.name'), key: 'name' },
+                  { ...me.get('headers.namespace'), label: t('hostname-generators.common.namespace'), key: 'namespace' },
+                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: t('hostname-generators.common.zone'), key: 'zone' }] : []),
+                  { ...me.get('headers.actions'), label: t('hostname-generators.common.actions'), key: 'actions', hideLabel: true },
+                ]"
+                :items="data?.items"
+                :is-selected-row="(item) => item.name === route.params.name"
+                @resize="me.set"
               >
-                <AppCollection
-                  data-testid="hostname-generator-collection"
-                  :headers="[
-                    { ...me.get('headers.name'), label: t('hostname-generators.common.name'), key: 'name' },
-                    { ...me.get('headers.namespace'), label: t('hostname-generators.common.namespace'), key: 'namespace' },
-                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: t('hostname-generators.common.zone'), key: 'zone' }] : []),
-                    { ...me.get('headers.actions'), label: t('hostname-generators.common.actions'), key: 'actions', hideLabel: true },
-                  ]"
-                  :items="data?.items"
-                  :is-selected-row="(item) => item.name === route.params.name"
-                  @resize="me.set"
-                >
-                  <template #name="{ row: item }">
-                    <XCopyButton
-                      :text="item.name"
-                    >
-                      <XAction
-                        data-action
-                        :to="{
-                          name: 'hostname-generator-summary-view',
-                          params: {
-                            name: item.id,
-                          },
-                          query: {
-                            page: route.params.page,
-                            size: route.params.size,
-                          },
-                        }"
-                      >
-                        {{ item.name }}
-                      </XAction>
-                    </XCopyButton>
-                  </template>
-
-                  <template #actions="{ row: item }">
-                    <XActionGroup>
-                      <XAction
-                        :to="{
-                          name: 'hostname-generator-detail-view',
-                          params: {
-                            name: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.actions.view') }}
-                      </XAction>
-                    </XActionGroup>
-                  </template>
-                </AppCollection>
-                <RouterView
-                  v-if="data?.items && route.params.name"
-                  v-slot="child"
-                >
-                  <SummaryView
-                    @close="route.replace({
-                      name: 'hostname-generator-list-view',
-                      params: {
-                        name: '',
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                      },
-                    })"
+                <template #name="{ row: item }">
+                  <XCopyButton
+                    :text="item.name"
                   >
-                    <component
-                      :is="child.Component"
-                      :items="data?.items"
-                    />
-                  </SummaryView>
-                </RouterView>
-              </DataCollection>
-            </template>
-          </DataLoader>
-        </XCard>
-      </div>
+                    <XAction
+                      data-action
+                      :to="{
+                        name: 'hostname-generator-summary-view',
+                        params: {
+                          name: item.id,
+                        },
+                        query: {
+                          page: route.params.page,
+                          size: route.params.size,
+                        },
+                      }"
+                    >
+                      {{ item.name }}
+                    </XAction>
+                  </XCopyButton>
+                </template>
+
+                <template #actions="{ row: item }">
+                  <XActionGroup>
+                    <XAction
+                      :to="{
+                        name: 'hostname-generator-detail-view',
+                        params: {
+                          name: item.id,
+                        },
+                      }"
+                    >
+                      {{ t('common.collection.actions.view') }}
+                    </XAction>
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+              <RouterView
+                v-if="data?.items && route.params.name"
+                v-slot="child"
+              >
+                <SummaryView
+                  @close="route.replace({
+                    name: 'hostname-generator-list-view',
+                    params: {
+                      name: '',
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                    },
+                  })"
+                >
+                  <component
+                    :is="child.Component"
+                    :items="data?.items"
+                  />
+                </SummaryView>
+              </RouterView>
+            </DataCollection>
+          </template>
+        </DataLoader>
+      </XCard>
     </AppView>
   </RouteView>
 </template>

--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -155,8 +155,11 @@
             <ul>
               <li
                 data-testid="warning-GLOBAL_STORE_TYPE_MEMORY"
-                v-html="t('common.warnings.GLOBAL_STORE_TYPE_MEMORY')"
-              />
+              >
+                <XI18n
+                  path="common.warnings.GLOBAL_STORE_TYPE_MEMORY"
+                />
+              </li>
             </ul>
           </XAlert>
         </div>

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -33,12 +33,18 @@
             <ul>
               <li
                 v-if="!props.mesh.mtlsBackend"
-                v-html="t('meshes.routes.item.mtls-warning')"
-              />
+              >
+                <XI18n
+                  path="meshes.routes.item.mtls-warning"
+                />
+              </li>
               <li
                 v-if="props.mesh.mtlsBackend && missingTLSPolicy"
-                v-html="t('meshes.routes.item.mtp-warning')"
-              />
+              >
+                <XI18n
+                  path="meshes.routes.item.mtp-warning"
+                />
+              </li>
             </ul>
           </template>
           <XLayout

--- a/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
@@ -19,8 +19,9 @@
         </h1>
       </template>
 
-      <div
-        v-html="t('meshes.routes.items.intro', {}, { defaultMessage: '' })"
+      <XI18n
+        path="meshes.routes.items.intro"
+        default-message=""
       />
 
       <XCard>

--- a/packages/kuma-gui/src/app/onboarding/components/OnboardingAlert.vue
+++ b/packages/kuma-gui/src/app/onboarding/components/OnboardingAlert.vue
@@ -20,8 +20,11 @@
         }"
       >
         <div class="onboarding-alert-content">
-          <div
-            v-html="t('main-overview.detail.onboarding.message', { name: t('common.product.name') })"
+          <XI18n
+            path="main-overview.detail.onboarding.message"
+            :params="{
+              name: t('common.product.name'),
+            }"
           />
 
           <XAction

--- a/packages/kuma-gui/src/app/onboarding/views/OnboardingMultiZoneView.vue
+++ b/packages/kuma-gui/src/app/onboarding/views/OnboardingMultiZoneView.vue
@@ -26,9 +26,9 @@
             </template>
 
             <template #content>
-              <div
+              <XI18n
                 class="onboarding-multi-zone-view-body"
-                v-html="t('onboarding.routes.multizone.body')"
+                path="onboarding.routes.multizone.body"
               />
 
               <div>
@@ -44,15 +44,16 @@
                     }]"
                     :key="status"
                   >
-                    <div
+                    <XI18n
                       class="onboarding-multi-zone-view-status"
                       :data-testid="`zone-${status.zone}-ingress-${status.ingress}`"
-                      v-html="t('onboarding.routes.multizone.status', {
+                      path="onboarding.routes.multizone.status"
+                      :params="{
                         zone: status.zone,
                         ingress: status.ingress,
-                      })"
-                    />
 
+                      }"
+                    />
                     <div
                       v-if="(['zone', 'ingress'] as const).some(item => status[item] === 'offline')"
                       class="onboarding-multi-zone-view-status-loading"

--- a/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
@@ -63,7 +63,10 @@
                   </PolicyTypeTag>
                 </h3>
               </header>
-              <div v-html="t(`policies.type.${type.name}.description`, undefined, { defaultMessage: t('policies.collection.description') })" />
+              <XI18n
+                :path="`policies.type.${type.name}.description`"
+                default-message="t('policies.collection.description')"
+              />
             </XCard>
 
             <XCard>
@@ -112,8 +115,12 @@
                             {{ t('policies.x-empty-state.title') }}
                           </h3>
                         </template>
-                        <div
-                          v-html="t('policies.x-empty-state.body', { type: type.name, suffix: route.params.s.length > 0 ? t('common.matchingsearch') : '' })"
+                        <XI18n
+                          path="policies.x-empty-state.body"
+                          :params="{
+                            type: type.name,
+                            suffix: route.params.s.length > 0 ? t('common.matchingsearch') : '',
+                          }"
                         />
                         <template
                           #action

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
@@ -24,8 +24,8 @@
     >
       <template
         v-for="warnings in [[
-          [t('services.mesh-external-service.notifications.mtls-warning'), typeof props.mesh.mtlsBackend === 'undefined'],
-          [t('services.mesh-external-service.notifications.no-zone-egress'), egresses && !egresses.items.find((egress) => typeof egress.zoneEgressInsight.connectedSubscription !== 'undefined')],
+          ['services.mesh-external-service.notifications.mtls-warning', typeof props.mesh.mtlsBackend === 'undefined'],
+          ['services.mesh-external-service.notifications.no-zone-egress', egresses && !egresses.items.find((egress) => typeof egress.zoneEgressInsight.connectedSubscription !== 'undefined')],
         ].filter(([_, bool]) => bool).map(item => item[0] as string)]"
         :key="typeof warnings"
       >
@@ -40,8 +40,11 @@
               <li
                 v-for="warning in warnings"
                 :key="warning"
-                v-html="warning"
-              />
+              >
+                <XI18n
+                  :path="warning"
+                />
+              </li>
             </ul>
           </template>
           <XCard>

--- a/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
@@ -37,8 +37,9 @@
           </XActionGroup>
         </template>
 
-        <div
-          v-html="t(`services.routes.items.navigation.${route.child()?.name}.description`, {}, { defaultMessage: '' })"
+        <XI18n
+          :path="`services.routes.items.navigation.${route.child()?.name}.description`"
+          default-message=""
         />
 
         <RouterView

--- a/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
@@ -75,11 +75,7 @@ const isProcessing = ref(false)
 async function handleCodeBlockRenderEvent({ preElement, codeElement, language, code }: CodeBlockEventData): Promise<void> {
   isProcessing.value = true
 
-  const escapedCode = code
-    // Replaces all “<” and “>” characters with their HTML entities because PrismJS needs that.
-    .replaceAll(/</g, '&lt;')
-    .replaceAll(/>/g, '&gt;')
-  highlightElement(preElement, codeElement, escapedCode, language as AvailableLanguages)
+  highlightElement(preElement, codeElement, code, language as AvailableLanguages)
 
   isProcessing.value = false
 }

--- a/packages/kuma-gui/src/app/x/components/x-code-block/highlightElement.ts
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/highlightElement.ts
@@ -39,7 +39,7 @@ export function highlightElement(preElement: Element, codeElement: Element, code
   }
 
   // Ensures Prism operates on the raw code and not on an already highlighted DOM fragment.
-  codeElement.innerHTML = code
+  codeElement.textContent = code
 
   Prism.highlightElement(codeElement)
 }

--- a/packages/kuma-gui/src/app/x/components/x-empty-state/README.md
+++ b/packages/kuma-gui/src/app/x/components/x-empty-state/README.md
@@ -19,9 +19,9 @@ on its own.
 
 But it also has title and default slots to allow you to alter the text. Please
 use semantic elements when changing the default state. You should use `p` tags
-or `<div v-html="t('markdown')" />` for default/body content and the correct
-level of `h*` tag for the title depending on your page and the position/level
-of the empty state.
+or `<XI18n path="i18n.path.to.markdown" />` for default/body content and the
+correct level of `h*` tag for the title depending on your page and the
+position/level of the empty state.
 
 <Story>
   <XEmptyState>

--- a/packages/kuma-gui/src/app/x/components/x-empty-state/XEmptyState.vue
+++ b/packages/kuma-gui/src/app/x/components/x-empty-state/XEmptyState.vue
@@ -1,96 +1,96 @@
 <template>
-  <template
-    v-for="prefix in [props.type.length > 0 ? `${props.type}.` : 'components.']"
-    :key="prefix"
+  <XI18n
+    v-slot="{ t }"
   >
     <template
-      v-for="{title, body, href, actionLabel, actionType} in [
-        {
-          title: t(`${prefix}x-empty-state.title`, undefined, { defaultMessage: t('components.x-empty-state.title') }),
-          body: t(`${prefix}x-empty-state.body`, undefined, { defaultMessage: t('components.x-empty-state.body') }),
-          href: t(`${prefix}x-empty-state.action.href`, undefined, { defaultMessage: '' }),
-          actionLabel: t(`${prefix}x-empty-state.action.label`, undefined, { defaultMessage: '' }),
-          actionType: t(`${prefix}x-empty-state.action.type`, undefined, { defaultMessage: '' }),
-        },
-      ]"
-      :key="title"
+      v-for="prefix in [props.type.length > 0 ? `${props.type}.` : 'components.']"
+      :key="prefix"
     >
-      <KEmptyState
-        class="x-empty-state"
-        data-testid="empty-block"
+      <template
+        v-for="{title, body, href, actionLabel, actionType} in [
+          {
+            title: t(`${prefix}x-empty-state.title`, undefined, { defaultMessage: t('components.x-empty-state.title') }),
+            body: t(`${prefix}x-empty-state.body`, undefined, { defaultMessage: t('components.x-empty-state.body') }),
+            href: t(`${prefix}x-empty-state.action.href`, undefined, { defaultMessage: '' }),
+            actionLabel: t(`${prefix}x-empty-state.action.label`, undefined, { defaultMessage: '' }),
+            actionType: t(`${prefix}x-empty-state.action.type`, undefined, { defaultMessage: '' }),
+          },
+        ]"
+        :key="title"
       >
-        <template
-          #icon
+        <KEmptyState
+          class="x-empty-state"
+          data-testid="empty-block"
         >
-          <slot name="icon" />
-        </template>
-        <template
-          #title
-        >
-          <slot
-            name="title"
+          <template
+            #icon
           >
-            <template
-              v-if="title.length > 0"
+            <slot name="icon" />
+          </template>
+          <template
+            #title
+          >
+            <slot
+              name="title"
             >
-              <header>
-                <!-- eslint-disable vue/no-v-text-v-html-on-component -->
-                <component
-                  :is="`h2`"
-                  v-html="title"
-                />
-                <!-- eslint-enable -->
-              </header>
-            </template>
-          </slot>
-        </template>
+              <template
+                v-if="title.length > 0"
+              >
+                <header>
+                  <h2>
+                    <XI18n
+                      :path="`${prefix}x-empty-state.title`"
+                      :default-message="t('components.x-empty-state.title')"
+                    />
+                  </h2>
+                </header>
+              </template>
+            </slot>
+          </template>
 
-        <template
-          v-if="slots.default"
-        >
-          <slot name="default" />
-        </template>
-        <template
-          v-else-if="body.length > 0"
-        >
-          <div
-            v-html="body"
-          />
-        </template>
-
-        <template
-          #action
-        >
-          <slot name="action">
-            <XAction
-              v-if="href.length > 0"
-              :action="(['docs', 'create'] as const).find((item) => item === actionType)"
-              :href="href"
-            >
-              {{ actionLabel }}
-            </XAction>
-            <XTeleportSlot
-              v-else
-              :name="`${props.type}-x-empty-state-actions`"
+          <template
+            v-if="slots.default"
+          >
+            <slot name="default" />
+          </template>
+          <template
+            v-else-if="body.length > 0"
+          >
+            <XI18n
+              :path="`${prefix}x-empty-state.body`"
+              :default-message="t('components.x-empty-state.body')"
             />
-          </slot>
-        </template>
-      </KEmptyState>
+          </template>
+
+          <template
+            #action
+          >
+            <slot name="action">
+              <XAction
+                v-if="href.length > 0"
+                :action="(['docs', 'create'] as const).find((item) => item === actionType)"
+                :href="href"
+              >
+                {{ actionLabel }}
+              </XAction>
+              <XTeleportSlot
+                v-else
+                :name="`${props.type}-x-empty-state-actions`"
+              />
+            </slot>
+          </template>
+        </KEmptyState>
+      </template>
     </template>
-  </template>
+  </XI18n>
 </template>
 
 <script lang="ts" setup>
 import { KEmptyState } from '@kong/kongponents'
-
-import { useI18n } from '@/app/application'
-
 const props = withDefaults(defineProps<{
   type?: string
 }>(), {
   type: '',
 })
 const slots = defineSlots()
-
-const { t } = useI18n()
 </script>

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressListView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressListView.vue
@@ -28,7 +28,10 @@
           />
         </h1>
       </template>
-      <div v-html="t('zone-egresses.routes.items.intro', {}, { defaultMessage: '' })" />
+      <XI18n
+        path="zone-egresses.routes.items.intro"
+        default-message=""
+      />
       <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
       <XCard>
         <DataLoader

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressListView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressListView.vue
@@ -17,7 +17,10 @@
     <AppView
       :docs="t('zone-ingresses.href.docs')"
     >
-      <div v-html="t('zone-ingresses.routes.items.intro', {}, { defaultMessage: '' })" />
+      <XI18n
+        path="zone-ingresses.routes.items.intro"
+        default-message=""
+      />
       <XCard>
         <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
         <DataLoader

--- a/packages/kuma-gui/src/app/zones/views/ZoneConfigView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneConfigView.vue
@@ -29,13 +29,17 @@
               v-for="warning in props.data.warnings"
               :key="warning.kind"
               :data-testid="`warning-${warning.kind}`"
-              v-html="t(`common.warnings.${warning.kind}`, {
-                ...warning.payload,
-                ...(warning.kind === 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS' ? {
-                  globalCpVersion: version?.version ?? '',
-                } : {}),
-              })"
-            />
+            >
+              <XI18n
+                :path="`common.warnings.${warning.kind}`"
+                :params="{
+                  zoneCpVersion: warning.payload.zoneCpVersion ?? '',
+                  ...(warning.kind === 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS' ? {
+                    globalCpVersion: version?.version ?? '',
+                  } : {}),
+                }"
+              />
+            </li>
           </ul>
         </template>
 

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
@@ -77,8 +77,12 @@
                     >
                       {{ t('common.delete_modal.title', { type: 'Zone' }) }}
                     </template>
-                    <div
-                      v-html="t('common.delete_modal.text', { type: 'Zone', name: data.name })"
+                    <XI18n
+                      path="common.delete_modal.text"
+                      :params="{
+                        type: 'Zone',
+                        name: data.name,
+                      }"
                     />
                     <DataLoader
                       class="mt-4"

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -25,13 +25,17 @@
               v-for="warning in props.data.warnings"
               :key="warning.kind"
               :data-testid="`warning-${warning.kind}`"
-              v-html="t(`common.warnings.${warning.kind}`, {
-                ...warning.payload,
-                ...(warning.kind === 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS' ? {
-                  globalCpVersion: version?.version ?? '',
-                } : {}),
-              })"
-            />
+            >
+              <XI18n
+                :path="`common.warnings.${warning.kind}`"
+                :params="{
+                  zoneCpVersion: warning.payload.zoneCpVersion ?? '',
+                  ...(warning.kind === 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS' ? {
+                    globalCpVersion: version?.version ?? '',
+                  } : {}),
+                }"
+              />
+            </li>
           </ul>
         </template>
         <XLayout
@@ -76,8 +80,8 @@
                     <XIcon
                       name="info"
                     >
-                      <div
-                        v-html="t('zone-cps.routes.item.version_warning')"
+                      <XI18n
+                        path="zone-cps.routes.item.version_warning"
                       />
                     </XIcon>
                   </template>

--- a/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
@@ -34,7 +34,10 @@
           :src="`/zone-egress-overviews?page=1&size=100`"
           @change="getEgresses"
         />
-        <div v-html="t('zone-cps.routes.items.intro', {}, { defaultMessage: '' })" />
+        <XI18n
+          path="zone-cps.routes.items.intro"
+          default-message=""
+        />
         <XCard>
           <XTeleportTemplate
             v-if="can('create zones') && (data?.items ?? []).length > 0"
@@ -205,8 +208,12 @@
                               >
                                 {{ t('common.delete_modal.title', { type: 'Zone' }) }}
                               </template>
-                              <div
-                                v-html="t('common.delete_modal.text', { type: 'Zone', name: row.name })"
+                              <XI18n
+                                path="common.delete_modal.text"
+                                :params="{
+                                  type: 'Zone',
+                                  name: row.name,
+                                }"
                               />
                               <DataLoader
                                 class="mt-4"


### PR DESCRIPTION
Part of https://github.com/kumahq/kuma-gui/issues/2813

This PR uses `<XI18n />` (https://github.com/kumahq/kuma-gui/pull/3420) throughout the application in place of `v-html`. 

I also turned our `vue/no-v-html` to `error` (it only warns by default)

This means we can start using "non-DNS safe" terms/vars for our i18n texts if we need to do that.

---

I also switched some usages of `innerHTML` to use `textContent` which, aside from other things, is apparently more performant, so may help further speed up our CodeBlock component.

Finally, I added `eslint-plugin-no-unsanitized`, i.e. if we are linting for `v-html` we should also lint for `innerHTML`, can't really depend on one without the other.

There'll be a separate PR to start using `<XI18n v-slot="{ t }" />` within non-route component (in the few places where we need that), and also using `<XI18n v-slot="{ t }" />` within `RouteView` to provide `RouteView::t`. Once that is done I'd like to somehow restrict usage of `useI18n()` so that the only way to translate/localize text is via `<XI18n />`.

---

(sidenote: our RouteAnnouncer functionality has been broken for quite some time, I'll fix that up in a separate PR)