### PR TITLE
feat(x-code-block): update shiki version, theme

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       typescript-eslint:
         patterns:
           - "@typescript-eslint/*"
+      shiki:
+        patterns:
+          - "shiki"
+          - "@shikijs/*"
 
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 50

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,6 @@ updates:
       typescript-eslint:
         patterns:
           - "@typescript-eslint/*"
-      shiki:
-        patterns:
-          - "shiki"
-          - "@shikijs/*"
 
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 50

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "kuma-gui",
       "workspaces": [
         "packages/*"
       ],
@@ -3355,6 +3354,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.3.2.tgz",
       "integrity": "sha512-UqI6bSxFzhexIJficZLKeB1L2Sc3xoNiAV0yHpfbg5meck93du+EKQtsGbBv66Ki53XZPhnR/kYkOr85elIuFw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "2.3.2"
@@ -3364,6 +3364,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.3.2.tgz",
       "integrity": "sha512-CBaMY+a3pepyC4SETi7+bSzO0f6hxEQJUUuS4uD7zppzjmrN4ZRtBqxaT+wOan26CR9eeJ5iBhc4qvWEwn7Eeg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.1",
@@ -3374,6 +3375,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.3.2.tgz",
       "integrity": "sha512-QAh7D/hhfYKHibkG2tti8vxNt3ekAH5EqkXJeJbTh7FGvTCWEI7BHqNCtMdjFvZ0vav5nvUgdvA7/HI7pfsB4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "2.3.2"
@@ -3383,6 +3385,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.3.2.tgz",
       "integrity": "sha512-CBaMY+a3pepyC4SETi7+bSzO0f6hxEQJUUuS4uD7zppzjmrN4ZRtBqxaT+wOan26CR9eeJ5iBhc4qvWEwn7Eeg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.1",
@@ -3415,6 +3418,7 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.1.tgz",
       "integrity": "sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
@@ -8839,6 +8843,7 @@
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.4.tgz",
       "integrity": "sha512-wxQzXtdbhiwGAUKrnQJXlOPmHnEehzphwkK7aluUPQ+lEc1xefC8pblMgpp2w5ldBTEfveRIrADcrhGIWrlTDA==",
+      "dev": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -11637,6 +11642,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.5.4.tgz",
+      "integrity": "sha512-yNxcQ8sKvURiTwP0mV6bLQCYE7NKfKRRWunhbZnXgxSmB1OXa1lHrN3o4DZd+0Si0kU5blidK7BcROO8qv5TZA==",
+      "license": "MIT"
+    },
     "node_modules/oniguruma-to-es": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
@@ -12253,6 +12264,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
       "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -13134,6 +13146,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.3.2.tgz",
       "integrity": "sha512-UZhz/gsUz7DHFbQBOJP7eXqvKyYvMGramxQiSDc83M/7OkWm6OdVHAReEc3vMLh6L6TRhgL9dvhXz9XDkCDaaw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/core": "2.3.2",
@@ -13150,6 +13163,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.3.2.tgz",
       "integrity": "sha512-s7vyL3LzUKm3Qwf36zRWlavX9BQMZTIq9B1almM63M5xBuSldnsTHCmsXzoF/Kyw4k7Xgas7yAyJz9VR/vcP1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/engine-javascript": "2.3.2",
@@ -13164,6 +13178,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.3.2.tgz",
       "integrity": "sha512-w3IEMu5HfL/OaJTsMbIfZ1HRPnWVYRANeDtmsdIIEgUOcLjzFJFQwlnkckGjKHekEzNqlMLbgB/twnfZ/EEAGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "2.3.2",
@@ -13175,6 +13190,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.3.2.tgz",
       "integrity": "sha512-vikMY1TroyZXUHIXbMnvY/mjtOxMn+tavcfAeQPgWS9FHcgFSUoEtywF5B5sOLb9NXb8P2vb7odkh3nj15/00A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "2.3.2",
