### PR TITLE
chore(lint): adds rule to enforce attributes on their own line always 

### DIFF
--- a/packages/config/src/eslint.cjs
+++ b/packages/config/src/eslint.cjs
@@ -264,6 +264,10 @@ function createEslintConfig(
           ],
           alphabetical: false,
         }],
+        'vue/first-attribute-linebreak': ['error', {
+          'singleline': 'below',
+          'multiline': 'below',
+        }],
         'vue/singleline-html-element-content-newline': ['error', {
           ignoreWhenNoAttributes: true,
           ignoreWhenEmpty: true,

--- a/packages/kuma-gui/src/app/App.vue
+++ b/packages/kuma-gui/src/app/App.vue
@@ -17,7 +17,9 @@
       <ApplicationShell
         class="kuma-application"
       >
-        <template #home>
+        <template
+          #home
+        >
           <img
             class="logo"
             src="@/assets/images/product-logo.png"
@@ -26,7 +28,9 @@
           >
         </template>
 
-        <template #navigation>
+        <template
+          #navigation
+        >
           <AppNavigator
             v-style="'--icon: var(--icon-home)'"
             data-testid="control-planes-navigator"
@@ -67,7 +71,9 @@
           />
         </template>
 
-        <template #bottomNavigation>
+        <template
+          #bottomNavigation
+        >
           <AppNavigator
             v-style="'--icon: var(--icon-configuration)'"
             :active="child.name === 'configuration-view'"

--- a/packages/kuma-gui/src/app/application/components/app-navigator/AppNavigator.vue
+++ b/packages/kuma-gui/src/app/application/components/app-navigator/AppNavigator.vue
@@ -2,7 +2,9 @@
   <li
     class="app-navigator"
   >
-    <slot name="default">
+    <slot
+      name="default"
+    >
       <XAction
         :class="{
           'is-active': props.active,

--- a/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
+++ b/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
@@ -31,7 +31,9 @@
             v-if="slots.title || slots.actions"
             class="app-view-title-bar"
           >
-            <KongIcon v-if="props.fullscreen" />
+            <KongIcon
+              v-if="props.fullscreen"
+            />
 
             <template
               v-if="summary.length > 0"
@@ -39,13 +41,17 @@
               <XTeleportTemplate
                 :to="{ name: summary }"
               >
-                <slot name="title" />
+                <slot
+                  name="title"
+                />
               </XTeleportTemplate>
             </template>
             <template
               v-else
             >
-              <slot name="title" />
+              <slot
+                name="title"
+              />
             </template>
 
             <div
@@ -55,7 +61,9 @@
                 v-if="slots.title"
                 name="app-view-docs"
               />
-              <slot name="actions">
+              <slot
+                name="actions"
+              >
                 <XTeleportSlot
                   :name="`${routeView.name}-actions`"
                 />

--- a/packages/kuma-gui/src/app/application/components/data-source/DataLoader.vue
+++ b/packages/kuma-gui/src/app/application/components/data-source/DataLoader.vue
@@ -51,7 +51,9 @@
         />
       </slot>
     </template>
-    <template v-else>
+    <template
+      v-else
+    >
       <slot
         name="loadable"
         :data="srcData as TypeOf<T>"

--- a/packages/kuma-gui/src/app/application/components/data-source/DataSource.vue
+++ b/packages/kuma-gui/src/app/application/components/data-source/DataSource.vue
@@ -4,7 +4,9 @@
     :error="error"
     :refresh="refresh"
   />
-  <span v-bind="attrs" />
+  <span
+    v-bind="attrs"
+  />
 </template>
 
 <script lang="ts" generic="T extends string | {

--- a/packages/kuma-gui/src/app/common/AccordionItem.vue
+++ b/packages/kuma-gui/src/app/common/AccordionItem.vue
@@ -10,7 +10,9 @@
       data-testid="accordion-item-button"
       @click="open"
     >
-      <slot name="accordion-header" />
+      <slot
+        name="accordion-header"
+      />
     </button>
 
     <transition
@@ -24,7 +26,9 @@
         class="accordion-item-content"
         data-testid="accordion-item-content"
       >
-        <slot name="accordion-content" />
+        <slot
+          name="accordion-content"
+        />
       </div>
     </transition>
   </li>

--- a/packages/kuma-gui/src/app/common/AccordionList.vue
+++ b/packages/kuma-gui/src/app/common/AccordionList.vue
@@ -1,5 +1,7 @@
 <template>
-  <ul class="accordion-list">
+  <ul
+    class="accordion-list"
+  >
     <slot />
   </ul>
 </template>

--- a/packages/kuma-gui/src/app/common/DefinitionCard.vue
+++ b/packages/kuma-gui/src/app/common/DefinitionCard.vue
@@ -9,13 +9,21 @@
       v-if="slots.icon || slots.title"
       class="definition-card-title"
     >
-      <slot name="icon" />
+      <slot
+        name="icon"
+      />
 
-      <slot name="title" />
+      <slot
+        name="title"
+      />
     </div>
 
-    <div class="definition-card-container">
-      <slot name="body" />
+    <div
+      class="definition-card-container"
+    >
+      <slot
+        name="body"
+      />
     </div>
   </div>
 </template>

--- a/packages/kuma-gui/src/app/common/ErrorBlock.vue
+++ b/packages/kuma-gui/src/app/common/ErrorBlock.vue
@@ -6,7 +6,9 @@
     <KEmptyState
       v-if="!prompt"
     >
-      <template #icon>
+      <template
+        #icon
+      >
         <DangerIcon
           v-if="props.appearance === 'danger'"
           :color="KUI_COLOR_TEXT_DANGER"
@@ -17,8 +19,12 @@
         />
       </template>
 
-      <template #title>
-        <slot name="title">
+      <template
+        #title
+      >
+        <slot
+          name="title"
+        >
           {{ error instanceof ApiError && error.detail ? error.detail : t('common.error_state.title') }}
         </slot>
       </template>
@@ -49,12 +55,18 @@
           data-testid="error-trace"
           max-width="auto"
         >
-          trace: <XCopyButton :text="error.instance" />
+          trace: <XCopyButton
+            :text="error.instance"
+          />
         </XBadge>
       </div>
 
-      <div class="error-block-message mt-4">
-        <slot v-if="slots.default" />
+      <div
+        class="error-block-message mt-4"
+      >
+        <slot
+          v-if="slots.default"
+        />
         <template
           v-else-if="props.error instanceof ApiError"
         >
@@ -73,7 +85,9 @@
             </li>
           </ul>
         </template>
-        <p v-else>
+        <p
+          v-else
+        >
           {{ props.error.message }}
         </p>
       </div>
@@ -87,7 +101,9 @@
         <div
           class="error-block-message"
         >
-          <slot v-if="slots.default" />
+          <slot
+            v-if="slots.default"
+          />
           <template
             v-else-if="props.error instanceof ApiError"
           >
@@ -106,7 +122,9 @@
               </li>
             </ul>
           </template>
-          <p v-else>
+          <p
+            v-else
+          >
             {{ error.message }}
           </p>
         </div>

--- a/packages/kuma-gui/src/app/common/PolicyTypeTag.vue
+++ b/packages/kuma-gui/src/app/common/PolicyTypeTag.vue
@@ -1,5 +1,7 @@
 <template>
-  <span class="policy-type-tag">
+  <span
+    class="policy-type-tag"
+  >
     <img
       v-if="POLICY_ICON[props.policyType]"
       class="policy-type-tag-icon"
@@ -7,7 +9,9 @@
       alt=""
     >
 
-    <BrainIcon v-else />
+    <BrainIcon
+      v-else
+    />
 
     <slot>
       {{ props.policyType }}

--- a/packages/kuma-gui/src/app/common/ResourceStatus.vue
+++ b/packages/kuma-gui/src/app/common/ResourceStatus.vue
@@ -4,37 +4,53 @@
       v-if="slots.icon"
       #icon
     >
-      <slot name="icon" />
+      <slot
+        name="icon"
+      />
     </template>
 
     <template
       v-if="slots.title"
       #title
     >
-      <slot name="title" />
+      <slot
+        name="title"
+      />
     </template>
 
-    <template #body>
+    <template
+      #body
+    >
       <XLayout
         type="separated"
       >
         <div>
-          <div class="status">
-            <template v-if="typeof props.online !== 'undefined'">
+          <div
+            class="status"
+          >
+            <template
+              v-if="typeof props.online !== 'undefined'"
+            >
               <span
                 :class="{ ['text-neutral']: props.online !== props.total }"
-              >{{ props.online }}</span><span class="status-separator">/</span>
+              >{{ props.online }}</span><span
+                class="status-separator"
+              >/</span>
             </template><span>{{ props.total }}</span>
           </div>
           <div
             v-if="slots.description"
             class="description"
           >
-            <slot name="description" />
+            <slot
+              name="description"
+            />
           </div>
         </div>
 
-        <slot name="body" />
+        <slot
+          name="body"
+        />
       </XLayout>
     </template>
   </DefinitionCard>

--- a/packages/kuma-gui/src/app/common/StatusBadge.vue
+++ b/packages/kuma-gui/src/app/common/StatusBadge.vue
@@ -1,5 +1,7 @@
 <template>
-  <component :is="props.status === 'not_available' ? XTooltip : XAnonymous">
+  <component
+    :is="props.status === 'not_available' ? XTooltip : XAnonymous"
+  >
     <XBadge
       class="status-badge"
       :appearance="BADGE_APPEARANCE[props.status]"

--- a/packages/kuma-gui/src/app/common/SummaryView.vue
+++ b/packages/kuma-gui/src/app/common/SummaryView.vue
@@ -10,8 +10,12 @@
     data-testid="summary"
     @close="emit('close')"
   >
-    <template #title>
-      <XTeleportSlot :name="id" />
+    <template
+      #title
+    >
+      <XTeleportSlot
+        :name="id"
+      />
     </template>
     <slot />
   </KSlideout>

--- a/packages/kuma-gui/src/app/common/TagList.vue
+++ b/packages/kuma-gui/src/app/common/TagList.vue
@@ -18,7 +18,11 @@
         :is="tag.route ? 'XAction' : 'span'"
         :to="tag.route"
       >
-        <span class="label">{{ tag.label }}</span>:<span class="value">{{ tag.value }}</span>
+        <span
+          class="label"
+        >{{ tag.label }}</span>:<span
+          class="value"
+        >{{ tag.value }}</span>
       </component>
     </XBadge>
   </component>

--- a/packages/kuma-gui/src/app/common/TargetRef.vue
+++ b/packages/kuma-gui/src/app/common/TargetRef.vue
@@ -1,5 +1,7 @@
 <template>
-  <span class="target-ref">
+  <span
+    class="target-ref"
+  >
     <XAction
       v-if="routeTarget !== null"
       :to="routeTarget"
@@ -9,7 +11,9 @@
       </XBadge>
     </XAction>
 
-    <XBadge v-else>
+    <XBadge
+      v-else
+    >
       <slot />
     </XBadge>
 

--- a/packages/kuma-gui/src/app/common/data-card/DataCard.vue
+++ b/packages/kuma-gui/src/app/common/data-card/DataCard.vue
@@ -3,12 +3,22 @@
     class="data-card"
   >
     <dl>
-      <div class="card">
-        <dt class="title">
-          <slot name="title" />
+      <div
+        class="card"
+      >
+        <dt
+          class="title"
+        >
+          <slot
+            name="title"
+          />
         </dt>
-        <dd class="body">
-          <slot name="default" />
+        <dd
+          class="body"
+        >
+          <slot
+            name="default"
+          />
         </dd>
       </div>
     </dl>

--- a/packages/kuma-gui/src/app/common/filter-bar/FilterBar.vue
+++ b/packages/kuma-gui/src/app/common/filter-bar/FilterBar.vue
@@ -15,9 +15,13 @@
         data-testid="filter-bar-focus-filter-input-button"
         @click="focusFilterInput"
       >
-        <span class="visually-hidden">Focus filter</span>
+        <span
+          class="visually-hidden"
+        >Focus filter</span>
 
-        <span class="filter-bar-icon">
+        <span
+          class="filter-bar-icon"
+        >
           <FilterIcon
             decorative
             data-testid="filter-bar-filter-icon"
@@ -61,7 +65,9 @@
         class="suggestion-box"
         data-testid="filter-bar-suggestion-box"
       >
-        <div class="suggestion-list">
+        <div
+          class="suggestion-list"
+        >
           <p
             v-if="tokenizerError !== null"
             class="filter-bar-error"
@@ -85,7 +91,9 @@
             class="suggestion-list-item"
             :class="{ 'suggestion-list-item-is-selected': selectedSuggestionItemIndex === index + 1 }"
           >
-            <b>{{ fieldEntry.fieldName }}</b><span v-if="fieldEntry.description !== ''">: {{ fieldEntry.description }}</span>
+            <b>{{ fieldEntry.fieldName }}</b><span
+              v-if="fieldEntry.description !== ''"
+            >: {{ fieldEntry.description }}</span>
 
             <button
               class="apply-suggestion-button"
@@ -95,7 +103,9 @@
               data-testid="filter-bar-apply-suggestion-button"
               @click="applySuggestion"
             >
-              <span class="visually-hidden">Add {{ fieldEntry.fieldName }}:</span>
+              <span
+                class="visually-hidden"
+              >Add {{ fieldEntry.fieldName }}:</span>
 
               <ChevronRightIcon
                 decorative

--- a/packages/kuma-gui/src/app/configuration/views/ConfigurationDetailView.vue
+++ b/packages/kuma-gui/src/app/configuration/views/ConfigurationDetailView.vue
@@ -18,7 +18,9 @@
         },
       ]"
     >
-      <template #title>
+      <template
+        #title
+      >
         <h1>
           <RouteTitle
             :title="t('configuration.routes.item.title')"

--- a/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
+++ b/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
@@ -3,12 +3,16 @@
     class="service-traffic-card"
     @click="click"
   >
-    <template #title>
+    <template
+      #title
+    >
       <TagList
         v-if="props.service.length > 0"
         :tags="[{label: 'kuma.io/service', value: props.service}]"
       />
-      <div class="title">
+      <div
+        class="title"
+      >
         <XBadge
           v-if="props.protocol !== ''"
           class="protocol"
@@ -22,11 +26,15 @@
             },
           ) }}
         </XBadge>
-        <slot name="default" />
+        <slot
+          name="default"
+        />
       </div>
     </template>
 
-    <template v-if="props.portName">
+    <template
+      v-if="props.portName"
+    >
       <dl>
         <div>
           <dt>Name</dt>
@@ -149,7 +157,9 @@
         </template>
       </dl>
     </template>
-    <template v-else>
+    <template
+      v-else
+    >
       <XProgress
         variant="line"
       />

--- a/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionGroup.vue
+++ b/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionGroup.vue
@@ -3,8 +3,12 @@
     class="service-traffic-group"
     :class="`type-${props.type}`"
   >
-    <div class="body">
-      <slot name="default" />
+    <div
+      class="body"
+    >
+      <slot
+        name="default"
+      />
     </div>
   </XCard>
 </template>

--- a/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionTraffic.vue
+++ b/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionTraffic.vue
@@ -1,18 +1,30 @@
 <template>
-  <div class="service-traffic">
-    <div class="actions">
-      <slot name="actions" />
+  <div
+    class="service-traffic"
+  >
+    <div
+      class="actions"
+    >
+      <slot
+        name="actions"
+      />
     </div>
 
     <DataCard
       class="header"
     >
-      <template #title>
-        <slot name="title" />
+      <template
+        #title
+      >
+        <slot
+          name="title"
+        />
       </template>
     <!-- <slot name="data" /> -->
     </DataCard>
-    <slot name="default" />
+    <slot
+      name="default"
+    />
   </div>
 </template>
 <script lang="ts" setup>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
@@ -45,7 +45,9 @@
               @filter-mode-change="route.update({ codeFilter: $event })"
               @reg-exp-mode-change="route.update({ codeRegExp: $event })"
             >
-              <template #primary-actions>
+              <template
+                #primary-actions
+              >
                 <XAction
                   action="refresh"
                   appearance="primary"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
@@ -47,7 +47,9 @@
             @filter-mode-change="route.update({ codeFilter: $event })"
             @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           >
-            <template #primary-actions>
+            <template
+              #primary-actions
+            >
               <XAction
                 action="refresh"
                 appearance="primary"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryView.vue
@@ -21,7 +21,9 @@
       v-slot="{ items }"
     >
       <AppView>
-        <template #title>
+        <template
+          #title
+        >
           <h2>
             Inbound {{ route.params.connection.replace('localhost', '').replace('_', ':') }}
           </h2>
@@ -48,7 +50,9 @@
           </template>
         </XTabs>
 
-        <RouterView v-slot="child">
+        <RouterView
+          v-slot="child"
+        >
           <component
             :is="child.Component"
             :data="items[0]"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
@@ -37,7 +37,9 @@
           @filter-mode-change="route.update({ codeFilter: $event })"
           @reg-exp-mode-change="route.update({ codeRegExp: $event })"
         >
-          <template #primary-actions>
+          <template
+            #primary-actions
+          >
             <XAction
               action="refresh"
               appearance="primary"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
@@ -45,7 +45,9 @@
               @filter-mode-change="route.update({ codeFilter: $event })"
               @reg-exp-mode-change="route.update({ codeRegExp: $event })"
             >
-              <template #primary-actions>
+              <template
+                #primary-actions
+              >
                 <XAction
                   action="refresh"
                   appearance="primary"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryStatsView.vue
@@ -43,7 +43,9 @@
             @filter-mode-change="route.update({ codeFilter: $event })"
             @reg-exp-mode-change="route.update({ codeRegExp: $event })"
           >
-            <template #primary-actions>
+            <template
+              #primary-actions
+            >
               <XAction
                 action="refresh"
                 appearance="primary"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryView.vue
@@ -8,13 +8,17 @@
     v-slot="{ route, t }"
   >
     <AppView>
-      <template #title>
+      <template
+        #title
+      >
         <h2>
           Outbound {{ route.params.connection }}
         </h2>
       </template>
 
-      <XTabs :selected="route.child()?.name">
+      <XTabs
+        :selected="route.child()?.name"
+      >
         <template
           v-for="item in route.children"
           :key="`${item.name}`"
@@ -33,7 +37,9 @@
           </XAction>
         </template>
       </XTabs>
-      <RouterView v-slot="{ Component }">
+      <RouterView
+        v-slot="{ Component }"
+      >
         <DataCollection
           :items="Object.entries(props.data)"
           :predicate="([key, _value]) => key === route.params.connection"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryXdsConfigView.vue
@@ -39,7 +39,9 @@
           @filter-mode-change="route.update({ codeFilter: $event })"
           @reg-exp-mode-change="route.update({ codeRegExp: $event })"
         >
-          <template #primary-actions>
+          <template
+            #primary-actions
+          >
             <XCheckbox
               :checked="route.params.includeEds"
               :label="t('connections.include_endpoints')"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsClustersView.vue
@@ -44,7 +44,9 @@
                 @filter-mode-change="route.update({ codeFilter: $event })"
                 @reg-exp-mode-change="route.update({ codeRegExp: $event })"
               >
-                <template #primary-actions>
+                <template
+                  #primary-actions
+                >
                   <XAction
                     action="refresh"
                     appearance="primary"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsStatsView.vue
@@ -45,7 +45,9 @@
                 @filter-mode-change="route.update({ codeFilter: $event })"
                 @reg-exp-mode-change="route.update({ codeRegExp: $event })"
               >
-                <template #primary-actions>
+                <template
+                  #primary-actions
+                >
                   <XAction
                     action="refresh"
                     appearance="primary"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsXdsConfigView.vue
@@ -45,7 +45,9 @@
                 @filter-mode-change="route.update({ codeFilter: $event })"
                 @reg-exp-mode-change="route.update({ codeRegExp: $event })"
               >
-                <template #primary-actions>
+                <template
+                  #primary-actions
+                >
                   <XCheckbox
                     :checked="route.params.includeEds"
                     label="Include Endpoints"

--- a/packages/kuma-gui/src/app/control-planes/components/ControlPlaneActionGroup.vue
+++ b/packages/kuma-gui/src/app/control-planes/components/ControlPlaneActionGroup.vue
@@ -1,6 +1,8 @@
 <template>
   <XActionGroup>
-    <template #control>
+    <template
+      #control
+    >
       <XAction
         action="expand"
         appearance="primary"
@@ -8,11 +10,15 @@
         {{ t("main-overview.action_menu.toggle_button") }}
       </XAction>
     </template>
-    <XAction :to="{ name: 'hostname-generator-root-view' }">
+    <XAction
+      :to="{ name: 'hostname-generator-root-view' }"
+    >
       {{ t("main-overview.action_menu.items.hostname_generators") }}
     </XAction>
 
-    <slot name="actions" />
+    <slot
+      name="actions"
+    />
   </XActionGroup>
 </template>
 

