### PR TITLE
fix: maintain tag anchor and key:value styling in KBadges

### DIFF
--- a/packages/kuma-gui/src/app/common/TagList.vue
+++ b/packages/kuma-gui/src/app/common/TagList.vue
@@ -18,7 +18,7 @@
         :is="tag.route ? 'XAction' : 'span'"
         :to="tag.route"
       >
-        {{ tag.label }}:<b>{{ tag.value }}</b>
+        <span class="label">{{ tag.label }}</span>:<span class="value">{{ tag.value }}</span>
       </component>
     </XBadge>
   </component>
@@ -113,11 +113,17 @@ function getRoute(tag: LabelValue): RouteLocationNamedRaw | undefined {
   justify-content: flex-end;
 }
 
-.tag {
-  font-weight: $kui-font-weight-regular;
-}
 
 .tag :deep(a) {
   color: currentColor;
+}
+.tag :deep(span.label) {
+  font-weight: $kui-font-weight-regular;
+}
+.tag :deep(span.value) {
+  font-weight: $kui-font-weight-semibold;
+}
+.tag :deep(a):hover {
+  text-decoration: underline;
 }
 </style>

--- a/packages/kuma-gui/src/app/common/TagList.vue
+++ b/packages/kuma-gui/src/app/common/TagList.vue
@@ -113,17 +113,16 @@ function getRoute(tag: LabelValue): RouteLocationNamedRaw | undefined {
   justify-content: flex-end;
 }
 
-
 .tag :deep(a) {
   color: currentColor;
+}
+.tag :deep(a):hover {
+  text-decoration: underline;
 }
 .tag :deep(span.label) {
   font-weight: $kui-font-weight-regular;
 }
 .tag :deep(span.value) {
   font-weight: $kui-font-weight-semibold;
-}
-.tag :deep(a):hover {
-  text-decoration: underline;
 }
 </style>


### PR DESCRIPTION
### current master (I couldn't manage to get a grab with rollover, but it underlines):

![Screenshot 2025-01-24 at 14 23 55](https://github.com/user-attachments/assets/1174fabb-e5e7-45ee-afec-df4ec3769fde)

### With https://github.com/kumahq/kuma-gui/pull/3460 applied (the mouse is rolled over the link but the pointer isn't in the grab):

![Screenshot 2025-01-24 at 14 18 00](https://github.com/user-attachments/assets/8b096d74-d29c-4ce6-beff-3285e3e73933)

### With this PR applied (the mouse is rolled over the link but the pointer isn't in the grab):

![Screenshot 2025-01-24 at 14 17 08](https://github.com/user-attachments/assets/3a65998b-59fb-4f4b-9697-095c3072063d)

Introduced in https://github.com/Kong/kongponents/pull/2585

I've mentioned a few times I kinda have a different approach to solve this sort of stuff completely, I might put up a draft PR soon.

Related to:

- https://github.com/Kong/kongponents/issues/2559
- https://github.com/kumahq/kuma-gui/pull/3323
- https://github.com/kumahq/kuma-gui/pull/3317
