### PR TITLE
feat: wrap nested route features in x-card

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -93,8 +93,6 @@ data-planes:
           title: Certificate issued by
         supported_backends:
           title: Supported CAs
-        disabled: !!text/markdown |
-          This Data Plane Proxy does not have mTLS configured, yet  — <a href="{KUMA_DOCS_URL}/policies/mutual-tls?{KUMA_UTM_QUERY_PARAMS}">Learn about certificates in {KUMA_PRODUCT_NAME}</a>
       subscriptions:
         title: XDS Connections
       rules:

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -428,8 +428,6 @@
           </RouterView>
 
           <div data-testid="dataplane-mtls">
-            <h2>{{ t('data-planes.routes.item.mtls.title') }}</h2>
-
             <template
               v-if="props.data.dataplaneInsight.mTLS"
             >
@@ -442,6 +440,10 @@
                 <XCard
                   class="mt-4"
                 >
+                  <template #title>
+                    {{ t('data-planes.routes.item.mtls.title') }}
+                  </template>
+
                   <div class="columns">
                     <DefinitionCard>
                       <template #title>
@@ -502,82 +504,74 @@
                 </XCard>
               </template>
             </template>
-
-            <template
-              v-else
-            >
-              <XAlert
-                class="mt-4"
-                variant="warning"
-              >
-                <XI18n
-                  path="data-planes.routes.item.mtls.disabled"
-                />
-              </XAlert>
-            </template>
           </div>
 
           <div
             v-if="props.data.dataplaneInsight.subscriptions.length > 0"
             data-testid="dataplane-subscriptions"
           >
-            <h2>{{ t('data-planes.routes.item.subscriptions.title') }}</h2>
-            <AppCollection
-              :headers="[
-                { ...me.get('headers.instanceId'), label: t('http.api.property.instanceId'), key: 'instanceId' },
-                { ...me.get('headers.version'), label: t('http.api.property.version'), key: 'version' },
-                { ...me.get('headers.connected'), label: t('http.api.property.connected'), key: 'connected' },
-                { ...me.get('headers.disconnected'), label: t('http.api.property.disconnected'), key: 'disconnected' },
-                { ...me.get('headers.responses'), label: t('http.api.property.responses'), key: 'responses' },
-              ]"
-              :is-selected-row="item => item.id === route.params.subscription"
-              :items="props.data.dataplaneInsight.subscriptions.map((_, i, arr) => arr[arr.length - (i + 1)])"
-              @resize="me.set"
-            >
-              <template
-                #instanceId="{ row: item }"
-              >
-                <XAction
-                  data-action
-                  :to="{
-                    name: 'data-plane-subscription-summary-view',
-                    params: {
-                      subscription: item.id,
-                    },
-                  }"
-                >
-                  {{ item.controlPlaneInstanceId }}
-                </XAction>
+            <XCard>
+              <template #title>
+                {{ t('data-planes.routes.item.subscriptions.title') }}
               </template>
-              <template
-                #version="{ row: item }"
-              >
-                {{ item.version?.kumaDp?.version ?? '-' }}
-              </template>
-              <template
-                #connected="{ row: item }"
-              >
-                {{ t('common.formats.datetime', { value: Date.parse(item.connectTime ?? '') }) }}
-              </template>
-              <template
-                #disconnected="{ row: item }"
+              
+              <AppCollection
+                :headers="[
+                  { ...me.get('headers.instanceId'), label: t('http.api.property.instanceId'), key: 'instanceId' },
+                  { ...me.get('headers.version'), label: t('http.api.property.version'), key: 'version' },
+                  { ...me.get('headers.connected'), label: t('http.api.property.connected'), key: 'connected' },
+                  { ...me.get('headers.disconnected'), label: t('http.api.property.disconnected'), key: 'disconnected' },
+                  { ...me.get('headers.responses'), label: t('http.api.property.responses'), key: 'responses' },
+                ]"
+                :is-selected-row="item => item.id === route.params.subscription"
+                :items="props.data.dataplaneInsight.subscriptions.map((_, i, arr) => arr[arr.length - (i + 1)])"
+                @resize="me.set"
               >
                 <template
-                  v-if="item.disconnectTime"
+                  #instanceId="{ row: item }"
                 >
-                  {{ t('common.formats.datetime', { value: Date.parse(item.disconnectTime) }) }}
+                  <XAction
+                    data-action
+                    :to="{
+                      name: 'data-plane-subscription-summary-view',
+                      params: {
+                        subscription: item.id,
+                      },
+                    }"
+                  >
+                    {{ item.controlPlaneInstanceId }}
+                  </XAction>
                 </template>
