### PR TITLE
Feature/zone traffic drawers

### DIFF
--- a/packages/kuma-gui/src/app/kuma/services/kuma-api/KumaApi.ts
+++ b/packages/kuma-gui/src/app/kuma/services/kuma-api/KumaApi.ts
@@ -93,6 +93,19 @@ export default class KumaApi extends Api {
     return this.client.get(`/zoneingresses/${zoneIngressName}/${dataPath}`, { params })
   }
 
+  getZoneIngressXds({ name }: { name: string, params?: any }, params?: any): Promise<Record<string, unknown>> {
+    return this.client.get(`/zoneingresses/${name}/xds`, { params })
+  }
+
+  getZoneIngressStats({ name }: { name: string, params?: any }, params?: any): Promise<string> {
+    return this.client.get(`/zoneingresses/${name}/stats`, { params })
+  }
+
+  getZoneIngressClusters({ name }: { name: string, params?: any }, params?: any): Promise<string> {
+    return this.client.get(`/zoneingresses/${name}/clusters`, { params })
+  }
+
+
   getAllZoneIngressOverviews(params?: PaginationParameters): Promise<PaginatedApiListResponse<ZoneIngressOverview>> {
     return this.client.get('/zone-ingresses/_overview', { params })
   }
@@ -110,6 +123,18 @@ export default class KumaApi extends Api {
    */
   getZoneEgressData({ zoneEgressName, dataPath }: { zoneEgressName: string, dataPath: 'xds' | 'stats' | 'clusters' }, params?: any): Promise<string> {
     return this.client.get(`/zoneegresses/${zoneEgressName}/${dataPath}`, { params })
+  }
+
+  getZoneEgressXds({ name }: { name: string, params?: any }, params?: any): Promise<Record<string, unknown>> {
+    return this.client.get(`/zoneegresses/${name}/xds`, { params })
+  }
+
+  getZoneEgressStats({ name }: { name: string, params?: any }, params?: any): Promise<string> {
+    return this.client.get(`/zoneegresses/${name}/stats`, { params })
+  }
+
+  getZoneEgressClusters({ name }: { name: string, params?: any }, params?: any): Promise<string> {
+    return this.client.get(`/zoneegresses/${name}/clusters`, { params })
   }
 
   getAllZoneEgressOverviews(params?: PaginationParameters): Promise<PaginatedApiListResponse<ZoneEgressOverview>> {

--- a/packages/kuma-gui/src/app/zone-egresses/data/index.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/data/index.ts
@@ -8,39 +8,21 @@ import type {
 
 type PartialInternalZoneEgress = PartialZoneEgressOverview['zoneEgress']
 
-// TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
-type InternalZoneEgress = {
-  socketAddress: string
-} & PartialInternalZoneEgress
-
-export type ZoneEgress = {
-  config: PartialZoneEgress
-  socketAddress: string
-} & PartialZoneEgress
-// end TODO
-
 export type ZoneEgressInsight = PartialZoneEgressInsight & DiscoverySubscriptionCollection & {}
 
-// TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
-const InternalZoneEgress = {
-  fromObject: (item: PartialInternalZoneEgress): InternalZoneEgress => {
-    return {
-      ...item,
-      socketAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
-    }
-  },
-}
-
 export const ZoneEgress = {
-  fromObject: (item: PartialZoneEgress): ZoneEgress => {
+  fromObject: (item: PartialZoneEgress) => {
     return {
       ...item,
       config: item,
       socketAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
+      networking: {
+        ...item.networking,
+        inboundAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
+      },
     }
   },
 }
-// end TODO
 export const ZoneEgressInsight = {
   fromObject: (item: PartialZoneEgressInsight | undefined): ZoneEgressInsight => {
     return {
@@ -49,6 +31,20 @@ export const ZoneEgressInsight = {
     }
   },
 }
+// TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
+const InternalZoneEgress = {
+  fromObject: (item: PartialInternalZoneEgress) => {
+    return {
+      ...item,
+      socketAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
+      networking: {
+        ...item.networking,
+        inboundAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
+      },
+    }
+  },
+}
+
 export const ZoneEgressOverview = {
   fromObject: (item: PartialZoneEgressOverview) => {
     const zoneEgressInsight = ZoneEgressInsight.fromObject(item.zoneEgressInsight)
@@ -86,3 +82,4 @@ export const ZoneEgressOverview = {
 }
 
 export type ZoneEgressOverview = ReturnType<typeof ZoneEgressOverview.fromObject>
+export type ZoneEgress = ReturnType<typeof ZoneEgress.fromObject>

--- a/packages/kuma-gui/src/app/zone-egresses/routes.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/routes.ts
@@ -14,7 +14,59 @@ export const routes = (prefix = 'egresses') => {
             path: 'overview',
             name: 'zone-egress-detail-view',
             component: () => import('@/app/zone-egresses/views/ZoneEgressDetailView.vue'),
-            children: subscriptions('zone-egress'),
+            children: [
+              ...((prefix) => {
+                return [
+                  {
+                    path: 'inbound/:connection',
+                    name: `${prefix}-connection-inbound-summary-view`,
+                    component: () => import('@/app/zone-egresses/views/ConnectionInboundSummaryView.vue'),
+                    children: [
+                      {
+                        path: 'stats',
+                        name: `${prefix}-connection-inbound-summary-stats-view`,
+                        component: () => import('@/app/zone-egresses/views/ConnectionInboundSummaryStatsView.vue'),
+                      },
+                      {
+                        path: 'clusters',
+                        name: `${prefix}-connection-inbound-summary-clusters-view`,
+                        component: () => import('@/app/zone-egresses/views/ConnectionInboundSummaryClustersView.vue'),
+                      },
+                      {
+                        path: 'xds-config',
+                        name: `${prefix}-connection-inbound-summary-xds-config-view`,
+                        component: () => import('@/app/zone-egresses/views/ConnectionInboundSummaryXdsConfigView.vue'),
+                      },
+                    ],
+                  },
+
+                  {
+                    path: 'outbound/:connection',
+                    name: `${prefix}-connection-outbound-summary-view`,
+                    component: () => import('@/app/zone-egresses/views/ConnectionOutboundSummaryView.vue'),
+                    children: [
+                      {
+                        path: 'stats',
+                        name: `${prefix}-connection-outbound-summary-stats-view`,
+                        component: () => import('@/app/zone-egresses/views/ConnectionOutboundSummaryStatsView.vue'),
+                      },
+                      {
+                        path: 'clusters',
+                        name: `${prefix}-connection-outbound-summary-clusters-view`,
+                        component: () => import('@/app/zone-egresses/views/ConnectionOutboundSummaryClustersView.vue'),
+                      },
+                      {
+                        path: 'xds-config',
+                        name: `${prefix}-connection-outbound-summary-xds-config-view`,
+                        component: () => import('@/app/zone-egresses/views/ConnectionOutboundSummaryXdsConfigView.vue'),
+                      },
+                    ],
+                  },
+
+                ]
+              })('zone-egress'),
+              ...subscriptions('zone-egress'),
+            ],
           },
           {
             path: 'xds-config',

--- a/packages/kuma-gui/src/app/zone-egresses/views/ConnectionInboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ConnectionInboundSummaryClustersView.vue
@@ -4,7 +4,7 @@
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
-      zoneIngress: '',
+      zoneEgress: '',
       connection: '',
     }"
     :name="props.routeName"
@@ -17,8 +17,8 @@
     <AppView>
       <DataLoader
         :src="uri(sources, '/connections/clusters/for/:proxyType/:name', {
-          name: route.params.zoneIngress,
-          proxyType: 'zone-ingress',
+          name: route.params.zoneEgress,
+          proxyType: 'zone-egress',
         })"
         v-slot="{ data , refresh }"
       >

--- a/packages/kuma-gui/src/app/zone-egresses/views/ConnectionInboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ConnectionInboundSummaryView.vue
@@ -1,0 +1,65 @@
+<template>
+  <RouteView
+    :name="props.routeName"
+    :params="{
+      connection: '',
+      inactive: false,
+    }"
+    v-slot="{ route, t }"
+  >
+    <DataCollection
+      :items="props.data"
+      :predicate="item => `${item.socketAddress.replace(':', '_')}` === route.params.connection"
+      :find="true"
+      v-slot="{ items }"
+    >
+      <AppView>
+        <template #title>
+          <h2>
+            Inbound :{{ route.params.connection.split('_').at(-1) }}
+          </h2>
+        </template>
+
+        <XTabs
+          :selected="route.child()?.name"
+        >
+          <template
+            v-for="{ name } in route.children"
+            :key="name"
+            #[`${name}-tab`]
+          >
+            <XAction
+              :to="{
+                name,
+                query: {
+                  inactive: route.params.inactive,
+                },
+              }"
+            >
+              {{ t(`connections.routes.item.navigation.${name.split('-')[5]}`) }}
+            </XAction>
+          </template>
+        </XTabs>
+
+        <RouterView v-slot="child">
+          <component
+            :is="child.Component"
+            :data="items[0]"
+            :networking="props.networking"
+          />
+        </RouterView>
+      </AppView>
+    </DataCollection>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import type { DataplaneNetworking } from '@/app/data-planes/data/'
+import type { ZoneEgress } from '@/app/zone-egresses/data/'
+
+const props = defineProps<{
+  data: ZoneEgress[]
+  networking: DataplaneNetworking
+  routeName: string
+}>()
+</script>

--- a/packages/kuma-gui/src/app/zone-egresses/views/ConnectionInboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ConnectionInboundSummaryXdsConfigView.vue
@@ -4,9 +4,8 @@
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
-      zoneIngress: '',
+      zoneEgress: '',
       connection: '',
-      includeEds: false,
     }"
     :name="props.routeName"
     v-slot="{ t, route, uri }"
@@ -17,11 +16,10 @@
     />
     <AppView>
       <DataLoader
-        :src="uri(sources, '/connections/xds/for/:proxyType/:name/outbound/:outbound/endpoints/:endpoints', {
-          name: route.params.zoneIngress,
-          outbound: route.params.connection,
-          endpoints: String(route.params.includeEds),
-          proxyType: 'zone-ingress',
+        :src="uri(sources, '/connections/xds/for/:proxyType/:name/inbound/:inbound', {
+          name: route.params.zoneEgress,
+          inbound: `${props.data.networking?.port}`,
+          proxyType: 'zone-egress',
         })"
         v-slot="{ data: raw, refresh }"
       >
