### PR TITLE
feat: add XNotification component

### DIFF
--- a/packages/kuma-gui/features/application/Warnings.feature
+++ b/packages/kuma-gui/features/application/Warnings.feature
@@ -2,8 +2,8 @@ Feature: application / warnings
 
   Background:
     Given the CSS selectors
-      | Alias                     | Selector                                         |
-      | memory-store-type-warning | [data-testid='warning-GLOBAL_STORE_TYPE_MEMORY'] |
+      | Alias                     | Selector                                              |
+      | memory-store-type-warning | [data-testid='notification-global-store-type-memory'] |
 
   Scenario: Using the memory store type shows a warning
     Given the environment

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
@@ -5,7 +5,7 @@ Feature: Dataplane details for built-in gateway
       | Alias             | Selector                                                           |
       | detail-view       | [data-testid='data-plane-detail-tabs-view']                        |
       | policies-view     | [data-testid='data-plane-policies-view']                           |
-      | warnings          | [data-testid='dataplane-warnings']                                 |
+      | warnings          | [data-testid^='notification-DPP_NO_MTLS']                          |
       | details           | [data-testid='dataplane-details']                                  |
       | route-item        | [data-testid='builtin-gateway-dataplane-policies'] .accordion-item |
       | route-item-button | $route-item:nth-child(1) [data-testid='accordion-item-button']     |

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
@@ -4,7 +4,7 @@ Feature: Dataplane details for delegated gateway
     Given the CSS selectors
       | Alias       | Selector                                    |
       | detail-view | [data-testid='data-plane-detail-tabs-view'] |
-      | warnings    | [data-testid='dataplane-warnings']          |
+      | warnings    | [data-testid^='notification-DPP_NO_MTLS']   |
       | details     | [data-testid='dataplane-details']           |
 
   Scenario: Overview tab has expected content
@@ -56,7 +56,7 @@ Feature: Dataplane details for delegated gateway
       |       193.107.134.106 |
       | kuma.io/protocol:http |
       | kuma.io/zone:zone-1   |
-    And the "$warnings" element doesn't exists
+    And the "$warnings" element doesn't exist
 
   Scenario: Overview tab shows warning when no mTLS is set
     And the URL "/meshes/default/dataplanes/dataplane-gateway_delegated-1/_overview" responds with

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
@@ -5,7 +5,6 @@ Feature: Dataplane details for standard Data Plane Proxy
       | Alias         | Selector                                    |
       | detail-view   | [data-testid='data-plane-detail-tabs-view'] |
       | clusters-view | [data-testid='data-plane-clusters-view']    |
-      | warnings      | [data-testid='dataplane-warnings']          |
       | details       | [data-testid='dataplane-details']           |
 
   Scenario: Overview tab has expected content

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
@@ -4,7 +4,7 @@ Feature: mesh / dataplanes / DataplaneDetailsTraffic
     Given the CSS selectors
       | Alias           | Selector                                            |
       | detail-view     | [data-testid='data-plane-detail-tabs-view']         |
-      | loading-warning | [data-testid='warning-stats-loading']               |
+      | loading-warning | [data-testid^='notification-warning-stats-loading'] |
       | traffic         | [data-testid='dataplane-traffic']                   |
       | outbounds       | [data-testid='dataplane-outbounds']                 |
       | inactiveToggle  | [data-testid='dataplane-outbounds-inactive-toggle'] |

--- a/packages/kuma-gui/features/mesh/dataplanes/Warnings.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Warnings.feature
@@ -2,11 +2,11 @@ Feature: mesh / dataplanes / warnings
 
   Background:
     Given the CSS selectors
-      | Alias                     | Selector                                                          |
-      | expired-cert-warning      | [data-testid='warning-CERT_EXPIRED']                              |
-      | unsupported-kuma-warning  | [data-testid='warning-INCOMPATIBLE_UNSUPPORTED_KUMA_DP']          |
-      | unsupported-envoy-warning | [data-testid='warning-INCOMPATIBLE_UNSUPPORTED_ENVOY']            |
-      | unsupported-zone-warning  | [data-testid='warning-INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS'] |
+      | Alias                     | Selector                                                                |
+      | expired-cert-warning      | [data-testid^='notification-CERT_EXPIRED']                              |
+      | unsupported-kuma-warning  | [data-testid^='notification-INCOMPATIBLE_UNSUPPORTED_KUMA_DP']          |
+      | unsupported-envoy-warning | [data-testid^='notification-INCOMPATIBLE_UNSUPPORTED_ENVOY']            |
+      | unsupported-zone-warning  | [data-testid^='notification-INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS'] |
 
   Scenario: With an expired certificate a cert warning is shown
     Given the URL "/meshes/default/dataplanes/dpp-1/_overview" responds with

--- a/packages/kuma-gui/features/onboarding/Index.feature
+++ b/packages/kuma-gui/features/onboarding/Index.feature
@@ -5,7 +5,7 @@ Feature: onboarding / index
       | Alias                   | Selector                                |
       | skip-button             | [data-testid='onboarding-skip-button']  |
       | environment-text        | [data-testid='kuma-environment']        |
-      | onboarding-notification | [data-testid='onboarding-notification'] |
+      | onboarding-notification | [data-testid='notification-onboarding'] |
 
   Scenario: Visiting the homepage with a fresh install shows the onboarding notification
     Given the environment

--- a/packages/kuma-gui/features/zones/zone-cps/Warnings.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/Warnings.feature
@@ -4,7 +4,7 @@ Feature: zones / warnings
     Given the CSS selectors
       | Alias                    | Selector                                                                       |
       | warning-no-subscriptions | [data-testid='warning-no-subscriptions']                                       |
-      | warning-zone-memory      | [data-testid='warning-ZONE_STORE_TYPE_MEMORY']                                 |
+      | warning-zone-memory      | [data-testid^='notification-ZONE_STORE_TYPE_MEMORY']                           |
       | zone-cp-table-row        | [data-testid='zone-cp-collection'] tbody tr                                    |
       | warning-trigger          | $zone-cp-table-row:nth-child(1) [data-testid="warning"]                        |
       | warning-memory           | $zone-cp-table-row:nth-child(1) [data-testid="warning-ZONE_STORE_TYPE_MEMORY"] |

--- a/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
+++ b/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
@@ -77,7 +77,7 @@
                   type="stack"
                 >
                   <template
-                    v-for="[variant, value] in hub.notifications.entries()"
+                    v-for="[variant, value] in hub.notifications"
                     :key="variant"
                   >
                     <XAlert
