### PR TITLE
fix(deps): don't use peerDependencies, we don't have consumers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17132,9 +17132,6 @@
         "stylelint-config-html": "^1.1.0",
         "stylelint-config-recommended-scss": "^14.1.0",
         "stylelint-config-recommended-vue": "^1.6.0"
-      },
-      "devDependencies": {
-        "eslint": "^9.23.0"
       }
     },
     "packages/fake-api": {
@@ -17147,7 +17144,6 @@
       },
       "devDependencies": {
         "@kumahq/config": "*",
-        "eslint": "^9.22.0",
         "typescript": "^5.8.2",
         "vite": "^6.0.0"
       }
@@ -17195,7 +17191,6 @@
         "@whyframe/vue": "^0.1.8",
         "cypress": "^14.2.0",
         "dotenv": "^16.4.7",
-        "eslint": "^9.23.0",
         "glob": "^11.0.0",
         "gray-matter": "^4.0.3",
         "husky": "^9.1.7",
@@ -17223,7 +17218,6 @@
       "version": "2.11.0",
       "devDependencies": {
         "@kumahq/config": "*",
-        "eslint": "^9.23.0",
         "openapi-typescript": "^7.6.1"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@kumahq/config": "*"
       },
+      "devDependencies": {
+        "eslint": "^9.23.0"
+      },
       "engines": {
         "node": ">=22.14",
         "npm": "^10.9.2"
@@ -17129,6 +17132,9 @@
         "stylelint-config-html": "^1.1.0",
         "stylelint-config-recommended-scss": "^14.1.0",
         "stylelint-config-recommended-vue": "^1.6.0"
+      },
+      "devDependencies": {
+        "eslint": "^9.23.0"
       }
     },
     "packages/fake-api": {
@@ -17217,6 +17223,7 @@
       "version": "2.11.0",
       "devDependencies": {
         "@kumahq/config": "*",
+        "eslint": "^9.23.0",
         "openapi-typescript": "^7.6.1"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -794,7 +794,6 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -1139,7 +1138,6 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-9.2.0.tgz",
       "integrity": "sha512-3nmRbG1bUAZP3fAaUBNmqWO0z0OSkykZZotfLjyhc8KWwDSOrOmMJlBTd474lpA8EWh4JFLAX3iXgynBqBvKzw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cucumber/gherkin": "^31.0.0",
@@ -1156,7 +1154,6 @@
       "version": "31.0.0",
       "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-31.0.0.tgz",
       "integrity": "sha512-wlZfdPif7JpBWJdqvHk1Mkr21L5vl4EfxVUOS4JinWGf3FLRV6IKUekBv5bb5VX79fkDcfDvESzcQ8WQc07Wgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cucumber/messages": ">=19.1.4 <=26"
@@ -1166,7 +1163,6 @@
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
       "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2826,6 +2822,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2865,6 +2862,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2885,6 +2883,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2905,6 +2904,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2925,6 +2925,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2945,6 +2946,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2965,6 +2967,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2985,6 +2988,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3005,6 +3009,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3025,6 +3030,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3045,6 +3051,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3065,6 +3072,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3085,6 +3093,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3105,6 +3114,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3253,6 +3263,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3266,6 +3277,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3279,6 +3291,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3292,6 +3305,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3305,6 +3319,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3318,6 +3333,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3331,6 +3347,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3344,6 +3361,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3357,6 +3375,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3370,6 +3389,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3383,6 +3403,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3396,6 +3417,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3409,6 +3431,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3422,6 +3445,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3435,6 +3459,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3448,6 +3473,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3461,6 +3487,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3474,6 +3501,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3487,6 +3515,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3500,6 +3529,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3594,7 +3624,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -3604,7 +3633,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3614,7 +3642,6 @@
       "version": "11.3.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
       "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
@@ -3624,7 +3651,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
       "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
@@ -3636,7 +3662,6 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
-      "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@stylistic/eslint-plugin": {
@@ -5329,7 +5354,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -5774,7 +5798,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
@@ -5863,7 +5886,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
       "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.2"
@@ -6062,7 +6084,6 @@
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -6469,7 +6490,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/cypress-fail-on-console-error/-/cypress-fail-on-console-error-5.1.1.tgz",
       "integrity": "sha512-JGpHxvwuSxDDT32cUflo0x7yJBFdhYsv5MVBPmNv/kulavQcl0cSguDtSpwWXhBXr1oBSzYUsQkxGnAN4EDqWA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chai": "^4.3.10",
@@ -6705,7 +6725,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
       "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-detect": "^4.0.0"
@@ -6767,7 +6786,6 @@
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "clone": "^1.0.2"
       },
@@ -6858,6 +6876,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -8750,7 +8769,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -9466,7 +9484,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.1.tgz",
       "integrity": "sha512-3jatXi9ObIsPGr3N5hGw/vWWcTkq6hUYhpQz4k0wLC+owqWi/LiugIw9x0EdNZ2yGedKN/HzePiBvaJRXa0Ujg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -10542,7 +10560,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/keyv": {
@@ -11234,7 +11251,6 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -11345,7 +11361,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
       "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
@@ -12037,7 +12052,6 @@
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.9.tgz",
       "integrity": "sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
@@ -12051,7 +12065,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/no-case": {
@@ -12068,6 +12081,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -12656,7 +12670,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -13487,6 +13500,7 @@
       "version": "4.37.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.37.0.tgz",
       "integrity": "sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -13643,7 +13657,7 @@
       "version": "1.86.0",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.86.0.tgz",
       "integrity": "sha512-zV8vGUld/+mP4KbMLJMX7TyGCuUp7hnkOScgCMsWuHtns8CWBoz+vmEhoGMXsaJrbUP8gj+F1dLvVe79sK8UdA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -13689,7 +13703,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -13705,7 +13719,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -14067,7 +14081,6 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
       "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
@@ -14086,7 +14099,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
       "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
-      "dev": true,
       "license": "(BSD-2-Clause OR WTFPL)",
       "peerDependencies": {
         "chai": "^4.0.0",
@@ -14097,7 +14109,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -14107,7 +14118,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15531,7 +15541,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
       "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16052,6 +16061,7 @@
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
       "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -16535,7 +16545,6 @@
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "defaults": "^1.0.3"
       }
@@ -17095,13 +17104,18 @@
       "name": "@kumahq/config",
       "version": "1.0.0",
       "dependencies": {
+        "@badeball/cypress-cucumber-preprocessor": "^22.0.1",
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.4",
+        "@cucumber/gherkin-utils": "^9.2.0",
         "@eslint/js": "^9.23.0",
         "@stylistic/eslint-plugin": "^4.2.0",
         "@stylistic/stylelint-plugin": "^3.1.2",
         "@typescript-eslint/eslint-plugin": "^8.28.0",
         "@typescript-eslint/parser": "^8.28.0",
         "@vue/eslint-config-typescript": "^14.5.0",
+        "cypress-fail-fast": "^7.1.1",
+        "cypress-fail-on-console-error": "^5.1.1",
+        "cypress-terminal-report": "^7.1.0",
         "esbuild": "^0.25.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-import-resolver-alias": "^1.1.2",
@@ -17115,14 +17129,6 @@
         "stylelint-config-html": "^1.1.0",
         "stylelint-config-recommended-scss": "^14.1.0",
         "stylelint-config-recommended-vue": "^1.6.0"
-      },
-      "peerDependencies": {
-        "@badeball/cypress-cucumber-preprocessor": "^22.0.0",
-        "cypress": "^14.0.0",
-        "cypress-fail-fast": "^7.1.1",
-        "cypress-terminal-report": "^7.0.4",
-        "eslint": "^9",
-        "stylelint": "^16.10.0"
       }
     },
     "packages/fake-api": {
@@ -17136,10 +17142,7 @@
       "devDependencies": {
         "@kumahq/config": "*",
         "eslint": "^9.22.0",
-        "typescript": "^5.8.2"
-      },
-      "peerDependencies": {
-        "cypress": "^14.0.0",
+        "typescript": "^5.8.2",
         "vite": "^6.0.0"
       }
     },
@@ -17170,7 +17173,6 @@
       },
       "devDependencies": {
         "@badeball/cypress-cucumber-preprocessor": "^22.0.1",
-        "@cucumber/gherkin-utils": "^9.2.0",
         "@faker-js/faker": "^9.6.0",
         "@kong/design-tokens": "^1.17.4",
         "@kumahq/config": "*",
@@ -17186,9 +17188,6 @@
         "@whyframe/core": "^0.1.13",
         "@whyframe/vue": "^0.1.8",
         "cypress": "^14.2.0",
-        "cypress-fail-fast": "^7.1.1",
-        "cypress-fail-on-console-error": "^5.1.1",
-        "cypress-terminal-report": "^7.1.0",
         "dotenv": "^16.4.7",
         "eslint": "^9.23.0",
         "glob": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "dependencies": {
     "@kumahq/config": "*"
   },
+  "devDependencies": {
+    "eslint": "^9.23.0"
+  },
   "engines": {
     "node": ">=22.14",
     "npm": "^10.9.2"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -43,8 +43,5 @@
     "stylelint-config-html": "^1.1.0",
     "stylelint-config-recommended-scss": "^14.1.0",
     "stylelint-config-recommended-vue": "^1.6.0"
-  },
-  "devDependencies": {
-    "eslint": "^9.23.0"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -43,5 +43,8 @@
     "stylelint-config-html": "^1.1.0",
     "stylelint-config-recommended-scss": "^14.1.0",
     "stylelint-config-recommended-vue": "^1.6.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.23.0"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,16 +12,24 @@
     ".": {
       "require": "./src/index.cjs",
       "import": "./src/index.ts"
+    },
+    "./cypress/e2e": {
+      "import": "./src/cypress/e2e.ts"
     }
   },
   "dependencies": {
     "@bahmutov/cypress-esbuild-preprocessor": "^2.2.4",
+    "@badeball/cypress-cucumber-preprocessor": "^22.0.1",
+    "@cucumber/gherkin-utils": "^9.2.0",
     "@eslint/js": "^9.23.0",
     "@stylistic/eslint-plugin": "^4.2.0",
     "@stylistic/stylelint-plugin": "^3.1.2",
     "@typescript-eslint/eslint-plugin": "^8.28.0",
     "@typescript-eslint/parser": "^8.28.0",
     "@vue/eslint-config-typescript": "^14.5.0",
+    "cypress-fail-fast": "^7.1.1",
+    "cypress-fail-on-console-error": "^5.1.1",
+    "cypress-terminal-report": "^7.1.0",
     "esbuild": "^0.25.0",
     "escape-string-regexp": "^4.0.0",
     "eslint-import-resolver-alias": "^1.1.2",
@@ -35,13 +43,5 @@
     "stylelint-config-html": "^1.1.0",
     "stylelint-config-recommended-scss": "^14.1.0",
     "stylelint-config-recommended-vue": "^1.6.0"
-  },
-  "peerDependencies": {
-    "@badeball/cypress-cucumber-preprocessor": "^22.0.0",
-    "cypress": "^14.0.0",
-    "cypress-fail-fast": "^7.1.1",
-    "cypress-terminal-report": "^7.0.4",
-    "eslint": "^9",
-    "stylelint": "^16.10.0"
   }
 }

--- a/packages/config/src/cypress/e2e.ts
+++ b/packages/config/src/cypress/e2e.ts
@@ -1,0 +1,8 @@
+import 'cypress-fail-fast'
+import failOnConsoleError from 'cypress-fail-on-console-error'
+import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector'
+
+installLogsCollector({
+  collectTypes: ['cons:warn', 'cons:debug'],
+})
+failOnConsoleError()

--- a/packages/fake-api/package.json
+++ b/packages/fake-api/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@kumahq/config": "*",
-    "eslint": "^9.22.0",
     "typescript": "^5.8.2",
     "vite": "^6.0.0"
   }