@@ -37,11 +35,6 @@
           @reg-exp-mode-change="route.update({ codeRegExp: $event })"
         >
           <template #primary-actions>
-            <XCheckbox
-              :checked="route.params.includeEds"
-              :label="t('connections.include_endpoints')"
-              @change="(value) => route.update({ includeEds: value})"
-            />
             <XAction
               action="refresh"
               appearance="primary"
@@ -57,7 +50,10 @@
 </template>
 <script lang="ts" setup>
 import { sources } from '@/app/connections/sources'
+import type { ZoneEgress } from '@/app/zone-egresses/data/'
+
 const props = defineProps<{
+  data: ZoneEgress
   routeName: string
 }>()
 </script>

--- a/packages/kuma-gui/src/app/zone-egresses/views/ConnectionOutboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ConnectionOutboundSummaryClustersView.vue
@@ -4,7 +4,7 @@
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
-      zoneIngress: '',
+      zoneEgress: '',
       connection: '',
     }"
     :name="props.routeName"
@@ -17,13 +17,13 @@
     <AppView>
       <DataLoader
         :src="uri(sources, '/connections/clusters/for/:proxyType/:name', {
-          name: route.params.zoneIngress,
-          proxyType: 'zone-ingress',
+          name: route.params.zoneEgress,
+          proxyType: 'zone-egress',
         })"
