### PR TITLE
chore(dataplanes): change all refs of route.dataPlane > route.proxy

### DIFF
--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
@@ -5,7 +5,7 @@
       codeFilter: false,
       codeRegExp: false,
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       connection: '',
     }"
     :name="props.routeName"
@@ -19,7 +19,7 @@
       <DataLoader
         :src="uri(sources, '/meshes/:mesh/dataplanes/:name/clusters', {
           mesh: route.params.mesh,
-          name: route.params.dataPlane,
+          name: route.params.proxy,
         })"
         v-slot="{ data , refresh }"
       >

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
@@ -5,7 +5,7 @@
       codeFilter: false,
       codeRegExp: false,
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       connection: '',
     }"
     :name="props.routeName"
@@ -19,7 +19,7 @@
       <DataLoader
         :src="uri(sources, '/meshes/:mesh/dataplanes/:name/stats/:address', {
           mesh: route.params.mesh,
-          name: route.params.dataPlane,
+          name: route.params.proxy,
           address: props.networking.inboundAddress,
         })"
         v-slot="{ data: stats, refresh }"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
@@ -5,7 +5,7 @@
       codeFilter: false,
       codeRegExp: false,
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       connection: '',
     }"
     :name="props.routeName"
@@ -19,7 +19,7 @@
       <DataLoader
         :src="uri(sources, '/meshes/:mesh/dataplanes/:dataplane/inbound/:inbound/xds', {
           mesh: route.params.mesh,
-          dataplane: route.params.dataPlane,
+          dataplane: route.params.proxy,
           inbound: `${props.data.port}`,
         })"
         v-slot="{ data: raw, refresh }"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
@@ -5,7 +5,7 @@
       codeFilter: false,
       codeRegExp: false,
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       connection: '',
     }"
     :name="props.routeName"
@@ -19,7 +19,7 @@
       <DataLoader
         :src="uri(sources, '/meshes/:mesh/dataplanes/:name/clusters', {
           mesh: route.params.mesh,
-          name: route.params.dataPlane,
+          name: route.params.proxy,
         })"
         v-slot="{ data, refresh }"
       >

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
@@ -5,7 +5,7 @@
       codeFilter: false,
       codeRegExp: false,
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       connection: '',
     }"
     :name="props.routeName"
@@ -19,7 +19,7 @@
       <DataLoader
         :src="uri(sources, '/meshes/:mesh/dataplanes/:name/stats/:address', {
           mesh: route.params.mesh,
-          name: route.params.dataPlane,
+          name: route.params.proxy,
           address: props.networking.inboundAddress,
         })"
 

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryXdsConfigView.vue
@@ -5,7 +5,7 @@
       codeFilter: false,
       codeRegExp: false,
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       connection: '',
       includeEds: false,
     }"
@@ -20,7 +20,7 @@
       <DataLoader
         :src="uri(sources, '/meshes/:mesh/dataplanes/:dataplane/outbound/:outbound/xds/:endpoints', {
           mesh: route.params.mesh,
-          dataplane: route.params.dataPlane,
+          dataplane: route.params.proxy,
           outbound: route.params.connection,
           endpoints: String(route.params.includeEds),
         })"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsClustersView.vue
@@ -3,7 +3,7 @@
     :name="props.routeName"
     :params="{
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
@@ -19,7 +19,7 @@
         <DataLoader
           :src="uri(sources, '/meshes/:mesh/dataplanes/:name/clusters', {
             mesh: route.params.mesh,
-            name: route.params.dataPlane,
+            name: route.params.proxy,
           })"
           v-slot="{ data, refresh }"
         >

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsStatsView.vue
@@ -3,7 +3,7 @@
     :name="props.routeName"
     :params="{
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
@@ -19,7 +19,7 @@
         <DataLoader
           :src="uri(sources, '/meshes/:mesh/dataplanes/:name/stats/:address', {
             mesh: route.params.mesh,
-            name: route.params.dataPlane,
+            name: route.params.proxy,
             address: props.networking.inboundAddress,
           })"
           v-slot="{ data: statsData, refresh }"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
@@ -3,7 +3,7 @@
     :name="props.routeName"
     :params="{
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
@@ -20,7 +20,7 @@
         <DataLoader
           :src="uri(sources, '/meshes/:mesh/dataplanes/:name/xds/:endpoints', {
             mesh: route.params.mesh,
-            name: route.params.dataPlane,
+            name: route.params.proxy,
             endpoints: String(route.params.includeEds),
           })"
           v-slot="{ data, refresh }"

