### PR TITLE
feat(policy-type-list-view): make sticky

### DIFF
--- a/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
@@ -115,6 +115,8 @@ import type { PolicyTypeCollectionSource } from '@/app/policies/sources'
 }
 
 .policy-type-list {
+  position: sticky;
+  top: calc(var(--AppHeaderHeight) + $kui-space-70);
   align-self: flex-start;
   max-width: 500px;
 }


### PR DESCRIPTION
Make the `PolicyTypeListView` sticky to the top. This is a minor improvement to UX as the `PolicyTypeListView` serves as a navigation bar and opens a nested route to the right, which is another potentially large table. When scrolling the table it can happen that the `PolicyTypeListView` scrolls out of the viewport. To reach the navigation again, the user might have to scroll up again.
As there is currently nothing else rendered below the `PolicyTypeListView`, there is nothing that potentially interferes.