### PR TITLE
chore: alters vue service container to require an app argument

### DIFF
--- a/packages/kuma-gui/.vitepress/theme/main.md
+++ b/packages/kuma-gui/.vitepress/theme/main.md
@@ -15,7 +15,6 @@ const $ = {
   ...VUE,
   ...APP,
   ...TOKENS,
-  globals: token('vue.globals'),
 }
 
 onMounted(async () => {
@@ -26,40 +25,6 @@ onMounted(async () => {
         application($),
         applicationDebug($),
         [
-          // temporary $.app replacement
-          [$.app, {
-            service: (
-              components,
-              directives,
-              plugins,
-              globals,
-            ) => {
-              return async (app) => {
-                components.forEach(([name, item]) => {
-                  app.component(name, item)
-                })
-                directives.forEach(([name, item]) => {
-                  app.directive(name, item)
-                })
-
-                plugins.forEach(([...args]) => {
-                  app.use(...args)
-                })
-
-                globals.forEach(([name, obj]) => {
-                  app.config.globalProperties[name] = obj
-                })
-
-                return app
-              }
-            },
-            arguments: [
-              $.components,
-              $.directives,
-              $.plugins,
-              $.globals,
-            ],
-          }],
           [token('docs.globals'), {
             service: (i18n) => {
               return [

--- a/packages/kuma-gui/src/main.ts
+++ b/packages/kuma-gui/src/main.ts
@@ -1,6 +1,8 @@
 // Importing styles here enforces a consistent stylesheet order between the Vite development server and the production build. See https://github.com/vitejs/vite/issues/4890.
 import './assets/styles/main.scss'
 
+import { createApp } from 'vue'
+
 import { services as application, TOKENS as APPLICATION } from '@/app/application'
 import { services as configuration } from '@/app/configuration'
 import { TOKENS } from '@/app/kuma'
@@ -62,27 +64,8 @@ async function mountVueApplication() {
     const msw = await import('@/app/msw')
     await get(msw.TOKENS.msw)
   }
-  const app = await get($.app)((await import('./app/App.vue')).default)
-
-  app.config.errorHandler = function (error) {
-    // Patches the vue-router MATCHER_NOT_FOUND error message back into the error object because vue-router explicitly creates an `Error` object with no message in production environments.
-    if (
-      error instanceof Error &&
-      error.message === '' &&
-      'type' in error &&
-      error.type === 1 &&
-      'location' in error
-    ) {
-      // Changing `error.message` causes Vue to throw the error twice even when `errorHandler` throws the same `Error` object.
-      error.message = `No match for ${JSON.stringify(error.location)}`
-
-      throw error
-    }
-
-    throw error
-  }
-
-  app.mount('#app')
+  const app = createApp((await import('./app/App.vue')).default);
+  (await get($.app)(app)).mount('#app')
 }
 
 mountVueApplication()


### PR DESCRIPTION
Changes `vue` service container so that the `app` service returns a function that requires the result of `createApp()` passed to it, instead of doing that itself.

This means that you have access to the result of `createApp` outside of the service contain and you don't need to build the container to get a reference to it.

It also makes it clearer where `createApp` is being called.

---

We'd already vaguely planned on reconfiguring it like this a very long time ago (see the temporary comment in the vitepress code I removed here)

I also spotted some more error wrapping code that we never use, so I removed that here also


