### PR TITLE
chore: use CSS isolation to avoid z-index battles

### DIFF
--- a/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
+++ b/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
@@ -144,15 +144,13 @@ onMounted(rewrite)
 </script>
 
 <style lang="scss" scoped>
+.app-collection {
+  isolation: isolate;
+}
 .app-collection :deep(td:first-child a) {
   color: inherit;
   font-weight: $kui-font-weight-semibold;
   text-decoration: none;
-}
-.app-collection :deep(thead) {
-  /* overwrite kongponents setting this to z-index:2 */
-  /* which causes overlay issues with other components */
-  z-index: auto !important;
 }
 
 .app-collection :deep(td:first-child li a) {


### PR DESCRIPTION
A better fix for https://github.com/kumahq/kuma-gui/pull/3729. It also means that if we ever need bulk actions with a max-height (this is the only configuration of KTable that requires the  z-index on the thead), the Kongponent will still be displayed as intended.

We might want to add this to every single X component to isolate ourselves from Kongponent z-index related side effects.

Note: I have a much better branch hanging around that has much better isolation of Kongponents which would prevent us from having these sorts of issues, I keep meaning to resurrect it 🤔 

Probably a good FYI to keep in mind from when I was looking into this:

The whole issue is caused by Kongponents providing custom/non-native icons for checkboxes:

![Screenshot 2025-04-11 at 12 04 38](https://github.com/user-attachments/assets/688d76e3-8211-4e29-8349-447fa2729d1d)

Lastly, we are due to change our dropdown filterbar thingie here soon, but I would guess we might hit this again at some point. Also good to keep in mind this checkbox weirdness because I've seen the tick icon disappearing before now and wondered "wow, what is happening here?!?!?"



