### PR TITLE
chore(deps/kuma-gui): remove openapi-typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17580,7 +17580,6 @@
         "jsdom": "^26.1.0",
         "markdown-it": "^14.1.0",
         "msw": "^2.7.6",
-        "openapi-typescript": "^7.7.1",
         "postcss": "^8.5.3",
         "postcss-html": "^1.8.0",
         "sass": "^1.87.0",

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -56,7 +56,6 @@
     "jsdom": "^26.1.0",
     "markdown-it": "^14.1.0",
     "msw": "^2.7.6",
-    "openapi-typescript": "^7.7.1",
     "postcss": "^8.5.3",
     "postcss-html": "^1.8.0",
     "sass": "^1.87.0",


### PR DESCRIPTION
After creating the `kuma-http-api` package in https://github.com/kumahq/kuma-gui/pull/3516 to house the openapi-typescript types generated from the kuma oas, we don't need the `openapi-typescript` dependency in the `kuma-gui` package anymore. This removes the dependency from `kuma-gui` and leaves it in `kuma-http-api`.