### PR TITLE
chore(deps): update package-lock for lockfile-lint change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5222,7 +5222,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.3.tgz",
       "integrity": "sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "js-yaml": "^3.10.0",
@@ -5236,7 +5235,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -5246,7 +5244,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -11460,7 +11457,6 @@
       "version": "4.14.1",
       "resolved": "https://registry.npmjs.org/lockfile-lint/-/lockfile-lint-4.14.1.tgz",
       "integrity": "sha512-NW0Tk1qfldhbhJWQENYQWANdmlanXKxvTJYRYKn56INYjaP2M07Ua2SJYkUMS+ZbYwxDzul/C6pDsV/NEXrl+A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "cosmiconfig": "^9.0.0",
@@ -11480,7 +11476,6 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/lockfile-lint-api/-/lockfile-lint-api-5.9.2.tgz",
       "integrity": "sha512-3QhxWxl3jT9GcMxuCnTsU8Tz5U6U1lKBlKBu2zOYOz/x3ONUoojEtky3uzoaaDgExcLqIX0Aqv2I7TZXE383CQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@yarnpkg/parsers": "^3.0.0-rc.48.1",
@@ -12476,7 +12471,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -14589,7 +14583,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/sshpk": {
@@ -17519,6 +17512,7 @@
         "eslint-plugin-vue": "^10.0.0",
         "glob": "^11.0.2",
         "globals": "^16.0.0",
+        "lockfile-lint": "^4.14.1",
         "stylelint-config-html": "^1.1.0",
         "stylelint-config-recommended-scss": "^14.1.0",
         "stylelint-config-recommended-vue": "^1.6.0",
@@ -17586,7 +17580,6 @@
         "glob": "^11.0.2",
         "gray-matter": "^4.0.3",
         "jsdom": "^26.1.0",
-        "lockfile-lint": "^4.14.1",
         "markdown-it": "^14.1.0",
         "msw": "^2.7.5",
         "openapi-typescript": "^7.6.1",


### PR DESCRIPTION
Updates lockfile from package change made in https://github.com/kumahq/kuma-gui/pull/3820 that was missed in the original PR.

If you look at the diff this has zero consequential changes, its just moving the dep from one place to another, but I noticed this during https://github.com/kumahq/kuma-gui/pull/3825 and I would like that PR to be clean.