### PR TITLE
chore(ci): renames .update to .sync target with additional dedupe

### DIFF
--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -4,14 +4,11 @@
 		&& npm $(if $(CI),clean-install,install) \
 					--ignore-scripts
 
-.PHONY: .update
-.update: check/node
+.PHONY: .sync
+.sync: check/node
 	@cd $(NPM_WORKSPACE_ROOT) \
 		&& npm install \
 					--ignore-scripts
-
-.PHONY: .dedupe
-.dedupe:
 	@npm dedupe
 
 .PHONY: .clean


### PR DESCRIPTION
We have places/times where we manually have to run `npm dedupe` after an install to prevent certain problematic duplications happening. Previously we have either been running `npm dedupe` manually, or when this wasn't possible, playing pot luck with editing with package.json file and re-running install to get things to "stick"

This PR renames `.update` to `.sync` and adds an `npm dedupe` at the end.

I feel `sync` is a better name than `update`, plus this will now fail as soon as it becomes apparent that `npm dedupe` has stopped working.

I've not exposed `.sync` in any of our root Makefiles here just yet, but after a little more verification I'm going to consider doing that.