### PR TITLE
feat(zones): show warning when NACKs are received

### DIFF
--- a/packages/kuma-gui/features/zones/zone-cps/Warnings.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/Warnings.feature
@@ -8,6 +8,7 @@ Feature: zones / warnings
       | zone-cp-table-row        | [data-testid='zone-cp-collection'] tbody tr                                    |
       | warning-trigger          | $zone-cp-table-row:nth-child(1) [data-testid="warning"]                        |
       | warning-memory           | $zone-cp-table-row:nth-child(1) [data-testid="warning-ZONE_STORE_TYPE_MEMORY"] |
+      | notification-nack        | [data-testid^='notification-NACK_RESPONSE_ZONE_TO_GLOBAL']                     |
     And the environment
       """
       KUMA_ZONE_COUNT: 1
@@ -73,6 +74,30 @@ Feature: zones / warnings
       """
     When I visit the "<URL>" URL
     Then the "$warning-zone-memory" element doesn't exist
+
+    Examples:
+      | URL                       |
+      | /zones/zone-cp-1/overview |
+      | /zones/zone-cp-1/config   |
+
+  Scenario Outline: When the connected subscription has a NACK "<URL>" shows a notification
+    Given the environment
+      """
+      KUMA_SUBSCRIPTION_COUNT: 1
+      """
+    And the URL "/zones/zone-cp-1/_overview" responds with
+      """
+      body:
+        zoneInsight:
+          subscriptions:
+            - connectTime: 2020-07-28T16:18:09.743141Z
+              disconnectTime: !!js/undefined
+              status:
+                total:
+                  responsesRejected: 100
+      """
+    When I visit the "<URL>" URL
+    Then the "$notification-nack" element exists
 
     Examples:
       | URL                       |

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -51,6 +51,9 @@ common:
       There is a mismatch between versions of Kuma DP (**{ kumaDp }**) and the Zone Control Plane.
     INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS: !!text/markdown |
       There is mismatch between versions of Zone Control Plane (**{ zoneCpVersion }**) and the Global Control Plane (**{ globalCpVersion }**)
+    NACK_RESPONSE_ZONE_TO_GLOBAL: !!text/markdown |
+      The Global Control Plane got NACK responses from the Zone Control Plane, check the Zone Control Plane logs for details.
+      To clear up the state, restart the Zone Control Plane.
   copyText: 'Copy'
   copySuccessText: 'Copied!'
   copyKubernetesText: 'Copy as Kubernetes'

--- a/packages/kuma-gui/src/app/zones/data/index.ts
+++ b/packages/kuma-gui/src/app/zones/data/index.ts
@@ -80,6 +80,12 @@ export const ZoneOverview = {
         },
       })
     }
+    if ((insight.connectedSubscription?.status.total.responsesRejected ?? 0) > 0) {
+      warnings.push({
+        kind: 'NACK_RESPONSE_ZONE_TO_GLOBAL',
+        payload: {},
+      })
+    }
     const state = {
       disabled: 'disabled',
       online: 'online',


### PR DESCRIPTION
When we receive a non-zero `total.responsesRejected` i.e. NACKs shows the following notification:

<img width="1719" alt="Screenshot 2025-02-24 at 11 31 05" src="https://github.com/user-attachments/assets/a53938e9-faf6-4d75-88b4-66889b43f2b2" />

Note: I've implemented this using the same approach as before. Once I've added some other notifications in I aim to go through and re-organize at least the i18n a little more consistently.

Closes https://github.com/kumahq/kuma-gui/issues/2153
