### PR TITLE
feat(cp-stats): add mesh-services

### DIFF
--- a/packages/kuma-gui/features/main-overview/DetailViewContent.feature
+++ b/packages/kuma-gui/features/main-overview/DetailViewContent.feature
@@ -72,12 +72,20 @@ Feature: Overview: Detail view content
             online: 1
         policies:
           total: 55
+        resources:
+          MeshService:
+            total: 1
+          MeshMultiZoneService:
+            total: 2
+          MeshExternalService:
+            total: 3
       """
     When I visit the "/" URL
     Then the page title contains "Overview"
     And the "[data-testid='zone-control-planes-status']" element doesn't exist
     And the "[data-testid='meshes-status']" element contains "3"
     And the "[data-testid='services-status']" element contains "15"
+    And the "[data-testid='services-status']" element contains "6"
     And the "[data-testid='data-plane-proxies-status']" element contains "9"
     And the "[data-testid='policies-status']" element contains "55"
     And the "$zone-control-planes-details" element doesn't exist
@@ -116,6 +124,13 @@ Feature: Overview: Detail view content
             online: 1
         policies:
           total: 55
+        resources:
+          MeshService:
+            total: 1
+          MeshMultiZoneService:
+            total: 2
+          MeshExternalService:
+            total: 3
       """
     And the URL "/zones/_overview" responds with
       """
@@ -148,6 +163,7 @@ Feature: Overview: Detail view content
     And the "[data-testid='zone-control-planes-status']" element contains "2"
     And the "[data-testid='meshes-status']" element contains "3"
     And the "[data-testid='services-status']" element contains "15"
+    And the "[data-testid='services-status']" element contains "6"
     And the "[data-testid='data-plane-proxies-status']" element contains "9"
     And the "[data-testid='policies-status']" element contains "55"
     And the "$zone-control-planes-details" element exists

--- a/packages/kuma-gui/src/app/common/DefinitionCard.vue
+++ b/packages/kuma-gui/src/app/common/DefinitionCard.vue
@@ -5,7 +5,10 @@
       [`definition-card--${props.layout}`]: true,
     }"
   >
-    <div class="definition-card-title">
+    <div
+      v-if="slots.icon || slots.title"
+      class="definition-card-title"
+    >
       <slot name="icon" />
 
       <slot name="title" />
@@ -23,6 +26,7 @@ const props = withDefaults(defineProps<{
 }>(), {
   layout: 'vertical',
 })
+const slots = defineSlots()
 </script>
 
 <style lang="scss" scoped>

--- a/packages/kuma-gui/src/app/common/ResourceStatus.vue
+++ b/packages/kuma-gui/src/app/common/ResourceStatus.vue
@@ -7,19 +7,34 @@
       <slot name="icon" />
     </template>
 
-    <template #title>
+    <template
+      v-if="slots.title"
+      #title
+    >
       <slot name="title" />
     </template>
 
     <template #body>
-      <XLayout type="separated">
-        <div class="status">
-          <template v-if="typeof props.online !== 'undefined'">
-            <span
-              :class="{ ['text-neutral']: props.online !== props.total }"
-            >{{ props.online }}</span><span class="status-separator">/</span>
-          </template><span>{{ props.total }}</span>
+      <XLayout
+        type="separated"
+      >
+        <div>
+          <div class="status">
+            <template v-if="typeof props.online !== 'undefined'">
+              <span
+                :class="{ ['text-neutral']: props.online !== props.total }"
+              >{{ props.online }}</span><span class="status-separator">/</span>
+            </template><span>{{ props.total }}</span>
+          </div>
+          <div
+            v-if="slots.description"
+            class="description"
+          >
+            <slot name="description" />
+          </div>
         </div>
+
+        <slot name="body" />
       </XLayout>
     </template>
   </DefinitionCard>
@@ -31,8 +46,10 @@ import DefinitionCard from './DefinitionCard.vue'
 const props = withDefaults(defineProps<{
   total: number
   online?: number
+  description?: string
 }>(), {
   online: undefined,
+  description: undefined,
 })
 const slots = defineSlots()
 </script>
@@ -40,5 +57,11 @@ const slots = defineSlots()
 <style lang="scss" scoped>
 .text-neutral {
   color: #{$kui-color-text-neutral};
+}
+.description {
+  font-weight: $kui-font-weight-regular;
+  font-size: $kui-font-size-20;
+  display: flex;
+  gap: $kui-space-20;
 }
 </style>

--- a/packages/kuma-gui/src/app/control-planes/components/ControlPlaneStatus.vue
+++ b/packages/kuma-gui/src/app/control-planes/components/ControlPlaneStatus.vue
@@ -59,7 +59,7 @@
 
         <template #title>
           <XI18n
-            :path="'main-overview.detail.about.services'"
+            path="main-overview.detail.about.services"
           />
         </template>
 
@@ -68,7 +68,7 @@
           #description
         >
           <XI18n
-            :path="'main-overview.detail.about.descriptions.mesh_services'"
+            path="main-overview.detail.about.descriptions.mesh_services"
           />
         </template>
 
@@ -79,14 +79,14 @@
           <ResourceStatus :total="props.globalInsight.services.internal.total">
             <template #description>
               <XI18n
-                :path="'main-overview.detail.about.descriptions.internal_services'"
+                path="main-overview.detail.about.descriptions.internal_services"
               />
 
               <XIcon
                 name="info"
               >
                 <XI18n
-                  :path="'main-overview.detail.about.infos.internal_services'"
+                  path="main-overview.detail.about.infos.internal_services"
                 />
               </XIcon>
             </template>

--- a/packages/kuma-gui/src/app/control-planes/components/ControlPlaneStatus.vue
+++ b/packages/kuma-gui/src/app/control-planes/components/ControlPlaneStatus.vue
@@ -45,54 +45,59 @@
         </template>
       </ResourceStatus>
 
-      <ResourceStatus
-        :total="props.globalInsight.services.meshServicesGeneric.total || props.globalInsight.services.internal.total"
-        data-testid="services-status"
+      <template
+        v-for="meshServicesGeneric in [(['MeshService', 'MeshMultiZoneService', 'MeshExternalService'] as const).reduce((acc, curr) => ({ total: acc.total + props.globalInsight.resources[curr].total }), { total: 0 })]"
+        :key="typeof meshServicesGeneric"
       >
-        <template #icon>
-          <img
-            class="icon"
-            src="@/assets/images/icon-wifi-tethering.svg?url"
-            alt=""
+        <ResourceStatus
+          :total="meshServicesGeneric.total || props.globalInsight.services.internal.total"
+          data-testid="services-status"
+        >
+          <template #icon>
+            <img
+              class="icon"
+              src="@/assets/images/icon-wifi-tethering.svg?url"
+              alt=""
+            >
+          </template>
+
+          <template #title>
+            <XI18n
+              path="main-overview.detail.about.services"
+            />
+          </template>
+
+          <template
+            v-if="meshServicesGeneric.total && props.globalInsight.services.internal.total > 0"
+            #description
           >
-        </template>
+            <XI18n
+              path="main-overview.detail.about.descriptions.mesh_services"
+            />
+          </template>
 
-        <template #title>
-          <XI18n
-            path="main-overview.detail.about.services"
-          />
-        </template>
-
-        <template
-          v-if="props.globalInsight.services.meshServicesGeneric.total && props.globalInsight.services.internal.total > 0"
-          #description
-        >
-          <XI18n
-            path="main-overview.detail.about.descriptions.mesh_services"
-          />
-        </template>
-
-        <template
-          v-if="props.globalInsight.services.meshServicesGeneric.total && props.globalInsight.services.internal.total > 0"
-          #body
-        >
-          <ResourceStatus :total="props.globalInsight.services.internal.total">
-            <template #description>
-              <XI18n
-                path="main-overview.detail.about.descriptions.internal_services"
-              />
-
-              <XIcon
-                name="info"
-              >
+          <template
+            v-if="meshServicesGeneric.total && props.globalInsight.services.internal.total > 0"
+            #body
+          >
+            <ResourceStatus :total="props.globalInsight.services.internal.total">
+              <template #description>
                 <XI18n
-                  path="main-overview.detail.about.infos.internal_services"
+                  path="main-overview.detail.about.descriptions.internal_services"
                 />
-              </XIcon>
-            </template>
-          </ResourceStatus>
-        </template>
-      </ResourceStatus>
+
+                <XIcon
+                  name="info"
+                >
+                  <XI18n
+                    path="main-overview.detail.about.infos.internal_services"
+                  />
+                </XIcon>
+              </template>
+            </ResourceStatus>
+          </template>
+        </ResourceStatus>
+      </template>
 
       <ResourceStatus
         :total="props.globalInsight.dataplanes.standard.total"

--- a/packages/kuma-gui/src/app/control-planes/components/ControlPlaneStatus.vue
+++ b/packages/kuma-gui/src/app/control-planes/components/ControlPlaneStatus.vue
@@ -46,7 +46,7 @@
       </ResourceStatus>
 
       <ResourceStatus
-        :total="props.globalInsight.services.internal.total"
+        :total="props.globalInsight.services.meshServicesGeneric.total || props.globalInsight.services.internal.total"
         data-testid="services-status"
       >
         <template #icon>
@@ -58,7 +58,39 @@
         </template>
 
         <template #title>
-          {{ t('main-overview.detail.about.services') }}
+          <XI18n
+            :path="'main-overview.detail.about.services'"
+          />
+        </template>
+
+        <template
+          v-if="props.globalInsight.services.meshServicesGeneric.total && props.globalInsight.services.internal.total > 0"
+          #description
+        >
+          <XI18n
+            :path="'main-overview.detail.about.descriptions.mesh_services'"
+          />
+        </template>
+
+        <template
+          v-if="props.globalInsight.services.meshServicesGeneric.total && props.globalInsight.services.internal.total > 0"
+          #body
+        >
+          <ResourceStatus :total="props.globalInsight.services.internal.total">
+            <template #description>
+              <XI18n
+                :path="'main-overview.detail.about.descriptions.internal_services'"
+              />
+
+              <XIcon
+                name="info"
+              >
+                <XI18n
+                  :path="'main-overview.detail.about.infos.internal_services'"
+                />
+              </XIcon>
+            </template>
+          </ResourceStatus>
         </template>
       </ResourceStatus>
 
@@ -116,6 +148,7 @@ const props = defineProps<{
 .about-card {
   container-type: inline-size;
   container-name: about-card;
+  contain: layout;
 }
 
 .card-header {

--- a/packages/kuma-gui/src/app/control-planes/data/index.ts
+++ b/packages/kuma-gui/src/app/control-planes/data/index.ts
@@ -16,13 +16,17 @@ export const GlobalInsight = {
     return {
       ...partialGlobalInsight,
       resources: {
+        ...partialGlobalInsight.resources,
         MeshService: {
+          ...partialGlobalInsight.resources.MeshService,
           total: partialGlobalInsight.resources.MeshService?.total ?? 0,
         },
         MeshMultiZoneService: {
+          ...partialGlobalInsight.resources.MeshMultiZoneService,
           total: partialGlobalInsight.resources.MeshMultiZoneService?.total ?? 0,
         },
         MeshExternalService: {
+          ...partialGlobalInsight.resources.MeshExternalService,
           total: partialGlobalInsight.resources.MeshExternalService?.total ?? 0,
         },
       },

--- a/packages/kuma-gui/src/app/control-planes/data/index.ts
+++ b/packages/kuma-gui/src/app/control-planes/data/index.ts
@@ -1,9 +1,9 @@
+import { type paths } from '@kumahq/kuma-http-api'
+
 import type { Config as PartialControlPlaneConfig } from '@/types/config.d'
-import type { GlobalInsight as PartialGlobalInsight } from '@/types/index.d'
 
 export type ControlPlaneConfig = PartialControlPlaneConfig
-
-export type GlobalInsight = PartialGlobalInsight
+export type PartialGlobalInsight = paths['/global-insight']['get']['responses']['200']['content']['application/json']
 
 export const ControlPlaneConfig = {
   fromObject(partialControlPlaneConfig: PartialControlPlaneConfig): ControlPlaneConfig {
@@ -12,7 +12,19 @@ export const ControlPlaneConfig = {
 }
 
 export const GlobalInsight = {
-  fromObject(partialGlobalInsight: PartialGlobalInsight): GlobalInsight {
-    return partialGlobalInsight
+  fromObject(partialGlobalInsight: PartialGlobalInsight) {
+    return {
+      ...partialGlobalInsight,
+      services: {
+        ...partialGlobalInsight.services,
+        meshServicesGeneric: {
+          total: ['MeshService', 'MeshMultiZoneService', 'MeshExternalService']
+            .map((serviceType) => partialGlobalInsight.resources[serviceType]?.total ?? 0)
+            .reduce((acc, curr) => acc + curr, 0),
+        },
+      },
+    }
   },
 }
+
+export type GlobalInsight = ReturnType<typeof GlobalInsight.fromObject>

--- a/packages/kuma-gui/src/app/control-planes/data/index.ts
+++ b/packages/kuma-gui/src/app/control-planes/data/index.ts
@@ -15,12 +15,15 @@ export const GlobalInsight = {
   fromObject(partialGlobalInsight: PartialGlobalInsight) {
     return {
       ...partialGlobalInsight,
-      services: {
-        ...partialGlobalInsight.services,
-        meshServicesGeneric: {
-          total: ['MeshService', 'MeshMultiZoneService', 'MeshExternalService']
-            .map((serviceType) => partialGlobalInsight.resources[serviceType]?.total ?? 0)
-            .reduce((acc, curr) => acc + curr, 0),
+      resources: {
+        MeshService: {
+          total: partialGlobalInsight.resources.MeshService?.total ?? 0,
+        },
+        MeshMultiZoneService: {
+          total: partialGlobalInsight.resources.MeshMultiZoneService?.total ?? 0,
+        },
+        MeshExternalService: {
+          total: partialGlobalInsight.resources.MeshExternalService?.total ?? 0,
         },
       },
     }

--- a/packages/kuma-gui/src/app/control-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/control-planes/locales/en-us/index.yaml
@@ -16,10 +16,10 @@ main-overview:
       data_plane_proxies: 'Data Plane Proxies'
       policies: Policies
       descriptions:
-        mesh_services: Mesh*Services
+        mesh_services: MeshServices
         internal_services: Services
       infos:
-        internal_services: Some of the meshes are in a transition and therefore some of the services are not migrated to MeshService yet.
+        internal_services: Some of the meshes are in a transition and therefore some of the services are not migrated to MeshService yet. MeshServices may include all types of MeshServices, MeshExternalServices and MeshMultiZoneServices.
     zone_control_planes:
       title: 'Zones'
     meshes:

--- a/packages/kuma-gui/src/app/control-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/control-planes/locales/en-us/index.yaml
@@ -15,6 +15,11 @@ main-overview:
       services: 'Services'
       data_plane_proxies: 'Data Plane Proxies'
       policies: Policies
+      descriptions:
+        mesh_services: Mesh*Services
+        internal_services: Services
+      infos:
+        internal_services: Some of the meshes are in a transition and therefore some of the services are not migrated to MeshService yet.
     zone_control_planes:
       title: 'Zones'
     meshes:

--- a/packages/kuma-gui/src/app/control-planes/sources.ts
+++ b/packages/kuma-gui/src/app/control-planes/sources.ts
@@ -1,3 +1,6 @@
+import { paths } from '@kumahq/kuma-http-api'
+import createClient from 'openapi-fetch'
+
 import { ControlPlaneConfig, GlobalInsight } from './data'
 import { defineSources } from '../application/services/data-source'
 import type { DataSourceResponse } from '@/app/application'
@@ -24,6 +27,11 @@ export const compare = (a: string, b: string) => {
   return 0
 }
 export const sources = (env: Env['var'], api: KumaApi) => {
+  const http = createClient<paths>({
+    baseUrl: '',
+    fetch: api.client.fetch,
+  })
+
   return defineSources({
     '/control-plane/addresses': async (): Promise<ControlPlaneAddresses> => {
       return {
@@ -81,7 +89,9 @@ export const sources = (env: Env['var'], api: KumaApi) => {
     },
 
     '/global-insight': async () => {
-      return GlobalInsight.fromObject(await api.getGlobalInsight())
+      const res = await http.GET('/global-insight')
+      
+      return GlobalInsight.fromObject(res.data!)
     },
   })
 }

--- a/packages/kuma-gui/src/test-support/FakeKuma.ts
+++ b/packages/kuma-gui/src/test-support/FakeKuma.ts
@@ -454,6 +454,27 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
     ] as const
     return this.faker.helpers.arrayElement<typeof items[number]>(items)
   }
+
+  resourceNames() {
+    const items = [
+      'Dataplane',
+      'MeshAccessLog',
+      'MeshCircuitBreaker',
+      'MeshExternalService',
+      'MeshGateway',
+      'MeshHTTPRoute',
+      'MeshLoadBalancingStrategy',
+      'MeshMetric',
+      'MeshMultiZoneService',
+      'MeshRetry',
+      'MeshService',
+      'MeshTimeout',
+      'MeshTrace',
+      'MeshTrafficPermission',
+      'Secret',
+    ]
+    return this.faker.helpers.arrayElements(items, { min: 0, max: items.length })
+  }
 }
 
 export default class FakeKuma extends Faker {

--- a/packages/kuma-gui/src/test-support/FakeKuma.ts
+++ b/packages/kuma-gui/src/test-support/FakeKuma.ts
@@ -245,7 +245,7 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
       ['offline', offline],
     ].filter(([_key, value]) => omitZeroValues ? value !== 0 : true)
 
-    return Object.fromEntries(values) as Required<DataPlaneProxyStatus>
+    return Object.fromEntries(values) as DataPlaneProxyStatus
   }
 
   globalInsightServices({ min = 0, max = 30 }: { min?: number, max?: number } = {}) {

--- a/packages/kuma-gui/src/test-support/FakeKuma.ts
+++ b/packages/kuma-gui/src/test-support/FakeKuma.ts
@@ -245,7 +245,7 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
       ['offline', offline],
     ].filter(([_key, value]) => omitZeroValues ? value !== 0 : true)
 
-    return Object.fromEntries(values) as DataPlaneProxyStatus
+    return Object.fromEntries(values) as Required<DataPlaneProxyStatus>
   }
 
   globalInsightServices({ min = 0, max = 30 }: { min?: number, max?: number } = {}) {

--- a/packages/kuma-gui/src/test-support/mocks/src/global-insight.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/global-insight.ts
@@ -1,8 +1,4 @@
-import { paths } from '@kumahq/kuma-http-api'
-
 import type { EndpointDependencies, MockResponder } from '@/test-support'
-
-type GlobalInsight = paths['/global-insight']['get']['responses']['200']['content']['application/json']
 
 export default ({ fake, env }: EndpointDependencies): MockResponder => (_req) => {
   const meshTotal = parseInt(env('KUMA_MESH_COUNT', `${fake.number.int({ min: 1, max: 100 })}`))
@@ -72,6 +68,6 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (_req) =>
       resources: {
         ...Object.fromEntries(fake.kuma.resourceNames().map((name) => [name, { total: fake.number.int({ min: 0, max: 20 })}])),
       },
-    } satisfies GlobalInsight,
+    },
   } 
 }

--- a/packages/kuma-gui/src/test-support/mocks/src/global-insight.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/global-insight.ts
@@ -70,51 +70,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (_req) =>
         },
       },
       resources: {
-        Dataplane: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshAccessLog: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshCircuitBreaker: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshExternalService: {
-          total: fake.number.int({ max: 25 }),
-        },
-        MeshGateway: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshHTTPRoute: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshLoadBalancingStrategy: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshMetric: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshMultiZoneService: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshRetry: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshService: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshTimeout: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshTrace: {
-          total: fake.number.int({ max:25 }),
-        },
-        MeshTrafficPermission: {
-          total: fake.number.int({ max:25 }),
-        },
-        Secret: {
-          total: fake.number.int({ max:25 }),
-        },
+        ...Object.fromEntries(fake.kuma.resourceNames().map((name) => [name, { total: fake.number.int({ min: 0, max: 20 })}])),
       },
     } satisfies GlobalInsight,
   } 

--- a/packages/kuma-gui/src/test-support/mocks/src/global-insight.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/global-insight.ts
@@ -1,4 +1,9 @@
+import { paths } from '@kumahq/kuma-http-api'
+
 import type { EndpointDependencies, MockResponder } from '@/test-support'
+
+type GlobalInsight = paths['/global-insight']['get']['responses']['200']['content']['application/json']
+
 export default ({ fake, env }: EndpointDependencies): MockResponder => (_req) => {
   const meshTotal = parseInt(env('KUMA_MESH_COUNT', `${fake.number.int({ min: 1, max: 100 })}`))
   const policyTotal = fake.number.int({ min: 1, max: 100 })
@@ -22,6 +27,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (_req) =>
     headers: {
     },
     body: {
+      createdAt: fake.kuma.nanodate(),
       dataplanes: {
         gatewayBuiltin: fake.kuma.partitionInto({
           online: Number,
@@ -63,6 +69,53 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (_req) =>
           online: zoneIngressOnline,
         },
       },
-    },
-  }
+      resources: {
+        Dataplane: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshAccessLog: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshCircuitBreaker: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshExternalService: {
+          total: fake.number.int({ max: 25 }),
+        },
+        MeshGateway: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshHTTPRoute: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshLoadBalancingStrategy: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshMetric: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshMultiZoneService: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshRetry: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshService: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshTimeout: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshTrace: {
+          total: fake.number.int({ max:25 }),
+        },
+        MeshTrafficPermission: {
+          total: fake.number.int({ max:25 }),
+        },
+        Secret: {
+          total: fake.number.int({ max:25 }),
+        },
+      },
+    } satisfies GlobalInsight,
+  } 
 }


### PR DESCRIPTION
This introduces `Mesh*Services` to our vcp stats. As it can happen that we have a mix of `Mesh*Services` and legacy services in the meshes, I added the possibility to show both in the same `ResourceStatus` including a `#description`.
To achieve this I've made the `#title`-slot optional and added an optional `#description`-slot. With this it's possible to nest multiple `ResourceStatus` in a "main" `ResourceStatus` which keeps the same layout and styling and also the declarative approach of rendering things.

In case there are no `Mesh*Services` it only renders the number of the legacy services. In case there are no legacy services, but `Mesh*Services` it renders the number of `Mesh*Services` only.
Only in case there is a mix of both it renders the `description` for both including an info about the legacy services.

![Screenshot 2025-02-18 at 14 43 13](https://github.com/user-attachments/assets/cfebf188-ef50-4eaa-8dca-0ddf6ae97ca0)
![image](https://github.com/user-attachments/assets/c1f0463c-daf7-4f84-9446-26eb3153ab85)
![Screenshot 2025-02-17 at 12 31 38](https://github.com/user-attachments/assets/e5fe3160-cffb-4873-900b-edd0e8f5ca2a)

---

Regarding `contain: layout`:
This is required to prevent the issues regarding wrong positioning of tooltips in an element of container-type: inline-size. Found this in [this article](https://dev.to/michaelcharles/chrome-129s-container-query-change-2i77).

Worth to mention that this solution is still not ideal. It creates a new stacking context and may require to set additional z-index for elements like tooltips that should overlay all other elements.


Closes #2966