### PR TITLE
fix(x-code-block): highlighted codeblock additional scrollbar

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
@@ -111,6 +111,7 @@ html.dark,
 .theme-dark {
   .shiki,
   .shiki span {
+    background-color: unset !important;
     color: var(--shiki-dark) !important;
     font-style: var(--shiki-dark-font-style) !important;
     font-weight: var(--shiki-dark-font-weight) !important;
@@ -127,7 +128,7 @@ html.dark,
   top: var(--app-view-content-top, var(--AppHeaderHeight, 0));
   background-color: $kui-color-background-inverse;
 }
-:deep(.shiki) {
-  background-color: unset !important;
+:deep(.highlighted-code-block) {
+  overflow: hidden !important;
 }
 </style>


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/3660 we spotted that there is a little additional scrollbar showing up on Mac if the system scrollbar setting is **not** set to `Always`.


https://github.com/user-attachments/assets/597d523f-63b7-47d8-9fd5-a71a84e96ae0

---

I've also moved the `background-color: unset` to the global `shiki, shiki span` ruleset.