### PR TITLE
fix(kuma-gui): missing lint/css make target

### DIFF
--- a/packages/kuma-gui/Makefile
+++ b/packages/kuma-gui/Makefile
@@ -35,6 +35,9 @@ lint: .lint/js .lint/ts .lint/css .lint/lock .lint/gherkin ## Dev: Run lint chec
 .PHONY: lint/script
 lint/script: .lint/script ## Dev: Run lint checks on both JS/TS
 
+.PHONY: lint/css
+lint/css: .lint/css ## Dev: Run lint checks on styles in .css, .scss and .vue files
+
 .PHONY: run
 run: .run ## Dev: run local development instance of the GUI. If you are working on the GUI then you are probably looking for this.
 


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/3823 we missed that `kuma-guis`'s lint-staged uses a make target `lint/css` to lint styles in `.css`, `.scss` and `.vue` files. We included this target from `config/src/mk/checks.mk`. The changes in #3823 included a renaming to `.lint/css` and exporting everything through `mk/index.mk`.
I've added a new target `lint/css` to `kuma-gui`, which calls `.lint/css`.