### PR TITLE
chore(dataplanes): switch reachable link based on meshServices.mode

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -1,11 +1,11 @@
 data-planes:
   notifications:
-    recommend-reachable-services: !!text/markdown |
-      We've identified outbound services that would benefit from using
-      <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a>
-      and/or
-      <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-services" target="_blank">Reachable Services</a>
-      to dramatically improve performance.
+    recommend-reachable: !!text/markdown |
+      We've identified outbound services that would benefit from using { mode, select,
+        Exclusive { <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a> }
+        ReachableBackends { <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a> }
+        other { <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-services" target="_blank">Reachable Services</a> }
+      } to dramatically improve performance.
   x-empty-state:
     title: There are no Dataplanes present
   components:

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -340,7 +340,8 @@
                         :uri="`data-planes.notifications.recommend-reachable-services:${props.data.id}`"
                       >
                         <XI18n
-                          path="data-planes.notifications.recommend-reachable-services"
+                          path="data-planes.notifications.recommend-reachable"
+                          :params="{ mode: props.mesh.meshServices.mode }"
                         />
                       </XNotification>
                       <DataCollection

--- a/packages/kuma-gui/src/types/index.d.ts
+++ b/packages/kuma-gui/src/types/index.d.ts
@@ -730,7 +730,7 @@ export interface Mesh extends Entity {
     zoneEgress?: boolean
   }
   meshServices?: {
-    mode?: 'Disabled' | ' Everywhere' | 'ReachableBackends' | 'Exclusive'
+    mode?: 'Disabled' | 'Everywhere' | 'ReachableBackends' | 'Exclusive'
   }
 }
 


### PR DESCRIPTION
Shows a slightly different info message on the Dataplane Viz page depending on your `meshServices.mode`

## Before

![Screenshot 2025-03-11 at 10 51 06](https://github.com/user-attachments/assets/b08632f7-4b36-4530-9d0b-26e80d05163e)

## After

![Screenshot 2025-03-11 at 10 50 46](https://github.com/user-attachments/assets/3d3ad7c0-5ddc-4b9c-a2c2-244d6482b31e)