-              </template>
-              <template
-                #responses="{ row: item }"
-              >
                 <template
-                  v-for="responses in [item.status?.total ?? {}]"
+                  #version="{ row: item }"
                 >
-                  {{ responses.responsesSent }}/{{ responses.responsesAcknowledged }}
+                  {{ item.version?.kumaDp?.version ?? '-' }}
                 </template>
-              </template>
-            </AppCollection>
+                <template
+                  #connected="{ row: item }"
+                >
+                  {{ t('common.formats.datetime', { value: Date.parse(item.connectTime ?? '') }) }}
+                </template>
+                <template
+                  #disconnected="{ row: item }"
+                >
+                  <template
+                    v-if="item.disconnectTime"
+                  >
+                    {{ t('common.formats.datetime', { value: Date.parse(item.disconnectTime) }) }}
+                  </template>
+                </template>
+                <template
+                  #responses="{ row: item }"
+                >
+                  <template
+                    v-for="responses in [item.status?.total ?? {}]"
+                  >
+                    {{ responses.responsesSent }}/{{ responses.responsesAcknowledged }}
+                  </template>
+                </template>
+              </AppCollection>
+            </XCard>
           </div>
         </XLayout>
       </AppView>
@@ -608,7 +602,12 @@ const props = defineProps<{
   mesh: Mesh
 }>()
 
-const warnings = computed(() => props.data.warnings.concat(...(props.data.isCertExpired ? [{ kind: 'CERT_EXPIRED' }] : [])))
+const warnings = computed(() =>
+  props.data.warnings.concat(
+    ...(props.data.isCertExpired ? [{ kind: 'CERT_EXPIRED' }] : []),
+    ...(!props.data.dataplaneInsight.mTLS ? [{ kind: 'DPP_NO_MTLS' }] : []),
+  ),
+)
 </script>
 
 <style lang="scss" scoped>

--- a/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailView.vue
@@ -55,8 +55,10 @@
             </DefinitionCard>
           </XAboutCard>
 
-          <div>
-            <h3>{{ t('external-services.detail.config') }}</h3>
+          <XCard>
+            <template #title>
+              {{ t('external-services.detail.config') }}
+            </template>
 
             <ResourceCodeBlock
               class="mt-4"
@@ -87,7 +89,7 @@
                 }"
               />
             </ResourceCodeBlock>
-          </div>
+          </XCard>
         </DataLoader>
       </div>
     </AppView>

--- a/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -64,181 +64,181 @@
           </XAboutCard>
         </DataLoader>
 
-        <div>
-          <h3>{{ t('delegated-gateways.detail.data_plane_proxies') }}</h3>
+        <XCard
+          class="mt-4"
+        >
+          <template #title>
+            {{ t('delegated-gateways.detail.data_plane_proxies') }}
+          </template>
 
-          <XCard
-            class="mt-4"
+          <search>
+            <FilterBar
+              class="data-plane-proxy-filter"
+              :placeholder="`tag: 'kuma.io/protocol: http'`"
+              :query="route.params.s"
+              :fields="{
+                name: { description: 'filter by name or parts of a name' },
+                protocol: { description: 'filter by “kuma.io/protocol” value' },
+                tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+              }"
+              @change="(e) => route.update({
+                ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
+              })"
+            />
+          </search>
+          <DataLoader
+            :src="`/meshes/${route.params.mesh}/dataplanes/for/service-insight/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
           >
-            <search>
-              <FilterBar
-                class="data-plane-proxy-filter"
-                :placeholder="`tag: 'kuma.io/protocol: http'`"
-                :query="route.params.s"
-                :fields="{
-                  name: { description: 'filter by name or parts of a name' },
-                  protocol: { description: 'filter by “kuma.io/protocol” value' },
-                  tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                  ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                }"
-                @change="(e) => route.update({
-                  ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                })"
-              />
-            </search>
-            <DataLoader
-              :src="`/meshes/${route.params.mesh}/dataplanes/for/service-insight/${route.params.service}?page=${route.params.page}&size=${route.params.size}&search=${route.params.s}`"
+            <template
+              #loadable="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
             >
-              <template
-                #loadable="{ data: dataplanesData }: DataplaneOverviewCollectionSource"
+              <DataCollection
+                type="data-planes"
+                :items="dataplanesData?.items ?? [undefined]"
+                :page="route.params.page"
+                :page-size="route.params.size"
+                :total="dataplanesData?.total"
+                @change="route.update"
               >
