### PR TITLE
fix: reset z-index of KTable headers to auto

### DIFF
--- a/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
+++ b/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
@@ -149,6 +149,11 @@ onMounted(rewrite)
   font-weight: $kui-font-weight-semibold;
   text-decoration: none;
 }
+.app-collection :deep(thead) {
+  /* overwrite kongponents setting this to z-index:2 */
+  /* which causes overlay issues with other components */
+  z-index: auto !important;
+}
 
 .app-collection :deep(td:first-child li a) {
   color: $kui-color-text-primary;


### PR DESCRIPTION
Overwrites kongponents setting KTable headers to `z-index: 2` in https://github.com/Kong/kongponents/pull/2629 which causes the following to happen:

### Before

![Screenshot 2025-04-01 at 19 16 52](https://github.com/user-attachments/assets/259b49e8-8f07-4bce-97ee-8b4692b69d25)

### After (this PR)

![Screenshot 2025-04-01 at 19 16 43](https://github.com/user-attachments/assets/f29c15d8-ae67-43c7-827a-f3332143ba10)

I also filed an issue upstream https://github.com/Kong/kongponents/issues/2678
