### PR TITLE
fix(codeblock): fix height of codeblock to use DOM recycling scrolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "kuma-gui",
       "workspaces": [
         "packages/*"
       ],
@@ -5982,6 +5981,12 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -11121,6 +11126,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "pathe": "^2.0.1",
+        "pkg-types": "^1.3.0",
+        "ufo": "^1.5.4"
+      }
+    },
     "node_modules/mocha": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
@@ -12001,7 +12018,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
@@ -12064,6 +12080,17 @@
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/pluralize": {
@@ -14963,6 +14990,12 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true
     },
+    "node_modules/ufo": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
+      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -15614,6 +15647,18 @@
       "integrity": "sha512-ZdOnUuYJL/wUsxISsC96TARzCdf1twaWooZoI14+g4RHsJltPY+Agw6Ox6pjuMqMX0uhSK1JOMFUFNCQGlcZGA==",
       "dependencies": {
         "github-buttons": "^2.22.0"
+      }
+    },
+    "node_modules/vue-global-events": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vue-global-events/-/vue-global-events-3.0.1.tgz",
+      "integrity": "sha512-9S7S3bG0XDBnpm2DJSSjpx6xIX/YIleycpnvmRRYSdiMltnzRfJQ8uVB3QX5eCLkmiv/Udg9UjO2wwpTO5LDvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pkg-types": "^1.0.3"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-router": {
@@ -16286,6 +16331,7 @@
         "shiki": "^3.2.1",
         "vue": "^3.5.13",
         "vue-github-button": "^3.1.3",
+        "vue-global-events": "^3.0.1",
         "vue-router": "^4.5.0"
       },
       "devDependencies": {

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -30,6 +30,7 @@
     "shiki": "^3.2.1",
     "vue": "^3.5.13",
     "vue-github-button": "^3.1.3",
+    "vue-global-events": "^3.0.1",
     "vue-router": "^4.5.0"
   },
   "devDependencies": {

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsClustersView.vue
@@ -25,27 +25,37 @@
           })"
           v-slot="{ data, refresh }"
         >
-          <XCodeBlock
-            language="json"
-            :code="data"
-            is-searchable
-            :query="route.params.codeSearch"
-            :is-filter-mode="route.params.codeFilter"
-            :is-reg-exp-mode="route.params.codeRegExp"
-            @query-change="route.update({ codeSearch: $event })"
-            @filter-mode-change="route.update({ codeFilter: $event })"
-            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          <XWindow
+            :resize="true"
+            v-slot="{ resize }"
           >
-            <template #primary-actions>
-              <XAction
-                action="refresh"
-                appearance="primary"
-                @click="refresh"
+            <div
+              ref="$el"
+            >
+              <XCodeBlock
+                :max-height="`${(resize?.target?.innerHeight ?? 0) - ($el?.getBoundingClientRect().top + 200)}`"
+                language="json"
+                :code="data"
+                is-searchable
+                :query="route.params.codeSearch"
+                :is-filter-mode="route.params.codeFilter"
+                :is-reg-exp-mode="route.params.codeRegExp"
+                @query-change="route.update({ codeSearch: $event })"
+                @filter-mode-change="route.update({ codeFilter: $event })"
+                @reg-exp-mode-change="route.update({ codeRegExp: $event })"
               >
-                Refresh
-              </XAction>
-            </template>
-          </XCodeBlock>
+                <template #primary-actions>
+                  <XAction
+                    action="refresh"
+                    appearance="primary"
+                    @click="refresh"
+                  >
+                    Refresh
+                  </XAction>
+                </template>
+              </XCodeBlock>
+            </div>
+          </XWindow>
         </DataLoader>
       </XCard>
     </AppView>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsStatsView.vue
@@ -26,27 +26,37 @@
           })"
           v-slot="{ data: statsData, refresh }"
         >
-          <XCodeBlock
-            language="json"
-            :code="statsData.raw"
-            is-searchable
-            :query="route.params.codeSearch"
-            :is-filter-mode="route.params.codeFilter"
-            :is-reg-exp-mode="route.params.codeRegExp"
-            @query-change="route.update({ codeSearch: $event })"
-            @filter-mode-change="route.update({ codeFilter: $event })"
-            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          <XWindow
+            :resize="true"
+            v-slot="{ resize }"
           >