-        v-slot="{ data , refresh }"
+        v-slot="{ data, refresh }"
       >
         <template
-          v-for="prefix in [route.params.connection.replace('_', ':')]"
+          v-for="prefix in [route.params.connection]"
           :key="typeof prefix"
         >
           <DataCollection

--- a/packages/kuma-gui/src/app/zone-egresses/views/ConnectionOutboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ConnectionOutboundSummaryStatsView.vue
@@ -4,7 +4,7 @@
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
-      zoneIngress: '',
+      zoneEgress: '',
       connection: '',
     }"
     :name="props.routeName"
@@ -17,9 +17,9 @@
     <AppView>
       <DataLoader
         :src="uri(sources, '/connections/stats/for/:proxyType/:name/:socketAddress', {
-          name: route.params.zoneIngress,
+          name: route.params.zoneEgress,
           socketAddress: props.networking.inboundAddress,
-          proxyType: 'zone-ingress',
+          proxyType: 'zone-egress',
         })"
 
         v-slot="{ data, refresh }"

--- a/packages/kuma-gui/src/app/zone-egresses/views/ConnectionOutboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ConnectionOutboundSummaryView.vue
@@ -1,0 +1,63 @@
+<template>
+  <RouteView
+    :name="props.routeName"
+    :params="{
+      connection: '',
+      inactive: false,
+    }"
+    v-slot="{ route, t }"
+  >
+    <AppView>
+      <template #title>
+        <h2>
+          Outbound {{ route.params.connection }}
+        </h2>
+      </template>
+
+      <XTabs :selected="route.child()?.name">
+        <template
+          v-for="item in route.children"
+          :key="`${item.name}`"
+          #[`${item.name}-tab`]
+        >
+          <XAction
+            :to="{
+              name: item.name,
+              query: {
+                inactive: route.params.inactive,
+              },
+
+            }"
+          >
+            {{ t(`connections.routes.item.navigation.${item.name.split('-')[5]}`) }}
+          </XAction>
+        </template>
+      </XTabs>
+      <RouterView
+        v-slot="{ Component }"
+      >
+        <DataCollection
+          :items="Object.entries(props.data)"
+          :predicate="([key, _value]) => key === route.params.connection"
+          :find="true"
+          v-slot="{ items }"
+        >
+          <component
+            :is="Component"
+            :data="items[0][1]"
+            :networking="props.networking"
+          />
+        </DataCollection>
+      </RouterView>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import type { DataplaneNetworking } from '@/app/data-planes/data/'
+const props = defineProps<{
+  data: Record<string, any>
+  networking: DataplaneNetworking
+  routeName: string
+}>()
+</script>

--- a/packages/kuma-gui/src/app/zone-egresses/views/ConnectionOutboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ConnectionOutboundSummaryXdsConfigView.vue
@@ -4,7 +4,7 @@
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
-      zoneIngress: '',
+      zoneEgress: '',
       connection: '',
       includeEds: false,
     }"
@@ -18,10 +18,10 @@
     <AppView>
       <DataLoader
         :src="uri(sources, '/connections/xds/for/:proxyType/:name/outbound/:outbound/endpoints/:endpoints', {
-          name: route.params.zoneIngress,
+          name: route.params.zoneEgress,
           outbound: route.params.connection,
           endpoints: String(route.params.includeEds),
-          proxyType: 'zone-ingress',
+          proxyType: 'zone-egress',
         })"
         v-slot="{ data: raw, refresh }"
       >

--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
@@ -32,6 +32,10 @@ const InternalZoneIngress = {
       availableServices: Array.isArray(item.availableServices) ? item.availableServices : [],
       socketAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
       advertisedSocketAddress: item.networking?.advertisedAddress && item.networking?.advertisedPort ? `${item.networking.advertisedAddress}:${item.networking.advertisedPort}` : '',
+      networking: {
+        ...item.networking,
+        inboundAddress: `${item.networking.address}:${item.networking.port}`,
+      },
     }
   },
 }

--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.ts
@@ -9,49 +9,23 @@ export type { AvailableService } from '@/types/index.d'
 
 type PartialInternalZoneIngress = PartialZoneIngressOverview['zoneIngress']
 
-// TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
-type InternalZoneIngress = {
-  socketAddress: string
-  advertisedSocketAddress: string
-} & Required<Pick<PartialInternalZoneIngress, 'availableServices'>> & PartialInternalZoneIngress
-
-export type ZoneIngress = {
-  config: PartialZoneIngress
-  socketAddress: string
-  advertisedSocketAddress: string
-} & Required<Pick<PartialZoneIngress, 'availableServices'>> & PartialZoneIngress
-// end TODO
-
 export type ZoneIngressInsight = PartialZoneIngressInsight & DiscoverySubscriptionCollection & {}
 
-// TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
-const InternalZoneIngress = {
-  fromObject: (item: PartialInternalZoneIngress): InternalZoneIngress => {
-    return {
-      ...item,
-      availableServices: Array.isArray(item.availableServices) ? item.availableServices : [],
-      socketAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
-      advertisedSocketAddress: item.networking?.advertisedAddress && item.networking?.advertisedPort ? `${item.networking.advertisedAddress}:${item.networking.advertisedPort}` : '',
-      networking: {
-        ...item.networking,
-        inboundAddress: `${item.networking.address}:${item.networking.port}`,
-      },
-    }
-  },
-}
-
 export const ZoneIngress = {
-  fromObject: (item: PartialZoneIngress): ZoneIngress => {
+  fromObject: (item: PartialZoneIngress) => {
     return {
       ...item,
       config: item,
       availableServices: Array.isArray(item.availableServices) ? item.availableServices : [],
       socketAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
       advertisedSocketAddress: item.networking?.advertisedAddress && item.networking?.advertisedPort ? `${item.networking.advertisedAddress}:${item.networking.advertisedPort}` : '',
+      networking: {
+        ...item.networking,
+        inboundAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
+      },
     }
   },
 }
-// end TODO
 export const ZoneIngressInsight = {
   fromObject: (item: PartialZoneIngressInsight | undefined): ZoneIngressInsight => {
     return {
@@ -60,6 +34,22 @@ export const ZoneIngressInsight = {
     }
   },
 }
+// TODO(jc) Theres probably a better way to not copy/pasta this i.e. make `Entity` composable
+const InternalZoneIngress = {
+  fromObject: (item: PartialInternalZoneIngress) => {
+    return {
+      ...item,
+      availableServices: Array.isArray(item.availableServices) ? item.availableServices : [],
+      socketAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
+      advertisedSocketAddress: item.networking?.advertisedAddress && item.networking?.advertisedPort ? `${item.networking.advertisedAddress}:${item.networking.advertisedPort}` : '',
+      networking: {
+        ...item.networking,
+        inboundAddress: item.networking?.address && item.networking?.port ? `${item.networking.address}:${item.networking.port}` : '',
+      },
+    }
+  },
+}
+
 export const ZoneIngressOverview = {
   fromObject: (item: PartialZoneIngressOverview) => {
     const zoneIngressInsight = ZoneIngressInsight.fromObject(item.zoneIngressInsight)
@@ -97,3 +87,4 @@ export const ZoneIngressOverview = {
 }
 
 export type ZoneIngressOverview = ReturnType<typeof ZoneIngressOverview.fromObject>
+export type ZoneIngress = ReturnType<typeof ZoneIngress.fromObject>

--- a/packages/kuma-gui/src/app/zone-ingresses/routes.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/routes.ts
@@ -27,11 +27,11 @@ export const routes = (prefix = 'ingresses') => {
                         name: `${prefix}-connection-inbound-summary-stats-view`,
                         component: () => import('@/app/zone-ingresses/views/ConnectionInboundSummaryStatsView.vue'),
                       },
-                      // {
-                      //   path: 'clusters',
-                      //   name: `${prefix}-connection-inbound-summary-clusters-view`,
-                      //   component: () => import('@/app/zone-ingresses/views/ConnectionInboundSummaryClustersView.vue'),
-                      // },
+                      {
+                        path: 'clusters',
+                        name: `${prefix}-connection-inbound-summary-clusters-view`,
+                        component: () => import('@/app/zone-ingresses/views/ConnectionInboundSummaryClustersView.vue'),
+                      },
                       {
                         path: 'xds-config',
                         name: `${prefix}-connection-inbound-summary-xds-config-view`,

--- a/packages/kuma-gui/src/app/zone-ingresses/routes.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/routes.ts
@@ -14,7 +14,59 @@ export const routes = (prefix = 'ingresses') => {
             path: 'overview',
             name: 'zone-ingress-detail-view',
             component: () => import('@/app/zone-ingresses/views/ZoneIngressDetailView.vue'),
-            children: subscriptions('zone-ingress'),
+            children: [
+              ...((prefix) => {
+                return [
+                  {
+                    path: 'inbound/:connection',
+                    name: `${prefix}-connection-inbound-summary-view`,
+                    component: () => import('@/app/zone-ingresses/views/ConnectionInboundSummaryView.vue'),
+                    children: [
+                      {
+                        path: 'stats',
+                        name: `${prefix}-connection-inbound-summary-stats-view`,
+                        component: () => import('@/app/zone-ingresses/views/ConnectionInboundSummaryStatsView.vue'),
+                      },
+                      // {
+                      //   path: 'clusters',
+                      //   name: `${prefix}-connection-inbound-summary-clusters-view`,
+                      //   component: () => import('@/app/zone-ingresses/views/ConnectionInboundSummaryClustersView.vue'),
+                      // },
+                      {
+                        path: 'xds-config',
+                        name: `${prefix}-connection-inbound-summary-xds-config-view`,
+                        component: () => import('@/app/zone-ingresses/views/ConnectionInboundSummaryXdsConfigView.vue'),
+                      },
+                    ],
+                  },
+
+                  {
+                    path: 'outbound/:connection',
+                    name: `${prefix}-connection-outbound-summary-view`,
+                    component: () => import('@/app/zone-ingresses/views/ConnectionOutboundSummaryView.vue'),
+                    children: [
+                      {
+                        path: 'stats',
+                        name: `${prefix}-connection-outbound-summary-stats-view`,
+                        component: () => import('@/app/zone-ingresses/views/ConnectionOutboundSummaryStatsView.vue'),
+                      },
+                      {
+                        path: 'clusters',
+                        name: `${prefix}-connection-outbound-summary-clusters-view`,
+                        component: () => import('@/app/zone-ingresses/views/ConnectionOutboundSummaryClustersView.vue'),
+                      },
+                      {
+                        path: 'xds-config',
+                        name: `${prefix}-connection-outbound-summary-xds-config-view`,
+                        component: () => import('@/app/zone-ingresses/views/ConnectionOutboundSummaryXdsConfigView.vue'),
+                      },
+                    ],
+                  },
+
+                ]
+              })('zone-ingress'),
+              ...subscriptions('zone-ingress'),
+            ],
           },
           {
             path: 'services',

--- a/packages/kuma-gui/src/app/zone-ingresses/sources.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/sources.ts
@@ -8,7 +8,6 @@ const includes = <T extends readonly string[]>(arr: T, item: string): item is T[
   return arr.includes(item as T[number])
 }
 
-export type ZoneIngressSource = DataSourceResponse<ZoneIngress>
 export type ZoneIngressOverviewCollection = CollectionResponse<ZoneIngressOverview>
 export type ZoneIngressOverviewSource = DataSourceResponse<ZoneIngressOverview>
 export type ZoneIngressOverviewCollectionSource = DataSourceResponse<ZoneIngressOverviewCollection>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryClustersView.vue
@@ -1,0 +1,66 @@
+<template>
+  <RouteView
+    :params="{
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+      zoneIngress: '',
+      connection: '',
+    }"
+    :name="props.routeName"
+    v-slot="{ route, uri }"
+  >
+    <RouteTitle
+      :render="false"
+      :title="`Clusters`"
+    />
+    <AppView>
+      <DataLoader
+        :src="uri(sources, '/connections/clusters/for/zone-ingress/:name', {
+          name: route.params.zoneIngress,
+        })"
+        v-slot="{ data , refresh }"
+      >
+        <template
+          v-for="prefix in [route.params.connection.replace('_', ':')]"
+          :key="typeof prefix"
+        >
+          {{ prefix }}
+          <DataCollection
+            :items="data.split('\n')"
+            :predicate="item => item.startsWith(`${prefix}::`)"
+            v-slot="{ items: lines }"
+          >
+            <XCodeBlock
+              language="json"
+              :code="lines.map(item => item.replace(`${prefix}::`, '')).join('\n')"
+              is-searchable
+              :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter"
+              :is-reg-exp-mode="route.params.codeRegExp"
+              @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            >
+              <template #primary-actions>
+                <XAction
+                  action="refresh"
+                  appearance="primary"
+                  @click="refresh"
+                >
+                  Refresh
+                </XAction>
+              </template>
+            </XCodeBlock>
+          </DataCollection>
+        </template>
+      </DataLoader>
+    </AppView>
+  </RouteView>
+</template>
+<script lang="ts" setup>
+import { sources } from '@/app/connections/sources'
+const props = defineProps<{
+  routeName: string
+}>()
+</script>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryStatsView.vue
@@ -1,0 +1,67 @@
+<template>
+  <RouteView
+    :params="{
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+      zoneIngress: '',
+      connection: '',
+    }"
+    :name="props.routeName"
+    v-slot="{ route, uri }"
+  >
+    <RouteTitle
+      :render="false"
+      :title="`Stats`"
+    />
+    <AppView>
+      <DataLoader
+        :src="uri(sources, '/connections/stats/for/zone-ingress/:name/:socketAddress', {
+          name: route.params.zoneIngress,
+          socketAddress: props.networking.inboundAddress,
+        })"
+        v-slot="{ data: stats, refresh }"
+      >
+        <DataCollection
+          :items="stats!.raw.split('\n')"
+          :predicate="item => [
+            `listener.${route.params.connection}`,
+          ].some(prefix => item.startsWith(prefix))"
+          v-slot="{ items: lines }"
+        >
+          <XCodeBlock
+            language="json"
+            :code="lines.map(item => item.replace(`${route.params.connection}.`, '').replace(`${props.data.name}.`, '')).join('\n')"
+            is-searchable
+            :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter"
+            :is-reg-exp-mode="route.params.codeRegExp"
+            @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          >
+            <template #primary-actions>
+              <XAction
+                action="refresh"
+                appearance="primary"
+                @click="refresh"
+              >
+                Refresh
+              </XAction>
+            </template>
+          </XCodeBlock>
+        </DataCollection>
+      </DataLoader>
+    </AppView>
+  </RouteView>
+</template>
+<script lang="ts" setup>
+import { sources } from '@/app/connections/sources'
+import type { DataplaneInbound, DataplaneNetworking } from '@/app/data-planes/data/'
+
+const props = defineProps<{
+  data: DataplaneInbound
+  networking: DataplaneNetworking
+  routeName: string
+}>()
+</script>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryStatsView.vue
@@ -16,9 +16,10 @@
     />
     <AppView>
       <DataLoader