--- a/packages/kuma-gui/src/app/control-planes/components/ControlPlaneStatus.vue
+++ b/packages/kuma-gui/src/app/control-planes/components/ControlPlaneStatus.vue
@@ -1,7 +1,13 @@
 <template>
-  <XCard class="about-card">
-    <div class="card-header">
-      <div class="card-title">
+  <XCard
+    class="about-card"
+  >
+    <div
+      class="card-header"
+    >
+      <div
+        class="card-title"
+      >
         <h2>{{ t('main-overview.detail.about.title') }}</h2>
       </div>
     </div>
@@ -15,7 +21,9 @@
         :total="props.globalInsight.zones.controlPlanes.total"
         data-testid="zone-control-planes-status"
       >
-        <template #icon>
+        <template
+          #icon
+        >
           <img
             class="icon"
             src="@/assets/images/zone.svg?url"
@@ -23,7 +31,9 @@
           >
         </template>
       
-        <template #title>
+        <template
+          #title
+        >
           {{ t('main-overview.detail.about.zone_control_planes') }}
         </template>
       </ResourceStatus>
@@ -32,7 +42,9 @@
         :total="props.globalInsight.meshes.total"
         data-testid="meshes-status"
       >
-        <template #icon>
+        <template
+          #icon
+        >
           <img
             class="icon"
             src="@/assets/images/mesh.svg?url"
@@ -40,7 +52,9 @@
           >
         </template>
 
-        <template #title>
+        <template
+          #title
+        >
           {{ t('main-overview.detail.about.meshes') }}
         </template>
       </ResourceStatus>
@@ -53,7 +67,9 @@
           :total="meshServicesGeneric.total || props.globalInsight.services.internal.total"
           data-testid="services-status"
         >
-          <template #icon>
+          <template
+            #icon
+          >
             <img
               class="icon"
               src="@/assets/images/icon-wifi-tethering.svg?url"
@@ -61,7 +77,9 @@
             >
           </template>
 
-          <template #title>
+          <template
+            #title
+          >
             <XI18n
               path="main-overview.detail.about.services"
             />
@@ -80,8 +98,12 @@
             v-if="meshServicesGeneric.total && props.globalInsight.services.internal.total > 0"
             #body
           >
-            <ResourceStatus :total="props.globalInsight.services.internal.total">
-              <template #description>
+            <ResourceStatus
+              :total="props.globalInsight.services.internal.total"
+            >
+              <template
+                #description
+              >
                 <XI18n
                   path="main-overview.detail.about.descriptions.internal_services"
                 />
@@ -103,7 +125,9 @@
         :total="props.globalInsight.dataplanes.standard.total"
         data-testid="data-plane-proxies-status"
       >
-        <template #icon>
+        <template
+          #icon
+        >
           <img
             class="icon"
             src="@/assets/images/icon-wifi-tethering.svg?url"
@@ -111,7 +135,9 @@
           >
         </template>
 
-        <template #title>
+        <template
+          #title
+        >
           {{ t('main-overview.detail.about.data_plane_proxies') }}
         </template>
       </ResourceStatus>
@@ -120,7 +146,9 @@
         :total="props.globalInsight.policies.total"
         data-testid="policies-status"
       >
-        <template #icon>
+        <template
+          #icon
+        >
           <img
             class="icon"
             src="@/assets/images/policy.svg?url"
@@ -128,7 +156,9 @@
           >
         </template>
 
-        <template #title>
+        <template
+          #title
+        >
           {{ t('main-overview.detail.about.policies') }}
         </template>
       </ResourceStatus>

--- a/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -4,14 +4,18 @@
     v-slot="{ can, t, uri, me }"
   >
     <AppView>
-      <template #title>
+      <template
+        #title
+      >
         <h1>
           <RouteTitle
             :title="t('main-overview.routes.item.title')"
           />
         </h1>
       </template>
-      <template #actions>
+      <template
+        #actions
+      >
         <ControlPlaneActionGroup />
       </template>
 
@@ -28,7 +32,9 @@
           />
         </DataLoader>
 
-        <div class="columns">
+        <div
+          class="columns"
+        >
           <XCard
             v-if="can('use zones')"
           >
@@ -41,8 +47,12 @@
               <template
                 #loadable="{ data }"
               >
-                <div class="card-header">
-                  <div class="card-title">
+                <div
+                  class="card-header"
+                >
+                  <div
+                    class="card-title"
+                  >
                     <h2>
                       {{ t('main-overview.detail.zone_control_planes.title') }}
                     </h2>
@@ -56,7 +66,9 @@
                   <div
                     class="card-actions"
                   >
-                    <XTeleportSlot name="control-plane-detail-view-zone-actions" />
+                    <XTeleportSlot
+                      name="control-plane-detail-view-zone-actions"
+                    />
                   </div>
                 </div>
 
@@ -79,8 +91,12 @@
               <template
                 #loadable="{ data }"
               >
-                <div class="card-header">
-                  <div class="card-title">
+                <div
+                  class="card-header"
+                >
+                  <div
+                    class="card-title"
+                  >
                     <h2>
                       {{ t('main-overview.detail.meshes.title') }}
                     </h2>

--- a/packages/kuma-gui/src/app/data-planes/components/BuiltinGatewayPolicies.vue
+++ b/packages/kuma-gui/src/app/data-planes/components/BuiltinGatewayPolicies.vue
@@ -1,11 +1,19 @@
 <template>
-  <div class="policies-list">
-    <div class="mesh-gateway-policy-list">
-      <h3 class="mb-2">
+  <div
+    class="policies-list"
+  >
+    <div
+      class="mesh-gateway-policy-list"
+    >
+      <h3
+        class="mb-2"
+      >
         Gateway policies
       </h3>
 
-      <ul v-if="gatewayDataplane.routePolicies.length > 0">
+      <ul
+        v-if="gatewayDataplane.routePolicies.length > 0"
+      >
         <li
           v-for="(policy, index) in gatewayDataplane.routePolicies"
           :key="index"
@@ -27,7 +35,9 @@
         </li>
       </ul>
 
-      <h3 class="mt-6 mb-2">
+      <h3
+        class="mt-6 mb-2"
+      >
         Listeners
       </h3>
 
@@ -41,8 +51,12 @@
               <b>Host</b>: {{ listenerEntry.hostName }}:{{ listenerEntry.port }} ({{ listenerEntry.protocol }})
             </div>
 
-            <template v-if="listenerEntry.routeEntries.length > 0">
-              <h4 class="mt-2 mb-2">
+            <template
+              v-if="listenerEntry.routeEntries.length > 0"
+            >
+              <h4
+                class="mt-2 mb-2"
+              >
                 Routes
               </h4>
 
@@ -54,8 +68,12 @@
                   v-for="(routeEntry, routeIndex) in listenerEntry.routeEntries"
                   :key="routeIndex"
                 >
-                  <template #accordion-header>
-                    <div class="dataplane-policy-header">
+                  <template
+                    #accordion-header
+                  >
+                    <div
+                      class="dataplane-policy-header"
+                    >
                       <div>
                         <div>
                           <b>Route</b>: <XAction
@@ -95,7 +113,9 @@
                     v-if="routeEntry.origins.length > 0"
                     #accordion-content
                   >
-                    <ul class="mt-1">
+                    <ul
+                      class="mt-1"
+                    >
                       <li
                         v-for="(policy, policyIndex) in routeEntry.origins"
                         :key="`${index}-${policyIndex}`"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -49,16 +49,24 @@
             :created="props.data.creationTime"
             :modified="props.data.modificationTime"
           >
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('http.api.property.status') }}
               </template>
 
-              <template #body>
+              <template
+                #body
+              >
                 <XLayout
                   type="separated"
                 >
-                  <StatusBadge :status="props.data.status" />
+                  <StatusBadge
+                    :status="props.data.status"
+                  />
                   <DataCollection
                     v-if="props.data.dataplaneType === 'standard'"
                     :items="props.data.dataplane.networking.inbounds"
@@ -95,7 +103,9 @@
               <template
                 #body
               >
-                <XBadge appearance="decorative">
+                <XBadge
+                  appearance="decorative"
+                >
                   <XAction
                     :to="{
                       name: 'zone-cp-detail-view',
@@ -109,13 +119,21 @@
                 </XBadge>
               </template>
             </DefinitionCard>
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('http.api.proptery.type') }}
               </template>
 
-              <template #body>
-                <XBadge appearance="decorative">
+              <template
+                #body
+              >
+                <XBadge
+                  appearance="decorative"
+                >
                   {{ t(`data-planes.type.${props.data.dataplaneType}`) }}
                 </XBadge>
               </template>
@@ -125,23 +143,35 @@
               v-if="props.data.namespace.length > 0"
               layout="horizontal"
             >
-              <template #title>
+              <template
+                #title
+              >
                 {{ t('http.api.property.namespace') }}
               </template>
 
-              <template #body>
-                <XBadge appearance="decorative">
+              <template
+                #body
+              >
+                <XBadge
+                  appearance="decorative"
+                >
                   {{ props.data.namespace }}
                 </XBadge>
               </template>
             </DefinitionCard>
 
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('http.api.property.address') }}
               </template>
 
-              <template #body>
+              <template
+                #body
+              >
                 <XCopyButton
                   variant="badge"
                   format="default"
@@ -153,13 +183,21 @@
             <template
               v-if="props.data.dataplane.networking.gateway"
             >
-              <DefinitionCard layout="horizontal">
-                <template #title>
+              <DefinitionCard
+                layout="horizontal"
+              >
+                <template
+                  #title
+                >
                   {{ t('http.api.property.tags') }}
                 </template>
 
-                <template #body>
-                  <TagList :tags="props.data.dataplane.networking.gateway.tags" />
+                <template
+                  #body
+                >
+                  <TagList
+                    :tags="props.data.dataplane.networking.gateway.tags"
+                  />
                 </template>
               </DefinitionCard>
             </template>
@@ -173,9 +211,15 @@
               type="columns"
             >
               <ConnectionTraffic>
-                <template #title>
-                  <XLayout type="separated">
-                    <XIcon name="inbound" />
+                <template
+                  #title
+                >
+                  <XLayout
+                    type="separated"
+                  >
+                    <XIcon
+                      name="inbound"
+                    />
                     <span>Inbounds</span>
                   </XLayout>
                 </template>
@@ -289,7 +333,9 @@
                     data-testid="dataplane-outbounds-inactive-toggle"
                     @change="(value) => route.update({ inactive: value})"
                   >
-                    <template #label>
+                    <template
+                      #label
+                    >
                       Show inactive
                     </template>
                   </XInputSwitch>
@@ -302,9 +348,15 @@
                     Refresh
                   </XAction>
                 </template>
-                <template #title>
-                  <XLayout type="separated">
-                    <XIcon name="outbound" />
+                <template
+                  #title
+                >
+                  <XLayout
+                    type="separated"
+                  >
+                    <XIcon
+                      name="outbound"
+                    />
                     <span>Outbounds</span>
                   </XLayout>
                 </template>
@@ -400,7 +452,9 @@
                     </template>
                   </template>
                 </template>
-                <template v-else>
+                <template
+                  v-else
+                >
                   <XEmptyState />
                 </template>
               </ConnectionTraffic>
@@ -435,7 +489,9 @@
             </SummaryView>
           </RouterView>
 
-          <div data-testid="dataplane-mtls">
+          <div
+            data-testid="dataplane-mtls"
+          >
             <template
               v-if="props.data.dataplaneInsight.mTLS"
             >
@@ -446,56 +502,80 @@
                 :key="mTLS"
               >
                 <XCard>
-                  <template #title>
+                  <template
+                    #title
+                  >
                     <h2>{{ t('data-planes.routes.item.mtls.title') }}</h2>
                   </template>
 
-                  <div class="columns">
+                  <div
+                    class="columns"
+                  >
                     <DefinitionCard>
-                      <template #title>
+                      <template
+                        #title
+                      >
                         {{ t('data-planes.routes.item.mtls.expiration_time.title') }}
                       </template>
 
-                      <template #body>
+                      <template
+                        #body
+                      >
                         {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
                       </template>
                     </DefinitionCard>
 
                     <DefinitionCard>
-                      <template #title>
+                      <template
+                        #title
+                      >
                         {{ t('data-planes.routes.item.mtls.generation_time.title') }}
                       </template>
 
-                      <template #body>
+                      <template
+                        #body
+                      >
                         {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
                       </template>
                     </DefinitionCard>
 
                     <DefinitionCard>
-                      <template #title>
+                      <template
+                        #title
+                      >
                         {{ t('data-planes.routes.item.mtls.regenerations.title') }}
                       </template>
 
-                      <template #body>
+                      <template
+                        #body
+                      >
                         {{ t('common.formats.integer', {value: mTLS.certificateRegenerations}) }}
                       </template>
                     </DefinitionCard>
                     <DefinitionCard>
-                      <template #title>
+                      <template
+                        #title
+                      >
                         {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
                       </template>
 
-                      <template #body>
+                      <template
+                        #body
+                      >
                         {{ mTLS.issuedBackend }}
                       </template>
                     </DefinitionCard>
 
                     <DefinitionCard>
-                      <template #title>
+                      <template
+                        #title
+                      >
                         {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
                       </template>
 
-                      <template #body>
+                      <template
+                        #body
+                      >
                         <ul>
                           <li
                             v-for="item in mTLS.supportedBackends"
@@ -517,7 +597,9 @@
             data-testid="dataplane-subscriptions"
           >
             <XCard>
-              <template #title>
+              <template
+                #title
+              >
                 <h2>{{ t('data-planes.routes.item.subscriptions.title') }}</h2>
               </template>
 

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -12,12 +12,18 @@
       <div
         class="stack-with-borders"
       >
-        <DefinitionCard layout="horizontal">
-          <template #title>
+        <DefinitionCard
+          layout="horizontal"
+        >
+          <template
+            #title
+          >
             Tags
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <TagList
               :tags="props.data.tags"
               alignment="right"
@@ -27,11 +33,15 @@
         <DefinitionCard
           layout="horizontal"
         >
-          <template #title>
+          <template
+            #title
+          >
             {{ t('http.api.property.state') }}
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <XBadge
               :appearance="props.data.state === 'Ready' ? 'success' : 'danger'"
             >
@@ -39,12 +49,18 @@
             </XBadge>
           </template>
         </DefinitionCard>
-        <DefinitionCard layout="horizontal">
-          <template #title>
+        <DefinitionCard
+          layout="horizontal"
+        >
+          <template
+            #title
+          >
             Protocol
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <XBadge
               appearance="info"
             >
@@ -52,12 +68,18 @@
             </XBadge>
           </template>
         </DefinitionCard>
-        <DefinitionCard layout="horizontal">
-          <template #title>
+        <DefinitionCard
+          layout="horizontal"
+        >
+          <template
+            #title
+          >
             Address
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <XCopyButton
               :text="`${props.data.addressPort}`"
             />
@@ -67,11 +89,15 @@
           v-if="props.data.serviceAddressPort.length > 0"
           layout="horizontal"
         >
-          <template #title>
+          <template
+            #title
+          >
             Service Address
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <XCopyButton
               :text="`${props.data.serviceAddressPort}`"
             />
@@ -81,11 +107,15 @@
           v-if="props.data.portName.length > 0"
           layout="horizontal"
         >
-          <template #title>
+          <template
+            #title
+          >
             Name
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <XCopyButton
               :text="`${props.data.portName}`"
             />
@@ -123,7 +153,9 @@
                   :items="[...rulesData!.rules, ...rulesData!.inboundRules]"
                   v-slot="{ items }"
                 >
-                  <div class="mt-4">
+                  <div
+                    class="mt-4"
+                  >
                     <AccordionList
                       :initially-open="0"
                       multiple-open
@@ -135,14 +167,18 @@
                       >
                         <XCard>
                           <AccordionItem>
-                            <template #accordion-header>
+                            <template
+                              #accordion-header
+                            >
                               <PolicyTypeTag
                                 :policy-type="key"
                               >
                                 {{ key }} ({{ rules!.length }})
                               </PolicyTypeTag>
                             </template>
-                            <template #accordion-content>
+                            <template
+                              #accordion-content
+                            >
                               <div
                                 class="stack-with-borders"
                               >
@@ -154,23 +190,35 @@
                                     v-if="item.matchers.length > 0"
                                     layout="horizontal"
                                   >
-                                    <template #title>
+                                    <template
+                                      #title
+                                    >
                                       From
                                     </template>
 
-                                    <template #body>
-                                      <p><RuleMatchers :items="item.matchers" /></p>
+                                    <template
+                                      #body
+                                    >
+                                      <p>
+                                        <RuleMatchers
+                                          :items="item.matchers"
+                                        />
+                                      </p>
                                     </template>
                                   </DefinitionCard>
                                   <DefinitionCard
                                     v-if="item.origins.length > 0"
                                     layout="horizontal"
                                   >
-                                    <template #title>
+                                    <template
+                                      #title
+                                    >
                                       Origin Policies
                                     </template>
 
-                                    <template #body>
+                                    <template
+                                      #body
+                                    >
                                       <ul>
                                         <li
                                           v-for="origin in item.origins"
@@ -202,7 +250,9 @@
                                     <dt>
                                       Config
                                     </dt>
-                                    <dd class="mt-2">
+                                    <dd
+                                      class="mt-2"
+                                    >
                                       <div>
                                         <XCodeBlock
                                           :code="YAML.stringify(item.raw)"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -46,7 +46,9 @@
             :selected="route.params.dataplaneType"
             @change="(value: string) => route.update({ page: 1, dataplaneType: value })"
           >
-            <template #selected="{ item }: { item: 'all' | 'standard' | 'builtin' | 'delegated'}">
+            <template
+              #selected="{ item }: { item: 'all' | 'standard' | 'builtin' | 'delegated'}"
+            >
               <XIcon
                 v-if="item !== 'all'"
                 :size="KUI_ICON_SIZE_40"
@@ -106,13 +108,19 @@
                 :is-selected-row="(row) => row.name === route.params.proxy"
                 @resize="me.set"
               >
-                <template #type="{ row: item }">
-                  <XIcon :name="item.dataplaneType">
+                <template
+                  #type="{ row: item }"
+                >
+                  <XIcon
+                    :name="item.dataplaneType"
+                  >
                     {{ t(`data-planes.type.${item.dataplaneType}`) }}
                   </XIcon>
                 </template>
 
-                <template #name="{ row: item }">
+                <template
+                  #name="{ row: item }"
+                >
                   <XAction
                     data-action
                     class="name-link"
@@ -135,11 +143,15 @@
                   </XAction>
                 </template>
 
-                <template #namespace="{ row: item }">
+                <template
+                  #namespace="{ row: item }"
+                >
                   {{ item.namespace }}
                 </template>
 
-                <template #services="{ row }">
+                <template
+                  #services="{ row }"
+                >
                   <XLayout
                     v-if="row.services.length > 0"
                     type="separated"
@@ -149,7 +161,9 @@
                       v-for="(service, index) in row.services"
                       :key="index"
                     >
-                      <XCopyButton :text="service">
+                      <XCopyButton
+                        :text="service"
+                      >
                         <XAction
                           v-if="row.dataplaneType === 'standard'"
                           :to="{
@@ -174,19 +188,25 @@
                           {{ service }}
                         </XAction>
 
-                        <template v-else>
+                        <template
+                          v-else
+                        >
                           {{ service }}
                         </template>
                       </XCopyButton>
                     </div>
                   </XLayout>
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.collection.none') }}
                   </template>
                 </template>
 
-                <template #zone="{ row }">
+                <template
+                  #zone="{ row }"
+                >
                   <XAction
                     v-if="row.zone"
                     :to="{
@@ -199,50 +219,70 @@
                     {{ row.zone }}
                   </XAction>
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.collection.none') }}
                   </template>
                 </template>
 
-                <template #certificate="{ row }">
-                  <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                <template
+                  #certificate="{ row }"
+                >
+                  <template
+                    v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime"
+                  >
                     {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
                   </template>
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('data-planes.components.data-plane-list.certificate.none') }}
                   </template>
                 </template>
 
-                <template #status="{ row }">
+                <template
+                  #status="{ row }"
+                >
                   <StatusBadge
                     :status="row.status"
                   />
                 </template>
 
-                <template #warnings="{ row }">
+                <template
+                  #warnings="{ row }"
+                >
                   <XIcon
                     v-if="row.isCertExpired || row.warnings.length > 0"
                     class="mr-1"
                     name="warning"
                   >
                     <ul>
-                      <template v-if="row.warnings.length > 0">
+                      <template
+                        v-if="row.warnings.length > 0"
+                      >
                         <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
                       </template>
 
-                      <template v-if="row.isCertExpired">
+                      <template
+                        v-if="row.isCertExpired"
+                      >
                         <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
                       </template>
                     </ul>
                   </XIcon>
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.collection.none') }}
                   </template>
                 </template>
 
-                <template #actions="{ row: item }">
+                <template
+                  #actions="{ row: item }"
+                >
                   <XActionGroup>
                     <XAction
                       :to="{

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
@@ -19,11 +19,15 @@
           <DefinitionCard
             layout="horizontal"
           >
-            <template #title>
+            <template
+              #title
+            >
               Protocol
             </template>
 
-            <template #body>
+            <template
+              #body
+            >
               <XBadge
                 appearance="info"
               >
@@ -87,11 +91,15 @@
                                     v-if="item.origins.length > 0"
                                     layout="horizontal"
                                   >
-                                    <template #title>
+                                    <template
+                                      #title
+                                    >
                                       Origin Policies
                                     </template>
 
-                                    <template #body>
+                                    <template
+                                      #body
+                                    >
                                       <DataCollection
                                         :predicate="(item) => {
                                           return typeof item.resourceMeta !== 'undefined'
@@ -152,7 +160,9 @@
 
                       v-slot="{ items }"
                     >
-                      <div class="mt-4">
+                      <div
+                        class="mt-4"
+                      >
                         <AccordionList
                           :initially-open="0"
                           multiple-open
@@ -164,14 +174,18 @@
                           >
                             <XCard>
                               <AccordionItem>
-                                <template #accordion-header>
+                                <template
+                                  #accordion-header
+                                >
                                   <PolicyTypeTag
                                     :policy-type="key"
                                   >
                                     {{ key }} ({{ rules!.length }})
                                   </PolicyTypeTag>
                                 </template>
-                                <template #accordion-content>
+                                <template
+                                  #accordion-content
+                                >
                                   <div
                                     class="stack-with-borders"
                                   >
@@ -183,23 +197,35 @@
                                         v-if="item.matchers.length > 0"
                                         layout="horizontal"
                                       >
-                                        <template #title>
+                                        <template
+                                          #title
+                                        >
                                           From
                                         </template>
 
-                                        <template #body>
-                                          <p><RuleMatchers :items="item.matchers" /></p>
+                                        <template
+                                          #body
+                                        >
+                                          <p>
+                                            <RuleMatchers
+                                              :items="item.matchers"
+                                            />
+                                          </p>
                                         </template>
                                       </DefinitionCard>
                                       <DefinitionCard
                                         v-if="item.origins.length > 0"
                                         layout="horizontal"
                                       >
-                                        <template #title>
+                                        <template
+                                          #title
+                                        >
                                           Origin Policies
                                         </template>
 
-                                        <template #body>
+                                        <template
+                                          #body
+                                        >
                                           <ul>
                                             <li
                                               v-for="origin in item.origins"
@@ -231,7 +257,9 @@
                                         <dt>
                                           Config
                                         </dt>
-                                        <dd class="mt-2">
+                                        <dd
+                                          class="mt-2"
+                                        >
                                           <div>
                                             <XCodeBlock
                                               :code="YAML.stringify(item.raw)"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -73,7 +73,9 @@
                 v-slot="{ items }"
               >
                 <XCard>
-                  <h3 class="mb-2">
+                  <h3
+                    class="mb-2"
+                  >
                     {{ t('data-planes.routes.item.rules.from') }}
                   </h3>
                   <template
@@ -104,7 +106,9 @@
                 v-slot="{ items }"
               >
                 <XCard>
-                  <h3 class="mb-2">
+                  <h3
+                    class="mb-2"
+                  >
                     {{ t('data-planes.routes.item.rules.inbound') }}
                   </h3>
                   <template
@@ -131,10 +135,14 @@
           </DataLoader>
 
           <!-- if we are in non-federated zone mode try and load/show legacy policies -->
-          <template v-if="!can('use zones')">
+          <template
+            v-if="!can('use zones')"
+          >
             <div>
               <!-- builtin gateways have different data/visuals than other types of dataplanes -->
-              <template v-if="props.data.dataplaneType === 'builtin'">
+              <template
+                v-if="props.data.dataplaneType === 'builtin'"
+              >
                 <DataLoader
                   :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.proxy}/gateway-dataplane-policies`"
                   :data="[policyTypesData]"
@@ -163,7 +171,9 @@
               </template>
 
               <!-- anything but builtin gateways -->
-              <template v-else>
+              <template
+                v-else
+              >
                 <DataLoader
                   :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.proxy}/sidecar-dataplane-policies`"
                   :data="[policyTypesData]"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePolicySummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePolicySummaryView.vue
@@ -17,7 +17,9 @@
       v-slot="{ data, error }: PolicySource"
     >
       <AppView>
-        <template #title>
+        <template
+          #title
+        >
           <h2>
             <XAction
               :to="{
@@ -45,7 +47,9 @@
             :format="route.params.format"
             :legacy="!props.policyTypes.find(({ name }) => name === data?.type )?.policy.isTargetRef"
           >
-            <template #header>
+            <template
+              #header
+            >
               <header>
                 <XLayout
                   type="separated"
@@ -79,7 +83,9 @@
               </header>
             </template>
 
-            <template v-if="route.params.format === 'universal'">
+            <template
+              v-if="route.params.format === 'universal'"
+            >
               <ResourceCodeBlock
                 data-testid="codeblock-yaml-universal"
                 language="yaml"
@@ -95,7 +101,9 @@
               />
             </template>
 
-            <template v-else-if="route.params.format === 'k8s'">
+            <template
+              v-else-if="route.params.format === 'k8s'"
+            >
               <DataLoader
                 :src="uri(sources, '/meshes/:mesh/policy-path/:path/policy/:name/as/kubernetes', {
                   mesh: route.params.mesh,

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -15,9 +15,13 @@
       :items="props.items"
       :predicate="item => item.id === route.params.proxy"
     >
-      <template #empty>
+      <template
+        #empty
+      >
         <XEmptyState>
-          <template #title>
+          <template
+            #title
+          >
             <h2>
               {{ t('common.collection.summary.empty_title', { type: 'Data Plane Proxy' }) }}
             </h2>
@@ -35,7 +39,9 @@
           :key="item.id"
         >
           <AppView>
-            <template #title>
+            <template
+              #title
+            >
               <h2
                 :class="`type-${item.dataplaneType}`"
               >
@@ -88,7 +94,9 @@
               </header>
             </XLayout>
 
-            <template v-if="route.params.format === 'structured'">
+            <template
+              v-if="route.params.format === 'structured'"
+            >
               <XLayout
                 type="stack"
                 data-testid="structured-view"
@@ -99,11 +107,15 @@
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('http.api.property.status') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       <XLayout
                         type="separated"
                       >
@@ -139,11 +151,15 @@
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       Type
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       {{ t(`data-planes.type.${item.dataplaneType}`) }}
                     </template>
                   </DefinitionCard>
@@ -152,11 +168,15 @@
                     v-if="item.namespace.length > 0"
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('data-planes.routes.item.namespace') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       {{ item.namespace }}
                     </template>
                   </DefinitionCard>
@@ -188,11 +208,15 @@
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('http.api.property.modificationTime') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       {{ t('common.formats.datetime', { value: Date.parse(item.modificationTime) }) }}
                     </template>
                   </DefinitionCard>
@@ -210,11 +234,15 @@
                     <DefinitionCard
                       layout="horizontal"
                     >
-                      <template #title>
+                      <template
+                        #title
+                      >
                         {{ t('http.api.property.tags') }}
                       </template>
 
-                      <template #body>
+                      <template
+                        #body
+                      >
                         <TagList
                           alignment="right"
                           :tags="item.dataplane.networking.gateway.tags"
@@ -225,11 +253,15 @@
                     <DefinitionCard
                       layout="horizontal"
                     >
-                      <template #title>
+                      <template
+                        #title
+                      >
                         {{ t('http.api.property.address') }}
                       </template>
 
-                      <template #body>
+                      <template
+                        #body
+                      >
                         <XCopyButton
                           :text="`${item.dataplane.networking.address}`"
                         />
@@ -240,7 +272,9 @@
               </XLayout>
             </template>
 
-            <template v-else-if="route.params.format === 'universal'">
+            <template
+              v-else-if="route.params.format === 'universal'"
+            >
               <ResourceCodeBlock
                 data-testid="codeblock-yaml-universal"
                 language="yaml"
@@ -256,7 +290,9 @@
               />
             </template>
 
-            <template v-else>
+            <template
+              v-else
+            >
               <DataLoader
                 :src="uri(sources, '/meshes/:mesh/dataplanes/:name/as/kubernetes', {
                   mesh: route.params.mesh,

--- a/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailTabsView.vue
@@ -30,10 +30,16 @@
         },
       ]"
     >
