### PR TITLE
chore: remove unnecessary XAction import

### DIFF
--- a/packages/kuma-gui/src/app/rules/components/RuleList.vue
+++ b/packages/kuma-gui/src/app/rules/components/RuleList.vue
@@ -117,7 +117,6 @@ import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import type { PolicyResourceType } from '@/app/policies/data'
 import RuleMatchers from '@/app/rules/components/RuleMatchers.vue'
 import type { Rule } from '@/app/rules/data'
-import XAction from '@/app/x/components/x-action/XAction.vue'
 const { t } = useI18n()
 
 const props = defineProps<{


### PR DESCRIPTION
I noticed we had an unnecessary XAction import. `X` components are global and therefore injectable, unless of course they are explicitly imported like in this instance.