@@ -94,8 +94,11 @@
                         <li
                           v-for="notification in value"
                           :key="notification"
+                          :data-testid="`notification-${notification}`"
                         >
-                          <XNotification :uri="notification" />
+                          <XNotification
+                            :uri="notification"
+                          />
                         </li>
                       </ul>
                     </XAlert>

--- a/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
+++ b/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
@@ -2,72 +2,114 @@
   <div
     class="app-view"
   >
-    <nav
-      v-if="!hasParent && _breadcrumbs.length > 0"
-      aria-label="Breadcrumb"
+    <DataSource
+      :src="`/me/~notifications`"
+      v-slot="{ data: dismissed, refresh: _refresh }"
     >
-      <XBreadcrumbs
-        :items="_breadcrumbs"
-      />
-    </nav>
-
-    <section
-      :class="{
-        'is-fullscreen': props.fullscreen,
-      }"
-    >
-      <header
-        v-if="slots.title || slots.actions"
-        class="app-view-title-bar"
+      <component
+        :is="props.notifications ? `XNotificationHub` : `XAnonymous`"
+        v-if="dismissed"
+        uri="props.name"
+        :dismissed="dismissed"
+        v-slot="hub"
       >
-        <KongIcon v-if="props.fullscreen" />
-
-        <template
-          v-if="summary.length > 0"
+        <nav
+          v-if="!hasParent && _breadcrumbs.length > 0"
+          aria-label="Breadcrumb"
         >
-          <XTeleportTemplate
-            :to="{ name: summary }"
-          >
-            <slot name="title" />
-          </XTeleportTemplate>
-        </template>
-        <template
-          v-else
-        >
-          <slot name="title" />
-        </template>
-
-        <div
-          class="actions"
-        >
-          <XTeleportSlot
-            v-if="slots.title"
-            name="app-view-docs"
+          <XBreadcrumbs
+            :items="_breadcrumbs"
           />
-          <slot name="actions">
-            <XTeleportSlot :name="`${routeView.name}-actions`" />
-          </slot>
-        </div>
-      </header>
+        </nav>
 
-      <aside
-        v-if="slots.notifications"
-      >
-        <XAlert
-          class="mb-4"
-          variant="warning"
+        <section
+          :class="{
+            'is-fullscreen': props.fullscreen,
+          }"
         >
-          <slot name="notifications" />
-        </XAlert>
-      </aside>
-      <XLayout
-        type="stack"
-      >
-        <slot
-          name="default"
-        />
-      </XLayout>
-    </section>
+          <header
+            v-if="slots.title || slots.actions"
+            class="app-view-title-bar"
+          >
+            <KongIcon v-if="props.fullscreen" />
+
+            <template
+              v-if="summary.length > 0"
+            >
+              <XTeleportTemplate
+                :to="{ name: summary }"
+              >
+                <slot name="title" />
+              </XTeleportTemplate>
+            </template>
+            <template
+              v-else
+            >
+              <slot name="title" />
+            </template>
+
+            <div
+              class="actions"
+            >
+              <XTeleportSlot
+                v-if="slots.title"
+                name="app-view-docs"
+              />
+              <slot name="actions">
+                <XTeleportSlot
+                  :name="`${routeView.name}-actions`"
+                />
+              </slot>
+            </div>
+          </header>
+
+          <XLayout
+            type="stack"
+          >
+            <aside
+              v-if="hub?.notifications?.size > 0"
+            >
+              <DataSink
+                :src="`/me/~notifications`"
+                v-slot="{ submit }"
+              >
+                <XLayout
+                  type="stack"
+                >
+                  <template
+                    v-for="[variant, value] in hub.notifications.entries()"
+                    :key="variant"
+                  >
+                    <XAlert
+                      :variant="variant"
+                      @dismiss="async () => {
+                        submit(Array.from(value))
+                        await nextTick()
+                        _refresh()
+                      }"
+                    >
+                      <ul
+                        class="notifications"
+                      >
+                        <li
+                          v-for="notification in value"
+                          :key="notification"
+                        >
+                          <XNotification :uri="notification" />
+                        </li>
+                      </ul>
+                    </XAlert>
+                  </template>
+                </XLayout>
+              </DataSink>
+            </aside>
+            <slot
+              name="default"
+            />
+          </XLayout>
+        </section>
+      </component>
+    </DataSource>
   </div>
   <XTeleportTemplate
     v-if="props.docs.length > 0"
@@ -87,7 +129,7 @@
 
 <script lang="ts" setup>
 import { KongIcon } from '@kong/icons'
-import { provide, inject, watch, ref, onBeforeUnmount } from 'vue'
+import { provide, inject, watch, ref, onBeforeUnmount, nextTick } from 'vue'
 
 import { ROUTE_VIEW_PARENT } from '../route-view/index'
 import type { RouteView } from '../route-view/RouteView.vue'
@@ -103,10 +145,12 @@ const props = withDefaults(defineProps<{
   breadcrumbs?: BreadcrumbItem[] | null
   fullscreen?: boolean
   docs?: string
+  notifications?: boolean
 }>(), {
   breadcrumbs: null,
   fullscreen: false,
   docs: '',
+  notifications: false,
 })
 const slots = defineSlots()
 
@@ -212,5 +256,15 @@ onBeforeUnmount(() => {
   justify-content: flex-end;
   align-items: center;
   gap: $kui-space-60;
+}
+.notifications {
+  padding: 0;
+}
+.notifications li {
+  margin-left: $kui-space-60;
+}
+.notifications li:only-child {
+  list-style-type: none;
+  padding: 0;
 }
 </style>

--- a/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
+++ b/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
@@ -4,7 +4,7 @@
   >
     <DataSource
       :src="`/me/~notifications`"
-      v-slot="{ data: dismissed, refresh: _refresh }"
+      v-slot="{ data: dismissed }"
     >
       <component
         :is="props.notifications ? `XNotificationHub` : `XAnonymous`"
@@ -71,7 +71,6 @@
             >
               <DataSink
                 :src="`/me/~notifications`"
-                v-slot="{ submit }"
               >
                 <XLayout
                   type="stack"
@@ -82,11 +81,6 @@
                   >
                     <XAlert
                       :variant="variant"
-                      @dismiss="async () => {
-                        submit(Array.from(value))
-                        await nextTick()
-                        _refresh()
-                      }"
                     >
                       <ul
                         class="notifications"
@@ -132,7 +126,7 @@
 
 <script lang="ts" setup>
 import { KongIcon } from '@kong/icons'
