### PR TITLE
chore(tests): add `name` search test

### DIFF
--- a/packages/kuma-gui/src/app/resources/data/Resource.spec.ts
+++ b/packages/kuma-gui/src/app/resources/data/Resource.spec.ts
@@ -12,6 +12,12 @@ describe('Resource.search', () => {
       },
     ],
     [
+      'name',
+      {
+        name: 'name',
+      },
+    ],
+    [
       'name:foo',
       {
         name: 'foo',


### PR DESCRIPTION
I spent quite a bit of time poking our new search logic whilst reviewing and I found a search case that our new search implementation covers but our old one didn't 🎉  (old implementation isn't quite totally removed yet but thats on our list)

I figured it would be good to keep a test for this case

