### PR TITLE
refactor: sync port types

### DIFF
--- a/packages/kuma-gui/features/application/Loading.feature
+++ b/packages/kuma-gui/features/application/Loading.feature
@@ -2,7 +2,7 @@ Feature: application / loading
 
   Background:
     Given the CSS selectors
-      | Alias              | Selector                      |
+      | Alias              | Selector                       |
       | collection-loading | [data-testid='table-skeleton'] |
 
   Scenario: Collections show a loading view

--- a/packages/kuma-gui/src/app/zone-egresses/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/zone-egresses/data/index.spec.ts
@@ -156,7 +156,7 @@ describe('ZoneEgressOverview', () => {
             item.zoneEgress.networking = {}
           }
           delete item.zoneEgress.networking?.address
-          item.zoneEgress.networking.port = '80'
+          item.zoneEgress.networking.port = 80
           return item
         })
         expect(actual.zoneEgress.socketAddress).toStrictEqual('')
@@ -202,7 +202,7 @@ describe('ZoneEgressOverview', () => {
             item.zoneEgress.networking = {}
           }
           item.zoneEgress.networking.address = '127.0.0.1'
-          item.zoneEgress.networking.port = '80'
+          item.zoneEgress.networking.port = 80
           return item
         })
         expect(actual.zoneEgress.socketAddress).toStrictEqual('127.0.0.1:80')
@@ -221,7 +221,7 @@ describe('ZoneEgressOverview', () => {
         modificationTime: '2021-07-13T08:40:59Z',
         networking: {
           address: '486f:d1db:efde:c143:94a5:cb9f:271a:c1a7',
-          port: '58936',
+          port: 58936,
         },
       }
       const actual = await fixture.setup((item) => {

--- a/packages/kuma-gui/src/app/zone-ingresses/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/zone-ingresses/data/index.spec.ts
@@ -215,9 +215,9 @@ describe('ZoneIngressOverview', () => {
             item.zoneIngress.networking = {}
           }
           delete item.zoneIngress.networking?.address
-          item.zoneIngress.networking.port = '80'
+          item.zoneIngress.networking.port = 80
           delete item.zoneIngress.networking?.advertisedAddress
-          item.zoneIngress.networking.advertisedPort = '80'
+          item.zoneIngress.networking.advertisedPort = 80
           return item
         })
         expect(actual.zoneIngress.socketAddress).toStrictEqual('')
@@ -271,9 +271,9 @@ describe('ZoneIngressOverview', () => {
             item.zoneIngress.networking = {}
           }
           item.zoneIngress.networking.address = '127.0.0.1'
-          item.zoneIngress.networking.port = '80'
+          item.zoneIngress.networking.port = 80
           item.zoneIngress.networking.advertisedAddress = '127.0.0.2'
-          item.zoneIngress.networking.advertisedPort = '81'
+          item.zoneIngress.networking.advertisedPort = 81
           return item
         })
         expect(actual.zoneIngress.socketAddress).toStrictEqual('127.0.0.1:80')
@@ -302,8 +302,8 @@ describe('ZoneIngressOverview', () => {
         networking: {
           address: '486f:d1db:efde:c143:94a5:cb9f:271a:c1a7',
           advertisedAddress: '190.26.201.59',
-          advertisedPort: '58329',
-          port: '58936',
+          advertisedPort: 58329,
+          port: 58936,
         },
       }
       const actual = await fixture.setup((item) => {

--- a/packages/kuma-gui/src/types/index.d.ts
+++ b/packages/kuma-gui/src/types/index.d.ts
@@ -633,8 +633,8 @@ export interface ZoneOverview extends MeshEntity {
 export interface ZoneIngressNetworking {
   address?: string
   advertisedAddress?: string
-  port?: string
-  advertisedPort?: string
+  port?: number
+  advertisedPort?: number
 }
 
 export interface AvailableService {
@@ -671,7 +671,7 @@ export interface ZoneIngressOverview extends MeshEntity {
 
 export interface ZoneEgressNetworking {
   address?: string
-  port?: string
+  port?: number
 }
 
 export interface ZoneEgress extends MeshEntity {


### PR DESCRIPTION
Some of the types for the `port`s in our custom types are not in sync with the type provided by the API (`string` vs `number`). This PR attempts to align them:

- `port` should be a `number` [kuma search path:.golden](https://github.com/search?q=repo%3Akumahq%2Fkuma+port+path%3A.golden&type=code)
- `advertisedPort` should be a `number` [kuma search](https://github.com/search?q=repo%3Akumahq%2Fkuma%20advertisedPort&type=code)
- `addressPort` should stay as `string` [kuma search](https://github.com/search?q=repo%3Akumahq%2Fkuma%20addressPort&type=code), i.e. `"backend.mesh:80"`
- `targetPort` is either `number | string` (also typed from `openapi-typescript`) [kuma search](https://github.com/search?q=repo%3Akumahq%2Fkuma+targetPort&type=code), i.e. `targetPort: http-metrics`, `targetPort: 3000`

Closes #2069 