### PR TITLE
chore: lint-staged lint/js only staged files

### DIFF
--- a/packages/config/src/mk/check.mk
+++ b/packages/config/src/mk/check.mk
@@ -16,13 +16,17 @@ check/node:
 .lint: lint/js lint/ts lint/css lint/lock lint/gherkin
 
 .PHONY: .lint/script
-.lint/script: lint/js lint/ts  ## Dev: Run lint checks on both JS/TS
+.lint/script: ARGS=$(filter-out $@,$(MAKECMDGOALS))
+.lint/script:
+	@$(MAKE) lint/js $(ARGS)
+	@$(MAKE) lint/ts $(ARGS)
 
 .PHONY: lint/js
+lint/js: ARGS=$(filter-out $@,$(MAKECMDGOALS))
 lint/js:
 	@npx eslint \
 		$(if $(CI),,--fix) \
-		.
+		$(if $(ARGS),$(ARGS),.)
 
 .PHONY: lint/ts
 lint/ts:


### PR DESCRIPTION
After moving more and more scripts over to makefile targets, we've noticed that lint-staged takes longer to check the staged files than before. This happens because currently our `lint/js` target lints all files (essentially `npx eslint .`) and doesn't consider the file argument passed over from lint-staged.

Unfortunately there is no option to run `vue-tsc` (same for `tsc`) on specific files only, it always runs for the whole project.