### PR TITLE
chore(deps): remove autoprefixer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5122,43 +5122,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/autoprefixer": {
-      "version": "10.4.20",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "caniuse-lite": "^1.0.30001646",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -8079,19 +8042,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fs-extra": {
@@ -11371,15 +11321,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16658,7 +16599,6 @@
         "@vue/test-utils": "^2.4.6",
         "@whyframe/core": "^0.1.12",
         "@whyframe/vue": "^0.1.7",
-        "autoprefixer": "^10.4.20",
         "cypress": "^14.0.0",
         "cypress-fail-fast": "^7.1.1",
         "cypress-fail-on-console-error": "^5.1.1",

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -46,7 +46,6 @@
     "@vue/test-utils": "^2.4.6",
     "@whyframe/core": "^0.1.12",
     "@whyframe/vue": "^0.1.7",
-    "autoprefixer": "^10.4.20",
     "cypress": "^14.0.0",
     "cypress-fail-fast": "^7.1.1",
     "cypress-fail-on-console-error": "^5.1.1",

--- a/packages/kuma-gui/src/app/application/components/app-navigator/AppNavigator.vue
+++ b/packages/kuma-gui/src/app/application/components/app-navigator/AppNavigator.vue
@@ -30,6 +30,7 @@ const props = withDefaults(defineProps<{
 :deep(a) {
   &::before {
     content: '';
+    -webkit-mask-image: var(--icon);
     mask-image: var(--icon);
     background-color: currentColor;
     height: 20px;


### PR DESCRIPTION
Removes autoprefixer and manually adds a prefix `-webkit-mask-image` in the only place where we weren't manually adding a `-webkit` prefix where potentially necessary.

Configuration for `autoprefixer` was removed back here https://github.com/kumahq/kuma-gui/pull/384/files#diff-05ed1c7f99e45b485708115502a1e0f28c8547e9a9a29c1b8664f79103cf7873, but the dependency wasn't, this means we've not been using autoprefixer for quite a while but [dutifully upgrading it in dependabot](https://github.com/kumahq/kuma-gui/pulls?q=is%3Apr+is%3Aclosed+author%3Aapp%2Fdependabot+autoprefixer).

All in all its less hassle to manually prefix than to support the dependency, especially considering that as prefixing is now generally frowned upon by browser vendors we are less and less likely to need to add vendor prefixes at all.