-                <DataCollection
-                  type="data-planes"
-                  :items="dataplanesData?.items ?? [undefined]"
-                  :page="route.params.page"
-                  :page-size="route.params.size"
-                  :total="dataplanesData?.total"
-                  @change="route.update"
+                <AppCollection
+                  class="data-plane-collection"
+                  data-testid="data-plane-collection"
+                  :headers="[
+                    { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                    { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                    { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
+                    { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                    { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                    { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                  ]"
+                  :items="dataplanesData?.items"
+                  :is-selected-row="(row) => row.name === route.params.proxy"
+                  @resize="me.set"
                 >
-                  <AppCollection
-                    class="data-plane-collection"
-                    data-testid="data-plane-collection"
-                    :headers="[
-                      { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                      { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                      ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                      { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
-                      { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                      { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
-                      { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                    ]"
-                    :items="dataplanesData?.items"
-                    :is-selected-row="(row) => row.name === route.params.proxy"
-                    @resize="me.set"
-                  >
-                    <template #name="{ row: item }">
-                      <XAction
-                        data-action
-                        class="name-link"
-                        :to="{
-                          name: 'delegated-gateway-data-plane-summary-view',
-                          params: {
-                            mesh: item.mesh,
-                            proxy: item.id,
-                          },
-                          query: {
-                            page: route.params.page,
-                            size: route.params.size,
-                            s: route.params.s,
-                          },
-                        }"
-                      >
-                        {{ item.name }}
-                      </XAction>
-                    </template>
-
-                    <template #namespace="{ row: item }">
-                      {{ item.namespace }}
-                    </template>
-
-                    <template #zone="{ row }">
-                      <XAction
-                        v-if="row.zone"
-                        :to="{
-                          name: 'zone-cp-detail-view',
-                          params: {
-                            zone: row.zone,
-                          },
-                        }"
-                      >
-                        {{ row.zone }}
-                      </XAction>
-
-                      <template v-else>
-                        {{ t('common.collection.none') }}
-                      </template>
-                    </template>
-
-                    <template #certificate="{ row }">
-                      <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                        {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                      </template>
-
-                      <template v-else>
-                        {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                      </template>
-                    </template>
-
-                    <template #status="{ row }">
-                      <StatusBadge :status="row.status" />
-                    </template>
-
-                    <template #warnings="{ row }">
-                      <XIcon
-                        v-if="row.isCertExpired || row.warnings.length > 0"
-                        class="mr-1"
-                        name="warning"
-                      >
-                        <ul>
-                          <template v-if="row.warnings.length > 0">
-                            <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                          </template>
-
-                          <template v-if="row.isCertExpired">
-                            <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                          </template>
-                        </ul>
-                      </XIcon>
-
-                      <template v-else>
-                        {{ t('common.collection.none') }}
-                      </template>
-                    </template>
-
-                    <template #actions="{ row: item }">
-                      <XActionGroup>
-                        <XAction
-                          :to="{
-                            name: 'data-plane-detail-view',
-                            params: {
-                              proxy: item.id,
-                            },
-                          }"
-                        >
-                          {{ t('common.collection.actions.view') }}
-                        </XAction>
-                      </XActionGroup>
-                    </template>
-                  </AppCollection>
-                  <RouterView
-                    v-if="route.params.proxy"
-                    v-slot="child"
-                  >
-                    <SummaryView
-                      @close="route.replace({
-                        name: route.name,
+                  <template #name="{ row: item }">
+                    <XAction
+                      data-action
+                      class="name-link"
+                      :to="{
+                        name: 'delegated-gateway-data-plane-summary-view',
                         params: {
-                          mesh: route.params.mesh,
+                          mesh: item.mesh,
+                          proxy: item.id,
                         },
                         query: {
                           page: route.params.page,
                           size: route.params.size,
                           s: route.params.s,
                         },
-                      })"
+                      }"
                     >
-                      <component
-                        :is="child.Component"
-                        v-if="typeof dataplanesData !== 'undefined'"
-                        :items="dataplanesData.items"
-                      />
-                    </SummaryView>
-                  </RouterView>
-                </DataCollection>
-              </template>
-            </DataLoader>
-          </XCard>
-        </div>
+                      {{ item.name }}
+                    </XAction>
+                  </template>
+
+                  <template #namespace="{ row: item }">
+                    {{ item.namespace }}
+                  </template>
+
+                  <template #zone="{ row }">
+                    <XAction
+                      v-if="row.zone"
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: row.zone,
+                        },
+                      }"
+                    >
+                      {{ row.zone }}
+                    </XAction>
+
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+
+                  <template #certificate="{ row }">
+                    <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                      {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                    </template>
+
+                    <template v-else>
+                      {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                    </template>
+                  </template>
+
+                  <template #status="{ row }">
+                    <StatusBadge :status="row.status" />
+                  </template>
+
+                  <template #warnings="{ row }">
+                    <XIcon
+                      v-if="row.isCertExpired || row.warnings.length > 0"
+                      class="mr-1"
+                      name="warning"
+                    >
+                      <ul>
+                        <template v-if="row.warnings.length > 0">
+                          <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+                        </template>
+
+                        <template v-if="row.isCertExpired">
+                          <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
+                        </template>
+                      </ul>
+                    </XIcon>
+
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'data-plane-detail-view',
+                          params: {
+                            proxy: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
+                  </template>
+                </AppCollection>
+                <RouterView
+                  v-if="route.params.proxy"
+                  v-slot="child"
+                >
+                  <SummaryView
+                    @close="route.replace({
+                      name: route.name,
+                      params: {
+                        mesh: route.params.mesh,
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                        s: route.params.s,
+                      },
+                    })"
+                  >
+                    <component
+                      :is="child.Component"
+                      v-if="typeof dataplanesData !== 'undefined'"
+                      :items="dataplanesData.items"
+                    />
+                  </SummaryView>
+                </RouterView>
+              </DataCollection>
+            </template>
+          </DataLoader>
+        </XCard>
       </XLayout>
     </AppView>
   </RouteView>

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -37,6 +37,8 @@ common:
   warnings:
     CERT_EXPIRED: !!text/markdown |
       The certificate for this dataplane has expired
+    DPP_NO_MTLS: !!text/markdown |
+      This Data Plane Proxy does not have mTLS configured, yet  — <a href="{KUMA_DOCS_URL}/policies/mutual-tls?{KUMA_UTM_QUERY_PARAMS}">Learn about certificates in {KUMA_PRODUCT_NAME}</a>
     ZONE_STORE_TYPE_MEMORY: !!text/markdown |
       This zone is using the `memory` store type. **Don't** use this store in production because the state isn't persisted. <a target="_blank" href="{KUMA_DOCS_URL}/documentation/configuration/#store">Read more about store types</a>
     GLOBAL_STORE_TYPE_MEMORY: !!text/markdown |

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -149,25 +149,28 @@
                 </XLayout>
               </XLayout>
             </XCard>
-            <ResourceCodeBlock
-              :resource="mesh.config"
-              v-slot="{ copy, copying }"
-            >
-              <DataSource
-                v-if="copying"
-                :src="uri(sources, '/meshes/:name/as/kubernetes', {
-                  name: route.params.mesh,
-                }, {
-                  cacheControl: 'no-store',
-                })"
-                @change="(data) => {
-                  copy((resolve) => resolve(data))
-                }"
-                @error="(e) => {
-                  copy((_resolve, reject) => reject(e))
-                }"
-              />
-            </ResourceCodeBlock>
+
+            <XCard>
+              <ResourceCodeBlock
+                :resource="mesh.config"
+                v-slot="{ copy, copying }"
+              >
+                <DataSource
+                  v-if="copying"
+                  :src="uri(sources, '/meshes/:name/as/kubernetes', {
+                    name: route.params.mesh,
+                  }, {
+                    cacheControl: 'no-store',
+                  })"
+                  @change="(data) => {
+                    copy((resolve) => resolve(data))
+                  }"
+                  @error="(e) => {
+                    copy((_resolve, reject) => reject(e))
+                  }"
+                />
+              </ResourceCodeBlock>
+            </XCard>
           </XLayout>
         </AppView>
       </template>

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
@@ -99,48 +99,85 @@
           </template>
         </DefinitionCard>
       </XAboutCard>
