### PR TITLE
chore(ci): dynamic matrices

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       spec_groups: ${{ steps.set-groups.outputs.result }}
+      packages: ${{ steps.meta.outputs.packages }}
+      unit: ${{ steps.meta.outputs.unit }}
+      e2e: ${{ steps.meta.outputs.e2e }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -49,6 +52,17 @@ jobs:
       - if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: |
           make install
+      - id: meta
+        run: |
+          echo "packages<<EOF" >> $GITHUB_OUTPUT
+            make meta/packages >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "unit<<EOF" >> $GITHUB_OUTPUT
+            make meta/unit >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "e2e<<EOF" >> $GITHUB_OUTPUT
+            make meta/e2e >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - id: set-groups
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
@@ -66,17 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package:
-          - name: "@kumahq/kuma-gui-monorepo"
-            path: ./
-          - name: "@kumahq/kuma-http-api"
-            path: ./packages/kuma-http-api
-          - name: "@kumahq/kuma-gui"
-            path: ./packages/kuma-gui
-          - name: "@kumahq/config"
-            path: ./packages/config
-          - name: "@kumahq/fake-api"
-            path: ./packages/fake-api
+        package: ${{ fromJSON(needs.install-dependencies.outputs.packages) }}
     name: |
       Linting ${{ matrix.package.name }}
     steps:
@@ -99,9 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package:
-          - name: "@kumahq/kuma-gui"
-            path: ./packages/kuma-gui
+        package: ${{ fromJSON(needs.install-dependencies.outputs.unit) }}
     name: |
       Unit tests: ${{ matrix.package.name }}
     steps:
@@ -126,9 +128,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package:
-          - name: "@kumahq/kuma-gui"
-            path: ./packages/kuma-gui
+        package: ${{ fromJSON(needs.install-dependencies.outputs.e2e) }}
         container: [0, 1, 2, 3]
     name: |
       Browser tests: ${{ matrix.package.name }}
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:
-          name: cypress-artifacts-${{ matrix.package.name }}-${{ matrix.container }}
+          name: cypress-artifacts-${{ matrix.package.slug }}-${{ matrix.container }}
           retention-days: ${{ github.event_name == 'pull_request' && 3 || 30 }}
           path: |
             ${{ matrix.package.path }}/cypress/screenshots


### PR DESCRIPTION
Automatically discover packages that need CI testing.

- adds several new make targets to:
  - print a JSON of all packages (i.e. workspaces plus the root package)
  - print a JSON of all workspaces (i.e. minus the root package)
  - print a JSON of workspaces that have `.feature` files
  - print a JSON of workspaces that have `.spec.ts` files
- using the above targets, we can figure out the matrices for each of our `cli-tests` and `browser-tests` jobs, plus pass _all_ packages to `lint-tests`

All in all this is prep work I've been wanting to do for preparing to split all our modules out into separate packages. This PR means that we can just add new ones and they'll all automatically be picked up by CI. i.e. zero config.

There might be a tiny bit of tweaking/renaming or something at some point in the future, but I'd like to get this in as the `.slug` property we have added here is useful for naming uploadable artifacts that can't have `/`s in their names.
