### PR TITLE
chore(ci): integrates further package linting

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,9 +7,13 @@ concurrency:
 
 on:
   push:
-    branches: [master, 'release-[0-9]+.[0-9]+']
+    branches:
+      - master
+      - release-[0-9]+.[0-9]+
   pull_request:
-    branches: [master, 'release-[0-9]+.[0-9]+']
+    branches:
+      - master
+      - release-[0-9]+.[0-9]+
   schedule:
     - cron: '31 11 * * 4'
 
@@ -25,7 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [javascript]
+        language:
+          - javascript
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: github/codeql-action/init@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9

--- a/.github/workflows/dispatch-merged-pr-notification.yml
+++ b/.github/workflows/dispatch-merged-pr-notification.yml
@@ -11,7 +11,7 @@ on:
       - master
       - release-[0-9]+.[0-9]+
 
-permissions: {}
+permissions: {} # disables permissions for all of the available permissions
 
 jobs:
   dispatch-merged-pr-notififcation:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
-# create-gui-pr.yaml is dependent on this name being "Tests"
-name: 'Tests'
+# release.yaml is dependant on this name being "main"
+name: 'main'
 
 # Ensures that only one workflow is run per branch at a time.
 concurrency:
@@ -8,9 +8,14 @@ concurrency:
 
 on:
   push:
-    branches: [master, 'release-[0-9]+.[0-9]+']
+    branches:
+      - master
+      - release-[0-9]+.[0-9]+
   pull_request:
-    types: [opened, reopened, synchronize]
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 permissions:
   contents: read # for checking out the repository (e.g. actions/checkout)
@@ -18,9 +23,6 @@ permissions:
 jobs:
   install-dependencies:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./packages/kuma-gui
     outputs:
       spec_groups: ${{ steps.set-groups.outputs.result }}
     steps:
@@ -48,16 +50,19 @@ jobs:
             const json = {
               'kuma-gui': ci.getPartitionedTestFiles(process.env.THREAD_COUNT, 'packages/kuma-gui/'),
             }
-
-
             return json
 
   lint-tests:
-    needs: [install-dependencies]
+    needs:
+      - install-dependencies
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package: ['kuma-gui', 'config']
+        package:
+          - ./
+          - ./packages/kuma-http-api
+          - ./packages/kuma-gui
+          - ./packages/config
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
@@ -70,14 +75,15 @@ jobs:
             /home/runner/.cache/Cypress
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
       - run: |
-          make -C ./packages/${{ matrix.package }} lint
+          make -C ${{ matrix.package }} lint
 
   cli-tests:
     needs: [install-dependencies]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./packages/kuma-gui
+    strategy:
+      matrix:
+        package:
+          - ./packages/kuma-gui
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
@@ -90,10 +96,11 @@ jobs:
             /home/runner/.cache/Cypress
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
       - run: |
-          make test/unit
+          make -C ${{ matrix.package }} test/unit
 
   browser-tests:
-    needs: [install-dependencies]
+    needs:
+      - install-dependencies
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -102,7 +109,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: ['kuma-gui']
+        package:
+          - kuma-gui
         container: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ run-name: |
 # in a release branch, one will actually have to update the workflow file in
 # the default branch, too.
 
+# Ensures that we only run one workflow per branch at a time.
+# Already running workflows will be cancelled.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || inputs.branch }}
+
 on:
   # Allows running the workflow manually.
   workflow_dispatch:
@@ -31,22 +37,16 @@ on:
         type: string
         description: The commit hash for which to create a release PR
   workflow_run:
-    workflows: ['Tests']
-    types: [completed]
-    # See “Filter pattern cheat sheet”
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+    workflows:
+      - main
+    types:
+      - completed
     branches:
       - master
       - release-[0-9]+.[0-9]+
 
 permissions:
   contents: read # for checking out the repository (e.g. actions/checkout)
-
-# Ensures that we only run one workflow per branch at a time.
-# Already running workflows will be cancelled.
-concurrency:
-  cancel-in-progress: true
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || inputs.branch }}
 
 jobs:
   # Creates a pull request in the main application to update its GUI i.e. a GUI release

--- a/packages/kuma-http-api/Makefile
+++ b/packages/kuma-http-api/Makefile
@@ -23,6 +23,9 @@ clean: .clean types/clean ## Dev: Remove all `node_modules` recursively and the 
 .PHONY: install
 install: .install ## Dev: Install all dependencies
 
+.PHONY: lint
+lint: lint/js ## Dev: Run lint checks
+
 ## When amending the specs also see `make generate/oas-for-ts` in the main kuma
 ## repository to regenerate the specs before running `make build`
 KUMAHQ_HTTP_API := $(NPM_WORKSPACE_ROOT)/$(shell cat $(NPM_WORKSPACE_ROOT)/package-lock.json | jq -r '.packages | to_entries[] | select(.value.name == "@kumahq/kuma-http-api") | .key')

--- a/packages/kuma-http-api/eslint.config.cjs
+++ b/packages/kuma-http-api/eslint.config.cjs
@@ -1,0 +1,12 @@
+/** @typedef {import('eslint').Linter.Config[]} Config */
+
+const { eslint } = require('@kumahq/config')
+
+const config = [
+  ...eslint(),
+  {
+    'ignores': ['index.d.ts'],
+  },
+]
+
+module.exports = config


### PR DESCRIPTION
Integrates work from https://github.com/kumahq/kuma-gui/pull/3545 into CI.

Also, while I was there I did a few nitty cleanup things:

- made 99.9% of arrays a uses linewise YAML arrays consistently (i.e. `-` vs `[]`)
- consistently moved `concurrency:` to the same places in all workflows
- changed the name of the `main.yml` workflow to `main` (the name is used for cross-referencing in another workflow). It seemed to me to be a good idea to keep the name of the workflow the same as the name of the file.
- ...possibly another couple of teensy tiny nitty things.