-      <template #title>
+      <template
+        #title
+      >
         <h1>
-          <XCopyButton :text="route.params.service">
-            <RouteTitle :title="t('external-services.routes.item.title', { name: route.params.service })" />
+          <XCopyButton
+            :text="route.params.service"
+          >
+            <RouteTitle
+              :title="t('external-services.routes.item.title', { name: route.params.service })"
+            />
           </XCopyButton>
         </h1>
       </template>

--- a/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/external-services/views/ExternalServiceDetailView.vue
@@ -27,12 +27,18 @@
             :created="data.creationTime"
             :modified="data.modificationTime"
           >
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('http.api.property.address') }}
               </template>
 
-              <template #body>
+              <template
+                #body
+              >
                 <XCopyButton
                   variant="badge"
                   format="default"
@@ -45,18 +51,26 @@
               v-if="data.tags"
               layout="horizontal"
             >
-              <template #title>
+              <template
+                #title
+              >
                 {{ t('http.api.property.tags') }}
               </template>
 
-              <template #body>
-                <TagList :tags="data.tags" />
+              <template
+                #body
+              >
+                <TagList
+                  :tags="data.tags"
+                />
               </template>
             </DefinitionCard>
           </XAboutCard>
 
           <XCard>
-            <template #title>
+            <template
+              #title
+            >
               <h3>{{ t('external-services.detail.config') }}</h3>
             </template>
 

--- a/packages/kuma-gui/src/app/external-services/views/ExternalServiceListView.vue
+++ b/packages/kuma-gui/src/app/external-services/views/ExternalServiceListView.vue
@@ -46,8 +46,12 @@
                 :items="data?.items"
                 @resize="me.set"
               >
-                <template #name="{ row: item }">
-                  <XCopyButton :text="item.name">
+                <template
+                  #name="{ row: item }"
+                >
+                  <XCopyButton
+                    :text="item.name"
+                  >
                     <XAction
                       :to="{
                         name: 'external-service-detail-view',
@@ -66,18 +70,24 @@
                   </XCopyButton>
                 </template>
 
-                <template #address="{ row }">
+                <template
+                  #address="{ row }"
+                >
                   <XCopyButton
                     v-if="row.networking.address"
                     :text="row.networking.address"
                   />
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.collection.none') }}
                   </template>
                 </template>
 
-                <template #actions="{ row: item }">
+                <template
+                  #actions="{ row: item }"
+                >
                   <XActionGroup>
                     <XAction
                       :to="{

--- a/packages/kuma-gui/src/app/gateways/components/ListenerRoutes.vue
+++ b/packages/kuma-gui/src/app/gateways/components/ListenerRoutes.vue
@@ -1,19 +1,35 @@
 <template>
-  <div class="listener-routes-card">
-    <div class="listener-routes">
-      <div class="column">
-        <div class="header">
-          <h2 class="title">
+  <div
+    class="listener-routes-card"
+  >
+    <div
+      class="listener-routes"
+    >
+      <div
+        class="column"
+      >
+        <div
+          class="header"
+        >
+          <h2
+            class="title"
+          >
             {{ t('builtin-gateways.detail.listeners') }}
           </h2>
 
-          <p class="count">
+          <p
+            class="count"
+          >
             {{ meshGateway.conf.listeners.length }}
           </p>
         </div>
 
-        <div class="content">
-          <div class="listener-list">
+        <div
+          class="content"
+        >
+          <div
+            class="listener-list"
+          >
             <template
               v-for="(listener, index) in meshGateway.conf.listeners"
               :key="index"
@@ -26,7 +42,9 @@
                 data-testid="listener-card"
                 @click="triggerAction"
               >
-                <div class="listener-card-header">
+                <div
+                  class="listener-card-header"
+                >
                   <XBadge
                     appearance="info"
                   >
@@ -51,17 +69,27 @@
                   v-if="listener.tags || listener.tls"
                   class="definition-list definition-list--horizontal mt-2"
                 >
-                  <div v-if="listener.tags">
-                    <dt class="text-neutral">
+                  <div
+                    v-if="listener.tags"
+                  >
+                    <dt
+                      class="text-neutral"
+                    >
                       {{ t('builtin-gateways.detail.tags') }}:
                     </dt>
                     <dd>
-                      <TagList :tags="listener.tags" />
+                      <TagList
+                        :tags="listener.tags"
+                      />
                     </dd>
                   </div>
 
-                  <div v-if="listener.tls">
-                    <dt class="text-neutral">
+                  <div
+                    v-if="listener.tls"
+                  >
+                    <dt
+                      class="text-neutral"
+                    >
                       {{ t('http.api.property.tls') }}:
                     </dt>
                     <dd>{{ listener.tls.mode ?? 'TERMINATE' }}</dd>
@@ -73,26 +101,40 @@
         </div>
       </div>
 
-      <div class="column">
-        <div class="header">
-          <h2 class="title">
+      <div
+        class="column"
+      >
+        <div
+          class="header"
+        >
+          <h2
+            class="title"
+          >
             {{ t('builtin-gateways.detail.routes') }}
           </h2>
 
-          <p class="count">
+          <p
+            class="count"
+          >
             {{ toRules.length }}
           </p>
         </div>
 
-        <div class="content">
-          <div class="to-rule-list">
+        <div
+          class="content"
+        >
+          <div
+            class="to-rule-list"
+          >
             <XEmptyState
               v-if="toRules.length === 0"
             >
               {{ t('builtin-gateways.detail.no_rules', { listener: props.selectedListenerIndex + 1 }) }}
             </XEmptyState>
 
-            <template v-else>
+            <template
+              v-else
+            >
               <template
                 v-for="(toRule, index) in toRules"
                 :key="index"
@@ -101,10 +143,16 @@
                   class="card route-card"
                   data-testid="route-card"
                 >
-                  <div class="stack-with-borders">
-                    <dl class="definition-list definition-list--horizontal mt-2">
+                  <div
+                    class="stack-with-borders"
+                  >
+                    <dl
+                      class="definition-list definition-list--horizontal mt-2"
+                    >
                       <div>
-                        <dt class="text-neutral visually-hidden">
+                        <dt
+                          class="text-neutral visually-hidden"
+                        >
                           {{ t('builtin-gateways.detail.type') }}:
                         </dt>
                         <dd>
@@ -114,9 +162,13 @@
                         </dd>
                       </div>
 
-                      <template v-if="!toRule.config.hostnames.includes('*')">
+                      <template
+                        v-if="!toRule.config.hostnames.includes('*')"
+                      >
                         <div>
-                          <dt class="text-neutral">
+                          <dt
+                            class="text-neutral"
+                          >
                             {{ t('builtin-gateways.detail.hostnames') }}:
                           </dt>
                           <dd>{{ toRule.config.hostnames.join(', ') }}</dd>
@@ -124,7 +176,9 @@
                       </template>
 
                       <div>
-                        <dt class="text-neutral">
+                        <dt
+                          class="text-neutral"
+                        >
                           {{ t('builtin-gateways.detail.matchers') }}:
                         </dt>
                         <dd>
@@ -133,16 +187,22 @@
                             :items="toRule.matchers"
                           />
 
-                          <code v-else>*</code>
+                          <code
+                            v-else
+                          >*</code>
                         </dd>
                       </div>
 
                       <div>
-                        <dt class="text-neutral">
+                        <dt
+                          class="text-neutral"
+                        >
                           {{ t('builtin-gateways.detail.origins') }}:
                         </dt>
                         <dd>
-                          <div class="list">
+                          <div
+                            class="list"
+                          >
                             <XBadge
                               v-for="(origin, originIndex) in toRule.origins"
                               :key="originIndex"
@@ -165,10 +225,14 @@
                       </div>
                     </dl>
 
-                    <div v-if="toRule.config.rules.length > 0">
+                    <div
+                      v-if="toRule.config.rules.length > 0"
+                    >
                       <b>{{ t('builtin-gateways.detail.rules') }}</b>:
 
-                      <div class="stack-small mt-2">
+                      <div
+                        class="stack-small mt-2"
+                      >
                         <div
                           v-for="(rule, ruleIndex) in toRule.config.rules"
                           :key="ruleIndex"
@@ -177,7 +241,9 @@
                           <div>
                             {{ t('builtin-gateways.detail.matches') }}:
 
-                            <div class="stack-small mt-2">
+                            <div
+                              class="stack-small mt-2"
+                            >
                               <RuleMatch
                                 v-for="(match, matchIndex) in rule.matches"
                                 :key="matchIndex"
@@ -186,10 +252,14 @@
                             </div>
                           </div>
 
-                          <div v-if="rule.default.filters.length > 0">
+                          <div
+                            v-if="rule.default.filters.length > 0"
+                          >
                             {{ t('builtin-gateways.detail.filters') }}:
 
-                            <div class="stack-small mt-2">
+                            <div
+                              class="stack-small mt-2"
+                            >
                               <RuleFilter
                                 v-for="(filter, filterIndex) in rule.default.filters"
                                 :key="filterIndex"
@@ -198,15 +268,21 @@
                             </div>
                           </div>
 
-                          <div v-if="rule.default.backendRefs.length > 0">
+                          <div
+                            v-if="rule.default.backendRefs.length > 0"
+                          >
                             {{ t('builtin-gateways.detail.services') }}:
 
-                            <div class="stack-small mt-2">
+                            <div
+                              class="stack-small mt-2"
+                            >
                               <div
                                 v-for="(backendRef, backendRefIndex) in rule.default.backendRefs"
                                 :key="backendRefIndex"
                               >
-                                <TargetRef :target-ref="backendRef">
+                                <TargetRef
+                                  :target-ref="backendRef"
+                                >
                                   {{ backendRef.name }}
                                 </TargetRef>
                               </div>
@@ -216,23 +292,31 @@
                       </div>
                     </div>
 
-                    <div v-if="((item: Rule | RouteRule): item is RouteRule => 'default' in item.config)(toRule)">
+                    <div
+                      v-if="((item: Rule | RouteRule): item is RouteRule => 'default' in item.config)(toRule)"
+                    >
                       <b>{{ t('builtin-gateways.detail.default') }}</b>:
 
                       <div
                         v-if="toRule.config.default.backendRefs && toRule.config.default.backendRefs.length > 0"
                         class="stack-small mt-2"
                       >
-                        <div class="rule stack-small">
+                        <div
+                          class="rule stack-small"
+                        >
                           <div>
                             {{ t('builtin-gateways.detail.services') }}:
 
-                            <div class="stack-small mt-2">
+                            <div
+                              class="stack-small mt-2"
+                            >
                               <div
                                 v-for="(backendRef, backendRefIndex) in toRule.config.default.backendRefs"
                                 :key="backendRefIndex"
                               >
-                                <TargetRef :target-ref="backendRef">
+                                <TargetRef
+                                  :target-ref="backendRef"
+                                >
                                   {{ backendRef.name }}
                                 </TargetRef>
                               </div>

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -71,11 +71,15 @@
                     :is-selected-row="(row) => row.name === route.params.proxy"
                     @resize="me.set"
                   >
-                    <template #namespace="{ row }">
+                    <template
+                      #namespace="{ row }"
+                    >
                       {{ row.namespace }}
                     </template>
 
-                    <template #name="{ row }">
+                    <template
+                      #name="{ row }"
+                    >
                       <XAction
                         data-action
                         class="name-link"
@@ -97,7 +101,9 @@
                       </XAction>
                     </template>
 
-                    <template #zone="{ row }">
+                    <template
+                      #zone="{ row }"
+                    >
                       <XAction
                         v-if="row.zone"
                         :to="{
@@ -110,48 +116,70 @@
                         {{ row.zone }}
                       </XAction>
 
-                      <template v-else>
+                      <template
+                        v-else
+                      >
                         {{ t('common.collection.none') }}
                       </template>
                     </template>
 
