### PR TITLE
feat(zones): adds filter based pagination to zone proxies

### DIFF
--- a/packages/kuma-gui/features/zones/zone-cps/egresses/Index.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/egresses/Index.feature
@@ -5,56 +5,30 @@ Feature: zones / egresses / index
       | Alias | Selector                                        |
       | item  | [data-testid='zone-egress-collection'] tbody tr |
 
-  Scenario Outline: List view has expected content in <Mode> Mode
+  Scenario: List view has expected content in global Mode
     Given the environment
       """
-      KUMA_MODE: <Mode>
-      KUMA_ZONEEGRESS_COUNT: 3
-      KUMA_SUBSCRIPTION_COUNT: 2
+      KUMA_MODE: global
+      KUMA_ZONEEGRESS_COUNT: 2
       """
-    And the URL "/zoneegresses/_overview" responds with
-      """
-      body:
-        items:
-          - name: zone-egress-1
-            zoneEgress:
-              zone: zone-cp-1
-            zoneEgressInsight:
-              subscriptions:
-                - connectTime: 2020-07-28T16:18:09.743141Z
-                  disconnectTime: 2020-07-28T16:18:09.743141Z
-                - connectTime: 2020-07-28T16:18:09.743141Z
-                  disconnectTime: !!js/undefined
-      
-          - name: zone-egress-2
-            zoneEgress:
-              zone: zone-cp-1
-            zoneEgressInsight:
-              subscriptions:
-                - connectTime: 2020-07-28T16:18:09.743141Z
-                  disconnectTime: 2020-07-28T16:18:09.743141Z
-                - connectTime: 2020-07-28T16:18:09.743141Z
-                  disconnectTime: 2020-07-28T16:18:09.743141Z
-      
-          - name: zone-egress-3-is-not-part-of-this-zone
-            zoneEgress:
-              zone: zone-cp-not-zone-cp-1
-            zoneEgressInsight:
-              subscriptions:
-                - connectTime: 2020-07-28T16:18:09.743141Z
-                  disconnectTime: 2020-07-28T16:18:09.743141Z
-                - connectTime: 2020-07-28T16:18:09.743141Z
-                  disconnectTime: 2020-07-28T16:18:09.743141Z
-      """
-    When I visit the "<URL>" URL
+    When I visit the "/zones/zone-cp-1/egresses" URL
     Then the page title contains "Egresses"
-    And the "$item" element exists <Items> times
-    Then the "$item:nth-child(1) .status-column" element contains "online"
-    Then the "$item:nth-child(1) .name-column" element contains "zone-egress-1"
-    Then the "$item:nth-child(2) .status-column" element contains "offline"
-    Then the "$item:nth-child(2) .name-column" element contains "zone-egress-2"
+    Then the URL "/zoneegresses/_overview" was requested with
+      """
+      searchParams:
+        filter[labels.kuma.io/zone]: "zone-cp-1"
+      """
 
-    Examples:
-      | Mode   | URL                       | Items |
-      | global | /zones/zone-cp-1/egresses |     2 |
-      | zone   | /zones/egresses           |     3 |
+  Scenario: List view has expected content in zone Mode
+    Given the environment
+      """
+      KUMA_MODE: zone
+      KUMA_ZONEEGRESS_COUNT: 2
+      """
+    When I visit the "/zones/egresses" URL
+    Then the page title contains "Egresses"
+    Then the URL "/zoneegresses/_overview" was not requested with
+      """
+      searchParams:
+        filter[labels.kuma.io/zone]: "zone-cp-1"
+      """

--- a/packages/kuma-gui/features/zones/zone-cps/ingresses/Index.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/ingresses/Index.feature
@@ -25,20 +25,10 @@ Feature: zones / ingresses / index
                   disconnectTime: 2020-07-28T16:18:09.743141Z
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: !!js/undefined
-      
+
           - name: zone-ingress-2
             zoneIngress:
               zone: zone-cp-1
-            zoneIngressInsight:
-              subscriptions:
-                - connectTime: 2020-07-28T16:18:09.743141Z
-                  disconnectTime: 2020-07-28T16:18:09.743141Z
-                - connectTime: 2020-07-28T16:18:09.743141Z
-                  disconnectTime: 2020-07-28T16:18:09.743141Z
-      
-          - name: zone-ingress-3-is-not-part-of-this-zone
-            zoneIngress:
-              zone: zone-cp-not-zone-cp-1
             zoneIngressInsight:
               subscriptions:
                 - connectTime: 2020-07-28T16:18:09.743141Z

