### PR TITLE
chore: bump packages to 2.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16233,7 +16233,7 @@
     },
     "packages/kuma-gui": {
       "name": "@kumahq/kuma-gui",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "dependencies": {
         "@gera2ld/tarjs": "^0.3.1",
         "@kong-ui-public/app-layout": "^4.3.11",
@@ -16635,7 +16635,7 @@
     },
     "packages/kuma-http-api": {
       "name": "@kumahq/kuma-http-api",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "devDependencies": {
         "@kumahq/config": "*",
         "openapi-typescript": "^7.6.1"

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kumahq/kuma-gui",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "private": true,
   "description": "Kuma Manager",
   "author": "Kong",

--- a/packages/kuma-http-api/package.json
+++ b/packages/kuma-http-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kumahq/kuma-http-api",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "private": true,
   "description": "Kuma OpenAPI to typescript converter and generated typescript types",
   "types": "index.d.ts",


### PR DESCRIPTION
Bumps master branch to next version of kuma/kuma-gui i.e. `2.11.0`

Related:

- https://github.com/kumahq/kuma-gui/issues/3154
- https://github.com/kumahq/kuma-gui/issues/2428