### PR TITLE
chore(deps): create dependabot eslint group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       typescript-eslint:
         patterns:
           - "@typescript-eslint/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/js"
 
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 50


### PR DESCRIPTION
Both `eslint` and `@eslint/js` are released from the same repo and always using the same version, so I think we can create a group to reduce the noise.