--- a/packages/kuma-gui/src/app/kuma/services/kuma-api/RestClient.ts
+++ b/packages/kuma-gui/src/app/kuma/services/kuma-api/RestClient.ts
@@ -110,13 +110,18 @@ function normalizeParameters(options?: RequestInit & { params?: any }): RequestI
       if (value === undefined) {
         continue
       }
+      switch (true) {
+        case Array.isArray(value):
+          for (const singleValue of value) {
+            params.push([param, singleValue])
+          }
+          break
+        case value !== null && typeof value === 'object':
+          Object.entries(value).forEach(([key, value]) => params.push([`${param}[${key}]`, value]))
+          break
+        default:
+          params.push([param, value])
 
-      if (Array.isArray(value)) {
-        for (const singleValue of value) {
-          params.push([param, singleValue])
-        }
-      } else {
-        params.push([param, value])
       }
     }
 

--- a/packages/kuma-gui/src/app/zone-egresses/sources.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/sources.ts
@@ -21,18 +21,12 @@ export const sources = (api: KumaApi) => {
   return defineSources({
     '/zone-cps/:name/egresses': async (params) => {
       const { name, size, page } = params
+      const filter = name !== '*' ? {
+        [`labels.${'kuma.io/zone'}`]: name,
+      } : undefined
       const offset = size * (page - 1)
 
-      const res = await api.getAllZoneEgressOverviews({ size, offset })
-      if (name !== '*') {
-        // temporary frontend filtering until we have support for filtering
-        // 'gresses by zone in the backend. Until we have backend support its fine
-        // to assume we won't need to recreate paging for 'gresses
-        res.items = res.items.filter((item) => {
-          return item.zoneEgress.zone === name
-        })
-        res.total = res.items.length
-      }
+      const res = await api.getAllZoneEgressOverviews({ size, offset, filter })
       return ZoneEgressOverview.fromCollection(res)
     },
 

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressListView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressListView.vue
@@ -1,10 +1,9 @@
 <template>
-  <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
   <RouteView
     name="zone-egress-list-view"
     :params="{
-      /* page: 1, */
-      /* size: me.pageSize, */
+      page: 1,
+      size: Number,
       zone: '',
       proxy: '',
       proxyType: '',
@@ -33,118 +32,113 @@
         path="zone-egresses.routes.items.intro"
         default-path="common.i18n.ignore-error"
       />
-      <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
       <XCard>
         <DataLoader
           :src="uri(sources, `/zone-cps/:name/egresses`, {
             name: route.params.zone || '*',
           }, {
-            page: 1,
-            size: 100,
+            page: route.params.page,
+            size: route.params.size,
           })"
+          variant="list"
+          v-slot="{ data }"
         >
-          <template
-            #loadable="{ data: egresses }"
+          <DataCollection
+            type="zone-egresses"
+            :items="data.items"
+            :page="route.params.page"
+            :page-size="route.params.size"
+            :total="data.total"
+            @change="route.update"
           >
-            <DataCollection
-              type="zone-egresses"
-              :items="egresses?.items ?? [undefined]"
-              :total="egresses?.total"
-              @change="route.update"
+            <AppCollection
+              class="zone-egress-collection"
+              data-testid="zone-egress-collection"
+              :headers="[
+                { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                { ...me.get('headers.socketAddress'), label: 'Address', key: 'socketAddress' },
+                { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+              ]"
+              :items="data.items"
+              :is-selected-row="(row) => row.name === route.params.proxy"
+              @resize="me.set"
             >
-              <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
-              <AppCollection
-                class="zone-egress-collection"
-                data-testid="zone-egress-collection"
-                :headers="[
-                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                  { ...me.get('headers.socketAddress'), label: 'Address', key: 'socketAddress' },
-                  { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                ]"
-                :items="egresses?.items"
-                :is-selected-row="(row) => row.name === route.params.proxy"
-                @resize="me.set"
-              >
-                <template #name="{ row: item }">
+              <template #name="{ row: item }">
+                <XAction
+                  data-action
+                  :to="{
+                    name: 'zone-egress-summary-view',
+                    params: {
+                      zone: route.params.zone,
+                      proxy: item.id,
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                    },
+                  }"
+                >
+                  {{ item.name }}
+                </XAction>
+              </template>
+
+              <template #socketAddress="{ row: item }">
+                <XCopyButton
+                  v-if="item.zoneEgress.socketAddress.length > 0"
+                  :text="item.zoneEgress.socketAddress"
+                />
+                <template v-else>
+                  {{ t('common.collection.none') }}
+                </template>
+              </template>
+
+              <template #status="{ row: item }">
+                <StatusBadge
+                  :status="item.state"
+                />
+              </template>
+
+              <template #actions="{ row: item }">
+                <XActionGroup>
                   <XAction
-                    data-action
                     :to="{
-                      name: 'zone-egress-summary-view',
+                      name: 'zone-egress-detail-view',
                       params: {
-                        zone: route.params.zone,
+                        proxyType: 'egresses',
                         proxy: item.id,
-                      },
-                      query: {
-                        // TODO: Update page & size once the list endpoint is being filtered by zone
-                        page: 1,
-                        size: 100,
                       },
                     }"
                   >
