### PR TITLE
feat(data-planes): add recommendation to to use reachable-services

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -2,9 +2,9 @@ data-planes:
   notifications:
     recommend-reachable-services: !!text/markdown |
       We've identified outbound services that would benefit from using
-      <a href="https://kuma.io/docs/2.9.x/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a>
+      <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a>
       and/or
-      <a href="https://kuma.io/docs/2.9.x/production/dp-config/transparent-proxying/#reachable-services" target="_blank">Reachable Services</a>
+      <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-services" target="_blank">Reachable Services</a>
       to dramatically improve performance.
   x-empty-state:
     title: There are no Dataplanes present

--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -1,4 +1,11 @@
 data-planes:
+  notifications:
+    recommend-reachable-services: !!text/markdown |
+      We've identified outbound services that would benefit from using
+      <a href="https://kuma.io/docs/2.9.x/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a>
+      and/or
+      <a href="https://kuma.io/docs/2.9.x/production/dp-config/transparent-proxying/#reachable-services" target="_blank">Reachable Services</a>
+      to dramatically improve performance.
   x-empty-state:
     title: There are no Dataplanes present
   components:

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -334,9 +334,18 @@
                       v-for="direction in ['upstream'] as const"
                       :key="direction"
                     >
+                      <XNotification
+                        v-if="Object.values(traffic.outbounds).find(item => (typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) ?? 0 > 0)"
+                        variant="info"
+                        :uri="`data-planes.notifications.recommend-reachable-services:${props.data.id}`"
+                      >
+                        <XI18n
+                          path="data-planes.notifications.recommend-reachable-services"
+                        />
+                      </XNotification>
                       <DataCollection
                         type="outbounds"
-                        :predicate="route.params.inactive ? undefined : ([key, item]) => ((typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) as (number | undefined) ?? 0) > 0"
+                        :predicate="route.params.inactive ? undefined : ([key, item]) => ((typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) ?? 0) > 0"
                         :items="Object.entries<any>(traffic.outbounds)"
                         v-slot="{ items: outbounds }"
                       >


### PR DESCRIPTION
When we've detected that you have a non-zero amount of outbounds with traffic, we show the following info level message, with links to documentation.

<img width="1720" alt="Screenshot 2025-02-24 at 11 52 41" src="https://github.com/user-attachments/assets/8875c6bd-1740-4c2a-a858-87a84c0d00dd" />


Closes https://github.com/kumahq/kuma-gui/issues/3513