-                    <template #certificate="{ row }">
-                      <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                    <template
+                      #certificate="{ row }"
+                    >
+                      <template
+                        v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime"
+                      >
                         {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
                       </template>
 
-                      <template v-else>
+                      <template
+                        v-else
+                      >
                         {{ t('data-planes.components.data-plane-list.certificate.none') }}
                       </template>
                     </template>
 
-                    <template #status="{ row }">
-                      <StatusBadge :status="row.status" />
+                    <template
+                      #status="{ row }"
+                    >
+                      <StatusBadge
+                        :status="row.status"
+                      />
                     </template>
 
-                    <template #warnings="{ row }">
+                    <template
+                      #warnings="{ row }"
+                    >
                       <XIcon
                         v-if="row.isCertExpired || row.warnings.length > 0"
                         class="mr-1"
                         name="warning"
                       >
                         <ul>
-                          <template v-if="row.warnings.length > 0">
+                          <template
+                            v-if="row.warnings.length > 0"
+                          >
                             <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
                           </template>
 
-                          <template v-if="row.isCertExpired">
+                          <template
+                            v-if="row.isCertExpired"
+                          >
                             <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
                           </template>
                         </ul>
                       </XIcon>
 
-                      <template v-else>
+                      <template
+                        v-else
+                      >
                         {{ t('common.collection.none') }}
                       </template>
                     </template>
 
-                    <template #actions="{ row: item }">
+                    <template
+                      #actions="{ row: item }"
+                    >
                       <XActionGroup>
                         <XAction
                           :to="{

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDetailView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDetailView.vue
@@ -24,7 +24,9 @@
             :data="[data, rules]"
             :errors="[error, rulesError]"
           >
-            <template v-if="rules && data">
+            <template
+              v-if="rules && data"
+            >
               <ListenerRoutes
                 :mesh-gateway="props.gateway"
                 :selected-listener-index="Number(route.params.listener)"

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayListView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayListView.vue
@@ -43,7 +43,9 @@
                 :items="data?.items"
                 @resize="me.set"
               >
-                <template #name="{ row: item }">
+                <template
+                  #name="{ row: item }"
+                >
                   <XCopyButton
                     :text="item.name"
                   >
@@ -66,8 +68,12 @@
                   </XCopyButton>
                 </template>
 
-                <template #zone="{ row }">
-                  <template v-if="row.labels && row.labels['kuma.io/origin'] === 'zone' && row.labels['kuma.io/zone']">
+                <template
+                  #zone="{ row }"
+                >
+                  <template
+                    v-if="row.labels && row.labels['kuma.io/origin'] === 'zone' && row.labels['kuma.io/zone']"
+                  >
                     <XAction
                       :to="{
                         name: 'zone-cp-detail-view',
@@ -80,12 +86,16 @@
                     </XAction>
                   </template>
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.detail.none') }}
                   </template>
                 </template>
 
-                <template #actions="{ row: item }">
+                <template
+                  #actions="{ row: item }"
+                >
                   <XActionGroup>
                     <XAction
                       :to="{

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewaySummaryView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewaySummaryView.vue
@@ -16,9 +16,13 @@
       :predicate="item => item.id === route.params.gateway"
       :find="true"
     >
-      <template #empty>
+      <template
+        #empty
+      >
         <XEmptyState>
-          <template #title>
+          <template
+            #title
+          >
             <h2>
               {{ t('common.collection.summary.empty_title', { type: 'Gateway' }) }}
             </h2>
@@ -36,7 +40,9 @@
           :key="item.id"
         >
           <AppView>
-            <template #title>
+            <template
+              #title
+            >
               <h2>
                 <XAction
                   :to="{
@@ -53,7 +59,9 @@
                 </XAction>
               </h2>
             </template>
-            <XLayout type="stack">
+            <XLayout
+              type="stack"
+            >
               <header>
                 <XLayout
                   type="separated"
@@ -86,7 +94,9 @@
                 </XLayout>
               </header>
 
-              <template v-if="route.params.format === 'structured'">
+              <template
+                v-if="route.params.format === 'structured'"
+              >
                 <div
                   class="stack-with-borders"
                   data-testid="structured-view"
@@ -95,18 +105,24 @@
                     v-if="item.namespace.length > 0"
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('gateways.routes.item.namespace') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       {{ item.namespace }}
                     </template>
                   </DefinitionCard>
                 </div>
               </template>
 
-              <template v-else-if="route.params.format === 'universal'">
+              <template
+                v-else-if="route.params.format === 'universal'"
+              >
                 <ResourceCodeBlock
                   data-testid="codeblock-yaml-universal"
                   language="yaml"
@@ -122,7 +138,9 @@
                 />
               </template>
 
-              <template v-else>
+              <template
+                v-else
+              >
                 <DataLoader
                   :src="uri(sources, '/meshes/:mesh/mesh-gateways/:name/as/kubernetes', {
                     mesh: route.params.mesh,

--- a/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailTabsView.vue
@@ -30,10 +30,16 @@
         },
       ]"
     >
-      <template #title>
+      <template
+        #title
+      >
         <h1>
-          <XCopyButton :text="route.params.service">
-            <RouteTitle :title="t('delegated-gateways.routes.item.title', { name: route.params.service })" />
+          <XCopyButton
+            :text="route.params.service"
+          >
+            <RouteTitle
+              :title="t('delegated-gateways.routes.item.title', { name: route.params.service })"
+            />
           </XCopyButton>
         </h1>
       </template>

--- a/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -12,7 +12,9 @@
     v-slot="{ can, route, t, me }"
   >
     <AppView>
-      <XLayout type="stack">
+      <XLayout
+        type="stack"
+      >
         <DataLoader
           :src="`/meshes/${route.params.mesh}/service-insights/${route.params.service}`"
           v-slot="{ data }: ServiceInsightSource"
@@ -23,22 +25,36 @@
             :created="data.creationTime"
             :modified="data.modificationTime"
           >
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('http.api.property.status') }}
               </template>
 
-              <template #body>
-                <StatusBadge :status="data.status" />
+              <template
+                #body
+              >
+                <StatusBadge
+                  :status="data.status"
+                />
               </template>
             </DefinitionCard>
 
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('http.api.property.address') }}
               </template>
 
-              <template #body>
+              <template
+                #body
+              >
                 <XCopyButton
                   v-if="data.addressPort"
                   variant="badge"
@@ -46,7 +62,9 @@
                   :text="data.addressPort"
                 />
 
-                <template v-else>
+                <template
+                  v-else
+                >
                   {{ t('common.detail.none') }}
                 </template>
               </template>
@@ -57,7 +75,9 @@
               :online="data.dataplanes?.online ?? 0"
               :total="data.dataplanes?.total ?? 0"
             >
-              <template #title>
+              <template
+                #title
+              >
                 {{ t('http.api.property.dataPlaneProxies') }}
               </template>
             </ResourceStatus>
@@ -65,7 +85,9 @@
         </DataLoader>
 
         <XCard>
-          <template #title>
+          <template
+            #title
+          >
             <h3>{{ t('delegated-gateways.detail.data_plane_proxies') }}</h3>
           </template>
 
@@ -116,7 +138,9 @@
                   :is-selected-row="(row) => row.name === route.params.proxy"
                   @resize="me.set"
                 >
-                  <template #name="{ row: item }">
+                  <template
+                    #name="{ row: item }"
+                  >
                     <XAction
                       data-action
                       class="name-link"
@@ -137,11 +161,15 @@
                     </XAction>
                   </template>
 
-                  <template #namespace="{ row: item }">
+                  <template
+                    #namespace="{ row: item }"
+                  >
                     {{ item.namespace }}
                   </template>
 
-                  <template #zone="{ row }">
+                  <template
+                    #zone="{ row }"
+                  >
                     <XAction
                       v-if="row.zone"
                       :to="{
@@ -154,48 +182,70 @@
                       {{ row.zone }}
                     </XAction>
 
-                    <template v-else>
+                    <template
+                      v-else
+                    >
                       {{ t('common.collection.none') }}
                     </template>
                   </template>
 
-                  <template #certificate="{ row }">
-                    <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                  <template
+                    #certificate="{ row }"
+                  >
+                    <template
+                      v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime"
+                    >
                       {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
                     </template>
 
-                    <template v-else>
+                    <template
+                      v-else
+                    >
                       {{ t('data-planes.components.data-plane-list.certificate.none') }}
                     </template>
                   </template>
 
-                  <template #status="{ row }">
-                    <StatusBadge :status="row.status" />
+                  <template
+                    #status="{ row }"
+                  >
+                    <StatusBadge
+                      :status="row.status"
+                    />
                   </template>
 
-                  <template #warnings="{ row }">
+                  <template
+                    #warnings="{ row }"
+                  >
                     <XIcon
                       v-if="row.isCertExpired || row.warnings.length > 0"
                       class="mr-1"
                       name="warning"
                     >
                       <ul>
-                        <template v-if="row.warnings.length > 0">
+                        <template
+                          v-if="row.warnings.length > 0"
+                        >
                           <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
                         </template>
 
-                        <template v-if="row.isCertExpired">
+                        <template
+                          v-if="row.isCertExpired"
+                        >
                           <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
                         </template>
                       </ul>
                     </XIcon>
 
-                    <template v-else>
+                    <template
+                      v-else
+                    >
                       {{ t('common.collection.none') }}
                     </template>
                   </template>
 
-                  <template #actions="{ row: item }">
+                  <template
+                    #actions="{ row: item }"
+                  >
                     <XActionGroup>
                       <XAction
                         :to="{

--- a/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayListView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayListView.vue
@@ -45,8 +45,12 @@
                 :items="data?.items"
                 @resize="me.set"
               >
-                <template #name="{ row: item }">
-                  <XCopyButton :text="item.name">
+                <template
+                  #name="{ row: item }"
+                >
+                  <XCopyButton
+                    :text="item.name"
+                  >
                     <XAction
                       :to="{
                         name: 'delegated-gateway-detail-view',
@@ -65,32 +69,48 @@
                   </XCopyButton>
                 </template>
 
-                <template #addressPort="{ row }">
+                <template
+                  #addressPort="{ row }"
+                >
                   <XCopyButton
                     v-if="row.addressPort"
                     :text="row.addressPort"
                   />
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.collection.none') }}
                   </template>
                 </template>
 
-                <template #dataplanes="{ row }">
-                  <template v-if="row.dataplanes">
+                <template
+                  #dataplanes="{ row }"
+                >
+                  <template
+                    v-if="row.dataplanes"
+                  >
                     {{ row.dataplanes.online || 0 }} / {{ row.dataplanes.total || 0 }}
                   </template>
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.collection.none') }}
                   </template>
                 </template>
 
-                <template #status="{ row }">
-                  <StatusBadge :status="row.status" />
+                <template
+                  #status="{ row }"
+                >
+                  <StatusBadge
+                    :status="row.status"
+                  />
                 </template>
 
-                <template #actions="{ row: item }">
+                <template
+                  #actions="{ row: item }"
+                >
                   <XActionGroup>
                     <XAction
                       :to="{

--- a/packages/kuma-gui/src/app/gateways/views/GatewayListTabsView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/GatewayListTabsView.vue
@@ -10,9 +10,13 @@
       :render="false"
       :title="t(`${route.child()?.name === 'builtin-gateway-list-view' ? 'builtin' : 'delegated'}-gateways.routes.items.title`)"
     />
-    <div class="stack">
+    <div
+      class="stack"
+    >
       <AppView>
-        <template #actions>
+        <template
+          #actions
+        >
           <DataCollection
             :items="route.children"
             :empty="false"

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorDetailView.vue
@@ -17,8 +17,12 @@
       })"
       v-slot="{ data }"
     >
-      <AppView :docs="t('hostname-generators.href.docs')">
-        <template #title>
+      <AppView
+        :docs="t('hostname-generators.href.docs')"
+      >
+        <template
+          #title
+        >
           <h1>
             <XCopyButton
               :text="data.name"
@@ -49,12 +53,18 @@
                 v-if="Object.keys(labels).length"
                 layout="horizontal"
               >
-                <template #title>
+                <template
+                  #title
+                >
                   {{ t('http.api.property.tags') }}
                 </template>
 
-                <template #body>
-                  <XLayout type="separated">
+                <template
+                  #body
+                >
+                  <XLayout
+                    type="separated"
+                  >
                     <template
                       v-for="(value, key) in labels"
                       :key="key"

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
@@ -11,7 +11,9 @@
     <AppView
       :docs="t('hostname-generators.href.docs')"
     >
-      <template #title>
+      <template
+        #title
+      >
         <h1>
           <RouteTitle
             :title="t('hostname-generators.routes.items.title')"
@@ -52,7 +54,9 @@
                 :is-selected-row="(item) => item.name === route.params.name"
                 @resize="me.set"
               >
-                <template #name="{ row: item }">
+                <template
+                  #name="{ row: item }"
+                >
                   <XCopyButton
                     :text="item.name"
                   >
@@ -74,7 +78,9 @@
                   </XCopyButton>
                 </template>
 
-                <template #actions="{ row: item }">
+                <template
+                  #actions="{ row: item }"
+                >
                   <XActionGroup>
                     <XAction
                       :to="{

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
@@ -18,7 +18,9 @@
         #item="{ item }"
       >
         <AppView>
-          <template #title>
+          <template
+            #title
+          >
             <h2>
               <XAction
                 :to="{
@@ -71,7 +73,9 @@
               </XLayout>
             </header>
             
-            <template v-if="route.params.format === 'structured'">
+            <template
+              v-if="route.params.format === 'structured'"
+            >
               <div
                 class="stack-with-borders"
                 data-testid="structured-view"
@@ -134,7 +138,9 @@
               </div>
             </template>
 
-            <template v-else-if="route.params.format === 'universal'">
+            <template
+              v-else-if="route.params.format === 'universal'"
+            >
               <ResourceCodeBlock
                 data-testid="codeblock-yaml-universal"
                 language="yaml"
@@ -150,7 +156,9 @@
               />
             </template>
 
-            <template v-else>
+            <template
+              v-else
+            >
               <DataLoader
                 :src="uri(sources, '/hostname-generators/:name/as/kubernetes', {
                   name: route.params.name,

--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -29,9 +29,15 @@
           <div
             class="horizontal-list"
           >
-            <slot name="header">
-              <XAction :to="{ name: 'home' }">
-                <slot name="home" />
+            <slot
+              name="header"
+            >
+              <XAction
+                :to="{ name: 'home' }"
+              >
+                <slot
+                  name="home"
+                />
               </XAction>
 
               <GithubButton
@@ -42,7 +48,9 @@
                 Star
               </GithubButton>
 
-              <div class="upgrade-check-wrapper">
+              <div
+                class="upgrade-check-wrapper"
+              >
                 <DataSource
                   :src="`/control-plane/version/latest`"
                   v-slot="{ data }"
@@ -76,7 +84,9 @@
           <div
             class="horizontal-list"
           >
-            <slot name="content-info">
+            <slot
+              name="content-info"
+            >
               <div
                 class="app-status app-status--mobile"
               >
@@ -89,7 +99,9 @@
                     Info
                   </XAction>
 
-                  <template #content>
+                  <template
+                    #content
+                  >
                     <p>
                       {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
                     </p>
@@ -97,7 +109,9 @@
                 </XPop>
               </div>
 
-              <p class="app-status app-status--desktop">
+              <p
+                class="app-status app-status--desktop"
+              >
                 {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
               </p>
 
@@ -136,12 +150,18 @@
         <div
           class="app-content-container"
         >
-          <div class="app-sidebar">
+          <div
+            class="app-sidebar"
+          >
             <nav
               aria-label="Main"
             >
-              <ul v-if="slots.navigation">
-                <slot name="navigation" />
+              <ul
+                v-if="slots.navigation"
+              >
+                <slot
+                  name="navigation"
+                />
               </ul>
 
               <div
@@ -150,8 +170,12 @@
                 class="navigation-separator"
               />
 
-              <ul v-if="slots.bottomNavigation">
-                <slot name="bottomNavigation" />
+              <ul
+                v-if="slots.bottomNavigation"
+              >
+                <slot
+                  name="bottomNavigation"
+                />
               </ul>
             </nav>
           </div>
@@ -196,7 +220,9 @@
                 </DataSink>
               </aside>
               <div>
-                <slot name="default" />
+                <slot
+                  name="default"
+                />
               </div>
             </XLayout>
           </main>

--- a/packages/kuma-gui/src/app/kuma/views/KumaNotFoundView.vue
+++ b/packages/kuma-gui/src/app/kuma/views/KumaNotFoundView.vue
@@ -3,16 +3,22 @@
     name="kuma-not-found-view"
   >
     <AppView>
-      <div class="overview">
+      <div
+        class="overview"
+      >
         <XEmptyState>
-          <template #icon>
+          <template
+            #icon
+          >
             <XIcon
               name="warning"
               class="mb-3"
             />
           </template>
 
-          <template #title>
+          <template
+            #title
+          >
             <h1>
               <RouteTitle
                 title="Page Not Found"
@@ -22,7 +28,9 @@
 
           <p>The page or entity you were looking for does not exist.</p>
 
-          <template #action>
+          <template
+            #action
+          >
             <XAction
               appearance="primary"
               :to="{ name: 'home' }"

--- a/packages/kuma-gui/src/app/meshes/components/MeshStatus.vue
+++ b/packages/kuma-gui/src/app/meshes/components/MeshStatus.vue
@@ -1,12 +1,18 @@
 <template>
   <XCard>
-    <div class="stack">
-      <div class="columns">
+    <div
+      class="stack"
+    >
+      <div
+        class="columns"
+      >
         <ResourceStatus
           :total="props.meshInsight?.services.total ?? 0"
           data-testid="services-status"
         >
-          <template #title>
+          <template
+            #title
+          >
             {{ t('meshes.detail.services') }}
           </template>
         </ResourceStatus>
@@ -16,7 +22,9 @@
           :online="props.meshInsight?.dataplanesByType.standard.online ?? 0"
           data-testid="data-plane-proxies-status"
         >
-          <template #title>
+          <template
+            #title
+          >
             {{ t('meshes.detail.data_plane_proxies') }}
           </template>
         </ResourceStatus>
@@ -25,16 +33,22 @@
           :total="props.meshInsight?.totalPolicyCount ?? 0"
           data-testid="policies-status"
         >
-          <template #title>
+          <template
+            #title
+          >
             {{ t('meshes.detail.policies') }}
           </template>
         </ResourceStatus>
         <DefinitionCard>
-          <template #title>
+          <template
+            #title
+          >
             {{ t('http.api.property.mtls') }}
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <XBadge
               v-if="!props.mesh.mtlsBackend"
               appearance="neutral"
@@ -42,7 +56,9 @@
               {{ t('meshes.detail.disabled') }}
             </XBadge>
 
-            <template v-else>
+            <template
+              v-else
+            >
               {{ props.mesh.mtlsBackend.type }} / {{ props.mesh.mtlsBackend.name }}
             </template>
           </template>

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailTabsView.vue
@@ -7,7 +7,9 @@
     v-slot="{ route, t }"
   >
     <AppView>
-      <template #title>
+      <template
+        #title
+      >
         <h1>
           <XCopyButton
             :text="route.params.mesh"

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -56,7 +56,9 @@
                 <DefinitionCard
                   layout="horizontal"
                 >
-                  <template #title>
+                  <template
+                    #title
+                  >
                     <XAction
                       :to="{
                         name: 'policy-list-view',
@@ -70,7 +72,9 @@
                     </XAction>
                   </template>
 
-                  <template #body>
+                  <template
+                    #body
+                  >
                     <XBadge
                       :appearance="stats.total > 0 ? 'success' : 'neutral'"
                     >
@@ -81,12 +85,18 @@
               </template>
             </template>
 
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('http.api.property.mtls') }}
               </template>
 
-              <template #body>
+              <template
+                #body
+              >
                 <XBadge
                   v-if="!props.mesh.mtlsBackend"
                   appearance="neutral"
@@ -94,8 +104,12 @@
                   {{ t('meshes.detail.disabled') }}
                 </XBadge>
 
-                <template v-else>
-                  <XBadge appearance="info">
+                <template
+                  v-else
+                >
+                  <XBadge
+                    appearance="info"
+                  >
                     {{ props.mesh.mtlsBackend.type }} / {{ props.mesh.mtlsBackend.name }}
                   </XBadge>
                 </template>
@@ -115,7 +129,9 @@
                   :total="data?.services.total ?? 0"
                   data-testid="services-status"
                 >
-                  <template #title>
+                  <template
+                    #title
+                  >
                     {{ t('meshes.detail.services') }}
                   </template>
                 </ResourceStatus>
@@ -125,7 +141,9 @@
                   :online="data?.dataplanesByType.standard.online ?? 0"
                   data-testid="data-plane-proxies-status"
                 >
-                  <template #title>
+                  <template
+                    #title
+                  >
                     {{ t('meshes.detail.data_plane_proxies') }}
                   </template>
                 </ResourceStatus>
@@ -134,7 +152,9 @@
                   :total="data?.totalPolicyCount ?? 0"
                   data-testid="policies-status"
                 >
-                  <template #title>
+                  <template
+                    #title
+                  >
                     {{ t('meshes.detail.policies') }}
                   </template>
                 </ResourceStatus>

--- a/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
@@ -18,7 +18,9 @@
       <AppView
         :docs="data?.items.length ? t('meshes.href.docs'):''"
       >
-        <template #title>
+        <template
+          #title
+        >
           <h1>
             <RouteTitle
               :title="t('meshes.routes.items.title')"

--- a/packages/kuma-gui/src/app/policies/components/PolicySummary.vue
+++ b/packages/kuma-gui/src/app/policies/components/PolicySummary.vue
@@ -2,8 +2,12 @@
   <XLayout
     type="stack"
   >
