### PR TITLE
feat: add XDownload component for downloading blobs

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -122,9 +122,9 @@
                       <XLayout
                         type="separated"
                       >
-                        <template
-                          v-for="bundle in [downloadBundle(toggle)]"
-                          :key="typeof bundle"
+                        <XDownload
+                          @start="toggle"
+                          v-slot="{ download: bundle }"
                         >
                           <DataLoader
                             variant="spinner"
@@ -153,7 +153,7 @@
                               </XAlert>
                             </template>
                           </DataLoader>
-                        </template>
+                        </XDownload>
                         <XAction
                           appearance="primary"
                           type="submit"
@@ -223,16 +223,6 @@ const specs = ref({
   dataplane: true,
   policies: true,
 })
-const downloadBundle = (close: () => void) => async (bundle: { name: string, url: string }) => {
-  const a = document.createElement('a')
-  a.download = bundle.name
-  a.href = bundle.url
-  setTimeout(() => { window.URL.revokeObjectURL(a.href) }, 60000)
-  await Promise.resolve()
-  a.click()
-  await Promise.resolve()
-  close()
-}
 </script>
 <style lang="scss" scoped>
   form {

--- a/packages/kuma-gui/src/app/x/components/x-download/README.md
+++ b/packages/kuma-gui/src/app/x/components/x-download/README.md
@@ -1,0 +1,4 @@
+# XDownload
+
+Renderless component to aid downloading of file blobs
+

--- a/packages/kuma-gui/src/app/x/components/x-download/XDownload.vue
+++ b/packages/kuma-gui/src/app/x/components/x-download/XDownload.vue
@@ -1,0 +1,47 @@
+<template>
+  <slot
+    :download="download"
+    name="default"
+  />
+</template>
+<script lang="ts" setup>
+
+const props = withDefaults(defineProps<{
+  revokeAfter?: number
+}>(), {
+  revokeAfter: 60000,
+})
+
+defineSlots<{
+  default(props: {
+    download: typeof download
+  }): any
+}>()
+
+const emit = defineEmits<{
+  (event: 'start'): void
+}>()
+
+const download = async (
+  {
+    url,
+    name = `download_${
+      new Date().toLocaleString('en-US', { year: 'numeric', month: '2-digit', day: '2-digit' }).split('/').reverse().join('-')
+    }_${
+      new Date().toLocaleString('en-US', { hour: '2-digit', hour12: false, minute: '2-digit', second: '2-digit' }).split(':').join('-')
+    }`,
+  }: {
+    name: string
+    url: string
+  }) => {
+  const a = document.createElement('a')
+  a.download = name
+  a.href = url
+  setTimeout(() => { window.URL.revokeObjectURL(a.href) }, props.revokeAfter)
+  await Promise.resolve()
+  a.click()
+  await Promise.resolve()
+  emit('start')
+}
+
+</script>

--- a/packages/kuma-gui/src/app/x/index.ts
+++ b/packages/kuma-gui/src/app/x/index.ts
@@ -11,6 +11,7 @@ import XCheckBox from './components/x-checkbox/XCheckbox.vue'
 import XCodeBlock from './components/x-code-block/XCodeBlock.vue'
 import XCopyButton from './components/x-copy-button/XCopyButton.vue'
 import XDisclosure from './components/x-disclosure/XDisclosure.vue'
+import XDownload from './components/x-download/XDownload.vue'
 import XEmptyState from './components/x-empty-state/XEmptyState.vue'
 import XI18n from './components/x-i18n/XI18n.vue'
 import XIcon from './components/x-icon/XIcon.vue'
@@ -63,6 +64,7 @@ declare module 'vue' {
     XTeleportSlot: typeof XTeleportSlot
     XTooltip: typeof XTooltip
     XDisclosure: typeof XDisclosure
+    XDownload: typeof XDownload
     XAboutCard: typeof XAboutCard
     XInputSwitch: typeof XInputSwitch
     XCheckbox: typeof XCheckBox
@@ -115,6 +117,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
           ['XTeleportSlot', XTeleportSlot],
           ['XTooltip', XTooltip],
           ['XDisclosure', XDisclosure],
+          ['XDownload', XDownload],
           ['XAboutCard', XAboutCard],
           ['XInputSwitch', XInputSwitch],
           ['XCheckbox', XCheckBox],


### PR DESCRIPTION
Adds a new `XDownload` component for downloading file blobs easily.

I've currently used it/provided an example in our Dataplanes downloading functionality, but it will also be rolled out to ZoneProxies (also see https://github.com/kumahq/kuma-gui/pull/3547)

This PR can go in before (and https://github.com/kumahq/kuma-gui/pull/3547 be rebased) or after https://github.com/kumahq/kuma-gui/pull/3547.

---

One thing I was unsure of was the name of the `start` event. I went through MDN looking for a name that felt HTML-like, and came up with `start` if anyone has suggestions for a name, that I like better than `start`, please lemme know!