### PR TITLE
chore: ignore attrs on XAnonymous

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-anonymous/XAnonymous.vue
+++ b/packages/kuma-gui/src/app/x/components/x-anonymous/XAnonymous.vue
@@ -1,3 +1,10 @@
 <template>
-  <slot name="default" />
+  <slot
+    name="default"
+  />
 </template>
+<script lang="ts" setup>
+defineOptions({
+  inheritAttrs: false,
+})
+</script>


### PR DESCRIPTION
Removes a bunch of Vue dev time warnings, which also show up in Cypress tests (I found this when working on something else soon to be PRed)

### Before

![Screenshot 2025-03-27 at 15 22 59](https://github.com/user-attachments/assets/3d03694c-d7ff-49e4-9230-7c937e65db4e)



### After


![Screenshot 2025-03-27 at 15 22 41](https://github.com/user-attachments/assets/38491a5c-e8d7-4fdc-8acb-a42eeb21ed7a)
