### PR TITLE
chore(ci): reduce the majority of fake-api to a createFetch function

### DIFF
--- a/packages/fake-api/src/cypress.ts
+++ b/packages/fake-api/src/cypress.ts
@@ -1,28 +1,22 @@
-import { createMerge, Router } from './index.ts'
-import type { Callback, Dependencies, FS, Mocker } from './index.ts'
-
-type Server = typeof cy
-
-type HistoryEntry = {
-  url: URL
-  request: {
-    method: string
-    body: Record<string, unknown>
-  }
-}
-type Client = { request: (request: HistoryEntry ) => void }
+import { createFetchSync } from './index.ts'
+import type { Middleware, Dependencies, FS, Mocker } from './index.ts'
 
 const reEscape = /[/\-\\^$*+?.()|[\]{}]/g
-const noop: Callback = (_merge, _req, response) => response
+const noop: Middleware = (_req, response) => response
 
-export const mocker = <TClient extends Client, TDependencies extends object = {}>(
-  cy: Server,
+export const mocker = <T extends object = {}>(
+  dependencies: Dependencies<T>,
   fs: FS,
-  client: TClient,
-  dependencies: Dependencies<TDependencies>,
 ): Mocker => {
-  const router = new Router(fs)
-  return (path, opts = {}, cb = noop) => {
+  return (path, opts = {}, middleware = noop) => {
+    const env = dependencies.env
+    dependencies.env = <T extends Parameters<typeof env>[0]>(key: T, d = '') => {
+      return env(key, opts[key] ?? d)
+    }
+    const fetch = createFetchSync({
+      dependencies,
+      fs,
+    })
     // if path is `*` then that means mock everything, which currently means
     // changing to `/`
     path = path === '*' ? '/' : path
@@ -33,45 +27,39 @@ export const mocker = <TClient extends Client, TDependencies extends object = {}
       },
       (req) => {
         try {
-          const mockEnv = (key: string, d = '') => {
-            if (typeof opts[key] !== 'undefined') {
-              return opts[key]
+          // headers can be string | string[], not string
+          const headers = Object.entries(req.headers).reduce((prev, [key, item]) => {
+            if (typeof item !== 'undefined') {
+              prev[key] = Array.isArray(item) ? item[0] : item
             }
-            return dependencies.env(key, d)
-          }
-          const path = req.url.replace(baseUrl, '')
-          const { route, params } = router.match(path)
-          const endpoint = route
-          const fetch = endpoint({
-            ...dependencies,
-            env: mockEnv,
-          })
-          const url = new URL(req.url)
-          const body = req.body
+            return prev
+          }, {} as Record<string, string>)
 
-          const request = {
+          const resp = fetch(req.url, {
             method: req.method,
-            params,
-            body,
-            url,
-          }
-          const _response = fetch(request)
-          const response = cb(createMerge(_response), request, _response)
-          // once the response has been rendered but not sent resolve any
-          // waiting request assertions this means that any mocking done after
-          // awaiting the request will happen on the subsequent request not this
-          // one
-          client.request({
-            url,
-            request,
+            headers,
           })
+          const type = resp.headers.get('Content-Type') ?? 'application/json'
+
+          const response = middleware({
+            url: new URL(req.url),
+            method: req.method,
+            body: req.body,
+            params: {},
+          }, {
+            headers: Object.fromEntries(resp.headers.entries()),
+            body: type.endsWith('/json') ? resp.json() : resp.text(),
+          })
+
           if (typeof response === 'undefined') {
             req.continue()
             return
           }
+
           req.reply({
+            contentType: type,
             statusCode: parseInt(response.headers?.['Status-Code'] ?? '200'),
-            delay: parseInt(mockEnv('KUMA_LATENCY', '0')),
+            delay: parseInt(dependencies.env('KUMA_LATENCY', opts['KUMA_LATENCY'] ?? '0')),
             body: response.body,
           })
         } catch (e) {

--- a/packages/fake-api/src/cypress.ts
+++ b/packages/fake-api/src/cypress.ts
@@ -8,19 +8,24 @@ export const mocker = <T extends object = {}>(
   dependencies: Dependencies<T>,
   fs: FS,
 ): Mocker => {
+
+
   return (path, opts = {}, middleware = noop) => {
     const env = dependencies.env
     dependencies.env = <T extends Parameters<typeof env>[0]>(key: T, d = '') => {
       return env(key, opts[key] ?? d)
     }
+    const baseUrl = dependencies.env('KUMA_API_URL')
+    const _fs = Object.fromEntries(Object.entries(fs).map(([route, response]) => {
+      return [route.includes('://') ? route : `${baseUrl}${route}`, response]
+    }))
     const fetch = createFetchSync({
       dependencies,
-      fs,
+      fs: _fs,
     })
     // if path is `*` then that means mock everything, which currently means
     // changing to `/`
     path = path === '*' ? '/' : path
-    const baseUrl = dependencies.env('KUMA_API_URL')
     return cy.intercept(
       {
         url: new RegExp(`${baseUrl}${path.replace(reEscape, '\\$&')}`),
@@ -38,6 +43,7 @@ export const mocker = <T extends object = {}>(
           const resp = fetch(req.url, {
             method: req.method,
             headers,
+            body: req.body,
           })
           const type = resp.headers.get('Content-Type') ?? 'application/json'
 

--- a/packages/fake-api/src/index.ts
+++ b/packages/fake-api/src/index.ts
@@ -34,20 +34,14 @@ export class Router<T> {
   routes: Map<URLPattern, T> = new Map()
   constructor(routes: Record<string, T>) {
     Object.entries(routes).forEach(([key, value]) => {
-      if (key.includes('://')) {
-        return
-      }
-      this.routes.set(new URLPattern({
-        pathname: escapeRoute(key),
-      }), value)
+      this.routes.set(new URLPattern(key), value)
     })
   }
 
   match(path: string) {
     for (const [pattern, route] of this.routes) {
-      const _url = `data:${path}`
-      if (pattern.test(_url)) {
-        const args = pattern.exec(_url)
+      if (pattern.test(path)) {
+        const args = pattern.exec(path)
         const params = args?.pathname.groups || {}
         return {
           route,
@@ -75,8 +69,7 @@ export const createFetchSync = <T extends object = {}>({ dependencies, fs }: { d
   return (url: string, options: RequestInit & { body?: Record<string, string>, headers?: Record<string, string | string[] | undefined>}) => {
 
     const _url = new URL(url)
-    // we currently only match on pathname
-    const { route, params } = router.match(_url.pathname)
+    const { route, params } = router.match(_url.toString())
 
     const cookies = strToEnv(String(options.headers?.cookie ?? '')).reduce((prev, [key, value]) => {
       prev[key] = value

--- a/packages/fake-api/src/index.ts
+++ b/packages/fake-api/src/index.ts
@@ -1,15 +1,10 @@
-import deepmerge from 'deepmerge'
 import { URLPattern } from 'urlpattern-polyfill'
-
-import type { ArrayMergeOptions } from 'deepmerge'
 
 export type RestRequest = {
   method: string
   params: Record<string, string | readonly string[]>
   body: Record<string, any>
-  url: {
-    searchParams: URLSearchParams
-  }
+  url: URL
 }
 
 export type MockResponse = {
@@ -19,11 +14,9 @@ export type MockResponse = {
 
 export type MockResponder = (req: RestRequest) => MockResponse
 
-type Merge = (obj: Partial<MockResponse>) => MockResponse
-
-export type Callback = (merge: Merge, req: RestRequest, response: MockResponse) => MockResponse
+export type Middleware = (request: RestRequest, response: MockResponse) => MockResponse
 export type Options = Record<string, string>
-export type Mocker = (route: string, opts: Options, cb: Callback) => void
+export type Mocker = (route: string, opts: Options, cb: Middleware) => void
 
 export type Dependencies<TDependencies extends object = {}, TFake extends object = {}> = {
   env: <T extends string>(key: T, d?: string) => string
@@ -36,34 +29,6 @@ export function escapeRoute(route: string): string {
   return route.replaceAll('+', '\\+')
 }
 
-// --begin
-// merges objects in array positions rather than replacing
-export const undefinedSymbol = Symbol('undefined')
-const combineMerge = (target: object[], source: object[], options: ArrayMergeOptions): object[] => {
-  const destination = target.slice()
-
-  source.forEach((item, index) => {
-    if (typeof destination[index] === 'undefined') {
-      destination[index] = options.cloneUnlessOtherwiseSpecified(item, options)
-    } else if (options.isMergeableObject(item)) {
-      destination[index] = deepmerge(target[index], item, options)
-    } else if (target.indexOf(item) === -1) {
-      destination.push(item)
-    }
-  })
-  return destination
-}
-
-export const createMerge = (response: MockResponse): Merge => (obj) => {
-  const merged = deepmerge(response, obj, { arrayMerge: combineMerge })
-  return JSON.parse(JSON.stringify(merged, (_key, value) => {
-    if (value === undefinedSymbol) {
-      return
-    }
-    return value
-  }))
-}
-// --end
 
 export class Router<T> {
   routes: Map<URLPattern, T> = new Map()
@@ -96,3 +61,63 @@ export class Router<T> {
     throw new Error(`Matching route for '${path}' not found`)
   }
 }
+const strToEnv = (str: string): [string, string][] => {
+  return str.split(';')
+    .map((item) => item.trim())
+    .filter((item) => item !== '')
+    .map((item) => {
+      const [key, ...value] = item.split('=')
+      return [key, value.join('=')] as [string, string]
+    })
+}
+export const createFetchSync = <T extends object = {}>({ dependencies, fs }: { dependencies: Dependencies<T>, fs: FS }) => {
+  const router = new Router(fs)
+  return (url: string, options: RequestInit & { body?: Record<string, string>, headers?: Record<string, string | string[] | undefined>}) => {
+
+    const _url = new URL(url)
+    // we currently only match on pathname
+    const { route, params } = router.match(_url.pathname)
+
+    const cookies = strToEnv(String(options.headers?.cookie ?? '')).reduce((prev, [key, value]) => {
+      prev[key] = value
+      return prev
+    }, {} as Record<string, string>)
+    const env = <T extends Parameters<typeof dependencies['env']>[0]>(key: T, d = '') => dependencies.env(key, cookies[key] ?? d)
+
+    const request = route({
+      ...dependencies,
+      env,
+    })
+    const response = request({
+      url: _url,
+      method: options.method ?? 'GET',
+      body: options.body ?? {},
+      params,
+    })
+    if (typeof response === 'undefined') {
+      throw new Error('not found')
+    }
+    return {
+      json: () => {
+        return response.body
+      },
+      text: () => {
+        return response.body.toString()
+      },
+      headers: new Map(Object.entries(response.headers ?? {})),
+    }
+  }
+}
+export const createFetchAsync = (...rest: Parameters<typeof createFetchSync>) => {
+  const fetch = createFetchSync(...rest)
+  return async (...rest: Parameters<typeof fetch>) => {
+    const { json, text, headers } = fetch(...rest)
+    return {
+      headers,
+      json: async (...rest: Parameters<typeof json>) => json(...rest),
+      text: async (...rest: Parameters<typeof text>) => text(...rest),
+    }
+  }
+}
+export const createFetch = createFetchAsync
+

--- a/packages/fake-api/src/msw.ts
+++ b/packages/fake-api/src/msw.ts
@@ -1,84 +1,70 @@
 import { http, HttpResponse, passthrough } from 'msw'
 
-import { createMerge, escapeRoute } from './index.ts'
-import type { Callback, Dependencies, FS, MockEndpoint, MockResponse, Options, RestRequest } from './index.ts'
+import { escapeRoute, createFetch } from './index.ts'
+import type { Dependencies, FS, MockEndpoint } from './index.ts'
 
-const noop: Callback = (_merge, _req, response) => response
-
-export const useResponder = <TDependencies extends object = {}>(fs: FS, dependencies: Dependencies<TDependencies>) => {
-  return (route: string, opts: Options = {}, cb: Callback = noop) => {
-    const mockEnv = (key: string, d = '') => (opts[key] ?? '') || dependencies.env(key, d)
-    if (route !== '*') {
-      dependencies.fake.seed(typeof opts.FAKE_SEED !== 'undefined' ? parseInt(typeof opts.FAKE_SEED) : 1)
-    }
-    const endpoint = fs[route]
-    const fetch = endpoint({
-      ...dependencies,
-      env: mockEnv,
-    })
-    return async (req: RestRequest): Promise<MockResponse> => {
-      const _response = fetch(req)
-      const latency = parseInt(mockEnv('KUMA_LATENCY', '0'))
-      if (latency !== 0) {
-        await new Promise(resolve => setTimeout(resolve, latency))
-      }
-      return cb(createMerge(_response), req, _response)
-    }
-  }
-}
-
-export const server = <TDependencies extends object = {}, TEnvKeys extends string = string>(mock: MockEndpoint<TDependencies>, options: {
-  env?: Record<TEnvKeys, string>
-  params?: Record<string, string>
-}, dependencies: Dependencies<TDependencies>) => {
+export const server = <TDependencies extends object = {}>(
+  mock: MockEndpoint<TDependencies>,
+  options: {
+    params?: Record<string, string>
+  },
+  dependencies: Dependencies<TDependencies>,
+) => {
   return async (env: Record<string, string>) => {
-    const responder = useResponder({
-      _: mock,
-    }, {
-      ...dependencies,
-      env: (key: keyof typeof env, d = '') => env[key] ?? d,
-    })
-    const request = responder('_')
-    return (await request(
-      {
-        method: 'GET',
-        body: {},
-        url: {
-          searchParams: new URLSearchParams(),
-        },
-        params: options.params ?? {},
+
+    dependencies.env = (key: keyof typeof env, d = '') => {
+      return env[key] ?? d
+    }
+
+    const route = Object.keys(options.params ?? {}).reduce((prev, item) => {
+      return `${prev}:${item}/`
+    }, '/')
+    const path = Object.values(options.params ?? {}).reduce((prev, item) => {
+      return `${prev}${item}/`
+    }, 'http://localhost/')
+
+    const fetch = createFetch({
+      dependencies,
+      fs: {
+        [route]: mock,
       },
-    ))?.body
+    })
+    const response = await fetch(path, {
+      method: 'GET',
+    })
+    return response.json()
   }
 }
 
 export const handler = <TDependencies extends object = {}>(fs: FS, dependencies: Dependencies<TDependencies>) => {
   const baseUrl = dependencies.env('KUMA_API_URL')
-  const responder = useResponder(fs, dependencies)
+  const fetch = createFetch({
+    dependencies,
+    fs,
+  })
   return (route: string) => {
-    const respond = responder(route)
     const base = route.includes('://') ? '' : baseUrl
     if (route.startsWith('://')) {
       route = route.replace('://', '')
     }
-    return http.all(`${base}${escapeRoute(route)}`, async ({ request, params }) => {
-      const response = await respond({
-        method: request.method,
-        url: new URL(request.url),
-        body: request.body ? JSON.parse(await new Response(request.body).text() || '{}') : {},
-        params: Object.fromEntries(
-          Object.entries(params).filter(
-            (entry): entry is [string, string | readonly string[]] => typeof entry[1] !== 'undefined',
-          ),
-        ),
+    return http.all(`${base}${escapeRoute(route)}`, async ({ request: req }) => {
+      // headers can be string | string[] | undefined, not string
+      const headers = Object.entries(req.headers).reduce((prev, [key, item]) => {
+        if (typeof item !== 'undefined') {
+          prev[key] = Array.isArray(item) ? item[0] : item
+        }
+        return prev
+      }, {} as Record<string, string>)
+      const response = await fetch(`${req.url ?? ''}`, {
+        method: req.method,
+        headers,
+        body: req.body ? JSON.parse(await new Response(req.body).text() || '{}') : {},
       })
-
       if (typeof response === 'undefined') {
         return passthrough()
       }
-
-      return HttpResponse.json(response.body, {
-        status: parseInt(response.headers?.['Status-Code'] ?? '200'),
+      return HttpResponse.json((await response.json()), {
+        status: parseInt(response.headers?.get('Status-Code') ?? '200'),
       })
     })
   }

--- a/packages/fake-api/src/vite.ts
+++ b/packages/fake-api/src/vite.ts
@@ -8,16 +8,19 @@ type PluginOptions<TDependencies extends object = {}> = {
 }
 
 export default <TDependencies extends object = {}>(opts: PluginOptions<TDependencies>): Plugin => {
-  const { fs, dependencies } = opts
-
-  const fetch = createFetch({
-    dependencies,
-    fs,
-  })
 
   return {
     name: 'fake-api',
     configureServer: async (server) => {
+      const { fs, dependencies } = opts
+      const baseUrl = `http://${server.config.server.host}:${server.config.server.port}`
+      const _fs = Object.fromEntries(Object.entries(fs).map(([route, response]) => {
+        return [route.includes('://') ? route : `${baseUrl}${route}`, response]
+      }))
+      const fetch = createFetch({
+        dependencies,
+        fs: _fs,
+      })
       server.middlewares.use(async (req, res, next) => {
         try {
           // headers can be string | string[] | undefined, not string

--- a/packages/kuma-gui/cypress/services.ts
+++ b/packages/kuma-gui/cypress/services.ts
@@ -5,7 +5,7 @@ import { token, ServiceDefinition, createInjections } from '@/services/utils'
 import type { EndpointDependencies } from '@/test-support'
 import { dependencies } from '@/test-support'
 import getClient from '@/test-support/client'
-import type { Callback, Options } from '@kumahq/fake-api'
+import type { Middleware, Options } from '@kumahq/fake-api'
 
 
 // this needs to come from testing
@@ -16,13 +16,11 @@ const env = (
 }
 type AEnv = ReturnType<typeof env>
 // temporary intercept returning Mocker
-type Mocker = (route: string, opts?: Options, cb?: Callback) => ReturnType<typeof cy['intercept']>
+type Mocker = (route: string, opts?: Options, cb?: Middleware) => ReturnType<typeof cy['intercept']>
 const $ = {
   EnvVars: token<EnvVars>('EnvVars'),
   env: token<AEnv>('env'),
 
-  cy: token<typeof cy>('cy'),
-  mockServer: token('mockServer'),
   mock: token<Mocker>('mocker'),
   Env: token('Env'),
   client: token<ReturnType<typeof getClient>>('client'),
@@ -51,27 +49,14 @@ export const services = <T extends Record<string, Token>>(app: T): ServiceDefini
     ],
   }],
 
-  [app.cy, {
-    constant: cy,
-  }],
   [$.client, {
     service: getClient,
-  }],
-  [app.mockServer, {
-    service: (mock: Mocker) => {
-      mock('*')
-    },
-    arguments: [
-      app.mock,
-    ],
   }],
   [app.mock, {
     service: mocker,
     arguments: [
-      app.cy,
-      app.fakeFS,
-      $.client,
       $.dependencies,
+      app.fakeFS,
     ],
   }],
   // this will eventually come from testing
@@ -86,6 +71,5 @@ export const services = <T extends Record<string, Token>>(app: T): ServiceDefini
 export const TOKENS = $
 export const [
   useMock,
-  useServer,
   useClient,
-] = createInjections($.mock, $.mockServer, $.client)
+] = createInjections($.mock, $.client)

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
@@ -21,7 +21,10 @@ Feature: Dataplane policies
       | inbound-rule-item                  | [data-testid='inbound-rule-list-0'] .accordion-item                   |
       | inbound-rule-item-button           | $inbound-rule-item:nth-child(1) [data-testid='accordion-item-button'] |
       | summary-slideout-container         | [data-testid='summary'] [data-testid='slideout-container']            |
-
+      And the environment
+      """
+        KUMA_RESOURCE_COUNT: 100
+      """
   Rule: Any networking type
 
     Scenario: Policies tab has expected content (MeshHTTPRoute with to rules)
@@ -336,14 +339,6 @@ Feature: Dataplane policies
                     port: 8080
                     tags:
                       kuma.io/service: foo
-        """
-      And the URL "/_resources" responds with
-        """
-        body:
-          resources:
-            - name: MeshHTTPRoute
-              policy:
-                isFromAsRules: true
         """
       When I visit the "/meshes/default/data-planes/dataplane-1/policies" URL
       Then the "$to-rule-item-content" element doesn't exist

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -171,9 +171,9 @@
                   v-slot="{ data: sidecarDataplaneData }: SidecarDataplaneCollectionSource"
                 >
                   <DataCollection
-                    :predicate="(item) => policyTypes[item.type]?.policy.isTargetRef === false"
-                    :items="sidecarDataplaneData!.policyTypeEntries"
                     :empty="false"
+                    :items="sidecarDataplaneData!.policyTypeEntries"
+                    :predicate="(item) => policyTypes[item.type]?.policy.isTargetRef === false"
                     v-slot="{ items }"
                   >
                     <h3>


### PR DESCRIPTION
Note this was reviewed previously and reverted, I've made additional amends to the original PR in the second commit here to keep the changes separate. I've also done some "pre-testing" elsewhere to make sure it works once we merge to try and avoid having to revert again if I messed up.

---

Refactors some more of fake-api, mostly:

- Reduce everything down to a reusable `createFetch`/`createFetchSync`, that returns something that is very fetch-like (i.e. very recognisable). Note: `createFetchSync` is needed for Cypress which is notorious weird with async things.
- I moved the YAML/JSON merging we do for overwriting responses during tests out of fake-api entirely. If you aren't doing tests like we are then you wouldn't need this in order to build basic fake-apis.

Probably a few other little bits. Unfortunately the PR is a little large, if it was me I'd look at/compare this locally to get a better feel for the improvement here.

We are still not quite done here, but with what we did before extracting things out into its own module, and what is here, I'm far happier with this code now.