--- a/packages/kuma-gui/src/app/data-planes/routes.ts
+++ b/packages/kuma-gui/src/app/data-planes/routes.ts
@@ -6,7 +6,7 @@ export const routes = () => {
   const item = (): RouteRecordRaw[] => {
     return [
       {
-        path: 'data-planes/:dataPlane',
+        path: 'data-planes/:proxy',
         name: 'data-plane-detail-tabs-view',
         component: () => import('@/app/data-planes/views/DataPlaneDetailTabsView.vue'),
         children: [
@@ -67,7 +67,7 @@ export const routes = () => {
 
     return [
       {
-        path: ':dataPlane',
+        path: ':proxy',
         name: `${fullPrefix}data-plane-summary-view`,
         component: () => import('@/app/data-planes/views/DataPlaneSummaryView.vue'),
       },

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneConfigView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneConfigView.vue
@@ -3,7 +3,7 @@
     name="data-plane-config-view"
     :params="{
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
@@ -19,7 +19,7 @@
         <DataLoader
           :src="uri(sources, `/meshes/:mesh/dataplanes/:name`, {
             mesh: route.params.mesh,
-            name: route.params.dataPlane,
+            name: route.params.proxy,
           })"
           v-slot="{ data }"
         >
@@ -38,7 +38,7 @@
               v-if="copying"
               :src="uri(sources, `/meshes/:mesh/dataplanes/:name/as/kubernetes`, {
                 mesh: route.params.mesh,
-                name: route.params.dataPlane,
+                name: route.params.proxy,
               }, {
                 cacheControl: 'no-store',
               })"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -3,14 +3,14 @@
     name="data-plane-detail-tabs-view"
     :params="{
       mesh: '',
-      dataPlane: '',
+      proxy: '',
     }"
     v-slot="{ route, t, uri }"
   >
     <DataSource
       :src="uri(sources, '/meshes/:mesh/dataplane-overviews/:name', {
         mesh: route.params.mesh,
-        name: route.params.dataPlane,
+        name: route.params.proxy,
       })"
       v-slot="{ data, error }"
     >
@@ -130,7 +130,7 @@
                             variant="spinner"
                             :src="downloading ? uri(sources, '/meshes/:mesh/dataplanes/:name/as/tarball/:spec', {
                               mesh: route.params.mesh,
-                              name: route.params.dataPlane,
+                              name: route.params.proxy,
                               spec: JSON.stringify(
                                 specs,
                               ),

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -2,7 +2,7 @@
   <RouteView
     :params="{
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       subscription: '',
       inactive: false,
     }"
@@ -12,7 +12,7 @@
     <DataSource
       :src="uri(sources, '/meshes/:mesh/dataplanes/:name/stats/:address', {
         mesh: route.params.mesh,
-        name: route.params.dataPlane,
+        name: route.params.proxy,
         address: props.data.dataplane.networking.inboundAddress,
       })"
       v-slot="{ data: traffic, error, refresh }"
@@ -410,7 +410,7 @@
                   name: 'data-plane-detail-view',
                   params: {
                     mesh: route.params.mesh,
-                    dataPlane: route.params.dataPlane,
+                    proxy: route.params.proxy,
                   },
                   query: {
                     inactive: route.params.inactive ? null : undefined,

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -2,7 +2,7 @@
   <RouteView
     :params="{
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       connection: '',
     }"
     :name="props.routeName"
@@ -100,7 +100,7 @@
         <DataLoader
           :src="uri(sources, '/meshes/:mesh/rules/for/:dataplane', {
             mesh: route.params.mesh,
-            dataplane: route.params.dataPlane,
+            dataplane: route.params.proxy,
           })"
           v-slot="{ data: rulesData }"
         >

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -7,7 +7,7 @@
       dataplaneType: 'all',
       s: '',
       mesh: '',
-      dataPlane: '',
+      proxy: '',
     }"
     v-slot="{ can, route, t, me, uri }"
   >
@@ -102,7 +102,7 @@
                   { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                 ]"
                 :items="data?.items"
-                :is-selected-row="(row) => row.name === route.params.dataPlane"
+                :is-selected-row="(row) => row.name === route.params.proxy"
                 @resize="me.set"
               >
                 <template #type="{ row: item }">
@@ -120,7 +120,7 @@
                       name: 'data-plane-summary-view',
                       params: {
                         mesh: item.mesh,
-                        dataPlane: item.id,
+                        proxy: item.id,
                       },
                       query: {
                         page: route.params.page,
@@ -247,7 +247,7 @@
                       :to="{
                         name: 'data-plane-detail-view',
                         params: {
-                          dataPlane: item.id,
+                          proxy: item.id,
                         },
                       }"
                     >

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
@@ -2,7 +2,7 @@
   <RouteView
     :params="{
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       connection: '',
     }"
     :name="props.routeName"
@@ -48,7 +48,7 @@
                 <DataLoader
                   :src="uri(sources, `/meshes/:mesh/rules/for/:dataplane`, {
                     mesh: route.params.mesh,
