### PR TITLE
chore: move some older env vars (strings) over to locales

### DIFF
--- a/packages/kuma-gui/.env
+++ b/packages/kuma-gui/.env
@@ -1,3 +1,2 @@
 VITE_VERSION_URL=https://kuma.io/latest_version
 VITE_KUMA_API_SERVER_URL=http://localhost:5681
-VITE_DOCS_BASE_URL=https://kuma.io/docs

--- a/packages/kuma-gui/src/app/application/services/env/env.spec.ts
+++ b/packages/kuma-gui/src/app/application/services/env/env.spec.ts
@@ -1,17 +1,8 @@
 import { describe, expect, test } from 'vitest'
 
-import Env, { normalizeBaseUrl, semver } from './Env'
+import Env, { normalizeBaseUrl } from './Env'
 
 describe('env', () => {
-  test('semver', () => {
-    expect(semver('1.1.1').patch).toBe('1.1.1')
-    expect(semver('0.0.0-preview.1').patch).toBe('0.0.0')
-    expect(semver('0.0.1-rc.1').patch).toBe('0.0.1')
-    expect(semver('10.10.1').major).toBe('10')
-    expect(semver('0.9.1').minor).toBe('0.9')
-    expect(semver('0.9.1-rc.10').pre).toBe('0.9.1-rc.10')
-  })
-
   test('var', () => {
     class MockEnv extends Env {
       protected getConfig() {
@@ -30,11 +21,9 @@ describe('env', () => {
     const env = new MockEnv(
       {
         KUMA_VERSION_URL: 'http://version.fake',
-        KUMA_DOCS_URL: 'http://docs.fake',
         KUMA_MOCK_API_ENABLED: 'false',
       },
     )
-    expect(env.var('KUMA_DOCS_URL')).toBe('http://docs.fake/110.127.x')
     expect(env.var('KUMA_VERSION')).toBe('110.127.30')
     expect(env.var('KUMA_API_URL')).toBe('/somewhere/else')
     expect(env.var('KUMA_BASE_PATH')).toBe('/not/gui')

--- a/packages/kuma-gui/src/app/application/services/i18n/I18n.ts
+++ b/packages/kuma-gui/src/app/application/services/i18n/I18n.ts
@@ -1,5 +1,6 @@
 import { createI18n } from '@kong-ui-public/i18n'
 
+import { semver } from '../../utilities'
 import { get } from '@/app/application'
 import type Env from '@/app/application/services/env/Env'
 
@@ -38,14 +39,19 @@ export default <T extends I18nRecord>(strs: T, env: Env['var']) => {
   })
   const globals = {
     KUMA_VERSION: env('KUMA_VERSION'),
-    KUMA_DOCS_URL: env('KUMA_DOCS_URL'),
+    KUMA_DOCS_URL: '',
     KUMA_UTM_QUERY_PARAMS: '',
     KUMA_PRODUCT_NAME: '',
   }
   try {
     globals.KUMA_UTM_QUERY_PARAMS = i18n.t('common.product.utm_query_params' as Parameters<typeof i18n['t']>[0])
     globals.KUMA_PRODUCT_NAME = i18n.t('common.product.name' as Parameters<typeof i18n['t']>[0])
-  } catch {
+    globals.KUMA_DOCS_URL = i18n.t(
+      'common.product.docs' as Parameters<typeof i18n['t']>[0],
+      semver(globals.KUMA_VERSION),
+    )
+  } catch (e) {
+    console.error(e)
     // passthrough
   }
   return {

--- a/packages/kuma-gui/src/app/application/utilities/index.spec.ts
+++ b/packages/kuma-gui/src/app/application/utilities/index.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest'
+
+import { semver } from './'
+describe('utilities', () => {
+  test('semver', () => {
+    expect(semver('1.1.1').patch).toBe('1.1.1')
+    expect(semver('0.0.0-preview.1').patch).toBe('0.0.0')
+    expect(semver('0.0.1-rc.1').patch).toBe('0.0.1')
+    expect(semver('10.10.1').major).toBe('10')
+    expect(semver('0.9.1').minor).toBe('0.9')
+    expect(semver('0.9.1-rc.10').pre).toBe('0.9.1-rc.10')
+  })
+})

--- a/packages/kuma-gui/src/app/application/utilities/index.ts
+++ b/packages/kuma-gui/src/app/application/utilities/index.ts
@@ -23,6 +23,25 @@ export const YAML = {
   },
 }
 
+export function semver(version: string): { major: string, minor: string, patch: string, pre: string } {
+  const [major, minor, ...patchPre] = version.split('.')
+  if (isNaN(parseInt(major))) {
+    return {
+      major,
+      minor: major,
+      patch: major,
+      pre: major,
+    }
+  }
+  const [patch, pre] = patchPre.join('.').split('-')
+  return {
+    major,
+    minor: `${major}.${minor}`,
+    patch: `${major}.${minor}.${patch}`,
+    pre: `${major}.${minor}.${patch}${typeof pre !== 'undefined' ? `-${pre}` : ''}`,
+  }
+}
+
 export function get(obj: any, path: string, defaultValue: any = undefined): any {
   if (!(typeof obj === 'object') || Array.isArray(obj)) {
     return defaultValue

--- a/packages/kuma-gui/src/app/control-planes/sources.ts
+++ b/packages/kuma-gui/src/app/control-planes/sources.ts
@@ -9,7 +9,6 @@ import type KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
 
 export type ControlPlaneAddresses = {
   http: string
-  kds: string
 }
 
 export type ControlPlaneAddressesSource = DataSourceResponse<ControlPlaneAddresses>
@@ -36,7 +35,6 @@ export const sources = (env: Env['var'], api: KumaApi) => {
     '/control-plane/addresses': async (): Promise<ControlPlaneAddresses> => {
       return {
         http: env('KUMA_API_URL'),
-        kds: env('KUMA_KDS_URL'),
       }
     },
 
@@ -90,7 +88,7 @@ export const sources = (env: Env['var'], api: KumaApi) => {
 
     '/global-insight': async () => {
       const res = await http.GET('/global-insight')
-      
+
       return GlobalInsight.fromObject(res.data!)
     },
   })

--- a/packages/kuma-gui/src/app/kuma/index.ts
+++ b/packages/kuma-gui/src/app/kuma/index.ts
@@ -26,7 +26,6 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     [app.EnvVars, {
       constant: {
         KUMA_VERSION_URL: import.meta.env.VITE_VERSION_URL,
-        KUMA_DOCS_URL: import.meta.env.VITE_DOCS_BASE_URL,
         KUMA_MOCK_API_ENABLED: import.meta.env.VITE_MOCK_API_ENABLED,
       } as EnvArgs,
     }],

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -3,13 +3,16 @@ common:
     ignore-error: ""
   product:
     name: Kuma
+    docs: |
+      https://kuma.io/docs/{ major, select,
+        0 {dev}
+        other {{minor}.x}
+      }
     utm_query_params: utm_source=Kuma&utm_medium=Kuma
     href:
-      # version: https://kuma.io/latest_version
       feedback: 'https://github.com/kumahq/kuma/issues/new/choose'
       install: 'https://kuma.io/install/latest/?{KUMA_UTM_QUERY_PARAMS}'
       docs:
-        # base: https://kuma.io/docs
         index: '{KUMA_DOCS_URL}/?{KUMA_UTM_QUERY_PARAMS}'
     environment:
       universal: Universal


### PR DESCRIPTION
Closes https://github.com/kumahq/kuma-gui/issues/2431

Moves or removes the last of our "strings" to i18n:

- `KUMA_KDS_URL` we no longer need here
- `KUMA_DOCS_URL` I've moved to i18n. The "re-shaping" from `2.9.0` to `2.9.x` is now controlled via i18n, so its an application level concern rather than a framework concern.

We have 2 non-index.html derived env vars left:

- `KUMA_MOCK_API_ENABLED` - actual env var
- `KUMA_VERSION_URL` - whilst this isn't index.html derived, and is a "string" we use it programatically i.e. we don't just "print the thing out to the screen", so I'm a little unsure about putting it in i18n. I'll likely move it/hardcode it directly into `main.ts` at some point or something similar. In any case its not a 100% i18n-able string.

