### PR TITLE
chore(zones): uses XDownload for zone bundle downloading

### DIFF
--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
@@ -130,9 +130,9 @@
                       <XLayout
                         type="separated"
                       >
-                        <template
-                          v-for="bundle in [downloadBundle(toggle)]"
-                          :key="typeof bundle"
+                        <XDownload
+                          @start="toggle"
+                          v-slot="{ download: bundle }"
                         >
                           <DataLoader
                             variant="spinner"
@@ -160,7 +160,7 @@
                               </XAlert>
                             </template>
                           </DataLoader>
-                        </template>
+                        </XDownload>
                         <XAction
                           appearance="primary"
                           type="submit"
@@ -221,17 +221,6 @@ const specs = ref({
   stats: true,
   proxy: true,
 })
-const downloadBundle = (close: () => void) => async (bundle: { name: string, url: string }) => {
-  const a = document.createElement('a')
-  a.download = bundle.name
-  a.href = bundle.url
-  setTimeout(() => { window.URL.revokeObjectURL(a.href) }, 60000)
-  await Promise.resolve()
-  a.click()
-  await Promise.resolve()
-  close()
-}
-
 </script>
 <style lang="scss" scoped>
   form {

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
@@ -129,9 +129,9 @@
                       <XLayout
                         type="separated"
                       >
-                        <template
-                          v-for="bundle in [downloadBundle(toggle)]"
-                          :key="typeof bundle"
+                        <XDownload
+                          @start="toggle"
+                          v-slot="{ download: bundle }"
                         >
                           <DataLoader
                             variant="spinner"
@@ -159,7 +159,7 @@
                               </XAlert>
                             </template>
                           </DataLoader>
-                        </template>
+                        </XDownload>
                         <XAction
                           appearance="primary"
                           type="submit"
@@ -221,17 +221,6 @@ const specs = ref({
   stats: true,
   proxy: true,
 })
-const downloadBundle = (close: () => void) => async (bundle: { name: string, url: string }) => {
-  const a = document.createElement('a')
-  a.download = bundle.name
-  a.href = bundle.url
-  setTimeout(() => { window.URL.revokeObjectURL(a.href) }, 60000)
-  await Promise.resolve()
-  a.click()
-  await Promise.resolve()
-  close()
-}
-
 </script>
 <style lang="scss" scoped>
   form {


### PR DESCRIPTION
Follow up of:

- https://github.com/kumahq/kuma-gui/pull/3547
- https://github.com/kumahq/kuma-gui/pull/3548

In https://github.com/kumahq/kuma-gui/pull/3548 we made XDownload but only added it to dataplanes (ZoneProxy bundling wasn't merged as yet)

This PS uses it for ZoneProxy bundling also.