### PR TITLE
chore(ci): reduce the majority of fake-api to a createFetch function

### DIFF
--- a/packages/fake-api/src/index.ts
+++ b/packages/fake-api/src/index.ts
@@ -1,7 +1,4 @@
-import deepmerge from 'deepmerge'
 import { URLPattern } from 'urlpattern-polyfill'
-
-import type { ArrayMergeOptions } from 'deepmerge'
 
 export type RestRequest = {
   method: string
@@ -17,9 +14,7 @@ export type MockResponse = {
 
 export type MockResponder = (req: RestRequest) => MockResponse
 
-type Merge = (obj: Partial<MockResponse>) => MockResponse
-
-export type Middleware = (request: RestRequest, response: MockResponse, merge: Merge) => MockResponse
+export type Middleware = (request: RestRequest, response: MockResponse) => MockResponse
 export type Options = Record<string, string>
 export type Mocker = (route: string, opts: Options, cb: Middleware) => void
 
@@ -34,34 +29,6 @@ export function escapeRoute(route: string): string {
   return route.replaceAll('+', '\\+')
 }
 
-// --begin
-// merges objects in array positions rather than replacing
-export const undefinedSymbol = Symbol('undefined')
-const combineMerge = (target: object[], source: object[], options: ArrayMergeOptions): object[] => {
-  const destination = target.slice()
-
-  source.forEach((item, index) => {
-    if (typeof destination[index] === 'undefined') {
-      destination[index] = options.cloneUnlessOtherwiseSpecified(item, options)
-    } else if (options.isMergeableObject(item)) {
-      destination[index] = deepmerge(target[index], item, options)
-    } else if (target.indexOf(item) === -1) {
-      destination.push(item)
-    }
-  })
-  return destination
-}
-
-export const createMerge = (response: MockResponse): Merge => (obj) => {
-  const merged = deepmerge(response, obj, { arrayMerge: combineMerge })
-  return JSON.parse(JSON.stringify(merged, (_key, value) => {
-    if (value === undefinedSymbol) {
-      return
-    }
-    return value
-  }))
-}
-// --end
 
 export class Router<T> {
   routes: Map<URLPattern, T> = new Map()

--- a/packages/fake-api/src/msw.ts
+++ b/packages/fake-api/src/msw.ts
@@ -1,84 +1,70 @@
 import { http, HttpResponse, passthrough } from 'msw'
 
-import { createMerge, escapeRoute } from './index.ts'
-import type { Callback, Dependencies, FS, MockEndpoint, MockResponse, Options, RestRequest } from './index.ts'
+import { escapeRoute, createFetch } from './index.ts'
+import type { Dependencies, FS, MockEndpoint } from './index.ts'
 
-const noop: Callback = (_merge, _req, response) => response
-
-export const useResponder = <TDependencies extends object = {}>(fs: FS, dependencies: Dependencies<TDependencies>) => {
-  return (route: string, opts: Options = {}, cb: Callback = noop) => {
-    const mockEnv = (key: string, d = '') => (opts[key] ?? '') || dependencies.env(key, d)
-    if (route !== '*') {
-      dependencies.fake.seed(typeof opts.FAKE_SEED !== 'undefined' ? parseInt(typeof opts.FAKE_SEED) : 1)
-    }
-    const endpoint = fs[route]
-    const fetch = endpoint({
-      ...dependencies,
-      env: mockEnv,
-    })
-    return async (req: RestRequest): Promise<MockResponse> => {
-      const _response = fetch(req)
-      const latency = parseInt(mockEnv('KUMA_LATENCY', '0'))
-      if (latency !== 0) {
-        await new Promise(resolve => setTimeout(resolve, latency))
-      }
-      return cb(createMerge(_response), req, _response)
-    }
-  }
-}
-
-export const server = <TDependencies extends object = {}, TEnvKeys extends string = string>(mock: MockEndpoint<TDependencies>, options: {
-  env?: Record<TEnvKeys, string>
-  params?: Record<string, string>
-}, dependencies: Dependencies<TDependencies>) => {
+export const server = <TDependencies extends object = {}>(
+  mock: MockEndpoint<TDependencies>,
+  options: {
+    params?: Record<string, string>
+  },
+  dependencies: Dependencies<TDependencies>,
+) => {
   return async (env: Record<string, string>) => {
-    const responder = useResponder({
-      _: mock,
-    }, {
-      ...dependencies,
-      env: (key: keyof typeof env, d = '') => env[key] ?? d,
-    })
-    const request = responder('_')
-    return (await request(
-      {
-        method: 'GET',
-        body: {},
-        url: {
-          searchParams: new URLSearchParams(),
-        },
-        params: options.params ?? {},
+
+    dependencies.env = (key: keyof typeof env, d = '') => {
+      return env[key] ?? d
+    }
+
+    const route = Object.keys(options.params ?? {}).reduce((prev, item) => {
+      return `${prev}:${item}/`
+    }, '/')
+    const path = Object.values(options.params ?? {}).reduce((prev, item) => {
+      return `${prev}${item}/`
+    }, 'http://localhost/')
+
+    const fetch = createFetch({
+      dependencies,
+      fs: {
+        [route]: mock,
       },
-    ))?.body
+    })
+    const response = await fetch(path, {
+      method: 'GET',
+    })
+    return response.json()
   }
 }
 
 export const handler = <TDependencies extends object = {}>(fs: FS, dependencies: Dependencies<TDependencies>) => {
   const baseUrl = dependencies.env('KUMA_API_URL')
-  const responder = useResponder(fs, dependencies)
+  const fetch = createFetch({
+    dependencies,
+    fs,
+  })
   return (route: string) => {
-    const respond = responder(route)
     const base = route.includes('://') ? '' : baseUrl
     if (route.startsWith('://')) {
       route = route.replace('://', '')
     }
-    return http.all(`${base}${escapeRoute(route)}`, async ({ request, params }) => {
-      const response = await respond({
-        method: request.method,
-        url: new URL(request.url),
-        body: request.body ? JSON.parse(await new Response(request.body).text() || '{}') : {},
-        params: Object.fromEntries(
-          Object.entries(params).filter(
-            (entry): entry is [string, string | readonly string[]] => typeof entry[1] !== 'undefined',
-          ),
-        ),
+    return http.all(`${base}${escapeRoute(route)}`, async ({ request: req }) => {
+      // headers can be string | string[] | undefined, not string
+      const headers = Object.entries(req.headers).reduce((prev, [key, item]) => {
+        if (typeof item !== 'undefined') {
+          prev[key] = Array.isArray(item) ? item[0] : item
+        }
+        return prev
+      }, {} as Record<string, string>)
+      const response = await fetch(`${req.url ?? ''}`, {
+        method: req.method,
+        headers,
+        body: req.body ? JSON.parse(await new Response(req.body).text() || '{}') : {},
       })
-
       if (typeof response === 'undefined') {
         return passthrough()
       }
-
-      return HttpResponse.json(response.body, {
-        status: parseInt(response.headers?.['Status-Code'] ?? '200'),
+      return HttpResponse.json((await response.json()), {
+        status: parseInt(response.headers?.get('Status-Code') ?? '200'),
       })
     })
   }

--- a/packages/kuma-gui/cypress/services.ts
+++ b/packages/kuma-gui/cypress/services.ts
@@ -5,7 +5,7 @@ import { token, ServiceDefinition, createInjections } from '@/services/utils'
 import type { EndpointDependencies } from '@/test-support'
 import { dependencies } from '@/test-support'
 import getClient from '@/test-support/client'
-import type { Callback, Options } from '@kumahq/fake-api'
+import type { Middleware, Options } from '@kumahq/fake-api'
 
 
 // this needs to come from testing
@@ -16,13 +16,11 @@ const env = (
 }
 type AEnv = ReturnType<typeof env>
 // temporary intercept returning Mocker
-type Mocker = (route: string, opts?: Options, cb?: Callback) => ReturnType<typeof cy['intercept']>
+type Mocker = (route: string, opts?: Options, cb?: Middleware) => ReturnType<typeof cy['intercept']>
 const $ = {
   EnvVars: token<EnvVars>('EnvVars'),
   env: token<AEnv>('env'),
 
-  cy: token<typeof cy>('cy'),
-  mockServer: token('mockServer'),
   mock: token<Mocker>('mocker'),
   Env: token('Env'),
   client: token<ReturnType<typeof getClient>>('client'),
@@ -51,27 +49,14 @@ export const services = <T extends Record<string, Token>>(app: T): ServiceDefini
     ],
   }],
 
-  [app.cy, {
-    constant: cy,
-  }],
   [$.client, {
     service: getClient,
-  }],
-  [app.mockServer, {
-    service: (mock: Mocker) => {
-      mock('*')
-    },
-    arguments: [
-      app.mock,
-    ],
   }],
   [app.mock, {
     service: mocker,
     arguments: [
-      app.cy,
-      app.fakeFS,
-      $.client,
       $.dependencies,
+      app.fakeFS,
     ],
   }],
   // this will eventually come from testing
@@ -86,6 +71,5 @@ export const services = <T extends Record<string, Token>>(app: T): ServiceDefini
 export const TOKENS = $
 export const [
   useMock,
-  useServer,
   useClient,
-] = createInjections($.mock, $.mockServer, $.client)
+] = createInjections($.mock, $.client)

--- a/packages/kuma-gui/cypress/support/step_definitions/index.ts
+++ b/packages/kuma-gui/cypress/support/step_definitions/index.ts
@@ -1,8 +1,36 @@
 import { When, Then, Before, Given, DataTable, After } from '@badeball/cypress-cucumber-preprocessor'
-import { undefinedSymbol } from '@kumahq/fake-api'
+import deepmerge from 'deepmerge'
 import jsYaml, { DEFAULT_SCHEMA, Type } from 'js-yaml'
 
 import { useMock, useClient } from '../../services'
+import type { ArrayMergeOptions } from 'deepmerge'
+
+// merges objects in array positions rather than replacing
+const undefinedSymbol = Symbol('undefined')
+const combineMerge = (target: object[], source: object[], options: ArrayMergeOptions): object[] => {
+  const destination = target.slice()
+
+  source.forEach((item, index) => {
+    if (typeof destination[index] === 'undefined') {
+      destination[index] = options.cloneUnlessOtherwiseSpecified(item, options)
+    } else if (options.isMergeableObject(item)) {
+      destination[index] = deepmerge(target[index], item, options)
+    } else if (target.indexOf(item) === -1) {
+      destination.push(item)
+    }
+  })
+  return destination
+}
+
+const merge = <T>(response: T, obj: Partial<T>): T => {
+  const merged = deepmerge<T>(response, obj, { arrayMerge: combineMerge })
+  return JSON.parse(JSON.stringify(merged, (_key, value) => {
+    if (value === undefinedSymbol) {
+      return
+    }
+    return value
+  }))
+}
 
 const console = {
   log: (message: unknown) => Cypress.log({ displayName: 'LOG', message: JSON.stringify(message) }),
@@ -102,7 +130,7 @@ Given('the URL {string} responds with', (url: string, yaml: string) => {
   // which mocks this specific url with the current env vars
   // records every request as a client.request
   // and merges any test case mock with the fake-fs mock
-  mock(url, env, (req, _response, mergeWithResponse) => {
+  mock(url, env, (req, response) => {
     // once the response has been rendered but not sent resolve any
     // waiting request assertions this means that any mocking done after
     // awaiting the request will happen on the subsequent request not this
@@ -114,13 +142,8 @@ Given('the URL {string} responds with', (url: string, yaml: string) => {
         body: req.body,
       },
     })
-
-    return mergeWithResponse(
-      (YAML.parse(yaml) || {}) as {
-        headers?: Record<string, string>
-        body?: Record<string, unknown>
-      },
-    )
+    // merge test mock in with fake-api mock
+    return merge(response, YAML.parse(yaml) ?? {})
   })
 })
 

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
@@ -53,6 +53,18 @@ Feature: Dataplane policies
                 hasToTargetRef: true
                 isFromAsRules: true
                 isTargetRef: true
+            - name: CircuitBreaker
+              path: circuit-breakers
+              singularDisplayName: Circuit Breaker
+              pluralDisplayname: Circuit Breakers
+              includeInFederation: true
+              readOnly: false
+              scope: Mesh
+              policy:
+                hasFromTargetRef: false
+                hasToTargetRef: false
+                isFromAsRules: false
+                isTargetRef: false
         """
   Rule: Any networking type
 

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
@@ -53,10 +53,10 @@ Feature: Dataplane policies
                 hasToTargetRef: true
                 isFromAsRules: true
                 isTargetRef: true
-            - name: CircuitBreaker
-              path: circuit-breakers
-              singularDisplayName: Circuit Breaker
-              pluralDisplayname: Circuit Breakers
+            - name: FaultInjection
+              path: fault-injections
+              singularDisplayName: Fault Injection
+              pluralDisplayname: Fault Injections
               includeInFederation: true
               readOnly: false
               scope: Mesh

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
@@ -22,6 +22,38 @@ Feature: Dataplane policies
       | inbound-rule-item-button           | $inbound-rule-item:nth-child(1) [data-testid='accordion-item-button'] |
       | summary-slideout-container         | [data-testid='summary'] [data-testid='slideout-container']            |
 
+      And the URL "/_resources" responds with
+        """
+        body:
+          resources:
+            - name: MeshHTTPRoute
+              policy:
+                isFromAsRules: true
+            - name: MeshProxyPatch
+              path: meshproxypatches
+              singularDisplayName: Mesh Proxy Patch
+              pluralDisplayname: Mesh Proxy Patches
+              includeInFederation: true
+              readOnly: false
+              scope: Mesh
+              policy:
+                hasFromTargetRef: false
+                hasToTargetRef: false
+                isFromAsRules: false
+                isTargetRef: false
+            - name: MeshTimeout
+              path: meshtimeouts
+              singularDisplayName: Mesh Timeout
+              pluralDisplayname: Mesh Timeouts
+              includeInFederation: true
+              readOnly: false
+              scope: Mesh
+              policy:
+                hasFromTargetRef: true
+                hasToTargetRef: true
+                isFromAsRules: true
+                isTargetRef: true
+        """
   Rule: Any networking type
 
     Scenario: Policies tab has expected content (MeshHTTPRoute with to rules)
@@ -238,35 +270,6 @@ Feature: Dataplane policies
         KUMA_DATAPLANE_TO_RULE_COUNT: 1
         KUMA_DATAPLANE_FROM_RULE_COUNT: 0
         """
-      And the URL "/_resources" responds with
-        """
-        body:
-          resources:
-            - name: MeshProxyPatch
-              path: meshproxypatches
-              singularDisplayName: Mesh Proxy Patch
-              pluralDisplayname: Mesh Proxy Patches
-              includeInFederation: true
-              readOnly: false
-              scope: Mesh
-              policy:
-                hasFromTargetRef: false
-                hasToTargetRef: false
-                isFromAsRules: false
-                isTargetRef: false
-            - name: MeshTimeout
-              path: meshtimeouts
-              singularDisplayName: Mesh Timeout
-              pluralDisplayname: Mesh Timeouts
-              includeInFederation: true
-              readOnly: false
-              scope: Mesh
-              policy:
-                hasFromTargetRef: true
-                hasToTargetRef: true
-                isFromAsRules: true
-                isTargetRef: true
-        """
       And the URL "/meshes/default/dataplanes/dataplane-1/_rules" responds with
         """
         body:
@@ -365,14 +368,6 @@ Feature: Dataplane policies
                     port: 8080
                     tags:
                       kuma.io/service: foo
-        """
-      And the URL "/_resources" responds with
-        """
-        body:
-          resources:
-            - name: MeshHTTPRoute
-              policy:
-                isFromAsRules: true
         """
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
       Then the "$to-rule-item-content" element doesn't exist

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
@@ -21,51 +21,10 @@ Feature: Dataplane policies
       | inbound-rule-item                  | [data-testid='inbound-rule-list-0'] .accordion-item                   |
       | inbound-rule-item-button           | $inbound-rule-item:nth-child(1) [data-testid='accordion-item-button'] |
       | summary-slideout-container         | [data-testid='summary'] [data-testid='slideout-container']            |
-
-      And the URL "/_resources" responds with
-        """
-        body:
-          resources:
-            - name: MeshHTTPRoute
-              policy:
-                isFromAsRules: true
-            - name: MeshProxyPatch
-              path: meshproxypatches
-              singularDisplayName: Mesh Proxy Patch
-              pluralDisplayname: Mesh Proxy Patches
-              includeInFederation: true
-              readOnly: false
-              scope: Mesh
-              policy:
-                hasFromTargetRef: false
-                hasToTargetRef: false
-                isFromAsRules: false
-                isTargetRef: false
-            - name: MeshTimeout
-              path: meshtimeouts
-              singularDisplayName: Mesh Timeout
-              pluralDisplayname: Mesh Timeouts
-              includeInFederation: true
-              readOnly: false
-              scope: Mesh
-              policy:
-                hasFromTargetRef: true
-                hasToTargetRef: true
-                isFromAsRules: true
-                isTargetRef: true
-            - name: FaultInjection
-              path: fault-injections
-              singularDisplayName: Fault Injection
-              pluralDisplayname: Fault Injections
-              includeInFederation: true
-              readOnly: false
-              scope: Mesh
-              policy:
-                hasFromTargetRef: false
-                hasToTargetRef: false
-                isFromAsRules: false
-                isTargetRef: false
-        """
+      And the environment
+      """
+        KUMA_RESOURCE_COUNT: 100
+      """
   Rule: Any networking type
 
     Scenario: Policies tab has expected content (MeshHTTPRoute with to rules)

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
@@ -238,6 +238,35 @@ Feature: Dataplane policies
         KUMA_DATAPLANE_TO_RULE_COUNT: 1
         KUMA_DATAPLANE_FROM_RULE_COUNT: 0
         """
+      And the URL "/_resources" responds with
+        """
+        body:
+          resources:
+            - name: MeshProxyPatch
+              path: meshproxypatches
+              singularDisplayName: Mesh Proxy Patch
+              pluralDisplayname: Mesh Proxy Patches
+              includeInFederation: true
+              readOnly: false
+              scope: Mesh
+              policy:
+                hasFromTargetRef: false
+                hasToTargetRef: false
+                isFromAsRules: false
+                isTargetRef: false
+            - name: MeshTimeout
+              path: meshtimeouts
+              singularDisplayName: Mesh Timeout
+              pluralDisplayname: Mesh Timeouts
+              includeInFederation: true
+              readOnly: false
+              scope: Mesh
+              policy:
+                hasFromTargetRef: true
+                hasToTargetRef: true
+                isFromAsRules: true
+                isTargetRef: true
+        """
       And the URL "/meshes/default/dataplanes/dataplane-1/_rules" responds with
         """
         body:

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -176,6 +176,9 @@
                     :predicate="(item) => policyTypes[item.type]?.policy.isTargetRef === false"
                     v-slot="{ items }"
                   >
+                    ==={{ policyTypes }}====<br>
+                    ===<br>
+                    ==={{ items }}====<br>
                     <h3>
                       {{ t('data-planes.routes.item.legacy_policies') }}
                     </h3>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -164,7 +164,6 @@
 
               <!-- anything but builtin gateways -->
               <template v-else>
-                ==={{ props.data.dataplaneType }}====
                 <DataLoader
                   :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.proxy}/sidecar-dataplane-policies`"
                   :data="[policyTypesData]"
@@ -172,9 +171,9 @@
                   v-slot="{ data: sidecarDataplaneData }: SidecarDataplaneCollectionSource"
                 >
                   <DataCollection
-                    :predicate="(item) => policyTypes[item.type]?.policy.isTargetRef === false"
-                    :items="sidecarDataplaneData!.policyTypeEntries"
                     :empty="false"
+                    :items="sidecarDataplaneData!.policyTypeEntries"
+                    :predicate="(item) => policyTypes[item.type]?.policy.isTargetRef === false"
                     v-slot="{ items }"
                   >
                     <h3>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -170,6 +170,7 @@
                   :errors="[policyTypesError]"
                   v-slot="{ data: sidecarDataplaneData }: SidecarDataplaneCollectionSource"
                 >
+                  ==={{ JSON.stringify(sidecarDataplaneData!.policyTypeEntries, null, 4) }}====
                   <DataCollection
                     :empty="false"
                     :items="sidecarDataplaneData!.policyTypeEntries"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -170,7 +170,6 @@
                   :errors="[policyTypesError]"
                   v-slot="{ data: sidecarDataplaneData }: SidecarDataplaneCollectionSource"
                 >
-                  ==={{ JSON.stringify(sidecarDataplaneData!.policyTypeEntries, null, 4) }}====
                   <DataCollection
                     :empty="false"
                     :items="sidecarDataplaneData!.policyTypeEntries"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -176,9 +176,6 @@
                     :predicate="(item) => policyTypes[item.type]?.policy.isTargetRef === false"
                     v-slot="{ items }"
                   >
-                    ==={{ policyTypes }}====<br>
-                    ===<br>
-                    ==={{ items }}====<br>
                     <h3>
                       {{ t('data-planes.routes.item.legacy_policies') }}
                     </h3>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -164,6 +164,7 @@
 
               <!-- anything but builtin gateways -->
               <template v-else>
+                ==={{ props.data.dataplaneType }}====
                 <DataLoader
                   :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.proxy}/sidecar-dataplane-policies`"
                   :data="[policyTypesData]"


### PR DESCRIPTION
Refactors some more of fake-api, mostly:

- Reduce everything down to a reusable `createFetch`/`createFetchSync`, that returns something that is very fetch-like (i.e. very recognisable). Note: `createFetchSync` is needed for Cypress which is notorious weird with async things.
- I moved the YAML/JSON merging we do for overwriting responses during tests out of fake-api entirely. If you aren't doing tests like we are then you wouldn't need this in order to build basic fake-apis.

Probably a few other little bits. Unfortunately the PR is a little large, if it was me I'd look at/compare this locally to get a better feel for the improvement here.

We are still not quite done here, but with what we did before extracting things out into its own module, and what is here, I'm far happier with this code now.