-                    {{ item.name }}
+                    {{ t('common.collection.actions.view') }}
                   </XAction>
-                </template>
-
-                <template #socketAddress="{ row: item }">
-                  <XCopyButton
-                    v-if="item.zoneEgress.socketAddress.length > 0"
-                    :text="item.zoneEgress.socketAddress"
-                  />
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-
-                <template #status="{ row: item }">
-                  <StatusBadge
-                    :status="item.state"
-                  />
-                </template>
-
-                <template #actions="{ row: item }">
-                  <XActionGroup>
-                    <XAction
-                      :to="{
-                        name: 'zone-egress-detail-view',
-                        params: {
-                          proxyType: 'egresses',
-                          proxy: item.id,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.actions.view') }}
-                    </XAction>
-                  </XActionGroup>
-                </template>
-              </AppCollection>
-              <RouterView
-                v-slot="{ Component }"
+                </XActionGroup>
+              </template>
+            </AppCollection>
+            <RouterView
+              v-slot="{ Component }"
+            >
+              <SummaryView
+                v-if="route.child()"
+                @close="route.replace({
+                  name: 'zone-egress-list-view',
+                  params: {
+                    zone: route.params.zone,
+                    proxyType: route.params.proxyType,
+                  },
+                  query: {
+                    page: route.params.page,
+                    size: route.params.size,
+                  },
+                })"
               >
-                <SummaryView
-                  v-if="route.child()"
-                  @close="route.replace({
-                    name: 'zone-egress-list-view',
-                    params: {
-                      zone: route.params.zone,
-                      proxyType: route.params.proxyType,
-                    },
-                    query: {
-                      // TODO: Update page & size once the list endpoint is being filtered by zone
-                      page: 1,
-                      size: 100,
-                    },
-                  })"
-                >
-                  <component
-                    :is="Component"
-                    v-if="typeof egresses !== 'undefined'"
-                    :items="egresses.items"
-                  />
-                </SummaryView>
-              </RouterView>
-            </DataCollection>
-          </template>
+                <component
+                  :is="Component"
+                  :items="data.items"
+                />
+              </SummaryView>
+            </RouterView>
+          </DataCollection>
         </DataLoader>
       </XCard>
     </AppView>
@@ -156,8 +150,4 @@ import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
-import type { ZoneOverview } from '@/app/zones/data'
-const _props = defineProps<{
-  data: ZoneOverview
-}>()
 </script>

--- a/packages/kuma-gui/src/app/zone-ingresses/sources.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/sources.ts
@@ -41,16 +41,12 @@ export const sources = (source: Source, api: KumaApi) => {
     },
     '/zone-cps/:name/ingresses': async (params) => {
       const { name, size, page } = params
+      const filter = {
+        [`labels.${'kuma.io/zone'}`]: name,
+      }
       const offset = size * (page - 1)
 
-      const res = await api.getAllZoneIngressOverviews({ size, offset })
-      // temporary frontend filtering until we have support for filtering
-      // 'gresses by zone in the backend. Until we have backend support its fine
-      // to assume we won't need to recreate paging for 'gresses
-      res.items = res.items.filter((item) => {
-        return item.zoneIngress.zone === name
-      })
-      res.total = res.items.length
+      const res = await api.getAllZoneIngressOverviews({ size, offset, filter })
       return ZoneIngressOverview.fromCollection(res)
     },
 

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressListView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressListView.vue
@@ -1,10 +1,9 @@
 <template>
-  <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
   <RouteView
     name="zone-ingress-list-view"
     :params="{
-      /* page: 1, */
-      /* size: me.pageSize, */
+      page: 1,
+      size: Number,
       zone: '',
       proxy: '',
     }"