-            <template #primary-actions>
-              <XAction
-                action="refresh"
-                appearance="primary"
-                @click="refresh"
+            <div
+              ref="$el"
+            >
+              <XCodeBlock
+                :max-height="`${(resize?.target?.innerHeight ?? 0) - ($el?.getBoundingClientRect().top + 200)}`"
+                language="json"
+                :code="statsData.raw"
+                is-searchable
+                :query="route.params.codeSearch"
+                :is-filter-mode="route.params.codeFilter"
+                :is-reg-exp-mode="route.params.codeRegExp"
+                @query-change="route.update({ codeSearch: $event })"
+                @filter-mode-change="route.update({ codeFilter: $event })"
+                @reg-exp-mode-change="route.update({ codeRegExp: $event })"
               >
-                Refresh
-              </XAction>
-            </template>
-          </XCodeBlock>
+                <template #primary-actions>
+                  <XAction
+                    action="refresh"
+                    appearance="primary"
+                    @click="refresh"
+                  >
+                    Refresh
+                  </XAction>
+                </template>
+              </XCodeBlock>
+            </div>
+          </XWindow>
         </DataLoader>
       </XCard>
     </AppView>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
@@ -20,39 +20,48 @@
       <XCard>
         <DataLoader
           :src="uri(sources, `/connections/xds/for/:proxyType/:name/:mesh/:endpoints`, {
-            proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress'})[route.params.proxyType] ?? 'dataplane',
+            proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress' })[route.params.proxyType] ?? 'dataplane',
             name: route.params.proxy,
             mesh: route.params.mesh || '*',
             endpoints: String(route.params.includeEds),
           })"
           v-slot="{ data, refresh }"
         >
-          <XCodeBlock
-            language="json"
-            :code="JSON.stringify(data, null, 2)"
-            is-searchable
-            :query="route.params.codeSearch"
-            :is-filter-mode="route.params.codeFilter"
-            :is-reg-exp-mode="route.params.codeRegExp"
-            @query-change="route.update({ codeSearch: $event })"
-            @filter-mode-change="route.update({ codeFilter: $event })"
-            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+          <XWindow
+            :resize="true"
+            v-slot="{ resize }"
           >
-            <template #primary-actions>
-              <XCheckbox
-                :checked="route.params.includeEds"
-                label="Include Endpoints"
-                @change="(value) => route.update({ includeEds: value})"
-              />
-              <XAction
-                action="refresh"
-                appearance="primary"
-                @click="refresh"
+            <div
+              ref="$el"
+            >
+              <XCodeBlock
+                :max-height="`${(resize?.target?.innerHeight ?? 0) - ($el?.getBoundingClientRect().top + 146)}`"
+                language="json"
+                :code="JSON.stringify(data, null, 2)"
+                is-searchable
+                :query="route.params.codeSearch"
+                :is-filter-mode="route.params.codeFilter"
+                :is-reg-exp-mode="route.params.codeRegExp"
+                @filter-mode-change="route.update({ codeFilter: $event })"
+                @reg-exp-mode-change="route.update({ codeRegExp: $event })"
               >
-                Refresh
-              </XAction>
-            </template>
-          </XCodeBlock>
+                <template #primary-actions>
+                  <XCheckbox
+                    :checked="route.params.includeEds"
+                    label="Include Endpoints"
+                    @change="(value) => route.update({ includeEds: value })"
+                  />
+                  <XAction
+                    action="refresh"
+                    appearance="primary"
+                    @click="refresh"
+                  >
+                    Refresh
+                  </XAction>
+                </template>
+              </XCodeBlock>
+            </div>
+          </XWindow>
         </DataLoader>
       </XCard>
     </AppView>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
@@ -35,7 +35,7 @@
               ref="$el"
             >
               <XCodeBlock
-                :max-height="`${(resize?.target?.innerHeight ?? 0) - ($el?.getBoundingClientRect().top + 146)}`"
+                :max-height="`${(resize?.target?.innerHeight ?? 0) - ($el?.getBoundingClientRect().top + 200)}`"
                 language="json"
                 :code="JSON.stringify(data, null, 2)"
                 is-searchable

--- a/packages/kuma-gui/src/app/x/components/x-code-block/ResourceCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/ResourceCodeBlock.vue
@@ -3,7 +3,7 @@
     language="yaml"
     :code="yamlUniversal"
     :is-searchable="props.isSearchable"
-    :code-max-height="props.codeMaxHeight"
+    :max-height="props.maxHeight"
     :query="props.query"
     :is-filter-mode="props.isFilterMode"
     :is-reg-exp-mode="props.isRegExpMode"
