### PR TITLE
chore: move XNotification to use :notify vs v-if

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -40,7 +40,7 @@
               },
             },
             {
-              bool: can('use zones') && props.data.zone && props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false,
+              bool: !!(can('use zones') && props.data.zone && props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false),
               key: 'dp-zone-cp-incompatible',
               params: {
                 kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
@@ -65,7 +65,7 @@
           :key="key"
         >
           <XNotification
-            v-if="bool"
+            :notify="bool"
             :data-testid="`warning-${key}`"
             :uri="`data-planes.notifications.${key}.${props.data.id}`"
           >
@@ -408,7 +408,7 @@
                       :key="direction"
                     >
                       <XNotification
-                        v-if="Object.values(traffic.outbounds).find(item => (typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) ?? 0 > 0)"
+                        :notify="!!Object.values(traffic.outbounds).find(item => (typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) ?? 0 > 0)"
                         variant="info"
                         :uri="`data-planes.notifications.recommend-reachable-services:${props.data.id}`"
                       >

--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -16,7 +16,7 @@
         v-slot="hub"
       >
         <XNotification
-          v-if="!can('use state')"
+          :notify="!can('use state')"
           uri="main-overview.notifications.store-memory"
         >
           <XI18n

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -22,7 +22,7 @@
         :notifications="true"
       >
         <XNotification
-          v-if="!props.mesh.mtlsBackend"
+          :notify="!props.mesh.mtlsBackend"
           :uri="`meshes.notifications.mtls-warning:${props.mesh.id}`"
         >
           <XI18n
@@ -46,7 +46,7 @@
                 :key="typeof stats"
               >
                 <XNotification
-                  v-if="policy === 'MeshTrafficPermission' && props.mesh.mtlsBackend && stats.total === 0"
+                  :notify="policy === 'MeshTrafficPermission' && props.mesh.mtlsBackend && stats.total === 0"
                   :uri="`meshes.notifications.mtp-warning:${props.mesh.id}`"
                 >
                   <XI18n

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceListView.vue
@@ -27,7 +27,7 @@
         :notifications="true"
       >
         <XNotification
-          v-if="!props.mesh.mtlsBackend"
+          :notify="!props.mesh.mtlsBackend"
           :uri="`mes-mtls-warning.${props.mesh.id}`"
         >
           <XI18n
@@ -35,7 +35,7 @@
           />
         </XNotification>
         <XNotification
-          v-if="egresses && !egresses.items.find((egress) => typeof egress.zoneEgressInsight.connectedSubscription !== 'undefined')"
+          :notify="egresses && !egresses.items.find((egress) => typeof egress.zoneEgressInsight.connectedSubscription !== 'undefined')"
           :uri="`mes-no-zone-ingress.${props.mesh.id}`"
         >
           <XI18n

--- a/packages/kuma-gui/src/app/x/components/x-notification/XNotification.vue
+++ b/packages/kuma-gui/src/app/x/components/x-notification/XNotification.vue
@@ -37,12 +37,10 @@ const slots = defineSlots()
 watch(() => {
   return !!(props.notify && slots.default)
 }, (bool) => {
-  if(bool) {
-    if(typeof provider !== 'undefined') {
+  if(typeof provider !== 'undefined') {
+    if(bool) {
       provider.set(props.uri, props)
-    }
-  } else {
-    if(typeof provider !== 'undefined') {
+    } else {
       provider.delete(props.uri)
     }
   }
@@ -53,10 +51,10 @@ if(props.notify && slots.default) {
       provider.set(props.uri, props)
     }
   })
-  onBeforeUnmount(() => {
-    if(typeof provider !== 'undefined') {
-      provider.delete(props.uri)
-    }
-  })
 }
+onBeforeUnmount(() => {
+  if(typeof provider !== 'undefined') {
+    provider.delete(props.uri)
+  }
+})
 </script>

--- a/packages/kuma-gui/src/app/x/components/x-notification/XNotification.vue
+++ b/packages/kuma-gui/src/app/x/components/x-notification/XNotification.vue
@@ -3,7 +3,7 @@
     v-if="typeof provider !== 'undefined'"
   >
     <XTeleportTemplate
-      v-if="slots.default"
+      v-if="props.notify && slots.default"
       :to="{ name: `${provider.uri}-${props.uri}` }"
     >
       <slot name="default" />
@@ -15,7 +15,7 @@
   </template>
 </template>
 <script lang="ts" setup>
-import { inject, onBeforeUnmount, onMounted } from 'vue'
+import { inject, onBeforeUnmount, onMounted, watch } from 'vue'
 
 import type { AlertAppearance } from '@kong/kongponents'
 const provider = inject<{
@@ -27,12 +27,27 @@ const provider = inject<{
 const props = withDefaults(defineProps<{
   uri: string
   variant?: AlertAppearance
+  notify?: boolean
 }>(), {
   variant: 'warning',
+  notify: false,
 })
 
 const slots = defineSlots()
-if(slots.default) {
+watch(() => {
+  return !!(props.notify && slots.default)
+}, (bool) => {
+  if(bool) {
+    if(typeof provider !== 'undefined') {
+      provider.set(props.uri, props)
+    }
+  } else {
+    if(typeof provider !== 'undefined') {
+      provider.delete(props.uri)
+    }
+  }
+})
+if(props.notify && slots.default) {
   onMounted(() => {
     if(typeof provider !== 'undefined') {
       provider.set(props.uri, props)

--- a/packages/kuma-gui/src/app/zones/views/ZoneConfigView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneConfigView.vue
@@ -44,7 +44,7 @@
           :key="key"
         >
           <XNotification
-            v-if="bool"
+            :notify="bool"
             :data-testid="`warning-${key}`"
             :uri="`zone-cps.notifications.${key}.${props.data.id}`"
           >

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -39,7 +39,7 @@
           :key="key"
         >
           <XNotification
-            v-if="bool"
+            :notify="bool"
             :data-testid="`warning-${key}`"
             :uri="`zone-cps.notifications.${key}.${props.data.id}`"
           >


### PR DESCRIPTION
Part of https://github.com/kumahq/kuma-gui/issues/3605

In the above issue we said:

> We need the dismissal actions to not only track when you have dismissed a notification and store that, but also remove that storage once the logic that showed the notification is reversed.

In order to know whether to show the notification we were using a `v-if` to show choose whether to show the notification or not. But given the above requirement we also need to remove the fact that you dismissed a notification if the conditional logic is reversed. This means if we continue to use `v-if` we can't do anything extra (like remove the localstorage value) from within the XNotification if we don't even render it.

This PR moves all notifications to use a `:notify` property, and moves the v-if inside the component based to decide whether to render anything based on this. As this boolean is now available to the component, if its `false` and we have a localStorage value for this notification, we know to remove it ready for the next time `:notify` is `true`.

Doing the localStorage manipulation will be a follow up PR concentrating on the XNotification component itself rather than the callsites for the XNotification.