-import { provide, inject, watch, ref, onBeforeUnmount, nextTick } from 'vue'
+import { provide, inject, watch, ref, onBeforeUnmount } from 'vue'
 
 import { ROUTE_VIEW_PARENT } from '../route-view/index'
 import type { RouteView } from '../route-view/RouteView.vue'

--- a/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
+++ b/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
@@ -9,7 +9,7 @@
       <component
         :is="props.notifications ? `XNotificationHub` : `XAnonymous`"
         v-if="dismissed"
-        uri="props.name"
+        :uri="id"
         :dismissed="dismissed"
         v-slot="hub"
       >
@@ -136,6 +136,7 @@ import { provide, inject, watch, ref, onBeforeUnmount, nextTick } from 'vue'
 
 import { ROUTE_VIEW_PARENT } from '../route-view/index'
 import type { RouteView } from '../route-view/RouteView.vue'
+import { uniqueId } from '@/app/application'
 import type { BreadcrumbItem } from '@kong/kongponents'
 type AppView = {
   addBreadcrumbs: (items: BreadcrumbItem[], sym: symbol) => void
@@ -157,6 +158,7 @@ const props = withDefaults(defineProps<{
 })
 const slots = defineSlots()
 
+const id = uniqueId('app-view')
 const routeView = inject<RouteView>(ROUTE_VIEW_PARENT)!
 
 const summary: string = inject('app-summary-view', '')

--- a/packages/kuma-gui/src/app/application/services/storage/index.ts
+++ b/packages/kuma-gui/src/app/application/services/storage/index.ts
@@ -1,7 +1,7 @@
 export default (prefix: string = 'kumahq-app', storage: Storage = window.localStorage) => {
-  const get = async (key: string): Promise<object> => {
+  const get = async (key: string, d = {}): Promise<object> => {
     try {
-      return JSON.parse(storage.getItem(`${prefix}:${key}`) ?? '{}')
+      return JSON.parse(storage.getItem(`${prefix}:${key}`) ?? JSON.stringify(d))
     } catch (e) {
       console.error(e)
     }

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -19,30 +19,26 @@
       })"
       v-slot="{ data: traffic, error, refresh }"
     >
-      <AppView>
-        <template
-          v-if="warnings.length > 0 || error"
-          #notifications
+      <AppView
+        :notifications="true"
+      >
+        <XNotification
+          v-for="warning in warnings"
+          :key="warning.kind"
+          :data-testid="`warning-${warning.kind}`"
+          :uri="`${warning.kind}.${props.data.id}`"
         >
-          <ul data-testid="dataplane-warnings">
-            <li
-              v-for="warning in warnings"
-              :key="warning.kind"
-              :data-testid="`warning-${warning.kind}`"
-            >
-              <XI18n
-                :path="`common.warnings.${warning.kind}`"
-                :params="warning.payload"
-              />
-            </li>
-            <li
-              v-if="error"
-              :data-testid="`warning-stats-loading`"
-            >
-              The below view is not enhanced with runtime stats (Error loading stats: <strong>{{ error.toString() }}</strong>)
-            </li>
-          </ul>
-        </template>
+          <XI18n
+            :path="`common.warnings.${warning.kind}`"
+            :params="warning.payload"
+          />
+        </XNotification>
+        <XNotification
+          v-if="error"
+          :uri="`warning-stats-loading.${props.data.id}`"
+        >
+          The below view is not enhanced with runtime stats (Error loading stats: <strong>{{ error.toString() }}</strong>)
+        </XNotification>
 
         <XLayout
           type="stack"
@@ -514,7 +510,7 @@
               <template #title>
                 <h2>{{ t('data-planes.routes.item.subscriptions.title') }}</h2>
               </template>
-              
+
               <AppCollection
                 :headers="[
                   { ...me.get('headers.instanceId'), label: t('http.api.property.instanceId'), key: 'instanceId' },

--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -175,7 +175,7 @@
                     type="stack"
                   >
                     <template
-                      v-for="[variant, value] in hub.notifications.entries()"
+                      v-for="[variant, value] in hub.notifications"
                       :key="variant"
                     >
                       <XAlert
@@ -192,8 +192,11 @@
                           <li
                             v-for="notification in value"
                             :key="notification"
+                            :data-testid="`notification-${notification}`"
                           >
-                            <XNotification :uri="notification" />
+                            <XNotification
+                              :uri="notification"
+                            />
                           </li>
                         </ul>
                       </XAlert>

--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -7,7 +7,7 @@
     />
     <DataSource
       :src="`/me/~notifications`"
-      v-slot="{ data: dismissed, refresh }"
+      v-slot="{ data: dismissed }"
     >
       <XNotificationHub
         v-if="dismissed"
@@ -173,7 +173,6 @@
               >
                 <DataSink
                   :src="`/me/~notifications`"
-                  v-slot="{ submit }"
                 >
                   <XLayout
                     type="stack"
@@ -184,11 +183,6 @@
                     >
                       <XAlert
                         :variant="variant"
-                        @dismiss="async () => {
-                          submit(Array.from(value))
-                          await nextTick()
-                          refresh()
-                        }"
                       >
                         <ul
                           class="notifications"
@@ -219,7 +213,6 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { nextTick } from 'vue'
 import GithubButton from 'vue-github-button'
 
 import { useEnv, useI18n, useCan } from '@/app/application'

--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -54,16 +54,20 @@
                     data-testid="upgrade-check"
                     appearance="info"
                   >
-                    <p>
-                      {{ t('common.product.name') }} update available
-                    </p>
-
-                    <XAction
-                      appearance="primary"
-                      :href="t('common.product.href.install')"
+                    <XLayout
+                      type="separated"
                     >
-                      Update
-                    </XAction>
+                      <p>
+                        {{ t('common.product.name') }} update available
+                      </p>
+
+                      <XAction
+                        appearance="primary"
+                        :href="t('common.product.href.install')"
+                      >
+                        Update
+                      </XAction>
+                    </XLayout>
                   </XAlert>
                 </DataSource>
               </div>
@@ -374,12 +378,10 @@ nav :deep(.app-navigator) > a {
     font-size: $kui-font-size-30;
   }
 
-  .upgrade-alert,
-  :deep(.alert-message) {
+  .upgrade-alert {
     display: flex;
     align-items: center;
     gap: $kui-space-50;
-
   }
 }
 </style>

--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -5,170 +5,214 @@
     <XTeleportSlot
       name="modal-layer"
     />
-    <header
-      role="banner"
+    <DataSource
+      :src="`/me/~notifications`"
+      v-slot="{ data: dismissed, refresh }"
     >
-      <div
-        class="horizontal-list"
+      <XNotificationHub
+        v-if="dismissed"
+        uri="application-shell"
+        :dismissed="dismissed"
+        v-slot="hub"
       >
-        <slot name="header">
-          <XAction :to="{ name: 'home' }">
-            <slot name="home" />
-          </XAction>
-
-          <GithubButton
-            class="gh-star"
-            href="https://github.com/kumahq/kuma"
-            aria-label="Star kumahq/kuma on GitHub"
-          >
-            Star
-          </GithubButton>
-
-          <div class="upgrade-check-wrapper">
-            <DataSource
-              :src="`/control-plane/version/latest`"
-              v-slot="{ data }"
-            >
-              <!-- make sure we have data but don't show errors or loaders -->
-              <XAlert
-                v-if="data && env('KUMA_VERSION') !== data.version"
-                class="upgrade-alert"
-                data-testid="upgrade-check"
-                appearance="info"
-              >
-                <div class="alert-content">
-                  <p>
-                    {{ t('common.product.name') }} update available
-                  </p>
-
-                  <XAction
-                    appearance="primary"
-                    :href="t('common.product.href.install')"
-                  >
-                    Update
-                  </XAction>
-                </div>
-              </XAlert>
-            </DataSource>
-          </div>
-        </slot>
-      </div>
-      <div
-        class="horizontal-list"
-      >
-        <slot name="content-info">
-          <div
-            class="app-status app-status--mobile"
-          >
-            <XPop
-              width="280"
-            >
-              <XAction
-                appearance="tertiary"
-              >
-                Info
-              </XAction>
-
-              <template #content>
-                <p>
-                  {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
-                </p>
-              </template>
-            </XPop>
-          </div>
-
-          <p class="app-status app-status--desktop">
-            {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
-          </p>
-
-          <XActionGroup>
-            <template
-              #control
-            >
-              <XAction
-                appearance="tertiary"
-              >
-                <XIcon
-                  name="help"
-                >
-                  Help
-                </XIcon>
-              </XAction>
-            </template>
-            <XAction
-              :href="t('common.product.href.docs.index')"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Documentation
-            </XAction>
-            <XAction
-              :href="t('common.product.href.feedback')"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Feedback
-            </XAction>
-            <XAction
-              :to="{ name: 'onboarding-welcome-view' }"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Onboarding
-            </XAction>
-          </XActionGroup>
-        </slot>
-      </div>
-    </header>
-    <div
-      class="app-content-container"
-    >
-      <div class="app-sidebar">
-        <nav
-          aria-label="Main"
+        <XNotification
+          v-if="!can('use state')"
+          uri="global-store-type-memory"
         >
-          <ul v-if="slots.navigation">
-            <slot name="navigation" />
-          </ul>
-
-          <div
-            v-if="slots.navigation && slots.bottomNavigation"
-            role="separator"
-            class="navigation-separator"
+          <XI18n
+            path="common.warnings.GLOBAL_STORE_TYPE_MEMORY"
           />
-
-          <ul v-if="slots.bottomNavigation">
-            <slot name="bottomNavigation" />
-          </ul>
-        </nav>
-      </div>
-      <main
-        class="app-main-content"
-      >
-        <div class="app-notifications">
-          <slot name="notifications" />
-          <XAlert
-            v-if="!can('use state')"
-            class="mb-4"
-            appearance="warning"
+        </XNotification>
+        <header
+          role="banner"
+        >
+          <div
+            class="horizontal-list"
           >
-            <ul>
-              <li
-                data-testid="warning-GLOBAL_STORE_TYPE_MEMORY"
+            <slot name="header">
+              <XAction :to="{ name: 'home' }">
+                <slot name="home" />
+              </XAction>
+
+              <GithubButton
+                class="gh-star"
+                href="https://github.com/kumahq/kuma"
+                aria-label="Star kumahq/kuma on GitHub"
               >
-                <XI18n
-                  path="common.warnings.GLOBAL_STORE_TYPE_MEMORY"
-                />
-              </li>
-            </ul>
-          </XAlert>
+                Star
+              </GithubButton>
+
+              <div class="upgrade-check-wrapper">
+                <DataSource
+                  :src="`/control-plane/version/latest`"
+                  v-slot="{ data }"
+                >
+                  <!-- make sure we have data but don't show errors or loaders -->
+                  <XAlert
+                    v-if="data && env('KUMA_VERSION') !== data.version"
+                    class="upgrade-alert"
+                    data-testid="upgrade-check"
+                    appearance="info"
+                  >
+                    <p>
+                      {{ t('common.product.name') }} update available
+                    </p>
+
+                    <XAction
+                      appearance="primary"
+                      :href="t('common.product.href.install')"
+                    >
+                      Update
+                    </XAction>
+                  </XAlert>
+                </DataSource>
+              </div>
+            </slot>
+          </div>
+          <div
+            class="horizontal-list"
+          >
+            <slot name="content-info">
+              <div
+                class="app-status app-status--mobile"
+              >
+                <XPop
+                  width="280"
+                >
+                  <XAction
+                    appearance="tertiary"
+                  >
+                    Info
+                  </XAction>
+
+                  <template #content>
+                    <p>
+                      {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
+                    </p>
+                  </template>
+                </XPop>
+              </div>
+
+              <p class="app-status app-status--desktop">
+                {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
+              </p>
+
+              <XActionGroup>
+                <template
+                  #control
+                >
+                  <XAction
+                    appearance="tertiary"
+                  >
+                    <XIcon
+                      name="help"
+                    >
+                      Help
+                    </XIcon>
+                  </XAction>
+                </template>
+                <XAction
+                  :href="t('common.product.href.docs.index')"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Documentation
+                </XAction>
+                <XAction
+                  :href="t('common.product.href.feedback')"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Feedback
+                </XAction>
+                <XAction
+                  :to="{ name: 'onboarding-welcome-view' }"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Onboarding
+                </XAction>
+              </XActionGroup>
+            </slot>
+          </div>
+        </header>
+        <div
+          class="app-content-container"
+        >
+          <div class="app-sidebar">
+            <nav
+              aria-label="Main"
+            >
+              <ul v-if="slots.navigation">
+                <slot name="navigation" />
+              </ul>
+
+              <div
+                v-if="slots.navigation && slots.bottomNavigation"
+                role="separator"
+                class="navigation-separator"
+              />
+
+              <ul v-if="slots.bottomNavigation">
+                <slot name="bottomNavigation" />
+              </ul>
+            </nav>
+          </div>
+          <main
+            class="app-main-content"
+          >
+            <XLayout
+              type="stack"
+            >
+              <aside
+                v-if="hub.notifications.size > 0"
+              >
+                <DataSink
+                  :src="`/me/~notifications`"
+                  v-slot="{ submit }"
+                >
+                  <XLayout
+                    type="stack"
+                  >
+                    <template
+                      v-for="[variant, value] in hub.notifications.entries()"
+                      :key="variant"
+                    >
+                      <XAlert
+                        :variant="variant"
+                        @dismiss="async () => {
+                          submit(Array.from(value))
+                          await nextTick()
+                          refresh()
+                        }"
+                      >
+                        <ul
+                          class="notifications"
+                        >
+                          <li
+                            v-for="notification in value"
+                            :key="notification"
+                          >
+                            <XNotification :uri="notification" />
+                          </li>
+                        </ul>
+                      </XAlert>
+                    </template>
+                  </XLayout>
+                </DataSink>
+              </aside>
+              <div>
+                <slot name="default" />
+              </div>
+            </XLayout>
+          </main>
         </div>
-        <slot name="default" />
-      </main>
-    </div>
+      </XNotificationHub>
+    </DataSource>
   </div>
 </template>
 <script lang="ts" setup>
+import { nextTick } from 'vue'
 import GithubButton from 'vue-github-button'
 
 import { useEnv, useI18n, useCan } from '@/app/application'
@@ -176,8 +220,8 @@ import { useEnv, useI18n, useCan } from '@/app/application'
 const slots = defineSlots()
 
 const env = useEnv()
-const can = useCan()
 const { t } = useI18n()
+const can = useCan()
 
 </script>
 <style lang="scss">
@@ -200,6 +244,17 @@ html.no-navigation {
 </style>
 
 <style lang="scss" scoped>
+.notifications {
+  padding: 0;
+}
+.notifications li {
+  margin-left: $kui-space-60;
+}
+.notifications li:only-child {
+  list-style-type: none;
+  padding: 0;
+}
+
 .app-content-container {
   padding-top: var(--AppHeaderHeight, initial);
   display: var(--AppDisplay);
@@ -313,13 +368,15 @@ nav :deep(.app-navigator) > a {
   .upgrade-alert {
     // Uses smaller paddings for this particular alert.
     padding: $kui-space-20 $kui-space-40;
+    font-size: $kui-font-size-30;
   }
 
-  .alert-content {
+  .upgrade-alert,
+  :deep(.alert-message) {
     display: flex;
     align-items: center;
-    font-size: $kui-font-size-30;
     gap: $kui-space-50;
+
   }
 }
 </style>

--- a/packages/kuma-gui/src/app/meshes/data/Mesh.ts
+++ b/packages/kuma-gui/src/app/meshes/data/Mesh.ts
@@ -11,6 +11,7 @@ export const Mesh = {
 
     return {
       ...item,
+      id: item.name,
       config: item,
       meshServices: ((item = {}) => {
         return {

--- a/packages/kuma-gui/src/app/meshes/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/meshes/data/index.spec.ts
@@ -65,6 +65,7 @@ describe('meshes data transformations', () => {
         }],
         expected: {
           name: 'protocol-4',
+          id: 'protocol-4',
           type: 'Mesh',
           creationTime: '2020-06-19T12:18:02.097986-04:00',
           modificationTime: '2020-06-19T12:18:02.097986-04:00',

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -28,7 +28,7 @@
           :notifications="true"
         >
           <XNotification
-            v-if="true || !props.mesh.mtlsBackend"
+            v-if="!props.mesh.mtlsBackend"
             :uri="`mtls-warning.${props.mesh.id}`"
           >
             <XI18n

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -25,28 +25,24 @@
       >
         <AppView
           :docs="t('meshes.href.docs')"
+          :notifications="true"
         >
-          <template
-            v-if="!props.mesh.mtlsBackend || missingTLSPolicy"
-            #notifications
+          <XNotification
+            v-if="true || !props.mesh.mtlsBackend"
+            :uri="`mtls-warning.${props.mesh.id}`"
           >
-            <ul>
-              <li
-                v-if="!props.mesh.mtlsBackend"
-              >
-                <XI18n
-                  path="meshes.routes.item.mtls-warning"
-                />
-              </li>
-              <li
-                v-if="props.mesh.mtlsBackend && missingTLSPolicy"
-              >
-                <XI18n
-                  path="meshes.routes.item.mtp-warning"
-                />
-              </li>
-            </ul>
-          </template>
+            <XI18n
+              path="meshes.routes.item.mtls-warning"
+            />
+          </XNotification>
+          <XNotification
+            v-if="props.mesh.mtlsBackend && missingTLSPolicy"
+            :uri="`mtp-warning.${props.mesh.id}`"
+          >
+            <XI18n
+              path="meshes.routes.item.mtp-warning"
+            />
+          </XNotification>
           <XLayout
             type="stack"
           >
@@ -152,7 +148,7 @@
 
             <XCard>
               <ResourceCodeBlock
-                :resource="mesh.config"
+                :resource="props.mesh.config"
                 v-slot="{ copy, copying }"
               >
                 <DataSource

--- a/packages/kuma-gui/src/app/onboarding/components/OnboardingAlert.vue
+++ b/packages/kuma-gui/src/app/onboarding/components/OnboardingAlert.vue
@@ -1,58 +1,30 @@
 <template>
-  <DataSource
-    :src="`/me/-onboarding-alert`"
-    v-slot="{ data, refresh }"
+  <XNotification
+    variant="success"
+    uri="onboarding"
   >
-    <DataSink
-      :src="`/me/-onboarding-alert`"
-      v-slot="{ submit }"
+    <XLayout
+      type="separated"
     >
-      <XAlert
-        v-if="data?.closed !== true"
-        variant="success"
-        data-testid="onboarding-notification"
-        @dismiss="async () => {
-          submit({
-            closed: true,
-          })
-          await nextTick()
-          refresh()
-        }"
+      <XI18n
+        v-slot="{ t }"
       >
-        <div class="onboarding-alert-content">
-          <XI18n
-            path="main-overview.detail.onboarding.message"
-            :params="{
-              name: t('common.product.name'),
-            }"
-          />
+        <XI18n
+          path="main-overview.detail.onboarding.message"
+          :params="{
+            name: t('common.product.name'),
+          }"
+        />
 
-          <XAction
-            appearance="primary"
-            size="small"
-            class="action-button"
-            :to="{ name: 'onboarding-welcome-view' }"
-          >
-            {{ t('main-overview.detail.onboarding.get_started_link') }}
-          </XAction>
-        </div>
-      </XAlert>
-    </DataSink>
-  </DataSource>
+        <XAction
+          appearance="primary"
+          size="small"
+          class="action-button"
+          :to="{ name: 'onboarding-welcome-view' }"
+        >
+          {{ t('main-overview.detail.onboarding.get_started_link') }}
+        </XAction>
+      </XI18n>
+    </XLayout>
+  </XNotification>
 </template>
-
-<script lang="ts" setup>
-import { nextTick } from 'vue'
-
-import { useI18n } from '@/app/application'
-const { t } = useI18n()
-</script>
-
-<style lang="scss" scoped>
-.onboarding-alert-content {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: $kui-space-60;
-}
-</style>

--- a/packages/kuma-gui/src/app/services/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/services/locales/en-us/index.yaml
@@ -31,7 +31,7 @@ services:
         mesh-service-list-view:
           label: MeshService
           description: !!text/markdown |
-            A <a href="{KUMA_DOCS_URL}/networking/meshservice/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">MeshService</a> represents a destination for traffic from elsewhere in the mesh and can define several networking details. The behaviour of this resource depends on the zone type. 
+            A <a href="{KUMA_DOCS_URL}/networking/meshservice/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">MeshService</a> represents a destination for traffic from elsewhere in the mesh and can define several networking details. The behaviour of this resource depends on the zone type.
         mesh-multi-zone-service-list-view:
           label: MeshMultiZoneService
           description: !!text/markdown |

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
@@ -22,166 +22,160 @@
       })"
       v-slot="{ data: egresses }"
     >
-      <template
-        v-for="warnings in [[
-          ['services.mesh-external-service.notifications.mtls-warning', typeof props.mesh.mtlsBackend === 'undefined'],
-          ['services.mesh-external-service.notifications.no-zone-egress', egresses && !egresses.items.find((egress) => typeof egress.zoneEgressInsight.connectedSubscription !== 'undefined')],
-        ].filter(([_, bool]) => bool).map(item => item[0] as string)]"
-        :key="typeof warnings"
+      <AppView
+        :docs="t('services.mesh-external-service.href.docs')"
+        :notifications="true"
       >
-        <AppView
-          :docs="t('services.mesh-external-service.href.docs')"
+        <XNotification
+          v-if="!props.mesh.mtlsBackend"
+          :uri="`mes-mtls-warning.${props.mesh.id}`"
         >
-          <template
-            v-if="warnings.length > 0"
-            #notifications
+          <XI18n
+            path="services.mesh-external-service.notifications.mtls-warning"
+          />
+        </XNotification>
+        <XNotification
+          v-if="egresses && !egresses.items.find((egress) => typeof egress.zoneEgressInsight.connectedSubscription !== 'undefined')"
+          :uri="`mes-no-zone-ingress.${props.mesh.id}`"
+        >
+          <XI18n
+            path="services.mesh-external-service.notifications.no-zone-egress"
+          />
+        </XNotification>
+        <XCard>
+          <DataLoader
+            :src="uri(sources, '/meshes/:mesh/mesh-external-services', {
+              mesh: route.params.mesh,
+            },{
+              page: route.params.page,
+              size: route.params.size,
+            })"
           >
-            <ul>
-              <li
-                v-for="warning in warnings"
-                :key="warning"
-              >
-                <XI18n
-                  :path="warning"
-                />
-              </li>
-            </ul>
-          </template>
-          <XCard>
-            <DataLoader
-              :src="uri(sources, '/meshes/:mesh/mesh-external-services', {
-                mesh: route.params.mesh,
-              },{
-                page: route.params.page,
-                size: route.params.size,
-              })"
+            <template
+              #loadable="{ data }"
             >
-              <template
-                #loadable="{ data }"
+              <DataCollection
+                type="services"
+                :items="data?.items ?? [undefined]"
+                :page="route.params.page"
+                :page-size="route.params.size"
+                :total="data?.total"
+                @change="route.update"
               >
-                <DataCollection
-                  type="services"
-                  :items="data?.items ?? [undefined]"
-                  :page="route.params.page"
-                  :page-size="route.params.size"
-                  :total="data?.total"
-                  @change="route.update"
+                <AppCollection
+                  data-testid="service-collection"
+                  :headers="[
+                    { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                    { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
+                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
+                    { ...me.get('headers.port'), label: 'Port', key: 'port' },
+                    { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+                  ]"
+                  :items="data?.items"
+                  :is-selected-row="(item) => item.name === route.params.service"
+                  @resize="me.set"
                 >
-                  <AppCollection
-                    data-testid="service-collection"
-                    :headers="[
-                      { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                      { ...me.get('headers.namespace'), label: 'Namespace', key: 'namespace' },
-                      ...(can('use zones') ? [{ ...me.get('headers.zone'), label: 'Zone', key: 'zone' }] : []),
-                      { ...me.get('headers.port'), label: 'Port', key: 'port' },
-                      { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                    ]"
-                    :items="data?.items"
-                    :is-selected-row="(item) => item.name === route.params.service"
-                    @resize="me.set"
+                  <template #name="{ row: item }">
+                    <XCopyButton
+                      :text="item.name"
+                    >
+                      <XAction
+                        data-action
+                        :to="{
+                          name: 'mesh-external-service-summary-view',
+                          params: {
+                            mesh: item.mesh,
+                            service: item.id,
+                          },
+                          query: {
+                            page: route.params.page,
+                            size: route.params.size,
+                          },
+                        }"
+                      >
+                        {{ item.name }}
+                      </XAction>
+                    </XCopyButton>
+                  </template>
+                  <template
+                    #namespace="{ row: item }"
                   >
-                    <template #name="{ row: item }">
-                      <XCopyButton
-                        :text="item.name"
+                    {{ item.namespace }}
+                  </template>
+                  <template #zone="{ row: item }">
+                    <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
+                      <XAction
+                        v-if="item.labels['kuma.io/zone']"
+                        :to="{
+                          name: 'zone-cp-detail-view',
+                          params: {
+                            zone: item.labels['kuma.io/zone'],
+                          },
+                        }"
                       >
-                        <XAction
-                          data-action
-                          :to="{
-                            name: 'mesh-external-service-summary-view',
-                            params: {
-                              mesh: item.mesh,
-                              service: item.id,
-                            },
-                            query: {
-                              page: route.params.page,
-                              size: route.params.size,
-                            },
-                          }"
-                        >
-                          {{ item.name }}
-                        </XAction>
-                      </XCopyButton>
-                    </template>
-                    <template
-                      #namespace="{ row: item }"
-                    >
-                      {{ item.namespace }}
-                    </template>
-                    <template #zone="{ row: item }">
-                      <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
-                        <XAction
-                          v-if="item.labels['kuma.io/zone']"
-                          :to="{
-                            name: 'zone-cp-detail-view',
-                            params: {
-                              zone: item.labels['kuma.io/zone'],
-                            },
-                          }"
-                        >
-                          {{ item.labels['kuma.io/zone'] }}
-                        </XAction>
-                      </template>
-
-                      <template v-else>
-                        {{ t('common.detail.none') }}
-                      </template>
-                    </template>
-                    <template
-                      #port="{ row: item }"
-                    >
-                      <template
-                        v-if="item.spec.match"
-                      >
-                        <KumaPort
-                          :port="item.spec.match"
-                        />
-                      </template>
+                        {{ item.labels['kuma.io/zone'] }}
+                      </XAction>
                     </template>
 
-                    <template #actions="{ row: item }">
-                      <XActionGroup>
-                        <XAction
-                          :to="{
-                            name: 'mesh-external-service-detail-view',
-                            params: {
-                              mesh: item.mesh,
-                              service: item.id,
-                            },
-                          }"
-                        >
-                          {{ t('common.collection.actions.view') }}
-                        </XAction>
-                      </XActionGroup>
+                    <template v-else>
+                      {{ t('common.detail.none') }}
                     </template>
