### PR TITLE
chore(x): reduce "internal dependencies" in x

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-code-block/ResourceCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/ResourceCodeBlock.vue
@@ -12,36 +12,40 @@
     @reg-exp-mode-change="emit('reg-exp-mode-change', $event)"
   >
     <template #secondary-actions>
-      <XDisclosure
-        v-slot="{ expanded, toggle }"
+      <XI18n
+        v-slot="{ t }"
       >
-        <KCodeBlockIconButton
-          v-if="props.showK8sCopyButton"
-          :copy-tooltip="t('common.copyKubernetesText')"
-          theme="dark"
-          @click="() => {
-            if (!expanded) {
-              toggle()
-            }
-          }"
+        <XDisclosure
+          v-slot="{ expanded, toggle }"
         >
-          <XIcon name="copy" />{{ t('common.copyKubernetesShortText') }}
-        </KCodeBlockIconButton>
-        <XCopyButton
-          format="hidden"
-          v-slot="{ copy }"
-        >
-          <slot
-            :copy="(cb: CopyCallback) => {
-              if (expanded) {
+          <KCodeBlockIconButton
+            v-if="props.showK8sCopyButton"
+            :copy-tooltip="t('common.copyKubernetesText')"
+            theme="dark"
+            @click="() => {
+              if (!expanded) {
                 toggle()
               }
-              cb((text: object) => copy(toYamlRepresentation(text)), onCopyReject)
             }"
-            :copying="expanded"
-          />
-        </XCopyButton>
-      </XDisclosure>
+          >
+            <XIcon name="copy" />{{ t('common.copyKubernetesShortText') }}
+          </KCodeBlockIconButton>
+          <XCopyButton
+            format="hidden"
+            v-slot="{ copy }"
+          >
+            <slot
+              :copy="(cb: CopyCallback) => {
+                if (expanded) {
+                  toggle()
+                }
+                cb((text: object) => copy(toYamlRepresentation(text)), onCopyReject)
+              }"
+              :copying="expanded"
+            />
+          </XCopyButton>
+        </XDisclosure>
+      </XI18n>
     </template>
   </XCodeBlock>
 </template>
@@ -49,12 +53,10 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 
-import { useI18n, YAML } from '@/app/application'
+import { YAML } from '@/app/application'
 
 type Resolve = (data: object) => void
 type CopyCallback = (resolve: Resolve, reject: (e: unknown) => void) => void
-
-const { t } = useI18n()
 
 const props = withDefaults(defineProps<{
   resource: object

--- a/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
+++ b/packages/kuma-gui/src/app/x/components/x-code-block/XCodeBlock.vue
@@ -43,9 +43,8 @@
 import { KCodeBlock } from '@kong/kongponents'
 import { createHighlighterCore } from 'shiki/core'
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
-import { ref } from 'vue'
+import { ref, useId } from 'vue'
 
-import { uniqueId } from '@/app/application'
 import type { CodeBlockEventData } from '@kong/kongponents'
 
 const props = withDefaults(defineProps<{
@@ -59,7 +58,7 @@ const props = withDefaults(defineProps<{
   isFilterMode?: boolean
   isRegExpMode?: boolean
 }>(), {
-  id: () => uniqueId('code-block'),
+  id: () => `x-code-block-${useId()}`,
   isSearchable: false,
   showCopyButton: true,
   maxHeight: undefined,

--- a/packages/kuma-gui/src/app/x/components/x-i18n/XI18n.vue
+++ b/packages/kuma-gui/src/app/x/components/x-i18n/XI18n.vue
@@ -22,7 +22,7 @@
         v-if="slotName === 'default'"
         :name="slotName"
         :t="t"
-        :format-list="i18n.formatList"
+        :format-list="formatList"
       />
       <XTeleportTemplate
         v-else
@@ -30,7 +30,7 @@
       >
         <slot
           :t="t"
-          :format-list="i18n.formatList"
+          :format-list="formatList"
           :name="slotName"
         />
       </XTeleportTemplate>
@@ -42,19 +42,16 @@
     <slot
       name="default"
       :t="t"
-      :format-list="i18n.formatList"
+      :format-list="formatList"
     />
   </template>
 </template>
 <script lang="ts" setup>
 // eslint-disable-next-line vue/prefer-import-from-vue
 import { escapeHtml } from '@vue/shared'
-import { useAttrs } from 'vue'
+import { useAttrs, useId } from 'vue'
 
-import { useI18n, uniqueId, useEnv } from '@/app/application'
-import createI18n from '@/app/application/services/i18n/I18n'
-
-const id = uniqueId('x-i18n')
+import { useI18n } from '../../'
 
 const icuEscapeHtml = (str: string) => str.replace(/</g, "'<'")
   .replace(/%7B/g, '{')
@@ -74,10 +71,10 @@ const props = withDefaults(defineProps<{
   defaultPath: undefined,
 })
 const slots = defineSlots()
-
 const attrs = useAttrs()
-
-const i18n = typeof props.strings !== 'undefined' ? createI18n(typeof props.strings === 'function' ? props.strings(icuEscapeHtml) : props.strings, useEnv()) : useI18n()
+const i18n = useI18n()
+const formatList = (strs: string[], options: Intl.ListFormatOptions) => new Intl.ListFormat(i18n.locale, options).format(strs)
+const id = `x-i18n-${useId()}`
 
 type TFunction = typeof i18n['t']
 const t: TFunction = (key, ...rest) => {

--- a/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
+++ b/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
@@ -53,9 +53,8 @@ import {
   RemoveIcon,
   KeyboardReturnIcon,
 } from '@kong/icons'
-import { useSlots, useAttrs } from 'vue'
+import { useSlots, useAttrs, useId } from 'vue'
 
-import { uniqueId } from '@/app/application'
 import XAnonymous from '@/app/x/components/x-anonymous/XAnonymous.vue'
 import XTooltip from '@/app/x/components/x-tooltip/XTooltip.vue'
 
@@ -91,7 +90,7 @@ const icons = {
   unhealthy: RemoveIcon,
   submit: KeyboardReturnIcon,
 } as const
-const id = uniqueId('-x-icon-tooltip')
+const id = `-x-icon-tooltip-${useId()}`
 const slots = useSlots()
 
 const props = withDefaults(defineProps<{

--- a/packages/kuma-gui/src/app/x/index.ts
+++ b/packages/kuma-gui/src/app/x/index.ts
@@ -116,8 +116,17 @@ declare module 'vue' {
     XSearch: typeof XSearch
   }
 }
+const deps = {
+  i18n: {
+    t: (str: string, _values?: Record<string, string>, _options?: Record<string, unknown>) => str,
+    locale: 'en-us',
+  },
+}
 const plugin: Plugin = {
-  install: (app, _options) => {
+  install: (app, options: Partial<typeof deps> = {}) => {
+    if(typeof options.i18n !== 'undefined') {
+      deps.i18n = options.i18n
+    }
     components.forEach(([name, item]) => {
       app.component(name, item)
     })
@@ -127,3 +136,4 @@ const plugin: Plugin = {
   },
 }
 export default plugin
+export const useI18n = () => deps.i18n


### PR DESCRIPTION
Removes the majority of "internal dependencies" of `x`.

"internal dependencies" meaning any of our own dependencies of `x` such as `@/app/application`.

3rd party dependencies (for the moment at least) we are fine with.

Note: The last YAML dependency we have here could either use `js-yaml` straight, or by just removing the `ResourceCodeBlock` component entirely. I'd rather do the latter seeing as we have https://github.com/kumahq/kuma-gui/issues/3673 as an issue already

Also, this one is probably a good "Hide Whitespace" in GH one.