--- a/packages/fake-api/package.json
+++ b/packages/fake-api/package.json
@@ -31,10 +31,7 @@
   "devDependencies": {
     "@kumahq/config": "*",
     "eslint": "^9.22.0",
-    "typescript": "^5.8.2"
-  },
-  "peerDependencies": {
-    "vite": "^6.0.0",
-    "cypress": "^14.0.0"
+    "typescript": "^5.8.2",
+    "vite": "^6.0.0"
   }
 }

--- a/packages/kuma-gui/cypress/support/e2e.ts
+++ b/packages/kuma-gui/cypress/support/e2e.ts
@@ -1,8 +1,1 @@
-import 'cypress-fail-fast'
-import failOnConsoleError from 'cypress-fail-on-console-error'
-import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector'
-installLogsCollector({
-  collectTypes: ['cons:warn'],
-})
-
-failOnConsoleError()
+import '@kumahq/config/cypress/e2e'

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -50,7 +50,6 @@
     "@whyframe/vue": "^0.1.8",
     "cypress": "^14.2.0",
     "dotenv": "^16.4.7",
-    "eslint": "^9.23.0",
     "glob": "^11.0.0",
     "gray-matter": "^4.0.3",
     "husky": "^9.1.7",

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@badeball/cypress-cucumber-preprocessor": "^22.0.1",
-    "@cucumber/gherkin-utils": "^9.2.0",
     "@faker-js/faker": "^9.6.0",
     "@kong/design-tokens": "^1.17.4",
     "@kumahq/config": "*",
