### PR TITLE
chore(notifications): normalize notification keys

### DIFF
--- a/packages/kuma-gui/features/application/Warnings.feature
+++ b/packages/kuma-gui/features/application/Warnings.feature
@@ -2,8 +2,8 @@ Feature: application / warnings
 
   Background:
     Given the CSS selectors
-      | Alias                     | Selector                                              |
-      | memory-store-type-warning | [data-testid='notification-global-store-type-memory'] |
+      | Alias                     | Selector                                                              |
+      | memory-store-type-warning | [data-testid='notification-main-overview.notifications.store-memory'] |
 
   Scenario: Using the memory store type shows a warning
     Given the environment

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
@@ -5,7 +5,7 @@ Feature: Dataplane details for built-in gateway
       | Alias             | Selector                                                           |
       | detail-view       | [data-testid='data-plane-detail-tabs-view']                        |
       | policies-view     | [data-testid='data-plane-policies-view']                           |
-      | warnings          | [data-testid^='notification-DPP_NO_MTLS']                          |
+      | warnings          | [data-testid^='notification-data-planes.notifications.no-mtls']    |
       | details           | [data-testid='dataplane-details']                                  |
       | route-item        | [data-testid='builtin-gateway-dataplane-policies'] .accordion-item |
       | route-item-button | $route-item:nth-child(1) [data-testid='accordion-item-button']     |

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
@@ -2,10 +2,10 @@ Feature: Dataplane details for delegated gateway
 
   Background:
     Given the CSS selectors
-      | Alias       | Selector                                    |
-      | detail-view | [data-testid='data-plane-detail-tabs-view'] |
-      | warnings    | [data-testid^='notification-DPP_NO_MTLS']   |
-      | details     | [data-testid='dataplane-details']           |
+      | Alias       | Selector                                                        |
+      | detail-view | [data-testid='data-plane-detail-tabs-view']                     |
+      | warnings    | [data-testid^='notification-data-planes.notifications.no-mtls'] |
+      | details     | [data-testid='dataplane-details']                               |
 
   Scenario: Overview tab has expected content
     Given the environment

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
@@ -2,12 +2,12 @@ Feature: mesh / dataplanes / DataplaneDetailsTraffic
 
   Background:
     Given the CSS selectors
-      | Alias           | Selector                                            |
-      | detail-view     | [data-testid='data-plane-detail-tabs-view']         |
-      | loading-warning | [data-testid^='notification-warning-stats-loading'] |
-      | traffic         | [data-testid='dataplane-traffic']                   |
-      | outbounds       | [data-testid='dataplane-outbounds']                 |
-      | inactiveToggle  | [data-testid='dataplane-outbounds-inactive-toggle'] |
+      | Alias           | Selector                                                                   |
+      | detail-view     | [data-testid='data-plane-detail-tabs-view']                                |
+      | loading-warning | [data-testid^='notification-data-planes.notifications.stats-not-enhanced'] |
+      | traffic         | [data-testid='dataplane-traffic']                                          |
+      | outbounds       | [data-testid='dataplane-outbounds']                                        |
+      | inactiveToggle  | [data-testid='dataplane-outbounds-inactive-toggle']                        |
 
   Scenario: Standard sidecar proxy shows the traffic component
     Given the environment

--- a/packages/kuma-gui/features/mesh/dataplanes/Warnings.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Warnings.feature
@@ -2,11 +2,11 @@ Feature: mesh / dataplanes / warnings
 
   Background:
     Given the CSS selectors
-      | Alias                     | Selector                                                                |
-      | expired-cert-warning      | [data-testid^='notification-CERT_EXPIRED']                              |
-      | unsupported-kuma-warning  | [data-testid^='notification-INCOMPATIBLE_UNSUPPORTED_KUMA_DP']          |
-      | unsupported-envoy-warning | [data-testid^='notification-INCOMPATIBLE_UNSUPPORTED_ENVOY']            |
-      | unsupported-zone-warning  | [data-testid^='notification-INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS'] |
+      | Alias                     | Selector                                                                        |
+      | expired-cert-warning      | [data-testid^='notification-data-planes.notifications.certificate-expired']     |
+      | unsupported-kuma-warning  | [data-testid^='notification-data-planes.notifications.dp-cp-incompatible']      |
+      | unsupported-envoy-warning | [data-testid^='notification-data-planes.notifications.envoy-dp-incompatible']   |
+      | unsupported-zone-warning  | [data-testid^='notification-data-planes.notifications.dp-zone-cp-incompatible'] |
 
   Scenario: With an expired certificate a cert warning is shown
     Given the URL "/meshes/default/dataplanes/dpp-1/_overview" responds with

--- a/packages/kuma-gui/features/zones/zone-cps/Warnings.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/Warnings.feature
@@ -2,13 +2,13 @@ Feature: zones / warnings
 
   Background:
     Given the CSS selectors
