### PR TITLE
fix(deps): pin entities-shared to 3.19.3 due to bad 3.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16347,7 +16347,7 @@
       "dependencies": {
         "@gera2ld/tarjs": "^0.3.1",
         "@kong-ui-public/app-layout": "^4.3.16",
-        "@kong-ui-public/entities-shared": "^3.19.3",
+        "@kong-ui-public/entities-shared": "3.19.3",
         "@kong-ui-public/i18n": "^2.2.10",
         "@kong/icons": "^1.21.2",
         "@kong/kongponents": "^9.25.0",

--- a/packages/kuma-gui/eslint.config.cjs
+++ b/packages/kuma-gui/eslint.config.cjs
@@ -3,7 +3,15 @@
 const { eslint } = require('@kumahq/config')
 
 const config = [
-  ...eslint({}),
+  ...eslint({
+    versionIgnorePatterns: {
+      dependencies: {
+        '@kong-ui-public/entities-shared': {
+          'type': 'string',
+        },
+      },
+    },
+  }),
   {
     ignores: [
       'public/mockServiceWorker.js',

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@gera2ld/tarjs": "^0.3.1",
     "@kong-ui-public/app-layout": "^4.3.16",
-    "@kong-ui-public/entities-shared": "^3.19.3",
+    "@kong-ui-public/entities-shared": "3.19.3",
     "@kong-ui-public/i18n": "^2.2.10",
     "@kong/icons": "^1.21.2",
     "@kong/kongponents": "^9.25.0",


### PR DESCRIPTION
We've noticed that various kong dependencies are being published with the string `"workspace:^"` in their `peerDependencies`. This is causing npm install to fail.

We've seen this specifically happening in `@kong-ui-public/entities-shared@3.20.0` but it could also be happening in other modules/version.

So at the very least we are pinning our version to not go past 3.19.3 until a fix is pushed upstream.