### PR TITLE
fix: removes extra padding adding via kongponents update

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-tabs/XTabs.vue
+++ b/packages/kuma-gui/src/app/x/components/x-tabs/XTabs.vue
@@ -82,13 +82,16 @@ watch(() => slots, () => {
 })
 </script>
 <style lang="scss" scoped>
+:deep(.tab-link) {
+  /* TODO(jc): override KTab's div styling  */
+  padding: 0 !important;
+}
 :deep(.tab-link) > * {
   transition: inherit;
   border-radius: inherit;
   color: inherit;
   outline: inherit;
-  /* TODO(jc): This can be removed if we ever get rid of the global link styling  */
-  text-decoration: none !important;
+  padding: $kui-space-30 $kui-space-50;
 }
 :deep(.tab-link) > *:focus-visible {
   background-color: $kui-color-background-neutral-weaker;


### PR DESCRIPTION
Several people have reported issue with being able to click on our tab component i.e. you have to click exactly on the text instead of being able to click on the entire button.

A recent kongponent update (https://github.com/Kong/kongponents/pull/2532) changed the padding of certain HTML elements, which removed the padding from our anchor links and added it to the surrounding div instead, meaning whilst it looked like you could click on the entire button to click the anchor, you where actually clicking the div, meaning the anchor wasn't navigating.

Also see https://github.com/Kong/kongponents/pull/2532/files#diff-01f83cc2092a263bfd47c1d0a4ba5e96dea98264d85282662a63f4fa18c44dedR177

This PR rearranges the padding using some overwrites to return the anchor its previous padded state.

There is still a little unclickable area between the button and the bottom border, but I think this is intentional form the kongponents authors. The additional difference with this area is that at least you don't see a pointer cursor when hovering over it.