### PR TITLE
chore(deps): removes overrides for esbuild etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "workspaces": [
     "packages/*"
   ],
-  "overrides": {
-    "@cucumber/messages": "^27.0.2",
-    "esbuild": "^0.25.0"
-  },
   "dependencies": {
     "@kumahq/config": "*"
   },


### PR DESCRIPTION
I actually thought I'd done this a little while back, this PR removes the overrides for esbuild and cucumber/messages.

The esbuild override in particular is causing issues for dependabot:

![Screenshot 2025-04-16 at 14 13 46](https://github.com/user-attachments/assets/6dd68496-b9a9-4232-9ec5-f1da67ec3b1e)

Overrides are generally bad and as we all know should only be used in the very rare case that we are blocked because of an upgrade somewhere (not for using as a replacement for incorrectly configured dependencies upstream).

In this case (from what I remember at the time) we were using them for the exact usecase, but as dependabot doesn't update them, they get forgotten about. Vaguely considering adding something that pesters us whenever we have something in overrides so we don't totally forget, something to think about.