-      <div>
-        <h3>
+      
+      <XCard
+        class="mt-4"
+      >
+        <template #title>
           Affected Data Plane Proxies
-        </h3>
-        <XCard
-          class="mt-4"
+        </template>
+          
+        <DataLoader
+          :src="uri(sources, '/meshes/:mesh/policy-path/:path/policy/:name/dataplanes', {
+            mesh: route.params.mesh,
+            path: route.params.policyPath,
+            name: route.params.policy,
+          },{
+            page: route.params.page,
+            size: route.params.size,
+          })"
         >
-          <DataLoader
-            :src="uri(sources, '/meshes/:mesh/policy-path/:path/policy/:name/dataplanes', {
-              mesh: route.params.mesh,
-              path: route.params.policyPath,
-              name: route.params.policy,
-            },{
-              page: route.params.page,
-              size: route.params.size,
-            })"
+          <template
+            #loadable="{ data: dataplanes }"
           >
-            <template
-              #loadable="{ data: dataplanes }"
+            <DataCollection
+              type="data-planes"
+              :items="dataplanes?.items ?? [undefined]"
+              :page="route.params.page"
+              :page-size="route.params.size"
+              :total="dataplanes?.total"
+              @change="route.update"
             >
-              <DataCollection
-                type="data-planes"
-                :items="dataplanes?.items ?? [undefined]"
-                :page="route.params.page"
-                :page-size="route.params.size"
-                :total="dataplanes?.total"
-                @change="route.update"
+              <AppCollection
+                :headers="[
+                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                  { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                ]"
+                :items="dataplanes?.items"
+                :is-selected-row="(row) => row.id === route.params.proxy"
+                @resize="me.set"
               >
