### PR TITLE
chore(deps): @kong-ui-public/entities-shared incorrect version installed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2450,6 +2450,24 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/@kong-ui-public/entities-shared": {
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/@kong-ui-public/entities-shared/-/entities-shared-3.19.2.tgz",
+      "integrity": "sha512-24Q2lEClyNa4Ds7wtHWqW6Pv6BAHQymu+rmmWxvVsnRG+PdXJD7z89dB8CnOhG8p6dEU+hdGG1X9kQrjjxtntg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@kong-ui-public/core": "^1.10.6",
+        "compare-versions": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@kong-ui-public/i18n": "^2.2.10",
+        "@kong/icons": "^1.21.1",
+        "@kong/kongponents": "^9.21.6",
+        "axios": "^1.7.7",
+        "vue": ">= 3.3.13 < 4",
+        "vue-router": "^4.4.5"
+      }
+    },
     "node_modules/@kong-ui-public/i18n": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@kong-ui-public/i18n/-/i18n-2.2.10.tgz",
@@ -16087,24 +16105,6 @@
       "license": "MIT",
       "dependencies": {
         "regexp-match-indices": "1.0.2"
-      }
-    },
-    "packages/kuma-gui/node_modules/@kong-ui-public/entities-shared": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@kong-ui-public/entities-shared/-/entities-shared-3.18.0.tgz",
-      "integrity": "sha512-JSbLlQP75iAx2MACCuv5O+tykITg/S5kU5UgzuWfuvVHPR3lDSqOVl4d0URm21DQLZIrFe2usvG5KQxeiP7d7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@kong-ui-public/core": "^1.10.6",
-        "compare-versions": "^6.1.1"
-      },
-      "peerDependencies": {
-        "@kong-ui-public/i18n": "^2.2.10",
-        "@kong/icons": "^1.21.1",
-        "@kong/kongponents": "^9.21.6",
-        "axios": "^1.7.7",
-        "vue": ">= 3.3.13 < 4",
-        "vue-router": "^4.4.5"
       }
     },
     "packages/kuma-gui/node_modules/commander": {


### PR DESCRIPTION
When cherry-picking the fix of https://github.com/kumahq/kuma-gui/pull/3650 for master, I noticed that the wrong version of `@kong-ui-public/entities-shared` is installed

```shell
kuma-gui@
└─┬ @kumahq/kuma-gui@2.11.0 -> ./packages/kuma-gui
  └── @kong-ui-public/entities-shared@3.18.0 invalid: "^3.19.2" from packages/kuma-gui
```

The version got bumped in the manifest in https://github.com/kumahq/kuma-gui/pull/3636, but not properly added to the lock-file.