### PR TITLE
feat(hostname-generators): add x-search

### DIFF
--- a/packages/kuma-gui/features/hostname-generators/Index.feature
+++ b/packages/kuma-gui/features/hostname-generators/Index.feature
@@ -8,6 +8,7 @@ Feature: hostname-generators / index
       | breadcrumbs                | .k-breadcrumbs                                             |
       | summary-slideout-container | [data-testid='summary'] [data-testid='slideout-container'] |
       | summary-title              | $summary-slideout-container [data-testid='slideout-title'] |
+      | input-search               | [data-testid='filter-bar-filter-input']                    |
 
   Scenario: Clicking a hostname generator action link and back again for <HostnameGenerator>
     Given the URL "/hostnamegenerators" responds with
@@ -45,3 +46,19 @@ Feature: hostname-generators / index
     Examples:
       | HostnameGenerator           | Selector           |
       | local-mesh-external-service | $item:nth-child(1) |
+
+  Scenario Outline: sending filters to the API
+    When I visit the "/hostname-generators" URL
+    Then the "$input-search" element exists
+    When I "type" "foo namespace:bar zone:baz kuma.io/service-name:qux" into the "$input-search" element
+    And I "type" "{enter}" into the "$input-search" element
+    Then the URL "/hostnamegenerators" was requested with
+      """
+      searchParams:
+        name: foo
+        filter[labels.k8s.kuma.io/namespace]: bar
+        filter[labels.kuma.io/zone]: baz
+        filter[labels.kuma.io/service-name]: qux
+        offset: 0
+        size: 50
+      """

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplanePolicies.feature
@@ -21,10 +21,11 @@ Feature: Dataplane policies
       | inbound-rule-item                  | [data-testid='inbound-rule-list-0'] .accordion-item                   |
       | inbound-rule-item-button           | $inbound-rule-item:nth-child(1) [data-testid='accordion-item-button'] |
       | summary-slideout-container         | [data-testid='summary'] [data-testid='slideout-container']            |
-      And the environment
+    And the environment
       """
         KUMA_RESOURCE_COUNT: 100
       """
+
   Rule: Any networking type
 
     Scenario: Policies tab has expected content (MeshHTTPRoute with to rules)

--- a/packages/kuma-gui/src/app/hostname-generators/data/HostnameGenerator.ts
+++ b/packages/kuma-gui/src/app/hostname-generators/data/HostnameGenerator.ts
@@ -1,9 +1,14 @@
+import { Resource } from '@/app/resources/data/Resource'
 import type { components } from '@kumahq/kuma-http-api'
 
 type HostnameGeneratorList = components['responses']['HostnameGeneratorList']['content']['application/json']
 type HostnameGeneratorItem = components['responses']['HostnameGeneratorItem']['content']['application/json']
 
 export const HostnameGenerator = {
+  search(query: string) {
+    return Resource.search(query)
+  },
+
   fromObject(item: HostnameGeneratorItem) {
     const labels = item.labels ?? {}
     const name = labels['kuma.io/display-name'] ?? item.name

--- a/packages/kuma-gui/src/app/hostname-generators/sources.ts
+++ b/packages/kuma-gui/src/app/hostname-generators/sources.ts
@@ -16,12 +16,14 @@ export const sources = (api: KumaApi) => {
       const { size } = params
       const offset = params.size * (params.page - 1)
 
+      const search = HostnameGenerator.search(params.search)
+
       const res = await http.GET('/hostnamegenerators', {
         params: {
-          // @ts-ignore TODO(schogges): remove ts-ignore once https://github.com/kumahq/kuma/issues/11339 is done
           query: {
             offset,
             size,
+            ...search,
           },
         },
       })

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorListView.vue
@@ -5,6 +5,7 @@
       name: '',
       page: 1,
       size: 15,
+      s: '',
     }"
     v-slot="{ route, t, can, uri, me }"
   >
@@ -23,97 +24,115 @@
         default-path="common.i18n.ignore-error"
       />
       <XCard>
-        <DataLoader
-          :src="uri(sources, '/hostname-generators', {}, {
-            page: route.params.page,
-            size: route.params.size,
-          })"
-        >
-          <template
-            #loadable="{ data }"
-          >
-            <DataCollection
-              type="hostname-generators"
-              :items="data?.items ?? [undefined]"
-              :page="route.params.page"
-              :page-size="route.params.size"
-              :total="data?.total"
-              @change="route.update"
+        <XLayout>
+          <search>
+            <form
+              @submit.prevent
             >
