### PR TITLE
fix: changes Xi18n's default-message prop to default-path

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -20,7 +20,7 @@
     >
       <XI18n
         path="data-planes.routes.items.intro"
-        default-message=""
+        default-path="common.i18n.ignore-error"
       />
       <XCard>
         <search>

--- a/packages/kuma-gui/src/app/gateways/views/GatewayListTabsView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/GatewayListTabsView.vue
@@ -43,7 +43,7 @@
 
         <XI18n
           :path="`gateways.routes.items.navigation.${route.child()?.name}.description`"
-          default-message=""
+          default-path="common.i18n.ignore-error"
         />
 
         <RouterView

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
@@ -20,7 +20,7 @@
       </template>
       <XI18n
         path="hostname-generators.routes.items.intro"
-        default-message=""
+        default-path="common.i18n.ignore-error"
       />
       <XCard>
         <DataLoader

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -1,4 +1,6 @@
 common:
+  i18n:
+    ignore-error: ""
   product:
     name: Kuma
     utm_query_params: utm_source=Kuma&utm_medium=Kuma

--- a/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
@@ -21,7 +21,7 @@
 
       <XI18n
         path="meshes.routes.items.intro"
-        default-message=""
+        default-path="common.i18n.ignore-error"
       />
 
       <XCard>

--- a/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
@@ -65,7 +65,7 @@
               </header>
               <XI18n
                 :path="`policies.type.${type.name}.description`"
-                default-message="t('policies.collection.description')"
+                default-path="policies.collection.description"
               />
             </XCard>
 

--- a/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
@@ -39,7 +39,7 @@
 
         <XI18n
           :path="`services.routes.items.navigation.${route.child()?.name}.description`"
-          default-message=""
+          default-path="common.i18n.ignore-error"
         />
 
         <RouterView

--- a/packages/kuma-gui/src/app/x/components/x-empty-state/XEmptyState.vue
+++ b/packages/kuma-gui/src/app/x/components/x-empty-state/XEmptyState.vue
@@ -40,7 +40,7 @@
                   <h2>
                     <XI18n
                       :path="`${prefix}x-empty-state.title`"
-                      :default-message="t('components.x-empty-state.title')"
+                      default-path="components.x-empty-state.title"
                     />
                   </h2>
                 </header>
@@ -58,7 +58,7 @@
           >
             <XI18n
               :path="`${prefix}x-empty-state.body`"
-              :default-message="t('components.x-empty-state.body')"
+              default-path="components.x-empty-state.body"
             />
           </template>
 

--- a/packages/kuma-gui/src/app/x/components/x-i18n/XI18n.vue
+++ b/packages/kuma-gui/src/app/x/components/x-i18n/XI18n.vue
@@ -10,7 +10,7 @@
       v-html="safeT(
         props.path,
         props.params,
-        typeof props.defaultMessage !== 'undefined' ? { defaultMessage: props.defaultMessage}: undefined,
+        typeof props.defaultPath === 'string' ? { defaultMessage: safeT(props.defaultPath)}: undefined,
       )"
     />
     <!-- eslint-enable -->
@@ -62,13 +62,13 @@ const props = withDefaults(defineProps<{
   prefix?: string
   path?: string
   params?: Record<string, string>
-  defaultMessage?: string
+  defaultPath?: string
 }>(), {
   strings: undefined,
   prefix: '',
   path: '',
   params: () => ({}),
-  defaultMessage: undefined,
+  defaultPath: undefined,
 })
 const slots = defineSlots()
 
@@ -101,7 +101,7 @@ const safeT: TFunction = (
   return i18n.t(
     `${key.startsWith('.') && props.prefix.length > 0 ? `${escapeHtml(props.prefix)}` : ''}${escapeHtml(key)}`,
     slotsOrParams,
-    typeof options?.defaultMessage !== 'undefined' ? { defaultMessage: escapeHtml(options.defaultMessage)} : options,
+    typeof options?.defaultMessage !== 'undefined' ? { defaultMessage: options.defaultMessage} : options,
   )
 }
 

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressListView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressListView.vue
@@ -30,7 +30,7 @@
       </template>
       <XI18n
         path="zone-egresses.routes.items.intro"
-        default-message=""
+        default-path="common.i18n.ignore-error"
       />
       <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
       <XCard>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressListView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressListView.vue
@@ -19,7 +19,7 @@
     >
       <XI18n
         path="zone-ingresses.routes.items.intro"
-        default-message=""
+        default-path="common.i18n.ignore-error"
       />
       <XCard>
         <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->

--- a/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
@@ -36,7 +36,7 @@
         />
         <XI18n
           path="zone-cps.routes.items.intro"
-          default-message=""
+          default-path="common.i18n.ignore-error"
         />
         <XCard>
           <XTeleportTemplate


### PR DESCRIPTION
We noticed this:

![image (3)](https://github.com/user-attachments/assets/7499366f-2cae-428b-9050-d69f3242aa7b)

which is the thing we are fixing here, but its a bit of a longer story due to what Xi18n should be doing.

---

The bug is that we aren't using a `:` here:

https://github.com/kumahq/kuma-gui/blob/603c39571c34fcdfad9eeafccf02ee4453fdc17b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue#L68

At first I was like "I can just add the `:` and job done", but then I was like "wait a second that means I can pass unencoded text into `default-message` using a normal `t` and `XI18n` will blindly render it, therefore bypassing any encoding.

This means we can't give `XI18n` a `default-message` prop, because we can't guarantee that its encoded correctly (i.e. sometimes we can use `t` which will encode it, but if we need some HTML in the string that `t` returns, then we can't guarantee and params passed to that are encoded correcly.

I chose to make `default-message` into `default-path` (which matches the `path` prop), i.e. you don't pass it a message to use for a default, you pass it a path, which is then looked up internally.

This means two things:

- You can't currently pass parameters to a default path (we don't need to, yet at least). We don't use a default very much so its no big deal later down the line to add a `default-path={ path 'common.something', params: {}}` or just an additional `default-params` props, or something.
- We need a i18n string that is literally a blank string i.e. `common.i18n.ignore-errors`. ... I'm actually wondering now if I should change this PR to make `ignoreErrors` an option instead 🤔 of the `common.i18n.ignore-errors` thing.

@schogges what do you think on this last bit, the more I think about it we should just make an `ignoreError` option or `ignoreMissingPath` or something, wdyt? Lmk if you don't follow the thinking here