@@ -13185,6 +13201,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.3.2.tgz",
       "integrity": "sha512-CBaMY+a3pepyC4SETi7+bSzO0f6hxEQJUUuS4uD7zppzjmrN4ZRtBqxaT+wOan26CR9eeJ5iBhc4qvWEwn7Eeg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.1",
@@ -13195,6 +13212,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.0.tgz",
       "integrity": "sha512-BJ3Jy22YlgejHSO7Fvmz1kKazlaPmRSUH+4adTDUS/dKQ4wLxI+gALZ8updbaux7/m7fIlpgOZ5fp/Inq5jUAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex-xs": "^1.0.0",
@@ -13206,6 +13224,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
       "integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -13215,6 +13234,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
       "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -15975,6 +15995,8 @@
         "@kong-ui-public/i18n": "^2.2.10",
         "@kong/icons": "^1.21.2",
         "@kong/kongponents": "^9.22.2",
+        "@shikijs/langs": "^3.2.1",
+        "@shikijs/themes": "^3.2.1",
         "@vue/shared": "^3.5.13",
         "@vueuse/core": "^12.7.0",
         "brandi": "^5.0.0",
@@ -15985,7 +16007,7 @@
         "path-to-regexp": "^8.2.0",
         "pretty-bytes": "^6.1.1",
         "set.prototype.difference": "^1.1.6",
-        "shiki": "^2.3.2",
+        "shiki": "^3.2.1",
         "vue": "^3.5.13",
         "vue-github-button": "^3.1.3",
         "vue-router": "^4.5.0"
@@ -16114,6 +16136,73 @@
         "regexp-match-indices": "1.0.2"
       }
     },
+    "packages/kuma-gui/node_modules/@shikijs/core": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-FhsdxMWYu/C11sFisEp7FMGBtX/OSSbnXZDMBhGuUDBNTdsoZlMSgQv5f90rwvzWAdWIW6VobD+G3IrazxA6dQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "packages/kuma-gui/node_modules/@shikijs/engine-javascript": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.2.1.tgz",
+      "integrity": "sha512-eMdcUzN3FMQYxOmRf2rmU8frikzoSHbQDFH2hIuXsrMO+IBOCI9BeeRkCiBkcLDHeRKbOCtYMJK3D6U32ooU9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.1.0"
+      }
+    },
+    "packages/kuma-gui/node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
+      "integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "packages/kuma-gui/node_modules/@shikijs/langs": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.1.tgz",
+      "integrity": "sha512-If0iDHYRSGbihiA8+7uRsgb1er1Yj11pwpX1c6HLYnizDsKAw5iaT3JXj5ZpaimXSWky/IhxTm7C6nkiYVym+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1"
+      }
+    },
+    "packages/kuma-gui/node_modules/@shikijs/themes": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.1.tgz",
+      "integrity": "sha512-k5DKJUT8IldBvAm8WcrDT5+7GA7se6lLksR+2E3SvyqGTyFMzU2F9Gb7rmD+t+Pga1MKrYFxDIeyWjMZWM6uBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1"
+      }
+    },
+    "packages/kuma-gui/node_modules/@shikijs/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "packages/kuma-gui/node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "packages/kuma-gui/node_modules/commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -16204,6 +16293,29 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "packages/kuma-gui/node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "packages/kuma-gui/node_modules/jackspeak": {
@@ -16315,6 +16427,18 @@
         "node": ">=10"
       }
     },
+    "packages/kuma-gui/node_modules/oniguruma-to-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.1.0.tgz",
+      "integrity": "sha512-SNwG909cSLo4vPyyPbU/VJkEc9WOXqu2ycBlfd1UCXLqk1IijcQktSBb2yRQ2UFPsDhpkaf+C1dtT3PkLK/yWA==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "oniguruma-parser": "^0.5.4",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "packages/kuma-gui/node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -16332,12 +16456,56 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/kuma-gui/node_modules/property-information": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.0.0.tgz",
+      "integrity": "sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "packages/kuma-gui/node_modules/proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
       "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/kuma-gui/node_modules/regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