-        :src="uri(sources, '/connections/stats/for/zone-ingress/:name/:socketAddress', {
+        :src="uri(sources, '/connections/stats/for/:proxyType/:name/:socketAddress', {
           name: route.params.zoneIngress,
           socketAddress: props.networking.inboundAddress,
+          proxyType: 'zone-ingress',
         })"
         v-slot="{ data: stats, refresh }"
       >

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryView.vue
@@ -1,0 +1,65 @@
+<template>
+  <RouteView
+    :name="props.routeName"
+    :params="{
+      connection: '',
+      inactive: false,
+    }"
+    v-slot="{ route, t }"
+  >
+    <DataCollection
+      :items="props.data"
+      :predicate="item => `${item.socketAddress.replace(':', '_')}` === route.params.connection"
+      :find="true"
+      v-slot="{ items }"
+    >
+      <AppView>
+        <template #title>
+          <h2>
+            Inbound :{{ route.params.connection.split('_').at(-1) }}
+          </h2>
+        </template>
+
+        <XTabs
+          :selected="route.child()?.name"
+        >
+          <template
+            v-for="{ name } in route.children"
+            :key="name"
+            #[`${name}-tab`]
+          >
+            <XAction
+              :to="{
+                name,
+                query: {
+                  inactive: route.params.inactive,
+                },
+              }"
+            >
+              {{ t(`connections.routes.item.navigation.${name.split('-')[5]}`) }}
+            </XAction>
+          </template>
+        </XTabs>
+
+        <RouterView v-slot="child">
+          <component
+            :is="child.Component"
+            :data="items[0]"
+            :networking="props.networking"
+          />
+        </RouterView>
+      </AppView>
+    </DataCollection>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import type { DataplaneNetworking } from '@/app/data-planes/data/'
+import type { ZoneIngress } from '@/app/zone-ingresses/data/'
+
+const props = defineProps<{
+  data: ZoneIngress[]
+  networking: DataplaneNetworking
+  routeName: string
+}>()
+</script>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryXdsConfigView.vue
@@ -16,9 +16,10 @@
     />
     <AppView>
       <DataLoader
