### PR TITLE
feat(zones): Add downloadable bundles to zone proxies

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -59,7 +59,7 @@ data-planes:
         options:
           xds: XDS Configuration
           eds: Include EDS
-          dataplane: Dataplane Configuration
+          proxy: Dataplane Configuration
           policies: Policies
           clusters: Envoy Clusters
           stats: Envoy Stats

--- a/packages/kuma-gui/src/app/data-planes/sources.ts
+++ b/packages/kuma-gui/src/app/data-planes/sources.ts
@@ -91,7 +91,7 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
         return value
       }).reduce((prev, [key]) => {
         switch (key) {
-          case 'dataplane':
+          case 'proxy':
             prev.push(async () => {
               return {
                 name: 'dataplane.yaml',

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -220,7 +220,7 @@ const specs = ref({
   xds: true,
   clusters: true,
   stats: true,
-  dataplane: true,
+  proxy: true,
   policies: true,
 })
 const downloadBundle = (close: () => void) => async (bundle: { name: string, url: string }) => {

--- a/packages/kuma-gui/src/app/zone-egresses/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/zone-egresses/locales/en-us/index.yaml
@@ -13,6 +13,19 @@ zone-egresses:
         zone-egress-stats-view: 'Stats'
         zone-egress-clusters-view: 'Clusters'
         zone-egress-config-view: 'YAML'
+      download:
+        title: Download bundle
+        description: !!text/markdown |
+          Include the following:
+        error: !!text/markdown |
+          Unable to generate bundle, please try again.
+        action: Download
+        options:
+          xds: XDS Configuration
+          eds: Include EDS
+          proxy: Zone Egress Configuration
+          clusters: Envoy Clusters
+          stats: Envoy Stats
       overview: 'Overview'
       config: 'Configuration'
       subscriptions:

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
@@ -58,6 +58,125 @@
           </h1>
         </template>
 
+        <template
+          #actions
+        >
+          <XDisclosure
+            v-slot="{ expanded, toggle }"
+          >
+            <XAction
+              appearance="primary"
+              @click="toggle"
+            >
+              Download Bundle
+            </XAction>
+            <XTeleportTemplate
+              v-if="expanded"
+              :to="{ name: 'modal-layer' }"
+            >
+              <XDisclosure
+                v-slot="{ expanded: downloading, toggle: download }"
+              >
+                <form
+                  @submit.prevent="download"
+                >
+                  <XModal
+                    :title="t('zone-egresses.routes.item.download.title')"
+                    @cancel="toggle"
+                  >
+                    <fieldset
+                      :disabled="downloading"
+                    >
+                      <XI18n
+                        path="zone-egresses.routes.item.download.description"
+                      />
+                      <ul>
+                        <template
+                          v-for="(spec, key) in specs"
+                          :key="typeof spec"
+                        >
+                          <li
+                            v-if="key !== 'eds'"
+                          >
+                            <XCheckbox
+                              v-model="specs[key]"
+                              @change="(bool: boolean) => {
+                                if(key === 'xds' && !bool) {
+                                  specs.eds = false
+                                }
+                              }"
+                            >
+                              {{ t(`zone-egresses.routes.item.download.options.${key}`) }}
+                            </XCheckbox>
+                            <ul
+                              v-if="key === 'xds'"
+                            >
+                              <li>
+                                <XCheckbox
+                                  v-model="specs.eds"
+                                  :disabled="!specs.xds"
+                                >
+                                  {{ t('zone-egresses.routes.item.download.options.eds') }}
+                                </XCheckbox>
+                              </li>
+                            </ul>
+                          </li>
+                        </template>
+                      </ul>
+                    </fieldset>
+                    <template
+                      #footer-actions
+                    >
+                      <XLayout
+                        type="separated"
+                      >
+                        <template
+                          v-for="bundle in [downloadBundle(toggle)]"
+                          :key="typeof bundle"
+                        >
+                          <DataLoader
+                            variant="spinner"
+                            :src="downloading ? uri(sources, '/zone-egresses/:name/as/tarball/:spec', {
+                              name: route.params.proxy,
+                              spec: JSON.stringify(
+                                specs,
+                              ),
+                            }, {
+                              cacheControl: 'no-cache',
+                            }) : ''"
+                            @change="bundle"
+                            @error="download"
+                          >
+                            <template
+                              #error
+                            >
+                              <XAlert
+                                appearance="warning"
+                                show-icon
+                              >
+                                <XI18n
+                                  t="zone-ingresses.routes.item.download.error"
+                                />
+                              </XAlert>
+                            </template>
+                          </DataLoader>
+                        </template>
+                        <XAction
+                          appearance="primary"
+                          type="submit"
+                          :disabled="downloading || Object.values(specs).every(bool => !bool)"
+                        >
+                          {{ t('zone-egresses.routes.item.download.action') }}
+                        </XAction>
+                      </XLayout>
+                    </template>
+                  </XModal>
+                </form>
+              </XDisclosure>
+            </XTeleportTemplate>
+          </XDisclosure>
+        </template>
+
         <DataLoader
           :data="[data]"
           :errors="[error]"
@@ -92,5 +211,37 @@
 </template>
 
 <script lang="ts" setup>
+import { ref } from 'vue'
+
 import { sources } from '../sources'
+const specs = ref({
+  eds: false,
+  xds: true,
+  clusters: true,
+  stats: true,
+  proxy: true,
+})
+const downloadBundle = (close: () => void) => async (bundle: { name: string, url: string }) => {
+  const a = document.createElement('a')
+  a.download = bundle.name
+  a.href = bundle.url
+  setTimeout(() => { window.URL.revokeObjectURL(a.href) }, 60000)
+  await Promise.resolve()
+  a.click()
+  await Promise.resolve()
+  close()
+}
+
 </script>
+<style lang="scss" scoped>
+  form {
+    :deep(p) {
+      margin-bottom: 1em !important;
+    }
+    ul {
+      margin: 0;
+      list-style-type: none;
+    }
+  }
+</style>
+

--- a/packages/kuma-gui/src/app/zone-ingresses/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/zone-ingresses/locales/en-us/index.yaml
@@ -14,6 +14,19 @@ zone-ingresses:
         zone-ingress-stats-view: 'Stats'
         zone-ingress-clusters-view: 'Clusters'
         zone-ingress-config-view: 'YAML'
+      download:
+        title: Download bundle
+        description: !!text/markdown |
+          Include the following:
+        error: !!text/markdown |
+          Unable to generate bundle, please try again.
+        action: Download
+        options:
+          xds: XDS Configuration
+          eds: Include EDS
+          proxy: Zone Ingress Configuration
+          clusters: Envoy Clusters
+          stats: Envoy Stats
       overview: 'Overview'
       config: Configuration
       subscriptions:


### PR DESCRIPTION
Similar to https://github.com/kumahq/kuma-gui/pull/3329 this PR adds downloadable "bundles" to both Zone Ingresses and Zone Egresses.

Pretty much a copy/pasta of the Dataplanes view. But I changed the Dataplanes view to use the key `proxies` instead of `dataplane` for consistency. Also, zone proxies don't have policies as an option to download.

Closes https://github.com/kumahq/kuma-gui/issues/3523
