### PR TITLE
fix: wrap RouteView::from in a function to prevent it causing a rerender

### DIFF
--- a/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
+++ b/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
@@ -47,7 +47,7 @@
           back: routerBack,
           children,
           child,
-          from,
+          from: getFrom,
         }"
       />
     </DataSource>
@@ -134,6 +134,7 @@ const title = ref<HTMLDivElement | null>(null)
 const titles = new Map<symbol, string>()
 const attributes = new Map<symbol, SupportedAttrs>()
 const from = ref<RouteLocationNormalizedLoaded | undefined>()
+const getFrom = () => from.value
 
 const joinTitle = (titles: string[]) => {
   return titles.reverse().concat(t('components.route-view.title', { name: t('common.product.name') })).join(' | ')


### PR DESCRIPTION
I noticed that our GH Star button was flickering again, which means we are re-rendering parts of the application that don't need re-rendering.

The fix here adds a wrapping function which needs calling in order to access the value, meaning we don't get unnecessary re-renders.