### PR TITLE
chore(ci): moves deploy/preview to be a dot target

### DIFF
--- a/packages/config/src/mk/build.mk
+++ b/packages/config/src/mk/build.mk
@@ -27,15 +27,14 @@ deploy/test:
 	@mkdir gui && \
 		mv dist/* gui && \
 		mv gui dist/gui && \
-		mv dist/gui/mockServiceWorker.js dist/ && \
-		cp ../../_redirects dist/_redirects
+		mv dist/gui/mockServiceWorker.js dist/
 
 .PHONY: deploy/e2e
 deploy/e2e:
 	@$(MAKE) build NOPRUNE=1
 	@$(MAKE) deploy/test
 
-.PHONY: deploy/preview
-deploy/preview:
+.PHONY: .deploy/preview
+.deploy/preview:
 	@$(MAKE) build/preview
 	@$(MAKE) deploy/test

--- a/packages/config/src/mk/run.mk
+++ b/packages/config/src/mk/run.mk
@@ -15,6 +15,6 @@
 .run/e2e: VITE ?= $(shell $(MAKE) resolve/bin BIN=vite)
 .run/e2e:
 	@$(MAKE) deploy/e2e
-	$(VITE) \
+	@$(VITE) \
 		-c ./vite.config.preview.ts \
 		preview

--- a/packages/kuma-gui/Makefile
+++ b/packages/kuma-gui/Makefile
@@ -59,9 +59,15 @@ test/e2e: .test/e2e ## Run browser-based e2e tests against a running GUI, you ma
 .PHONY: build ## Dev: build a production artifact in `./dist`
 build: .build
 
+# Called via netlify.toml
+.PHONY: deploy/preview
+deploy/preview: .deploy/preview
+	@$(MAKE) .deploy/preview && \
+		cp ../../_redirects dist/_redirects
+
 .PHONY: prune
 prune:
-	@$(MAKE) .sbom/exclude EXCLUDE_PATH=$(KUMAHQ_CONFIG) ## CI: Removes any dependencies unnessary for building
+	@$(MAKE) .sbom/exclude EXCLUDE_PATH=$(KUMAHQ_CONFIG) ## CI: Removes any dependencies unnecessary for building
 
 .PHONY: release
 release: KUMAHQ_KUMA_GUI=$(NPM_WORKSPACE_ROOT)/$(shell cat $(NPM_WORKSPACE_ROOT)/package-lock.json | jq -r '.packages | to_entries[] | select(.value.name == "@kumahq/kuma-gui") | .key')


### PR DESCRIPTION
Makes `.deploy/preview` a "dot target" so it can be overridden per project.

Netlify is only used currently for `kuma-gui` so we only copy the `_redirects` file into the deploy/distribution for `kuma-gui`