-                  </AppCollection>
-                  <RouterView
-                    v-if="data?.items && route.params.service"
-                    v-slot="child"
+                  </template>
+                  <template
+                    #port="{ row: item }"
                   >
-                    <SummaryView
-                      @close="route.replace({
-                        name: 'mesh-external-service-list-view',
-                        params: {
-                          mesh: route.params.mesh,
-                        },
-                        query: {
-                          page: route.params.page,
-                          size: route.params.size,
-                        },
-                      })"
+                    <template
+                      v-if="item.spec.match"
                     >
-                      <component
-                        :is="child.Component"
-                        :items="data?.items"
+                      <KumaPort
+                        :port="item.spec.match"
                       />
-                    </SummaryView>
-                  </RouterView>
-                </DataCollection>
-              </template>
-            </DataLoader>
-          </XCard>
-        </AppView>
-      </template>
+                    </template>
+                  </template>
+
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'mesh-external-service-detail-view',
+                          params: {
+                            mesh: item.mesh,
+                            service: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
+                  </template>
+                </AppCollection>
+                <RouterView
+                  v-if="data?.items && route.params.service"
+                  v-slot="child"
+                >
+                  <SummaryView
+                    @close="route.replace({
+                      name: 'mesh-external-service-list-view',
+                      params: {
+                        mesh: route.params.mesh,
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                      },
+                    })"
+                  >
+                    <component
+                      :is="child.Component"
+                      :items="data?.items"
+                    />
+                  </SummaryView>
+                </RouterView>
+              </DataCollection>
+            </template>
+          </DataLoader>
+        </XCard>
+      </AppView>
     </DataSource>
   </RouteView>
 </template>

