### PR TITLE
fix: fixes detection of cacheControl setting for DataSources

### DIFF
--- a/packages/kuma-gui/src/app/application/services/data-source/index.ts
+++ b/packages/kuma-gui/src/app/application/services/data-source/index.ts
@@ -74,7 +74,7 @@ type Hideable = EventTarget & { hidden: boolean }
 
 export const getSource = (doc: Hideable) => {
   return (cb: (source: RetryingEventSource) => Promise<unknown>, config: Configuration = {}) => {
-    return new CallableEventSource<Configuration>(async function * (this: RetryingEventSource) {
+    return new CallableEventSource<Configuration>(async function* (this: RetryingEventSource) {
       // TODO: refactor and remove eslint-disable directive
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const self = this
@@ -140,7 +140,7 @@ export const create: Creator = (src, router) => {
       size: parseInt(queryParams.get('size') || '0'),
       page: parseInt(queryParams.get('page') || '0'),
       search: queryParams.get('search') || '',
-      cacheControl: ['no-store', 'no-cache'].reduce((prev, item) => queryParams.has(item) ? item : prev, ''),
+      cacheControl: ['no-store', 'no-cache'].reduce((prev, item) => queryParams.has(item) ? item : prev, queryParams.get('cacheControl') ?? ''),
     },
     ...route.params,
   }


### PR DESCRIPTION
Fixes detection of cacheControl setting for DataSources

A long time ago we used the form `?no-cache` to turn off caching for DataSources, but we changed it to use `cacheControl: no-cache` a while back. The piece of code here didn't cope for that change. Therefore in some instances turning off the cache wasn't working. We only turn off the cache in a small amount of places. 


Here's a good example of the issue in the PR which should have had this fix in it:

https://github.com/kumahq/kuma-gui/pull/2453/files#diff-529c3a751eb79cebe6b1e5ad6966b966887fb03638960a4c7fc1f2e32201f458L34