### PR TITLE
chore(dependabot): group all @typescript-eslint dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    groups:
+      dev-deps:
+        dependency-type: "development"
+        patterns:
+          - "@typescript-eslint/*"
+
+      
 
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 50

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
         patterns:
           - "@typescript-eslint/*"
 
-      
-
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 50
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,7 @@ updates:
     labels:
       - "dependencies"
     groups:
-      dev-deps:
-        dependency-type: "development"
+      typescript-eslint:
         patterns:
           - "@typescript-eslint/*"
 


### PR DESCRIPTION
In order to reduce the amount of individual dependabot PRs and to update companion packages in one go, we can group them. With this we are now starting to group all `@typescript-eslint/*` dependencies.