--- a/packages/kuma-gui/src/app/x/components/x-alert/XAlert.vue
+++ b/packages/kuma-gui/src/app/x/components/x-alert/XAlert.vue
@@ -1,5 +1,6 @@
 <template>
   <KAlert
+    show-icon
     :appearance="props.variant"
     :dismissible="typeof attrs.onDismiss === 'function'"
   >
@@ -30,5 +31,8 @@ const attrs = useAttrs()
 <style lang="scss" scoped>
 :deep(.k-button.primary) {
   color: $kui-color-text-inverse !important;
+}
+:deep(a:not([class])) {
+  text-decoration: underline !important;
 }
 </style>

--- a/packages/kuma-gui/src/app/x/components/x-notification/README.md
+++ b/packages/kuma-gui/src/app/x/components/x-notification/README.md
@@ -1,0 +1,2 @@
+# XNotification
+

--- a/packages/kuma-gui/src/app/x/components/x-notification/XNotification.vue
+++ b/packages/kuma-gui/src/app/x/components/x-notification/XNotification.vue
@@ -1,0 +1,47 @@
+<template>
+  <template
+    v-if="typeof provider !== 'undefined'"
+  >
+    <XTeleportTemplate
+      v-if="slots.default"
+      :to="{ name: `${provider.uri}-${props.uri}` }"
+    >
+      <slot name="default" />
+    </XTeleportTemplate>
+    <XTeleportSlot
+      v-else
+      :name="`${provider.uri}-${props.uri}`"
+    />
+  </template>
+</template>
+<script lang="ts" setup>
+import { inject, onBeforeUnmount, onMounted } from 'vue'
+
+import type { AlertAppearance } from '@kong/kongponents'
+const provider = inject<{
+  set(uri: string, obj: { variant: AlertAppearance } ): void
+  delete(uri: string): void
+  uri: string
+}>('x-notification-hub')
+
+const props = withDefaults(defineProps<{
+  uri: string
+  variant?: AlertAppearance
+}>(), {
+  variant: 'warning',
+})
+
+const slots = defineSlots()
+if(slots.default) {
+  onMounted(() => {
+    if(typeof provider !== 'undefined') {
+      provider.set(props.uri, props)
+    }
+  })
+  onBeforeUnmount(() => {
+    if(typeof provider !== 'undefined') {
+      provider.delete(props.uri)
+    }
+  })
+}
+</script>