-    <slot name="header" />
-    <template v-if="props.format === 'structured'">
+    <slot
+      name="header"
+    />
+    <template
+      v-if="props.format === 'structured'"
+    >
       <div
         class="mt-4 stack-with-borders"
         data-testid="structured-view"
@@ -11,11 +15,15 @@
         <DefinitionCard
           layout="horizontal"
         >
-          <template #title>
+          <template
+            #title
+          >
             {{ t('http.api.property.type') }}
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <XBadge
               v-if="props.policy.type"
               appearance="neutral"
@@ -28,16 +36,22 @@
           v-if="!props.legacy"
           layout="horizontal"
         >
-          <template #title>
+          <template
+            #title
+          >
             {{ t('http.api.property.targetRef') }}
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <XBadge
               v-if="props.policy.spec?.targetRef"
               appearance="neutral"
             >
-              {{ props.policy.spec.targetRef.kind }}<span v-if="props.policy.spec.targetRef.name">:<b>{{ props.policy.spec.targetRef.name }}</b></span>
+              {{ props.policy.spec.targetRef.kind }}<span
+                v-if="props.policy.spec.targetRef.name"
+              >:<b>{{ props.policy.spec.targetRef.name }}</b></span>
             </XBadge>
             <XBadge
               v-else
@@ -51,11 +65,15 @@
           v-if="props.policy.namespace.length > 0"
           layout="horizontal"
         >
-          <template #title>
+          <template
+            #title
+          >
             {{ t('data-planes.routes.item.namespace') }}
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             {{ props.policy.namespace }}
           </template>
         </DefinitionCard>
@@ -103,9 +121,13 @@
       />
     </template>
 
-    <template v-else>
+    <template
+      v-else
+    >
       <div>
-        <div class="mt-4">
+        <div
+          class="mt-4"
+        >
           <slot />
         </div>
       </div>

--- a/packages/kuma-gui/src/app/policies/components/PolicyTypeEntryList.vue
+++ b/packages/kuma-gui/src/app/policies/components/PolicyTypeEntryList.vue
@@ -7,16 +7,26 @@
       v-for="(policyTypeEntry, index) in items"
       :key="index"
     >
-      <template #accordion-header>
-        <h3 class="policy-type-heading">
-          <PolicyTypeTag :policy-type="policyTypeEntry.type">
+      <template
+        #accordion-header
+      >
+        <h3
+          class="policy-type-heading"
+        >
+          <PolicyTypeTag
+            :policy-type="policyTypeEntry.type"
+          >
             {{ policyTypeEntry.type }} ({{ policyTypeEntry.connections.length }})
           </PolicyTypeTag>
         </h3>
       </template>
 
-      <template #accordion-content>
-        <div class="policy-list">
+      <template
+        #accordion-content
+      >
+        <div
+          class="policy-list"
+        >
           <KTableView
             class="policy-type-table"
             :data="policyTypeEntry.connections"
@@ -31,7 +41,9 @@
             hide-pagination
             is-clickable
           >
-            <template #sourceTags="{ row }: { row: PolicyTypeEntryConnection }">
+            <template
+              #sourceTags="{ row }: { row: PolicyTypeEntryConnection }"
+            >
               <TagList
                 v-if="row.sourceTags.length > 0"
                 class="tag-list"
@@ -39,12 +51,16 @@
                 :tags="row.sourceTags"
               />
 
-              <template v-else>
+              <template
+                v-else
+              >
                 —
               </template>
             </template>
 
-            <template #destinationTags="{ row }: { row: PolicyTypeEntryConnection }">
+            <template
+              #destinationTags="{ row }: { row: PolicyTypeEntryConnection }"
+            >
               <TagList
                 v-if="row.destinationTags.length > 0"
                 class="tag-list"
@@ -52,23 +68,35 @@
                 :tags="row.destinationTags"
               />
 
-              <template v-else>
+              <template
+                v-else
+              >
                 —
               </template>
             </template>
 
-            <template #name="{ row }: { row: PolicyTypeEntryConnection }">
-              <template v-if="row.name !== null">
+            <template
+              #name="{ row }: { row: PolicyTypeEntryConnection }"
+            >
+              <template
+                v-if="row.name !== null"
+              >
                 {{ row.name }}
               </template>
 
-              <template v-else>
+              <template
+                v-else
+              >
                 —
               </template>
             </template>
 
-            <template #origins="{ row }: { row: PolicyTypeEntryConnection }">
-              <ul v-if="row.origins.length > 0">
+            <template
+              #origins="{ row }: { row: PolicyTypeEntryConnection }"
+            >
+              <ul
+                v-if="row.origins.length > 0"
+              >
                 <li
                   v-for="(origin, originIndex) in row.origins"
                   :key="`${index}-${originIndex}`"
@@ -88,13 +116,19 @@
                 </li>
               </ul>
 
-              <template v-else>
+              <template
+                v-else
+              >
                 —
               </template>
             </template>
 
-            <template #config="{ row }: { row: PolicyTypeEntryConnection, rowKey: number }">
-              <template v-if="row.config">
+            <template
+              #config="{ row }: { row: PolicyTypeEntryConnection, rowKey: number }"
+            >
+              <template
+                v-if="row.config"
+              >
                 <XCodeBlock
                   :code="YAML.stringify(row.config)"
                   language="yaml"
@@ -102,7 +136,9 @@
                 />
               </template>
 
-              <template v-else>
+              <template
+                v-else
+              >
                 —
               </template>
             </template>

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailTabsView.vue
@@ -39,7 +39,9 @@
           },
         ]"
       >
-        <template #title>
+        <template
+          #title
+        >
           <h1
             v-if="data"
           >

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailView.vue
@@ -18,7 +18,9 @@
         :created="props.data.creationTime"
         :modified="props.data.modificationTime"
       >
-        <DefinitionCard layout="horizontal">
+        <DefinitionCard
+          layout="horizontal"
+        >
           <template
             #title
           >
@@ -27,7 +29,9 @@
           <template
             #body
           >
-            <XBadge appearance="decorative">
+            <XBadge
+              appearance="decorative"
+            >
               {{ props.data.type }}
             </XBadge>
           </template>
@@ -44,7 +48,9 @@
           <template
             #body
           >
-            <XBadge appearance="decorative">
+            <XBadge
+              appearance="decorative"
+            >
               {{ props.data.namespace }}
             </XBadge>
           </template>
@@ -61,7 +67,9 @@
           <template
             #body
           >
-            <XBadge appearance="decorative">
+            <XBadge
+              appearance="decorative"
+            >
               <XAction
                 :to="{
                   name: 'zone-cp-detail-view',
@@ -79,16 +87,22 @@
           v-if="props.data.spec"
           layout="horizontal"
         >
-          <template #title>
+          <template
+            #title
+          >
             {{ t('http.api.property.targetRef') }}
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <XBadge
               v-if="props.data.spec.targetRef"
               appearance="neutral"
             >
-              {{ props.data.spec.targetRef.kind }}<span v-if="props.data.spec.targetRef.name">:<b>{{ props.data.spec.targetRef.name }}</b></span>
+              {{ props.data.spec.targetRef.kind }}<span
+                v-if="props.data.spec.targetRef.name"
+              >:<b>{{ props.data.spec.targetRef.name }}</b></span>
             </XBadge>
             <XBadge
               v-else
@@ -101,7 +115,9 @@
       </XAboutCard>
       
       <XCard>
-        <template #title>
+        <template
+          #title
+        >
           <h3>Affected Data Plane Proxies</h3>
         </template>
           
@@ -137,7 +153,9 @@
                 :is-selected-row="(row) => row.id === route.params.proxy"
                 @resize="me.set"
               >
-                <template #name="{ row: item }">
+                <template
+                  #name="{ row: item }"
+                >
                   <XAction
                     data-action
                     :to="{
@@ -151,11 +169,15 @@
                   </XAction>
                 </template>
 
-                <template #namespace="{ row: item }">
+                <template
+                  #namespace="{ row: item }"
+                >
                   {{ item.namespace }}
                 </template>
 
-                <template #zone="{ row }">
+                <template
+                  #zone="{ row }"
+                >
                   <XAction
                     v-if="row.zone"
                     :to="{
@@ -168,12 +190,16 @@
                     {{ row.zone }}
                   </XAction>
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.collection.none') }}
                   </template>
                 </template>
 
-                <template #actions="{ row: item }">
+                <template
+                  #actions="{ row: item }"
+                >
                   <XActionGroup>
                     <XAction
                       :to="{

--- a/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
@@ -15,14 +15,20 @@
       :predicate="(policyType) => typeof policyType !== 'undefined' && policyType.path === route.params.policyPath"
       :items="props.policyTypes ?? []"
     >
-      <template #empty>
+      <template
+        #empty
+      >
         <XEmptyState>
           {{ t('policies.routes.items.empty') }}
         </XEmptyState>
       </template>
-      <template #item="{ item: type }">
+      <template
+        #item="{ item: type }"
+      >
         <AppView>
-          <div class="stack">
+          <div
+            class="stack"
+          >
             <XCard>
               <header>
                 <div>
@@ -45,7 +51,9 @@
                     :href="t('policies.href.docs', { name: type.name })"
                     data-testid="policy-documentation-link"
                   >
-                    <span class="visually-hidden">{{ t('common.documentation') }}</span>
+                    <span
+                      class="visually-hidden"
+                    >{{ t('common.documentation') }}</span>
                   </XAction>
                 </div>
                 <h3>
@@ -103,7 +111,9 @@
                       #empty
                     >
                       <XEmptyState>
-                        <template #title>
+                        <template
+                          #title
+                        >
                           <h3>
                             {{ t('policies.x-empty-state.title') }}
                           </h3>
@@ -162,7 +172,9 @@
                           </template>
                         </template>
 
-                        <template #name="{ row }">
+                        <template
+                          #name="{ row }"
+                        >
                           <XAction
                             data-action
                             :to="{
@@ -181,16 +193,22 @@
                             {{ row.name }}
                           </XAction>
                         </template>
-                        <template #namespace="{ row: item }">
+                        <template
+                          #namespace="{ row: item }"
+                        >
                           {{ item.namespace.length > 0 ? item.namespace : t('common.detail.none') }}
                         </template>
 
-                        <template #targetRef="{ row }">
+                        <template
+                          #targetRef="{ row }"
+                        >
                           <XBadge
                             v-if="typeof row.spec?.targetRef !== 'undefined'"
                             appearance="neutral"
                           >
-                            {{ row.spec.targetRef.kind }}<span v-if="row.spec.targetRef.name">:<b>{{ row.spec.targetRef.name }}</b></span>
+                            {{ row.spec.targetRef.kind }}<span
+                              v-if="row.spec.targetRef.name"
+                            >:<b>{{ row.spec.targetRef.name }}</b></span>
                           </XBadge>
                           <XBadge
                             v-else
@@ -200,8 +218,12 @@
                           </XBadge>
                         </template>
 
-                        <template #zone="{ row }">
-                          <template v-if="row.zone">
+                        <template
+                          #zone="{ row }"
+                        >
+                          <template
+                            v-if="row.zone"
+                          >
                             <XAction
                               :to="{
                                 name: 'zone-cp-detail-view',
@@ -214,12 +236,16 @@
                             </XAction>
                           </template>
 
-                          <template v-else>
+                          <template
+                            v-else
+                          >
                             {{ t('common.detail.none') }}
                           </template>
                         </template>
 
-                        <template #actions="{ row: item }">
+                        <template
+                          #actions="{ row: item }"
+                        >
                           <XActionGroup>
                             <XAction
                               :to="{

--- a/packages/kuma-gui/src/app/policies/views/PolicySummaryView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicySummaryView.vue
@@ -17,9 +17,13 @@
       :predicate="item => item.id === route.params.policy"
       :find="true"
     >
-      <template #empty>
+      <template
+        #empty
+      >
         <XEmptyState>
-          <template #title>
+          <template
+            #title
+          >
             <h2>
               {{ t('common.collection.summary.empty_title', { type: props.policyType.name }) }}
             </h2>
@@ -37,7 +41,9 @@
           :key="item.id"
         >
           <AppView>
-            <template #title>
+            <template
+              #title
+            >
               <h2>
                 <XAction
                   :to="{
@@ -61,7 +67,9 @@
               :format="route.params.format"
               :legacy="!props.policyType.policy?.isTargetRef"
             >
-              <template #header>
+              <template
+                #header
+              >
                 <header>
                   <XLayout
                     type="separated"
@@ -95,7 +103,9 @@
                 </header>
               </template>
 
-              <template v-if="route.params.format === 'universal'">
+              <template
+                v-if="route.params.format === 'universal'"
+              >
                 <ResourceCodeBlock
                   data-testid="codeblock-yaml-universal"
                   language="yaml"
@@ -111,7 +121,9 @@
                 />
               </template>
 
-              <template v-else-if="route.params.format === 'k8s'">
+              <template
+                v-else-if="route.params.format === 'k8s'"
+              >
                 <DataLoader
                   :src="uri(sources, '/meshes/:mesh/policy-path/:path/policy/:name/as/kubernetes', {
                     mesh: route.params.mesh,

--- a/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
@@ -72,7 +72,9 @@
                           {{ policyType.name }}
                         </XAction>
 
-                        <div class="policy-count">
+                        <div
+                          class="policy-count"
+                        >
                           {{ meshInsight?.policies?.[policyType.name]?.total ?? 0 }}
                         </div>
                       </div>
@@ -81,8 +83,12 @@
                 </template>
               </DataLoader>
             </XCard>
-            <div class="policy-list">
-              <RouterView v-slot="{ Component }">
+            <div
+              class="policy-list"
+            >
+              <RouterView
+                v-slot="{ Component }"
+              >
                 <component
                   :is="Component"
                   :policy-types="data?.policyTypes"

--- a/packages/kuma-gui/src/app/rules/components/RuleFilter.vue
+++ b/packages/kuma-gui/src/app/rules/components/RuleFilter.vue
@@ -1,22 +1,34 @@
 <template>
-  <div class="filter">
-    <XBadge appearance="neutral">
+  <div
+    class="filter"
+  >
+    <XBadge
+      appearance="neutral"
+    >
       {{ props.filter.type }}
     </XBadge>
 
     <div>
-      <template v-if="props.filter.type === 'RequestHeaderModifier'">
-        <div class="list">
+      <template
+        v-if="props.filter.type === 'RequestHeaderModifier'"
+      >
+        <div
+          class="list"
+        >
           <template
             v-for="(value, key) in props.filter.requestHeaderModifier"
             :key="key"
           >
-            <template v-if="value">
+            <template
+              v-if="value"
+            >
               <span
                 v-for="(entry, index) in value"
                 :key="index"
               >
-                <span class="text-neutral">
+                <span
+                  class="text-neutral"
+                >
                   {{ key }}:
                 </span>
 
@@ -27,18 +39,26 @@
         </div>
       </template>
 
-      <template v-else-if="props.filter.type === 'ResponseHeaderModifier'">
-        <div class="list">
+      <template
+        v-else-if="props.filter.type === 'ResponseHeaderModifier'"
+      >
+        <div
+          class="list"
+        >
           <template
             v-for="(value, key) in props.filter.responseHeaderModifier"
             :key="key"
           >
-            <template v-if="value">
+            <template
+              v-if="value"
+            >
               <span
                 v-for="(entry, index) in value"
                 :key="index"
               >
-                <span class="text-neutral">
+                <span
+                  class="text-neutral"
+                >
                   {{ key }}:
                 </span>
 
@@ -49,32 +69,50 @@
         </div>
       </template>
 
-      <template v-else-if="props.filter.type === 'RequestMirror'">
-        <TargetRef :target-ref="props.filter.requestMirror.backendRef">
+      <template
+        v-else-if="props.filter.type === 'RequestMirror'"
+      >
+        <TargetRef
+          :target-ref="props.filter.requestMirror.backendRef"
+        >
           {{ props.filter.requestMirror.backendRef.name }}
         </TargetRef>
 
-        <template v-if="props.filter.requestMirror.percentage">
+        <template
+          v-if="props.filter.requestMirror.percentage"
+        >
           ({{ props.filter.requestMirror.percentage }}%)
         </template>
       </template>
 
-      <template v-else-if="props.filter.type === 'RequestRedirect'">
-        <div class="list">
+      <template
+        v-else-if="props.filter.type === 'RequestRedirect'"
+      >
+        <div
+          class="list"
+        >
           <div
             v-for="(value, key) in props.filter.requestRedirect"
             :key="key"
           >
-            <template v-if="value">
-              <span class="text-neutral">
+            <template
+              v-if="value"
+            >
+              <span
+                class="text-neutral"
+              >
                 {{ key }}:
               </span>
 
-              <template v-if="typeof value === 'object'">
+              <template
+                v-if="typeof value === 'object'"
+              >
                 {{ value.type === 'ReplaceFullPath' ? value.replaceFullPath : value.replacePrefixMatch }}
               </template>
 
-              <template v-else>
+              <template
+                v-else
+              >
                 {{ value }}
               </template>
             </template>
@@ -82,22 +120,34 @@
         </div>
       </template>
 
-      <template v-else>
-        <div class="list">
+      <template
+        v-else
+      >
+        <div
+          class="list"
+        >
           <div
             v-for="(value, key) in props.filter.urlRewrite"
             :key="key"
           >
-            <template v-if="value">
-              <span class="text-neutral">
+            <template
+              v-if="value"
+            >
+              <span
+                class="text-neutral"
+              >
                 {{ key }}:
               </span>
 
-              <template v-if="typeof value === 'object'">
+              <template
+                v-if="typeof value === 'object'"
+              >
                 {{ value.type === 'ReplaceFullPath' ? value.replaceFullPath : value.replacePrefixMatch }}
               </template>
 
-              <template v-else>
+              <template
+                v-else
+              >
                 {{ value }}
               </template>
             </template>

--- a/packages/kuma-gui/src/app/rules/components/RuleList.vue
+++ b/packages/kuma-gui/src/app/rules/components/RuleList.vue
@@ -17,20 +17,30 @@
         v-for="(items, type) in policies"
         :key="type"
       >
-        <template #accordion-header>
-          <h3 class="policy-type-heading">
-            <PolicyTypeTag :policy-type="type">
+        <template
+          #accordion-header
+        >
+          <h3
+            class="policy-type-heading"
+          >
+            <PolicyTypeTag
+              :policy-type="type"
+            >
               {{ type }}
             </PolicyTypeTag>
           </h3>
         </template>
 
-        <template #accordion-content>
+        <template
+          #accordion-content
+        >
           <template
             v-for="hasMatchers in [items.some((item) => item.matchers.length > 0)]"
             :key="hasMatchers"
           >
-            <div class="policy-list">
+            <div
+              class="policy-list"
+            >
               <AppCollection
                 class="policy-type-table"
                 :class="{
@@ -55,13 +65,19 @@
                     />
                   </span>
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     <i>{{ t('data-planes.routes.item.matches_everything') }}</i>
                   </template>
                 </template>
 
-                <template #origins="{ row }">
-                  <ul v-if="row.origins.length > 0">
+                <template
+                  #origins="{ row }"
+                >
+                  <ul
+                    v-if="row.origins.length > 0"
+                  >
                     <li
                       v-for="(origin, originIndex) in row.origins"
                       :key="`${type}-${originIndex}`"
@@ -81,13 +97,19 @@
                     </li>
                   </ul>
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.collection.none') }}
                   </template>
                 </template>
 
-                <template #config="{ row }">
-                  <template v-if="Object.keys(row.raw).length > 0">
+                <template
+                  #config="{ row }"
+                >
+                  <template
+                    v-if="Object.keys(row.raw).length > 0"
+                  >
                     <XCodeBlock
                       :code="YAML.stringify(row.raw)"
                       language="yaml"
@@ -95,7 +117,9 @@
                     />
                   </template>
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.collection.none') }}
                   </template>
                 </template>

--- a/packages/kuma-gui/src/app/rules/components/RuleMatch.vue
+++ b/packages/kuma-gui/src/app/rules/components/RuleMatch.vue
@@ -1,9 +1,17 @@
 <template>
-  <dl class="stack-small">
-    <template v-if="props.match.method">
-      <div class="match">
+  <dl
+    class="stack-small"
+  >
+    <template
+      v-if="props.match.method"
+    >
+      <div
+        class="match"
+      >
         <dt>
-          <XBadge appearance="neutral">
+          <XBadge
+            appearance="neutral"
+          >
             Method
           </XBadge>
         </dt>
@@ -14,36 +22,54 @@
       </div>
     </template>
 
-    <template v-if="props.match.path">
-      <div class="match">
+    <template
+      v-if="props.match.path"
+    >
+      <div
+        class="match"
+      >
         <dt>
-          <XBadge appearance="neutral">
+          <XBadge
+            appearance="neutral"
+          >
             Path
           </XBadge>
         </dt>
 
         <dd>
-          <span><span class="text-neutral">type:</span> {{ props.match.path.type }}</span>
+          <span><span
+            class="text-neutral"
+          >type:</span> {{ props.match.path.type }}</span>
           <code>{{ props.match.path.value }}</code>
         </dd>
       </div>
     </template>
 