-      | Alias                    | Selector                                                                       |
-      | warning-no-subscriptions | [data-testid='warning-no-subscriptions']                                       |
-      | warning-zone-memory      | [data-testid^='notification-ZONE_STORE_TYPE_MEMORY']                           |
-      | zone-cp-table-row        | [data-testid='zone-cp-collection'] tbody tr                                    |
-      | warning-trigger          | $zone-cp-table-row:nth-child(1) [data-testid="warning"]                        |
-      | warning-memory           | $zone-cp-table-row:nth-child(1) [data-testid="warning-ZONE_STORE_TYPE_MEMORY"] |
-      | notification-nack        | [data-testid^='notification-NACK_RESPONSE_ZONE_TO_GLOBAL']                     |
+      | Alias                    | Selector                                                                  |
+      | warning-no-subscriptions | [data-testid='warning-no-subscriptions']                                  |
+      | warning-zone-memory      | [data-testid^='notification-zone-cps.notifications.store-memory']         |
+      | zone-cp-table-row        | [data-testid='zone-cp-collection'] tbody tr                               |
+      | warning-trigger          | $zone-cp-table-row:nth-child(1) [data-testid="warning"]                   |
+      | warning-memory           | $zone-cp-table-row:nth-child(1) [data-testid="warning-store-memory"]      |
+      | notification-nack        | [data-testid^='notification-zone-cps.notifications.global-nack-response'] |
     And the environment
       """
       KUMA_ZONE_COUNT: 1

--- a/packages/kuma-gui/src/app/control-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/control-planes/locales/en-us/index.yaml
@@ -1,4 +1,8 @@
 main-overview:
+  notifications:
+    store-memory: !!text/markdown |
+      This control plane is using the `memory` store type. **Don't** use this store in production because the state isn't persisted.
+      <a target="_blank" href="{KUMA_DOCS_URL}/documentation/configuration/#store">Read more about store types</a>
   routes:
     item:
       title: Overview

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneInsight.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneInsight.ts
@@ -2,12 +2,13 @@ import { DiscoverySubscriptionCollection } from '@/app/subscriptions/data'
 import type {
   DataPlaneInsight as PartialDataplaneInsight,
 } from '@/types/index.d'
-export type DataplaneInsight = PartialDataplaneInsight & DiscoverySubscriptionCollection & {}
+
 export const DataplaneInsight = {
-  fromObject(item: PartialDataplaneInsight | undefined): DataplaneInsight {
+  fromObject(item?: PartialDataplaneInsight) {
     return {
-      ...item,
+      ...(item ?? {}),
       ...DiscoverySubscriptionCollection.fromArray(item?.subscriptions),
     }
   },
 }
+export type DataplaneInsight = ReturnType<typeof DataplaneInsight.fromObject>

--- a/packages/kuma-gui/src/app/data-planes/index.ts
+++ b/packages/kuma-gui/src/app/data-planes/index.ts
@@ -15,7 +15,6 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       arguments: [
         app.source,
         app.api,
-        app.can,
       ],
       labels: [
         app.sources,

--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -10,7 +10,7 @@ data-planes:
       Unsupported version of Kuma DP (**{ kumaDp }**)
     envoy-dp-incompatible: !!text/markdown |
       Envoy (**{ envoy }**) is unsupported by the current version of Kuma DP (**{ kumaDp }**)
-    dp-zone-incompatible: !!text/markdown |
+    dp-zone-cp-incompatible: !!text/markdown |
       There is a mismatch between versions of Kuma DP (**{ kumaDp }**) and the Zone Control Plane.
     certificate-expired: !!text/markdown |
       The certificate for this dataplane has expired

--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -6,6 +6,21 @@ data-planes:
         ReachableBackends { <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-backends" target="_blank">Reachable Backends</a> }
         other { <a href="{KUMA_DOCS_URL}/production/dp-config/transparent-proxying/#reachable-services" target="_blank">Reachable Services</a> }
       } to dramatically improve performance.
+    dp-cp-incompatible: !!text/markdown |
+      Unsupported version of Kuma DP (**{ kumaDp }**)
+    envoy-dp-incompatible: !!text/markdown |
+      Envoy (**{ envoy }**) is unsupported by the current version of Kuma DP (**{ kumaDp }**)
+    dp-zone-incompatible: !!text/markdown |
+      There is a mismatch between versions of Kuma DP (**{ kumaDp }**) and the Zone Control Plane.
+    certificate-expired: !!text/markdown |
+      The certificate for this dataplane has expired
+    no-mtls: !!text/markdown |
+      This Data Plane Proxy does not have mTLS configured, yet —
+      <a href="{KUMA_DOCS_URL}/policies/mutual-tls?{KUMA_UTM_QUERY_PARAMS}" target="_blank">Learn about certificates in {KUMA_PRODUCT_NAME}</a>
+    stats-not-enhanced: !!text/markdown |
+      The below view is not enhanced with runtime stats (Error loading stats: **{ error }**)
+
+
   x-empty-state:
     title: There are no Dataplanes present
   components:
@@ -114,6 +129,9 @@ data-planes:
       title: Data Plane Proxies
       intro: !!text/markdown |
         Data Plane Proxies are sidecar proxies deployed alongside each service instance, responsible for handling all traffic, enforcing policies and facilitating communication between services.
+      warnings:
+        dp-cp-incompatible: Version mismatch
+        certificate-expired: Certificate expired
   href:
     docs:
       data_plane_proxy: '{KUMA_DOCS_URL}/production/dp-config/dpp?{KUMA_UTM_QUERY_PARAMS}'

--- a/packages/kuma-gui/src/app/data-planes/sources.ts
+++ b/packages/kuma-gui/src/app/data-planes/sources.ts
@@ -7,7 +7,6 @@ import {
   MeshGatewayDataplane,
   SidecarDataplane,
 } from './data'
-import type { Can } from '../application/services/can'
 import type { DataSourceResponse } from '@/app/application'
 import { YAML } from '@/app/application'
 import { defineSources, type Source } from '@/app/application/services/data-source'
@@ -35,7 +34,7 @@ export type MeshGatewayDataplaneSource = DataSourceResponse<MeshGatewayDataplane
 const includes = <T extends readonly string[]>(arr: T, item: string): item is T[number] => {
   return arr.includes(item as T[number])
 }
-export const sources = (source: Source, api: KumaApi, can: Can) => {
+export const sources = (source: Source, api: KumaApi) => {
   const http = createClient<paths>({
     baseUrl: '',
     fetch: api.client.fetch,
@@ -45,10 +44,9 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
     '/dataplanes/poll': (params) => {
       const { size, page } = params
       const offset = size * (page - 1)
-      const canUseZones = can('use zones')
 
       return source(async (source) => {
-        const res = DataplaneOverview.fromCollection(await api.getAllDataplaneOverviews({ size, offset }), canUseZones)
+        const res = DataplaneOverview.fromCollection(await api.getAllDataplaneOverviews({ size, offset }))
         if (res.total > 0 && res.items.every(item => item.status === 'online')) {
           source.close()
         }
@@ -60,9 +58,8 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
       const OfflineError = class extends Error { }
       const { size, page } = params
       const offset = size * (page - 1)
-      const canUseZones = can('use zones')
       return source(async () => {
-        const res = DataplaneOverview.fromCollection(await api.getAllDataplaneOverviews({ size, offset }), canUseZones)
+        const res = DataplaneOverview.fromCollection(await api.getAllDataplaneOverviews({ size, offset }))
         if (res.total > 0 && res.items.every((item) => item.status === 'online')) {
           return res
         } else {
@@ -179,7 +176,7 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
     },
 
     '/meshes/:mesh/dataplane-overviews/:name': async (params) => {
-      return DataplaneOverview.fromObject(await api.getDataplaneOverviewFromMesh(params), can('use zones'))
+      return DataplaneOverview.fromObject(await api.getDataplaneOverviewFromMesh(params))
     },
 
     '/meshes/:mesh/dataplanes/of/:type': async (params) => {
@@ -198,7 +195,7 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
         ...gatewayParams,
         offset,
         size,
-      }), can('use zones'))
+      }))
     },
 
     '/meshes/:mesh/dataplanes/for/mesh-service/:tags': async (params) => {
@@ -217,7 +214,7 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
         ...filterParams,
         offset,
         size,
-      }), can('use zones'))
+      }))
     },
 
     '/meshes/:mesh/dataplanes/for/service-insight/:service': async (params) => {
@@ -236,7 +233,7 @@ export const sources = (source: Source, api: KumaApi, can: Can) => {
         ...filterParams,
         offset,
         size,
-      }), can('use zones'))
+      }))
     },
   })
 }

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -220,25 +220,38 @@
                   />
                 </template>
 
-                <template #warnings="{ row }">
-                  <XIcon
-                    v-if="row.isCertExpired || row.warnings.length > 0"
-                    class="mr-1"
-                    name="warning"
+                <template #warnings="{ row : item }">
+                  <template
+                    v-for="warnings in [[
+                      {
+                        bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                        key: 'dp-cp-incompatible',
+                      },
+                      {
+                        bool: item.isCertExpired,
+                        key: 'certificate-expired',
+                      },
+                    ].filter(({ bool }) => bool)]"
+                    :key="typeof warnings"
                   >
-                    <ul>
-                      <template v-if="row.warnings.length > 0">
-                        <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                      </template>
-
-                      <template v-if="row.isCertExpired">
-                        <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                      </template>
-                    </ul>
-                  </XIcon>
-
-                  <template v-else>
-                    {{ t('common.collection.none') }}
+                    <XIcon
+                      v-if="warnings.length > 0"
+                      name="warning"
+                      data-testid="warning"
+                    >
+                      <ul>
+                        <li
+                          v-for="{ key } in warnings"
+                          :key="key"
+                          :data-testid="`warning-${key}`"
+                        >
+                          {{ t(`data-planes.routes.items.warnings.${key}`) }}
+                        </li>
+                      </ul>
+                    </XIcon>
+                    <template v-else>
+                      {{ t('common.collection.none') }}
+                    </template>
                   </template>
                 </template>
 

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -129,25 +129,38 @@
                       <StatusBadge :status="row.status" />
                     </template>
 
-                    <template #warnings="{ row }">
-                      <XIcon
-                        v-if="row.isCertExpired || row.warnings.length > 0"
-                        class="mr-1"
-                        name="warning"
+                    <template #warnings="{ row: item }">
+                      <template
+                        v-for="warnings in [[
+                          {
+                            bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                            key: 'dp-cp-incompatible',
+                          },
+                          {
+                            bool: item.isCertExpired,
+                            key: 'certificate-expired',
+                          },
+                        ].filter(({ bool }) => bool)]"
+                        :key="typeof warnings"
                       >
-                        <ul>
-                          <template v-if="row.warnings.length > 0">
-                            <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                          </template>
-
-                          <template v-if="row.isCertExpired">
-                            <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                          </template>
-                        </ul>
-                      </XIcon>
-
-                      <template v-else>
-                        {{ t('common.collection.none') }}
+                        <XIcon
+                          v-if="warnings.length > 0"
+                          name="warning"
+                          data-testid="warning"
+                        >
+                          <ul>
+                            <li
+                              v-for="{ key } in warnings"
+                              :key="key"
+                              :data-testid="`warning-${key}`"
+                            >
+                              {{ t(`data-planes.routes.items.warnings.${key}`) }}
+                            </li>
+                          </ul>
+                        </XIcon>
+                        <template v-else>
+                          {{ t('common.collection.none') }}
+                        </template>
                       </template>
                     </template>
 

--- a/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -173,25 +173,38 @@
                     <StatusBadge :status="row.status" />
                   </template>
 
-                  <template #warnings="{ row }">
-                    <XIcon
-                      v-if="row.isCertExpired || row.warnings.length > 0"
-                      class="mr-1"
-                      name="warning"
+                  <template #warnings="{ row: item }">
+                    <template
+                      v-for="warnings in [[
+                        {
+                          bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                          key: 'dp-cp-incompatible',
+                        },
+                        {
+                          bool: item.isCertExpired,
+                          key: 'certificate-expired',
+                        },
+                      ].filter(({ bool }) => bool)]"
+                      :key="typeof warnings"
                     >
-                      <ul>
-                        <template v-if="row.warnings.length > 0">
-                          <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                        </template>
-
-                        <template v-if="row.isCertExpired">
-                          <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                        </template>
-                      </ul>
-                    </XIcon>
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
+                      <XIcon
+                        v-if="warnings.length > 0"
+                        name="warning"
+                        data-testid="warning"
+                      >
+                        <ul>
+                          <li
+                            v-for="{ key } in warnings"
+                            :key="key"
+                            :data-testid="`warning-${key}`"
+                          >
+                            {{ t(`data-planes.routes.items.warnings.${key}`) }}
+                          </li>
+                        </ul>
+                      </XIcon>
+                      <template v-else>
+                        {{ t('common.collection.none') }}
+                      </template>
                     </template>
                   </template>
 

--- a/packages/kuma-gui/src/app/hostname-generators/data/HostnameGenerator.ts
+++ b/packages/kuma-gui/src/app/hostname-generators/data/HostnameGenerator.ts
@@ -1,8 +1,7 @@
-import type { components, paths } from '@kumahq/kuma-http-api'
+import type { components } from '@kumahq/kuma-http-api'
 
-export type HostnameGeneratorList = components['responses']['HostnameGeneratorList']['content']['application/json']
-export type HostnameGeneratorItem = components['responses']['HostnameGeneratorItem']['content']['application/json']
-export type HostnameGeneratorGetParams = paths['/hostnamegenerators/{name}']['get']['parameters']
+type HostnameGeneratorList = components['responses']['HostnameGeneratorList']['content']['application/json']
+type HostnameGeneratorItem = components['responses']['HostnameGeneratorItem']['content']['application/json']
 
 export const HostnameGenerator = {
   fromObject(item: HostnameGeneratorItem) {

--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -17,10 +17,10 @@
       >
         <XNotification
           v-if="!can('use state')"
-          uri="global-store-type-memory"
+          uri="main-overview.notifications.store-memory"
         >
           <XI18n
-            path="common.warnings.GLOBAL_STORE_TYPE_MEMORY"
+            path="main-overview.notifications.store-memory"
           />
         </XNotification>
         <header

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -37,25 +37,6 @@ common:
   not_applicable: N/A
   matchingsearch: " matching that search"
   refresh: Refresh
-  warnings:
-    CERT_EXPIRED: !!text/markdown |
-      The certificate for this dataplane has expired
-    DPP_NO_MTLS: !!text/markdown |
-      This Data Plane Proxy does not have mTLS configured, yet  — <a href="{KUMA_DOCS_URL}/policies/mutual-tls?{KUMA_UTM_QUERY_PARAMS}">Learn about certificates in {KUMA_PRODUCT_NAME}</a>
-    ZONE_STORE_TYPE_MEMORY: !!text/markdown |
-      This zone is using the `memory` store type. **Don't** use this store in production because the state isn't persisted. <a target="_blank" href="{KUMA_DOCS_URL}/documentation/configuration/#store">Read more about store types</a>
-    GLOBAL_STORE_TYPE_MEMORY: !!text/markdown |
-      This control plane is using the `memory` store type. **Don't** use this store in production because the state isn't persisted. <a target="_blank" href="{KUMA_DOCS_URL}/documentation/configuration/#store">Read more about store types</a>
-    INCOMPATIBLE_UNSUPPORTED_ENVOY: !!text/markdown |
-      Envoy (**{ envoy }**) is unsupported by the current version of Kuma DP (**{ kumaDp }**)
-    INCOMPATIBLE_UNSUPPORTED_KUMA_DP: !!text/markdown |
-      Unsupported version of Kuma DP (**{ kumaDp }**)
-    INCOMPATIBLE_ZONE_CP_AND_KUMA_DP_VERSIONS: !!text/markdown |
-      There is a mismatch between versions of Kuma DP (**{ kumaDp }**) and the Zone Control Plane.
-    INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS: !!text/markdown |
-      There is mismatch between versions of Zone Control Plane (**{ zoneCpVersion }**) and the Global Control Plane (**{ globalCpVersion }**)
-    NACK_RESPONSE_ZONE_TO_GLOBAL: !!text/markdown |
-      The Global Control Plane got NACK responses from the Zone Control Plane. Refer to the Zone Control Plane logs for more details.
   copyText: 'Copy'
   copySuccessText: 'Copied!'
   copyKubernetesText: 'Copy as Kubernetes'

--- a/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
@@ -341,25 +341,38 @@
                       <StatusBadge :status="row.status" />
                     </template>
 
-                    <template #warnings="{ row }">
-                      <XIcon
-                        v-if="row.isCertExpired || row.warnings.length > 0"
-                        class="mr-1"
-                        name="warning"
+                    <template #warnings="{ row: item }">
+                      <template
+                        v-for="warnings in [[
+                          {
+                            bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                            key: 'dp-cp-incompatible',
+                          },
+                          {
+                            bool: item.isCertExpired,
+                            key: 'certificate-expired',
+                          },
+                        ].filter(({ bool }) => bool)]"
+                        :key="typeof warnings"
                       >
-                        <ul>
-                          <template v-if="row.warnings.length > 0">
-                            <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                          </template>
-
-                          <template v-if="row.isCertExpired">
-                            <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                          </template>
-                        </ul>
-                      </XIcon>
-
-                      <template v-else>
-                        {{ t('common.collection.none') }}
+                        <XIcon
+                          v-if="warnings.length > 0"
+                          name="warning"
+                          data-testid="warning"
+                        >
+                          <ul>
+                            <li
+                              v-for="{ key } in warnings"
+                              :key="key"
+                              :data-testid="`warning-${key}`"
+                            >
+                              {{ t(`data-planes.routes.items.warnings.${key}`) }}
+                            </li>
+                          </ul>
+                        </XIcon>
+                        <template v-else>
+                          {{ t('common.collection.none') }}
+                        </template>
                       </template>
                     </template>
 

--- a/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
@@ -188,25 +188,38 @@
                     <StatusBadge :status="row.status" />
                   </template>
 
-                  <template #warnings="{ row }">
-                    <XIcon
-                      v-if="row.isCertExpired || row.warnings.length > 0"
-                      class="mr-1"
-                      name="warning"
+                  <template #warnings="{ row: item }">
+                    <template
+                      v-for="warnings in [[
+                        {
+                          bool: item.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false || item.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                          key: 'dp-cp-incompatible',
+                        },
+                        {
+                          bool: item.isCertExpired,
+                          key: 'certificate-expired',
+                        },
+                      ].filter(({ bool }) => bool)]"
+                      :key="typeof warnings"
                     >
-                      <ul>
-                        <template v-if="row.warnings.length > 0">
-                          <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
-                        </template>
-
-                        <template v-if="row.isCertExpired">
-                          <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
-                        </template>
-                      </ul>
-                    </XIcon>
-
-                    <template v-else>
-                      {{ t('common.collection.none') }}
+                      <XIcon
+                        v-if="warnings.length > 0"
+                        name="warning"
+                        data-testid="warning"
+                      >
+                        <ul>
+                          <li
+                            v-for="{ key } in warnings"
+                            :key="key"
+                            :data-testid="`warning-${key}`"
+                          >
+                            {{ t(`data-planes.routes.items.warnings.${key}`) }}
+                          </li>
+                        </ul>
+                      </XIcon>
+                      <template v-else>
+                        {{ t('common.collection.none') }}
+                      </template>
                     </template>
                   </template>
 

--- a/packages/kuma-gui/src/app/subscriptions/data/index.ts
+++ b/packages/kuma-gui/src/app/subscriptions/data/index.ts
@@ -10,6 +10,7 @@ const acknowledgements = [
   'responsesAcknowledged',
   'responsesRejected',
 ] as const
+
 type Acknowledgements = {
   [key in (typeof acknowledgements)[number]]: number
 }
@@ -67,7 +68,6 @@ export const DiscoverySubscriptionCollection = {
     return SubscriptionCollection.fromArray(items)
   },
 }
-export type DiscoverySubscriptionCollection = ReturnType<typeof DiscoverySubscriptionCollection.fromArray>
 export const SubscriptionCollection = {
   fromArray: <T extends PartialSubscription>(items?: T[]) => {
     const subscriptions = Array.isArray(items) ? items.map(Subscription.fromObject<T>) : []
@@ -94,3 +94,4 @@ export const SubscriptionCollection = {
   },
 }
 export type SubscriptionCollection = ReturnType<typeof SubscriptionCollection.fromArray>
+export type DiscoverySubscriptionCollection = ReturnType<typeof DiscoverySubscriptionCollection.fromArray>

--- a/packages/kuma-gui/src/app/zones/data/index.ts
+++ b/packages/kuma-gui/src/app/zones/data/index.ts
@@ -65,27 +65,6 @@ export const ZoneOverview = {
   fromObject: (item: PartialZoneOverview) => {
     const insight = ZoneInsight.fromObject(item.zoneInsight)
     const zone = Zone.fromObject(item.zone)
-    const warnings = []
-    if (insight.store === 'memory') {
-      warnings.push({
-        kind: 'ZONE_STORE_TYPE_MEMORY',
-        payload: {},
-      })
-    }
-    if (!get(insight, 'version.kumaCp.kumaCpGlobalCompatible', true)) {
-      warnings.push({
-        kind: 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS',
-        payload: {
-          zoneCpVersion: get(insight, 'version.kumaCp.version', '-'),
-        },
-      })
-    }
-    if ((insight.connectedSubscription?.status.total.responsesRejected ?? 0) > 0) {
-      warnings.push({
-        kind: 'NACK_RESPONSE_ZONE_TO_GLOBAL',
-        payload: {},
-      })
-    }
     const state = {
       disabled: 'disabled',
       online: 'online',
@@ -98,7 +77,6 @@ export const ZoneOverview = {
       zone,
       // first check see if the zone is disabled, if not look for the connectedSubscription
       state: !zone.enabled ? state.disabled : typeof insight.connectedSubscription !== 'undefined' ? state.online : state.offline,
-      warnings,
     }
   },
   fromCollection: (collection: CollectionResponse<PartialZoneOverview>) => {

--- a/packages/kuma-gui/src/app/zones/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/zones/locales/en-us/index.yaml
@@ -17,6 +17,14 @@ zone-cps:
         =1 { Zone }
         other { Zones }
       }
+  notifications:
+    store-memory: !!text/markdown |
+      This zone is using the `memory` store type. **Don't** use this store in production because the state isn't persisted.
+      <a target="_blank" href="{KUMA_DOCS_URL}/documentation/configuration/#store">Read more about store types</a>
+    global-cp-incompatible: !!text/markdown |
+      There is mismatch between versions of Zone Control Plane (**{ zoneCpVersion }**) and the Global Control Plane (**{ globalCpVersion }**)
+    global-nack-response: !!text/markdown |
+      The Global Control Plane got NACK responses from the Zone Control Plane. Refer to the Zone Control Plane logs for more details.
 
   x-empty-state:
     title: No Zones yet...
@@ -24,11 +32,11 @@ zone-cps:
       There are no Zones present
     action:
       <<: *zone-cps.docs
-  
+
   x-growth-empty-state:
       title: Create your first zone
       body: !!text/markdown |
-        Zones define network boundaries (e.g., clusters, VPCs) and connect to a global control plane that centrally manages and distributes configurations. 
+        Zones define network boundaries (e.g., clusters, VPCs) and connect to a global control plane that centrally manages and distributes configurations.
       action:
         <<: *zones.growth-docs
 
@@ -65,8 +73,9 @@ zone-cps:
         disconnected: Disconnected
         responses: Responses (sent/ack'ed)
   list:
-    INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS: 'Version mismatch'
-    ZONE_STORE_TYPE_MEMORY: 'Uses memory store'
+    warnings:
+      store-memory: Uses memory store
+      global-cp-incompatible: Version mismatch
   detail:
     subscriptions: 'KDS Connections'
     configuration_title: 'Configuration'

--- a/packages/kuma-gui/src/app/zones/views/ZoneConfigView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneConfigView.vue
@@ -22,22 +22,38 @@
       <AppView
         :notifications="true"
       >
-        <XNotification
-          v-for="warning in props.data.warnings"
-          :key="warning.kind"
-          :data-testid="`warning-${warning.kind}`"
-          :uri="`${warning.kind}.${props.data.id}`"
-        >
-          <XI18n
-            :path="`common.warnings.${warning.kind}`"
-            :params="{
-              zoneCpVersion: warning.payload.zoneCpVersion ?? '',
-              ...(warning.kind === 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS' ? {
+        <template
+          v-for="{ bool, key, params } in [
+            {
+              bool: props.data.zoneInsight.store === 'memory',
+              key: 'store-memory',
+            },
+            {
+              bool: !props.data.zoneInsight.version?.kumaCp?.kumaCpGlobalCompatible,
+              key: 'global-cp-incompatible',
+              params: {
+                zoneCpVersion: props.data.zoneInsight.version?.kumaCp?.version ?? '-',
                 globalCpVersion: version?.version ?? '',
-              } : {}),
-            }"
-          />
-        </XNotification>
+              },
+            },
+            {
+              bool: (props.data.zoneInsight.connectedSubscription?.status.total.responsesRejected ?? 0) > 0,
+              key: 'global-nack-response',
+            },
+          ]"
+          :key="key"
+        >
+          <XNotification
+            v-if="bool"
+            :data-testid="`warning-${key}`"
+            :uri="`zone-cps.notifications.${key}.${props.data.id}`"
+          >
+            <XI18n
+              :path="`zone-cps.notifications.${key}`"
+              :params="Object.fromEntries(Object.entries(params ?? {}))"
+            />
+          </XNotification>
+        </template>
 
         <XCard>
           <XCodeBlock

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -17,22 +17,38 @@
         :docs="t('zones.href.docs.cta')"
         :notifications="true"
       >
-        <XNotification
-          v-for="warning in props.data.warnings"
-          :key="warning.kind"
-          :data-testid="`warning-${warning.kind}`"
-          :uri="`${warning.kind}.${props.data.id}`"
-        >
-          <XI18n
-            :path="`common.warnings.${warning.kind}`"
-            :params="{
-              zoneCpVersion: warning.payload.zoneCpVersion ?? '',
-              ...(warning.kind === 'INCOMPATIBLE_ZONE_AND_GLOBAL_CPS_VERSIONS' ? {
+        <template
+          v-for="{ bool, key, params } in [
+            {
+              bool: props.data.zoneInsight.store === 'memory',
+              key: 'store-memory',
+            },
+            {
+              bool: !props.data.zoneInsight.version?.kumaCp?.kumaCpGlobalCompatible,
+              key: 'global-cp-incompatible',
+              params: {
+                zoneCpVersion: props.data.zoneInsight.version?.kumaCp?.version ?? '-',
                 globalCpVersion: version?.version ?? '',
-              } : {}),
-            }"
-          />
-        </XNotification>
+              },
+            },
+            {
+              bool: (props.data.zoneInsight.connectedSubscription?.status.total.responsesRejected ?? 0) > 0,
+              key: 'global-nack-response',
+            },
+          ]"
+          :key="key"
+        >
+          <XNotification
+            v-if="bool"
+            :data-testid="`warning-${key}`"
+            :uri="`zone-cps.notifications.${key}.${props.data.id}`"
+          >
+            <XI18n
+              :path="`zone-cps.notifications.${key}`"
+              :params="Object.fromEntries(Object.entries(params ?? {}))"
+            />
+          </XNotification>
+        </template>
         <XLayout
           data-testid="detail-view-details"
           type="stack"

--- a/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
@@ -143,24 +143,40 @@
                     />
                   </template>
 
-                  <template #warnings="{ row: item }">
-                    <XIcon
-                      v-if="item.warnings.length > 0"
-                      name="warning"
-                      data-testid="warning"
+                  <template
+                    #warnings="{ row: item }"
+                  >
+                    <template
+                      v-for="warnings in [[
+                        {
+                          bool: item.zoneInsight.store === 'memory',
+                          key: 'store-memory',
+                        },
+                        {
+                          bool: !item.zoneInsight.version?.kumaCp?.kumaCpGlobalCompatible,
+                          key: 'global-cp-incompatible',
+                        },
+                      ].filter(({ bool }) => bool)]"
+                      :key="typeof warnings"
                     >
-                      <ul>
-                        <li
-                          v-for="warning in item.warnings"
-                          :key="warning.kind"
-                          :data-testid="`warning-${warning.kind}`"
-                        >
-                          {{ t(`zone-cps.list.${warning.kind}`) }}
-                        </li>
-                      </ul>
-                    </XIcon>
-                    <template v-else>
-                      {{ t('common.collection.none') }}
+                      <XIcon
+                        v-if="warnings.length > 0"
+                        name="warning"
+                        data-testid="warning"
+                      >
+                        <ul>
+                          <li
+                            v-for="{ key } in warnings"
+                            :key="key"
+                            :data-testid="`warning-${key}`"
+                          >
+                            {{ t(`zone-cps.list.warnings.${key}`) }}
+                          </li>
+                        </ul>
+                      </XIcon>
+                      <template v-else>
+                        {{ t('common.collection.none') }}
+                      </template>
                     </template>
                   </template>
 

--- a/packages/kuma-gui/src/test-support/mocks/src/hostname-generators/_/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/hostname-generators/_/_overview.ts
@@ -1,5 +1,7 @@
-import type { HostnameGeneratorItem } from '@/app/hostname-generators/data'
 import type { EndpointDependencies, MockResponder } from '@/test-support'
+import type { components } from '@kumahq/kuma-http-api'
+
+type HostnameGenerator = components['responses']['HostnameGeneratorItem']['content']['application/json']
 
 export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => {
   const { params } = req
@@ -43,7 +45,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
     },
     creationTime: creationTime.toISOString(),
     modificationTime: fake.date.between({ from: creationTime, to: Date.now() }).toISOString(),
-  } satisfies HostnameGeneratorItem
+  } satisfies HostnameGenerator
 
   return {
     headers: {},

--- a/packages/kuma-gui/src/test-support/mocks/src/hostname-generators/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/hostname-generators/_overview.ts
@@ -1,5 +1,8 @@
-import type { HostnameGeneratorItem } from '@/app/hostname-generators/data'
 import type { EndpointDependencies, MockResponder } from '@/test-support'
+import type { components } from '@kumahq/kuma-http-api'
+
+type HostnameGenerator = components['responses']['HostnameGeneratorItem']['content']['application/json']
+
 export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (req) => {
   const { offset, total, next, pageTotal } = pager(
     `${fake.number.int({ min: 1, max: 100 })}`,
@@ -13,7 +16,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     headers: {},
     body: {
       total,
-      items: Array.from({ length: pageTotal }).map((_, i): HostnameGeneratorItem => {
+      items: Array.from({ length: pageTotal }).map((_, i) => {
         const meshServiceTypeSelector = fake.kuma.meshServiceTypeSelector()
         const namespace = fake.word.noun()
         const displayName = `${fake.science.chemicalElement().name.toLowerCase()}-${offset + i}-service`
@@ -50,7 +53,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
           },
           creationTime: creationTime.toISOString(),
           modificationTime: fake.date.between({ from: creationTime, to: Date.now() }).toISOString(),
-        } satisfies HostnameGeneratorItem
+        } satisfies HostnameGenerator
       }),
       next,
     },

--- a/packages/kuma-gui/src/types/index.d.ts
+++ b/packages/kuma-gui/src/types/index.d.ts
@@ -216,11 +216,9 @@ export interface EnvoyVersion {
   kumaDpCompatible?: boolean
 }
 export interface Version {
+  envoy: EnvoyVersion
   kumaDp: KumaDpVersion
   kumaCp?: KumaCpVersion
-
-  envoy: EnvoyVersion
-
   dependencies: Record<string, string>
 }
 
@@ -286,14 +284,6 @@ export type DataplaneGateway = {
    * Type of the gateway. **Default**: `'DELEGATED'`
    */
   type?: 'BUILTIN' | 'DELEGATED'
-}
-
-export type DataplaneWarning = {
-  kind: string
-  payload?: {
-    kumaDp: string
-    envoy?: string
-  }
 }
 
 export type DataplaneInbound = {


### PR DESCRIPTION
- Changes all out notifications to use lowercase i18n keys that all live on a `<module-name>.notifications` property.
- Simplifies notifications so that are "calculated" in place instead of some in the data layer and some in the view layer. They are now all in the view layer. This means we can be more intentional about what notifications are shown where. The is a small bug here where we try to show a NACK warning on the zone listing page when we shouldn't.
- Due to the above point, I made some amends to the dataplane data layer
- Noticed a few tiny things in HostnameGenerators data mainly around using the generated types in the mocks rather than our application types.

Note tests are gonna fall on their face here, I wanted to put up a draft PR to share progress, my next steps is fixing up the tests.

Part of https://github.com/kumahq/kuma-gui/issues/3605

I'm considering making a reusable/include-like component here, possibly for the DataplaneListing, still considering it but it shouldn't necessarily block review/merge, we can do a follow up.

