### PR TITLE
fix(ci): remove dedupe from sync target

### DIFF
--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -9,7 +9,6 @@
 	@cd $(NPM_WORKSPACE_ROOT) \
 		&& npm install \
 					--ignore-scripts
-	@npm dedupe
 
 .PHONY: .clean
 .clean:


### PR DESCRIPTION
`npm dedupe` can sometimes break overtime, we added it to our CI so we could notice when it breaks and therefore investigate. I've investigated some more and realized a few more things.

~I think that because we sometimes have a a nested package-lock.json _aswell_ as our root JSON, and I'm guessing that `npm` uses the position of a `package-lock.json` as the root folder where it will install everything by default is in some cases making certain packages eventually be installed a sub folder other than root. This eventually contributes to npm finding it difficult to install non-duplicated packages and then eventually getting into a state where `npm dedupe` fails to work. This is my theory anyway. I'm hoping we can do something to prevent this nested package-lock.json from being there when we install, which will mean we won't need `npm dedupe` and even if we do it won't break 🤞~ This isn't correct 😭 

Shorter term `npm dedupe` is currently blocking us, so I want to remove for now, and potentially add back later if we ever need it. If we do that we will need to do a full `npm upgrade` of all our deps first.