### PR TITLE
chore: add boolean default storage route.params

### DIFF
--- a/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
+++ b/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
@@ -55,7 +55,7 @@
     </DataSource>
   </div>
 </template>
-<script lang="ts" setup generic="T extends Record<string, string | number | boolean | typeof Number | typeof String> = {}">
+<script lang="ts" setup generic="T extends Record<string, string | number | boolean | typeof Number | typeof String | typeof Boolean> = {}">
 import { computed, provide, inject, ref, watch, onBeforeUnmount, reactive, useAttrs } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -106,7 +106,13 @@ const router = useRouter()
 const sym = Symbol('route-view')
 
 type PrimitiveParams = Record<string, string | number | boolean>
-type Params = { [P in keyof T]: T[P] extends NumberConstructor ? number : T[P] extends StringConstructor ? string : T[P] }
+type Params = {
+  [P in keyof T]:
+  T[P] extends NumberConstructor ? number :
+    T[P] extends StringConstructor ? string :
+      T[P] extends BooleanConstructor ? boolean :
+        T[P]
+}
 type RouteReplaceParams = Parameters<typeof router['push']>
 
 const setTitle = createTitleSetter(document)
@@ -241,7 +247,7 @@ const routeUpdate = (params: Partial<PrimitiveParams>): void => {
   // would instead use a single source of truth which in this case would be
   // localStorage
   local = Object.entries(params).reduce((prev, [key, value]) => {
-    if([Number, String].some(item => props.params[key] === item)) {
+    if([Number, String, Boolean].some(item => props.params[key] === item)) {
       prev[key] = value
     }
     return prev

--- a/packages/kuma-gui/src/app/application/utilities/index.ts
+++ b/packages/kuma-gui/src/app/application/utilities/index.ts
@@ -1,6 +1,6 @@
 import jsYaml from 'js-yaml'
 
-type URLParamDefault = string | number | boolean | NumberConstructor | StringConstructor
+type URLParamDefault = string | number | boolean | NumberConstructor | StringConstructor | BooleanConstructor
 type URLParamValues = string | number | boolean
 type URLParamValue = string | null
 
@@ -93,6 +93,8 @@ export const urlParam = function <T extends URLParamValue> (param: T | T[]): T {
 //
 export const normalizeUrlParam = (param: URLParamValue, definition: URLParamDefault): URLParamValues => {
   switch (true) {
+    case definition === Boolean:
+      return param === null ? true : !!param
     case typeof definition === 'boolean':
       return param === null ? true : definition
     case definition === Number:

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryView.vue
@@ -2,8 +2,8 @@
   <RouteView
     :name="props.routeName"
     :params="{
+      inactive: Boolean,
       connection: '',
-      inactive: false,
     }"
     v-slot="{ route, t }"
   >

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryView.vue
@@ -2,8 +2,8 @@
   <RouteView
     :name="props.routeName"
     :params="{
+      inactive: Boolean,
       connection: '',
-      inactive: false,
     }"
     v-slot="{ route, t }"
   >

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
@@ -8,7 +8,7 @@
       codeSearch: '',
       codeFilter: false,
       codeRegExp: false,
-      includeEds: false,
+      includeEds: Boolean,
     }"
     v-slot="{ route, t, uri }"
   >

--- a/packages/kuma-gui/src/app/connections/views/zones/ConnectionInboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/connections/views/zones/ConnectionInboundSummaryView.vue
@@ -3,7 +3,7 @@
     :name="props.routeName"
     :params="{
       connection: '',
-      inactive: false,
+      inactive: Boolean,
     }"
     v-slot="{ route, t }"
   >

--- a/packages/kuma-gui/src/app/connections/views/zones/ConnectionOutboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/connections/views/zones/ConnectionOutboundSummaryView.vue
@@ -3,7 +3,7 @@
     :name="props.routeName"
     :params="{
       connection: '',
-      inactive: false,
+      inactive: Boolean,
     }"
     v-slot="{ route, t }"
   >

--- a/packages/kuma-gui/src/app/connections/views/zones/ConnectionOutboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/zones/ConnectionOutboundSummaryXdsConfigView.vue
@@ -7,7 +7,7 @@
       proxy: '',
       proxyType: '',
       connection: '',
-      includeEds: false,
+      includeEds: Boolean,
     }"
     :name="props.routeName"
     v-slot="{ t, route, uri }"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -1,10 +1,10 @@
 <template>
   <RouteView
     :params="{
+      inactive: Boolean,
       mesh: '',
       proxy: '',
       subscription: '',
-      inactive: false,
     }"
     name="data-plane-detail-view"
     v-slot="{ route, t, can, me, uri }"

--- a/packages/kuma-gui/src/app/me/sources.ts
+++ b/packages/kuma-gui/src/app/me/sources.ts
@@ -22,6 +22,8 @@ export const sources = ({ get, set }: Storage) => {
             params: {
               size: 50,
               format: 'structured',
+              inactive: false,
+              includeEds: false,
             },
           },
           app,

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
@@ -2,9 +2,9 @@
   <RouteView
     name="zone-egress-detail-view"
     :params="{
+      inactive: Boolean,
       subscription: '',
       proxy: '',
-      inactive: false,
     }"
     v-slot="{ t, route, me, uri }"
   >

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -4,7 +4,7 @@
     :params="{
       subscription: '',
       proxy: '',
-      inactive: false,
+      inactive: Boolean,
     }"
     v-slot="{ t, me, route, uri }"
   >


### PR DESCRIPTION
Builds on the work we did in https://github.com/kumahq/kuma-gui/pull/3457 to allow us to persist default values of a `boolean` type.

I then used this for `inactive` (used in traffic views) and `includeEds` (used in XDSConfig views)