### PR TITLE
chore(ci): iterative improvements to releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
-name: 'Build and release to kumahq/kuma'
+name: release
 run-name: |
-  Build and release to kumahq/kuma (branch: ${{ github.event.workflow_run.head_branch || inputs.branch }})
+  release (branch: ${{ github.event.workflow_run.head_branch || inputs.branch }})
 
 # **Note 1**: You can merge a pull request into a release branch of the form
 # “release-$MAJOR.$MINOR” (e.g. “release-2.1”) in order to create the GUI
@@ -25,6 +25,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || inputs.branch }}
 
 on:
+
   # Allows running the workflow manually.
   workflow_dispatch:
     inputs:
@@ -58,12 +59,18 @@ jobs:
     #
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./packages/kuma-gui
+    strategy:
+      matrix:
+        package:
+          - name: "@kumahq/kuma-gui"
+            path: packages/kuma-gui
+            destination: kumahq/kuma
+    name: |
+      Releasing ${{ matrix.package.name }} to ${{ matrix.package.destination }}
     env:
       SHA: ${{ github.event.workflow_run.head_sha || inputs.sha }}
       BRANCH: ${{ github.event.workflow_run.head_branch || inputs.branch }}
+      APP_WORKSPACE: repository
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -73,16 +80,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      # Syft, used to generate the SBOM, struggles with npm projects when:
-      # - Two packages, in the same repository, are separate npm workloads
-      #   which share a common `package-lock.json`.
-      # - One package (e.g., `packages/config`) defines peerDependencies and
-      #   is referenced as a devDependency in another package
-      #   (e.g., `packages/kuma-gui`).
-      # [...]
-      # More information in ./packages/kuma-gui/mk/release.mk
       - run: |
-          make release/prune
+          make -C ${{ matrix.package.path }} build
 
       - uses: Kong/public-shared-actions/security-actions/sca@0ccacffed804d85da3f938a1b78c12831935f992
         id: sbom
@@ -95,45 +94,44 @@ jobs:
           config: .syft.yaml
           fail_build: 'true' # Fail job if critical vulnerabilities are detected
 
-      - run: |
-          make install/sync
-          make build/sync
-
       - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
         id: github-app-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          # Access to kuma needs to be explicitly included here so that a pull request can be opened in that repository.
           owner: ${{ github.repository_owner }}
+          # Access to kuma needs to be explicitly included here so that a pull
+          # request can be opened in that repository.
           repositories: "kuma-gui,kuma"
+
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # This needs to be a token that grants read access to `HOST_REPOSITORY`. If that repository is private, it needs general access to the `repo` scope which grants access to read private repositories. Otherwise, you will run into an error telling you that the checkout actions can’t determine the repository’s default branch. This is on account of a lack of access not because it can’t determine the default branch.
           token: ${{ steps.github-app-token.outputs.token }}
-          repository: ${{ vars.HOST_REPOSITORY }}
           ref: ${{ env.BRANCH }}
-          path: ./packages/kuma-gui/main-application
+          path: ${{ env.APP_WORKSPACE }}
+          repository: ${{ matrix.package.destination }}
 
       - run: |
-          cd main-application
+          make -C ${{ matrix.package.path }} release \
+            DESTINATION=${{github.workspace}}/${{ env.APP_WORKSPACE }}/app/kuma-ui/pkg/resources
 
-          echo 'Copying Grype and SBOM reports ...'
-          mkdir -p ${{ vars.HOST_REPORTS_DIRECTORY }}
-          rm -f ${{ vars.HOST_REPORTS_DIRECTORY }}/kuma-gui*.{json,sarif}
-          mv ../../../kuma-gui*.{json,sarif} ${{ vars.HOST_REPORTS_DIRECTORY }}
-
-          echo 'Replacing GUI dist files ...'
-          rm -rf ${{ vars.HOST_DIST_DIRECTORY }}
-          cp -r ../${{ vars.DIST_DIRECTORY }}/ ${{ vars.HOST_DIST_DIRECTORY }}
+      ## For testing if you've commented out the create-pull-request step
+      # - run: |
+      #     cd ${{ env.APP_WORKSPACE }} && git ls-files --exclude-standard --modified --deleted --others -t
 
       # https://github.com/peter-evans/create-pull-request
       - uses: peter-evans/create-pull-request@dd2324fc52d5d43c699a5636bcf19fceaa70c284 # v7.0.7
         with:
