### PR TITLE
refactor: replace mock hacker.noun with word.noun

### DIFF
--- a/packages/kuma-gui/src/test-support/FakeKuma.ts
+++ b/packages/kuma-gui/src/test-support/FakeKuma.ts
@@ -26,7 +26,7 @@ export class K8sModule {
   }
 
   namespace() {
-    return this.faker.helpers.arrayElement([this.faker.hacker.noun(), 'kuma-system'])
+    return this.faker.helpers.arrayElement([this.faker.word.noun(), 'kuma-system'])
   }
 
   namespaceSuffix() {
@@ -150,12 +150,12 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
   }
 
   serviceName(serviceType: 'internal' | 'external' | 'gateway_builtin' | 'gateway_delegated' = 'internal') {
-    const prefix = `${this.faker.hacker.noun()}-`
+    const prefix = `${this.faker.word.noun()}-`
 
     if (serviceType === 'gateway_delegated' || serviceType === 'gateway_builtin') {
       return prefix + serviceType
     } else {
-      return prefix + `${this.faker.hacker.noun()}_svc.mesh:80_${serviceType}`
+      return prefix + `${this.faker.word.noun()}_svc.mesh:80_${serviceType}`
     }
   }
 
@@ -284,12 +284,12 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
       this.faker.helpers.multiple(
         () => [
           this.faker.helpers.arrayElement([
-            this.faker.hacker.noun(),
+            this.faker.word.noun(),
             'k8s.kuma.io/service-name',
             'not-kuma.io/service',
             'not/kuma.io/service',
           ]),
-          this.faker.hacker.noun(),
+          this.faker.word.noun(),
         ],
         { count: this.faker.number.int({ min: 1, max: 3 }) },
       ),
@@ -332,7 +332,7 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
           gateway: {
             tags: this.tags({
               service: service ?? this.serviceName(type),
-              zone: isMultizone && this.faker.datatype.boolean() ? this.faker.hacker.noun() : undefined,
+              zone: isMultizone && this.faker.datatype.boolean() ? this.faker.word.noun() : undefined,
             }),
             ...(dataplaneType && { type: dataplaneType }),
           },