-              <AppCollection
-                data-testid="hostname-generator-collection"
-                :headers="[
-                  { ...me.get('headers.name'), label: t('hostname-generators.common.name'), key: 'name' },
-                  { ...me.get('headers.namespace'), label: t('hostname-generators.common.namespace'), key: 'namespace' },
-                  ...(can('use zones') ? [{ ...me.get('headers.zone'), label: t('hostname-generators.common.zone'), key: 'zone' }] : []),
-                  { ...me.get('headers.actions'), label: t('hostname-generators.common.actions'), key: 'actions', hideLabel: true },
-                ]"
-                :items="data?.items"
-                :is-selected-row="(item) => item.name === route.params.name"
-                @resize="me.set"
+              <XSearch
+                class="search-field"
+                :keys="['name', 'namespace', ...(can('use zones') ? ['zone'] : [])]"
+                :value="route.params.s"
+                @change="(s) => route.update({ s, page: 1 })"
+              />
+            </form>
+          </search>
+        
+          <DataLoader
+            :src="uri(sources, '/hostname-generators', {}, {
+              page: route.params.page,
+              size: route.params.size,
+              search: route.params.s,
+            })"
+          >
+            <template
+              #loadable="{ data }"
+            >
+              <DataCollection
+                type="hostname-generators"
+                :items="data?.items ?? [undefined]"
+                :page="route.params.page"
+                :page-size="route.params.size"
+                :total="data?.total"
+                @change="route.update"
               >
-                <template #name="{ row: item }">
-                  <XCopyButton
-                    :text="item.name"
-                  >
-                    <XAction
-                      data-action
-                      :to="{
-                        name: 'hostname-generator-summary-view',
-                        params: {
-                          name: item.id,
-                        },
-                        query: {
-                          page: route.params.page,
-                          size: route.params.size,
-                        },
-                      }"
-                    >
-                      {{ item.name }}
-                    </XAction>
-                  </XCopyButton>
-                </template>
-
-                <template #actions="{ row: item }">
-                  <XActionGroup>
-                    <XAction
-                      :to="{
-                        name: 'hostname-generator-detail-view',
-                        params: {
-                          name: item.id,
-                        },
-                      }"
-                    >
-                      {{ t('common.collection.actions.view') }}
-                    </XAction>
-                  </XActionGroup>
-                </template>
-              </AppCollection>
-              <RouterView
-                v-if="data?.items && route.params.name"
-                v-slot="child"
-              >
-                <SummaryView
-                  @close="route.replace({
-                    name: 'hostname-generator-list-view',
-                    params: {
-                      name: '',
-                    },
-                    query: {
-                      page: route.params.page,
-                      size: route.params.size,
-                    },
-                  })"
+                <AppCollection
+                  data-testid="hostname-generator-collection"
+                  :headers="[
+                    { ...me.get('headers.name'), label: t('hostname-generators.common.name'), key: 'name' },
+                    { ...me.get('headers.namespace'), label: t('hostname-generators.common.namespace'), key: 'namespace' },
+                    ...(can('use zones') ? [{ ...me.get('headers.zone'), label: t('hostname-generators.common.zone'), key: 'zone' }] : []),
+                    { ...me.get('headers.actions'), label: t('hostname-generators.common.actions'), key: 'actions', hideLabel: true },
+                  ]"
+                  :items="data?.items"
+                  :is-selected-row="(item) => item.name === route.params.name"
+                  @resize="me.set"
                 >
-                  <component
-                    :is="child.Component"
-                    :items="data?.items"
-                  />
-                </SummaryView>
-              </RouterView>
-            </DataCollection>
-          </template>
-        </DataLoader>
+                  <template #name="{ row: item }">
+                    <XCopyButton
+                      :text="item.name"
+                    >
+                      <XAction
+                        data-action
+                        :to="{
+                          name: 'hostname-generator-summary-view',
+                          params: {
+                            name: item.id,
+                          },
+                          query: {
+                            page: route.params.page,
+                            size: route.params.size,
+                            s: route.params.s,
+                          },
+                        }"
+                      >
+                        {{ item.name }}
+                      </XAction>
+                    </XCopyButton>
+                  </template>
+
+                  <template #actions="{ row: item }">
+                    <XActionGroup>
+                      <XAction
+                        :to="{
+                          name: 'hostname-generator-detail-view',
+                          params: {
+                            name: item.id,
+                          },
+                        }"
+                      >
+                        {{ t('common.collection.actions.view') }}
+                      </XAction>
+                    </XActionGroup>
+                  </template>
+                </AppCollection>
+                <RouterView
+                  v-if="data?.items && route.params.name"
+                  v-slot="child"
+                >
+                  <SummaryView
+                    @close="route.replace({
+                      name: 'hostname-generator-list-view',
+                      params: {
+                        name: '',
+                      },
+                      query: {
+                        page: route.params.page,
+                        size: route.params.size,
+                        s: route.params.s,
+                      },
+                    })"
+                  >
+                    <component
+                      :is="child.Component"
+                      :items="data?.items"
+                    />
+                  </SummaryView>
+                </RouterView>
+              </DataCollection>
+            </template>
+          </DataLoader>
+        </XLayout>
       </XCard>
     </AppView>
   </RouteView>
@@ -125,3 +144,8 @@ import AppCollection from '@/app/application/components/app-collection/AppCollec
 import SummaryView from '@/app/common/SummaryView.vue'
 import XCopyButton from '@/app/x/components/x-copy-button/XCopyButton.vue'
 </script>
+<style lang="scss" scoped>
+.search-field {
+  width: 100%;
+}
+</style>


### PR DESCRIPTION
Adds `XSearch` to `HostnameGeneratorListView` in order to let users filter by `name` and any label (i.e. `k8s.kuma.io/namespace`).

Part of #3757