### PR TITLE
chore(ci): turn Makefile meta targets into dot targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
       spec_groups: ${{ steps.set-groups.outputs.result }}
       packages: ${{ steps.meta.outputs.packages }}
       unit: ${{ steps.meta.outputs.unit }}
+      preview: ${{ steps.meta.outputs.preview }}
       e2e: ${{ steps.meta.outputs.e2e }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -59,6 +60,9 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
           echo "unit<<EOF" >> $GITHUB_OUTPUT
             make meta/unit >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "preview<<EOF" >> $GITHUB_OUTPUT
+            make meta/preview >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
           echo "e2e<<EOF" >> $GITHUB_OUTPUT
             make meta/e2e >> $GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,18 @@ install: .install ## Dev: Install all dependencies
 
 .PHONY: lint
 lint: .lint/js .lint/lock ## Dev: Run lint checks on the workspace root only. Note: individual sub projects have their own `make lint`
+
+.PHONY: meta/workspaces
+meta/workspaces: .meta/workspaces
+
+.PHONY: meta/packages
+meta/packages: .meta/packages
+
+.PHONY: meta/unit
+meta/unit: .meta/unit
+
+.PHONY: meta/e2e
+meta/e2e: .meta/e2e
+
+.PHONY: meta/preview
+meta/preview: .meta/preview

--- a/packages/config/src/mk/help.mk
+++ b/packages/config/src/mk/help.mk
@@ -30,26 +30,31 @@ confirm:
 		fi \
 	fi
 
-.PHONY: meta/packages
-meta/packages:
-	@(npm query ':root';npm query .workspace) | jq --slurp add | \
-		jq -r '. |map({name, path, slug: .name | sub("/";"-") | sub("@";"")})'
-
-.PHONY: meta/workspaces
-meta/workspaces:
+.PHONY: .meta/workspaces
+.meta/workspaces:
 	@npm query .workspace | \
-		jq -r -c 'map({name, path, slug: .name | sub("/";"-") | sub("@";"")}) | .[]' | \
+		jq -r -c 'map(. + {slug: .name | sub("/";"-") | sub("@";"")}) | .[]' | \
 	while read -r workspace; \
-	do (printf '{"e2e": %s, "unit": %s }' \
+	do (printf '{"e2e": %s, "unit": %s, "preview": %s }' \
 		$$([[ $$(find $$(echo $$workspace | jq -r '.path') -name "*.feature") ]] && echo 'true' || echo 'false') \
 		$$([[ $$(find $$(echo $$workspace | jq -r '.path') -name "*.spec.ts") ]] && echo 'true' || echo 'false') \
+		$$([[ $$(find $$(echo $$workspace | jq -r '.path') -depth 1 -name "index.html") ]] && echo 'true' || echo 'false') \
 		; echo $$workspace) | jq --slurp add \
 	;done | jq --slurp
 
-.PHONY: meta/unit
-meta/unit:
-	@$(MAKE) -s meta/workspaces | jq -r 'map(select(.unit == true))'
+.PHONY: .meta/packages
+.meta/packages:
+	@(npm query ':root';$(MAKE) meta/workspaces) | jq --slurp add | \
+		jq -r 'map(. + {slug: .name | sub("/";"-") | sub("@";"")})'
 
-.PHONY: meta/e2e
-meta/e2e:
-	@$(MAKE) -s meta/workspaces | jq -r 'map(select(.e2e == true))'
+.PHONY: .meta/unit
+.meta/unit:
+	@$(MAKE) meta/workspaces | jq -r 'map(select(.unit == true))'
+
+.PHONY: .meta/e2e
+.meta/e2e:
+	@$(MAKE) meta/workspaces | jq -r 'map(select(.e2e == true))'
+
+.PHONY: .meta/preview
+.meta/preview:
+	@$(MAKE) meta/workspaces | jq -r 'map(select(.preview == true))'


### PR DESCRIPTION
I figured we probably want these targets as "dot targets" so we can overwrite them if we need to.

I also exposed the entire package.json to CI instead of just the name, path and 'slug'. This means that if we want to add any meta data to our package.json's just for CI we can.

I also added a `meta/preview` based on whether a workspace has a `index.html` that we don't use as yet, but I would love to be able to deploy multiple PR preview sites based on this.

Just to note, there may be a little more related work in a few days on top of this, I'm just taking little nibbles at this until I get to a point where I can pull it all together.