### PR TITLE
fix(me/sources): preferences stored on route level not merged

### DIFF
--- a/packages/kuma-gui/src/app/me/sources.ts
+++ b/packages/kuma-gui/src/app/me/sources.ts
@@ -15,15 +15,18 @@ export const sources = ({ get, set }: Storage) => {
         get('/'),
         get(params.route),
       ])
-      return merge(
-        {
-          params: {
-            size: 50,
-            format: 'structured',
+
+      return merge.all(
+        [
+          {
+            params: {
+              size: 50,
+              format: 'structured',
+            },
           },
-        },
-        app,
-        route,
+          app,
+          route,
+        ],
       )
     },
     '/me/:route/:data': async (params) => {


### PR DESCRIPTION
The preferences stored on a route level did not get merged after splitting up sources and storage of `me` in #3408 . Using `merge` only allows to merge two objects. To merge more than two objects we have to use `merge.all` ([ref](https://www.npmjs.com/package/deepmerge#mergeallarrayofobjects-options)).
TypeScript would have catched that if we would have added another object, because of too many parameters. Unfortunately the options object is not strongly typed enough to catch `object` as `deepmerge.Options`.