### PR TITLE
feat(tools): adds "execute on all workspaces" Makefile decorator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ MK := $(KUMAHQ_CONFIG)/src/mk
 .DEFAULT_GOAL := help
 include $(MK)/help.mk
 
+include $(MK)/decorators.mk
 include $(MK)/install.mk
 include $(MK)/check.mk
 

--- a/packages/config/src/mk/decorators.mk
+++ b/packages/config/src/mk/decorators.mk
@@ -1,0 +1,5 @@
+.PHONY: ws/%
+ws/%: ## Dev: Run the same command in every package in the workspace i.e. `make ws/lint`
+	@for dir in $(shell npm query .workspace | jq -r '.[].location'); do \
+		$(MAKE) -C $(NPM_WORKSPACE_ROOT)/$$dir $(subst ws/,,$@); \
+	done


### PR DESCRIPTION
This target calls a Makefile target on all packages within the workspace:

i.e. `make ws/lint` will run `make lint` on all packages. If the target doesn't exist, the command will fail only for that sub-package.