### PR TITLE
chore(docs): adds some colouring to our Make errors

### DIFF
--- a/packages/config/src/mk/check.mk
+++ b/packages/config/src/mk/check.mk
@@ -8,8 +8,12 @@ check/node: NPM_VERSION:=$(shell cat $(NPM_WORKSPACE_ROOT)/package.json | jq -r 
 check/node: NODE_VERSION:=v$(shell head -n1 $(NPM_WORKSPACE_ROOT)/.nvmrc)
 check/node:
 	@node -v | grep $(NODE_VERSION) &> /dev/null || ( \
-		echo "Make sure node-$(NODE_VERSION) is installed (please see the root .nvmrc for nvm installation)"; \
-		echo "Once the correct version of node is installed, re-run your make target"; \
+		printf "\033[91m%-30s\033[0m %s" \
+			"Make sure node-$(NODE_VERSION) is installed!" && \
+		printf "\033[90m%-30s\033[0m %s\n" \
+			"(see root .nvmrc for nvm installation or use your chosen tool)" ; \
+		printf "\033[33m%-30s\033[0m %s\n" \
+			"Once the correct version of node is installed, re-run your make target" && \
 		exit 1; \
 	)
 	@npm ls -g "npm@$(NPM_VERSION)" | grep "empty" > /dev/null && ( \


### PR DESCRIPTION
If you try and run any of our Make targets without the correct version of node installed it now looks like this:

<img width="915" alt="Screenshot 2025-05-16 at 17 25 28" src="https://github.com/user-attachments/assets/bd72bc7f-a8f5-410a-bc39-04e5120248e6" />
