### PR TITLE
feat(x-search): add dropdown

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -30,7 +30,7 @@
           >
             <XSearch
               class="search-field"
-              placeholder="Filter by name, tag, zone or namespace..."
+              :keys="['name', 'tag', 'zone', 'namespace']"
               :value="route.params.s"
               @change="(s) => route.update({ page: 1, s })"
             />
@@ -307,7 +307,6 @@ import AppCollection from '@/app/application/components/app-collection/AppCollec
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
 import type { Mesh } from '@/app/meshes/data'
-
 const props = defineProps<{
   mesh: Mesh
 }>()
@@ -343,6 +342,10 @@ search {
 .search-field {
   flex-basis: 310px;
   flex-grow: 1;
+}
+
+.search-field {
+  flex: 1;
 }
 
 .name-link {

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -28,7 +28,7 @@
               >
                 <XSearch
                   class="search-field"
-                  placeholder="Filter by name, tag, zone or namespace..."
+                  :keys="['name', 'tag', 'zone', 'namespace']"
                   :value="route.params.s"
                   @change="(s) => route.update({ page: 1, s })"
                 />

--- a/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/DelegatedGatewayDetailView.vue
@@ -76,7 +76,7 @@
             >
               <XSearch
                 class="search-field"
-                placeholder="Filter by name, tag, zone or namespace..."
+                :keys="['name', 'tag', 'zone', 'namespace']"
                 :value="route.params.s"
                 @change="(s) => route.update({ page: 1, s })"
               />

--- a/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
@@ -243,7 +243,7 @@
               >
                 <XSearch
                   class="search-field"
-                  placeholder="Filter by name, tag, zone or namespace..."
+                  :keys="['name', 'tag', 'zone', 'namespace']"
                   :value="route.params.s"
                   @change="(s) => route.update({ page: 1, s })"
                 />

--- a/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
@@ -84,8 +84,9 @@
             >
               <XSearch
                 class="search-field"
-                placeholder="Filter by name, tag, zone or namespace..."
+                :keys="['name', 'tag', 'zone', 'namespace']"
                 :value="route.params.s"
+                name="s"
                 @change="(s) => route.update({ page: 1, s })"
               />
             </form>

--- a/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceDetailView.vue
@@ -86,7 +86,6 @@
                 class="search-field"
                 :keys="['name', 'tag', 'zone', 'namespace']"
                 :value="route.params.s"
-                name="s"
                 @change="(s) => route.update({ page: 1, s })"
               />
             </form>

--- a/packages/kuma-gui/src/app/x/components/x-i18n/XI18n.vue
+++ b/packages/kuma-gui/src/app/x/components/x-i18n/XI18n.vue
@@ -22,6 +22,7 @@
         v-if="slotName === 'default'"
         :name="slotName"
         :t="t"
+        :format-list="i18n.formatList"
       />
       <XTeleportTemplate
         v-else
@@ -29,6 +30,7 @@
       >
         <slot
           :t="t"
+          :format-list="i18n.formatList"
           :name="slotName"
         />
       </XTeleportTemplate>
@@ -40,6 +42,7 @@
     <slot
       name="default"
       :t="t"
+      :format-list="i18n.formatList"
     />
   </template>
 </template>

--- a/packages/kuma-gui/src/app/x/components/x-i18n/XI18n.vue
+++ b/packages/kuma-gui/src/app/x/components/x-i18n/XI18n.vue
@@ -2,9 +2,8 @@
   <template
     v-if="props.path.length > 0"
   >
-    <!-- eslint-disable vue/no-v-html, vue/no-v-html-on-component, vue/no-v-text-v-html-on-component -->
-    <component
-      :is="props.tag ?? 'div'"
+    <!-- eslint-disable vue/no-v-html -->
+    <div
       class="x-i18n"
       data-testid="x-i18n"
       v-bind="attrs"
@@ -64,14 +63,12 @@ const props = withDefaults(defineProps<{
   path?: string
   params?: Record<string, string>
   defaultPath?: string
-  tag?: 'span'
 }>(), {
   strings: undefined,
   prefix: '',
   path: '',
   params: () => ({}),
   defaultPath: undefined,
-  tag: undefined,
 })
 const slots = defineSlots()
 

--- a/packages/kuma-gui/src/app/x/components/x-i18n/XI18n.vue
+++ b/packages/kuma-gui/src/app/x/components/x-i18n/XI18n.vue
@@ -2,8 +2,9 @@
   <template
     v-if="props.path.length > 0"
   >
-    <!-- eslint-disable vue/no-v-html -->
-    <div
+    <!-- eslint-disable vue/no-v-html, vue/no-v-html-on-component, vue/no-v-text-v-html-on-component -->
+    <component
+      :is="props.tag ?? 'div'"
       class="x-i18n"
       data-testid="x-i18n"
       v-bind="attrs"
@@ -63,12 +64,14 @@ const props = withDefaults(defineProps<{
   path?: string
   params?: Record<string, string>
   defaultPath?: string
+  tag?: 'span'
 }>(), {
   strings: undefined,
   prefix: '',
   path: '',
   params: () => ({}),
   defaultPath: undefined,
+  tag: undefined,
 })
 const slots = defineSlots()
 

--- a/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
+++ b/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
@@ -51,6 +51,7 @@ import {
   PlugIcon,
   VitalsIcon,
   RemoveIcon,
+  KeyboardReturnIcon,
 } from '@kong/icons'
 import { useSlots, useAttrs } from 'vue'
 
@@ -88,6 +89,7 @@ const icons = {
   connected: PlugIcon,
   healthy: VitalsIcon,
   unhealthy: RemoveIcon,
+  submit: KeyboardReturnIcon,
 } as const
 const id = uniqueId('-x-icon-tooltip')
 const slots = useSlots()

--- a/packages/kuma-gui/src/app/x/components/x-search/README.md
+++ b/packages/kuma-gui/src/app/x/components/x-search/README.md
@@ -1,0 +1,16 @@
+# x-search
+
+The `XSearch` component is an input field that highlights `key:value` pairs and offers guidance through a dropdown that includes information about the searchable content.
+
+<Story height="600">
+  <search>
+    <form>
+      <XSearch
+        name="search"
+        placeholder="Filter by name, protocol, service or tag..."
+        :default-value="route.params.search"
+        :keys="['name', 'protocol', 'service', 'tag']"
+      />
+    </form>
+  </search>
+</Story>

--- a/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
+++ b/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
@@ -13,7 +13,7 @@
       data-testid="filter-bar"
       @click="inputRef?.focus()"
     >
-      <XI18n v-slot="{ t }">
+      <XI18n v-slot="{ t, formatList }">
         <div class="icon-wrapper">
           <XIcon
             class="icon"
@@ -63,18 +63,23 @@
               v-for="(chunk, i) in inputValue.split(regex).filter(Boolean)"
               :key="chunk+i"
             >
-              <span v-if="regex.test(chunk)">
+              <dl v-if="regex.test(chunk)">
                 <template
                   v-for="([key, ...values], j) in [chunk.split(':')]"
                   :key="key+j"
                 >
-                  <span v-if="!values.length">{{ props.defaultKey }}:<span class="text-important">{{ key }}</span></span>
-                  <span v-else>{{ key }}:</span><span class="text-important">{{ values.join(':') }}</span>
+                  <template v-if="!values.length">
+                    <dt>{{ props.defaultKey }}:</dt><dd class="text-important">
+                      {{ key }}
+                    </dd>
+                  </template>
+                  <template v-else>
+                    <dt>{{ key }}:</dt><dl class="text-important">
+                      {{ values.join(':') }}
+                    </dl>
+                  </template>
                 </template>
-              </span>
-              <span v-else>
-                {{ chunk }}
-              </span>
+              </dl>
             </template>
             <XBadge appearance="decorative">
               {{ t("components.x-search.submit") }}
@@ -103,9 +108,6 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
-
-import { useI18n } from '@/app/application'
-const { formatList } = useI18n() 
 
 const props = withDefaults(defineProps<{
   /**
@@ -282,7 +284,6 @@ input {
   width: 0;
 }
 
-
 :deep(.popover) {
   position: absolute !important;
   top: 100% !important;
@@ -306,8 +307,17 @@ input {
       border-top: $kui-border-width-10 solid $kui-color-border;
     }
 
+    .filter-block {
+      display: flex;
+      gap: $kui-space-40;
+    }
+
     p {
       line-height: $kui-line-height-40;
+    }
+
+    dl {
+      display: inline-flex;
     }
   }
 

--- a/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
+++ b/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
@@ -74,9 +74,9 @@
                     </dd>
                   </template>
                   <template v-else>
-                    <dt>{{ key }}:</dt><dl class="text-important">
+                    <dt>{{ key }}:</dt><dd class="text-important">
                       {{ values.join(':') }}
-                    </dl>
+                    </dd>
                   </template>
                 </template>
               </dl>

--- a/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
+++ b/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
@@ -1,58 +1,140 @@
 <template>
-  <div
-    v-style="`--width:${width}px`"
-    class="container"
-    data-testid="filter-bar"
-    @click.stop="inputRef?.focus()"
+  <KPop
+    ref="dropdownRef"
+    class="dropdown"
+    hide-close-icon
+    hide-caret
+    @open="() => isDropdownOpen = true"
+    @close="() => isDropdownOpen = false"
   >
-    <div class="icon-wrapper">
-      <XIcon
-        class="icon"
-        name="search"
-      />
-    </div>
     <div
-      ref="containerRef"
-      class="input-container"
+      v-style="`--width:${width}px`"
+      class="container"
+      data-testid="filter-bar"
+      @click="inputRef?.focus()"
     >
-      <div
-        ref="contentRef"
-        class="content-wrapper"
-      >
-        <template
-          v-for="(chunk, index) in inputValue.split(regex).filter(Boolean)"
-          :key="chunk+index"
-        >
-          <span :class="{ highlight: regex.test(chunk) }">{{ chunk }}</span>
-        </template>
+      <div class="icon-wrapper">
+        <XIcon
+          class="icon"
+          name="search"
+        />
       </div>
-      <div class="input-wrapper">
-        <input
-          ref="inputRef"
-          type="text"
-          :defaultValue="props.value"
-          :placeholder="props.placeholder"
-          data-testid="filter-bar-filter-input"
-          :name="props.name"
-          @input="onInput"
-          @change="emit('change', inputValue)"
+      <div
+        ref="containerRef"
+        class="input-container"
+      >
+        <div
+          ref="contentRef"
+          class="content-wrapper"
         >
+          <template
+            v-for="(chunk, index) in inputValue.split(regex).filter(Boolean)"
+            :key="chunk+index"
+          >
+            <span :class="{ highlight: regex.test(chunk) }">{{ chunk }}</span>
+          </template>
+        </div>
+        <div class="input-wrapper">
+          <input
+            ref="inputRef"
+            type="text"
+            :defaultValue="props.value"
+            :placeholder="props.placeholder ?? t('components.x-search.filterBy', { count: props.keys.length, keys: formatList(props.keys, { type: 'disjunction' }) })"
+            data-testid="filter-bar-filter-input"
+            :name="props.name"
+            @input="onInput"
+            @change="emit('change', inputValue)"
+            @keyup="onKeyEvent"
+          >
+        </div>
       </div>
     </div>
-  </div>
+    
+    <template #content>
+      <div class="dropdown-item">
+        <p
+          v-if="inputValue.length"
+          class="filter-block"
+        >
+          <template
+            v-for="(chunk, i) in inputValue.split(regex).filter(Boolean)"
+            :key="chunk+i"
+          >
+            <span v-if="regex.test(chunk)">
+              <template
+                v-for="([key, ...values], j) in [chunk.split(':')]"
+                :key="key+j"
+              >
+                <span v-if="!values.length">{{ props.defaultKey }}:<span class="text-important">{{ key }}</span></span>
+                <span v-else>{{ key }}:</span><span class="text-important">{{ values.join(':') }}</span>
+              </template>
+            </span>
+            <span v-else>
+              {{ chunk }}
+            </span>
+          </template>
+          <XBadge appearance="decorative">
+            <XI18n
+              tag="span"
+              path="components.x-search.submit"
+            />
+            <XIcon name="submit" />
+          </XBadge>
+        </p>
+        <XI18n
+          v-else
+          path="components.x-search.placeholder"
+        />
+      </div>
+      <div
+        v-if="props.keys.length"
+        class="dropdown-item bg-neutral-weakest"
+      >
+        <p class="logic-block">
+          <XI18n
+            tag="span"
+            class="text-important"
+            path="components.x-search.logic"
+          /> {{ props.keys.join(', ') }}
+        </p>
+      </div>
+    </template>
+  </KPop>
 </template>
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 
+import { useI18n } from '@/app/application'
+const { t, formatList } = useI18n() 
+
 const props = withDefaults(defineProps<{
+  /**
+   * The placeholder of the input
+   */
   placeholder?: string
+  /**
+   * A previous filter query as defaultValue
+   */
   value?: string
+  /**
+   * Name of the field used in forms
+   */
   name?: string
+  /**
+   * Provides info about filterable keys
+   */
+  keys?: string[]
+  /**
+   * The default key, that is being used to filter for when there is no `key:value` pair but only a `value`
+   */
+  defaultKey?: string
 }>(), {
   placeholder: undefined,
   name: undefined,
   value: '',
+  keys: () => [],
+  defaultKey: 'name',
 })
 
 const emit = defineEmits<{
@@ -65,6 +147,18 @@ const width = ref<number | undefined>()
 const containerRef = ref<null | HTMLElement>(null)
 const contentRef = ref<null | HTMLElement>(null)
 const inputRef = ref<null | HTMLInputElement>(null)
+const dropdownRef = ref<null | HTMLInputElement>(null)
+const isDropdownOpen = ref<boolean>(false)
+
+const onKeyEvent = ({ key }: KeyboardEvent) => {
+  switch(key) {
+    case 'Enter':
+    case 'Escape':
+      return isDropdownOpen.value && dropdownRef.value?.hidePopover()
+    default:
+      return !isDropdownOpen.value && dropdownRef.value?.showPopover()
+  }
+}
 
 const onInput = (event: Event): void => {
   const value = (event.target as HTMLInputElement)?.value
@@ -84,15 +178,15 @@ onMounted(() => {
 
 <style scoped lang="scss">
 .container {
-  min-width: inherit;
-  width: 0;
+  width: 100%;
+  position: relative;
+  font-family: $kui-font-family-code;
   position: relative;
   display: inline-flex;
   vertical-align: middle;
   cursor: text;
   outline: none;
   align-items: center;
-  font-family: $kui-font-family-code;
   font-size: $kui-font-size-30;
   border-radius: $kui-border-radius-20;
   box-shadow: $kui-shadow-border;
@@ -181,5 +275,53 @@ input {
   outline: none;
   caret-color: $kui-color-text;
   line-height: $kui-font-size-70;
+}
+
+.dropdown {
+  position: relative;
+  min-width: inherit;
+  width: 0;
+}
+
+
+:deep(.popover) {
+  position: absolute !important;
+  top: 100% !important;
+  left: 0;
+  width: 100%;
+
+  .popover-container {
+    width: 100% !important;
+    margin-top: unset !important;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .dropdown-item {
+    color: $kui-color-text-neutral;
+    font-family: $kui-font-family-code;
+    padding: $kui-space-50 $kui-space-60;
+    font-size: $kui-font-size-30;
+
+    &:not(:first-child) {
+      border-top: $kui-border-width-10 solid $kui-color-border;
+    }
+
+    p {
+      line-height: $kui-line-height-40;
+    }
+  }
+
+  .bg-neutral-weakest {
+    background-color: $kui-color-background-neutral-weakest;
+  }
+
+  .text-important {
+    color: $kui-color-text;
+  }
+}
+
+:deep(.k-badge) {
+  font-family: $kui-font-family-code;
 }
 </style>

--- a/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
+++ b/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
@@ -13,91 +13,90 @@
       data-testid="filter-bar"
       @click="inputRef?.focus()"
     >
-      <div class="icon-wrapper">
-        <XIcon
-          class="icon"
-          name="search"
-        />
-      </div>
-      <div
-        ref="containerRef"
-        class="input-container"
-      >
+      <XI18n v-slot="{ t }">
+        <div class="icon-wrapper">
+          <XIcon
+            class="icon"
+            name="search"
+          />
+        </div>
         <div
-          ref="contentRef"
-          class="content-wrapper"
+          ref="containerRef"
+          class="input-container"
         >
-          <template
-            v-for="(chunk, index) in inputValue.split(regex).filter(Boolean)"
-            :key="chunk+index"
+          <div
+            ref="contentRef"
+            class="content-wrapper"
           >
-            <span :class="{ highlight: regex.test(chunk) }">{{ chunk }}</span>
-          </template>
+            <template
+              v-for="(chunk, index) in inputValue.split(regex).filter(Boolean)"
+              :key="chunk+index"
+            >
+              <span :class="{ highlight: regex.test(chunk) }">{{ chunk }}</span>
+            </template>
+          </div>
+          <div class="input-wrapper">
+            <input
+              ref="inputRef"
+              type="text"
+              :defaultValue="props.value"
+              :placeholder="props.placeholder ?? t('components.x-search.filterBy', { count: props.keys.length, keys: formatList(props.keys, { type: 'disjunction' }) })"
+              data-testid="filter-bar-filter-input"
+              :name="props.name"
+              @input="onInput"
+              @change="emit('change', inputValue)"
+              @keyup="onKeyEvent"
+            >
+          </div>
         </div>
-        <div class="input-wrapper">
-          <input
-            ref="inputRef"
-            type="text"
-            :defaultValue="props.value"
-            :placeholder="props.placeholder ?? t('components.x-search.filterBy', { count: props.keys.length, keys: formatList(props.keys, { type: 'disjunction' }) })"
-            data-testid="filter-bar-filter-input"
-            :name="props.name"
-            @input="onInput"
-            @change="emit('change', inputValue)"
-            @keyup="onKeyEvent"
-          >
-        </div>
-      </div>
+      </XI18n>
     </div>
     
     <template #content>
-      <div class="dropdown-item">
-        <p
-          v-if="inputValue.length"
-          class="filter-block"
-        >
-          <template
-            v-for="(chunk, i) in inputValue.split(regex).filter(Boolean)"
-            :key="chunk+i"
+      <XI18n v-slot="{ t }">
+        <div class="dropdown-item">
+          <p
+            v-if="inputValue.length"
+            class="filter-block"
           >
-            <span v-if="regex.test(chunk)">
-              <template
-                v-for="([key, ...values], j) in [chunk.split(':')]"
-                :key="key+j"
-              >
-                <span v-if="!values.length">{{ props.defaultKey }}:<span class="text-important">{{ key }}</span></span>
-                <span v-else>{{ key }}:</span><span class="text-important">{{ values.join(':') }}</span>
-              </template>
-            </span>
-            <span v-else>
-              {{ chunk }}
-            </span>
-          </template>
-          <XBadge appearance="decorative">
-            <XI18n
-              tag="span"
-              path="components.x-search.submit"
-            />
-            <XIcon name="submit" />
-          </XBadge>
-        </p>
-        <XI18n
-          v-else
-          path="components.x-search.placeholder"
-        />
-      </div>
-      <div
-        v-if="props.keys.length"
-        class="dropdown-item bg-neutral-weakest"
-      >
-        <p class="logic-block">
+            <template
+              v-for="(chunk, i) in inputValue.split(regex).filter(Boolean)"
+              :key="chunk+i"
+            >
+              <span v-if="regex.test(chunk)">
+                <template
+                  v-for="([key, ...values], j) in [chunk.split(':')]"
+                  :key="key+j"
+                >
+                  <span v-if="!values.length">{{ props.defaultKey }}:<span class="text-important">{{ key }}</span></span>
+                  <span v-else>{{ key }}:</span><span class="text-important">{{ values.join(':') }}</span>
+                </template>
+              </span>
+              <span v-else>
+                {{ chunk }}
+              </span>
+            </template>
+            <XBadge appearance="decorative">
+              {{ t("components.x-search.submit") }}
+              <XIcon name="submit" />
+            </XBadge>
+          </p>
           <XI18n
-            tag="span"
-            class="text-important"
-            path="components.x-search.logic"
-          /> {{ props.keys.join(', ') }}
-        </p>
-      </div>
+            v-else
+            path="components.x-search.placeholder"
+          />
+        </div>
+        <div
+          v-if="props.keys.length"
+          class="dropdown-item bg-neutral-weakest"
+        >
+          <p class="logic-block">
+            <span class="text-important">
+              {{ t("components.x-search.logic") }}
+            </span> {{ props.keys.join(', ') }}
+          </p>
+        </div>
+      </XI18n>
     </template>
   </KPop>
 </template>
@@ -106,7 +105,7 @@
 import { onMounted, ref } from 'vue'
 
 import { useI18n } from '@/app/application'
-const { t, formatList } = useI18n() 
+const { formatList } = useI18n() 
 
 const props = withDefaults(defineProps<{
   /**

--- a/packages/kuma-gui/src/app/x/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/x/locales/en-us/index.yaml
@@ -9,5 +9,13 @@ components:
     action:
       label: ''
       href: ''
-
-
+  x-search:
+    placeholder: !!text/markdown |
+      Type to filter...
+    filterBy: | 
+      { count, plural,
+        =0 {Type to filter...}
+        other {Filter by {keys}...}
+      }
+    logic: 'Logic:'
+    submit: submit


### PR DESCRIPTION
Adds a dropdown to the `XSearch` component which displays some more information about the filter/search logic, i.e. the actual search query.
In order to make the component more reusable in different places, I've turned the props into optional and provide fallbacks and defaults within the component.

I've added `formatList` (coming from our i18n, `formatjs createIntl().formatList`) to `XI18n` such that we have the dependency to i18n only in one place.

I might change the internal behaviour of `defaultKey`, but first want to see how this component will be used in other places. Probably will change it to fall back to `keys[0]` instead of fixed `name`, since there might be places where we don't have a `name` but still don't want set a `defaultKey` 🤔 

~In order to make the `XI18n` usable inline, I've added an optional prop `tag`, which has one option for now: `span`. So the `XI18n` component can now render as either `div` or `span`. Can eventually grow in case we want to support headlines and more. I probably wouldn't allow any string for this, but also it might be hard to track the whole list of HTML tags that are usually used for text. Therefore I would keep an eye on that and eventually reevaluate the decision here.~

I've also started with some basic documentation and will add more step by step.

Closes #3709 