-        :src="uri(sources, '/connections/xds/for/zone-ingress/:name/inbound/:inbound', {
+        :src="uri(sources, '/connections/xds/for/:proxyType/:name/inbound/:inbound', {
           name: route.params.zoneIngress,
           inbound: `${props.data.networking?.port}`,
+          proxyType: 'zone-ingress',
         })"
         v-slot="{ data: raw, refresh }"
       >

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionInboundSummaryXdsConfigView.vue
@@ -1,0 +1,58 @@
+<template>
+  <RouteView
+    :params="{
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+      zoneIngress: '',
+      connection: '',
+    }"
+    :name="props.routeName"
+    v-slot="{ t, route, uri }"
+  >
+    <RouteTitle
+      :render="false"
+      :title="t('connections.routes.item.navigation.xds')"
+    />
+    <AppView>
+      <DataLoader
+        :src="uri(sources, '/connections/xds/for/zone-ingress/:name/inbound/:inbound', {
+          name: route.params.zoneIngress,
+          inbound: `${props.data.networking?.port}`,
+        })"
+        v-slot="{ data: raw, refresh }"
+      >
+        <XCodeBlock
+          language="json"
+          :code="JSON.stringify(raw, null, 2)"
+          is-searchable
+          :query="route.params.codeSearch"
+          :is-filter-mode="route.params.codeFilter"
+          :is-reg-exp-mode="route.params.codeRegExp"
+          @query-change="route.update({ codeSearch: $event })"
+          @filter-mode-change="route.update({ codeFilter: $event })"
+          @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+        >
+          <template #primary-actions>
+            <XAction
+              action="refresh"
+              appearance="primary"
+              @click="refresh"
+            >
+              {{ t('common.refresh') }}
+            </XAction>
+          </template>
+        </XCodeBlock>
+      </DataLoader>
+    </AppView>
+  </RouteView>
+</template>
+<script lang="ts" setup>
+import { sources } from '@/app/connections/sources'
+import type { ZoneIngress } from '@/app/zone-ingresses/data/'
+
+const props = defineProps<{
+  data: ZoneIngress
+  routeName: string
+}>()
+</script>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionOutboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionOutboundSummaryClustersView.vue
@@ -1,0 +1,65 @@
+<template>
+  <RouteView
+    :params="{
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+      zoneIngress: '',
+      connection: '',
+    }"
+    :name="props.routeName"
+    v-slot="{ route, uri }"
+  >
+    <RouteTitle
+      :render="false"
+      :title="`Clusters`"
+    />
+    <AppView>
+      <DataLoader
+        :src="uri(sources, '/connections/clusters/for/zone-ingress/:name', {
+          name: route.params.zoneIngress,
+        })"
+        v-slot="{ data, refresh }"
+      >
+        <template
+          v-for="prefix in [route.params.connection]"
+          :key="typeof prefix"
+        >
+          <DataCollection
+            :items="data.split('\n')"
+            :predicate="item => item.startsWith(`${prefix}::`)"
+            v-slot="{ items: lines }"
+          >
+            <XCodeBlock
+              language="json"
+              :code="lines.map(item => item.replace(`${prefix}::`, '')).join('\n')"
+              is-searchable
+              :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter"
+              :is-reg-exp-mode="route.params.codeRegExp"
+              @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            >
+              <template #primary-actions>
+                <XAction
+                  action="refresh"
+                  appearance="primary"
+                  @click="refresh"
+                >
+                  Refresh
+                </XAction>
+              </template>
+            </XCodeBlock>
+          </DataCollection>
+        </template>
+      </DataLoader>
+    </AppView>
+  </RouteView>
+</template>
+<script lang="ts" setup>
+import { sources } from '@/app/connections/sources'
+const props = defineProps<{
+  routeName: string
+}>()
+</script>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionOutboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionOutboundSummaryClustersView.vue
@@ -16,8 +16,9 @@
     />
     <AppView>
       <DataLoader
