### PR TITLE
chore(ci): adds resolver to resolve node execs from @kumahq/config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4845,7 +4845,6 @@
       "version": "2.4.12",
       "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.12.tgz",
       "integrity": "sha512-RLrFdXEaQBWfSnYGVxvR2WrO6Bub0unkdHYIdC31HzIEqATIuuhRRzYu76iGPZ6OtA4Au1SnW0ZwIqPP217YhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/source-map": "2.4.12"
@@ -4855,14 +4854,12 @@
       "version": "2.4.12",
       "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.12.tgz",
       "integrity": "sha512-bUFIKvn2U0AWojOaqf63ER0N/iHIBYZPpNGogfLPQ68F5Eet6FnLlyho7BS0y2HJ1jFhSif7AcuTx1TqsCzRzw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
       "version": "2.4.12",
       "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.12.tgz",
       "integrity": "sha512-HJB73OTJDgPc80K30wxi3if4fSsZZAOScbj2fcicMuOPoOkcf9NNAINb33o+DzhBdF9xTKC1gnPmIRDous5S0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.12",
@@ -4924,7 +4921,6 @@
       "version": "2.7.16",
       "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
       "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "de-indent": "^1.0.2",
@@ -4996,7 +4992,6 @@
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.10.tgz",
       "integrity": "sha512-+yNoYx6XIKuAO8Mqh1vGytu8jkFEOH5C8iOv3i8Z/65A7x9iAOXA97Q+PqZ3nlm2lxf5rOJuIGI/wDtx/riNYw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "~2.4.11",
@@ -5372,7 +5367,6 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
       "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ansi-colors": {
@@ -6968,7 +6962,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
       "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -12283,7 +12276,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -12876,7 +12868,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-exists": {
@@ -16775,7 +16766,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vue": {
@@ -16907,7 +16897,6 @@
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.10.tgz",
       "integrity": "sha512-jWZ1xSaNbabEV3whpIDMbjVSVawjAyW+x1n3JeGQo7S0uv2n9F/JMgWW90tGWNFRKya4YwKMZgCtr0vRAM7DeQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "~2.4.11",
@@ -17532,7 +17521,8 @@
         "globals": "^16.0.0",
         "stylelint-config-html": "^1.1.0",
         "stylelint-config-recommended-scss": "^14.1.0",
-        "stylelint-config-recommended-vue": "^1.6.0"
+        "stylelint-config-recommended-vue": "^1.6.0",
+        "vue-tsc": "^2.2.10"
       }
     },
     "packages/fake-api": {
@@ -17609,8 +17599,7 @@
         "vite": "^6.3.3",
         "vite-svg-loader": "^5.1.0",
         "vitepress": "^2.0.0-alpha.5",
-        "vitest": "^3.1.2",
-        "vue-tsc": "^2.2.10"
+        "vitest": "^3.1.2"
       }
     },
     "packages/kuma-http-api": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -42,6 +42,7 @@
     "globals": "^16.0.0",
     "stylelint-config-html": "^1.1.0",
     "stylelint-config-recommended-scss": "^14.1.0",
-    "stylelint-config-recommended-vue": "^1.6.0"
+    "stylelint-config-recommended-vue": "^1.6.0",
+    "vue-tsc": "^2.2.10"
   }
 }

--- a/packages/config/src/mk/check.mk
+++ b/packages/config/src/mk/check.mk
@@ -1,3 +1,8 @@
+
+resolve/bin:
+	@cd $(KUMAHQ_CONFIG) && \
+		node -e \
+			"const p = require.resolve('$(BIN)/package.json');const { dirname, resolve } = require('path'); console.log(resolve(dirname(p), require(p).bin['$(BIN)']))"
 .PHONY: check/node
 check/node: NPM_VERSION:=$(shell cat $(NPM_WORKSPACE_ROOT)/package.json | jq -r '.engines.npm')
 check/node: NODE_VERSION:=v$(shell head -n1 $(NPM_WORKSPACE_ROOT)/.nvmrc)
@@ -26,8 +31,9 @@ lint/js:
 		.
 
 .PHONY: lint/ts
+lint/ts: TSC ?= $(shell $(MAKE) resolve/bin BIN=vue-tsc)
 lint/ts:
-	@npx vue-tsc \
+	@$(TSC) \
 		--noEmit
 
 .PHONY: lint/css

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -67,8 +67,7 @@
     "vite": "^6.3.3",
     "vite-svg-loader": "^5.1.0",
     "vitepress": "^2.0.0-alpha.5",
-    "vitest": "^3.1.2",
-    "vue-tsc": "^2.2.10"
+    "vitest": "^3.1.2"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
TLDR; Adds a "node resolver" to our Makefile scripts

---

We've moved all of our CI/dev utility scripts over to Makefiles, because:

- Its overly difficult writing scripts inside JSON files (package.json)
- Makefiles are sharable, package.json scripts aren't
- All other benefits of Make

The one downside is, Make does not use node import/modules or node resolution for its binaries.

This means that if we install something in `@kumahq/config` and run one of `@kumahq/config`s Make scripts that uses a node binary it isn't necessarily looked up properly because Make uses its `cwd` and `$PATH` as a "path".

We've been using `npx` which relies on the executable being installed in root for a Make call.

So from `/packages/kuma-gui` to find an executable in `/`.

Whereas if we install the executable in `@kumahq/config` there is every chance that the executable will end up in `/packages/config`, so using `npx` from within `/packages/kuma-gui` will not find for example `/packages/config/node_modules/.bin/vue-tsc`.

This PR adds a simple node resolver to lookup any Makefile binaries for any of the make targets we use. We then use that to call `vue-tsc`.

Depending on how successful this is we can roll it out in a similar fashion across out Makefile targets and move any executable dependencies of `@kumahq/config` to where they should be (in `@kumahq/config`)