--- a/packages/kuma-gui/src/app/x/components/x-notification/XNotificationHub.vue
+++ b/packages/kuma-gui/src/app/x/components/x-notification/XNotificationHub.vue
@@ -1,0 +1,58 @@
+<template>
+  <XProvider
+    name="x-notification-hub"
+    :service="hub"
+  >
+    <slot
+      name="default"
+      :notifications="notifications"
+      :uri="`x-notification-hub-${props.uri}`"
+    />
+  </XProvider>
+</template>
+<script lang="ts" setup>
+import { shallowRef, watch } from 'vue'
+
+import type { AlertAppearance } from '@kong/kongponents'
+const props = withDefaults(defineProps<{
+  uri: string
+  dismissed?: string[]
+}>(), {
+  dismissed: () => [],
+})
+const notifications = shallowRef<Map<AlertAppearance, Set<string>>>(
+  new Map(),
+)
+
+const del = (keys: string[]) => {
+  if(keys.length === 0) {
+    return
+  }
+  const n = new Map()
+  notifications.value.forEach((value, variant) => {
+    const diff = value.difference(new Set(keys))
+    if(diff.size > 0) {
+      n.set(variant, diff)
+    }
+  })
+  notifications.value = n
+}
+const hub = {
+  set: (str: string, { variant }: { variant: AlertAppearance } ) => {
+    if(props.dismissed.includes(str)) {
+      return
+    }
+    const s = notifications.value.has(variant) ? notifications.value.get(variant) : new Set<string>()
+    notifications.value = new Map(notifications.value.set(variant, s!.add(str)).entries())
+  },
+  delete: (str: string) => {
+    del([str])
+  },
+  uri: `x-notification-hub-${props.uri}`,
+
+}
+watch(() => props.dismissed, () => {
+  del(props.dismissed)
+}, { immediate: true })
+
+</script>