+      "integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "packages/kuma-gui/node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "packages/kuma-gui/node_modules/shiki": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.2.1.tgz",
+      "integrity": "sha512-VML/2o1/KGYkEf/stJJ+s9Ypn7jUKQPomGLGYso4JJFMFxVDyPNsjsI3MB3KLjlMOeH44gyaPdXC6rik2WXvUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.2.1",
+        "@shikijs/engine-javascript": "3.2.1",
+        "@shikijs/engine-oniguruma": "3.2.1",
+        "@shikijs/langs": "3.2.1",
+        "@shikijs/themes": "3.2.1",
+        "@shikijs/types": "3.2.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
     },
     "packages/kuma-gui/node_modules/yargs-parser": {
       "version": "21.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15995,8 +15995,6 @@
         "@kong-ui-public/i18n": "^2.2.10",
         "@kong/icons": "^1.21.2",
         "@kong/kongponents": "^9.22.2",
-        "@shikijs/langs": "^3.2.1",
-        "@shikijs/themes": "^3.2.1",
         "@vue/shared": "^3.5.13",
         "@vueuse/core": "^12.7.0",
         "brandi": "^5.0.0",

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -17,6 +17,8 @@
     "@kong-ui-public/i18n": "^2.2.10",
     "@kong/icons": "^1.21.2",
     "@kong/kongponents": "^9.22.2",
+    "@shikijs/langs": "^3.2.1",
+    "@shikijs/themes": "^3.2.1",
     "@vue/shared": "^3.5.13",
     "@vueuse/core": "^12.7.0",
     "brandi": "^5.0.0",
@@ -27,10 +29,10 @@
     "path-to-regexp": "^8.2.0",
     "pretty-bytes": "^6.1.1",
     "set.prototype.difference": "^1.1.6",
+    "shiki": "^3.2.1",
     "vue": "^3.5.13",
     "vue-github-button": "^3.1.3",
-    "vue-router": "^4.5.0",
-    "shiki": "^2.3.2"
+    "vue-router": "^4.5.0"
   },
   "devDependencies": {
     "@badeball/cypress-cucumber-preprocessor": "^22.0.1",

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -17,8 +17,6 @@
     "@kong-ui-public/i18n": "^2.2.10",
     "@kong/icons": "^1.21.2",
     "@kong/kongponents": "^9.22.2",
-    "@shikijs/langs": "^3.2.1",
-    "@shikijs/themes": "^3.2.1",
     "@vue/shared": "^3.5.13",
     "@vueuse/core": "^12.7.0",
     "brandi": "^5.0.0",

--- a/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
@@ -78,13 +78,13 @@ const processing = ref(false)
 const codeHighlighter = new Promise<Awaited<ReturnType<typeof createHighlighterCore>>>((resolve) => {
   createHighlighterCore({
     langs: [
-      import('@shikijs/langs/json'),
-      import('@shikijs/langs/yaml'),
-      import('@shikijs/langs/bash'),
+      import('shiki/langs/json.mjs'),
+      import('shiki/langs/yaml.mjs'),
+      import('shiki/langs/bash.mjs'),
     ],
     themes: [
-      import('@shikijs/themes/catppuccin-latte'),
-      import('@shikijs/themes/catppuccin-mocha'),
+      import('shiki/themes/catppuccin-latte.mjs'),
+      import('shiki/themes/catppuccin-mocha.mjs'),
     ],
     // TODO(@schogges): use createJavascriptRawEngine for further optimization of bundle size (requires pre-compiled langs)
     engine: createJavaScriptRegexEngine(),

--- a/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
@@ -83,7 +83,7 @@ const codeHighlighter = new Promise<Awaited<ReturnType<typeof createHighlighterC
       import('@shikijs/langs/bash'),
     ],
     themes: [
-      // TODO: add catppuccin-latte as soon as we support light theme
+      import('@shikijs/themes/catppuccin-latte'),
       import('@shikijs/themes/catppuccin-mocha'),
     ],
     // TODO(@schogges): use createJavascriptRawEngine for further optimization of bundle size (requires pre-compiled langs)
@@ -96,12 +96,28 @@ async function handleCodeBlockRenderEvent({ codeElement, language, code }: CodeB
   // we can ignore eslint no-unsanitized/property as all code content is stringified and shiki adds safe HTML for highlighting.
   // eslint-disable-next-line no-unsanitized/property
   codeElement.innerHTML = (await codeHighlighter).codeToHtml(code, {
-    theme: 'catppuccin-mocha',
     lang: language,
+    themes: {
+      light: 'catppuccin-latte',
+      dark: 'catppuccin-mocha',
+    },
   })
   processing.value = false
 }
 </script>
+<style lang="scss">
+// Shiki code blocks; dark theme: https://shiki.style/guide/dual-themes#class-based-dark-mode
+html.dark,
+.theme-dark {
+  .shiki,
+  .shiki span {
+    color: var(--shiki-dark) !important;
+    font-style: var(--shiki-dark-font-style) !important;
+    font-weight: var(--shiki-dark-font-weight) !important;
+    text-decoration: var(--shiki-dark-text-decoration) !important;
+  }
+}
+</style>
 
 <style lang="scss" scoped>
 // Makes code block actions sticky

--- a/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
@@ -41,7 +41,8 @@
 
 <script lang="ts" setup>
 import { type CodeBlockEventData, KCodeBlock } from '@kong/kongponents'
-import { createHighlighterCore, createJavaScriptRegexEngine } from 'shiki'
+import { createHighlighterCore } from 'shiki/core'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
 import { ref } from 'vue'
 
 import { uniqueId } from '@/app/application'
@@ -77,12 +78,13 @@ const processing = ref(false)
 const codeHighlighter = new Promise<Awaited<ReturnType<typeof createHighlighterCore>>>((resolve) => {
   createHighlighterCore({
     langs: [
-      import('shiki/langs/json.mjs'),
-      import('shiki/langs/yaml.mjs'),
-      import('shiki/langs/bash.mjs'),
+      import('@shikijs/langs/json'),
+      import('@shikijs/langs/yaml'),
+      import('@shikijs/langs/bash'),
     ],
     themes: [
-      import('shiki/themes/material-theme-palenight.mjs'),
+      // TODO: add catppuccin-latte as soon as we support light theme
+      import('@shikijs/themes/catppuccin-mocha'),
     ],
     // TODO(@schogges): use createJavascriptRawEngine for further optimization of bundle size (requires pre-compiled langs)
     engine: createJavaScriptRegexEngine(),
@@ -94,7 +96,7 @@ async function handleCodeBlockRenderEvent({ codeElement, language, code }: CodeB
   // we can ignore eslint no-unsanitized/property as all code content is stringified and shiki adds safe HTML for highlighting.
   // eslint-disable-next-line no-unsanitized/property
   codeElement.innerHTML = (await codeHighlighter).codeToHtml(code, {
-    theme: 'material-theme-palenight',
+    theme: 'catppuccin-mocha',
     lang: language,
   })
   processing.value = false

--- a/packages/kuma-gui/tsconfig.json
+++ b/packages/kuma-gui/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "strict": true,
     "importHelpers": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
As part of the version bump of shiki I changed some things:

- bump `shiki` to `3.2.1`
- changed the theme to `catppuccin-latte` (light) and `catppuccin-mocha` (dark) 
- changed [`moduleResolution`](https://www.typescriptlang.org/tsconfig/#moduleResolution) to `bundler`. Previous `node` is deprecated.