-    <template v-if="props.match.queryParams && props.match.queryParams.length > 0">
+    <template
+      v-if="props.match.queryParams && props.match.queryParams.length > 0"
+    >
       <div
         v-for="(param, index) in props.match.queryParams"
         :key="index"
       >
-        <div class="match">
+        <div
+          class="match"
+        >
           <dt>
-            <XBadge appearance="neutral">
+            <XBadge
+              appearance="neutral"
+            >
               QueryParameter
             </XBadge>
           </dt>
 
           <dd>
-            <div class="list">
-              <span><span class="text-neutral">type:</span> {{ param.type }}</span>
+            <div
+              class="list"
+            >
+              <span><span
+                class="text-neutral"
+              >type:</span> {{ param.type }}</span>
               <span>{{ param.name }}:{{ param.value }}</span>
             </div>
           </dd>
@@ -51,22 +77,32 @@
       </div>
     </template>
 
-    <template v-if="props.match.headers && props.match.headers.length > 0">
+    <template
+      v-if="props.match.headers && props.match.headers.length > 0"
+    >
       <div
         v-for="(header, index) in props.match.headers"
         :key="index"
         class="match"
       >
         <dt>
-          <XBadge appearance="neutral">
+          <XBadge
+            appearance="neutral"
+          >
             Header
           </XBadge>
         </dt>
 
         <dd>
-          <div class="list">
-            <span><span class="text-neutral">type:</span> {{ header.type ?? 'Exact' }}</span>
-            <span>{{ header.name }}<span v-if="header.value">:{{ header.value }}</span></span>
+          <div
+            class="list"
+          >
+            <span><span
+              class="text-neutral"
+            >type:</span> {{ header.type ?? 'Exact' }}</span>
+            <span>{{ header.name }}<span
+              v-if="header.value"
+            >:{{ header.value }}</span></span>
           </div>
         </dd>
       </div>

--- a/packages/kuma-gui/src/app/rules/components/RuleMatchers.vue
+++ b/packages/kuma-gui/src/app/rules/components/RuleMatchers.vue
@@ -3,7 +3,9 @@
     v-for="({ key, value, not }, i) in props.items"
     :key="i"
   >
-    <span class="rule-matchers"><span
+    <span
+      class="rule-matchers"
+    ><span
       v-if="i > 0"
       class="and"
     > and<br></span><abbr

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailTabsView.vue
@@ -37,11 +37,15 @@
           },
         ]"
       >
-        <template #title>
+        <template
+          #title
+        >
           <h1
             v-if="data"
           >
-            <XCopyButton :text="route.params.service">
+            <XCopyButton
+              :text="route.params.service"
+            >
               <RouteTitle
                 :title="t('services.routes.item.title', { name: data.name })"
               />

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailView.vue
@@ -11,7 +11,9 @@
     v-slot="{ route, can, t, uri, me }"
   >
     <AppView>
-      <XLayout type="stack">
+      <XLayout
+        type="stack"
+      >
         <XAboutCard
           :title="t('services.mesh-external-service.about.title')"
           :created="props.data.creationTime"
@@ -30,7 +32,9 @@
             <template
               #body
             >
-              <XBadge appearance="decorative">
+              <XBadge
+                appearance="decorative"
+              >
                 {{ props.data.namespace }}
               </XBadge>
             </template>
@@ -47,7 +51,9 @@
             <template
               #body
             >
-              <XBadge appearance="decorative">
+              <XBadge
+                appearance="decorative"
+              >
                 <XAction
                   :to="{
                     name: 'zone-cp-detail-view',
@@ -104,7 +110,9 @@
 
         
         <XCard>
-          <template #title>
+          <template
+            #title
+          >
             {{ t('services.detail.hostnames.title') }}
           </template>
 
@@ -115,7 +123,9 @@
               serviceName: route.params.service,
             })"
           >
-            <template #loadable="{ data: hostnames }">
+            <template
+              #loadable="{ data: hostnames }"
+            >
               <DataCollection
                 type="hostnames"
                 :items="hostnames?.items ?? [undefined]"
@@ -130,15 +140,21 @@
                   ]"
                   @resize="me.set"
                 >
-                  <template #hostname="{ row: item }">
+                  <template
+                    #hostname="{ row: item }"
+                  >
                     <b>
                       <XCopyButton
                         :text="item.hostname"
                       />
                     </b>
                   </template>
-                  <template #zones="{ row: item }">
-                    <XLayout type="separated">
+                  <template
+                    #zones="{ row: item }"
+                  >
+                    <XLayout
+                      type="separated"
+                    >
                       <XBadge
                         v-for="(zone, index) of item.zones"
                         :key="index"

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
@@ -75,7 +75,9 @@
                   :is-selected-row="(item) => item.name === route.params.service"
                   @resize="me.set"
                 >
-                  <template #name="{ row: item }">
+                  <template
+                    #name="{ row: item }"
+                  >
                     <XCopyButton
                       :text="item.name"
                     >
@@ -102,8 +104,12 @@
                   >
                     {{ item.namespace }}
                   </template>
-                  <template #zone="{ row: item }">
-                    <template v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']">
+                  <template
+                    #zone="{ row: item }"
+                  >
+                    <template
+                      v-if="item.labels && item.labels['kuma.io/origin'] === 'zone' && item.labels['kuma.io/zone']"
+                    >
                       <XAction
                         v-if="item.labels['kuma.io/zone']"
                         :to="{
@@ -117,7 +123,9 @@
                       </XAction>
                     </template>
 
-                    <template v-else>
+                    <template
+                      v-else
+                    >
                       {{ t('common.detail.none') }}
                     </template>
                   </template>
@@ -133,7 +141,9 @@
                     </template>
                   </template>
 
-                  <template #actions="{ row: item }">
+                  <template
+                    #actions="{ row: item }"
+                  >
                     <XActionGroup>
                       <XAction
                         :to="{

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceSummaryView.vue
@@ -19,7 +19,9 @@
         #item="{ item }"
       >
         <AppView>
-          <template #title>
+          <template
+            #title
+          >
             <h2>
               <XAction
                 :to="{
@@ -72,7 +74,9 @@
                 </div>
               </XLayout>
             </header>
-            <template v-if="route.params.format === 'structured'">
+            <template
+              v-if="route.params.format === 'structured'"
+            >
               <div
                 class="stack-with-borders"
                 data-testid="structured-view"
@@ -121,16 +125,22 @@
                   v-if="item.spec.match"
                   layout="horizontal"
                 >
-                  <template #title>
+                  <template
+                    #title
+                  >
                     Port
                   </template>
-                  <template #body>
+                  <template
+                    #body
+                  >
                     <KumaPort
                       :port="item.spec.match"
                     />
                   </template>
                 </DefinitionCard>
-                <DefinitionCard layout="horizontal">
+                <DefinitionCard
+                  layout="horizontal"
+                >
                   <template
                     #title
                   >
@@ -149,7 +159,9 @@
               </div>
             </template>
 
-            <template v-else-if="route.params.format === 'universal'">
+            <template
+              v-else-if="route.params.format === 'universal'"
+            >
               <ResourceCodeBlock
                 data-testid="codeblock-yaml-universal"
                 language="yaml"
@@ -165,7 +177,9 @@
               />
             </template>
 
-            <template v-else>
+            <template
+              v-else
+            >
               <DataLoader
                 :src="uri(sources, '/meshes/:mesh/mesh-service/:name/as/kubernetes', {
                   mesh: route.params.mesh,

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailTabsView.vue
@@ -37,11 +37,15 @@
           },
         ]"
       >
-        <template #title>
+        <template
+          #title
+        >
           <h1
             v-if="data"
           >
-            <XCopyButton :text="route.params.service">
+            <XCopyButton
+              :text="route.params.service"
+            >
               <RouteTitle
                 :title="t('services.routes.item.title', { name: data.name })"
               />

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailView.vue
@@ -11,13 +11,17 @@
     v-slot="{ route, t, uri, me }"
   >
     <AppView>
-      <XLayout type="stack">
+      <XLayout
+        type="stack"
+      >
         <XAboutCard
           :title="t('services.mesh-multi-zone-service.about.title')"
           :created="props.data.creationTime"
           :modified="props.data.modificationTime"
         >
-          <DefinitionCard layout="horizontal">
+          <DefinitionCard
+            layout="horizontal"
+          >
             <template
               #title
             >
@@ -26,7 +30,9 @@
             <template
               #body
             >
-              <template v-if="props.data.spec.ports.length">
+              <template
+                v-if="props.data.spec.ports.length"
+              >
                 <KumaPort
                   v-for="connection in props.data.spec.ports"
                   :key="connection.port"
@@ -36,12 +42,16 @@
                   }"
                 />
               </template>
-              <template v-else>
+              <template
+                v-else
+              >
                 {{ t('common.detail.none') }}
               </template>
             </template>
           </DefinitionCard>
-          <DefinitionCard layout="horizontal">
+          <DefinitionCard
+            layout="horizontal"
+          >
             <template
               #title
             >
@@ -50,7 +60,9 @@
             <template
               #body
             >
-              <template v-if="Object.keys(data.spec.selector.meshService.matchLabels).length">
+              <template
+                v-if="Object.keys(data.spec.selector.meshService.matchLabels).length"
+              >
                 <XBadge
                   v-for="(value, key) in data.spec.selector.meshService.matchLabels"
                   :key="`${key}:${value}`"
@@ -59,7 +71,9 @@
                   {{ key }}:{{ value }}
                 </XBadge>
               </template>
-              <template v-else>
+              <template
+                v-else
+              >
                 {{ t('common.detail.none') }}
               </template>
             </template>
@@ -67,7 +81,9 @@
         </XAboutCard>
         
         <XCard>
-          <template #title>
+          <template
+            #title
+          >
             {{ t('services.detail.hostnames.title') }}
           </template>
 
@@ -78,7 +94,9 @@
               serviceName: route.params.service,
             })"
           >
-            <template #loadable="{ data: hostnames }">
+            <template
+              #loadable="{ data: hostnames }"
+            >
               <DataCollection
                 type="hostnames"
                 :items="hostnames?.items ?? [undefined]"
@@ -93,15 +111,21 @@
                   ]"
                   @resize="me.set"
                 >
-                  <template #hostname="{ row: item }">
+                  <template
+                    #hostname="{ row: item }"
+                  >
                     <b>
                       <XCopyButton
                         :text="item.hostname"
                       />
                     </b>
                   </template>
-                  <template #zones="{ row: item }">
-                    <XLayout type="separated">
+                  <template
+                    #zones="{ row: item }"
+                  >
+                    <XLayout
+                      type="separated"
+                    >
                       <XBadge
                         v-for="(zone, index) of item.zones"
                         :key="index"

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceListView.vue
@@ -47,7 +47,9 @@
                 :is-selected-row="(item) => item.name === route.params.service"
                 @resize="me.set"
               >
-                <template #name="{ row: item }">
+                <template
+                  #name="{ row: item }"
+                >
                   <XCopyButton
                     :text="item.name"
                   >
@@ -102,7 +104,9 @@
                     </XBadge>
                   </XLayout>
                 </template>
-                <template #actions="{ row: item }">
+                <template
+                  #actions="{ row: item }"
+                >
                   <XActionGroup>
                     <XAction
                       :to="{

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceSummaryView.vue
@@ -19,7 +19,9 @@
         #item="{ item }"
       >
         <AppView>
-          <template #title>
+          <template
+            #title
+          >
             <h2>
               <XAction
                 :to="{
@@ -72,7 +74,9 @@
                 </div>
               </XLayout>
             </header>
-            <template v-if="route.params.format === 'structured'">
+            <template
+              v-if="route.params.format === 'structured'"
+            >
               <div
                 class="stack-with-borders"
                 data-testid="structured-view"
@@ -131,7 +135,9 @@
               </div>
             </template>
 
-            <template v-else-if="route.params.format === 'universal'">
+            <template
+              v-else-if="route.params.format === 'universal'"
+            >
               <ResourceCodeBlock
                 data-testid="codeblock-yaml-universal"
                 language="yaml"
@@ -147,7 +153,9 @@
               />
             </template>
 
-            <template v-else>
+            <template
+              v-else
+            >
               <DataLoader
                 :src="uri(sources, '/meshes/:mesh/mesh-service/:name/as/kubernetes', {
                   mesh: route.params.mesh,

--- a/packages/kuma-gui/src/app/services/views/MeshServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceDetailTabsView.vue
@@ -37,11 +37,15 @@
           },
         ]"
       >
-        <template #title>
+        <template
+          #title
+        >
           <h1
             v-if="data"
           >
-            <XCopyButton :text="route.params.service">
+            <XCopyButton
+              :text="route.params.service"
+            >
               <RouteTitle
                 :title="t('services.routes.item.title', { name: data.name })"
               />

--- a/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
@@ -15,18 +15,26 @@
     v-slot="{ can, route, t, uri, me }"
   >
     <AppView>
-      <XLayout type="stack">
+      <XLayout
+        type="stack"
+      >
         <XAboutCard
           :title="t('services.mesh-service.about.title')"
           :created="props.data.creationTime"
           :modified="props.data.modificationTime"
         >
-          <DefinitionCard layout="horizontal">
-            <template #title>
+          <DefinitionCard
+            layout="horizontal"
+          >
+            <template
+              #title
+            >
               {{ t('http.api.property.state') }}
             </template>
 
-            <template #body>
+            <template
+              #body
+            >
               <XBadge
                 :appearance="props.data.spec.state === 'Available' ? 'success' : 'danger'"
               >
@@ -38,12 +46,18 @@
             v-if="props.data.namespace.length > 0"
             layout="horizontal"
           >
-            <template #title>
+            <template
+              #title
+            >
               {{ t('http.api.property.namespace') }}
             </template>
 
-            <template #body>
-              <XBadge appearance="decorative">
+            <template
+              #body
+            >
+              <XBadge
+                appearance="decorative"
+              >
                 {{ props.data.namespace }}
               </XBadge>
             </template>
@@ -60,7 +74,9 @@
             <template
               #body
             >
-              <XBadge appearance="decorative">
+              <XBadge
+                appearance="decorative"
+              >
                 <XAction
                   :to="{
                     name: 'zone-cp-detail-view',
@@ -74,7 +90,9 @@
               </XBadge>
             </template>
           </DefinitionCard>
-          <DefinitionCard layout="horizontal">
+          <DefinitionCard
+            layout="horizontal"
+          >
             <template
               #title
             >
@@ -83,7 +101,9 @@
             <template
               #body
             >
-              <template v-if="props.data.spec.ports.length">
+              <template
+                v-if="props.data.spec.ports.length"
+              >
                 <KumaPort
                   v-for="connection in props.data.spec.ports"
                   :key="connection.port"
@@ -93,12 +113,16 @@
                   }"
                 />
               </template>
-              <template v-else>
+              <template
+                v-else
+              >
                 {{ t('common.detail.none') }}
               </template>
             </template>
           </DefinitionCard>
-          <DefinitionCard layout="horizontal">
+          <DefinitionCard
+            layout="horizontal"
+          >
             <template
               #title
             >
@@ -107,7 +131,9 @@
             <template
               #body
             >
-              <template v-if="Object.keys(props.data.spec.selector.dataplaneTags).length">
+              <template
+                v-if="Object.keys(props.data.spec.selector.dataplaneTags).length"
+              >
                 <XBadge
                   v-for="(value, key) in props.data.spec.selector.dataplaneTags"
                   :key="`${key}:${value}`"
@@ -116,7 +142,9 @@
                   {{ key }}:{{ value }}
                 </XBadge>
               </template>
-              <template v-else>
+              <template
+                v-else
+              >
                 {{ t('common.detail.none') }}
               </template>
             </template>
@@ -124,7 +152,9 @@
         </XAboutCard>
 
         <XCard>
-          <template #title>
+          <template
+            #title
+          >
             {{ t('services.detail.hostnames.title') }}
           </template>
 
@@ -135,7 +165,9 @@
               serviceName: route.params.service,
             })"
           >
-            <template #loadable="{ data: hostnames }">
+            <template
+              #loadable="{ data: hostnames }"
+            >
               <DataCollection
                 type="hostnames"
                 :items="hostnames?.items ?? [undefined]"
@@ -150,15 +182,21 @@
                   ]"
                   @resize="me.set"
                 >
-                  <template #hostname="{ row: item }">
+                  <template
+                    #hostname="{ row: item }"
+                  >
                     <b>
                       <XCopyButton
                         :text="item.hostname"
                       />
                     </b>
                   </template>
-                  <template #zones="{ row: item }">
-                    <XLayout type="separated">
+                  <template
+                    #zones="{ row: item }"
+                  >
+                    <XLayout
+                      type="separated"
+                    >
                       <XBadge
                         v-for="(zone, index) of item.zones"
                         :key="index"
@@ -184,7 +222,9 @@
         </XCard>
 
         <XCard>
-          <template #title>
+          <template
+            #title
+          >
             {{ t('services.detail.dpp-status.title') }}
           </template>
 
@@ -197,10 +237,16 @@
               :online="props.data.status.dataplaneProxies.connected"
               data-testid="connected-dpps"
             >
-              <template #icon>
-                <XIcon name="connected" />
+              <template
+                #icon
+              >
+                <XIcon
+                  name="connected"
+                />
               </template>
-              <template #title>
+              <template
+                #title
+              >
                 {{ t('services.detail.dpp-status.connected') }}
               </template>
             </ResourceStatus>
@@ -209,10 +255,16 @@
               :total="props.data.status.dataplaneProxies.healthy"
               data-testid="healthy-dpps"
             >
-              <template #icon>
-                <XIcon name="health" />
+              <template
+                #icon
+              >
+                <XIcon
+                  name="health"
+                />
               </template>
-              <template #title>
+              <template
+                #title
+              >
                 {{ t('services.detail.dpp-status.healthy') }}
               </template>
             </ResourceStatus>
@@ -223,7 +275,9 @@
           <XCard
             class="mt-4"
           >
-            <template #title>
+            <template
+              #title
+            >
               {{ t('services.detail.data_plane_proxies') }}
             </template>
             <search>
@@ -284,7 +338,9 @@
                     :is-selected-row="(row) => row.name === route.params.proxy"
                     @resize="me.set"
                   >
-                    <template #name="{ row: item }">
+                    <template
+                      #name="{ row: item }"
+                    >
                       <XAction
                         class="name-link"
                         :to="{
@@ -305,11 +361,15 @@
                       </XAction>
                     </template>
 
-                    <template #namespace="{ row: item }">
+                    <template
+                      #namespace="{ row: item }"
+                    >
                       {{ item.namespace }}
                     </template>
 
-                    <template #zone="{ row }">
+                    <template
+                      #zone="{ row }"
+                    >
                       <XAction
                         v-if="row.zone"
                         :to="{
@@ -322,48 +382,70 @@
                         {{ row.zone }}
                       </XAction>
 
-                      <template v-else>
+                      <template
+                        v-else
+                      >
                         {{ t('common.collection.none') }}
                       </template>
                     </template>
 
