### PR TITLE
fix(tests): ensures KUMA_MESH_COUNT is 3 for control-planes test

### DIFF
--- a/packages/kuma-gui/features/control-planes/DetailView.feature
+++ b/packages/kuma-gui/features/control-planes/DetailView.feature
@@ -5,6 +5,10 @@ Feature: control-planes / DetailView
       | Alias                       | Selector                                    |
       | zone-control-planes-details | [data-testid='zone-control-planes-details'] |
       | meshes-details              | [data-testid='meshes-details']              |
+    And the environment
+      """
+      KUMA_MESH_COUNT: 3
+      """
     And the URL "/mesh-insights" responds with
       """
       body:
@@ -43,7 +47,6 @@ Feature: control-planes / DetailView
   Scenario: Shows expected content
     Given the environment
       """
-      KUMA_MESH_COUNT: 3
       KUMA_RESOURCE_COUNT: 100
       KUMA_ACTIVE_RESOURCE_COUNT: 0
       """


### PR DESCRIPTION
We spotted a flake appearing due to changed mocks which seems to be because the mesh count can sometimes be less than 3.

This PR ensures that we always get 3 meshes in order to partially overwrite 3 meshes in the response