### PR TITLE
chore: minor X cleanup

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-about-card/XAboutCard.vue
+++ b/packages/kuma-gui/src/app/x/components/x-about-card/XAboutCard.vue
@@ -1,33 +1,37 @@
 <template>
-  <AppAboutSection
-    :created="props.created ? t('common.formats.datetime', { value: Date.parse(props.created)}) : undefined"
-    :modified="props.modified ? t('common.formats.datetime', { value: Date.parse(props.modified)}) : undefined"
+  <XI18n
+    v-slot="{ t }"
   >
-    <template
-      v-for="(_, slotName) in slots"
-      :key="slotName"
-      #[slotName]="slotProps"
+    <AppAboutSection
+      v-bind="attrs"
+      :created="props.created ? t('common.formats.datetime', { value: Date.parse(props.created)}) : undefined"
+      :modified="props.modified ? t('common.formats.datetime', { value: Date.parse(props.modified)}) : undefined"
     >
-      <slot
-        :name="slotName"
-        v-bind="(slotProps)"
-      />
-    </template>
-  </AppAboutSection>
+      <template
+        v-for="(_, slotName) in slots"
+        :key="slotName"
+        #[slotName]="slotProps"
+      >
+        <slot
+          :name="slotName"
+          v-bind="(slotProps)"
+        />
+      </template>
+    </AppAboutSection>
+  </XI18n>
 </template>
 
 <script setup lang="ts">
 import { AppAboutSection } from '@kong-ui-public/app-layout'
-import { useI18n } from '@kong-ui-public/i18n'
-
+import { useAttrs } from 'vue'
 
 const props = defineProps<{
   created?: string
   modified?: string
 }>()
 const slots = defineSlots()
+const attrs = useAttrs()
 
-const { t } = useI18n()
 </script>
 
 <style lang="scss" scoped>

--- a/packages/kuma-gui/src/app/x/components/x-action/XAction.vue
+++ b/packages/kuma-gui/src/app/x/components/x-action/XAction.vue
@@ -171,10 +171,11 @@
 </template>
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
-import { KDropdownItem, ButtonAppearance } from '@kong/kongponents'
+import { KDropdownItem, KButton } from '@kong/kongponents'
 import { computed, watch, inject } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 
+import type { ButtonAppearance } from '@kong/kongponents'
 import type { RouteLocationNamedRaw } from 'vue-router'
 type BooleanLocationQueryValue = string | number | undefined | boolean
 type BooleanLocationQueryRaw = Record<string | number, BooleanLocationQueryValue | BooleanLocationQueryValue[]>

--- a/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
@@ -40,12 +40,13 @@
 </template>
 
 <script lang="ts" setup>
-import { type CodeBlockEventData, KCodeBlock } from '@kong/kongponents'
+import { KCodeBlock } from '@kong/kongponents'
 import { createHighlighterCore } from 'shiki/core'
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
 import { ref } from 'vue'
 
 import { uniqueId } from '@/app/application'
+import type { CodeBlockEventData } from '@kong/kongponents'
 
 const props = withDefaults(defineProps<{
   id?: string

--- a/packages/kuma-gui/src/app/x/components/x-input/XInput.vue
+++ b/packages/kuma-gui/src/app/x/components/x-input/XInput.vue
@@ -16,6 +16,7 @@
   </KInput>
 </template>
 <script lang="ts" setup>
+import { KInput } from '@kong/kongponents'
 import { useDebounceFn } from '@vueuse/core'
 import { computed } from 'vue'
 

--- a/packages/kuma-gui/src/app/x/components/x-prompt/XPrompt.vue
+++ b/packages/kuma-gui/src/app/x/components/x-prompt/XPrompt.vue
@@ -17,7 +17,9 @@
   </KPrompt>
 </template>
 <script lang="ts" setup>
+import { KPrompt } from '@kong/kongponents'
 import { onBeforeUnmount, provide } from 'vue'
+
 const emit = defineEmits<{
   (e: 'cancel'): void
   (e: 'submit'): void

--- a/packages/kuma-gui/src/app/x/components/x-tabs/XTabs.vue
+++ b/packages/kuma-gui/src/app/x/components/x-tabs/XTabs.vue
@@ -24,6 +24,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { KTabs } from '@kong/kongponents'
 import { useAttrs, computed, onMounted, ref, watch } from 'vue'
 
 import type { Tab } from '@kong/kongponents'


### PR DESCRIPTION
I spotted some more tiny bits in our `x` module that will affect our ability to make it into a completely zero dependency module in the future.

- Missing Kongponents imports where we were depending on kongponents being available globally.
- one instance I spotted of direct usage of `@kong-ui-public/i18n`, we should try and use `XI18n` exclusively within `x`. I hope to provide a very simple but injectable instance of i18n eventually making `x` zero dependency.