### PR TITLE
refactor(x-search): use useResizeObserver

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
+++ b/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
@@ -107,7 +107,8 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { useResizeObserver } from '@vueuse/core'
+import { ref } from 'vue'
 
 const props = withDefaults(defineProps<{
   /**
@@ -166,14 +167,11 @@ const onInput = (event: Event): void => {
   inputValue.value = value
 }
 
-onMounted(() => {
-  const observer = new ResizeObserver(([e]) => {
-    width.value = e?.contentRect?.width
+useResizeObserver(contentRef, ([entry]) => {
+  width.value = entry?.contentRect?.width
 
-    // keep the cursor position in the view
-    containerRef.value?.scrollBy(inputRef.value?.scrollLeft ?? 0, 0)
-  })
-  observer.observe(contentRef.value as HTMLElement)
+  // keep the cursor position in the view
+  containerRef.value?.scrollBy(inputRef.value?.scrollLeft ?? 0, 0)
 })
 </script>
 


### PR DESCRIPTION
We hit a flake a couple of times `ResizeObserver loop completed with undelivered notifications` which could be the result of not cleaning up the resize observer we register in `XSearch.onMounted`. While thinking of creating a custom hook to prevent us running into this case again, we decided to leverage one of `@vueuse`'s exported hooks `useResizeObserver` which should already include everything we need instead of reinventing the wheel.