### PR TITLE
feat(policy-list-view): use x-search

### DIFF
--- a/packages/kuma-gui/features/mesh/policies/Index.feature
+++ b/packages/kuma-gui/features/mesh/policies/Index.feature
@@ -13,6 +13,7 @@ Feature: mesh / policies / index
       | action           | $item:first-child [data-action]                                                          |
       | button-docs      | [data-testid='policy-documentation-link']                                                |
       | breadcrumbs      | .k-breadcrumbs                                                                           |
+      | input-search     | [data-testid='filter-bar-filter-input']                                                  |
     And the environment
       """
       KUMA_MODE: global
@@ -143,3 +144,18 @@ Feature: mesh / policies / index
     Then the "$items-header" element exists 4 times
     When I click the "[data-testid='policy-type-link-MeshFaultInjection']" element
     Then the "$items-header" element exists 6 times
+
+  Scenario: Sending filters
+    When I visit the "/meshes/default/policies/meshgateways" URL
+    Then the "$input-search" element exists
+    Then I "type" "foo namespace:bar zone:baz" into the "$input-search" element
+    And I "type" "{enter}" into the "$input-search" element
+    Then the URL "/meshes/default/meshgateways" was requested with
+      """
+      searchParams:
+        name: foo
+        filter[labels.k8s.kuma.io/namespace]: bar
+        filter[labels.kuma.io/zone]: baz
+        offset: 0
+        size: 50
+      """

--- a/packages/kuma-gui/src/app/policies/data/index.ts
+++ b/packages/kuma-gui/src/app/policies/data/index.ts
@@ -1,5 +1,6 @@
 import { paths } from '@kumahq/kuma-http-api'
 
+import { Resource } from '@/app/resources/data/Resource'
 import type { PaginatedApiListResponse } from '@/types/api.d'
 import type {
   PolicyDataplane as PartialPolicyDataplane,
@@ -41,6 +42,10 @@ export const PolicyDataplane = {
 }
 
 export const Policy = {
+  search(query: string) {
+    return Resource.search(query)
+  },
+
   fromObject(item: PartialPolicy) {
     const labels = typeof item.labels !== 'undefined' ? item.labels : {}
     return {

--- a/packages/kuma-gui/src/app/policies/sources.ts
+++ b/packages/kuma-gui/src/app/policies/sources.ts
@@ -27,14 +27,14 @@ export const sources = (api: KumaApi) => {
 
       return PolicyResourceType.fromCollection(res.data!)
     },
-
+    
     '/meshes/:mesh/policy-path/:path': async (params) => {
       const { mesh, path, size } = params
       const offset = params.size * (params.page - 1)
 
-      const name = params.search.length > 0 ? params.search : undefined
+      const search = Policy.search(params.search)
 
-      return Policy.fromCollection(await api.getAllPolicyEntitiesFromMesh({ mesh, path }, { offset, size, name }))
+      return Policy.fromCollection(await api.getAllPolicyEntitiesFromMesh({ mesh, path }, { offset, size, ...search }))
     },
 
     '/meshes/:mesh/policy-path/:path/policy/:name': async (params) => {

--- a/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
@@ -67,15 +67,11 @@
                 <form
                   @submit.prevent
                 >
-                  <XInput
-                    placeholder="Filter by name..."
-                    type="search"
-                    appearance="search"
+                  <XSearch
+                    class="search-field"
+                    :keys="['name', 'namespace', ...(can('use zones') && type.policy.isTargetRef ? ['zone'] : [])]"
                     :value="route.params.s"
-                    :debounce="1000"
-                    @change="(e) => route.update({
-                      s: e,
-                    })"
+                    @change="(s) => route.update({ s })"
                   />
                 </form>
               </search>
@@ -175,6 +171,7 @@
                               query: {
                                 page: route.params.page,
                                 size: route.params.size,
+                                s: route.params.s,
                               },
                             }"
                           >
@@ -252,6 +249,7 @@
                         query: {
                           page: route.params.page,
                           size: route.params.size,
+                          s: route.params.s,
                         },
                       })"
                     >
@@ -317,5 +315,8 @@ search form {
   color: inherit;
   font-weight: $kui-font-weight-semibold;
   text-decoration: none;
+}
+.search-field {
+  flex: 1;
 }
 </style>

--- a/packages/kuma-gui/src/app/resources/data/Resource.ts
+++ b/packages/kuma-gui/src/app/resources/data/Resource.ts
@@ -1,0 +1,44 @@
+/**
+ * Filters should follow the rules of [kong-aip#160](https://kong-aip.netlify.app/aip/160/).
+ * 
+ * `filters` are the current defaults, but may not necessarily be used depending on the actual requirements of an API.
+ */
+const filters = {
+  namespace: 'filter[labels.k8s.kuma.io/namespace]',
+  zone: 'filter[labels.kuma.io/zone]',
+}
+
+type SearchOptions = {
+  defaultKey?: string
+}
+
+const isShortFilter = (k: string): k is keyof typeof filters => k in filters
+
+export const Resource = {
+  search(query: string, options: SearchOptions = {}) {
+    const { defaultKey = 'name' } = options
+    const parts = query.trim().split(/\s+/)
+
+    return parts.reduce((acc, curr) => {
+      const [key, value] = curr.split(/:(.*)/)
+      
+      switch(true) {
+        case Boolean(value): {
+          const _key = isShortFilter(key) ? filters[key] : key
+          return {
+            ...acc,
+            [_key]: value,
+          }
+        }
+        case curr.includes(':') || (!key && !value):
+          // at this point this would be an invalid query, i.e. `name:`
+          return acc
+        default:
+          return {
+            ...acc,
+            [defaultKey]: key,
+          }
+      }
+    }, {} as Record<string, string>)
+  },
+}

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/circuit-breakers.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/circuit-breakers.ts
@@ -7,6 +7,8 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     req,
     `/meshes/${params.mesh}/circuit-breakers`,
   )
+  
+  const queryName = req.url.searchParams.get('name')
 
   return {
     headers: {},
@@ -14,7 +16,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.word.noun()}-${id}`
+        const name = `${queryName?.padEnd(queryName.length + 1, '-') ?? ''}${fake.word.noun()}-${id}`
         return {
           type: 'CircuitBreaker',
           mesh: params.mesh,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/fault-injections.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/fault-injections.ts
@@ -7,13 +7,15 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     `/meshes/${mesh}/fault-injections`,
   )
 
+  const queryName = req.url.searchParams.get('name')
+
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.word.noun()}-${id}`
+        const name = `${queryName?.padEnd(queryName.length + 1, '-') ?? ''}${fake.word.noun()}-${id}`
 
         return {
           type: 'FaultInjection',

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/health-checks.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/health-checks.ts
@@ -3,12 +3,14 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
   const total = fake.number.int(200)
 
+  const queryName = req.url.searchParams.get('name')
+
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.word.noun()}-${i}`
+        const name = `${queryName?.padEnd(queryName.length + 1, '-') ?? ''}${fake.word.noun()}-${i}`
         return {
           type: 'HealthCheck',
           mesh: params.mesh,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshfaultinjections.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshfaultinjections.ts
@@ -9,16 +9,19 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
     `/meshes/${mesh}/meshfaultinjections`,
   )
 
+  const queryName = req.url.searchParams.get('name')
+  const queryNamespace = req.url.searchParams.get('filter[labels.k8s.kuma.io/namespace]')
+
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.word.noun()}-${id}`
+        const name = `${queryName?.padEnd(queryName.length + 1, '-') ?? ''}${fake.word.noun()}-${id}`
 
         const displayName = `${name}${fake.kuma.dataplaneSuffix(k8s)}`
-        const nspace = fake.k8s.namespace()
+        const nspace = queryNamespace ?? fake.k8s.namespace()
         return {
           type: 'MeshFaultInjection',
           mesh,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgatewayroutes.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgatewayroutes.ts
@@ -3,12 +3,14 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
   const total = fake.number.int(200)
 
+  const queryName = req.url.searchParams.get('name')
+
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.word.noun()}-${i}`
+        const name = `${queryName?.padEnd(queryName.length + 1, '-') ?? ''}${fake.word.noun()}-${i}`
         return {
           type: 'MeshGatewayRoute',
           mesh: params.mesh,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgateways.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshgateways.ts
@@ -12,6 +12,10 @@ export default ({ env, fake, pager }: EndpointDependencies): MockResponder => (r
   )
   const listenerCount = parseInt(env('KUMA_LISTENER_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
 
+  const queryName = req.url.searchParams.get('name')
+  const queryNamespace = req.url.searchParams.get('filter[labels.k8s.kuma.io/namespace]')
+  const queryZone = req.url.searchParams.get('filter[labels.kuma.io/zone]')
+
   return {
     headers: {},
     body: {
@@ -21,8 +25,9 @@ export default ({ env, fake, pager }: EndpointDependencies): MockResponder => (r
         const id = offset + i
         const name = `${fake.word.noun()}-${id}`
 
-        const displayName = `${name}${fake.kuma.dataplaneSuffix(k8s)}`
-        const nspace = fake.k8s.namespace()
+        const displayName = `${queryName?.padEnd(queryName.length + 1, '-') ?? ''}${name}${fake.kuma.dataplaneSuffix(k8s)}`
+        const nspace = queryNamespace ?? fake.k8s.namespace()
+        const zone = queryZone ?? fake.word.noun()
 
         return {
           type: 'MeshGateway',
@@ -33,7 +38,7 @@ export default ({ env, fake, pager }: EndpointDependencies): MockResponder => (r
           labels: {
             'kuma.io/display-name': displayName,
             'kuma.io/origin': fake.kuma.origin(),
-            'kuma.io/zone': fake.word.noun(),
+            'kuma.io/zone': zone,
             ...(k8s
               ? {
                 'k8s.kuma.io/namespace': nspace,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshhttproutes.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshhttproutes.ts
@@ -11,13 +11,18 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
   )
   const ruleMatchCount = parseInt(env('KUMA_RULE_MATCH_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
 
+  const nameQuery = req.url.searchParams.get('name')
+  const namespaceQuery = req.url.searchParams.get('filter[labels.k8s.kuma.io/namespace]')
+  const zoneQuery = req.url.searchParams.get('filter[labels.kuma.io/zone]')
+
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.word.noun()}-${id}`
+        const name = `${nameQuery?.padEnd(nameQuery.length + 1, '-') ?? ''}${fake.word.noun()}-${id}`
+        const zone = zoneQuery ?? fake.word.noun()
 
         return {
           type: 'MeshHTTPRoute',
@@ -25,13 +30,13 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
           name,
           creationTime: '2024-03-01T09:20:28Z',
           modificationTime: '2024-03-01T09:20:28Z',
-          ...(fake.datatype.boolean() && {
+          ...((namespaceQuery || fake.datatype.boolean()) && {
             labels: {
-              'k8s.kuma.io/namespace': 'kuma-system',
-              'kuma.io/display-name': 'demo-app',
+              'k8s.kuma.io/namespace': namespaceQuery ?? 'kuma-system',
+              'kuma.io/display-name': name,
               'kuma.io/mesh': 'default',
               'kuma.io/origin': 'zone',
-              'kuma.io/zone': fake.word.noun(),
+              'kuma.io/zone': zone,
             },
           }),
           spec: {

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/timeouts.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/timeouts.ts
@@ -3,12 +3,14 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
   const total = fake.number.int(200)
 
+  const nameQuery = req.url.searchParams.get('name')
+
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.word.noun()}-${i}`
+        const name = `${nameQuery?.padEnd(nameQuery.length + 1, '-') ?? ''}${fake.word.noun()}-${i}`
         return {
           type: 'Timeout',
           mesh: params.mesh,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-logs.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-logs.ts
@@ -3,12 +3,14 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
   const total = fake.number.int(200)
 
+  const nameQuery = req.url.searchParams.get('name')
+
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.word.noun()}-${i}`
+        const name = `${nameQuery?.padEnd(nameQuery.length + 1, '-') ?? ''}${fake.word.noun()}-${i}`
         return {
           type: 'TrafficLog',
           mesh: params.mesh,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-permissions.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-permissions.ts
@@ -6,6 +6,8 @@ export default ({ fake, pager }: EndpointDependencies): MockResponder => (req) =
     `/meshes/${req.params.mesh}/traffic-permissions`,
   )
 
+  const nameQuery = req.url.searchParams.get('name')
+
   return {
     headers: {},
     body: {
@@ -13,7 +15,7 @@ export default ({ fake, pager }: EndpointDependencies): MockResponder => (req) =
       next,
       items: Array.from({ length: pageTotal }).map((_, i) => {
         const id = offset + i
-        const name = `${fake.word.noun()}-${id}`
+        const name = `${nameQuery?.padEnd(nameQuery.length + 1, '-') ?? ''}${fake.word.noun()}-${id}`
 
         return {
           type: 'TrafficPermission',

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-routes.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-routes.ts
@@ -3,12 +3,14 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
   const total = fake.number.int(200)
 
+  const nameQuery = req.url.searchParams.get('name')
+
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.word.noun()}-${i}`
+        const name = `${nameQuery?.padEnd(nameQuery.length + 1, '-') ?? ''}${fake.word.noun()}-${i}`
         return {
           type: 'TrafficRoute',
           mesh: params.mesh,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-traces.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/traffic-traces.ts
@@ -3,12 +3,14 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
   const total = fake.number.int(200)
 
+  const nameQuery = req.url.searchParams.get('name')
+
   return {
     headers: {},
     body: {
       total,
       items: Array.from({ length: total }).map((_, i) => {
-        const name = `${fake.word.noun()}-${i}`
+        const name = `${nameQuery?.padEnd(nameQuery.length + 1, '-') ?? ''}${fake.word.noun()}-${i}`
         return {
           type: 'TrafficTrace',
           mesh: params.mesh,


### PR DESCRIPTION
Replaces the current custom implementation of a search field with the new `XSearch` component and allow filtering for `name`, `namespace` and `zone` (in case it's supported by the respective policy type). I've updated the mocks to reflect the filter query.

As discussed in https://github.com/kumahq/kuma-gui/pull/3821, in order to DRY the parsing of the `search` string and as suggested I've added a `Resources.search` to `resources/data/Resource` to be shared with other modules.

Part of #3757