-        :src="uri(sources, '/connections/clusters/for/zone-ingress/:name', {
+        :src="uri(sources, '/connections/clusters/for/:proxyType/:name', {
           name: route.params.zoneIngress,
+          proxyType: 'zone-ingress',
         })"
         v-slot="{ data, refresh }"
       >

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionOutboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionOutboundSummaryStatsView.vue
@@ -1,0 +1,64 @@
+<template>
+  <RouteView
+    :params="{
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+      zoneIngress: '',
+      connection: '',
+    }"
+    :name="props.routeName"
+    v-slot="{ route, uri }"
+  >
+    <RouteTitle
+      :render="false"
+      :title="`Stats`"
+    />
+    <AppView>
+      <DataLoader
+        :src="uri(sources, '/connections/stats/for/zone-ingress/:name/:socketAddress', {
+          name: route.params.zoneIngress,
+          socketAddress: props.networking.inboundAddress,
+        })"
+
+        v-slot="{ data, refresh }"
+      >
+        <DataCollection
+          :items="data!.raw.split('\n')"
+          :predicate="item => item.includes(`.${route.params.connection}.`)"
+          v-slot="{ items: lines }"
+        >
+          <XCodeBlock
+            language="json"
+            :code="lines.map((item) => item.replace(`${route.params.connection}.`, '')).join('\n')"
+            is-searchable
+            :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter"
+            :is-reg-exp-mode="route.params.codeRegExp"
+            @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          >
+            <template #primary-actions>
+              <XAction
+                action="refresh"
+                appearance="primary"
+                @click="refresh"
+              >
+                Refresh
+              </XAction>
+            </template>
+          </XCodeBlock>
+        </DataCollection>
+      </DataLoader>
+    </AppView>
+  </RouteView>
+</template>
+<script lang="ts" setup>
+import { sources } from '@/app/connections/sources'
+import type { DataplaneNetworking } from '@/app/data-planes/data/'
+const props = defineProps<{
+  networking: DataplaneNetworking
+  routeName: string
+}>()
+</script>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionOutboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionOutboundSummaryView.vue
@@ -1,0 +1,63 @@
+<template>
+  <RouteView
+    :name="props.routeName"
+    :params="{
+      connection: '',
+      inactive: false,
+    }"
+    v-slot="{ route, t }"
+  >
+    <AppView>
+      <template #title>
+        <h2>
+          Outbound {{ route.params.connection }}
+        </h2>
+      </template>
+
+      <XTabs :selected="route.child()?.name">
+        <template
+          v-for="item in route.children"
+          :key="`${item.name}`"
+          #[`${item.name}-tab`]
+        >
+          <XAction
+            :to="{
+              name: item.name,
+              query: {
+                inactive: route.params.inactive,
+              },
+
+            }"
+          >
+            {{ t(`connections.routes.item.navigation.${item.name.split('-')[5]}`) }}
+          </XAction>
+        </template>
+      </XTabs>
+      <RouterView
+        v-slot="{ Component }"
+      >
+        <DataCollection
+          :items="Object.entries(props.data)"
+          :predicate="([key, _value]) => key === route.params.connection"
+          :find="true"
+          v-slot="{ items }"
+        >
+          <component
+            :is="Component"
+            :data="items[0][1]"
+            :networking="props.networking"
+          />
+        </DataCollection>
+      </RouterView>
+    </AppView>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import type { DataplaneNetworking } from '@/app/data-planes/data/'
+const props = defineProps<{
+  data: Record<string, any>
+  networking: DataplaneNetworking
+  routeName: string
+}>()
+</script>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionOutboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ConnectionOutboundSummaryXdsConfigView.vue
@@ -1,0 +1,62 @@
+<template>
+  <RouteView
+    :params="{
+      codeSearch: '',
+      codeFilter: false,
+      codeRegExp: false,
+      zoneIngress: '',
+      connection: '',
+      includeEds: false,
+    }"
+    :name="props.routeName"
+    v-slot="{ t, route, uri }"
+  >
+    <RouteTitle
+      :render="false"
+      :title="t('connections.routes.item.navigation.xds')"
+    />
+    <AppView>
+      <DataLoader
+        :src="uri(sources, '/connections/xds/for/zone-ingress/:name/outbound/:outbound/endpoints/:endpoints', {
+          name: route.params.zoneIngress,
+          outbound: route.params.connection,
+          endpoints: String(route.params.includeEds),
+        })"
+        v-slot="{ data: raw, refresh }"
+      >
+        <XCodeBlock
+          language="json"
+          :code="JSON.stringify(raw, null, 2)"
+          is-searchable
+          :query="route.params.codeSearch"
+          :is-filter-mode="route.params.codeFilter"
+          :is-reg-exp-mode="route.params.codeRegExp"
+          @query-change="route.update({ codeSearch: $event })"
+          @filter-mode-change="route.update({ codeFilter: $event })"
+          @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+        >
+          <template #primary-actions>
+            <XCheckbox
+              :checked="route.params.includeEds"
+              :label="t('connections.include_endpoints')"
+              @change="(value) => route.update({ includeEds: value})"
+            />
+            <XAction
+              action="refresh"
+              appearance="primary"
+              @click="refresh"
+            >
+              {{ t('common.refresh') }}
+            </XAction>
+          </template>
+        </XCodeBlock>
+      </DataLoader>
+    </AppView>
+  </RouteView>
+</template>
+<script lang="ts" setup>
+import { sources } from '@/app/connections/sources'
+const props = defineProps<{
+  routeName: string
+}>()
+</script>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -86,9 +86,10 @@
         </DefinitionCard>
       </XAboutCard>
       <DataLoader
