### PR TITLE
fix(ci): use crossplatform -maxdepth for meta/preview

### DIFF
--- a/packages/config/src/mk/help.mk
+++ b/packages/config/src/mk/help.mk
@@ -35,7 +35,7 @@ confirm:
 	do (printf '{"e2e": %s, "unit": %s, "preview": %s }' \
 		$$([[ $$(find $$(echo $$workspace | jq -r '.path') -name "*.feature") ]] && echo 'true' || echo 'false') \
 		$$([[ $$(find $$(echo $$workspace | jq -r '.path') -name "*.spec.ts") ]] && echo 'true' || echo 'false') \
-		$$([[ $$(find $$(echo $$workspace | jq -r '.path') -depth 1 -name "index.html") ]] && echo 'true' || echo 'false') \
+		$$([[ $$(find $$(echo $$workspace | jq -r '.path') -maxdepth 1 -name "index.html") ]] && echo 'true' || echo 'false') \
 		; echo $$workspace) | jq --slurp add \
 	;done | jq --slurp
 


### PR DESCRIPTION
`-depth` seems to work differently on macOS, `-maxdepth` seems to be the more crossplatform/correct thing to use for restricting `find`s depth 🤦 

This doesn't affect us here yet, which explains why this issue was non-blocking, but I found it when trying things out elsewhere.

## Before 

<img width="491" alt="Screenshot 2025-05-15 at 10 26 23" src="https://github.com/user-attachments/assets/58e2b604-5587-4640-a215-e1f1d1dc3a54" />

### After

<img width="578" alt="Screenshot 2025-05-15 at 10 27 11" src="https://github.com/user-attachments/assets/2dd1784d-e5e0-4839-a18c-38e59ade371f" />

