### PR TITLE
fix(services): adds missing paging to MeshMultizoneService

### DIFF
--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceListView.vue
@@ -31,6 +31,10 @@
             <DataCollection
               type="services"
               :items="data?.items ?? [undefined]"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="data?.total"
+              @change="route.update"
             >
               <AppCollection
                 :headers="[
@@ -39,12 +43,8 @@
                   { ...me.get('headers.labels'), label: 'Selector', key: 'labels' },
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
-                :page-number="route.params.page"
-                :page-size="route.params.size"
-                :total="data?.total"
                 :items="data?.items"
                 :is-selected-row="(item) => item.name === route.params.service"
-                @change="route.update"
                 @resize="me.set"
               >
                 <template #name="{ row: item }">


### PR DESCRIPTION
The MeshMultizoneService listing was not showing paging correctly. Turns out this section was missed in the original PR for this refactor around pagination:

https://github.com/kumahq/kuma-gui/pull/2846