--- a/packages/kuma-gui/src/app/x/index.ts
+++ b/packages/kuma-gui/src/app/x/index.ts
@@ -18,6 +18,8 @@ import XInput from './components/x-input/XInput.vue'
 import XInputSwitch from './components/x-input-switch/XInputSwitch.vue'
 import XLayout from './components/x-layout/XLayout.vue'
 import XModal from './components/x-modal/XModal.vue'
+import XNotification from './components/x-notification/XNotification.vue'
+import XNotificationHub from './components/x-notification/XNotificationHub.vue'
 import XProgress from './components/x-progress/XProgress.vue'
 import XPrompt from './components/x-prompt/XPrompt.vue'
 import XProvider from './components/x-provider/XProvider.vue'
@@ -54,6 +56,8 @@ declare module 'vue' {
     XEmptyState: typeof XEmptyState
     XLayout: typeof XLayout
     XModal: typeof XModal
+    XNotification: typeof XNotification
+    XNotificationHub: typeof XNotificationHub
     XPrompt: typeof XPrompt
     XProvider: typeof XProvider
     XProgress: typeof XProgress
@@ -106,6 +110,8 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
           ['XInput', XInput],
           ['XLayout', XLayout],
           ['XModal', XModal],
+          ['XNotification', XNotification],
+          ['XNotificationHub', XNotificationHub],
           ['XPrompt', XPrompt],
           ['XProvider', XProvider],
           ['XProgress', XProgress],

--- a/packages/kuma-gui/src/app/zones/data/index.ts
+++ b/packages/kuma-gui/src/app/zones/data/index.ts
@@ -87,6 +87,7 @@ export const ZoneOverview = {
     } as const
     return {
       ...item,
+      id: item.name,
       zoneInsight: insight,
       zone,
       // first check see if the zone is disabled, if not look for the connectedSubscription

--- a/packages/kuma-gui/src/app/zones/views/ZoneConfigView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneConfigView.vue
@@ -19,29 +19,25 @@
       })"
       v-slot="{ data: version }"
     >