-                <AppCollection
-                  :headers="[
-                    { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                    { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                    { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                  ]"
-                  :items="dataplanes?.items"
-                  :is-selected-row="(row) => row.id === route.params.proxy"
-                  @resize="me.set"
-                >
-                  <template #name="{ row: item }">
+                <template #name="{ row: item }">
+                  <XAction
+                    data-action
+                    :to="{
+                      name: 'data-plane-detail-view',
+                      params: {
+                        proxy: item.id,
+                      },
+                    }"
+                  >
+                    {{ item.name }}
+                  </XAction>
+                </template>
+
+                <template #namespace="{ row: item }">
+                  {{ item.namespace }}
+                </template>
+
+                <template #zone="{ row }">
+                  <XAction
+                    v-if="row.zone"
+                    :to="{
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: row.zone,
+                      },
+                    }"
+                  >
+                    {{ row.zone }}
+                  </XAction>
+
+                  <template v-else>
+                    {{ t('common.collection.none') }}
+                  </template>
+                </template>
+
+                <template #actions="{ row: item }">
+                  <XActionGroup>
                     <XAction
-                      data-action
                       :to="{
                         name: 'data-plane-detail-view',
                         params: {
@@ -148,75 +185,38 @@
                         },
                       }"
                     >
-                      {{ item.name }}
+                      {{ t('common.collection.actions.view') }}
                     </XAction>
-                  </template>
-
-                  <template #namespace="{ row: item }">
-                    {{ item.namespace }}
-                  </template>
-
-                  <template #zone="{ row }">
-                    <XAction
-                      v-if="row.zone"
-                      :to="{
-                        name: 'zone-cp-detail-view',
-                        params: {
-                          zone: row.zone,
-                        },
-                      }"
-                    >
-                      {{ row.zone }}
-                    </XAction>
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
-                    </template>
-                  </template>
-
-                  <template #actions="{ row: item }">
-                    <XActionGroup>
-                      <XAction
-                        :to="{
-                          name: 'data-plane-detail-view',
-                          params: {
-                            proxy: item.id,
-                          },
-                        }"
-                      >
-                        {{ t('common.collection.actions.view') }}
-                      </XAction>
-                    </XActionGroup>
-                  </template>
-                </AppCollection>
-                <RouterView
-                  v-slot="{ Component }"
+                  </XActionGroup>
+                </template>
+              </AppCollection>
+              <RouterView
+                v-slot="{ Component }"
+              >
+                <SummaryView
+                  v-if="route.child()"
+                  @close="route.replace({
+                    params: {
+                      mesh: route.params.mesh,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                      s: route.params.s,
+                    },
+                  })"
                 >
-                  <SummaryView
-                    v-if="route.child()"
-                    @close="route.replace({
-                      params: {
-                        mesh: route.params.mesh,
-                      },
-                      query: {
-                        page: route.params.page,
-                        size: route.params.size,
-                        s: route.params.s,
-                      },
-                    })"
-                  >
-                    <component
-                      :is="Component"
-                      v-if="typeof dataplanes !== 'undefined'"
-                      :items="dataplanes.items"
-                    />
-                  </SummaryView>
-                </RouterView>
-              </DataCollection>
-            </template>
-          </DataLoader>
-        </XCard>
-      </div>
+                  <component
+                    :is="Component"
+                    v-if="typeof dataplanes !== 'undefined'"
+                    :items="dataplanes.items"
+                  />
+                </SummaryView>
+              </RouterView>
+            </DataCollection>
+          </template>
+        </DataLoader>
+      </XCard>
     </AppView>
   </RouteView>
 </template>

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailView.vue
@@ -163,28 +163,30 @@
           </DataLoader>
         </XCard>
 
