### PR TITLE
feature: adds v-style directive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5258,6 +5258,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -5396,7 +5397,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
@@ -6715,7 +6717,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.5.56",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.56.tgz",
-      "integrity": "sha512-7lXb9dAvimCFdvUMTyucD4mnIndt/xhRKFAlky0CyFogdnNmdPQNoHI23msF/2V4mpTxMzgMdjK4+YRlFlRQZw=="
+      "integrity": "sha512-7lXb9dAvimCFdvUMTyucD4mnIndt/xhRKFAlky0CyFogdnNmdPQNoHI23msF/2V4mpTxMzgMdjK4+YRlFlRQZw==",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -6905,6 +6908,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-map": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/es-map/-/es-map-1.0.6.tgz",
+      "integrity": "sha512-JWn54TeYJe93WHhduTh9MUqEkjhbCjU8vqq1q9FyCrOle/utr1i8PmzK2vXnP6BeLsBLvb1zV4fSkpVnT4LW1A==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-get-iterator": "^1.1.3",
+        "es-set-tostringtag": "^2.0.3",
+        "for-each": "^0.3.3",
+        "get-intrinsic": "^1.2.4",
+        "globalthis": "^1.0.4",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.7",
+        "object.entries": "^1.1.8"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/es-shims/es-map?sponsor=1"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
@@ -6921,6 +6948,35 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-set/-/es-set-1.1.2.tgz",
+      "integrity": "sha512-tGLC1yArXhXwZTm3D6xbu1JL4S3cUtRRggbFWHhqTxpPc975fmcLL1VB0QOnAY8q5TBdul7YTjfEOT2VpUGcCg==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-map": "^1.0.6",
+        "es-set-tostringtag": "^2.0.3",
+        "for-each": "^0.3.3",
+        "functions-have-names": "^1.2.3",
+        "get-intrinsic": "^1.2.4",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.7",
+        "iterate-value": "^1.0.2",
+        "object.entries": "^1.1.8",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/es-shims/Set?sponsor=1"
       }
     },
     "node_modules/es-set-tostringtag": {
@@ -9362,6 +9418,26 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
+    "node_modules/iterate-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
+      "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/iterate-value": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+      "dependencies": {
+        "es-get-iterator": "^1.0.2",
+        "iterate-iterator": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
@@ -11136,7 +11212,8 @@
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "peer": true
     },
     "node_modules/node-source-walk": {
       "version": "7.0.0",
@@ -11285,6 +11362,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
+      "integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
@@ -12767,6 +12857,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/set.prototype.difference": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/set.prototype.difference/-/set.prototype.difference-1.1.6.tgz",
+      "integrity": "sha512-shFefhP67SOJy81rOQ9EKkVoEAM0+xrtDWIn6Fyzwm+7IBqjMvqu1/CJkMWtv9K4O3asyq5UmzrqDrh5P6cG5w==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-set": "^1.1.1",
+        "is-set": "^2.0.3",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shebang-command": {
@@ -14839,6 +14949,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.0"
@@ -16366,6 +16477,7 @@
         "path-to-regexp": "^8.2.0",
         "pretty-bytes": "^6.1.1",
         "prismjs": "^1.29.0",
+        "set.prototype.difference": "^1.1.6",
         "vue": "^3.5.13",
         "vue-github-button": "^3.1.3",
         "vue-router": "^4.5.0"

--- a/packages/config/src/eslint.cjs
+++ b/packages/config/src/eslint.cjs
@@ -240,11 +240,19 @@ function createEslintConfig(
             key: 'data-test-id',
             message: 'Using "data-test-id" is not allowed. Use "data-testid" instead.',
           },
+          {
+            key: 'style',
+            message: 'Using "style" is not allowed. Use "v-style" instead.',
+          },
         ],
         'vue/no-restricted-v-bind': ['error',
           {
             argument: 'data-test-id',
             message: 'Using "data-test-id" is not allowed. Use "data-testid" instead.',
+          },
+          {
+            argument: 'style',
+            message: 'Using "style" is not allowed. Use "v-style" instead.',
           },
         ],
         'vue/no-undef-components': ['error', {

--- a/packages/kuma-gui/.vitepress/config.ts
+++ b/packages/kuma-gui/.vitepress/config.ts
@@ -27,7 +27,7 @@ const md = markdown(
   },
 )
 
-const h1re = /^#+\s+.+/
+const h1re = /#+\s+.+/
 
 const get = (path: string) => {
   const items = globSync(path)
@@ -45,6 +45,9 @@ const get = (path: string) => {
 const files = get('{src,docs}/**/*.md')
 const sections = Object.groupBy(files.filter(({ data }) => typeof data.section !== 'undefined'), (item) => {
   return item.data.section
+})
+const directives = files.filter((item) => {
+  return item.data.type === 'directive'
 })
 const components = files.filter((item) => {
   // we default to type: component seeing as thats the thing we will use docs for most
@@ -132,6 +135,16 @@ export default defineConfig({
           }) ?? []
         }
       }),
+      {
+        text: 'Directive Index',
+        collapsed: false,
+        items: directives.map((item) => {
+          return {
+            text: item.data.title,
+            link: item.path,
+          }
+        })
+      },
       {
         text: 'Component Index',
         collapsed: false,

--- a/packages/kuma-gui/.vitepress/theme/main.md
+++ b/packages/kuma-gui/.vitepress/theme/main.md
@@ -30,12 +30,16 @@ onMounted(async () => {
           [$.app, {
             service: (
               components,
+              directives,
               plugins,
               globals,
             ) => {
               return async (app) => {
-                components.forEach(([name, component]) => {
-                  app.component(name, component)
+                components.forEach(([name, item]) => {
+                  app.component(name, item)
+                })
+                directives.forEach(([name, item]) => {
+                  app.directive(name, item)
                 })
 
                 plugins.forEach(([...args]) => {
@@ -51,6 +55,7 @@ onMounted(async () => {
             },
             arguments: [
               $.components,
+              $.directives,
               $.plugins,
               $.globals,
             ],

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -26,6 +26,7 @@
     "path-to-regexp": "^8.2.0",
     "pretty-bytes": "^6.1.1",
     "prismjs": "^1.29.0",
+    "set.prototype.difference": "^1.1.6",
     "vue": "^3.5.13",
     "vue-github-button": "^3.1.3",
     "vue-router": "^4.5.0"

--- a/packages/kuma-gui/src/app/App.vue
+++ b/packages/kuma-gui/src/app/App.vue
@@ -3,10 +3,10 @@
   <!-- we want to make sure they are retrieved/correctly set -->
   <DataSource
     :src="`/control-plane/addresses`"
-    v-slot="{data: addresses}: ControlPlaneAddressesSource"
+    v-slot="{ data: addresses }: ControlPlaneAddressesSource"
   >
     <RouteView
-      v-if="typeof addresses !== 'undefined'"
+      v-if="typeof addresses !== 'undefined' && child.name !== ''"
       name="app"
       :attrs="{
         class: 'kuma-ready',
@@ -28,54 +28,54 @@
 
         <template #navigation>
           <AppNavigator
+            v-style="'--icon: var(--icon-home)'"
             data-testid="control-planes-navigator"
             :active="child.name === 'home'"
             label="Home"
             :to="{
               name: 'home',
             }"
-            style="--icon: var(--icon-home);"
           />
           <AppNavigator
             v-if="can('use zones')"
+            v-style="'--icon: var(--icon-zones)'"
             data-testid="zones-navigator"
             :active="child.name === 'zone-index-view'"
             label="Zones"
             :to="{
               name: 'zone-index-view',
             }"
-            style="--icon: var(--icon-zones);"
           />
           <AppNavigator
             v-else
+            v-style="'--icon: var(--icon-zone-egresses)'"
             data-testid="zone-egresses-navigator"
             :active="child.name === 'zone-egress-index-view'"
             label="Zone Egresses"
             :to="{
               name: 'zone-egress-list-view',
             }"
-            style="--icon: var(--icon-zone-egresses);"
           />
           <AppNavigator
+            v-style="'--icon: var(--icon-meshes)'"
             :active="child.name === 'mesh-index-view'"
             data-testid="meshes-navigator"
             label="Meshes"
             :to="{
               name: 'mesh-index-view',
             }"
-            style="--icon: var(--icon-meshes);"
           />
         </template>
 
         <template #bottomNavigation>
           <AppNavigator
+            v-style="'--icon: var(--icon-configuration)'"
             :active="child.name === 'configuration-view'"
             data-testid="configuration-navigator"
             label="Configuration"
             :to="{
               name: 'configuration-view',
             }"
-            style="--icon: var(--icon-configuration);"
           />
         </template>
 

--- a/packages/kuma-gui/src/app/App.vue
+++ b/packages/kuma-gui/src/app/App.vue
@@ -6,7 +6,7 @@
     v-slot="{ data: addresses }: ControlPlaneAddressesSource"
   >
     <RouteView
-      v-if="typeof addresses !== 'undefined' && child.name !== ''"
+      v-if="typeof addresses !== 'undefined'"
       name="app"
       :attrs="{
         class: 'kuma-ready',

--- a/packages/kuma-gui/src/app/application/components/data-source/DataSource.vue
+++ b/packages/kuma-gui/src/app/application/components/data-source/DataSource.vue
@@ -4,7 +4,7 @@
     :error="error"
     :refresh="refresh"
   />
-  <span />
+  <span v-bind="attrs" />
 </template>
 
 <script lang="ts" generic="T extends string | {
@@ -12,11 +12,12 @@
   typeOf(): any
 }" setup
 >
-import { watch, ref, onBeforeUnmount } from 'vue'
+import { watch, ref, onBeforeUnmount, useAttrs } from 'vue'
 
 import { useDataSourcePool } from '@/app/application'
 import type { TypeOf } from '@/app/application'
 
+const attrs = useAttrs()
 const data = useDataSourcePool()
 
 const props = defineProps<{

--- a/packages/kuma-gui/src/app/application/index.ts
+++ b/packages/kuma-gui/src/app/application/index.ts
@@ -1,5 +1,7 @@
 // @ts-ignore TS comes with a Object.groupBy declaration but not a polyfill
 import groupBy from 'object.groupby'
+// @ts-ignore TS comes with a set.prototype.difference declaration but not a polyfill
+import difference from 'set.prototype.difference'
 
 import AppView from './components/app-view/AppView.vue'
 import DataCollection from './components/data-collection/DataCollection.vue'
@@ -40,6 +42,10 @@ if (!('structuredClone' in globalThis)) {
 // temporary Object.groupBy polyfill
 // TODO(jc): delete this once we get to 2026
 groupBy.shim()
+
+// temporary Set.prototype.difference polyfill
+// TODO(jc): delete this once we get to 2026
+difference.shim()
 
 export type { DataSourceResponse, Source, TypeOf } from './services/data-source'
 type Sources = ConstructorParameters<typeof DataSourcePool>[0]

--- a/packages/kuma-gui/src/app/x/components/x-action-group/README.md
+++ b/packages/kuma-gui/src/app/x/components/x-action-group/README.md
@@ -9,7 +9,9 @@ open the group. This can be customized via the `control` slot.
 The below shows examples of each layout.
 
 <Story height="340">
-  <div style="display: grid;grid-template-columns: repeat(2, calc(50% -10px));gap: 20px;">
+  <div
+    v-style="'display: grid;grid-template-columns: repeat(2, calc(50% -10px));gap: 20px;'"
+  >
     <XActionGroup
       :expanded="false"
     >

--- a/packages/kuma-gui/src/app/x/components/x-action/README.md
+++ b/packages/kuma-gui/src/app/x/components/x-action/README.md
@@ -13,14 +13,20 @@ the `XAction` a `to`/`href` or a `@click` event.
   >
     External link to Github Repo
   </XAction>
-  <hr style="margin: 20px auto;" />
+  <hr
+    v-style="'margin: 20px auto'"
+  />
   <XAction
     @click="() => console.log('Hi')"
   >
     Native Button that `console.log`s `Hi` on click
   </XAction>
-  <hr style="margin: 20px auto;" />
-  <div style="display: grid;gap: 20px;grid-template-columns: repeat(2, calc(50% - 10px));">
+  <hr
+    v-style="'margin: 20px auto'"
+  />
+  <div
+    v-style="'display: grid;gap: 20px;grid-template-columns: repeat(2, calc(50% - 10px))'"
+  >
     <XAction
       appearance="primary"
       @click="() => console.log('Hi')"

--- a/packages/kuma-gui/src/app/x/directives/style/README.md
+++ b/packages/kuma-gui/src/app/x/directives/style/README.md
@@ -1,0 +1,39 @@
+---
+type: directive
+---
+
+# v-style
+
+Replacement for HTML `style=""` for authors to use a declarative/config style
+but use `el.style.setProperty` under-the-hood.
+
+Additionally adds support via `v-style.next` (think `nextTick`) to transition
+CSS properties easily.
+
+<Story>
+  <div
+    v-style="'color: red'"
+  >
+    Text colored red
+  </div>
+  <div
+    v-style="'padding: 10px;border: 1px solid red'"
+  >
+    Text with 10px padding and red border
+  </div>
+  <div
+    v-style="{
+      'color: red': true,
+      'border: 1px solid blue': true,
+      'padding: 100px': false,
+    }"
+  >
+    Text colored red with a blue border but no padding
+  </div>
+  <div
+    v-style="'transition: color 2s'"
+    v-style.next="'color: red'"
+  >
+    Text colored normal transitioning to colored red
+  </div>
+</Story>

--- a/packages/kuma-gui/src/app/x/directives/style/index.ts
+++ b/packages/kuma-gui/src/app/x/directives/style/index.ts
@@ -1,0 +1,56 @@
+type DirectiveValue = Record<string, boolean> | string
+type DirectiveModifiers = Record<'next', boolean | undefined>
+const getDeclarations = (spec: DirectiveValue): string[] => {
+  // allow string or { 'prop: value' : boolean }
+  return Object.entries(typeof spec === 'string' ? { [spec]: true } : spec)
+    // only truthy values
+    .filter(([_, value]) => value)
+    // allow several declarations in one key
+    .map(([key, _]) => key.split(';'))
+    // flatten everything to string[]
+    .flat()
+    // trim and remove any ''s
+    .map(item => item.trim()).filter(Boolean)
+}
+const setDeclaration = ($el: HTMLElement, item: string) => {
+  const [property, value] = item.split(':')
+  const important = value.includes('!important')
+  $el.style.setProperty(property.trim(), important ? value.replace('!important', '').trim() : value.trim(), important ? 'important' : '') // priority
+}
+const removeDeclaration = ($el: HTMLElement, item: string) => {
+  const [property] = item.split(':')
+  $el.style.removeProperty(property.trim())
+}
+export default (map = new WeakMap<HTMLElement, Set<string>>()) => {
+  const created = ($el: HTMLElement, { value, modifiers: _ }: { value: DirectiveValue, modifiers: DirectiveModifiers }) => {
+    const declarations = getDeclarations(value)
+    map.set($el, new Set(declarations))
+    declarations.forEach(item => setDeclaration($el, item))
+  }
+  const updated = ($el: HTMLElement, { value, modifiers: _ }: { value: DirectiveValue, modifiers: DirectiveModifiers }) => {
+    const previous = map.get($el) ?? new Set()
+    const declarations = new Set(getDeclarations(value))
+    Array.from(previous.difference(declarations)).forEach(item => removeDeclaration($el, item))
+    Array.from(declarations.difference(previous)).forEach(item => setDeclaration($el, item))
+    map.set($el, declarations)
+  }
+  return {
+    created: (...args: Parameters<typeof created>) => {
+      if (args[1].modifiers.next) {
+        setTimeout(() => created(...args), 0)
+      } else {
+        created(...args)
+      }
+    },
+    beforeUpdate: (...args: Parameters<typeof updated>) => {
+      if (args[1].modifiers.next) {
+        setTimeout(() => updated(...args), 0)
+      } else {
+        updated(...args)
+      }
+    },
+    unmounted: ($el: HTMLElement) => {
+      map.delete($el)
+    },
+  }
+}

--- a/packages/kuma-gui/src/app/x/index.ts
+++ b/packages/kuma-gui/src/app/x/index.ts
@@ -26,9 +26,11 @@ import XTabs from './components/x-tabs/XTabs.vue'
 import XTeleportSlot from './components/x-teleport/XTeleportSlot.vue'
 import XTeleportTemplate from './components/x-teleport/XTeleportTemplate.vue'
 import XTooltip from './components/x-tooltip/XTooltip.vue'
+import vStyle from './directives/style'
 import locales from './locales/en-us/index.yaml'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
+
 
 type Token = ReturnType<typeof token>
 
@@ -120,6 +122,16 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       },
       labels: [
         app.components,
+      ],
+    }],
+    [token('x.directives'), {
+      service: () => {
+        return [
+          ['style', vStyle()],
+        ]
+      },
+      labels: [
+        app.directives,
       ],
     }],
     [token('x.locales'), {


### PR DESCRIPTION
Adds a `v-style` directive to allow us to set occasional inline styles within a strict CSP environment.

Additionally makes it easy to add simple CSS transitions that often require waiting a tick before applying a rule.

Note: There are a couple of unrelated changes here that I bumped into whilst working on this. Happy to split those off if necessary.

~**P.S. I need to add some sort of `Set.difference` polyfill here, its a bit new at the moment.**~ 👈 this is done
~**P.P.S. Cypresses ~Chrome~ Electron (ooooh it uses Electron 🤔 ) doesn't support Set.difference either so it also failed our tests 🎉  **~