### PR TITLE
chore: import KToggle into XDisclosure

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-disclosure/XDisclosure.vue
+++ b/packages/kuma-gui/src/app/x/components/x-disclosure/XDisclosure.vue
@@ -8,3 +8,6 @@
     />
   </KToggle>
 </template>
+<script lang="ts" setup>
+import { KToggle } from '@kong/kongponents'
+</script>


### PR DESCRIPTION
We were playing around making things better and we noticed that this import was missing, I figured I may aswell PR it now rather than just reset my local clone