@@ -50,9 +49,6 @@
     "@whyframe/core": "^0.1.13",
     "@whyframe/vue": "^0.1.8",
     "cypress": "^14.2.0",
-    "cypress-fail-fast": "^7.1.1",
-    "cypress-fail-on-console-error": "^5.1.1",
-    "cypress-terminal-report": "^7.1.0",
     "dotenv": "^16.4.7",
     "eslint": "^9.23.0",
     "glob": "^11.0.0",

--- a/packages/kuma-http-api/package.json
+++ b/packages/kuma-http-api/package.json
@@ -9,7 +9,6 @@
   },
   "devDependencies": {
     "@kumahq/config": "*",
-    "eslint": "^9.23.0",
     "openapi-typescript": "^7.6.1"
   }
 }

--- a/packages/kuma-http-api/package.json
+++ b/packages/kuma-http-api/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@kumahq/config": "*",
+    "eslint": "^9.23.0",
     "openapi-typescript": "^7.6.1"
   }
 }


### PR DESCRIPTION
When we made `@kumahq/config` we started adding peerDependencies to define the version of the "hosts" that we provide config/plugins for.

The thing is as dependbot (rightly) doesn't touch peerDependencies, and the node ecosystem can sometimes move quite fast (major bumps are a common occurrence), this means that our peerDependencies can quite quickly get out of sync with what we have defined as root/application/host dependencies. This is causing issues and unnecessary work to keep these in sync manually (no dependbot).

