### PR TITLE
refactor(meshes): slightly refactors MTP notification

### DIFF
--- a/packages/kuma-gui/src/app/meshes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/meshes/locales/en-us/index.yaml
@@ -4,6 +4,20 @@ meshes:
     label: Documentation
     href: &meshes.docs.href '{KUMA_DOCS_URL}/production/mesh?{KUMA_UTM_QUERY_PARAMS}'
 
+  notifications:
+    mtls-warning: !!text/markdown |
+      mTLS is not enabled on this mesh.
+      <a href="{KUMA_DOCS_URL}/policies/mutual-tls/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">
+        Consider enabling mTLS to get the most of out of {KUMA_PRODUCT_NAME}
+      </a>
+    mtp-warning: !!text/markdown |
+      mTLS is enabled but you do not have a
+      <a href="{KUMA_DOCS_URL}/policies/meshtrafficpermission/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">
+        MeshTrafficPermission policy
+      </a>
+      for this mesh.
+
+
   common:
     name: Name
     type: |
@@ -39,10 +53,6 @@ meshes:
         data-plane-list-view: Data Plane Proxies
         policy-list-index-view: Policies
       overview: 'Overview'
-      mtls-warning: !!text/markdown |
-        mTLS is not enabled on this mesh. <a href="{KUMA_DOCS_URL}/policies/mutual-tls/?{KUMA_UTM_QUERY_PARAMS}" target="_blank">Consider enabling mTLS to get the most of out of {KUMA_PRODUCT_NAME}</a>
-      mtp-warning: !!text/markdown |
-        mTLS is enabled but you do not have a <a href="{KUMA_DOCS_URL}/policies/meshtrafficpermission/?{KUMA_UTM_QUERY_PARAMS}">MeshTrafficPermission policy</a> for this mesh.
       about:
         title: About this Mesh
     items:

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -17,159 +17,154 @@
       })"
       v-slot="{ data }"
     >
-      <template
-        v-for="missingTLSPolicy in [
-          ['MeshTrafficPermission', 'TrafficPermission'].reduce((prev, item) => prev + (data?.policies?.[item]?.total ?? 0), 0) === 0,
-        ]"
-        :key="missingTLSPolicy"
+      <AppView
+        :docs="t('meshes.href.docs')"
+        :notifications="true"
       >
-        <AppView
-          :docs="t('meshes.href.docs')"
-          :notifications="true"
+        <XNotification
+          v-if="!props.mesh.mtlsBackend"
+          :uri="`meshes.notifications.mtls-warning:${props.mesh.id}`"
         >
-          <XNotification
-            v-if="!props.mesh.mtlsBackend"
-            :uri="`mtls-warning.${props.mesh.id}`"
+          <XI18n
+            path="meshes.notifications.mtls-warning"
+          />
+        </XNotification>
+        <XLayout
+          type="stack"
+        >
+          <XAboutCard
+            :title="t('meshes.routes.item.about.title')"
+            :created="props.mesh.creationTime"
+            :modified="props.mesh.modificationTime"
           >
-            <XI18n
-              path="meshes.routes.item.mtls-warning"
-            />
-          </XNotification>
-          <XNotification
-            v-if="props.mesh.mtlsBackend && missingTLSPolicy"
-            :uri="`mtp-warning.${props.mesh.id}`"
-          >
-            <XI18n
-              path="meshes.routes.item.mtp-warning"
-            />
-          </XNotification>
-          <XLayout
-            type="stack"
-          >
-            <XAboutCard
-              :title="t('meshes.routes.item.about.title')"
-              :created="props.mesh.creationTime"
-              :modified="props.mesh.modificationTime"
+            <template
+              v-for="policy in ['MeshTrafficPermission', 'MeshMetric', 'MeshAccessLog', 'MeshTrace']"
+              :key="policy"
             >
               <template
-                v-for="policy in ['MeshTrafficPermission', 'MeshMetric', 'MeshAccessLog', 'MeshTrace']"
-                :key="policy"
+                v-for="stats in [data?.policies?.[policy] ?? { total: 0 }]"
+                :key="typeof stats"
               >
-                <template
-                  v-for="enabled in [Object.entries(data?.policies ?? {}).find(([key]) => key === policy)]"
-                  :key="enabled"
+                <XNotification
+                  v-if="policy === 'MeshTrafficPermission' && props.mesh.mtlsBackend && stats.total === 0"
+                  :uri="`meshes.notifications.mtp-warning:${props.mesh.id}`"
                 >