-                    dataplane: route.params.dataPlane,
+                    dataplane: route.params.proxy,
                   })"
                   v-slot="{ data: rulesData }"
                 >

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -3,7 +3,7 @@
     name="data-plane-policies-view"
     :params="{
       mesh: '',
-      dataPlane: '',
+      proxy: '',
     }"
     v-slot="{ can, route, t, uri }"
   >
@@ -27,7 +27,7 @@
             <DataLoader
               :src="uri(sources, '/meshes/:mesh/rules/for/:dataplane', {
                 mesh: route.params.mesh,
-                dataplane: route.params.dataPlane,
+                dataplane: route.params.proxy,
               })"
               :data="[policyTypesData]"
               :errors="[policyTypesError]"
@@ -105,7 +105,7 @@
                 <!-- builtin gateways have different data/visuals than other types of dataplanes -->
                 <template v-if="props.data.dataplaneType === 'builtin'">
                   <DataLoader
-                    :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/gateway-dataplane-policies`"
+                    :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.proxy}/gateway-dataplane-policies`"
                     :data="[policyTypesData]"
                     :errors="[policyTypesError]"
                     v-slot="{ data: gatewayDataplane }: MeshGatewayDataplaneSource"
@@ -134,7 +134,7 @@
                 <!-- anything but builtin gateways -->
                 <template v-else>
                   <DataLoader
-                    :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.dataPlane}/sidecar-dataplane-policies`"
+                    :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.proxy}/sidecar-dataplane-policies`"
                     :data="[policyTypesData]"
                     :errors="[policyTypesError]"
                     v-slot="{ data: sidecarDataplaneData }: SidecarDataplaneCollectionSource"
@@ -174,7 +174,7 @@
             name: 'data-plane-policies-view',
             params: {
               mesh: route.params.mesh,
-              dataPlane: route.params.dataPlane,
+              proxy: route.params.proxy,
             },
           })"
         >

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -3,7 +3,7 @@
     :name="props.routeName"
     :params="{
       mesh: '',
-      dataPlane: '',
+      proxy: '',
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
@@ -13,7 +13,7 @@
   >
     <DataCollection
       :items="props.items"
-      :predicate="item => item.id === route.params.dataPlane"
+      :predicate="item => item.id === route.params.proxy"
     >
       <template #empty>
         <XEmptyState>
@@ -43,7 +43,7 @@
                   :to="{
                     name: 'data-plane-detail-view',
                     params: {
-                      dataPlane: item.id,
+                      proxy: item.id,
                     },
                   }"
                 >
@@ -256,7 +256,7 @@
                     v-if="copying"
                     :src="uri(sources, `/meshes/:mesh/dataplanes/:name/as/kubernetes`, {
                       mesh: route.params.mesh,
-                      name: route.params.dataPlane,
+                      name: route.params.proxy,
                     }, {
                       cacheControl: 'no-store',
                     })"

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -8,7 +8,7 @@
       page: 1,
       size: Number,
       s: '',
-      dataPlane: '',
+      proxy: '',
     }"
     v-slot="{ can, route, t, me }"
   >
@@ -67,7 +67,7 @@
                       { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                     ]"
                     :items="dataplanesData?.items"
-                    :is-selected-row="(row) => row.name === route.params.dataPlane"
+                    :is-selected-row="(row) => row.name === route.params.proxy"
                     @resize="me.set"
                   >
                     <template #namespace="{ row }">
@@ -83,7 +83,7 @@
                           name: 'builtin-gateway-data-plane-summary-view',
                           params: {
                             mesh: row.mesh,
-                            dataPlane: row.id,
+                            proxy: row.id,
                           },
                           query: {
                             page: route.params.page,
@@ -156,7 +156,7 @@
                           :to="{
                             name: 'data-plane-detail-view',
                             params: {
-                              dataPlane: item.id,
+                              proxy: item.id,
                             },
                           }"
                         >
@@ -166,7 +166,7 @@
                     </template>
                   </AppCollection>
                   <RouterView
-                    v-if="route.params.dataPlane"
+                    v-if="route.params.proxy"
                     v-slot="child"
                   >
                     <SummaryView

--- a/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -7,7 +7,7 @@
       page: 1,
       size: Number,
       s: '',
-      dataPlane: '',
+      proxy: '',
     }"
     v-slot="{ can, route, t, me }"
   >
@@ -113,7 +113,7 @@
                       { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                     ]"
                     :items="dataplanesData?.items"
-                    :is-selected-row="(row) => row.name === route.params.dataPlane"
+                    :is-selected-row="(row) => row.name === route.params.proxy"
                     @resize="me.set"
                   >
                     <template #name="{ row: item }">