-                    <template #certificate="{ row }">
-                      <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                    <template
+                      #certificate="{ row }"
+                    >
+                      <template
+                        v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime"
+                      >
                         {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
                       </template>
 
-                      <template v-else>
+                      <template
+                        v-else
+                      >
                         {{ t('data-planes.components.data-plane-list.certificate.none') }}
                       </template>
                     </template>
 
-                    <template #status="{ row }">
-                      <StatusBadge :status="row.status" />
+                    <template
+                      #status="{ row }"
+                    >
+                      <StatusBadge
+                        :status="row.status"
+                      />
                     </template>
 
-                    <template #warnings="{ row }">
+                    <template
+                      #warnings="{ row }"
+                    >
                       <XIcon
                         v-if="row.isCertExpired || row.warnings.length > 0"
                         class="mr-1"
                         name="warning"
                       >
                         <ul>
-                          <template v-if="row.warnings.length > 0">
+                          <template
+                            v-if="row.warnings.length > 0"
+                          >
                             <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
                           </template>
 
-                          <template v-if="row.isCertExpired">
+                          <template
+                            v-if="row.isCertExpired"
+                          >
                             <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
                           </template>
                         </ul>
                       </XIcon>
 
-                      <template v-else>
+                      <template
+                        v-else
+                      >
                         {{ t('common.collection.none') }}
                       </template>
                     </template>
 
-                    <template #actions="{ row: item }">
+                    <template
+                      #actions="{ row: item }"
+                    >
                       <XActionGroup>
                         <XAction
                           :to="{

--- a/packages/kuma-gui/src/app/services/views/MeshServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceListView.vue
@@ -51,7 +51,9 @@
                 :is-selected-row="(item) => item.name === route.params.service"
                 @resize="me.set"
               >
-                <template #name="{ row: item }">
+                <template
+                  #name="{ row: item }"
+                >
                   <XCopyButton
                     :text="item.name"
                   >
@@ -78,8 +80,12 @@
                 >
                   {{ item.namespace }}
                 </template>
-                <template #zone="{ row: item }">
-                  <template v-if="item.zone">
+                <template
+                  #zone="{ row: item }"
+                >
+                  <template
+                    v-if="item.zone"
+                  >
                     <XAction
                       :to="{
                         name: 'zone-cp-detail-view',
@@ -92,7 +98,9 @@
                     </XAction>
                   </template>
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.detail.none') }}
                   </template>
                 </template>
@@ -127,7 +135,9 @@
                     />
                   </XLayout>
                 </template>
-                <template #actions="{ row: item }">
+                <template
+                  #actions="{ row: item }"
+                >
                   <XActionGroup>
                     <XAction
                       :to="{

--- a/packages/kuma-gui/src/app/services/views/MeshServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceSummaryView.vue
@@ -74,7 +74,9 @@
                 </div>
               </XLayout>
             </header>
-            <template v-if="route.params.format === 'structured'">
+            <template
+              v-if="route.params.format === 'structured'"
+            >
               <div
                 class="stack-with-borders"
                 data-testid="structured-view"
@@ -176,7 +178,9 @@
                     </XLayout>
                   </template>
                 </DefinitionCard>
-                <DefinitionCard layout="horizontal">
+                <DefinitionCard
+                  layout="horizontal"
+                >
                   <template
                     #title
                   >
@@ -202,7 +206,9 @@
               </div>
             </template>
             
-            <template v-else-if="route.params.format === 'universal'">
+            <template
+              v-else-if="route.params.format === 'universal'"
+            >
               <ResourceCodeBlock
                 data-testid="codeblock-yaml-universal"
                 language="yaml"
@@ -218,7 +224,9 @@
               />
             </template>
 
-            <template v-else>
+            <template
+              v-else
+            >
               <DataLoader
                 :src="uri(sources, '/meshes/:mesh/mesh-service/:name/as/kubernetes', {
                   mesh: route.params.mesh,

--- a/packages/kuma-gui/src/app/services/views/ServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceDetailTabsView.vue
@@ -30,9 +30,13 @@
         },
       ]"
     >
-      <template #title>
+      <template
+        #title
+      >
         <h1>
-          <XCopyButton :text="route.params.service">
+          <XCopyButton
+            :text="route.params.service"
+          >
             <RouteTitle
               :title="t('services.routes.item.title', { name: route.params.service })"
             />

--- a/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
@@ -30,23 +30,39 @@
             :created="data.creationTime"
             :modified="data.modificationTime"
           >
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('http.api.property.status') }}
               </template>
 
-              <template #body>
-                <StatusBadge :status="data.status" />
+              <template
+                #body
+              >
+                <StatusBadge
+                  :status="data.status"
+                />
               </template>
             </DefinitionCard>
 
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('http.api.property.address') }}
               </template>
 
-              <template #body>
-                <template v-if="data.addressPort">
+              <template
+                #body
+              >
+                <template
+                  v-if="data.addressPort"
+                >
                   <XCopyButton
                     variant="badge"
                     format="default"
@@ -54,7 +70,9 @@
                   />
                 </template>
 
-                <template v-else>
+                <template
+                  v-else
+                >
                   {{ t('common.detail.none') }}
                 </template>
               </template>
@@ -65,7 +83,9 @@
               :online="data.dataplanes?.online ?? 0"
               :total="data.dataplanes?.total ?? 0"
             >
-              <template #title>
+              <template
+                #title
+              >
                 {{ t('http.api.property.dataPlaneProxies') }}
               </template>
             </ResourceStatus>
@@ -73,7 +93,9 @@
         </DataLoader>
 
         <XCard>
-          <template #title>
+          <template
+            #title
+          >
             <h3>{{ t('services.detail.data_plane_proxies') }}</h3>
           </template>
 
@@ -131,7 +153,9 @@
                   :is-selected-row="(row) => row.name === route.params.proxy"
                   @resize="me.set"
                 >
-                  <template #name="{ row: item }">
+                  <template
+                    #name="{ row: item }"
+                  >
                     <XAction
                       data-action
                       class="name-link"
@@ -152,11 +176,15 @@
                     </XAction>
                   </template>
 
-                  <template #namespace="{ row: item }">
+                  <template
+                    #namespace="{ row: item }"
+                  >
                     {{ item.namespace }}
                   </template>
 
-                  <template #zone="{ row }">
+                  <template
+                    #zone="{ row }"
+                  >
                     <XAction
                       v-if="row.zone"
                       :to="{
@@ -169,48 +197,70 @@
                       {{ row.zone }}
                     </XAction>
 
-                    <template v-else>
+                    <template
+                      v-else
+                    >
                       {{ t('common.collection.none') }}
                     </template>
                   </template>
 
-                  <template #certificate="{ row }">
-                    <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
+                  <template
+                    #certificate="{ row }"
+                  >
+                    <template
+                      v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime"
+                    >
                       {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
                     </template>
 
-                    <template v-else>
+                    <template
+                      v-else
+                    >
                       {{ t('data-planes.components.data-plane-list.certificate.none') }}
                     </template>
                   </template>
 
-                  <template #status="{ row }">
-                    <StatusBadge :status="row.status" />
+                  <template
+                    #status="{ row }"
+                  >
+                    <StatusBadge
+                      :status="row.status"
+                    />
                   </template>
 
-                  <template #warnings="{ row }">
+                  <template
+                    #warnings="{ row }"
+                  >
                     <XIcon
                       v-if="row.isCertExpired || row.warnings.length > 0"
                       class="mr-1"
                       name="warning"
                     >
                       <ul>
-                        <template v-if="row.warnings.length > 0">
+                        <template
+                          v-if="row.warnings.length > 0"
+                        >
                           <li>{{ t('data-planes.components.data-plane-list.version_mismatch') }}</li>
                         </template>
 
-                        <template v-if="row.isCertExpired">
+                        <template
+                          v-if="row.isCertExpired"
+                        >
                           <li>{{ t('data-planes.components.data-plane-list.cert_expired') }}</li>
                         </template>
                       </ul>
                     </XIcon>
 
-                    <template v-else>
+                    <template
+                      v-else
+                    >
                       {{ t('common.collection.none') }}
                     </template>
                   </template>
 
-                  <template #actions="{ row: item }">
+                  <template
+                    #actions="{ row: item }"
+                  >
                     <XActionGroup>
                       <XAction
                         :to="{

--- a/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceListTabsView.vue
@@ -10,7 +10,9 @@
       class="stack"
     >
       <AppView>
-        <template #actions>
+        <template
+          #actions
+        >
           <XActionGroup
             :expanded="true"
           >

--- a/packages/kuma-gui/src/app/services/views/ServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceListView.vue
@@ -51,8 +51,12 @@
                 :is-selected-row="(row) => row.name === route.params.service"
                 @resize="me.set"
               >
-                <template #name="{ row: item }">
-                  <XCopyButton :text="item.name">
+                <template
+                  #name="{ row: item }"
+                >
+                  <XCopyButton
+                    :text="item.name"
+                  >
                     <XAction
                       data-action
                       :to="{
@@ -72,18 +76,24 @@
                   </XCopyButton>
                 </template>
 
-                <template #addressPort="{ row }">
+                <template
+                  #addressPort="{ row }"
+                >
                   <XCopyButton
                     v-if="row.addressPort"
                     :text="row.addressPort"
                   />
 
-                  <template v-else>
+                  <template
+                    v-else
+                  >
                     {{ t('common.collection.none') }}
                   </template>
                 </template>
 
-                <template #online="{ row: item }">
+                <template
+                  #online="{ row: item }"
+                >
                   <template
                     v-if="item.dataplanes"
                   >
@@ -96,11 +106,17 @@
                   </template>
                 </template>
 
-                <template #status="{ row: item }">
-                  <StatusBadge :status="item.status" />
+                <template
+                  #status="{ row: item }"
+                >
+                  <StatusBadge
+                    :status="item.status"
+                  />
                 </template>
 
-                <template #actions="{ row: item }">
+                <template
+                  #actions="{ row: item }"
+                >
                   <XActionGroup>
                     <XAction
                       :to="{

--- a/packages/kuma-gui/src/app/subscriptions/views/SubscriptionSummaryView.vue
+++ b/packages/kuma-gui/src/app/subscriptions/views/SubscriptionSummaryView.vue
@@ -18,7 +18,9 @@
         #item="{ item }"
       >
         <AppView>
-          <template #title>
+          <template
+            #title
+          >
             <h2>
               {{ item.zoneInstanceId ?? item.globalInstanceId ?? item.controlPlaneInstanceId }}
             </h2>
@@ -55,7 +57,9 @@
               </XLayout>
             </header>
 
-            <template v-if="route.params.output === 'structured'">
+            <template
+              v-if="route.params.output === 'structured'"
+            >
               <XLayout
                 type="stack"
                 data-testid="structured-view"
@@ -66,11 +70,15 @@
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('http.api.property.version') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       <template
                         v-for="version in [item.version?.kumaCp?.version]"
                       >
@@ -81,11 +89,15 @@
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('http.api.property.connectTime') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       {{ t('common.formats.datetime', { value: Date.parse(item.connectTime ?? '') }) }}
                     </template>
                   </DefinitionCard>
@@ -93,22 +105,30 @@
                     v-if="item.disconnectTime"
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('http.api.property.disconnectTime') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       {{ t('common.formats.datetime', { value: Date.parse(item.disconnectTime) }) }}
                     </template>
                   </DefinitionCard>
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('subscriptions.routes.item.headers.responses') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       <template
                         v-for="responses in [item.status?.total ?? {}]"
                       >
@@ -124,11 +144,15 @@
                       v-if="item[prop]"
                       layout="horizontal"
                     >
-                      <template #title>
+                      <template
+                        #title
+                      >
                         {{ t(`http.api.property.${prop}`) }}
                       </template>
 
-                      <template #body>
+                      <template
+                        #body
+                      >
                         {{ item[prop] }}
                       </template>
                     </DefinitionCard>
@@ -136,11 +160,15 @@
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('http.api.property.id') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       {{ item.id }}
                     </template>
                   </DefinitionCard>
@@ -149,7 +177,9 @@
                   v-if="Object.keys(item.status.acknowledgements).length === 0"
                   variant="info"
                 >
-                  <template #icon>
+                  <template
+                    #icon
+                  >
                     <PortalIcon />
                   </template>
 
@@ -160,19 +190,25 @@
                   class="mt-8 stack-with-borders"
                 >
                   <div>
-                    <slot name="default" />
+                    <slot
+                      name="default"
+                    />
                   </div>
                   <DefinitionCard
                     class="mt-4"
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       <strong>
                         {{ t('subscriptions.routes.item.headers.type') }}
                       </strong>
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       {{ t('subscriptions.routes.item.headers.stat') }}
                     </template>
                   </DefinitionCard>
@@ -183,11 +219,15 @@
                     <DefinitionCard
                       layout="horizontal"
                     >
-                      <template #title>
+                      <template
+                        #title
+                      >
                         {{ t(`http.api.property.${key}`) }}
                       </template>
 
-                      <template #body>
+                      <template
+                        #body
+                      >
                         {{ _item.responsesSent }}/{{ _item.responsesAcknowledged }}
                       </template>
                     </DefinitionCard>
@@ -196,7 +236,9 @@
               </XLayout>
             </template>
 
-            <template v-else>
+            <template
+              v-else
+            >
               <XCodeBlock
                 language="yaml"
                 :code="YAML.stringify(item.$raw)"

--- a/packages/kuma-gui/src/app/x/components/x-action-group/XActionGroup.vue
+++ b/packages/kuma-gui/src/app/x/components/x-action-group/XActionGroup.vue
@@ -15,7 +15,9 @@
         }"
         width="auto"
       >
-        <template #default>
+        <template
+          #default
+        >
           <slot
             v-if="slots.control"
             name="control"
@@ -27,15 +29,21 @@
             appearance="tertiary"
             size="small"
           >
-            <XIcon name="more" />
+            <XIcon
+              name="more"
+            />
           </XAction>
         </template>
-        <template #items>
+        <template
+          #items
+        >
           <XProvider
             name="x-action-group"
             :service="props"
           >
-            <slot name="default" />
+            <slot
+              name="default"
+            />
           </XProvider>
         </template>
       </KDropdown>

--- a/packages/kuma-gui/src/app/x/components/x-action/XAction.vue
+++ b/packages/kuma-gui/src/app/x/components/x-action/XAction.vue
@@ -16,7 +16,9 @@
       :danger="props.appearance === 'danger' ? true : false"
       @click="emit('click')"
     >
-      <slot name="default" />
+      <slot
+        name="default"
+      />
     </KDropdownItem>
   </template>
   <template
@@ -40,7 +42,9 @@
           :name="props.action as ('create' | 'refresh' | 'progress')"
         />
       </template>
-      <slot name="default" />
+      <slot
+        name="default"
+      />
       <template
         v-if="['expand'].includes(props.action)"
       >
@@ -61,7 +65,9 @@
         query,
       }"
     >
-      <slot name="default" />
+      <slot
+        name="default"
+      />
     </RouterLink>
   </template>
 
@@ -119,7 +125,9 @@
       v-bind="$attrs"
       :for="props.for"
     >
-      <slot name="default" />
+      <slot
+        name="default"
+      />
     </label>
   </template>
   <template
@@ -140,7 +148,9 @@
           :name="props.action as ('create' | 'refresh' | 'progress')"
         />
       </template>
-      <slot name="default" />
+      <slot
+        name="default"
+      />
       <template
         v-if="['expand'].includes(props.action)"
       >
@@ -165,7 +175,9 @@
           :size="KUI_ICON_SIZE_40"
         />
       </template>
-      <span><slot name="default" /></span>
+      <span><slot
+        name="default"
+      /></span>
     </button>
   </template>
 </template>

--- a/packages/kuma-gui/src/app/x/components/x-alert/XAlert.vue
+++ b/packages/kuma-gui/src/app/x/components/x-alert/XAlert.vue
@@ -9,7 +9,9 @@
       :key="key"
       #[`${key}`]
     >
-      <slot :name="key" />
+      <slot
+        :name="key"
+      />
     </template>
   </KAlert>
 </template>

--- a/packages/kuma-gui/src/app/x/components/x-badge/XBadge.vue
+++ b/packages/kuma-gui/src/app/x/components/x-badge/XBadge.vue
@@ -2,7 +2,9 @@
   <KBadge
     :max-width="props.maxWidth"
   >
-    <slot name="default" />
+    <slot
+      name="default"
+    />
   </KBadge>
 </template>
 

--- a/packages/kuma-gui/src/app/x/components/x-code-block/ResourceCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/ResourceCodeBlock.vue
@@ -11,7 +11,9 @@
     @filter-mode-change="emit('filter-mode-change', $event)"
     @reg-exp-mode-change="emit('reg-exp-mode-change', $event)"
   >
-    <template #secondary-actions>
+    <template
+      #secondary-actions
+    >
       <XDisclosure
         v-slot="{ expanded, toggle }"
       >
@@ -25,7 +27,9 @@
             }
           }"
         >
-          <XIcon name="copy" />{{ t('common.copyKubernetesShortText') }}
+          <XIcon
+            name="copy"
+          />{{ t('common.copyKubernetesShortText') }}
         </KCodeBlockIconButton>
         <XCopyButton
           format="hidden"

--- a/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
@@ -9,7 +9,9 @@
         type="separated"
         justify="end"
       >
-        <slot name="primary-actions" />
+        <slot
+          name="primary-actions"
+        />
       </XLayout>
     </template>
     <KCodeBlock
@@ -33,7 +35,9 @@
         v-if="slots['secondary-actions']"
         #secondary-actions
       >
-        <slot name="secondary-actions" />
+        <slot
+          name="secondary-actions"
+        />
       </template>
     </KCodeBlock>
   </XLayout>

--- a/packages/kuma-gui/src/app/x/components/x-empty-state/XEmptyState.vue
+++ b/packages/kuma-gui/src/app/x/components/x-empty-state/XEmptyState.vue
@@ -24,7 +24,9 @@
           appearance="secondary"
           data-testid="empty-block"
         >
-          <template #image>
+          <template
+            #image
+          >
             <slot
               v-if="slots.icon"
               name="icon"
@@ -39,14 +41,18 @@
                 :size="KUI_ICON_SIZE_50"
               />
             </div>
-            <AnalyticsIcon v-else />
+            <AnalyticsIcon
+              v-else
+            />
           </template>
           <template
             v-if="title.length"
             #title
           >
             <header>
-              <h2 class="x-empty-state-title">
+              <h2
+                class="x-empty-state-title"
+              >
                 <XI18n
                   :path="`${prefix}x-growth-empty-state.title`"
                   default-path="components.x-empty-state.title"
@@ -73,7 +79,9 @@
           <template
             #actions
           >
-            <slot name="action">
+            <slot
+              name="action"
+            >
               <XTeleportSlot
                 :name="`${props.type}-x-empty-state-actions`"
               />
@@ -101,7 +109,9 @@
           <template
             #icon
           >
-            <slot name="icon" />
+            <slot
+              name="icon"
+            />
           </template>
           <template
             #title
@@ -127,7 +137,9 @@
           <template
             v-if="slots.default"
           >
-            <slot name="default" />
+            <slot
+              name="default"
+            />
           </template>
           <template
             v-else-if="body.length > 0"
@@ -141,7 +153,9 @@
           <template
             #action
           >
-            <slot name="action">
+            <slot
+              name="action"
+            >
               <XTeleportSlot
                 :name="`${props.type}-x-empty-state-actions`"
               />

--- a/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
+++ b/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
@@ -15,7 +15,9 @@
       :class="`x-icon-icon x-icon-${props.name}-icon`"
     />
 
-    <template #content>
+    <template
+      #content
+    >
       <div
         :id="id"
       >

--- a/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
+++ b/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
@@ -3,7 +3,9 @@
     :is="props.type === 'separated' && props.truncate ? KTruncate : 'div'"
     :class="['x-layout', props.type, props.size, props.justify]"
   >
-    <slot name="default" />
+    <slot
+      name="default"
+    />
   </component>
 </template>
 <script lang="ts" setup>

--- a/packages/kuma-gui/src/app/x/components/x-modal/XModal.vue
+++ b/packages/kuma-gui/src/app/x/components/x-modal/XModal.vue
@@ -7,7 +7,9 @@
       :key="key"
       #[`${key}`]
     >
-      <slot :name="key" />
+      <slot
+        :name="key"
+      />
     </template>
   </KModal>
 </template>

--- a/packages/kuma-gui/src/app/x/components/x-notification/XNotification.vue
+++ b/packages/kuma-gui/src/app/x/components/x-notification/XNotification.vue
@@ -6,7 +6,9 @@
       v-if="slots.default"
       :to="{ name: `${provider.uri}-${props.uri}` }"
     >
-      <slot name="default" />
+      <slot
+        name="default"
+      />
     </XTeleportTemplate>
     <XTeleportSlot
       v-else

--- a/packages/kuma-gui/src/app/x/components/x-progress/XProgress.vue
+++ b/packages/kuma-gui/src/app/x/components/x-progress/XProgress.vue
@@ -3,7 +3,9 @@
     v-if="props.variant === 'legacy'"
     data-testid="loading-block"
   >
-    <template #icon>
+    <template
+      #icon
+    >
       <XIcon
         class="mb-3"
         name="progress"
@@ -11,7 +13,9 @@
       />
     </template>
 
-    <template #title>
+    <template
+      #title
+    >
       Loading data …
     </template>
   </KEmptyState>

--- a/packages/kuma-gui/src/app/x/components/x-prompt/XPrompt.vue
+++ b/packages/kuma-gui/src/app/x/components/x-prompt/XPrompt.vue
@@ -10,10 +10,14 @@
     <template
       #title
     >
-      <slot name="title" />
+      <slot
+        name="title"
+      />
     </template>
 
-    <slot name="default" />
+    <slot
+      name="default"
+    />
   </KPrompt>
 </template>
 <script lang="ts" setup>

--- a/packages/kuma-gui/src/app/x/components/x-provider/XProvider.vue
+++ b/packages/kuma-gui/src/app/x/components/x-provider/XProvider.vue
@@ -1,5 +1,7 @@
 <template>
-  <slot name="default" />
+  <slot
+    name="default"
+  />
 </template>
 <script lang="ts" setup>
 import { provide } from 'vue'

--- a/packages/kuma-gui/src/app/x/components/x-select/XSelect.vue
+++ b/packages/kuma-gui/src/app/x/components/x-select/XSelect.vue
@@ -19,8 +19,12 @@
         :name="`${item?.value}-option`"
       />
     </template>
-    <template #item-template="{ item }: any">
-      <slot :name="`${item.value}-option`" />
+    <template
+      #item-template="{ item }: any"
+    >
+      <slot
+        :name="`${item.value}-option`"
+      />
     </template>
   </KSelect>
 </template>

