### PR TITLE
fix(dpp-inbound-summary/rules): incorrectly shows both inbounds and from rules

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -117,7 +117,9 @@
                 :key="`${typeof policyTypes}`"
               >
                 <DataCollection
-                  :predicate="(item) => { return (item.ruleType === 'inbound' || (item.ruleType === 'from' && Boolean(policyTypes[item.type]?.[0]?.policy.isFromAsRules))) && Number(item.inbound!.port) === Number(route.params.connection.split('_')[1])}"
+                  :predicate="(item) => {
+                    return (item.ruleType === 'inbound' || (item.ruleType === 'from' && !Boolean(policyTypes[item.type]?.[0]?.policy.isFromAsRules))) && Number(item.inbound!.port) === Number(route.params.connection.split('_')[1])
+                  }"
                   :items="[...rulesData!.rules, ...rulesData!.inboundRules]"
                   v-slot="{ items }"
                 >


### PR DESCRIPTION
TL;DR Only show `from`-rules if `policy.isFromAsRules` is `false`.

Similar to [DataPlanePoliciesView - fromRules](https://github.com/kumahq/kuma-gui/blob/2d448ae1ff9922aa54416f6710188e2b2ff5a714/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue#L70) we only want to show both `from` and `inboundRules` in case the flag `policy.isFromAsRules` is set to `false`.