### PR TITLE
fix: prevents KSelect/XSelect from firing events twice

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-select/XSelect.vue
+++ b/packages/kuma-gui/src/app/x/components/x-select/XSelect.vue
@@ -1,5 +1,6 @@
 <template>
   <KSelect
+    v-model="selected"
     :label="props.label"
     :items="items"
     @selected="emit('change', String($event.value))"
@@ -25,7 +26,7 @@
 </template>
 <script lang="ts" setup>
 import { KSelect } from '@kong/kongponents'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 const emit = defineEmits<{
   (event: 'change', value: string): void
@@ -40,12 +41,13 @@ const props = withDefaults(defineProps<{
 
 const slots = defineSlots()
 
+const selected = ref(props.selected)
+
 const items = computed(() => {
   const items = Object.keys(slots).reduce<
     {
       value: string
       label: string
-      selected: boolean
     }[]
   >((prev, key) => {
     const pos = key.lastIndexOf('-option')
@@ -55,15 +57,11 @@ const items = computed(() => {
         {
           value: item,
           label: item,
-          selected: item === props.selected,
         },
       )
     }
     return prev
   }, [])
-  if (items.find(item => item.selected) === undefined) {
-    items[0].selected = true
-  }
   return items
 })
 


### PR DESCRIPTION
I found that KSelect `select` event would fire twice if you change the `items` as a result of the the first `select` event.

I would guess that KSelect could do something like firing a select event as a result of a non-user-interaction if you change the `selected` property of an `item`. So even though the menu has already been changed/selected by the user, if you change `items` immediately after to be the same as the user selection, it re-fires the same event. But kinda just guessing.

I moved XSelect to use a different approach which avoids using `items[].selected`, which fixes the issue, and I no longer see the double events.

From my investigation this issue doesn't seem to be affecting anything currently, but it'd best if our XSelect component didn't fire `change` twice.