### PR TITLE
chore(lint): add CSS selector-combinator-space-after/before always lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3475,6 +3475,51 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@stylistic/stylelint-plugin": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-3.1.2.tgz",
+      "integrity": "sha512-tylFJGMQo62alGazK74MNxFjMagYOHmBZiePZFOJK2n13JZta0uVkB3Bh5qodUmOLtRH+uxH297EibK14UKm8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.1",
+        "@csstools/css-tokenizer": "^3.0.1",
+        "@csstools/media-query-list-parser": "^3.0.1",
+        "is-plain-object": "^5.0.0",
+        "postcss-selector-parser": "^6.1.2",
+        "postcss-value-parser": "^4.2.0",
+        "style-search": "^0.1.0",
+        "stylelint": "^16.8.2"
+      },
+      "engines": {
+        "node": "^18.12 || >=20.9"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.8.0"
+      }
+    },
+    "node_modules/@stylistic/stylelint-plugin/node_modules/@csstools/media-query-list-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.1.tgz",
+      "integrity": "sha512-HNo8gGD02kHmcbX6PvCoUuOQvn4szyB9ca63vZHKX5A81QytgDG4oxG4IaEfHTlEZSZ6MjPEMWIVU+zF2PZcgw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.1",
+        "@csstools/css-tokenizer": "^3.0.1"
+      }
+    },
     "node_modules/@teppeis/multimaps": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-3.0.0.tgz",
@@ -13794,6 +13839,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
+      "license": "ISC"
+    },
     "node_modules/stylelint": {
       "version": "16.14.1",
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.14.1.tgz",
@@ -16152,6 +16203,7 @@
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.4",
         "@eslint/js": "^9.17.0",
         "@stylistic/eslint-plugin": "^3.1.0",
+        "@stylistic/stylelint-plugin": "^3.1.2",
         "@typescript-eslint/eslint-plugin": "^8.25.0",
         "@typescript-eslint/parser": "^8.25.0",
         "@vue/eslint-config-typescript": "^14.3.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -18,6 +18,7 @@
     "@bahmutov/cypress-esbuild-preprocessor": "^2.2.4",
     "@eslint/js": "^9.17.0",
     "@stylistic/eslint-plugin": "^3.1.0",
+    "@stylistic/stylelint-plugin": "^3.1.2",
     "@typescript-eslint/eslint-plugin": "^8.25.0",
     "@typescript-eslint/parser": "^8.25.0",
     "@vue/eslint-config-typescript": "^14.3.0",

--- a/packages/config/src/stylelint.cjs
+++ b/packages/config/src/stylelint.cjs
@@ -6,9 +6,16 @@ function createStylelintConfig() {
       'stylelint-config-recommended-scss',
       'stylelint-config-recommended-vue/scss',
     ],
-    plugins: ['@kong/design-tokens/stylelint-plugin'],
-    ignoreFiles: ['dist/**/*'],
+    plugins: [
+      '@stylistic/stylelint-plugin',
+      '@kong/design-tokens/stylelint-plugin',
+    ],
+    ignoreFiles: [
+      'dist/**/*',
+    ],
     rules: {
+      '@stylistic/selector-combinator-space-before': 'always',
+      '@stylistic/selector-combinator-space-after': 'always',
       '@kong/design-tokens/use-proper-token': [
         true,
         {

--- a/packages/kuma-gui/features/zones/zone-cps/ingresses/Index.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/ingresses/Index.feature
@@ -25,7 +25,7 @@ Feature: zones / ingresses / index
                   disconnectTime: 2020-07-28T16:18:09.743141Z
                 - connectTime: 2020-07-28T16:18:09.743141Z
                   disconnectTime: !!js/undefined
-
+      
           - name: zone-ingress-2
             zoneIngress:
               zone: zone-cp-1

--- a/packages/kuma-gui/src/assets/styles/_components.scss
+++ b/packages/kuma-gui/src/assets/styles/_components.scss
@@ -8,11 +8,11 @@ For stacking elements with consistent space between.
 Adapted from https://every-layout.dev/layouts/stack/.
 */
 
-.stack>*+* {
+.stack > * + * {
   margin-block-start: $kui-space-70;
 }
 
-.stack-small>*+* {
+.stack-small > * + * {
   margin-block-start: $kui-space-40;
 }
 
@@ -21,7 +21,7 @@ Adapted from https://every-layout.dev/layouts/stack/.
 
 Variant of .stack with a horizontal border in the center of the gap.
 */
-.stack-with-borders>*+* {
+.stack-with-borders > * + * {
   margin-block-start: $kui-space-40;
   border-block-start: $kui-border-width-10 solid $kui-color-border;
   padding-block-start: $kui-space-40;
@@ -43,7 +43,7 @@ Adapted from https://every-layout.dev/layouts/switcher/.
   gap: $kui-space-80;
 }
 
-.columns>* {
+.columns > * {
   flex-grow: 1;
   flex-basis: calc((var(--threshold) - 100%) * 999);
   min-inline-size: 0;
@@ -54,6 +54,6 @@ Adapted from https://every-layout.dev/layouts/switcher/.
 
 Variant of .columns with a vertical border at the right side of each column (except the last).
 */
-.columns-with-borders>*:not(:last-child) {
+.columns-with-borders > *:not(:last-child) {
   border-right: $kui-border-width-10 solid $kui-color-border;
 }


### PR DESCRIPTION
Adds a CSS lint rule to force spaces around selector combinator.

Just to note, this is a code style rule, but at least we all agree on it 😅 .

It also adds a dev dependency 🙈 , so if that dependency ends up in our weekly dependabot's all the time I am 100% ok with removing it again (along with the rule).

Closes https://github.com/kumahq/kuma-gui/issues/1484