### PR TITLE
feat(mesh): add info to activate meshServices

### DIFF
--- a/packages/kuma-gui/features/mesh/Warnings.feature
+++ b/packages/kuma-gui/features/mesh/Warnings.feature
@@ -1,0 +1,27 @@
+Feature: mesh / warnings
+
+  Background:
+    Given the CSS selectors
+      | Alias                     | Selector                                                                        |
+      | mesh-service-activation      | [data-testid^='notification-meshes.notifications.mesh-service-activation']     |
+
+    Rule: MeshService activation
+
+      Scenario: meshServices is not configured
+        Given the URL "/meshes/default" responds with
+          """
+          body:
+            meshServices: !!js/undefined
+          """
+        When I visit the "/meshes/default/overview" URL
+        Then the "$mesh-service-activation" element exists
+
+      Scenario: meshServices is configured
+        Given the URL "/meshes/default" responds with
+          """
+          body:
+            meshServices:
+              mode: Exclusive
+          """
+        When I visit the "/meshes/default/overview" URL
+        Then the "$mesh-service-activation" element doesn't exists

--- a/packages/kuma-gui/features/mesh/Warnings.feature
+++ b/packages/kuma-gui/features/mesh/Warnings.feature
@@ -2,26 +2,26 @@ Feature: mesh / warnings
 
   Background:
     Given the CSS selectors
-      | Alias                     | Selector                                                                        |
-      | mesh-service-activation      | [data-testid^='notification-meshes.notifications.mesh-service-activation']     |
+      | Alias                   | Selector                                                                   |
+      | mesh-service-activation | [data-testid^='notification-meshes.notifications.mesh-service-activation'] |
 
-    Rule: MeshService activation
+  Rule: MeshService activation
 
-      Scenario: meshServices is not configured
-        Given the URL "/meshes/default" responds with
-          """
-          body:
-            meshServices: !!js/undefined
-          """
-        When I visit the "/meshes/default/overview" URL
-        Then the "$mesh-service-activation" element exists
+    Scenario: meshServices is not configured
+      Given the URL "/meshes/default" responds with
+        """
+        body:
+          meshServices: !!js/undefined
+        """
+      When I visit the "/meshes/default/overview" URL
+      Then the "$mesh-service-activation" element exists
 
-      Scenario: meshServices is configured
-        Given the URL "/meshes/default" responds with
-          """
-          body:
-            meshServices:
-              mode: Exclusive
-          """
-        When I visit the "/meshes/default/overview" URL
-        Then the "$mesh-service-activation" element doesn't exists
+    Scenario: meshServices is configured
+      Given the URL "/meshes/default" responds with
+        """
+        body:
+          meshServices:
+            mode: Exclusive
+        """
+      When I visit the "/meshes/default/overview" URL
+      Then the "$mesh-service-activation" element doesn't exists

--- a/packages/kuma-gui/src/app/meshes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/meshes/locales/en-us/index.yaml
@@ -20,6 +20,8 @@ meshes:
         MeshTrafficPermission policy
       </a>
       for this mesh.
+    mesh-service-activation: !!text/markdown |
+      This Mesh has not enabled a mode for MeshServices yet. Consider a <a target="_blank" href="{KUMA_DOCS_URL}/networking/meshservice/#migration">migration to MeshServices</a> to get the most out of your Mesh.
 
 
   common:

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -29,6 +29,15 @@
             path="meshes.notifications.mtls-warning"
           />
         </XNotification>
+        <XNotification
+          :notify="!mesh.meshServices.mode || mesh.meshServices.mode === 'Disabled'"
+          :uri="`meshes.notifications.mesh-service-activation:${route.params.mesh}`"
+          variant="info"
+        >
+          <XI18n
+            path="meshes.notifications.mesh-service-activation"
+          />
+        </XNotification>
         <XLayout
           type="stack"
         >

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -30,7 +30,7 @@
           />
         </XNotification>
         <XNotification
-          :notify="!mesh.meshServices.mode || mesh.meshServices.mode === 'Disabled'"
+          :notify="mesh.meshServices.mode === 'Disabled'"
           :uri="`meshes.notifications.mesh-service-activation:${route.params.mesh}`"
           variant="info"
         >


### PR DESCRIPTION
In case `meshServices` mode has not been configured or set to `Disabled`, we want to inform the users to migrate to `MeshService`s. Includes a link to [meshservice/migration](https://kuma.io/docs/2.10.x/networking/meshservice/#migration).

Closes #3161