-                  <DefinitionCard layout="horizontal">
-                    <template #title>
-                      <XAction
-                        :to="{
-                          name: 'policy-list-view',
-                          params: {
-                            mesh: route.params.mesh,
-                            policyPath: `${policy.toLowerCase()}s`,
-                          },
-                        }"
-                      >
-                        {{ policy }}
-                      </XAction>
-                    </template>
+                  <XI18n
+                    path="meshes.notifications.mtp-warning"
+                  />
+                </XNotification>
+                <DefinitionCard
+                  layout="horizontal"
+                >
+                  <template #title>
+                    <XAction
+                      :to="{
+                        name: 'policy-list-view',
+                        params: {
+                          mesh: route.params.mesh,
+                          policyPath: `${policy.toLowerCase()}s`,
+                        },
+                      }"
+                    >
+                      {{ policy }}
+                    </XAction>
+                  </template>
 
-                    <template #body>
-                      <XBadge
-                        :appearance="enabled ? 'success' : 'neutral'"
-                      >
-                        {{ enabled ? t('meshes.detail.enabled') : t('meshes.detail.disabled') }}
-                      </XBadge>
-                    </template>
-                  </DefinitionCard>
-                </template>
-              </template>
-
-              <DefinitionCard layout="horizontal">
-                <template #title>
-                  {{ t('http.api.property.mtls') }}
-                </template>
-
-                <template #body>
-                  <XBadge
-                    v-if="!props.mesh.mtlsBackend"
-                    appearance="neutral"
-                  >
-                    {{ t('meshes.detail.disabled') }}
-                  </XBadge>
-
-                  <template v-else>
-                    <XBadge appearance="info">
-                      {{ props.mesh.mtlsBackend.type }} / {{ props.mesh.mtlsBackend.name }}
+                  <template #body>
+                    <XBadge
+                      :appearance="stats.total > 0 ? 'success' : 'neutral'"
+                    >
+                      {{ stats.total > 0 ? t('meshes.detail.enabled') : t('meshes.detail.disabled') }}
                     </XBadge>
                   </template>
-                </template>
-              </DefinitionCard>
-            </XAboutCard>
+                </DefinitionCard>
+              </template>
+            </template>
 
-            <XCard>
-              <XLayout
-                type="stack"
-              >
-                <XLayout
-                  type="columns"
-                  class="columns-with-borders"
+            <DefinitionCard layout="horizontal">
+              <template #title>
+                {{ t('http.api.property.mtls') }}
+              </template>
+
+              <template #body>
+                <XBadge
+                  v-if="!props.mesh.mtlsBackend"
+                  appearance="neutral"
                 >
-                  <ResourceStatus
-                    :total="data?.services.total ?? 0"
-                    data-testid="services-status"
-                  >
-                    <template #title>
-                      {{ t('meshes.detail.services') }}
-                    </template>
-                  </ResourceStatus>
+                  {{ t('meshes.detail.disabled') }}
+                </XBadge>
 
-                  <ResourceStatus
-                    :total="data?.dataplanesByType.standard.total ?? 0"
-                    :online="data?.dataplanesByType.standard.online ?? 0"
-                    data-testid="data-plane-proxies-status"
-                  >
-                    <template #title>
-                      {{ t('meshes.detail.data_plane_proxies') }}
-                    </template>
-                  </ResourceStatus>
+                <template v-else>
+                  <XBadge appearance="info">
+                    {{ props.mesh.mtlsBackend.type }} / {{ props.mesh.mtlsBackend.name }}
+                  </XBadge>
+                </template>
+              </template>
+            </DefinitionCard>
+          </XAboutCard>
 
-                  <ResourceStatus
-                    :total="data?.totalPolicyCount ?? 0"
-                    data-testid="policies-status"
-                  >
-                    <template #title>
-                      {{ t('meshes.detail.policies') }}
-                    </template>
-                  </ResourceStatus>
-                </XLayout>
-              </XLayout>
-            </XCard>
-
-            <XCard>
-              <ResourceCodeBlock
-                :resource="props.mesh.config"
-                v-slot="{ copy, copying }"
+          <XCard>
+            <XLayout
+              type="stack"
+            >
+              <XLayout
+                type="columns"
+                class="columns-with-borders"
               >
