### PR TITLE
feat(notifications): adds dismissal, GC and resetting to notifications

### DIFF
--- a/packages/kuma-gui/src/app/App.vue
+++ b/packages/kuma-gui/src/app/App.vue
@@ -79,7 +79,17 @@
           />
         </template>
 
-        <AppView>
+        <AppView
+          :notifications="true"
+        >
+          <XNotification
+            :notify="!can('use state')"
+            uri="main-overview.notifications.store-memory"
+          >
+            <XI18n
+              path="main-overview.notifications.store-memory"
+            />
+          </XNotification>
           <RouterView />
         </AppView>
       </ApplicationShell>

--- a/packages/kuma-gui/src/app/App.vue
+++ b/packages/kuma-gui/src/app/App.vue
@@ -82,15 +82,13 @@
         <AppView
           :notifications="true"
         >
-          <XNotification
-            :notify="!can('use state')"
-            uri="main-overview.notifications.store-memory"
+          <RouterView
+            v-slot="{ Component }"
           >
-            <XI18n
-              path="main-overview.notifications.store-memory"
+            <component
+              :is="Component"
             />
-          </XNotification>
-          <RouterView />
+          </RouterView>
         </AppView>
       </ApplicationShell>
     </RouteView>

--- a/packages/kuma-gui/src/app/control-planes/views/ControlPlaneRootView.vue
+++ b/packages/kuma-gui/src/app/control-planes/views/ControlPlaneRootView.vue
@@ -1,8 +1,17 @@
 <template>
   <RouteView
     name="control-plane-root-view"
+    v-slot="{ can }"
   >
     <AppView>
+      <XNotification
+        :notify="!can('use state')"
+        uri="main-overview.notifications.store-memory"
+      >
+        <XI18n
+          path="main-overview.notifications.store-memory"
+        />
+      </XNotification>
       <RouterView
         v-slot="{ Component }"
       >

--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -5,216 +5,161 @@
     <XTeleportSlot
       name="modal-layer"
     />
-    <DataSource
-      :src="`/me/~notifications`"
-      v-slot="{ data: dismissed }"
+    <header
+      role="banner"
     >
-      <XNotificationHub
-        v-if="dismissed"
-        uri="application-shell"
-        :dismissed="dismissed"
-        v-slot="hub"
+      <div
+        class="horizontal-list"
       >
-        <XNotification
-          :notify="!can('use state')"
-          uri="main-overview.notifications.store-memory"
-        >
-          <XI18n
-            path="main-overview.notifications.store-memory"
-          />
-        </XNotification>
-        <header
-          role="banner"
-        >
-          <div
-            class="horizontal-list"
+        <slot name="header">
+          <XAction :to="{ name: 'control-plane-root-view' }">
+            <slot name="home" />
+          </XAction>
+
+          <GithubButton
+            class="gh-star"
+            href="https://github.com/kumahq/kuma"
+            aria-label="Star kumahq/kuma on GitHub"
           >
-            <slot name="header">
-              <XAction :to="{ name: 'control-plane-root-view' }">
-                <slot name="home" />
+            Star
+          </GithubButton>
+
+          <div class="upgrade-check-wrapper">
+            <DataSource
+              :src="`/control-plane/version/latest`"
+              v-slot="{ data }"
+            >
+              <!-- make sure we have data but don't show errors or loaders -->
+              <XAlert
+                v-if="data && env('KUMA_VERSION') !== data.version"
+                class="upgrade-alert"
+                data-testid="upgrade-check"
+                appearance="info"
+              >
+                <XLayout
+                  type="separated"
+                >
+                  <p>
+                    {{ t('common.product.name') }} update available
+                  </p>
+
+                  <XAction
+                    appearance="primary"
+                    :href="t('common.product.href.install')"
+                  >
+                    Update
+                  </XAction>
+                </XLayout>
+              </XAlert>
+            </DataSource>
+          </div>
+        </slot>
+      </div>
+      <div
+        class="horizontal-list"
+      >
+        <slot name="content-info">
+          <div
+            class="app-status app-status--mobile"
+          >
+            <XPop
+              width="280"
+            >
+              <XAction
+                appearance="tertiary"
+              >
+                Info
               </XAction>
 