-          # Note: This token can be a GITHUB_TOKEN if the created PR doesn’t need to trigger workflows `on: push` or `on: pull_request`. However, we definitely need to trigger workflows (e.g. to run test workflows on the PR). Instead, we should use a personal access token (PAT). See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs for a more detailed explanation.
+          # Note: This token can be a GITHUB_TOKEN if the created PR doesn’t
+          # need to trigger workflows `on: push` or `on: pull_request`.
+          # However, we definitely need to trigger workflows (e.g. to run test
+          # workflows on the PR). Instead, we should use a personal access
+          # token (PAT). See
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          # for a more detailed explanation.
           token: ${{ steps.github-app-token.outputs.token }}
-          path: ./packages/kuma-gui/main-application
+          path: ${{ env.APP_WORKSPACE }}
           base: ${{ env.BRANCH }}
           commit-message: |
             chore(deps): bump ${{ github.repository }} to ${{ env.SHA }}

--- a/packages/config/src/mk/build.mk
+++ b/packages/config/src/mk/build.mk
@@ -1,12 +1,8 @@
 .PHONY: .build
-.build:
+.build: $(if $(NOPRUNE),,prune) install
 	@npx vite \
 		-c ./vite.config.production.ts \
 		build
-
-.PHONY: .build/sync
-.build/sync:
-	@$(MAKE) build
 
 .PHONY: build/preview
 build/preview:
@@ -31,7 +27,7 @@ deploy/test:
 
 .PHONY: deploy/e2e
 deploy/e2e:
-	@$(MAKE) build
+	@$(MAKE) build NOPRUNE=1
 	@$(MAKE) deploy/test
 
 .PHONY: deploy/preview

--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -1,10 +1,14 @@
 .PHONY: .install
 .install: check/node
-	@npm install
+	@cd $(NPM_WORKSPACE_ROOT) \
+		&& npm $(if $(CI),clean-install,install) \
+					--ignore-scripts
 
-.PHONY: .install/sync
-.install/sync:
-	npm clean-install
+.PHONY: .update
+.update: check/node
+	@cd $(NPM_WORKSPACE_ROOT) \
+		&& npm install \
+					--ignore-scripts
 
 .PHONY: .dedupe
 .dedupe:

--- a/packages/kuma-gui/Makefile
+++ b/packages/kuma-gui/Makefile
@@ -62,5 +62,12 @@ test/e2e: .test/e2e ## Run browser-based e2e tests against a running GUI, you ma
 .PHONY: build ## Dev: build a production artifact in `./dist`
 build: .build
 
-.PHONY: release/prune
-release/prune: .release/prune
+.PHONY: prune
+prune:
+	@$(MAKE) .sbom/exclude EXCLUDE_PATH=$(KUMAHQ_CONFIG) ## CI: Removes any dependencies unnessary for building
+
+.PHONY: release
+release: KUMAHQ_KUMA_GUI=$(NPM_WORKSPACE_ROOT)/$(shell cat $(NPM_WORKSPACE_ROOT)/package-lock.json | jq -r '.packages | to_entries[] | select(.value.name == "@kumahq/kuma-gui") | .key')
+release: SRC?=$(KUMAHQ_KUMA_GUI)/dist
+release: .release ## CI: 'releases' a built artifact, depends on the build artifact from 'make build'
+

--- a/packages/kuma-http-api/.gitignore
+++ b/packages/kuma-http-api/.gitignore
@@ -1,1 +1,1 @@
-repo
+kuma

--- a/packages/kuma-http-api/.gitignore
+++ b/packages/kuma-http-api/.gitignore
@@ -1,1 +1,1 @@
-kuma
+repo


### PR DESCRIPTION
~**DO NOT MERGE at least until the code marked `DO NOT MERGE` is removed**~ 👈 These have been removed

Further iterates on our `release.yml` workflow. The intention here is to simplify it enough so it literally calls `make build` and `make release`. The only reason we split these in two is so we can use GH Actions to generate an SBOM instead of the Makefile itself.

This approach means that we can potentially loop through several packages in our workspace building and releasing each one with scripts controlled by the Makefile itself, not CI YAML (which for reasons cannot be totally versioned)

Separately I also added a similar Makefile target so you can test verify the SBOM locally using `syft`. Note: This is not what we use in CI and is only for testing/verification purposes.

Lastly, this would be good to get in the before we cut for release so that moving forwards subsequent branches only need to support `make build` and `make release`, but no big deal if this slips into 2.11

---

~Firstly looking for an "approval in principle" at which point we'll have to remove some test code here/uncomment some non-test code.~ This is sorted, no looking for a proper approval


