### PR TITLE
chore(deps): remove dotenv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7473,19 +7473,6 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
-    "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -17671,7 +17658,6 @@
         "@whyframe/core": "^0.1.13",
         "@whyframe/vue": "^0.1.8",
         "cypress": "^14.3.0",
-        "dotenv": "^16.5.0",
         "glob": "^11.0.0",
         "gray-matter": "^4.0.3",
         "jsdom": "^26.0.0",

--- a/packages/kuma-gui/.env
+++ b/packages/kuma-gui/.env
@@ -1,2 +1,1 @@
 VITE_VERSION_URL=https://kuma.io/latest_version
-VITE_KUMA_API_SERVER_URL=http://localhost:5681

--- a/packages/kuma-gui/cypress.config.ts
+++ b/packages/kuma-gui/cypress.config.ts
@@ -1,15 +1,14 @@
 import { cypress } from '@kumahq/config'
 import { defineConfig } from 'cypress'
-import dotenv from 'dotenv'
 
-const env = dotenv.config().parsed as { [key: string]: string }
-
-Object.entries({
+const env = Object.entries({
   // default base URL for testing against
   KUMA_BASE_URL: 'http://localhost:5681/gui',
-}).forEach(([key, d]: [string, string]) => {
-  env[key] = process.env[key] ?? d
-})
+  KUMA_API_URL: 'http://localhost:5681',
+}).reduce((prev, [key, d]: [string, string]) => {
+  prev[key] = process.env[key] ?? d
+  return prev
+}, {} as Record<string, string>)
 
 export default defineConfig({
   ...cypress(env),

--- a/packages/kuma-gui/cypress/services.ts
+++ b/packages/kuma-gui/cypress/services.ts
@@ -32,10 +32,7 @@ type Token = ReturnType<typeof token>
 export const services = <T extends Record<string, Token>>(app: T): ServiceDefinition[] => [
   [$.EnvVars, {
     constant: {
-      KUMA_API_URL: Cypress.env('VITE_KUMA_API_SERVER_URL'),
-      KUMA_VERSION_URL: Cypress.env('VITE_VERSION_URL'),
-      KUMA_DOCS_URL: Cypress.env('VITE_DOCS_BASE_URL'),
-      KUMA_MOCK_API_ENABLED: Cypress.env('VITE_MOCK_API_ENABLED'),
+      KUMA_API_URL: Cypress.env('KUMA_API_URL'),
     },
   }],
 

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -50,7 +50,6 @@
     "@whyframe/core": "^0.1.13",
     "@whyframe/vue": "^0.1.8",
     "cypress": "^14.3.0",
-    "dotenv": "^16.5.0",
     "glob": "^11.0.0",
     "gray-matter": "^4.0.3",
     "jsdom": "^26.0.0",

--- a/packages/kuma-gui/src/shims-env.d.ts
+++ b/packages/kuma-gui/src/shims-env.d.ts
@@ -1,7 +1,5 @@
 interface ImportMetaEnv {
   readonly VITE_VERSION_URL: string
-  readonly VITE_KUMA_API_SERVER_URL: string
-  readonly VITE_DOCS_BASE_URL: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Putting this up in draft while I verify this is fine.

---

Removes top-level dependency (actually surprisingly removes the dependency entirely 🎉 , I thought vite would use this but apparently not) and removes a weirdly named `VITE_` var which is only used in Cypress not `VITE_`

Probably related to https://github.com/kumahq/kuma-gui/issues/2431 and our overall work to remove unnecessary environment variables that should either be i18n strings, or something else. In this case the something else is "actual bash env var falling back to hardcoded", rather than "actual bash env var falling back to `.env` file var" (loss of locality).

There'd maybe a case for keeping this if we had a tonne of env vars that we used everywhere, or if we needed to switch locally often - neither of which we need.