-        <ResourceCodeBlock
-          :resource="props.data.config"
-          is-searchable
-          :query="route.params.codeSearch"
-          :is-filter-mode="route.params.codeFilter"
-          :is-reg-exp-mode="route.params.codeRegExp"
-          @query-change="route.update({ codeSearch: $event })"
-          @filter-mode-change="route.update({ codeFilter: $event })"
-          @reg-exp-mode-change="route.update({ codeRegExp: $event })"
-          v-slot="{ copy, copying }"
-        >
-          <DataSource
-            v-if="copying"
-            :src="`/meshes/${props.data.mesh}/mesh-external-service/${props.data.id}/as/kubernetes?no-store`"
-            @change="(data) => {
-              copy((resolve) => resolve(data))
-            }"
-            @error="(e) => {
-              copy((_resolve, reject) => reject(e))
-            }"
-          />
-        </ResourceCodeBlock>
+        <XCard>
+          <ResourceCodeBlock
+            :resource="props.data.config"
+            is-searchable
+            :query="route.params.codeSearch"
+            :is-filter-mode="route.params.codeFilter"
+            :is-reg-exp-mode="route.params.codeRegExp"
+            @query-change="route.update({ codeSearch: $event })"
+            @filter-mode-change="route.update({ codeFilter: $event })"
+            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            v-slot="{ copy, copying }"
+          >
+            <DataSource
+              v-if="copying"
+              :src="`/meshes/${props.data.mesh}/mesh-external-service/${props.data.id}/as/kubernetes?no-store`"
+              @change="(data) => {
+                copy((resolve) => resolve(data))
+              }"
+              @error="(e) => {
+                copy((_resolve, reject) => reject(e))
+              }"
+            />
+          </ResourceCodeBlock>
+        </XCard>
       </XLayout>
     </AppView>
   </RouteView>

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailView.vue
@@ -126,7 +126,7 @@
           </DataLoader>
         </XCard>
 
-        <div>
+        <XCard>
           <ResourceCodeBlock
             :resource="props.data.config"
             is-searchable
@@ -149,7 +149,7 @@
               }"
             />
           </ResourceCodeBlock>
-        </div>
+        </XCard>
       </XLayout>
     </AppView>
   </RouteView>

--- a/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
@@ -72,191 +72,189 @@
           </XAboutCard>
         </DataLoader>
 
-        <div>
-          <h3>
+        <XCard
+          class="mt-4"
+        >
+          <template #title>
             {{ t('services.detail.data_plane_proxies') }}
-          </h3>
+          </template>
 
-          <XCard
-            class="mt-4"
-          >
-            <search>
-              <FilterBar
-                class="data-plane-proxy-filter"
-                :placeholder="`name:dataplane-name`"
-                :query="route.params.s"
-                :fields="{
-                  name: { description: 'filter by name or parts of a name' },
-                  protocol: { description: 'filter by “kuma.io/protocol” value' },
-                  tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
-                  ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
-                }"
-                @change="(e) => route.update({
-                  ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
-                })"
-              />
-            </search>
-            <DataLoader
-              :src="uri(dataplaneSources, `/meshes/:mesh/dataplanes/for/service-insight/:service`, {
-                mesh: route.params.mesh,
-                service: route.params.service,
-              }, {
-                page: route.params.page,
-                size: route.params.size,
-                search: route.params.s,
+          <search>
+            <FilterBar
+              class="data-plane-proxy-filter"
+              :placeholder="`name:dataplane-name`"
+              :query="route.params.s"
+              :fields="{
+                name: { description: 'filter by name or parts of a name' },
+                protocol: { description: 'filter by “kuma.io/protocol” value' },
+                tag: { description: 'filter by tags (e.g. “tag: version:2”)' },
+                ...(can('use zones') && { zone: { description: 'filter by “kuma.io/zone” value' } }),
+              }"
+              @change="(e) => route.update({
+                ...Object.fromEntries(e.entries()) as Record<string, string | undefined>,
               })"
+            />
+          </search>
+          <DataLoader
+            :src="uri(dataplaneSources, `/meshes/:mesh/dataplanes/for/service-insight/:service`, {
+              mesh: route.params.mesh,
+              service: route.params.service,
+            }, {
+              page: route.params.page,
+              size: route.params.size,
+              search: route.params.s,
+            })"
+          >
+            <template
+              #loadable="{ data }"
             >
-              <template
-                #loadable="{ data }"
+              <DataCollection
+                type="data-planes"
+                :items="data?.items ?? [undefined]"
+                :page="route.params.page"
+                :page-size="route.params.size"
+                :total="data?.total"
+                @change="route.update"
               >