@@ -22,129 +21,124 @@
         default-path="common.i18n.ignore-error"
       />
       <XCard>
-        <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
         <DataLoader
           :src="uri(sources, `/zone-cps/:name/ingresses`, {
             name: route.params.zone,
           }, {
-            page: 1,
-            size: 100,
+            page: route.params.page,
+            size: route.params.size,
           })"
+          variant="list"
+          v-slot="{ data }"
         >
-          <template
-            #loadable="{ data: ingresses }"
+          <DataCollection
+            type="zone-ingresses"
+            :items="data.items"
+            :page="route.params.page"
+            :page-size="route.params.size"
+            :total="data.total"
+            @change="route.update"
           >
-            <DataCollection
-              type="zone-ingresses"
-              :items="ingresses?.items ?? [undefined]"
-              :total="ingresses?.total"
-              @change="route.update"
+            <AppCollection
+              class="zone-ingress-collection"
+              data-testid="zone-ingress-collection"
+              :headers="[
+                { ...me.get('headers.name'), label: 'Name', key: 'name' },
+                { ...me.get('headers.socketAddress'), label: 'Address', key: 'socketAddress' },
+                { ...me.get('headers.advertisedSocketAddress'), label: 'Advertised address', key: 'advertisedSocketAddress' },
+                { ...me.get('headers.status'), label: 'Status', key: 'status' },
+                { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
+              ]"
+              :items="data.items"
+              :is-selected-row="(row) => row.name === route.params.proxy"
+              @resize="me.set"
             >
-              <!-- TODO: Update page & size once the list endpoint is being filtered by zone -->
-              <AppCollection
-                class="zone-ingress-collection"
-                data-testid="zone-ingress-collection"
-                :headers="[
-                  { ...me.get('headers.name'), label: 'Name', key: 'name' },
-                  { ...me.get('headers.socketAddress'), label: 'Address', key: 'socketAddress' },
-                  { ...me.get('headers.advertisedSocketAddress'), label: 'Advertised address', key: 'advertisedSocketAddress' },
-                  { ...me.get('headers.status'), label: 'Status', key: 'status' },
-                  { ...me.get('headers.actions'), label: 'Actions', key: 'actions', hideLabel: true },
-                ]"
-                :items="ingresses?.items"
-                :is-selected-row="(row) => row.name === route.params.proxy"
-                @resize="me.set"
-              >
-                <template #name="{ row: item }">
+              <template #name="{ row: item }">
+                <XAction
+                  data-action
+                  :to="{
+                    name: 'zone-ingress-summary-view',
+                    params: {
+                      zone: route.params.zone,
+                      proxy: item.id,
+                      proxyType: 'ingresses',
+                    },
+                    query: {
+                      page: route.params.page,
+                      size: route.params.size,
+                    },
+                  }"
+                >
+                  {{ item.name }}
+                </XAction>
+              </template>
+
+              <template #socketAddress="{ row: item }">
+                <XCopyButton
+                  v-if="item.zoneIngress.socketAddress.length > 0"
+                  :text="item.zoneIngress.socketAddress"
+                />
+                <template v-else>
+                  {{ t('common.collection.none') }}
+                </template>
+              </template>
+
+              <template #advertisedSocketAddress="{ row: item }">
+                <XCopyButton
+                  v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
+                  :text="item.zoneIngress.advertisedSocketAddress"
+                />
+                <template v-else>
+                  {{ t('common.collection.none') }}
+                </template>
+              </template>
+
+              <template #status="{ row: item }">
+                <StatusBadge
+                  :status="item.state"
+                />
+              </template>
+
+              <template #actions="{ row: item }">
+                <XActionGroup>
                   <XAction
-                    data-action
                     :to="{
-                      name: 'zone-ingress-summary-view',
+                      name: 'zone-ingress-detail-view',
                       params: {
-                        zone: route.params.zone,
                         proxy: item.id,
                         proxyType: 'ingresses',
                       },
-                      query: {
-                        // TODO: Update page & size once the list endpoint is being filtered by zone
-                        page: 1,
-                        size: 100,
-                      },
                     }"
                   >
-                    {{ item.name }}
+                    {{ t('common.collection.actions.view') }}
                   </XAction>
-                </template>
+                </XActionGroup>
+              </template>
+            </AppCollection>
 
