### PR TITLE
chore(ci): allow filenames (with no @) in `uses:`

### DIFF
--- a/packages/config/src/workflow.schema.json
+++ b/packages/config/src/workflow.schema.json
@@ -2,9 +2,9 @@
   "type": "object",
   "definitions": {
     "shaOnlyVersion": {
-      "$comment": "matches '<uri-like>@<40 character git sha>' or kumahq/*@main",
+      "$comment": "matches '<uri-like>@<40 character git sha>' or 'kumahq/*@main' or './' with no @",
       "type": "string",
-      "pattern": "(^kumahq/[a-zA-Z0-9-_/.]+@main)|(^[a-zA-Z0-9-_/.]+@[a-z0-9]{40})"
+      "pattern": "(^[a-zA-Z0-9-_/.]+@[a-z0-9]{40})|(^kumahq/[a-zA-Z0-9-_/.]+@main)|(^.\/[a-zA-Z0-9-_/.]+$)"
     },
     "job": {
       "properties": {


### PR DESCRIPTION
One last change here, this allows `./filepath/local-workflow.yml`

Sorry for the noise!

Oh I also reordered the possibilities to be the same as the comment