@@ -349,7 +349,7 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
             const tags = this.tags({
               protocol: this.protocol(),
               service: service ?? this.serviceName(),
-              zone: isMultizone && this.faker.datatype.boolean() ? this.faker.hacker.noun() : undefined,
+              zone: isMultizone && this.faker.datatype.boolean() ? this.faker.word.noun() : undefined,
             })
 
             return {
@@ -379,8 +379,8 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
   }
 
   dataplaneMtls() {
-    const issuedBackend = this.faker.hacker.noun()
-    const supportedBackends = [issuedBackend].concat(this.faker.helpers.multiple(this.faker.hacker.noun))
+    const issuedBackend = this.faker.word.noun()
+    const supportedBackends = [issuedBackend].concat(this.faker.helpers.multiple(() => this.faker.word.noun()))
 
     return {
       certificateExpirationTime: this.faker.date.anytime(),

--- a/packages/kuma-gui/src/test-support/mocks/src/config.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/config.ts
@@ -2,7 +2,7 @@ import type { EndpointDependencies, MockResponder } from '@/test-support'
 
 export default ({ env, fake }: EndpointDependencies): MockResponder => (_req) => {
   const mode = env('KUMA_MODE', 'global') === 'global' ? 'global' : 'zone'
-  const zoneName = mode === 'zone' ? fake.hacker.noun() : undefined
+  const zoneName = mode === 'zone' ? fake.word.noun() : undefined
 
   return {
     headers: {},

--- a/packages/kuma-gui/src/test-support/mocks/src/dataplanes/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/dataplanes/_overview.ts
@@ -48,10 +48,10 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const isMtlsEnabled = isMtlsEnabledOverride !== '' ? isMtlsEnabledOverride === 'true' : fake.datatype.boolean()
 
         const type = filterType ?? fake.helpers.arrayElement(['gateway_builtin', 'gateway_delegated', 'proxy'])
-        const mesh = `${fake.hacker.noun()}-${id}`
+        const mesh = `${fake.word.noun()}-${id}`
         const service = tags['kuma.io/service']
 
-        const displayName = `${_name || fake.hacker.noun()}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
+        const displayName = `${_name || fake.word.noun()}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
         const nspace = fake.k8s.namespace()
 
         return {
@@ -76,7 +76,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
               return {
                 id: '118b4d6f-7a98-4172-96d9-85ffb8b20b16',
-                controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
+                controlPlaneInstanceId: `${fake.word.noun()}-${i}`,
                 ...fake.kuma.connection(item, i, arr),
                 status: {
                   lastUpdateTime: '2021-02-17T10:48:03.638434Z',

--- a/packages/kuma-gui/src/test-support/mocks/src/hostname-generators/_/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/hostname-generators/_/_overview.ts
@@ -19,7 +19,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
         'kuma.io/env': fake.kuma.env(),
         'kuma.io/mesh': 'default',
         'kuma.io/origin': fake.kuma.origin(),
-        'kuma.io/zone': fake.hacker.noun(),
+        'kuma.io/zone': fake.word.noun(),
       }
       : {},
     spec: {

--- a/packages/kuma-gui/src/test-support/mocks/src/hostname-generators/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/hostname-generators/_overview.ts
@@ -15,7 +15,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       total,
       items: Array.from({ length: pageTotal }).map((_, i): HostnameGeneratorItem => {
         const meshServiceTypeSelector = fake.kuma.meshServiceTypeSelector()
-        const namespace = fake.hacker.noun()
+        const namespace = fake.word.noun()
         const displayName = `${fake.science.chemicalElement().name.toLowerCase()}-${offset + i}-service`
         const creationTime = fake.date.past()
 
@@ -29,7 +29,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               'kuma.io/env': fake.kuma.env(),
               'kuma.io/mesh': 'default',
               'kuma.io/origin': fake.kuma.origin(),
-              'kuma.io/zone': fake.hacker.noun(),
+              'kuma.io/zone': fake.word.noun(),
             }
             : {},
           spec: {

--- a/packages/kuma-gui/src/test-support/mocks/src/mesh-insights.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/mesh-insights.ts
@@ -12,7 +12,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = id === 0 ? 'default' : `${fake.hacker.noun()}-${id}`
+        const name = id === 0 ? 'default' : `${fake.word.noun()}-${id}`
 
         const serviceTotal = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 1, max: 30 })}`))
 

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes.ts
@@ -10,7 +10,7 @@ export default ({ fake, env, pager }: EndpointDependencies): MockResponder => (r
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
-        const name = i === 0 ? 'default' : `${fake.hacker.noun()}-${i}`
+        const name = i === 0 ? 'default' : `${fake.word.noun()}-${i}`
 
         return {
           name,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/circuit-breakers.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/circuit-breakers.ts
@@ -14,7 +14,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.hacker.noun()}-${id}`
+        const name = `${fake.word.noun()}-${id}`
         return {
           type: 'CircuitBreaker',
           mesh: params.mesh,
@@ -25,14 +25,14 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             {
               match: {
                 region: 'us',
-                service: `${fake.hacker.noun()}`,
+                service: `${fake.word.noun()}`,
               },
             },
           ],
           destinations: [
             {
               match: {
-                service: `${fake.hacker.noun()}`,
+                service: `${fake.word.noun()}`,
               },
             },
           ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/circuit-breakers/_/_resources/dataplanes.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/circuit-breakers/_/_resources/dataplanes.ts
@@ -14,7 +14,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const displayName = `${fake.hacker.noun()}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
+        const displayName = `${fake.word.noun()}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
         const nspace = fake.k8s.namespace()
 
         return {
@@ -27,7 +27,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 'kuma.io/display-name': displayName,
                 'k8s.kuma.io/namespace': nspace,
                 'kuma.io/origin': fake.kuma.origin(),
-                'kuma.io/zone': fake.hacker.noun(),
+                'kuma.io/zone': fake.word.noun(),
               },
             }
             : {}),

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/_overview.ts
@@ -37,7 +37,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
   const isMultizone = fake.datatype.boolean()
   const isMtlsEnabled = isMtlsEnabledOverride !== '' ? isMtlsEnabledOverride === 'true' : fake.datatype.boolean()
 
-  const service = fake.hacker.noun()
+  const service = fake.word.noun()
 
   const parts = String(name).split('.')
   const displayName = parts.slice(0, -1).join('.')
@@ -76,7 +76,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
                 tags: fake.kuma.tags({
                   protocol: ports[i].protocol,
                   service,
-                  zone: isMultizone && fake.datatype.boolean() ? fake.hacker.noun() : undefined,
+                  zone: isMultizone && fake.datatype.boolean() ? fake.word.noun() : undefined,
                 }),
                 ...(fake.datatype.boolean() ? {
                   state: fake.kuma.inboundState(),
@@ -94,7 +94,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
             gateway: {
               tags: fake.kuma.tags({
                 service,
-                zone: isMultizone && fake.datatype.boolean() ? fake.hacker.noun() : undefined,
+                zone: isMultizone && fake.datatype.boolean() ? fake.word.noun() : undefined,
               }),
               type,
             },
@@ -114,7 +114,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
         subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
           return {
             id: fake.string.uuid(),
-            controlPlaneInstanceId: fake.hacker.noun(),
+            controlPlaneInstanceId: fake.word.noun(),
             ...fake.kuma.connection(item, i, arr),
             generation: fake.number.int({ min: 1, max: 500 }),
             status: (() => {

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/_rules.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/_rules.ts
@@ -41,7 +41,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
         labels: {
           'kuma.io/display-name': displayName,
           'kuma.io/origin': fake.kuma.origin(),
-          'kuma.io/zone': fake.hacker.noun(),
+          'kuma.io/zone': fake.word.noun(),
           ...(k8s
             ? {
               'k8s.kuma.io/namespace': nspace,
@@ -54,7 +54,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
           return {
             type: fake.kuma.policyName(),
             toResourceRules: Array.from({ length: toResourceRuleCount }).map(() => {
-              const clusterName = env('KUMA_CLUSTER_NAME', `${fake.hacker.noun()}_${fake.hacker.noun()}_${fake.hacker.noun()}_${fake.hacker.noun()}_${fake.helpers.arrayElement(['msvc', 'mzsvc', 'extsvc'])}_${fake.number.int({ min: 1, max: 65535 })}`)
+              const clusterName = env('KUMA_CLUSTER_NAME', `${fake.word.noun()}_${fake.word.noun()}_${fake.word.noun()}_${fake.word.noun()}_${fake.helpers.arrayElement(['msvc', 'mzsvc', 'extsvc'])}_${fake.number.int({ min: 1, max: 65535 })}`)
               const [mesh, service, nspace, zone] = clusterName.split('_')
 
               return {
@@ -76,7 +76,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
                 },
                 resourceSectionName: '',
                 origin: Array.from({ length: fake.number.int({ min: 1, max: 3 }) }).map(() => {
-                  const displayName = fake.hacker.noun()
+                  const displayName = fake.word.noun()
                   const nspace = fake.k8s.namespace()
                   const id = `${name}.${nspace}`
                   return {
@@ -87,7 +87,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
                       labels: {
                         'kuma.io/display-name': displayName,
                         'kuma.io/origin': fake.kuma.origin(),
-                        'kuma.io/zone': fake.hacker.noun(),
+                        'kuma.io/zone': fake.word.noun(),
                         ...(k8s
                           ? {
                             'k8s.kuma.io/namespace': nspace,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/clusters.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/clusters.ts
@@ -11,7 +11,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
 
   // Allows the service tag to be synchronized between overview and stats.
   fake.kuma.seed(name as string)
-  const service = fake.hacker.noun()
+  const service = fake.word.noun()
 
   if (type === 'gateway_builtin') {
     return {
@@ -242,7 +242,7 @@ kuma:envoy:admin::127.0.0.1:9901::local_origin_success_rate::-1`,
   const inboundCount = parseInt(env('KUMA_DATAPLANEINBOUND_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
   const ports = Array.from({ length: inboundCount }).map(() => fake.number.int({ min: 1, max: 65535 }))
   const serviceCount = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 7, max: 50 })}`))
-  const services = Array.from({ length: serviceCount }).map(() => `${fake.hacker.noun()}_svc_${fake.number.int({ min: 1, max: 65535 })}`)
+  const services = Array.from({ length: serviceCount }).map(() => `${fake.word.noun()}_svc_${fake.number.int({ min: 1, max: 65535 })}`)
   //
 
   fake.kuma.seed()

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/stats.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/stats.ts
@@ -14,9 +14,9 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
   const serviceCount = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 7, max: 50 })}`))
   const services = Array.from({ length: serviceCount }).map(() => {
     if (fake.datatype.boolean()) {
-      return `${fake.hacker.noun()}_${fake.hacker.noun()}_${fake.hacker.noun()}_${fake.hacker.noun()}_${fake.helpers.arrayElement(['msvc', 'mzsvc', 'extsvc'])}_${fake.number.int({ min: 1, max: 65535 })}`
+      return `${fake.word.noun()}_${fake.word.noun()}_${fake.word.noun()}_${fake.word.noun()}_${fake.helpers.arrayElement(['msvc', 'mzsvc', 'extsvc'])}_${fake.number.int({ min: 1, max: 65535 })}`
     } else {
-      return `${fake.hacker.noun()}_svc_${fake.number.int({ min: 1, max: 65535 })}`
+      return `${fake.word.noun()}_svc_${fake.number.int({ min: 1, max: 65535 })}`
     }
   })
   fake.kuma.seed()

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/xds.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/xds.ts
@@ -16,9 +16,9 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
   const serviceCount = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 7, max: 50 })}`))
   const services = Array.from({ length: serviceCount }).map(() => {
     if (fake.datatype.boolean()) {
-      return `${fake.hacker.noun()}_${fake.hacker.noun()}_${fake.hacker.noun()}_${fake.hacker.noun()}_${fake.helpers.arrayElement(['msvc', 'mzsvc', 'extsvc'])}_${fake.number.int({ min: 1, max: 65535 })}`
+      return `${fake.word.noun()}_${fake.word.noun()}_${fake.word.noun()}_${fake.word.noun()}_${fake.helpers.arrayElement(['msvc', 'mzsvc', 'extsvc'])}_${fake.number.int({ min: 1, max: 65535 })}`
     } else {
-      return `${fake.hacker.noun()}_svc_${fake.number.int({ min: 1, max: 65535 })}`
+      return `${fake.word.noun()}_svc_${fake.number.int({ min: 1, max: 65535 })}`
     }
   })
   if (env('KUMA_CLUSTER_NAME', '').length > 0) {

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_overview.ts
@@ -56,7 +56,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const type = filterType || fake.helpers.arrayElement(['BUILTIN', 'DELEGATED', 'STANDARD'])
         // we include the type in the name so when we link using the name
         // we keep the type in the URL so the corresponding item mock knows the type
-        const name = `${fake.hacker.noun()}-${type.toLowerCase()}`
+        const name = `${fake.word.noun()}-${type.toLowerCase()}`
         const displayName = `${_name || name}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
         const nspace = fake.k8s.namespace()
         const service = tags['kuma.io/service']
@@ -91,7 +91,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                     tags: fake.kuma.tags({
                       protocol: fake.kuma.protocol(),
                       service,
-                      zone: isMultizone && fake.datatype.boolean() ? fake.hacker.noun() : undefined,
+                      zone: isMultizone && fake.datatype.boolean() ? fake.word.noun() : undefined,
                     }),
                     ...(fake.datatype.boolean() ? {
                       state: fake.kuma.inboundState(),
@@ -109,7 +109,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 gateway: {
                   tags: fake.kuma.tags({
                     service,
-                    zone: isMultizone && fake.datatype.boolean() ? fake.hacker.noun() : undefined,
+                    zone: isMultizone && fake.datatype.boolean() ? fake.word.noun() : undefined,
                   }),
                   type,
                 },
@@ -129,7 +129,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
             subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
               return {
                 id: fake.string.uuid(),
-                controlPlaneInstanceId: `${fake.hacker.noun()}-${i}`,
+                controlPlaneInstanceId: `${fake.word.noun()}-${i}`,
                 ...fake.kuma.connection(item, i, arr),
                 status: (() => {
                   const xcks = fake.number.int({ min: 100, max: 500 })

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/external-services.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/external-services.ts
@@ -17,7 +17,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const id = offset + i
         const mesh = req.params.mesh as string
         const nameQueryParam = req.url.searchParams.get('name')
-        const name = nameQueryParam ?? `${fake.hacker.noun()}-external-${id}`
+        const name = nameQueryParam ?? `${fake.word.noun()}-external-${id}`
 
         return {
           type: 'ExternalService',

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/fault-injections.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/fault-injections.ts
@@ -13,7 +13,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.hacker.noun()}-${id}`
+        const name = `${fake.word.noun()}-${id}`
 
         return {
           type: 'FaultInjection',
@@ -22,14 +22,14 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
           sources: [
             {
               match: {
-                service: `${fake.hacker.noun()}`,
+                service: `${fake.word.noun()}`,
               },
             },
           ],
           destinations: [
             {
               match: {
-                service: `${fake.hacker.noun()}`,
+                service: `${fake.word.noun()}`,
               },
             },
           ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/fault-injections/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/fault-injections/_.ts
@@ -13,14 +13,14 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
       sources: [
         {
           match: {
-            service: fake.hacker.noun(),
+            service: fake.word.noun(),
           },
         },
       ],
       destinations: [
         {
           match: {
-            service: fake.hacker.noun(),
+            service: fake.word.noun(),
           },
         },
       ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/health-checks.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/health-checks.ts
@@ -8,7 +8,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.hacker.noun()}-${i}`
+        const name = `${fake.word.noun()}-${i}`
         return {
           type: 'HealthCheck',
           mesh: params.mesh,
@@ -16,14 +16,14 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
           sources: [
             {
               match: {
-                service: `${fake.hacker.noun()}`,
+                service: `${fake.word.noun()}`,
               },
             },
           ],
           destinations: [
             {
               match: {
-                service: `${fake.hacker.noun()}`,
+                service: `${fake.word.noun()}`,
               },
             },
           ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/health-checks/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/health-checks/_.ts
@@ -13,14 +13,14 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
       sources: [
         {
           match: {
-            service: fake.hacker.noun(),
+            service: fake.word.noun(),
           },
         },
       ],
       destinations: [
         {
           match: {
-            service: fake.hacker.noun(),
+            service: fake.word.noun(),
           },
         },
       ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshexternalservices.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshexternalservices.ts
@@ -22,7 +22,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       next,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.hacker.noun()}`
+        const name = `${fake.word.noun()}`
         const displayName = `${_name || name}-${id}`
         const nspace = fake.k8s.namespace()
 
@@ -38,7 +38,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 'kuma.io/display-name': displayName,
                 'k8s.kuma.io/namespace': nspace,
                 'kuma.io/origin': 'zone',
-                'kuma.io/zone': fake.hacker.noun(),
+                'kuma.io/zone': fake.word.noun(),
               },
             }
             : {}),

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshexternalservices/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshexternalservices/_.ts
@@ -30,7 +30,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
             'kuma.io/display-name': displayName,
             'k8s.kuma.io/namespace': nspace,
             'kuma.io/origin': 'zone',
-            'kuma.io/zone': fake.hacker.noun(),
+            'kuma.io/zone': fake.word.noun(),
           },
         }
         : {}),

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshfaultinjections.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshfaultinjections.ts
@@ -15,7 +15,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.hacker.noun()}-${id}`
+        const name = `${fake.word.noun()}-${id}`
 
         const displayName = `${name}${fake.kuma.dataplaneSuffix(k8s)}`
         const nspace = fake.k8s.namespace()
@@ -39,7 +39,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               {
                 targetRef: {
                   kind: 'MeshService',
-                  name: fake.hacker.noun(),
+                  name: fake.word.noun(),
                 },
                 default: {
                   http: [

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshfaultinjections/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshfaultinjections/_.ts
@@ -28,7 +28,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
           {
             targetRef: {
               kind: 'MeshService',
-              name: fake.hacker.noun(),
+              name: fake.word.noun(),
             },
             default: {
               http: [

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgatewayroutes.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgatewayroutes.ts
@@ -8,7 +8,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.hacker.noun()}-${i}`
+        const name = `${fake.word.noun()}-${i}`
         return {
           type: 'MeshGatewayRoute',
           mesh: params.mesh,
@@ -37,7 +37,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
                   backends: [
                     {
                       destination: {
-                        'kuma.io/service': `${fake.hacker.noun()}`,
+                        'kuma.io/service': `${fake.word.noun()}`,
                       },
                     },
                   ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgatewayroutes/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgatewayroutes/_.ts
@@ -34,7 +34,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
               backends: [
                 {
                   destination: {
-                    'kuma.io/service': fake.hacker.noun(),
+                    'kuma.io/service': fake.word.noun(),
                   },
                 },
               ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgateways.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgateways.ts
@@ -19,7 +19,7 @@ export default ({ env, fake, pager }: EndpointDependencies): MockResponder => (r
       next,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.hacker.noun()}-${id}`
+        const name = `${fake.word.noun()}-${id}`
 
         const displayName = `${name}${fake.kuma.dataplaneSuffix(k8s)}`
         const nspace = fake.k8s.namespace()
@@ -33,7 +33,7 @@ export default ({ env, fake, pager }: EndpointDependencies): MockResponder => (r
           labels: {
             'kuma.io/display-name': displayName,
             'kuma.io/origin': fake.kuma.origin(),
-            'kuma.io/zone': fake.hacker.noun(),
+            'kuma.io/zone': fake.word.noun(),
             ...(k8s
               ? {
                 'k8s.kuma.io/namespace': nspace,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgateways/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgateways/_.ts
@@ -27,7 +27,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
       labels: {
         'kuma.io/display-name': displayName,
         'kuma.io/origin': fake.kuma.origin(),
-        'kuma.io/zone': fake.hacker.noun(),
+        'kuma.io/zone': fake.word.noun(),
         ...(k8s
           ? {
             'k8s.kuma.io/namespace': nspace,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshhttproutes.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshhttproutes.ts
@@ -17,7 +17,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.hacker.noun()}-${id}`
+        const name = `${fake.word.noun()}-${id}`
 
         return {
           type: 'MeshHTTPRoute',
@@ -31,7 +31,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               'kuma.io/display-name': 'demo-app',
               'kuma.io/mesh': 'default',
               'kuma.io/origin': 'zone',
-              'kuma.io/zone': fake.hacker.noun(),
+              'kuma.io/zone': fake.word.noun(),
             },
           }),
           spec: {

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshhttproutes/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshhttproutes/_.ts
@@ -23,7 +23,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
           'kuma.io/display-name': 'demo-app',
           'kuma.io/mesh': 'default',
           'kuma.io/origin': 'zone',
-          'kuma.io/zone': fake.hacker.noun(),
+          'kuma.io/zone': fake.word.noun(),
         },
       }),
       spec: {

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshmultizoneservices.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshmultizoneservices.ts
@@ -23,7 +23,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       next,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.hacker.noun()}`
+        const name = `${fake.word.noun()}`
         const displayName = `${_name || name}-${id}`
         const nspace = fake.k8s.namespace()
 
@@ -39,14 +39,14 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 'kuma.io/display-name': displayName,
                 'k8s.kuma.io/namespace': nspace,
                 'kuma.io/origin': 'zone',
-                'kuma.io/zone': fake.hacker.noun(),
+                'kuma.io/zone': fake.word.noun(),
               },
             }
             : {}),
           spec: {
             ports: Array.from({ length: 5 }).map(_ => (
               {
-                name: fake.helpers.arrayElement([fake.hacker.noun(), String(fake.internet.port())]),
+                name: fake.helpers.arrayElement([fake.word.noun(), String(fake.internet.port())]),
                 port: fake.internet.port(),
                 targetPort: fake.internet.port(),
                 appProtocol: fake.kuma.protocol(),
@@ -60,10 +60,10 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
           },
           status: {
             meshServices: Array.from({ length: serviceCount }).map(_ => ({
-              name: `${fake.hacker.noun()}-${i}`,
-              mesh: fake.hacker.noun(),
+              name: `${fake.word.noun()}-${i}`,
+              mesh: fake.word.noun(),
               namespace: `${k8s ? `.${fake.k8s.namespace()}` : ''}`,
-              zone: fake.hacker.noun(),
+              zone: fake.word.noun(),
             })),
             addresses: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
               hostname: fake.internet.domainName(),

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshmultizoneservices/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshmultizoneservices/_.ts
@@ -40,7 +40,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
         },
         ports: Array.from({ length: 5 }).map(_ => (
           {
-            name: fake.helpers.arrayElement([fake.hacker.noun(), String(fake.internet.port())]),
+            name: fake.helpers.arrayElement([fake.word.noun(), String(fake.internet.port())]),
             port: fake.internet.port(),
             targetPort: fake.internet.port(),
             appProtocol: fake.kuma.protocol(),
@@ -49,10 +49,10 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
       },
       status: {
         meshServices: Array.from({ length: serviceCount }).map((_, i) => ({
-          name: `${fake.hacker.noun()}-${i}`,
-          mesh: fake.hacker.noun(),
+          name: `${fake.word.noun()}-${i}`,
+          mesh: fake.word.noun(),
           namespace: `${k8s ? `${fake.k8s.namespace()}` : ''}`,
-          zone: fake.hacker.noun(),
+          zone: fake.word.noun(),
         })),
         addresses: Array.from({ length: fake.number.int({ min: 1, max: 5 }) }).map(_ => ({
           hostname: fake.internet.domainName(),

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshservices.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshservices.ts
@@ -22,7 +22,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       next,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.hacker.noun()}`
+        const name = `${fake.word.noun()}`
         const displayName = `${_name || name}-${id}`
         const nspace = fake.k8s.namespace()
 
@@ -40,14 +40,14 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 'kuma.io/display-name': displayName,
                 'k8s.kuma.io/namespace': nspace,
                 'kuma.io/origin': 'zone',
-                'kuma.io/zone': fake.hacker.noun(),
+                'kuma.io/zone': fake.word.noun(),
               },
             }
             : {}),
           spec: {
             ports: Array.from({ length: 5 }).map(_ => (
               {
-                name: fake.helpers.arrayElement([fake.hacker.noun(), String(fake.internet.port())]),
+                name: fake.helpers.arrayElement([fake.word.noun(), String(fake.internet.port())]),
                 port: fake.internet.port(),
                 targetPort: fake.internet.port(),
                 appProtocol: fake.kuma.protocol(),

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshservices/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshservices/_.ts
@@ -30,14 +30,14 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
             'kuma.io/display-name': parts.slice(0, -1).join('.'),
             'k8s.kuma.io/namespace': parts.pop()!,
             'kuma.io/origin': 'zone',
-            'kuma.io/zone': fake.hacker.noun(),
+            'kuma.io/zone': fake.word.noun(),
           },
         }
         : {}),
       spec: {
         ports: Array.from({ length: 5 }).map(_ => (
           {
-            name: fake.helpers.arrayElement([fake.hacker.noun(), String(fake.internet.port())]),
+            name: fake.helpers.arrayElement([fake.word.noun(), String(fake.internet.port())]),
             port: fake.internet.port(),
             targetPort: fake.internet.port(),
             appProtocol: fake.kuma.protocol(),

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/proxytemplates.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/proxytemplates.ts
@@ -8,7 +8,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.hacker.noun()}-${i}`
+        const name = `${fake.word.noun()}-${i}`
         return {
           type: 'ProxyTemplate',
           mesh: params.mesh,
@@ -16,7 +16,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
           selectors: [
             {
               match: {
-                service: `${fake.hacker.noun()}`,
+                service: `${fake.word.noun()}`,
               },
             },
           ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/proxytemplates/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/proxytemplates/_.ts
@@ -13,7 +13,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
       selectors: [
         {
           match: {
-            service: fake.hacker.noun(),
+            service: fake.word.noun(),
           },
         },
       ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/retries.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/retries.ts
@@ -8,7 +8,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.hacker.noun()}-${i}`
+        const name = `${fake.word.noun()}-${i}`
         return {
           type: 'Retry',
           mesh: params.mesh,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/service-insights.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/service-insights.ts
@@ -20,7 +20,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const id = offset + i
         const serviceType = serviceTypes || fake.datatype.boolean() ? fake.kuma.serviceType({ serviceTypes }) : undefined
         const mesh = req.params.mesh as string
-        const name = `${fake.hacker.noun()}-${id}-${serviceType}`
+        const name = `${fake.word.noun()}-${id}-${serviceType}`
         const addressPort = serviceType !== 'external' ? `${name}.mesh:${fake.internet.port()}` : undefined
         const status = serviceType !== 'external' ? fake.kuma.serviceStatusKeyword() : undefined
         const dataplanes = serviceType !== 'external' ? fake.kuma.healthStatus() : undefined

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/timeouts.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/timeouts.ts
@@ -8,7 +8,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.hacker.noun()}-${i}`
+        const name = `${fake.word.noun()}-${i}`
         return {
           type: 'Timeout',
           mesh: params.mesh,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-logs.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-logs.ts
@@ -8,7 +8,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.hacker.noun()}-${i}`
+        const name = `${fake.word.noun()}-${i}`
         return {
           type: 'TrafficLog',
           mesh: params.mesh,
@@ -16,7 +16,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
           sources: [
             {
               match: {
-                service: `${fake.hacker.noun()}`,
+                service: `${fake.word.noun()}`,
                 version: '1.0',
               },
             },
@@ -24,7 +24,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
           destinations: [
             {
               match: {
-                service: `${fake.hacker.noun()}`,
+                service: `${fake.word.noun()}`,
               },
             },
           ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-logs/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-logs/_.ts
@@ -15,7 +15,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
       sources: [
         {
           match: {
-            service: fake.hacker.noun(),
+            service: fake.word.noun(),
             version: '1.0',
           },
         },
@@ -23,7 +23,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
       destinations: [
         {
           match: {
-            service: fake.hacker.noun(),
+            service: fake.word.noun(),
           },
         },
       ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-permissions.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-permissions.ts
@@ -13,7 +13,7 @@ export default ({ fake, pager }: EndpointDependencies): MockResponder => (req) =
       next,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.hacker.noun()}-${id}`
+        const name = `${fake.word.noun()}-${id}`
 
         return {
           type: 'TrafficPermission',
@@ -22,14 +22,14 @@ export default ({ fake, pager }: EndpointDependencies): MockResponder => (req) =
           sources: [
             {
               match: {
-                service: `${fake.hacker.noun()}`,
+                service: `${fake.word.noun()}`,
               },
             },
           ],
           destinations: [
             {
               match: {
-                service: `${fake.hacker.noun()}`,
+                service: `${fake.word.noun()}`,
               },
             },
           ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-permissions/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-permissions/_.ts
@@ -15,14 +15,14 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
       sources: [
         {
           match: {
-            service: fake.hacker.noun(),
+            service: fake.word.noun(),
           },
         },
       ],
       destinations: [
         {
           match: {
-            service: fake.hacker.noun(),
+            service: fake.word.noun(),
           },
         },
       ],

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-routes.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-routes.ts
@@ -8,7 +8,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.hacker.noun()}-${i}`
+        const name = `${fake.word.noun()}-${i}`
         return {
           type: 'TrafficRoute',
           mesh: params.mesh,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-traces.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-traces.ts
@@ -8,7 +8,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.hacker.noun()}-${i}`
+        const name = `${fake.word.noun()}-${i}`
         return {
           type: 'TrafficTrace',
           mesh: params.mesh,
@@ -21,7 +21,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
             },
           ],
           conf: {
-            backend: `${fake.hacker.noun()}`,
+            backend: `${fake.word.noun()}`,
           },
         }
       }),

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-traces/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-traces/_.ts
@@ -13,7 +13,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
       creationTime: '2020-05-12T12:31:45.606217+02:00',
       modificationTime: '2020-05-12T12:31:45.606217+02:00',
       conf: {
-        backend: fake.hacker.noun(),
+        backend: fake.word.noun(),
       },
       selectors: [
         {

--- a/packages/kuma-gui/src/test-support/mocks/src/zone-ingresses/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zone-ingresses/_.ts
@@ -2,7 +2,7 @@ import type { EndpointDependencies, MockResponder } from '@/test-support'
 
 export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const { name } = req.params
-  const zoneName = fake.hacker.noun()
+  const zoneName = fake.word.noun()
 
   return {
     headers: {},

--- a/packages/kuma-gui/src/test-support/mocks/src/zone-ingresses/_/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zone-ingresses/_/_overview.ts
@@ -12,7 +12,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
     nspace = ''
   }
 
-  const zoneName = fake.hacker.noun()
+  const zoneName = fake.word.noun()
 
   const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
   const serviceCount = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
@@ -42,12 +42,12 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
           advertisedPort: fake.internet.port(),
         },
         availableServices: Array.from({ length: serviceCount }).map(_ => {
-          const mesh = `${fake.hacker.noun()}-app`
+          const mesh = `${fake.word.noun()}-app`
           return {
             tags: {
               app: mesh,
               'kuma.io/protocol': fake.kuma.protocol(),
-              'kuma.io/service': `${mesh}_${fake.hacker.noun()}_svc_${fake.number.int({ min: 0, max: 65535 })}`,
+              'kuma.io/service': `${mesh}_${fake.word.noun()}_svc_${fake.number.int({ min: 0, max: 65535 })}`,
               'kuma.io/zone': zoneName,
               'pod-template-hash': fake.string.alphanumeric({ casing: 'lower', length: 10 }),
             },
@@ -62,7 +62,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
             subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
               return {
                 id: fake.string.uuid(),
-                controlPlaneInstanceId: fake.hacker.noun(),
+                controlPlaneInstanceId: fake.word.noun(),
                 ...fake.kuma.connection(item, i, arr),
                 generation: fake.number.int({ min: 1, max: 500 }),
                 status: (() => {

--- a/packages/kuma-gui/src/test-support/mocks/src/zone-ingresses/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zone-ingresses/_overview.ts
@@ -14,7 +14,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
 
-        const displayName = `${fake.hacker.noun()}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
+        const displayName = `${fake.word.noun()}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
         const nspace = fake.k8s.namespace()
 
         const zoneName = env('KUMA_ZONE_NAME', 'zone-0')
@@ -44,12 +44,12 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               advertisedPort: fake.internet.port(),
             },
             availableServices: Array.from({ length: serviceCount }).map(_ => {
-              const mesh = `${fake.hacker.noun()}-app`
+              const mesh = `${fake.word.noun()}-app`
               return {
                 tags: {
                   app: mesh,
                   'kuma.io/protocol': fake.kuma.protocol(),
-                  'kuma.io/service': `${mesh}_${fake.hacker.noun()}_svc_${fake.number.int({ min: 0, max: 65535 })}`,
+                  'kuma.io/service': `${mesh}_${fake.word.noun()}_svc_${fake.number.int({ min: 0, max: 65535 })}`,
                   'kuma.io/zone': zoneName,
                   'pod-template-hash': fake.string.alphanumeric({ casing: 'lower', length: 10 }),
                 },
@@ -64,7 +64,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
                   return {
                     id: fake.string.uuid(),
-                    controlPlaneInstanceId: fake.hacker.noun(),
+                    controlPlaneInstanceId: fake.word.noun(),
                     ...fake.kuma.connection(item, i, arr),
                     generation: fake.number.int({ min: 1, max: 500 }),
                     status: (() => {

--- a/packages/kuma-gui/src/test-support/mocks/src/zoneegresses/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zoneegresses/_.ts
@@ -2,7 +2,7 @@ import type { EndpointDependencies, MockResponder } from '@/test-support'
 
 export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const { name } = req.params
-  const zoneName = fake.hacker.noun()
+  const zoneName = fake.word.noun()
 
   return {
     headers: {},

--- a/packages/kuma-gui/src/test-support/mocks/src/zoneegresses/_/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zoneegresses/_/_overview.ts
@@ -7,7 +7,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
   const displayName = parts.slice(0, -1).join('.')
   const nspace = parts.pop()
 
-  const zoneName = fake.hacker.noun()
+  const zoneName = fake.word.noun()
 
   const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
 
@@ -42,7 +42,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
             subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
               return {
                 id: fake.string.uuid(),
-                controlPlaneInstanceId: fake.hacker.noun(),
+                controlPlaneInstanceId: fake.word.noun(),
                 ...fake.kuma.connection(item, i, arr),
                 generation: 409,
                 status: {

--- a/packages/kuma-gui/src/test-support/mocks/src/zoneegresses/_/clusters.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zoneegresses/_/clusters.ts
@@ -3,7 +3,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (_req) =>
   const inboundCount = parseInt(env('KUMA_DATAPLANEINBOUND_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
   const ports = Array.from({ length: inboundCount }).map(() => fake.number.int({ min: 1, max: 65535 }))
   const serviceCount = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 7, max: 50 })}`))
-  const services = Array.from({ length: serviceCount }).map(() => `${fake.hacker.noun()}_svc_${fake.number.int({ min: 1, max: 65535 })}`)
+  const services = Array.from({ length: serviceCount }).map(() => `${fake.word.noun()}_svc_${fake.number.int({ min: 1, max: 65535 })}`)
   //
 
   const inbounds = ports.map(port => {

--- a/packages/kuma-gui/src/test-support/mocks/src/zoneegresses/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zoneegresses/_overview.ts
@@ -13,7 +13,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
 
-        const displayName = `${fake.hacker.noun()}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
+        const displayName = `${fake.word.noun()}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
         const nspace = fake.k8s.namespace()
 
         const zoneName = env('KUMA_ZONE_NAME', 'zone-0')
@@ -49,7 +49,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
                   return {
                     id: fake.string.uuid(),
-                    controlPlaneInstanceId: fake.hacker.noun(),
+                    controlPlaneInstanceId: fake.word.noun(),
                     ...fake.kuma.connection(item, i, arr),
                     generation: 409,
                     status: {

--- a/packages/kuma-gui/src/test-support/mocks/src/zoneingresses/_/clusters.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zoneingresses/_/clusters.ts
@@ -3,7 +3,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (_req) =>
   const inboundCount = parseInt(env('KUMA_DATAPLANEINBOUND_COUNT', `${fake.number.int({ min: 1, max: 5 })}`))
   const ports = Array.from({ length: inboundCount }).map(() => fake.number.int({ min: 1, max: 65535 }))
   const serviceCount = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 7, max: 50 })}`))
-  const services = Array.from({ length: serviceCount }).map(() => `${fake.hacker.noun()}_svc_${fake.number.int({ min: 1, max: 65535 })}`)
+  const services = Array.from({ length: serviceCount }).map(() => `${fake.word.noun()}_svc_${fake.number.int({ min: 1, max: 65535 })}`)
   //
 
   const inbounds = ports.map(port => {

--- a/packages/kuma-gui/src/test-support/mocks/src/zones.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zones.ts
@@ -13,7 +13,7 @@ export default ({ fake, env, pager }: EndpointDependencies): MockResponder => (r
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.hacker.noun()}-${id}`
+        const name = `${fake.word.noun()}-${id}`
         return {
           type: 'Zone',
           name,

--- a/packages/kuma-gui/src/test-support/mocks/src/zones/_/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zones/_/_overview.ts
@@ -31,10 +31,10 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
                 id: fake.string.uuid(),
                 ...(fake.datatype.boolean()
                   ? {
-                    globalInstanceId: `global-${fake.hacker.noun()}`,
+                    globalInstanceId: `global-${fake.word.noun()}`,
                   }
                   : {}),
-                zoneInstanceId: `zone-${fake.hacker.noun()}`,
+                zoneInstanceId: `zone-${fake.word.noun()}`,
                 version: {
                   kumaCp: {
                     version: fake.kuma.version(),

--- a/packages/kuma-gui/src/test-support/mocks/src/zones/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zones/_overview.ts
@@ -15,7 +15,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const shouldHaveZoneInsight = subscriptionCount !== 0 || fake.datatype.boolean()
 
         const id = offset + i
-        const name = i === 0 ? 'zone-0' : `${fake.hacker.noun()}-${id}`
+        const name = i === 0 ? 'zone-0' : `${fake.word.noun()}-${id}`
 
         return {
           type: 'ZoneOverview',
@@ -35,7 +35,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                     },
                   }),
                   id: fake.string.uuid(),
-                  globalInstanceId: fake.hacker.noun(),
+                  globalInstanceId: fake.word.noun(),
                   ...fake.kuma.connection(item, i, arr),
                   status: {
                     lastUpdateTime: '2021-02-19T07:06:16.384057Z',


### PR DESCRIPTION
Using `hacker.noun` for our mocks could lead to spaces within the mocked values. This is something we want to avoid because certain resources should not include spaces. Therefore it's better to move everything to `word.noun`. The consequence is just that our mocked values are not "tech"-style.