### PR TITLE
chore: merges release-2.10 branch into master finishing off the 2.10 release cycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "kuma-gui",
       "workspaces": [
         "packages/*"
       ],

--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -1,11 +1,11 @@
 data-planes:
   notifications:
-    recommend-reachable-services: !!text/markdown |
-      We've identified outbound services that would benefit from using
-      <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a>
-      and/or
-      <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-services" target="_blank">Reachable Services</a>
-      to dramatically improve performance.
+    recommend-reachable: !!text/markdown |
+      We've identified outbound services that would benefit from using { mode, select,
+        Exclusive { <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a> }
+        ReachableBackends { <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a> }
+        other { <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-services" target="_blank">Reachable Services</a> }
+      } to dramatically improve performance.
   x-empty-state:
     title: There are no Dataplanes present
   components:

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -340,7 +340,8 @@
                         :uri="`data-planes.notifications.recommend-reachable-services:${props.data.id}`"
                       >
                         <XI18n
-                          path="data-planes.notifications.recommend-reachable-services"
+                          path="data-planes.notifications.recommend-reachable"
+                          :params="{ mode: props.mesh.meshServices.mode }"
                         />
                       </XNotification>
                       <DataCollection

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -117,7 +117,9 @@
                 :key="`${typeof policyTypes}`"
               >
                 <DataCollection
-                  :predicate="(item) => { return (item.ruleType === 'inbound' || (item.ruleType === 'from' && Boolean(policyTypes[item.type]?.[0]?.policy.isFromAsRules))) && Number(item.inbound!.port) === Number(route.params.connection.split('_')[1])}"
+                  :predicate="(item) => {
+                    return (item.ruleType === 'inbound' || (item.ruleType === 'from' && !Boolean(policyTypes[item.type]?.[0]?.policy.isFromAsRules))) && Number(item.inbound!.port) === Number(route.params.connection.split('_')[1])
+                  }"
                   :items="[...rulesData!.rules, ...rulesData!.inboundRules]"
                   v-slot="{ items }"
                 >

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -55,8 +55,7 @@ common:
     INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS: !!text/markdown |
       There is mismatch between versions of Zone Control Plane (**{ zoneCpVersion }**) and the Global Control Plane (**{ globalCpVersion }**)
     NACK_RESPONSE_ZONE_TO_GLOBAL: !!text/markdown |
-      The Global Control Plane got NACK responses from the Zone Control Plane, check the Zone Control Plane logs for details.
-      To clear up the state, restart the Zone Control Plane.
+      The Global Control Plane got NACK responses from the Zone Control Plane. Refer to the Zone Control Plane logs for more details.
   copyText: 'Copy'
   copySuccessText: 'Copied!'
   copyKubernetesText: 'Copy as Kubernetes'

--- a/packages/kuma-gui/src/types/index.d.ts
+++ b/packages/kuma-gui/src/types/index.d.ts
@@ -730,7 +730,7 @@ export interface Mesh extends Entity {
     zoneEgress?: boolean
   }
   meshServices?: {
-    mode?: 'Disabled' | ' Everywhere' | 'ReachableBackends' | 'Exclusive'
+    mode?: 'Disabled' | 'Everywhere' | 'ReachableBackends' | 'Exclusive'
   }
 }
 


### PR DESCRIPTION
See title

---

My personal opinion on these is still that during the release period, we should still work off of master and backport/cherry-pick back to the release branch.

Basically any approach that means we get to keep the separate commits in the git history, I believe this will need to be squashed and therefore we lose all the individual commits (I could be wrong, we'll see now)

---

In the meantime I need to figure out how to sort the DCO failures