Moreover, we are in total control of the `@kumahq/config` _and_ our host app, and we don't publicly publish `@kumahq/config`, so in reality whenever we bump the dependency in our host app (that needs to be in sync with the peerDependencies) we should be bumping the peerDependencies to the exact same version. This then begs the question, why are we bumping in multiple places, when we can just bump in one. i.e. in our unique situation what's the point of defining peerDependencies if we are in full control of our entire codebase and we don't provide a comsumable package to anyone else (where peerDependencies would then become useful)

Theres probably more to say here, but the above is pretty much the gist of it. All in all we decided we would remove and not use peerDependencies at all.

This PR removes the peerDependencies we were using and moves what we had there into the correct places.

Whilst doing this I spotted that we use certain cypress plugins in two places just "because Cypress" so I also did the necessary work to make it so we could specify these plugins in one single place in `@kumahq/config` instead of also in `@kumahq/kuma-gui`.

As discussed over the past few days, there may end up being places where we need to ensure a dependency is either in the root of the monorepo, or in its individual workspace/application as a result of removing peerDependencies. If/as and when we discover those we just move them as and when.

Following this we said we would reassess in a couple of months to see what effect this has had on our projects.

As a result of this PR the only cypress related dependencies you need to install in one of our applications that needs e2e testing is `cypress` itself and `@badeball/cypress-cucumber-preprocessor`, which we use in our `steps` file. At some point our steps file will also be moved out of the application and into a shareable packge/module. At which point all an application will need to install locally is `cypress` itself plus `@kumahq/config`