-                <DataCollection
-                  type="data-planes"
-                  :items="data?.items ?? [undefined]"
-                  :page="route.params.page"
-                  :page-size="route.params.size"
-                  :total="data?.total"
-                  @change="route.update"
+                <AppCollection
+                  class="data-plane-collection"
+                  data-testid="data-plane-collection"
+                  :headers="[
+                    { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                    { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                    { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
+                    { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                    { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
+                    { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                  ]"
+                  :items="data?.items"
+                  :is-selected-row="(row) => row.name === route.params.proxy"
+                  @resize="me.set"
                 >
-                  <AppCollection
-                    class="data-plane-collection"
-                    data-testid="data-plane-collection"
-                    :headers="[
-                      { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                      { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                      ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                      { ...me.get('headers.certificate'), label: 'Certificate Info', key: 'certificate' },
-                      { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                      { ...me.get('headers.warnings'), label: 'Warnings', key: 'warnings', hideLabel: true },
-                      { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                    ]"
-                    :items="data?.items"
-                    :is-selected-row="(row) => row.name === route.params.proxy"
-                    @resize="me.set"
-                  >
-                    <template #name="{ row: item }">
-                      <XAction
-                        data-action
-                        class="name-link"
-                        :to="{
-                          name: 'service-data-plane-summary-view',
-                          params: {
-                            mesh: item.mesh,
-                            proxy: item.id,
-                          },
-                          query: {
-                            page: route.params.page,
-                            size: route.params.size,
-                            s: route.params.s,
-                          },
-                        }"
-                      >
-                        {{ item.name }}
-                      </XAction>
-                    </template>
-
-                    <template #namespace="{ row: item }">
-                      {{ item.namespace }}
-                    </template>
-
-                    <template #zone="{ row }">
-                      <XAction
-                        v-if="row.zone"
-                        :to="{
-                          name: 'zone-cp-detail-view',
-                          params: {
-                            zone: row.zone,
-                          },
-                        }"
-                      >
-                        {{ row.zone }}
-                      </XAction>
-
-                      <template v-else>
-                        {{ t('common.collection.none') }}
-                      </template>
-                    </template>
-
-                    <template #certificate="{ row }">
-                      <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                        {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                      </template>
-
-                      <template v-else>
-                        {{ t('data-planes.components.data-plane-list.certificate.none') }}
-                      </template>
-                    </template>
-
-                    <template #status="{ row }">
-                      <StatusBadge :status="row.status" />
-                    </template>
-
-                    <template #warnings="{ row }">
-                      <XIcon
-                        v-if="row.isCertExpired || row.warnings.length > 0"
-                        class="mr-1"
-                        name="warning"
-                      >
-                        <ul>
-                          <template v-if="row.warnings.length > 0">
-                            <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                          </template>
-
-                          <template v-if="row.isCertExpired">
-                            <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                          </template>
-                        </ul>
-                      </XIcon>
-
-                      <template v-else>
-                        {{ t('common.collection.none') }}
-                      </template>
-                    </template>
-
-                    <template #actions="{ row: item }">
-                      <XActionGroup>
-                        <XAction
-                          :to="{
-                            name: 'data-plane-detail-view',
-                            params: {
-                              proxy: item.id,
-                            },
-                          }"
-                        >
-                          {{ t('common.collection.actions.view') }}
-                        </XAction>
-                      </XActionGroup>
-                    </template>
-                  </AppCollection>
-
-                  <RouterView
-                    v-slot="{ Component }"
-                  >
-                    <SummaryView
-                      v-if="route.child()"
-                      @close="route.replace({
-                        name: route.name,
+                  <template #name="{ row: item }">
+                    <XAction
+                      data-action
+                      class="name-link"
+                      :to="{
+                        name: 'service-data-plane-summary-view',
                         params: {
-                          mesh: route.params.mesh,
+                          mesh: item.mesh,
+                          proxy: item.id,
                         },
                         query: {
                           page: route.params.page,
                           size: route.params.size,
                           s: route.params.s,
                         },
-                      })"
+                      }"
                     >
-                      <component
-                        :is="Component"
-                        v-if="typeof data !== 'undefined'"
-                        :items="data.items"
-                      />
-                    </SummaryView>
-                  </RouterView>
-                </DataCollection>
-              </template>
-            </DataLoader>
-          </XCard>
-        </div>
+                      {{ item.name }}
+                    </XAction>
+                  </template>
+
+                  <template #namespace="{ row: item }">
+                    {{ item.namespace }}
+                  </template>
+
+                  <template #zone="{ row }">
+                    <XAction
+                      v-if="row.zone"
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: row.zone,
+                        },
+                      }"
+                    >
+                      {{ row.zone }}
+                    </XAction>
+
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+
+                  <template #certificate="{ row }">
+                    <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                      {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
+                    </template>
+
+                    <template v-else>
+                      {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                    </template>
+                  </template>
+
+                  <template #status="{ row }">
+                    <StatusBadge :status="row.status" />
+                  </template>
+
+                  <template #warnings="{ row }">
+                    <XIcon
+                      v-if="row.isCertExpired || row.warnings.length > 0"
+                      class="mr-1"
+                      name="warning"
+                    >
+                      <ul>
+                        <template v-if="row.warnings.length > 0">
+                          <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
+                        </template>
+
+                        <template v-if="row.isCertExpired">
+                          <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
+                        </template>
+                      </ul>
+                    </XIcon>
+
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
+                  </template>
+
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'data-plane-detail-view',
+                          params: {
+                            proxy: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
+                  </template>
+                </AppCollection>
+
+                <RouterView
+                  v-slot="{ Component }"
+                >
+                  <SummaryView
+                    v-if="route.child()"
+                    @close="route.replace({
+                      name: route.name,
+                      params: {
+                        mesh: route.params.mesh,
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                        s: route.params.s,
+                      },
+                    })"
+                  >
+                    <component
+                      :is="Component"
+                      v-if="typeof data !== 'undefined'"
+                      :items="data.items"
+                    />
+                  </SummaryView>
+                </RouterView>
+              </DataCollection>
+            </template>
+          </DataLoader>
+        </XCard>
       </div>
     </AppView>
   </RouteView>

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
@@ -222,10 +222,13 @@
             </SummaryView>
           </RouterView>
         </DataLoader>
-        <div
+        <XCard
           v-if="props.data.zoneEgressInsight.subscriptions.length > 0"
         >
-          <h2>{{ t('zone-egresses.routes.item.subscriptions.title') }}</h2>
+          <template #title>
+            {{ t('zone-egresses.routes.item.subscriptions.title') }}
+          </template>
+        
           <AppCollection
             :headers="[
               { ...me.get('headers.instanceId'), label: t('http.api.property.instanceId'), key: 'instanceId' },
@@ -282,7 +285,7 @@
               </template>
             </template>
           </AppCollection>
-        </div>
+        </XCard>
       </XLayout>
     </AppView>
   </RouteView>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -253,10 +253,13 @@
         </RouterView>
       </DataLoader>
 
-      <div
+      <XCard
         v-if="props.data.zoneIngressInsight.subscriptions.length > 0"
       >
-        <h2>{{ t('zone-ingresses.routes.item.subscriptions.title') }}</h2>
+        <template #title>
+          {{ t('zone-ingresses.routes.item.subscriptions.title') }}
+        </template>
+        
         <AppCollection
           :headers="[
             { ...me.get('headers.instanceId'), label: t('http.api.property.instanceId'), key: 'instanceId' },
@@ -313,7 +316,7 @@
             </template>
           </template>
         </AppCollection>
-      </div>
+      </XCard>
     </AppView>
   </RouteView>
 </template>

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -113,10 +113,13 @@
             </DefinitionCard>
           </XAboutCard>
 
-          <div
+          <XCard
             v-if="props.data.zoneInsight.subscriptions.length > 0"
           >
-            <h2>{{ t('zone-cps.detail.subscriptions') }}</h2>
+            <template #title>
+              {{ t('zone-cps.detail.subscriptions') }}
+            </template>
+
             <AppCollection
               :headers="[
                 { ...me.get('headers.zoneInstanceId'), label: t('zone-cps.routes.items.headers.zoneInstanceId'), key: 'zoneInstanceId' },
@@ -196,7 +199,7 @@
                 </component>
               </SummaryView>
             </RouterView>
-          </div>
+          </XCard>
         </XLayout>
       </AppView>
     </DataSource>


### PR DESCRIPTION
In addition to wrap tables nested in routes in `XCard`, I decided to wrap all nested features in `XCard`. Also some of the titles of these features where not part of the `XCard` and I moved them to the `#title` slot. This contributes to overall consistency.

---

Apart from moving things to `XCard` I moved the warning about missing tls in the `DataPlaneDetailView` to the other warnings, which improves visibility on that as it's now at the top of the page.

![image](https://github.com/user-attachments/assets/5d07cba2-1030-412d-b692-c26dc9e80785)

Some more examples:

![image](https://github.com/user-attachments/assets/71ed07db-7a3b-4e34-9e74-a291c84c4146)
![image](https://github.com/user-attachments/assets/03a402cd-2be6-4e56-8f87-326f61aab77e)