-      <AppView>
-        <template
-          v-if="props.data.warnings.length > 0"
-          #notifications
+      <AppView
+        :notifications="true"
+      >
+        <XNotification
+          v-for="warning in props.data.warnings"
+          :key="warning.kind"
+          :data-testid="`warning-${warning.kind}`"
+          :uri="`${warning.kind}.${props.data.id}`"
         >
-          <ul>
-            <li
-              v-for="warning in props.data.warnings"
-              :key="warning.kind"
-              :data-testid="`warning-${warning.kind}`"
-            >
-              <XI18n
-                :path="`common.warnings.${warning.kind}`"
-                :params="{
-                  zoneCpVersion: warning.payload.zoneCpVersion ?? '',
-                  ...(warning.kind === 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS' ? {
-                    globalCpVersion: version?.version ?? '',
-                  } : {}),
-                }"
-              />
-            </li>
-          </ul>
-        </template>
+          <XI18n
+            :path="`common.warnings.${warning.kind}`"
+            :params="{
+              zoneCpVersion: warning.payload.zoneCpVersion ?? '',
+              ...(warning.kind === 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS' ? {
+                globalCpVersion: version?.version ?? '',
+              } : {}),
+            }"
+          />
+        </XNotification>
 
         <XCard>
           <XCodeBlock

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -15,29 +15,24 @@
     >
       <AppView
         :docs="t('zones.href.docs.cta')"
+        :notifications="true"
       >
-        <template
-          v-if="props.data.warnings.length > 0"
-          #notifications
+        <XNotification
+          v-for="warning in props.data.warnings"
+          :key="warning.kind"
+          :data-testid="`warning-${warning.kind}`"
+          :uri="`${warning.kind}.${props.data.id}`"
         >
-          <ul>
-            <li
-              v-for="warning in props.data.warnings"
-              :key="warning.kind"
-              :data-testid="`warning-${warning.kind}`"
-            >
-              <XI18n
-                :path="`common.warnings.${warning.kind}`"
-                :params="{
-                  zoneCpVersion: warning.payload.zoneCpVersion ?? '',
-                  ...(warning.kind === 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS' ? {
-                    globalCpVersion: version?.version ?? '',
-                  } : {}),
-                }"
-              />
-            </li>
-          </ul>
-        </template>
+          <XI18n
+            :path="`common.warnings.${warning.kind}`"
+            :params="{
+              zoneCpVersion: warning.payload.zoneCpVersion ?? '',
+              ...(warning.kind === 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS' ? {
+                globalCpVersion: version?.version ?? '',
+              } : {}),
+            }"
+          />
+        </XNotification>
         <XLayout
           data-testid="detail-view-details"
           type="stack"


### PR DESCRIPTION
This PR completely rebuilds our notifications and replaces all instances of our current ones to use the new approach. (I would guess there will be a further PR to amend where we put certain notifications, user-wise I've tried to keep things exactly the same for now)

### Different variants

<img width="1323" alt="Screenshot 2025-02-18 at 14 08 31" src="https://github.com/user-attachments/assets/6271b1d5-4717-4d60-ae61-595d3f217432" />

### Different "areas"

<img width="1330" alt="Screenshot 2025-02-18 at 14 08 43" src="https://github.com/user-attachments/assets/ba033baa-785f-42b0-a08b-d8c1f8a3f9ec" />

### Multiple notifications of the same type

<img width="1327" alt="Screenshot 2025-02-18 at 14 11 00" src="https://github.com/user-attachments/assets/301c03c2-0a51-483c-8775-c98dd0c2cc66" />

---

The biggest question I have is surround notification dismissal.

For example, if I dismiss a notification about using the memory store for the `default` Mesh, I would guess I still would need to see a warning if I then created a new mesh called `johns-mesh`? If you carry this on, what about dismissal of notifications for a specific MeshExternalService?

I've tried to not to overthink it too much for now, and namespaced certain warnings (for example the Mesh example I gave above)


Closes https://github.com/kumahq/kuma-gui/issues/2705