### PR TITLE
fix(ci): always check for Cypress and install

### DIFF
--- a/packages/config/src/mk/test.mk
+++ b/packages/config/src/mk/test.mk
@@ -19,6 +19,7 @@
 .PHONY: .test/e2e
 .test/e2e: CYPRESS_SPEC?=**/*.feature
 .test/e2e:
+	@npx cypress install
 ifdef KUMA_TEST_BROWSER
 	@TZ=UTC \
 		npx cypress \


### PR DESCRIPTION
When running `test/e2e` always check for Cypress and install. If Cypress is already installed then skip

We need to add this because we disabled automatically running npm scripts on install during https://github.com/kumahq/kuma-gui/pull/3607

