### PR TITLE
chore(control-planes): move routing to be a child of control-planes

### DIFF
--- a/packages/kuma-gui/src/app/App.vue
+++ b/packages/kuma-gui/src/app/App.vue
@@ -33,7 +33,7 @@
             :active="child.name === 'control-plane-detail-view'"
             label="Home"
             :to="{
-              name: 'home',
+              name: 'control-plane-root-view',
             }"
           />
           <AppNavigator
@@ -100,7 +100,7 @@ type StringNamedRouteRecordRaw = RouteRecordRaw & {
   name: string
 }
 const router = useRouter()
-const children: StringNamedRouteRecordRaw[] = (router.getRoutes().find((route) => route.name === 'home')?.children.map(item => {
+const children: StringNamedRouteRecordRaw[] = (router.getRoutes().find((route) => route.name === 'control-plane-root-view')?.children.map(item => {
   item.name = String(item.name)
   return item as StringNamedRouteRecordRaw
 }) ?? [])

--- a/packages/kuma-gui/src/app/App.vue
+++ b/packages/kuma-gui/src/app/App.vue
@@ -30,7 +30,7 @@
           <AppNavigator
             v-style="'--icon: var(--icon-home)'"
             data-testid="control-planes-navigator"
-            :active="child.name === 'home'"
+            :active="child.name === 'control-plane-detail-view'"
             label="Home"
             :to="{
               name: 'home',
@@ -100,7 +100,7 @@ type StringNamedRouteRecordRaw = RouteRecordRaw & {
   name: string
 }
 const router = useRouter()
-const children: StringNamedRouteRecordRaw[] = (router.getRoutes().find((route) => route.name === 'app')?.children.map(item => {
+const children: StringNamedRouteRecordRaw[] = (router.getRoutes().find((route) => route.name === 'home')?.children.map(item => {
   item.name = String(item.name)
   return item as StringNamedRouteRecordRaw
 }) ?? [])

--- a/packages/kuma-gui/src/app/application/routes.ts
+++ b/packages/kuma-gui/src/app/application/routes.ts
@@ -4,9 +4,9 @@ import type { RouteRecordRaw } from 'vue-router'
 export const routes = (notFoundViews: (() => Promise<Component>)[]): RouteRecordRaw[] => {
   return [
     {
-      path: '/404',
-      name: 'kuma-not-found-view',
-      alias: '/:pathMatch(.*)*',
+      path: '404',
+      name: 'app-not-found-view',
+      alias: ':pathMatch(.*)*',
       component: () => notFoundViews[notFoundViews.length - 1](),
     },
   ]

--- a/packages/kuma-gui/src/app/application/services/data-source/Router.spec.ts
+++ b/packages/kuma-gui/src/app/application/services/data-source/Router.spec.ts
@@ -40,6 +40,6 @@ describe('Router', () => {
       },
     })
 
-    expect(() => router.match('/kuma-not-found-view/')).toThrow(Error)
+    expect(() => router.match('/undefined-uri/')).toThrow(Error)
   })
 })

--- a/packages/kuma-gui/src/app/control-planes/routes.ts
+++ b/packages/kuma-gui/src/app/control-planes/routes.ts
@@ -3,7 +3,7 @@ export const routes = (): RouteRecordRaw[] => {
   return [
     {
       path: '',
-      name: 'home',
+      name: 'control-plane-root-view',
       component: () => import('@/app/control-planes/views/ControlPlaneRootView.vue'),
       redirect: { name: 'control-plane-detail-view' },
       children: [

--- a/packages/kuma-gui/src/app/control-planes/routes.ts
+++ b/packages/kuma-gui/src/app/control-planes/routes.ts
@@ -4,7 +4,15 @@ export const routes = (): RouteRecordRaw[] => {
     {
       path: '',
       name: 'home',
-      component: () => import('@/app/control-planes/views/ControlPlaneDetailView.vue'),
+      component: () => import('@/app/control-planes/views/ControlPlaneRootView.vue'),
+      redirect: { name: 'control-plane-detail-view' },
+      children: [
+        {
+          path: '',
+          name: 'control-plane-detail-view',
+          component: () => import('@/app/control-planes/views/ControlPlaneDetailView.vue'),
+        },
+      ],
     },
   ]
 }

--- a/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    name="home"
+    name="control-plane-detail-view"
     v-slot="{ can, t, uri, me }"
   >
     <AppView>

--- a/packages/kuma-gui/src/app/control-planes/views/ControlPlaneRootView.vue
+++ b/packages/kuma-gui/src/app/control-planes/views/ControlPlaneRootView.vue
@@ -1,0 +1,16 @@
+<template>
+  <RouteView
+    name="home"
+  >
+    <AppView>
+      <RouterView
+        v-slot="{ Component }"
+      >
+        <component
+          :is="Component"
+        />
+      </RouterView>
+    </AppView>
+  </RouteView>
+</template>
+

--- a/packages/kuma-gui/src/app/control-planes/views/ControlPlaneRootView.vue
+++ b/packages/kuma-gui/src/app/control-planes/views/ControlPlaneRootView.vue
@@ -1,6 +1,6 @@
 <template>
   <RouteView
-    name="home"
+    name="control-plane-root-view"
   >
     <AppView>
       <RouterView

--- a/packages/kuma-gui/src/app/hostname-generators/index.ts
+++ b/packages/kuma-gui/src/app/hostname-generators/index.ts
@@ -3,6 +3,7 @@ import { routes } from './routes'
 import { sources } from './sources'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
+import type { RouteRecordRaw } from 'vue-router'
 
 type Token = ReturnType<typeof token>
 
@@ -18,12 +19,17 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
     }],
     [token('hostname-generators.routes'), {
-      service: routes,
-      arguments: [
-        app.can,
-      ],
+      service: () => {
+        return [
+          (item: RouteRecordRaw) => {
+            if (item.name === 'control-plane-root-view') {
+              item.children = (item.children ?? []).concat(routes())
+            }
+          },
+        ]
+      },
       labels: [
-        app.routes,
+        app.routeWalkers,
       ],
     }],
     [token('hostname-generators.locales'), {

--- a/packages/kuma-gui/src/app/hostname-generators/routes.ts
+++ b/packages/kuma-gui/src/app/hostname-generators/routes.ts
@@ -9,7 +9,7 @@ export const routes = (
 ): RouteRecordRaw[] => {
   return [
     {
-      path: '/hostname-generators',
+      path: 'hostname-generators',
       name: 'hostname-generator-root-view',
       redirect: { name: 'hostname-generator-list-view' },
       component: () => import('@/app/hostname-generators/views/HostnameGeneratorRootView.vue'),

--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -30,7 +30,7 @@
             class="horizontal-list"
           >
             <slot name="header">
-              <XAction :to="{ name: 'home' }">
+              <XAction :to="{ name: 'control-plane-root-view' }">
                 <slot name="home" />
               </XAction>
 

--- a/packages/kuma-gui/src/app/kuma/views/KumaNotFoundView.vue
+++ b/packages/kuma-gui/src/app/kuma/views/KumaNotFoundView.vue
@@ -25,7 +25,7 @@
           <template #action>
             <XAction
               appearance="primary"
-              :to="{ name: 'home' }"
+              :to="{ name: 'control-plane-root-view' }"
             >
               Go Home
             </XAction>

--- a/packages/kuma-gui/src/app/meshes/index.ts
+++ b/packages/kuma-gui/src/app/meshes/index.ts
@@ -33,7 +33,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       service: (r) => {
         return [
           (item: RouteRecordRaw) => {
-            if (item.name === 'home') {
+            if (item.name === 'control-plane-root-view') {
               item.children = (item.children ?? []).concat(routes(r[0], r[1], r[2], r[3]))
             }
           },

--- a/packages/kuma-gui/src/app/meshes/index.ts
+++ b/packages/kuma-gui/src/app/meshes/index.ts
@@ -10,6 +10,7 @@ import { services as rules } from '@/app/rules'
 import { services as servicesModule } from '@/app/services'
 import type { ServiceDefinition } from '@/services/utils'
 import { token } from '@/services/utils'
+import type { RouteRecordRaw } from 'vue-router'
 
 type Token = ReturnType<typeof token>
 
@@ -30,13 +31,19 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
     [token('meshes.routes'), {
       service: (r) => {
-        return routes(r[0], r[1], r[2], r[3])
+        return [
+          (item: RouteRecordRaw) => {
+            if (item.name === 'home') {
+              item.children = (item.children ?? []).concat(routes(r[0], r[1], r[2], r[3]))
+            }
+          },
+        ]
       },
       arguments: [
         mesh.routes,
       ],
       labels: [
-        app.routes,
+        app.routeWalkers,
       ],
     }],
     [token('meshes.locales'), {

--- a/packages/kuma-gui/src/app/meshes/routes.ts
+++ b/packages/kuma-gui/src/app/meshes/routes.ts
@@ -13,7 +13,7 @@ export const routes = (
 ): RouteRecordRaw[] => {
   return [
     {
-      path: '/meshes',
+      path: 'meshes',
       name: 'mesh-index-view',
       redirect: { name: 'mesh-list-view' },
       component: () => import('@/app/meshes/views/MeshRootView.vue'),

--- a/packages/kuma-gui/src/app/zones/index.ts
+++ b/packages/kuma-gui/src/app/zones/index.ts
@@ -27,7 +27,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       service: (can) => {
         return [
           (item: RouteRecordRaw) => {
-            if (item.name === 'home') {
+            if (item.name === 'control-plane-root-view') {
               item.children = (item.children ?? []).concat(routes(can))
             }
           },

--- a/packages/kuma-gui/src/app/zones/index.ts
+++ b/packages/kuma-gui/src/app/zones/index.ts
@@ -8,6 +8,7 @@ import egressLocales from '@/app/zone-egresses/locales/en-us/index.yaml'
 import ingressLocales from '@/app/zone-ingresses/locales/en-us/index.yaml'
 import type { ServiceDefinition } from '@/services/utils'
 import { token, createInjections } from '@/services/utils'
+import type { RouteRecordRaw } from 'vue-router'
 
 type Token = ReturnType<typeof token>
 
@@ -22,14 +23,21 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
         return ZoneControlPlanesList
       },
     }],
-
     [token('zones.routes'), {
-      service: routes,
+      service: (can) => {
+        return [
+          (item: RouteRecordRaw) => {
+            if (item.name === 'home') {
+              item.children = (item.children ?? []).concat(routes(can))
+            }
+          },
+        ]
+      },
       arguments: [
         app.can,
       ],
       labels: [
-        app.routes,
+        app.routeWalkers,
       ],
     }],
     [token('zone.sources'), {

--- a/packages/kuma-gui/src/app/zones/routes.ts
+++ b/packages/kuma-gui/src/app/zones/routes.ts
@@ -7,7 +7,7 @@ import type { RouteRecordRaw } from 'vue-router'
 export const routes = (
   can: Can,
 ): RouteRecordRaw[] => {
-  const prefix = '/zones'
+  const prefix = 'zones'
   return [
     ...(can('use zones')
       ? [


### PR DESCRIPTION
Closes https://github.com/kumahq/kuma-gui/issues/3570

After this goes in I'll probably make some immediate amends ontop of https://github.com/kumahq/kuma-gui/pull/3789, so ideally this would go in first.

I probably should have done this PR first tbf. The plan is to put the notification about "control-plane using a memory store" in the control-plane module where it belongs. The only reason we haven't done that already is because we had no where to put it that meant its always visible, so it ended up going in App.vue.
