### PR TITLE
chore(ci): moves lockfile-lint to @kumahq/config

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-vue": "^10.0.0",
     "glob": "^11.0.2",
     "globals": "^16.0.0",
+    "lockfile-lint": "^4.14.1",
     "stylelint-config-html": "^1.1.0",
     "stylelint-config-recommended-scss": "^14.1.0",
     "stylelint-config-recommended-vue": "^1.6.0",

--- a/packages/config/src/mk/check.mk
+++ b/packages/config/src/mk/check.mk
@@ -49,8 +49,9 @@ lint/gherkin:
 		-exec npx gherkin-utils format '{}' +
 
 .PHONY: lint/lock
+lint/lock: LOCK_LINT ?= $(shell $(MAKE) resolve/bin BIN=lockfile-lint)
 lint/lock:
-	@npx lockfile-lint \
+	@$(LOCK_LINT) \
 		--path package-lock.json \
 		--allowed-hosts npm \
 		--validate-https

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -54,7 +54,6 @@
     "glob": "^11.0.2",
     "gray-matter": "^4.0.3",
     "jsdom": "^26.1.0",
-    "lockfile-lint": "^4.14.1",
     "markdown-it": "^14.1.0",
     "msw": "^2.7.5",
     "openapi-typescript": "^7.6.1",


### PR DESCRIPTION
Uses the approach added in https://github.com/kumahq/kuma-gui/pull/3818 to move lockfile-lint.

This should be enough to unblock us 😅 . Once we are unblocked I'll do a single PR to move all of them.

I actually think this is a major win for us 🎉 