### PR TITLE
fix(x-search): internal state not updated on props.value change

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
+++ b/packages/kuma-gui/src/app/x/components/x-search/XSearch.vue
@@ -108,7 +108,7 @@
 
 <script setup lang="ts">
 import { useResizeObserver } from '@vueuse/core'
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 const props = withDefaults(defineProps<{
   /**
@@ -172,6 +172,10 @@ useResizeObserver(contentRef, ([entry]) => {
 
   // keep the cursor position in the view
   containerRef.value?.scrollBy(inputRef.value?.scrollLeft ?? 0, 0)
+})
+
+watch(() => props.value, () => {
+  inputValue.value = props.value
 })
 </script>
 


### PR DESCRIPTION
While working on https://github.com/kumahq/kuma-gui/pull/3896 we noticed that the internal state does not update in case the `:value` prop is being updated. This makes sure that when the `value` changes the internal state is being updated and the value properly displayed.