-        :src="uri(sources, '/connections/stats/for/zone-ingress/:name/:socketAddress', {
+        :src="uri(sources, '/connections/stats/for/:proxyType/:name/:socketAddress', {
           name: route.params.zoneIngress,
           socketAddress: props.data.zoneIngress.socketAddress,
+          proxyType: 'zone-ingress',
         })"
         v-slot="{ data: traffic, refresh }"
       >
@@ -333,7 +334,7 @@ const props = defineProps<{
 const _route = useRoute()
 </script>
 <style lang="scss" scoped>
-.service-traffic-group:not(.type-passthrough) .service-traffic-card {
+.service-traffic-card {
   cursor: pointer;
 }
 </style>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -114,7 +114,20 @@
                       protocol=""
                       :traffic="stats"
                     >
-                      :{{ name.split('_').at(-1) }}
+                      <XAction
+                        data-action
+                        :to="{
+                          name: ((name) => name.includes('bound') ? name.replace('-outbound-', '-inbound-') : 'zone-ingress-connection-inbound-summary-stats-view')(String(_route.name)),
+                          params: {
+                            connection: name,
+                          },
+                          query: {
+                            inactive: route.params.inactive,
+                          },
+                        }"
+                      >
+                        :{{ name.split('_').at(-1) }}
+                      </XAction>
                     </ConnectionCard>
                   </template>
                 </DataCollection>
@@ -184,7 +197,20 @@
                               :traffic="outbound"
                               :direction="direction"
                             >
-                              {{ name }}
+                              <XAction
+                                data-action
+                                :to="{
+                                  name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'zone-ingress-connection-outbound-summary-stats-view')(String(_route.name)),
+                                  params: {
+                                    connection: name,
+                                  },
+                                  query: {
+                                    inactive: route.params.inactive,
+                                  },
+                                }"
+                              >
+                                {{ name }}
+                              </XAction>
                             </ConnectionCard>
                           </template>
                         </XLayout>
@@ -196,6 +222,32 @@
             </ConnectionTraffic>
           </XLayout>
         </XCard>
+
+        <RouterView
+          v-slot="child"
+        >
+          <SummaryView
+            v-if="child.route.name !== route.name"
+            width="670px"
+            @close="function () {
+              route.replace({
+                name: 'zone-ingress-detail-view',
+                params: {
+                  zoneIngress: route.params.zoneIngress,
+                },
+                query: {
+                  inactive: route.params.inactive ? null : undefined,
+                },
+              })
+            }"
+          >
+            <component
+              :is="child.Component"
+              :data="route.params.subscription.length > 0 ? props.data.zoneIngressInsight.subscriptions : (child.route.name as string).includes('-inbound-') ? [props.data.zoneIngress] : traffic?.outbounds || {}"
+              :networking="props.data.zoneIngress.networking"
+            />
+          </SummaryView>
+        </RouterView>
       </DataLoader>
 
       <div
@@ -258,27 +310,6 @@
             </template>
           </template>
         </AppCollection>
-        <RouterView
-          v-slot="{ Component }"
-        >
-          <SummaryView
-            v-if="route.child()"
-            width="670px"
-            @close="function () {
-              route.replace({
-                name: 'zone-ingress-detail-view',
-                params: {
-                  zoneIngress: route.params.zoneIngress,
-                },
-              })
-            }"
-          >
-            <component
-              :is="Component"
-              :data="props.data.zoneIngressInsight.subscriptions"
-            />
-          </SummaryView>
-        </RouterView>
       </div>
     </AppView>
   </RouteView>
@@ -294,8 +325,15 @@ import ConnectionCard from '@/app/connections/components/connection-traffic/Conn
 import ConnectionGroup from '@/app/connections/components/connection-traffic/ConnectionGroup.vue'
 import ConnectionTraffic from '@/app/connections/components/connection-traffic/ConnectionTraffic.vue'
 import { sources } from '@/app/connections/sources'
+import { useRoute } from '@/app/vue'
 
 const props = defineProps<{
   data: ZoneIngressOverview
 }>()
+const _route = useRoute()
 </script>
+<style lang="scss" scoped>
+.service-traffic-group:not(.type-passthrough) .service-traffic-card {
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
Whilst there looks like there is a lot going on here, its mainly copy/pasted from the similar view over in Dataplanes and most of the code here was pre-existing.

---

This PR replicates the Dataplane Traffic drawers from over in the dataplanes section into both ZoneIngress and ZoneEgress.

I began by trying to make the code used for Dataplanes more reusable so I coulduse it for both ZoneIngress and ZoneEgress. I found that for several reasons this was overly complicated to do and would have required quite a lot of change within Dataplanes also.

For instance:

- explicitly named route params such as `params.dataPlane`, `params.zoneIngress` and `params.zoneEgress`
- explicitly named route props such as `props.zoneIngress` and `props.zoneEgress`
- explicitly named source URIs `zone-ingress`/`zone-egress` (this one was relatively easy to address and is addressed in this PR)
- Dataplane Proxy URIs require a `mesh` specifying whereas Zone Proxy URIs don't
- ...probably more edge cases

Therefore I chose to mostly copy/paste over the approach from Dataplanes to ZoneIngress, and then again to ZoneEgress (ZoneIngress and ZoneEgress modules are mostly copy pasted anyway).

I plan to make some follow up PRs to reduce the repetition here.

I'll try and add some inlines, but please ask questions if anything isn't clear.