-              <GithubButton
-                class="gh-star"
-                href="https://github.com/kumahq/kuma"
-                aria-label="Star kumahq/kuma on GitHub"
-              >
-                Star
-              </GithubButton>
-
-              <div class="upgrade-check-wrapper">
-                <DataSource
-                  :src="`/control-plane/version/latest`"
-                  v-slot="{ data }"
-                >
-                  <!-- make sure we have data but don't show errors or loaders -->
-                  <XAlert
-                    v-if="data && env('KUMA_VERSION') !== data.version"
-                    class="upgrade-alert"
-                    data-testid="upgrade-check"
-                    appearance="info"
-                  >
-                    <XLayout
-                      type="separated"
-                    >
-                      <p>
-                        {{ t('common.product.name') }} update available
-                      </p>
-
-                      <XAction
-                        appearance="primary"
-                        :href="t('common.product.href.install')"
-                      >
-                        Update
-                      </XAction>
-                    </XLayout>
-                  </XAlert>
-                </DataSource>
-              </div>
-            </slot>
+              <template #content>
+                <p>
+                  {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
+                </p>
+              </template>
+            </XPop>
           </div>
-          <div
-            class="horizontal-list"
-          >
-            <slot name="content-info">
-              <div
-                class="app-status app-status--mobile"
+
+          <p class="app-status app-status--desktop">
+            {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
+          </p>
+
+          <XActionGroup>
+            <template
+              #control
+            >
+              <XAction
+                appearance="tertiary"
               >
-                <XPop
-                  width="280"
+                <XIcon
+                  name="help"
                 >
-                  <XAction
-                    appearance="tertiary"
-                  >
-                    Info
-                  </XAction>
-
-                  <template #content>
-                    <p>
-                      {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
-                    </p>
-                  </template>
-                </XPop>
-              </div>
-
-              <p class="app-status app-status--desktop">
-                {{ t('common.product.name') }} <b>{{ env('KUMA_VERSION') }}</b> on <b>{{ t(`common.product.environment.${env('KUMA_ENVIRONMENT')}`) }}</b> ({{ t(`common.product.mode.${env('KUMA_MODE')}`) }})
-              </p>
-
-              <XActionGroup>
-                <template
-                  #control
-                >
-                  <XAction
-                    appearance="tertiary"
-                  >
-                    <XIcon
-                      name="help"
-                    >
-                      Help
-                    </XIcon>
-                  </XAction>
-                </template>
-                <XAction
-                  :href="t('common.product.href.docs.index')"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Documentation
-                </XAction>
-                <XAction
-                  :href="t('common.product.href.feedback')"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Feedback
-                </XAction>
-              </XActionGroup>
-            </slot>
-          </div>
-        </header>
-        <div
-          class="app-content-container"
+                  Help
+                </XIcon>
+              </XAction>
+            </template>
+            <XAction
+              :href="t('common.product.href.docs.index')"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Documentation
+            </XAction>
+            <XAction
+              :href="t('common.product.href.feedback')"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Feedback
+            </XAction>
+          </XActionGroup>
+        </slot>
+      </div>
+    </header>
+    <div
+      class="app-content-container"
+    >
+      <div class="app-sidebar">
+        <nav
+          aria-label="Main"
         >
-          <div class="app-sidebar">
-            <nav
-              aria-label="Main"
-            >
-              <ul v-if="slots.navigation">
-                <slot name="navigation" />
-              </ul>
+          <ul v-if="slots.navigation">
+            <slot name="navigation" />
+          </ul>
 
-              <div
-                v-if="slots.navigation && slots.bottomNavigation"
-                role="separator"
-                class="navigation-separator"
-              />
+          <div
+            v-if="slots.navigation && slots.bottomNavigation"
+            role="separator"
+            class="navigation-separator"
+          />
 
-              <ul v-if="slots.bottomNavigation">
-                <slot name="bottomNavigation" />
-              </ul>
-            </nav>
+          <ul v-if="slots.bottomNavigation">
+            <slot name="bottomNavigation" />
+          </ul>
+        </nav>
+      </div>
+      <main
+        class="app-main-content"
+      >
+        <XLayout
+          type="stack"
+        >
+          <div>
+            <slot name="default" />
           </div>
-          <main
-            class="app-main-content"
-          >
-            <XLayout
-              type="stack"
-            >
-              <aside
-                v-if="hub.notifications.size > 0"
-              >
-                <DataSink
-                  :src="`/me/~notifications`"
-                >
-                  <XLayout
-                    type="stack"
-                  >
-                    <template
-                      v-for="[variant, value] in hub.notifications"
-                      :key="variant"
-                    >
-                      <XAlert
-                        :variant="variant"
-                      >
-                        <ul
-                          class="notifications"
-                        >
-                          <li
-                            v-for="notification in value"
-                            :key="notification"
-                            :data-testid="`notification-${notification}`"
-                          >
-                            <XNotification
-                              :uri="notification"
-                            />
-                          </li>
-                        </ul>
-                      </XAlert>
-                    </template>
-                  </XLayout>
-                </DataSink>
-              </aside>
-              <div>
-                <slot name="default" />
-              </div>
-            </XLayout>
-          </main>
-        </div>
-      </XNotificationHub>
-    </DataSource>
+        </XLayout>
+      </main>
+    </div>
   </div>
 </template>
 <script lang="ts" setup>
 import GithubButton from 'vue-github-button'
 
-import { useEnv, useI18n, useCan } from '@/app/application'
+import { useEnv, useI18n } from '@/app/application'
 
 const slots = defineSlots()
 
 const env = useEnv()
 const { t } = useI18n()
-const can = useCan()
 
 </script>
 <style lang="scss">
@@ -237,17 +182,6 @@ html.no-navigation {
 </style>
 
 <style lang="scss" scoped>
-.notifications {
-  padding: 0;
-}
-.notifications li {
-  margin-left: $kui-space-60;
-}
-.notifications li:only-child {
-  list-style-type: none;
-  padding: 0;
-}
-
 .app-content-container {
   padding-top: var(--AppHeaderHeight, initial);
   display: var(--AppDisplay);

--- a/packages/kuma-gui/src/app/x/components/x-notification/XNotification.vue
+++ b/packages/kuma-gui/src/app/x/components/x-notification/XNotification.vue
@@ -25,6 +25,7 @@ import type { AlertAppearance } from '@kong/kongponents'
 const provider = inject<{
   set(uri: string, obj: { variant: AlertAppearance } ): void
   delete(uri: string): void
+  reset(uri: string): void
   uri: string
 }>('x-notification-hub')
 
@@ -45,14 +46,18 @@ watch(() => {
     if(bool) {
       provider.set(props.uri, props)
     } else {
-      provider.delete(props.uri)
+      provider.reset(props.uri)
     }
   }
 })
-if(props.notify && slots.default) {
+if(slots.default) {
   onMounted(() => {
     if(typeof provider !== 'undefined') {
-      provider.set(props.uri, props)
+      if(props.notify) {
+        provider.set(props.uri, props)
+      } else {
+        provider.reset(props.uri)
+      }
     }
   })
 }

--- a/packages/kuma-gui/src/app/x/components/x-notification/XNotificationHub.vue
+++ b/packages/kuma-gui/src/app/x/components/x-notification/XNotificationHub.vue
@@ -14,6 +14,11 @@
 import { shallowRef, watch } from 'vue'
 
 import type { AlertAppearance } from '@kong/kongponents'
+
+const emit = defineEmits<{
+  (event: 'reset', value: string): void
+}>()
+
 const props = withDefaults(defineProps<{
   uri: string
   dismissed?: string[]
@@ -47,6 +52,10 @@ const hub = {
   },
   delete: (str: string) => {
     del([str])
+  },
+  reset: (str: string) => {
+    del([str])
+    emit('reset', str)
   },
   uri: `x-notification-hub-${props.uri}`,
 


### PR DESCRIPTION
At a general level this PR adds a dismissal button to all our notifications.

If you dismiss a an alert box, all notifications within that box are saved to localStorage as dismissed for 7 days at which point it is "un-dismissed" meaning you will see the notification again if you haven't resolved what it is warning you about.

localStorage values also be removed i.e. "un-dismissed" if we detect that you have resolved the reason for the warning, meaning if you then remove whatever you did to resolve the warning, you will be warned again.

Further notes:

- I moved around AppView a little so I could put all the notification display all in one place in AppView (instead of also in ApplicationShell), this also meant I could remove some CSS that we no longer need (we are now using XLayout for the same layout)
- ~I moved the memory store notification to the `App.vue` file so that it is visible all the time, this will mean we will have to duplicate this. Ideally this notification would be in ControlPlaneDetailView, but the routing structure is incorrect (see https://github.com/kumahq/kuma-gui/issues/3570)~ We resolved the linked issue with further work and now the notification is where we want it in ControlPlaneDetailView


Closes https://github.com/kumahq/kuma-gui/issues/3605