### PR TITLE
refactor(resource/search): reuse short filters for both labels and tags

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/Index.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Index.feature
@@ -100,7 +100,7 @@ Feature: mesh / dataplanes / index
     When I visit the "/meshes/default/data-planes" URL
     Then the "$input-search" element isn't disabled
     And I wait for 500 ms
-    When I "type" "tag:kuma.io/service:system-1" into the "$input-search" element
+    When I "type" "tag:service:system-1" into the "$input-search" element
     And I "type" "{enter}" into the "$input-search" element
     Then the URL "/meshes/default/dataplanes/_overview" was requested with
       """

--- a/packages/kuma-gui/features/mesh/services/Item.feature
+++ b/packages/kuma-gui/features/mesh/services/Item.feature
@@ -86,7 +86,7 @@ Feature: mesh / services / item
     Scenario: The clear search button sends a new request with no search params
       Then the "$input-search" element isn't disabled
       And I wait for 500 ms
-      When I "type" "name:a-service tag:kuma.io/protocol:tcp" into the "$input-search" element
+      When I "type" "name:a-service tag:protocol:tcp" into the "$input-search" element
       And I clear the "$input-search" element
       Then the URL "/meshes/default/dataplanes/_overview" wasn't requested with
         """
@@ -105,7 +105,7 @@ Feature: mesh / services / item
     Scenario: The clear search button sends a new request with the correct service tag
       Then the "$input-search" element isn't disabled
       And I wait for 500 ms
-      When I "type" "name:a-service tag:kuma.io/protocol:tcp" into the "$input-search" element
+      When I "type" "name:a-service tag:protocol:tcp" into the "$input-search" element
       And I "type" "{enter}" into the "$input-search" element
       Then the URL "/meshes/default/dataplanes/_overview" was requested with
         """

--- a/packages/kuma-gui/src/app/common/TagList.vue
+++ b/packages/kuma-gui/src/app/common/TagList.vue
@@ -77,7 +77,7 @@ function getRoute(tag: LabelValue): RouteLocationNamedRaw | undefined {
       return {
         name: 'data-plane-list-view',
         query: {
-          s: `tag:kuma.io/service:${tag.value}`,
+          s: `tag:service:${tag.value}`,
         },
       }
     }

--- a/packages/kuma-gui/src/app/resources/data/Resource.spec.ts
+++ b/packages/kuma-gui/src/app/resources/data/Resource.spec.ts
@@ -51,6 +51,27 @@ describe('Resource.search', () => {
         ['filter[labels.kuma.io/zone]']: 'baz',
       },
     ],
+    [
+      'tag:namespace:foo tag:zone:bar tag:kuma.io/service:baz',
+      {
+        tag: ['k8s.kuma.io/namespace:foo', 'kuma.io/zone:bar', 'kuma.io/service:baz'],
+      },
+    ],
+    [
+      'label:namespace:foo label:zone:bar label:kuma.io/service:baz',
+      {
+        ['filter[labels.k8s.kuma.io/namespace]']: 'foo',
+        ['filter[labels.kuma.io/zone]']: 'bar',
+        ['filter[labels.kuma.io/service]']: 'baz',
+      },
+    ],
+    [
+      'label:namespace:foo tag:zone:bar',
+      {
+        ['filter[labels.k8s.kuma.io/namespace]']: 'foo',
+        tag: ['kuma.io/zone:bar'],
+      },
+    ],
 
     // Labels
     [


### PR DESCRIPTION
Follow-up to #3948 

Initially I thought we will drop support for `tag`s and move all over to `label`s. At least for dataplanes we need to keep supporting `tag`s for a while. This change makes sure that we can use short filters (i.e. `zone` => `kuma.io/zone`) for both `label`s and `tag`s.
To cover that I've added some more cases to the unit test and reverted the changes made in the browser tests.