--- a/packages/kuma-gui/src/app/x/components/x-teleport/XTeleportTemplate.vue
+++ b/packages/kuma-gui/src/app/x/components/x-teleport/XTeleportTemplate.vue
@@ -3,7 +3,9 @@
     v-if="ready"
     :to="`[data-x-teleport-id='${props.to.name}']`"
   >
-    <slot name="default" />
+    <slot
+      name="default"
+    />
   </Teleport>
 </template>
 <script lang="ts" setup>

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailTabsView.vue
@@ -50,7 +50,9 @@
           <h1
             v-if="data"
           >
-            <XCopyButton :text="data.name">
+            <XCopyButton
+              :text="data.name"
+            >
               <RouteTitle
                 :title="t('zone-egresses.routes.item.title', { name: data.name })"
               />
@@ -197,7 +199,9 @@
             </template>
           </XTabs>
 
-          <RouterView v-slot="child">
+          <RouterView
+            v-slot="child"
+          >
             <component
               :is="child.Component"
               :networking="data?.zoneEgress.networking"

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
@@ -9,19 +9,29 @@
     v-slot="{ t, route, me, uri }"
   >
     <AppView>
-      <XLayout type="stack">
+      <XLayout
+        type="stack"
+      >
         <XAboutCard
           :title="t('zone-egresses.routes.item.about.title')"
           :created="props.data.creationTime"
           :modified="props.data.modificationTime"
         >
-          <DefinitionCard layout="horizontal">
-            <template #title>
+          <DefinitionCard
+            layout="horizontal"
+          >
+            <template
+              #title
+            >
               {{ t('http.api.property.status') }}
             </template>
 
-            <template #body>
-              <StatusBadge :status="props.data.state" />
+            <template
+              #body
+            >
+              <StatusBadge
+                :status="props.data.state"
+              />
             </template>
           </DefinitionCard>
 
@@ -29,23 +39,35 @@
             v-if="props.data.namespace.length > 0"
             layout="horizontal"
           >
-            <template #title>
+            <template
+              #title
+            >
               {{ t('http.api.property.namespace') }}
             </template>
 
-            <template #body>
-              <XBadge appearance="decorative">
+            <template
+              #body
+            >
+              <XBadge
+                appearance="decorative"
+              >
                 {{ props.data.namespace }}
               </XBadge>
             </template>
           </DefinitionCard>
 
-          <DefinitionCard layout="horizontal">
-            <template #title>
+          <DefinitionCard
+            layout="horizontal"
+          >
+            <template
+              #title
+            >
               {{ t('http.api.property.address') }}
             </template>
 
-            <template #body>
+            <template
+              #body
+            >
               <XCopyButton
                 v-if="props.data.zoneEgress.socketAddress.length > 0"
                 variant="badge"
@@ -53,7 +75,9 @@
                 :text="props.data.zoneEgress.socketAddress"
               />
 
-              <template v-else>
+              <template
+                v-else
+              >
                 {{ t('common.detail.none') }}
               </template>
             </template>
@@ -119,7 +143,9 @@
                     data-testid="dataplane-outbounds-inactive-toggle"
                     @change="(value) => route.update({ inactive: value})"
                   >
-                    <template #label>
+                    <template
+                      #label
+                    >
                       Show inactive
                     </template>
                   </XInputSwitch>
@@ -226,7 +252,9 @@
         <XCard
           v-if="props.data.zoneEgressInsight.subscriptions.length > 0"
         >
-          <template #title>
+          <template
+            #title
+          >
             <h2>{{ t('zone-egresses.routes.item.subscriptions.title') }}</h2>
           </template>
         

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressListView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressListView.vue
@@ -64,7 +64,9 @@
               :is-selected-row="(row) => row.name === route.params.proxy"
               @resize="me.set"
             >
-              <template #name="{ row: item }">
+              <template
+                #name="{ row: item }"
+              >
                 <XAction
                   data-action
                   :to="{
@@ -83,23 +85,31 @@
                 </XAction>
               </template>
 
-              <template #socketAddress="{ row: item }">
+              <template
+                #socketAddress="{ row: item }"
+              >
                 <XCopyButton
                   v-if="item.zoneEgress.socketAddress.length > 0"
                   :text="item.zoneEgress.socketAddress"
                 />
-                <template v-else>
+                <template
+                  v-else
+                >
                   {{ t('common.collection.none') }}
                 </template>
               </template>
 
-              <template #status="{ row: item }">
+              <template
+                #status="{ row: item }"
+              >
                 <StatusBadge
                   :status="item.state"
                 />
               </template>
 
-              <template #actions="{ row: item }">
+              <template
+                #actions="{ row: item }"
+              >
                 <XActionGroup>
                   <XAction
                     :to="{

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
@@ -15,9 +15,13 @@
       :predicate="item => item.id === route.params.proxy"
       :find="true"
     >
-      <template #empty>
+      <template
+        #empty
+      >
         <XEmptyState>
-          <template #title>
+          <template
+            #title
+          >
             <h2>
               {{ t('common.collection.summary.empty_title', { type: 'ZoneEgress' }) }}
             </h2>
@@ -36,7 +40,9 @@
           :key="item.id"
         >
           <AppView>
-            <template #title>
+            <template
+              #title
+            >
               <h2>
                 <XAction
                   :to="{
@@ -90,7 +96,9 @@
                 </XLayout>
               </header>
 
-              <template v-if="route.params.format === 'structured'">
+              <template
+                v-if="route.params.format === 'structured'"
+              >
                 <XLayout
                   type="stack"
                   class="stack-with-borders"
@@ -99,11 +107,15 @@
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('http.api.property.status') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       <StatusBadge
                         :status="item.state"
                       />
@@ -114,11 +126,15 @@
                     v-if="item.namespace.length > 0"
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('data-planes.routes.item.namespace') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       {{ item.namespace }}
                     </template>
                   </DefinitionCard>
@@ -126,11 +142,15 @@
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('http.api.property.address') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       <template
                         v-if="item.zoneEgress.socketAddress.length > 0"
                       >
@@ -139,7 +159,9 @@
                         />
                       </template>
 
-                      <template v-else>
+                      <template
+                        v-else
+                      >
                         {{ t('common.detail.none') }}
                       </template>
                     </template>
@@ -147,7 +169,9 @@
                 </XLayout>
               </template>
 
-              <template v-else-if="route.params.format === 'universal'">
+              <template
+                v-else-if="route.params.format === 'universal'"
+              >
                 <ResourceCodeBlock
                   data-testid="codeblock-yaml-universal"
                   language="yaml"
@@ -163,7 +187,9 @@
                 />
               </template>
 
-              <template v-else>
+              <template
+                v-else
+              >
                 <DataLoader
                   :src="uri(sources, '/zone-egresses/:name/as/kubernetes', {
                     name: route.params.proxy,

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailTabsView.vue
@@ -197,7 +197,9 @@
             </template>
           </XTabs>
 
-          <RouterView v-slot="child">
+          <RouterView
+            v-slot="child"
+          >
             <component
               :is="child.Component"
               :networking="data?.zoneIngress.networking"

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -14,12 +14,18 @@
         :created="props.data.creationTime"
         :modified="props.data.modificationTime"
       >
-        <DefinitionCard layout="horizontal">
-          <template #title>
+        <DefinitionCard
+          layout="horizontal"
+        >
+          <template
+            #title
+          >
             {{ t('http.api.property.status') }}
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <StatusBadge
               :status="props.data.state"
             />
@@ -30,23 +36,35 @@
           v-if="props.data.namespace.length > 0"
           layout="horizontal"
         >
-          <template #title>
+          <template
+            #title
+          >
             {{ t('http.api.property.namespace') }}
           </template>
 
-          <template #body>
-            <XBadge appearance="decorative">
+          <template
+            #body
+          >
+            <XBadge
+              appearance="decorative"
+            >
               {{ props.data.namespace }}
             </XBadge>
           </template>
         </DefinitionCard>
 
-        <DefinitionCard layout="horizontal">
-          <template #title>
+        <DefinitionCard
+          layout="horizontal"
+        >
+          <template
+            #title
+          >
             {{ t('http.api.property.address') }}
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <template
               v-if="props.data.zoneIngress.socketAddress.length > 0"
             >
@@ -57,29 +75,41 @@
               />
             </template>
 
-            <template v-else>
+            <template
+              v-else
+            >
               {{ t('common.detail.none') }}
             </template>
           </template>
         </DefinitionCard>
 
-        <DefinitionCard layout="horizontal">
-          <template #title>
+        <DefinitionCard
+          layout="horizontal"
+        >
+          <template
+            #title
+          >
             {{ t('http.api.property.advertisedAddress') }}
           </template>
 
-          <template #body>
+          <template
+            #body
+          >
             <template
               v-if="props.data.zoneIngress.advertisedSocketAddress.length > 0"
             >
-              <XBadge appearance="decorative">
+              <XBadge
+                appearance="decorative"
+              >
                 <XCopyButton
                   :text="props.data.zoneIngress.advertisedSocketAddress"
                 />
               </XBadge>
             </template>
 
-            <template v-else>
+            <template
+              v-else
+            >
               {{ t('common.detail.none') }}
             </template>
           </template>
@@ -145,7 +175,9 @@
                   data-testid="dataplane-outbounds-inactive-toggle"
                   @change="(value) => route.update({ inactive: value})"
                 >
-                  <template #label>
+                  <template
+                    #label
+                  >
                     Show inactive
                   </template>
                 </XInputSwitch>
@@ -257,7 +289,9 @@
       <XCard
         v-if="props.data.zoneIngressInsight.subscriptions.length > 0"
       >
-        <template #title>
+        <template
+          #title
+        >
           <h2>{{ t('zone-ingresses.routes.item.subscriptions.title') }}</h2>
         </template>
         

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressListView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressListView.vue
@@ -53,7 +53,9 @@
               :is-selected-row="(row) => row.name === route.params.proxy"
               @resize="me.set"
             >
-              <template #name="{ row: item }">
+              <template
+                #name="{ row: item }"
+              >
                 <XAction
                   data-action
                   :to="{
@@ -73,33 +75,45 @@
                 </XAction>
               </template>
 
-              <template #socketAddress="{ row: item }">
+              <template
+                #socketAddress="{ row: item }"
+              >
                 <XCopyButton
                   v-if="item.zoneIngress.socketAddress.length > 0"
                   :text="item.zoneIngress.socketAddress"
                 />
-                <template v-else>
+                <template
+                  v-else
+                >
                   {{ t('common.collection.none') }}
                 </template>
               </template>
 
-              <template #advertisedSocketAddress="{ row: item }">
+              <template
+                #advertisedSocketAddress="{ row: item }"
+              >
                 <XCopyButton
                   v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
                   :text="item.zoneIngress.advertisedSocketAddress"
                 />
-                <template v-else>
+                <template
+                  v-else
+                >
                   {{ t('common.collection.none') }}
                 </template>
               </template>
 
-              <template #status="{ row: item }">
+              <template
+                #status="{ row: item }"
+              >
                 <StatusBadge
                   :status="item.state"
                 />
               </template>
 
-              <template #actions="{ row: item }">
+              <template
+                #actions="{ row: item }"
+              >
                 <XActionGroup>
                   <XAction
                     :to="{

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
@@ -25,7 +25,9 @@
             ]"
             :items="props.data.zoneIngress.availableServices"
           >
-            <template #name="{ row: item }">
+            <template
+              #name="{ row: item }"
+            >
               <XAction
                 :to="{
                   name: 'service-detail-view',
@@ -39,7 +41,9 @@
               </XAction>
             </template>
 
-            <template #mesh="{ row: item }">
+            <template
+              #mesh="{ row: item }"
+            >
               <XAction
                 :to="{
                   name: 'mesh-detail-view',
@@ -52,15 +56,21 @@
               </XAction>
             </template>
 
-            <template #protocol="{ row: item }">
+            <template
+              #protocol="{ row: item }"
+            >
               {{ item.tags['kuma.io/protocol'] ?? t('common.collection.none') }}
             </template>
 
-            <template #instances="{ row: item }">
+            <template
+              #instances="{ row: item }"
+            >
               {{ item.instances }}
             </template>
 
-            <template #actions="{ row: item }">
+            <template
+              #actions="{ row: item }"
+            >
               <XActionGroup>
                 <XAction
                   :to="{

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -15,9 +15,13 @@
       :predicate="item => item.id === route.params.proxy"
       :find="true"
     >
-      <template #empty>
+      <template
+        #empty
+      >
         <XEmptyState>
-          <template #title>
+          <template
+            #title
+          >
             <h2>
               {{ t('common.collection.summary.empty_title', { type: 'ZoneIngress' }) }}
             </h2>
@@ -35,7 +39,9 @@
           :key="item.id"
         >
           <AppView>
-            <template #title>
+            <template
+              #title
+            >
               <h2>
                 <XAction
                   :to="{
@@ -88,7 +94,9 @@
                   </div>
                 </XLayout>
               </header>
-              <template v-if="route.params.format === 'structured'">
+              <template
+                v-if="route.params.format === 'structured'"
+              >
                 <div
                   class="stack-with-borders"
                   data-testid="structured-view"
@@ -96,11 +104,15 @@
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('http.api.property.status') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       <StatusBadge
                         :status="item.state"
                       />
@@ -111,11 +123,15 @@
                     v-if="item.namespace.length > 0"
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('data-planes.routes.item.namespace') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       {{ item.namespace }}
                     </template>
                   </DefinitionCard>
@@ -123,11 +139,15 @@
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('http.api.property.address') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       <template
                         v-if="item.zoneIngress.socketAddress.length > 0"
                       >
@@ -136,7 +156,9 @@
                         />
                       </template>
 
-                      <template v-else>
+                      <template
+                        v-else
+                      >
                         {{ t('common.detail.none') }}
                       </template>
                     </template>
@@ -145,11 +167,15 @@
                   <DefinitionCard
                     layout="horizontal"
                   >
-                    <template #title>
+                    <template
+                      #title
+                    >
                       {{ t('http.api.property.advertisedAddress') }}
                     </template>
 
-                    <template #body>
+                    <template
+                      #body
+                    >
                       <template
                         v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
                       >
@@ -158,7 +184,9 @@
                         />
                       </template>
 
-                      <template v-else>
+                      <template
+                        v-else
+                      >
                         {{ t('common.detail.none') }}
                       </template>
                     </template>
@@ -166,7 +194,9 @@
                 </div>
               </template>
 
-              <template v-else-if="route.params.format === 'universal'">
+              <template
+                v-else-if="route.params.format === 'universal'"
+              >
                 <ResourceCodeBlock
                   data-testid="codeblock-yaml-universal"
                   language="yaml"
@@ -182,7 +212,9 @@
                 />
               </template>
 
-              <template v-else>
+              <template
+                v-else
+              >
                 <DataLoader
                   :src="uri(sources, '/zone-ingresses/:name/as/kubernetes', {
                     name: route.params.proxy,

--- a/packages/kuma-gui/src/app/zones/components/ZoneControlPlanesList.vue
+++ b/packages/kuma-gui/src/app/zones/components/ZoneControlPlanesList.vue
@@ -33,7 +33,9 @@
             </XIcon>
           </template>
         </template>
-        <template #name="{ row: item }">
+        <template
+          #name="{ row: item }"
+        >
           <XAction
             data-action
             :to="{
@@ -47,7 +49,9 @@
           </XAction>
         </template>
 
-        <template #status="{ row: item }">
+        <template
+          #status="{ row: item }"
+        >
           <StatusBadge
             :status="item.state"
           />

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
@@ -21,9 +21,13 @@
           },
         ]"
       >
-        <template #title>
+        <template
+          #title
+        >
           <h1>
-            <XCopyButton :text="route.params.zone">
+            <XCopyButton
+              :text="route.params.zone"
+            >
               <RouteTitle
                 :title="t('zone-cps.routes.item.title', { name: route.params.zone })"
               />
@@ -112,7 +116,9 @@
           </template>
         </XTabs>
 
-        <RouterView v-slot="child">
+        <RouterView
+          v-slot="child"
+        >
           <component
             :is="child.Component"
             :data="data"

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -42,13 +42,21 @@
             :created="props.data.creationTime"
             :modified="props.data.modificationTime"
           >
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('http.api.property.status') }}
               </template>
 
-              <template #body>
-                <StatusBadge :status="props.data.state" />
+              <template
+                #body
+              >
+                <StatusBadge
+                  :status="props.data.state"
+                />
               </template>
             </DefinitionCard>
             <DefinitionCard
@@ -58,12 +66,18 @@
                 outdated: version?.outdated,
               }"
             >
-              <template #title>
+              <template
+                #title
+              >
                 {{ t('zone-cps.routes.item.version') }}
               </template>
 
-              <template #body>
-                <XLayout type="separated">
+              <template
+                #body
+              >
+                <XLayout
+                  type="separated"
+                >
                   <XBadge
                     :appearance="version?.outdated === true ? 'warning' : 'decorative'"
                   >
@@ -83,25 +97,41 @@
                 </XLayout>
               </template>
             </DefinitionCard>
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('http.api.property.type') }}
               </template>
 
-              <template #body>
-                <XBadge appearance="decorative">
+              <template
+                #body
+              >
+                <XBadge
+                  appearance="decorative"
+                >
                   {{ t(`common.product.environment.${props.data.zoneInsight.environment || 'unknown'}`) }}
                 </XBadge>
               </template>
             </DefinitionCard>
 
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <DefinitionCard
+              layout="horizontal"
+            >
+              <template
+                #title
+              >
                 {{ t('zone-cps.routes.item.authentication_type') }}
               </template>
 
-              <template #body>
-                <XBadge appearance="decorative">
+              <template
+                #body
+              >
+                <XBadge
+                  appearance="decorative"
+                >
                   {{ props.data.zoneInsight.authenticationType || t('common.not_applicable') }}
                 </XBadge>
               </template>
@@ -111,7 +141,9 @@
           <XCard
             v-if="props.data.zoneInsight.subscriptions.length > 0"
           >
-            <template #title>
+            <template
+              #title
+            >
               <h2>{{ t('zone-cps.detail.subscriptions') }}</h2>
             </template>
 

--- a/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
@@ -18,7 +18,9 @@
       <AppView
         :docs="data && data?.items?.length ? t('zones.href.docs.cta'): ''"
       >
-        <template #title>
+        <template
+          #title
+        >
           <h1>
             <RouteTitle
               :title="t('zone-cps.routes.items.title')"
@@ -99,7 +101,9 @@
                       </XIcon>
                     </template>
                   </template>
-                  <template #name="{ row: item }">
+                  <template
+                    #name="{ row: item }"
+                  >
                     <XAction
                       data-action
                       :to="{
@@ -117,11 +121,15 @@
                     </XAction>
                   </template>
 
-                  <template #zoneCpVersion="{ row: item }">
+                  <template
+                    #zoneCpVersion="{ row: item }"
+                  >
                     {{ get(item.zoneInsight, 'version.kumaCp.version', t('common.collection.none')) }}
                   </template>
 
-                  <template #ingress="{ row: item }">
+                  <template
+                    #ingress="{ row: item }"
+                  >
                     <template
                       v-for="proxies in [ingresses[item.name] || {online: [], offline: []}]"
                     >
@@ -129,7 +137,9 @@
                     </template>
                   </template>
 
-                  <template #egress="{ row: item }">
+                  <template
+                    #egress="{ row: item }"
+                  >
                     <template
                       v-for="proxies in [egresses[item.name] || {online: [], offline: []}]"
                     >
@@ -137,13 +147,17 @@
                     </template>
                   </template>
 
-                  <template #state="{ row: item }">
+                  <template
+                    #state="{ row: item }"
+                  >
                     <StatusBadge
                       :status="item.state"
                     />
                   </template>
 
-                  <template #warnings="{ row: item }">
+                  <template
+                    #warnings="{ row: item }"
+                  >
                     <XIcon
                       v-if="item.warnings.length > 0"
                       name="warning"
@@ -159,7 +173,9 @@
                         </li>
                       </ul>
                     </XIcon>
-                    <template v-else>
+                    <template
+                      v-else
+                    >
                       {{ t('common.collection.none') }}
                     </template>
                   </template>


### PR DESCRIPTION
Yep linting... 😆 

Whilst working on https://github.com/kumahq/kuma-gui/pull/3728 I noticed that our linting (maybe my IDE) was fiddling with where attributes are. It seems like the rule it is applying is:

- If its a single attribute keep it on the same line as the node
- If its more than one attribute, put them all on separate lines

^ This makes things inconsistent.

---

Moreover on a personal level, I very much prefer line-wise editing, its makes it so much easier to add and remove "settings", and this is probably the best reason for enforcing trailing commas everywhere for example.

All in all, I kinda don't care if the linter didn't mess with these at all, and we just add features, but the linter keeps fiddling with things and adding unrelated changes to PRs, so I decided to PR a rule so it stops doing this.

Happy to hear other opinions if this isn't preferred by others.