-                <template #socketAddress="{ row: item }">
-                  <XCopyButton
-                    v-if="item.zoneIngress.socketAddress.length > 0"
-                    :text="item.zoneIngress.socketAddress"
-                  />
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-
-                <template #advertisedSocketAddress="{ row: item }">
-                  <XCopyButton
-                    v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
-                    :text="item.zoneIngress.advertisedSocketAddress"
-                  />
-                  <template v-else>
-                    {{ t('common.collection.none') }}
-                  </template>
-                </template>
-
-                <template #status="{ row: item }">
-                  <StatusBadge
-                    :status="item.state"
-                  />
-                </template>
-
-                <template #actions="{ row: item }">
-                  <XActionGroup>
-                    <XAction
-                      :to="{
-                        name: 'zone-ingress-detail-view',
-                        params: {
-                          proxy: item.id,
-                          proxyType: 'ingresses',
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.actions.view') }}
-                    </XAction>
-                  </XActionGroup>
-                </template>
-              </AppCollection>
-
-              <RouterView
-                v-if="route.child()"
-                v-slot="{ Component }"
+            <RouterView
+              v-if="route.child()"
+              v-slot="{ Component }"
+            >
+              <SummaryView
+                @close="route.replace({
+                  name: 'zone-ingress-list-view',
+                  params: {
+                    zone: route.params.zone,
+                  },
+                  query: {
+                    page: route.params.page,
+                    size: route.params.size,
+                  },
+                })"
               >
-                <SummaryView
-                  @close="route.replace({
-                    name: 'zone-ingress-list-view',
-                    params: {
-                      zone: route.params.zone,
-                    },
-                    query: {
-                      // TODO: Update page & size once the list endpoint is being filtered by zone
-                      page: 1,
-                      size: 100,
-                    },
-                  })"
-                >
-                  <component
-                    :is="Component"
-                    v-if="typeof ingresses !== 'undefined'"
-                    :items="ingresses.items"
-                  />
-                </SummaryView>
-              </RouterView>
-            </DataCollection>
-          </template>
+                <component
+                  :is="Component"
+                  :items="data.items"
+                />
+              </SummaryView>
+            </RouterView>
+          </DataCollection>
         </DataLoader>
       </XCard>
     </AppView>
@@ -156,8 +150,4 @@ import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
-import type { ZoneOverview } from '@/app/zones/data'
-const _props = defineProps<{
-  data: ZoneOverview
-}>()
 </script>

--- a/packages/kuma-gui/src/test-support/mocks/src/zone-ingresses/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zone-ingresses/_overview.ts
@@ -7,6 +7,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     '/zone-ingresses/_overview',
   )
 
+  const zoneName = env('KUMA_ZONE_NAME', req.url.searchParams.get('filter[labels.kuma.io/zone]') ?? 'zone-0')
   return {
     headers: {},
     body: {
@@ -17,7 +18,6 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const displayName = `${fake.word.noun()}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
         const nspace = fake.k8s.namespace()
 
-        const zoneName = env('KUMA_ZONE_NAME', 'zone-0')
 
         const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
         const serviceCount = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))

--- a/packages/kuma-gui/src/test-support/mocks/src/zoneegresses/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zoneegresses/_overview.ts
@@ -6,6 +6,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     req,
     '/zoneegresses/_overview',
   )
+  const zoneName = env('KUMA_ZONE_NAME', req.url.searchParams.get('filter[labels.kuma.io/zone]') ?? 'zone-0')
   return {
     headers: {},
     body: {
@@ -16,7 +17,6 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const displayName = `${fake.word.noun()}-${id}${fake.kuma.dataplaneSuffix(k8s)}`
         const nspace = fake.k8s.namespace()
 
-        const zoneName = env('KUMA_ZONE_NAME', 'zone-0')
 
         const subscriptionCount = parseInt(env('KUMA_SUBSCRIPTION_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
 

--- a/packages/kuma-gui/src/types/api.d.ts
+++ b/packages/kuma-gui/src/types/api.d.ts
@@ -23,6 +23,7 @@ export interface PaginatedApiListResponse<ResourceType> extends ApiListResponse<
 export interface PaginationParameters {
   size?: number
   offset?: number
+  filter?: Record<string, string>
 }
 
 export interface SingleResourceParameters {


### PR DESCRIPTION
Following https://github.com/kumahq/kuma/pull/12840 this PR adds support for proper paging of Zone Proxies via the GUI. Previousy we would just request a large number of Zone Proxies and filter for the ones we were interested in, with no paging (max of 100 proxies)

The GUI now pages Zone Ingresses and Zone Egresses just like any other resource in the GUI

Closes https://github.com/kumahq/kuma-gui/issues/3521