### PR TITLE
Revert "chore(ci): reduce the majority of fake-api to a createFetch function"

### DIFF
--- a/packages/fake-api/src/cypress.ts
+++ b/packages/fake-api/src/cypress.ts
@@ -1,22 +1,28 @@
-import { createFetchSync } from './index.ts'
-import type { Middleware, Dependencies, FS, Mocker } from './index.ts'
+import { createMerge, Router } from './index.ts'
+import type { Callback, Dependencies, FS, Mocker } from './index.ts'
+
+type Server = typeof cy
+
+type HistoryEntry = {
+  url: URL
+  request: {
+    method: string
+    body: Record<string, unknown>
+  }
+}
+type Client = { request: (request: HistoryEntry ) => void }
 
 const reEscape = /[/\-\\^$*+?.()|[\]{}]/g
-const noop: Middleware = (_req, response) => response
+const noop: Callback = (_merge, _req, response) => response
 
-export const mocker = <T extends object = {}>(
-  dependencies: Dependencies<T>,
+export const mocker = <TClient extends Client, TDependencies extends object = {}>(
+  cy: Server,
   fs: FS,
+  client: TClient,
+  dependencies: Dependencies<TDependencies>,
 ): Mocker => {
-  return (path, opts = {}, middleware = noop) => {
-    const env = dependencies.env
-    dependencies.env = <T extends Parameters<typeof env>[0]>(key: T, d = '') => {
-      return env(key, opts[key] ?? d)
-    }
-    const fetch = createFetchSync({
-      dependencies,
-      fs,
-    })
+  const router = new Router(fs)
+  return (path, opts = {}, cb = noop) => {
     // if path is `*` then that means mock everything, which currently means
     // changing to `/`
     path = path === '*' ? '/' : path
@@ -27,39 +33,45 @@ export const mocker = <T extends object = {}>(
       },
       (req) => {
         try {
-          // headers can be string | string[], not string
-          const headers = Object.entries(req.headers).reduce((prev, [key, item]) => {
-            if (typeof item !== 'undefined') {
-              prev[key] = Array.isArray(item) ? item[0] : item
+          const mockEnv = (key: string, d = '') => {
+            if (typeof opts[key] !== 'undefined') {
+              return opts[key]
             }
-            return prev
-          }, {} as Record<string, string>)
-
-          const resp = fetch(req.url, {
-            method: req.method,
-            headers,
+            return dependencies.env(key, d)
+          }
+          const path = req.url.replace(baseUrl, '')
+          const { route, params } = router.match(path)
+          const endpoint = route
+          const fetch = endpoint({
+            ...dependencies,
+            env: mockEnv,
           })
-          const type = resp.headers.get('Content-Type') ?? 'application/json'
+          const url = new URL(req.url)
+          const body = req.body
 
-          const response = middleware({
-            url: new URL(req.url),
+          const request = {
             method: req.method,
-            body: req.body,
-            params: {},
-          }, {
-            headers: Object.fromEntries(resp.headers.entries()),
-            body: type.endsWith('/json') ? resp.json() : resp.text(),
+            params,
+            body,
+            url,
+          }
+          const _response = fetch(request)
+          const response = cb(createMerge(_response), request, _response)
+          // once the response has been rendered but not sent resolve any
+          // waiting request assertions this means that any mocking done after
+          // awaiting the request will happen on the subsequent request not this
+          // one
+          client.request({
+            url,
+            request,
           })
-
           if (typeof response === 'undefined') {
             req.continue()
             return
           }
-
           req.reply({
-            contentType: type,
             statusCode: parseInt(response.headers?.['Status-Code'] ?? '200'),
-            delay: parseInt(dependencies.env('KUMA_LATENCY', opts['KUMA_LATENCY'] ?? '0')),
+            delay: parseInt(mockEnv('KUMA_LATENCY', '0')),
             body: response.body,
           })
         } catch (e) {

--- a/packages/fake-api/src/index.ts
+++ b/packages/fake-api/src/index.ts
@@ -1,10 +1,15 @@
+import deepmerge from 'deepmerge'
 import { URLPattern } from 'urlpattern-polyfill'
+
+import type { ArrayMergeOptions } from 'deepmerge'
 
 export type RestRequest = {
   method: string
   params: Record<string, string | readonly string[]>
   body: Record<string, any>
-  url: URL
+  url: {
+    searchParams: URLSearchParams
+  }
 }
 
 export type MockResponse = {
@@ -14,9 +19,11 @@ export type MockResponse = {
 
 export type MockResponder = (req: RestRequest) => MockResponse
 
-export type Middleware = (request: RestRequest, response: MockResponse) => MockResponse
+type Merge = (obj: Partial<MockResponse>) => MockResponse
+
+export type Callback = (merge: Merge, req: RestRequest, response: MockResponse) => MockResponse
 export type Options = Record<string, string>
-export type Mocker = (route: string, opts: Options, cb: Middleware) => void
+export type Mocker = (route: string, opts: Options, cb: Callback) => void
 
 export type Dependencies<TDependencies extends object = {}, TFake extends object = {}> = {
   env: <T extends string>(key: T, d?: string) => string
@@ -29,6 +36,34 @@ export function escapeRoute(route: string): string {
   return route.replaceAll('+', '\\+')
 }
 
+// --begin
+// merges objects in array positions rather than replacing
+export const undefinedSymbol = Symbol('undefined')
+const combineMerge = (target: object[], source: object[], options: ArrayMergeOptions): object[] => {
+  const destination = target.slice()
+
+  source.forEach((item, index) => {
+    if (typeof destination[index] === 'undefined') {
+      destination[index] = options.cloneUnlessOtherwiseSpecified(item, options)
+    } else if (options.isMergeableObject(item)) {
+      destination[index] = deepmerge(target[index], item, options)
+    } else if (target.indexOf(item) === -1) {
+      destination.push(item)
+    }
+  })
+  return destination
+}
+
+export const createMerge = (response: MockResponse): Merge => (obj) => {
+  const merged = deepmerge(response, obj, { arrayMerge: combineMerge })
+  return JSON.parse(JSON.stringify(merged, (_key, value) => {
+    if (value === undefinedSymbol) {
+      return
+    }
+    return value
+  }))
+}
+// --end
 
 export class Router<T> {
   routes: Map<URLPattern, T> = new Map()
@@ -61,63 +96,3 @@ export class Router<T> {
     throw new Error(`Matching route for '${path}' not found`)
   }
 }
-const strToEnv = (str: string): [string, string][] => {
-  return str.split(';')
-    .map((item) => item.trim())
-    .filter((item) => item !== '')
-    .map((item) => {
-      const [key, ...value] = item.split('=')
-      return [key, value.join('=')] as [string, string]
-    })
-}
-export const createFetchSync = <T extends object = {}>({ dependencies, fs }: { dependencies: Dependencies<T>, fs: FS }) => {
-  const router = new Router(fs)
-  return (url: string, options: RequestInit & { body?: Record<string, string>, headers?: Record<string, string | string[] | undefined>}) => {
-
-    const _url = new URL(url)
-    // we currently only match on pathname
-    const { route, params } = router.match(_url.pathname)
-
-    const cookies = strToEnv(String(options.headers?.cookie ?? '')).reduce((prev, [key, value]) => {
-      prev[key] = value
-      return prev
-    }, {} as Record<string, string>)
-    const env = <T extends Parameters<typeof dependencies['env']>[0]>(key: T, d = '') => dependencies.env(key, cookies[key] ?? d)
-
-    const request = route({
-      ...dependencies,
-      env,
-    })
-    const response = request({
-      url: _url,
-      method: options.method ?? 'GET',
-      body: options.body ?? {},
-      params,
-    })
-    if (typeof response === 'undefined') {
-      throw new Error('not found')
-    }
-    return {
-      json: () => {
-        return response.body
-      },
-      text: () => {
-        return response.body.toString()
-      },
-      headers: new Map(Object.entries(response.headers ?? {})),
-    }
-  }
-}
-export const createFetchAsync = (...rest: Parameters<typeof createFetchSync>) => {
-  const fetch = createFetchSync(...rest)
-  return async (...rest: Parameters<typeof fetch>) => {
-    const { json, text, headers } = fetch(...rest)
-    return {
-      headers,
-      json: async (...rest: Parameters<typeof json>) => json(...rest),
-      text: async (...rest: Parameters<typeof text>) => text(...rest),
-    }
-  }
-}
-export const createFetch = createFetchAsync
-

--- a/packages/fake-api/src/msw.ts
+++ b/packages/fake-api/src/msw.ts
@@ -1,70 +1,84 @@
 import { http, HttpResponse, passthrough } from 'msw'
 
-import { escapeRoute, createFetch } from './index.ts'
-import type { Dependencies, FS, MockEndpoint } from './index.ts'
+import { createMerge, escapeRoute } from './index.ts'
+import type { Callback, Dependencies, FS, MockEndpoint, MockResponse, Options, RestRequest } from './index.ts'
 
-export const server = <TDependencies extends object = {}>(
-  mock: MockEndpoint<TDependencies>,
-  options: {
-    params?: Record<string, string>
-  },
-  dependencies: Dependencies<TDependencies>,
-) => {
-  return async (env: Record<string, string>) => {
+const noop: Callback = (_merge, _req, response) => response
 
-    dependencies.env = (key: keyof typeof env, d = '') => {
-      return env[key] ?? d
+export const useResponder = <TDependencies extends object = {}>(fs: FS, dependencies: Dependencies<TDependencies>) => {
+  return (route: string, opts: Options = {}, cb: Callback = noop) => {
+    const mockEnv = (key: string, d = '') => (opts[key] ?? '') || dependencies.env(key, d)
+    if (route !== '*') {
+      dependencies.fake.seed(typeof opts.FAKE_SEED !== 'undefined' ? parseInt(typeof opts.FAKE_SEED) : 1)
     }
+    const endpoint = fs[route]
+    const fetch = endpoint({
+      ...dependencies,
+      env: mockEnv,
+    })
+    return async (req: RestRequest): Promise<MockResponse> => {
+      const _response = fetch(req)
+      const latency = parseInt(mockEnv('KUMA_LATENCY', '0'))
+      if (latency !== 0) {
+        await new Promise(resolve => setTimeout(resolve, latency))
+      }
+      return cb(createMerge(_response), req, _response)
+    }
+  }
+}
 
-    const route = Object.keys(options.params ?? {}).reduce((prev, item) => {
-      return `${prev}:${item}/`
-    }, '/')
-    const path = Object.values(options.params ?? {}).reduce((prev, item) => {
-      return `${prev}${item}/`
-    }, 'http://localhost/')
-
-    const fetch = createFetch({
-      dependencies,
-      fs: {
-        [route]: mock,
+export const server = <TDependencies extends object = {}, TEnvKeys extends string = string>(mock: MockEndpoint<TDependencies>, options: {
+  env?: Record<TEnvKeys, string>
+  params?: Record<string, string>
+}, dependencies: Dependencies<TDependencies>) => {
+  return async (env: Record<string, string>) => {
+    const responder = useResponder({
+      _: mock,
+    }, {
+      ...dependencies,
+      env: (key: keyof typeof env, d = '') => env[key] ?? d,
+    })
+    const request = responder('_')
+    return (await request(
+      {
+        method: 'GET',
+        body: {},
+        url: {
+          searchParams: new URLSearchParams(),
+        },
+        params: options.params ?? {},
       },
-    })
-    const response = await fetch(path, {
-      method: 'GET',
-    })
-    return response.json()
+    ))?.body
   }
 }
 
 export const handler = <TDependencies extends object = {}>(fs: FS, dependencies: Dependencies<TDependencies>) => {
   const baseUrl = dependencies.env('KUMA_API_URL')
-  const fetch = createFetch({
-    dependencies,
-    fs,
-  })
+  const responder = useResponder(fs, dependencies)
   return (route: string) => {
+    const respond = responder(route)
     const base = route.includes('://') ? '' : baseUrl
     if (route.startsWith('://')) {
       route = route.replace('://', '')
     }
-    return http.all(`${base}${escapeRoute(route)}`, async ({ request: req }) => {
-      // headers can be string | string[] | undefined, not string
-      const headers = Object.entries(req.headers).reduce((prev, [key, item]) => {
-        if (typeof item !== 'undefined') {
-          prev[key] = Array.isArray(item) ? item[0] : item
-        }
-        return prev
-      }, {} as Record<string, string>)
-      const response = await fetch(`${req.url ?? ''}`, {
-        method: req.method,
-        headers,
-        body: req.body ? JSON.parse(await new Response(req.body).text() || '{}') : {},
+    return http.all(`${base}${escapeRoute(route)}`, async ({ request, params }) => {
+      const response = await respond({
+        method: request.method,
+        url: new URL(request.url),
+        body: request.body ? JSON.parse(await new Response(request.body).text() || '{}') : {},
+        params: Object.fromEntries(
+          Object.entries(params).filter(
+            (entry): entry is [string, string | readonly string[]] => typeof entry[1] !== 'undefined',
+          ),
+        ),
       })
+
       if (typeof response === 'undefined') {
         return passthrough()
       }
-      return HttpResponse.json((await response.json()), {
-        status: parseInt(response.headers?.get('Status-Code') ?? '200'),
+
+      return HttpResponse.json(response.body, {
+        status: parseInt(response.headers?.['Status-Code'] ?? '200'),
       })
     })
   }

--- a/packages/fake-api/src/vite.ts
+++ b/packages/fake-api/src/vite.ts
@@ -1,4 +1,6 @@
-import { createFetch } from './index.ts'
+
+
+import { Router } from './index.ts'
 import type { Dependencies, FS } from './index.ts'
 import type { Plugin } from 'vite'
 
@@ -6,31 +8,69 @@ type PluginOptions<TDependencies extends object = {}> = {
   fs: FS<TDependencies>
   dependencies: Dependencies<TDependencies>
 }
+type FetchOptions = {
+  method?: string
+  body?: Record<string, string>
+  headers?: Record<string, string | string[] | undefined>
+}
+
+const strToEnv = (str: string): [string, string][] => {
+  return str.split(';')
+    .map((item) => item.trim())
+    .filter((item) => item !== '')
+    .map((item) => {
+      const [key, ...value] = item.split('=')
+      return [key, value.join('=')] as [string, string]
+    })
+}
 
 export default <TDependencies extends object = {}>(opts: PluginOptions<TDependencies>): Plugin => {
   const { fs, dependencies } = opts
+  const router = new Router(fs)
+  const fetch = async (url: string, options: FetchOptions) => {
+    const cookies = strToEnv(String(options.headers?.cookie ?? '')).reduce((prev, [key, value]) => {
+      prev[key] = value
+      return prev
+    }, {} as Record<string, string>)
 
-  const fetch = createFetch({
-    dependencies,
-    fs,
-  })
+    const _url = new URL(url)
+    const { route, params } = router.match(_url.pathname)
+
+    const env = <T extends Parameters<typeof dependencies['env']>[0]>(key: T, d = '') => dependencies.env(key, cookies[key] ?? d)
+
+    const request = route({
+      ...dependencies,
+      env,
+    })
+    const response = request({
+      url: _url,
+      method: options.method ?? 'GET',
+      body: options.body ?? {},
+      params,
+    })
+    if (typeof response === 'undefined') {
+      throw new Error('not found')
+    }
+    await new Promise(resolve => setTimeout(resolve, parseInt(env('KUMA_LATENCY', '0'))))
+    return {
+      json: async () => {
+        return response.body
+      },
+      text: async () => {
+        return response.body.toString()
+      },
+      headers: new Map(Object.entries(response.headers ?? {})),
+    }
+  }
 
   return {
     name: 'fake-api',
     configureServer: async (server) => {
       server.middlewares.use(async (req, res, next) => {
         try {
-          // headers can be string | string[] | undefined, not string
-          const headers = Object.entries(req.headers).reduce((prev, [key, item]) => {
-            if(typeof item !== 'undefined') {
-              prev[key] = Array.isArray(item) ? item[0] : item
-            }
-            return prev
-          }, {} as Record<string, string>)
-
           const response = await fetch(`http://${server.config.server.host}:${server.config.server.port}${req.url ?? ''}`, {
             method: req.method,
-            headers,
+            headers: req.headers,
           })
           const type = response.headers.get('Content-Type') ?? 'application/json'
           res.setHeader('Content-Type', type)

--- a/packages/kuma-gui/cypress/support/step_definitions/index.ts
+++ b/packages/kuma-gui/cypress/support/step_definitions/index.ts
@@ -1,36 +1,8 @@
 import { When, Then, Before, Given, DataTable, After } from '@badeball/cypress-cucumber-preprocessor'
-import deepmerge from 'deepmerge'
+import { undefinedSymbol } from '@kumahq/fake-api'
 import jsYaml, { DEFAULT_SCHEMA, Type } from 'js-yaml'
 
-import { useMock, useClient } from '../../services'
-import type { ArrayMergeOptions } from 'deepmerge'
-
-// merges objects in array positions rather than replacing
-const undefinedSymbol = Symbol('undefined')
-const combineMerge = (target: object[], source: object[], options: ArrayMergeOptions): object[] => {
-  const destination = target.slice()
-
-  source.forEach((item, index) => {
-    if (typeof destination[index] === 'undefined') {
-      destination[index] = options.cloneUnlessOtherwiseSpecified(item, options)
-    } else if (options.isMergeableObject(item)) {
-      destination[index] = deepmerge(target[index], item, options)
-    } else if (target.indexOf(item) === -1) {
-      destination.push(item)
-    }
-  })
-  return destination
-}
-
-const merge = <T>(response: T, obj: Partial<T>): T => {
-  const merged = deepmerge<T>(response, obj, { arrayMerge: combineMerge })
-  return JSON.parse(JSON.stringify(merged, (_key, value) => {
-    if (value === undefinedSymbol) {
-      return
-    }
-    return value
-  }))
-}
+import { useServer, useMock, useClient } from '../../services'
 
 const console = {
   log: (message: unknown) => Cypress.log({ displayName: 'LOG', message: JSON.stringify(message) }),
@@ -54,24 +26,12 @@ let env = {}
 let selectors: Record<string, string> = {}
 let localStorage: Set<string>
 const client = useClient()
-const mock = useMock()
 Before(() => {
   client.reset()
   env = {}
   selectors = {}
   localStorage = new Set()
-  // mock everything with no specific env vars
-  // record every request as a client.request
-  mock('*', {}, (req, response) => {
-    client.request({
-      url: req.url,
-      request: {
-        method: req.method,
-        body: req.body,
-      },
-    })
-    return response
-  })
+  useServer()
 })
 After(() => {
   Array.from(localStorage).forEach((key) => {
@@ -126,24 +86,18 @@ Given('the localStorage', (yaml: string) => {
 })
 
 Given('the URL {string} responds with', (url: string, yaml: string) => {
+  const mock = useMock()
   // mock is a call to cy.intercept
-  // which mocks this specific url with the current env vars
-  // records every request as a client.request
-  // and merges any test case mock with the fake-fs mock
-  mock(url, env, (req, response) => {
-    // once the response has been rendered but not sent resolve any
-    // waiting request assertions this means that any mocking done after
-    // awaiting the request will happen on the subsequent request not this
-    // one
-    client.request({
-      url: req.url,
-      request: {
-        method: req.method,
-        body: req.body,
+  // the callback below gives the opportunity to mutate the mock response
+  // the respond function/argument is just a specifically configured deepmerge
+  mock(url, env, (respond) => {
+    const response = respond(
+      (YAML.parse(yaml) || {}) as {
+        headers?: Record<string, string>
+        body?: Record<string, unknown>
       },
-    })
-    // merge test mock in with fake-api mock
-    return merge(response, YAML.parse(yaml) ?? {})
+    )
+    return response
   })
 })
 

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
@@ -21,10 +21,7 @@ Feature: Dataplane policies
       | inbound-rule-item                  | [data-testid='inbound-rule-list-0'] .accordion-item                   |
       | inbound-rule-item-button           | $inbound-rule-item:nth-child(1) [data-testid='accordion-item-button'] |
       | summary-slideout-container         | [data-testid='summary'] [data-testid='slideout-container']            |
-      And the environment
-      """
-        KUMA_RESOURCE_COUNT: 100
-      """
+
   Rule: Any networking type
 
     Scenario: Policies tab has expected content (MeshHTTPRoute with to rules)
@@ -339,6 +336,14 @@ Feature: Dataplane policies
                     port: 8080
                     tags:
                       kuma.io/service: foo
+        """
+      And the URL "/_resources" responds with
+        """
+        body:
+          resources:
+            - name: MeshHTTPRoute
+              policy:
+                isFromAsRules: true
         """
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
       Then the "$to-rule-item-content" element doesn't exist

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -171,9 +171,9 @@
                   v-slot="{ data: sidecarDataplaneData }: SidecarDataplaneCollectionSource"
                 >
                   <DataCollection
-                    :empty="false"
-                    :items="sidecarDataplaneData!.policyTypeEntries"
                     :predicate="(item) => policyTypes[item.type]?.policy.isTargetRef === false"
+                    :items="sidecarDataplaneData!.policyTypeEntries"
+                    :empty="false"
                     v-slot="{ items }"
                   >
                     <h3>


### PR DESCRIPTION
Reverts kumahq/kuma-gui#3734

This causes issues elsewhere, which I'm not sure if are due to our GithubActions or not. I don't want to block further work today so I'm reverting this for now. Will bring it back later.

In the meantime I'm gonna start taking a look at those GitHubActions and make them a little easier to work with, they are the last ones we have totally refactored so I may as well bite the bullet and finish up these last ones.