### PR TITLE
feature: adds dev-time CSP headers

### DIFF
--- a/packages/kuma-gui/vite.plugins.ts
+++ b/packages/kuma-gui/vite.plugins.ts
@@ -67,6 +67,16 @@ const server = (template: string = './index.html', vars: Partial<KumaHtmlVars> =
           }).filter(([_, value]) => typeof value !== 'undefined')),
         } satisfies KumaHtmlVars,
       )
+      res.setHeader('Content-Security-Policy', [
+        "default-src 'self'",
+        "script-src 'self'",
+        "script-src-elem 'self'",
+        "img-src 'self' data: ",
+        "style-src 'self' 'unsafe-inline'",
+        // in production connect-src would use kuma's environment variable for
+        // setting the location of the HTTP API (or just use the default)
+        "connect-src 'self' localhost:5681 https://kuma.io",
+      ].join(';'))
       res.end(body)
     } else {
       next()

--- a/packages/kuma-gui/vite.plugins.ts
+++ b/packages/kuma-gui/vite.plugins.ts
@@ -1,5 +1,5 @@
-import crypto from 'crypto'
 import { readFile, stat } from 'fs/promises'
+import crypto from 'node:crypto'
 import { dirname } from 'path'
 
 import type { KumaHtmlVars } from '@/app/application/services/env/Env'

--- a/packages/kuma-gui/vite.plugins.ts
+++ b/packages/kuma-gui/vite.plugins.ts
@@ -38,7 +38,11 @@ export const kumaIndexHtmlVars = (): Plugin => {
     transformIndexHtml: (template) => interpolate(template, htmlVars),
   }
 }
-const server = (template: string = './index.html', vars: Partial<KumaHtmlVars> = {}) => async (server: PreviewServer | ViteDevServer) => {
+const server = (
+  template: string = './index.html',
+  vars: Partial<KumaHtmlVars> = {},
+  csp: boolean = true,
+) => async (server: PreviewServer | ViteDevServer) => {
   server.middlewares.use('/', async (req, res, next) => {
     const url = req.originalUrl || ''
     const baseGuiPath = vars.baseGuiPath || '/gui'
@@ -67,16 +71,19 @@ const server = (template: string = './index.html', vars: Partial<KumaHtmlVars> =
           }).filter(([_, value]) => typeof value !== 'undefined')),
         } satisfies KumaHtmlVars,
       )
-      res.setHeader('Content-Security-Policy', [
-        "default-src 'self'",
-        "script-src 'self'",
-        "script-src-elem 'self'",
-        "img-src 'self' data: ",
-        "style-src 'self' 'unsafe-inline'",
-        // in production connect-src would use kuma's environment variable for
-        // setting the location of the HTTP API (or just use the default)
-        "connect-src 'self' localhost:5681 https://kuma.io",
-      ].join(';'))
+      if (csp) {
+        res.setHeader('Content-Security-Policy', [
+          "default-src 'self'",
+          "script-src 'self'",
+          "script-src-elem 'self'",
+          "img-src 'self' data: ",
+          "style-src 'self' 'unsafe-inline'",
+          // in production connect-src would use kuma's environment variable for
+          // setting the location of the HTTP API (or just use the default)
+          "connect-src 'self' localhost:5681 https://kuma.io",
+        ].join(';'))
+      }
+
       res.end(body)
     } else {
       next()

--- a/packages/kuma-gui/vite.plugins.ts
+++ b/packages/kuma-gui/vite.plugins.ts
@@ -83,8 +83,9 @@ const server = (
           "img-src 'self' data: ",
           // in a production environment the nonce is not required
           // its only used for vite dev-time live reloading client
-          // the sha256 _is_ required
-          `style-src 'self' 'sha256-UtFm94bwcb1Z4CU0svC29YMU26pP5RoZDN8zoniSJhU=' 'sha256-qo7STIM1L/OgU9y0De47mqod1UZFLJfTn36bRC42rfA=' 'nonce-${nonce}'`,
+          // the sha256 _will be_ required
+          // 'sha256-UtFm94bwcb1Z4CU0svC29YMU26pP5RoZDN8zoniSJhU=' 'sha256-qo7STIM1L/OgU9y0De47mqod1UZFLJfTn36bRC42rfA=' 'nonce-${nonce}'
+          "style-src 'unsafe-inline'",
           // in production connect-src would use kuma's environment variable for
           // setting the location of the HTTP API (or just use the default)
           "connect-src 'self' localhost:5681 https://kuma.io",

--- a/packages/kuma-gui/vite.plugins.ts
+++ b/packages/kuma-gui/vite.plugins.ts
@@ -59,6 +59,10 @@ const server = (
           return prev
         }, {} as Record<string, string>)
 
+      // we create a totally new index.html from our template here
+      // so anything added by Vite that is not in our index.html template
+      // will be removed. Ideally we would take vites output and use that as the template
+      // but its not clear how to get vites output from within this middleware
       let body = interpolate(
         await read(template),
         {


### PR DESCRIPTION
Adds stricter CSP headers to our development vite server.

Whilst this is dev time only, it ensures that our GUI runs on a similarly configured server (such as https://github.com/kumahq/kuma/issues/12553)

---

As mentioned in other places, it would be good to add work so we can remove the `style-src 'unsafe-inline'`. This will require a globally available `v-style` directive which adds/removes/modifies styles imperatively behind the scenes.

Testing:

Using `make run`, add the following or similar anchor with an inline script and click it.

<img width="1719" alt="Untitled-1" src="https://github.com/user-attachments/assets/8d493851-9a92-45fe-95e6-b67ea4606a5c" />