-                <DataSource
-                  v-if="copying"
-                  :src="uri(sources, '/meshes/:name/as/kubernetes', {
-                    name: route.params.mesh,
-                  }, {
-                    cacheControl: 'no-store',
-                  })"
-                  @change="(data) => {
-                    copy((resolve) => resolve(data))
-                  }"
-                  @error="(e) => {
-                    copy((_resolve, reject) => reject(e))
-                  }"
-                />
-              </ResourceCodeBlock>
-            </XCard>
-          </XLayout>
-        </AppView>
-      </template>
+                <ResourceStatus
+                  :total="data?.services.total ?? 0"
+                  data-testid="services-status"
+                >
+                  <template #title>
+                    {{ t('meshes.detail.services') }}
+                  </template>
+                </ResourceStatus>
+
+                <ResourceStatus
+                  :total="data?.dataplanesByType.standard.total ?? 0"
+                  :online="data?.dataplanesByType.standard.online ?? 0"
+                  data-testid="data-plane-proxies-status"
+                >
+                  <template #title>
+                    {{ t('meshes.detail.data_plane_proxies') }}
+                  </template>
+                </ResourceStatus>
+
+                <ResourceStatus
+                  :total="data?.totalPolicyCount ?? 0"
+                  data-testid="policies-status"
+                >
+                  <template #title>
+                    {{ t('meshes.detail.policies') }}
+                  </template>
+                </ResourceStatus>
+              </XLayout>
+            </XLayout>
+          </XCard>
+
+          <XCard>
+            <ResourceCodeBlock
+              :resource="props.mesh.config"
+              v-slot="{ copy, copying }"
+            >
+              <DataSource
+                v-if="copying"
+                :src="uri(sources, '/meshes/:name/as/kubernetes', {
+                  name: route.params.mesh,
+                }, {
+                  cacheControl: 'no-store',
+                })"
+                @change="(data) => {
+                  copy((resolve) => resolve(data))
+                }"
+                @error="(e) => {
+                  copy((_resolve, reject) => reject(e))
+                }"
+              />
+            </ResourceCodeBlock>
+          </XCard>
+        </XLayout>
+      </AppView>
     </DataSource>
   </RouteView>
 </template>

--- a/packages/kuma-gui/src/test-support/mocks/src/mesh-insights/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/mesh-insights/_.ts
@@ -2,13 +2,12 @@ import type { EndpointDependencies, MockResponder } from '@/test-support'
 export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
 
-  const policyTypes = fake.kuma.policyNames({ min: Number.MAX_VALUE }, { includeLegacy: true })
-
   const serviceTotal = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 1, max: 30 })}`))
 
   const standard = fake.kuma.healthStatus()
   const gatewayBuiltin = fake.kuma.healthStatus()
   const gatewayDelegated = fake.kuma.healthStatus()
+
   const gateway = {
     total: (gatewayBuiltin.total ?? 0) + (gatewayDelegated.total ?? 0),
     online: (gatewayBuiltin.online ?? 0) + (gatewayDelegated.online ?? 0),
@@ -41,11 +40,9 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
         gatewayDelegated,
       },
       policies: {
-        ...policyTypes.reduce((prev: Record<string, { total: number }>, item) => {
-          if (fake.datatype.boolean()) {
-            prev[item] = {
-              total: fake.number.int(20),
-            }
+        ...fake.kuma.policyNames().reduce((prev: Record<string, { total: number }>, item) => {
+          prev[item] = {
+            total: fake.number.int(20),
           }
           return prev
         }, {}),

--- a/packages/kuma-gui/src/test-support/mocks/src/resources.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/resources.ts
@@ -1,12 +1,12 @@
 import type { EndpointDependencies, MockResponder } from '@/test-support'
 export default ({ fake }: EndpointDependencies): MockResponder => (_req) => {
-  const policies = Array.from(fake.kuma.policyNames({ min: Number.MAX_VALUE }, { includeLegacy: true }))
-  const legacyPolicies = fake.kuma.policyNamesLegacy({ min: Number.MAX_VALUE })
-  
+  const policies = Array.from(fake.kuma.policyNames({ min: Number.MAX_SAFE_INTEGER }))
+  const legacyPolicies = fake.kuma.policyNamesLegacy({ min: Number.MAX_SAFE_INTEGER })
+
   return {
     headers: {},
     body: {
-      resources: fake.kuma.resourceNames({ min: Number.MAX_VALUE }).map((name) => {
+      resources: fake.kuma.resourceNames({ min: Number.MAX_SAFE_INTEGER }).map((name) => {
         const scope = fake.helpers.arrayElement(['Mesh', 'Global'])
 
         return {


### PR DESCRIPTION
Refactors the MTP notification we have when you have mTLS enabled but no MeshTrafficPermission.

---

While I was doing this I noticed that the faker `policyNames` code wasn't quite the same interface as faker, and I think the randomness wasn't quite working because max was defaulting to a super big value (which I think meant a low chance of getting low numbers) so I made some slight changes there after I looked in fakers code to see exactly how they do this and then made a `maxmin` helper to replicate fakers types/functionality so we keep the same interface everywhere.

This meant:

1. Altering slightly the `{ min, max }` args and how they are defaulted.
2. Using `Number.MAX_SAFE_INTEGER` over `Number.MAX_VALUE` as a "give me all the things" placeholder
3. If you use `Number.MAX_SAFE_INTEGER` to say "potentially include all of them" we don't pass that along to arrayElements
4. I removed includeLegacy where it wasn't needed, mostly because where i was using it I had to write `(undefined, { includeLegacy: true})`

I _think_ this is the functionality we want for `policyNames`

---

Apart from this I also made the policy enabling/disabling rendering work based on `total: 0` as well as just existence, which again is the functionality I _think_ we want?

Closes https://github.com/kumahq/kuma-gui/issues/2851