@@ -124,7 +124,7 @@
                           name: 'delegated-gateway-data-plane-summary-view',
                           params: {
                             mesh: item.mesh,
-                            dataPlane: item.id,
+                            proxy: item.id,
                           },
                           query: {
                             page: route.params.page,
@@ -201,7 +201,7 @@
                           :to="{
                             name: 'data-plane-detail-view',
                             params: {
-                              dataPlane: item.id,
+                              proxy: item.id,
                             },
                           }"
                         >
@@ -211,7 +211,7 @@
                     </template>
                   </AppCollection>
                   <RouterView
-                    v-if="route.params.dataPlane"
+                    v-if="route.params.proxy"
                     v-slot="child"
                   >
                     <SummaryView

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
@@ -8,7 +8,7 @@
       mesh: '',
       policy: '',
       policyPath: '',
-      dataPlane: '',
+      proxy: '',
     }"
     v-slot="{ route, t, uri, can, me }"
   >
@@ -135,7 +135,7 @@
                     { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                   ]"
                   :items="dataplanes?.items"
-                  :is-selected-row="(row) => row.id === route.params.dataPlane"
+                  :is-selected-row="(row) => row.id === route.params.proxy"
                   @resize="me.set"
                 >
                   <template #name="{ row: item }">
@@ -144,7 +144,7 @@
                       :to="{
                         name: 'data-plane-detail-view',
                         params: {
-                          dataPlane: item.id,
+                          proxy: item.id,
                         },
                       }"
                     >
@@ -180,7 +180,7 @@
                         :to="{
                           name: 'data-plane-detail-view',
                           params: {
-                            dataPlane: item.id,
+                            proxy: item.id,
                           },
                         }"
                       >

--- a/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
@@ -7,7 +7,7 @@
       page: 1,
       size: Number,
       s: '',
-      dataPlane: '',
+      proxy: '',
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
@@ -184,7 +184,7 @@
                       { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                     ]"
                     :items="dataplanes?.items"
-                    :is-selected-row="(row) => row.name === route.params.dataPlane"
+                    :is-selected-row="(row) => row.name === route.params.proxy"
                     @resize="me.set"
                   >
                     <template #name="{ row: item }">
@@ -194,7 +194,7 @@
                           name: 'mesh-service-data-plane-summary-view',
                           params: {
                             mesh: item.mesh,
-                            dataPlane: item.id,
+                            proxy: item.id,
                           },
                           query: {
                             page: route.params.page,
@@ -272,7 +272,7 @@
                           :to="{
                             name: 'data-plane-detail-view',
                             params: {
-                              dataPlane: item.id,
+                              proxy: item.id,
                             },
                           }"
                         >
@@ -282,7 +282,7 @@
                     </template>
                   </AppCollection>
                   <RouterView
-                    v-if="route.params.dataPlane"
+                    v-if="route.params.proxy"
                     v-slot="child"
                   >
                     <SummaryView

--- a/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
@@ -7,7 +7,7 @@
       page: 1,
       size: Number,
       s: '',
-      dataPlane: '',
+      proxy: '',
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
@@ -130,7 +130,7 @@
                       { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
                     ]"
                     :items="data?.items"
-                    :is-selected-row="(row) => row.name === route.params.dataPlane"
+                    :is-selected-row="(row) => row.name === route.params.proxy"
                     @resize="me.set"
                   >
                     <template #name="{ row: item }">
@@ -141,7 +141,7 @@
                           name: 'service-data-plane-summary-view',
                           params: {
                             mesh: item.mesh,
-                            dataPlane: item.id,
+                            proxy: item.id,
                           },
                           query: {
                             page: route.params.page,
@@ -218,7 +218,7 @@
                           :to="{
                             name: 'data-plane-detail-view',
                             params: {
-                              dataPlane: item.id,
+                              proxy: item.id,
                             },
                           }"
                         >


### PR DESCRIPTION
Ideally we want to reuse some views used in dataplanes with some views used in zone-ingress/egrees (i.e. ZoneProxies). 

If we stand any chance of doing this without making some serious changes elsewhere, we need to make some more things similar.

This PR changes all instances of the `route.params.dataPlane` route parameter to instead use `route.params.proxy`. Back in https://github.com/kumahq/kuma-gui/pull/3509 we changed all the "zone proxy" views to also use the same name. At the end of the day Zone Proxies are just dataplanes i.e. they are essentially the same thing (an instance of Envoy).

I'm honestly not totally sure to what extent we'll be able to reuse still (edit: I found doing this is very helpful 😸 ), but at the very least this change gets rid of an awkward casing of `dataPlane`. `proxy` is better as its a single word and there is no chance of getting weird casing differences like `pRoXy`