@@ -58,14 +58,14 @@ const { t } = useI18n()
 
 const props = withDefaults(defineProps<{
   resource: object
-  codeMaxHeight?: string
+  maxHeight?: string
   isSearchable?: boolean
   query?: string
   isFilterMode?: boolean
   isRegExpMode?: boolean
   showK8sCopyButton?: boolean
 }>(), {
-  codeMaxHeight: undefined,
+  maxHeight: undefined,
   isSearchable: false,
   query: '',
   isFilterMode: false,

--- a/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
@@ -14,7 +14,7 @@
     </template>
     <KCodeBlock
       :id="id"
-      :max-height="props.codeMaxHeight"
+      :max-height="props.maxHeight"
       :code="props.code"
       :language="language"
       :initial-filter-mode="props.isFilterMode"
@@ -53,7 +53,7 @@ const props = withDefaults(defineProps<{
   language: 'json' | 'yaml' | 'bash'
   isSearchable?: boolean
   showCopyButton?: boolean
-  codeMaxHeight?: string
+  maxHeight?: string
   query?: string
   isFilterMode?: boolean
   isRegExpMode?: boolean
@@ -61,7 +61,7 @@ const props = withDefaults(defineProps<{
   id: () => uniqueId('code-block'),
   isSearchable: false,
   showCopyButton: true,
-  codeMaxHeight: undefined,
+  maxHeight: undefined,
   query: '',
   isFilterMode: false,
   isRegExpMode: false,

--- a/packages/kuma-gui/src/app/x/components/x-window/README.md
+++ b/packages/kuma-gui/src/app/x/components/x-window/README.md
@@ -1,0 +1,3 @@
+# x-window
+
+A renderless component for easy/declarative window listening

--- a/packages/kuma-gui/src/app/x/components/x-window/XWindow.vue
+++ b/packages/kuma-gui/src/app/x/components/x-window/XWindow.vue
@@ -1,0 +1,34 @@
+<template>
+  <GlobalEvents
+    target="window"
+    v-bind="{
+      ...(props.resize ? { onResize: (e: WindowEvent) => resizeRef = e} : {}),
+    }"
+  />
+  <slot
+    name="default"
+    :resize="resizeRef"
+  />
+</template>
+<script lang="ts" setup>
+import { ref } from 'vue'
+import { GlobalEvents } from 'vue-global-events'
+
+type WindowEvent = Event & {
+  target?: Window
+}
+
+defineSlots<{
+  default(props: {
+    resize: WindowEvent
+  }): any
+}>()
+
+const props = withDefaults(defineProps<{
+  resize?: boolean
+}>(), {
+  resize: false,
+})
+const resizeRef = ref<WindowEvent>(new Event('resize') as WindowEvent)
+window.dispatchEvent(resizeRef.value)
+</script>

--- a/packages/kuma-gui/src/app/x/index.ts
+++ b/packages/kuma-gui/src/app/x/index.ts
@@ -29,6 +29,7 @@ import XTabs from './components/x-tabs/XTabs.vue'
 import XTeleportSlot from './components/x-teleport/XTeleportSlot.vue'
 import XTeleportTemplate from './components/x-teleport/XTeleportTemplate.vue'
 import XTooltip from './components/x-tooltip/XTooltip.vue'
+import XWindow from './components/x-window/XWindow.vue'
 import vStyle from './directives/style'
 import locales from './locales/en-us/index.yaml'
 import type { ServiceDefinition } from '@/services/utils'
@@ -72,6 +73,7 @@ declare module 'vue' {
     XAboutCard: typeof XAboutCard
     XInputSwitch: typeof XInputSwitch
     XCheckbox: typeof XCheckBox
+    XWindow: typeof XWindow
   }
 }
 
@@ -127,6 +129,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
           ['XAboutCard', XAboutCard],
           ['XInputSwitch', XInputSwitch],
           ['XCheckbox', XCheckBox],
+          ['XWindow', XWindow],
         ]
       },
       labels: [


### PR DESCRIPTION
Also see https://github.com/kumahq/kuma-gui/issues/3152, specifically https://github.com/kumahq/kuma-gui/issues/3152#issuecomment-2758069136

---

Looks like the line numbers we render here can cause a massive slowdown in re-renders, specifically when typing to search large configs.

The upstream KCodeBlock that we use for this does have a virtual scroller for the line numbers built in, but because of the nature of some virtual scrollers, and definitely in this case, you need to fix the height of the container of the thing that contains the virtual scroller. This means that the KCodeBlock now controls the scrolling, not the browser window.

Note: I only implemented this in the "full page" XDS Config pages for now, so if you are viewing the PR preview make sure you are looking at it on this page.

