### PR TITLE
chore(x-select): adds XSelect :expanded for radio group type layouts

### DIFF
--- a/packages/kuma-gui/.vitepress/theme/main.md
+++ b/packages/kuma-gui/.vitepress/theme/main.md
@@ -7,6 +7,7 @@ import { createApp } from 'whyframe:app'
 import { TOKENS as APP, services as application } from '@/app/application'
 import { services as applicationDebug } from '@/app/application/debug'
 import { TOKENS as VUE, services as vue } from '@/app/vue'
+import X from '@/app/x'
 import { TOKENS } from '@/app/kuma'
 import { build, token } from '@/services/utils'
 import '../../src/assets/styles/main.scss'
@@ -36,6 +37,19 @@ onMounted(async () => {
             ],
             labels: [
               $.globals,
+            ],
+          }],
+          [token('x'), {
+            service: (i18n) => {
+              return [
+                [X, { i18n }],
+              ]
+            },
+            arguments:[
+              $.i18n,
+            ],
+            labels: [
+              $.plugins,
             ],
           }],
         ],

--- a/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
+++ b/packages/kuma-gui/src/app/x/components/x-layout/XLayout.vue
@@ -10,7 +10,7 @@
 import { KTruncate } from '@kong/kongponents'
 const props = withDefaults(defineProps<{
   // TODO(jc) :variant
-  type?: 'stack' | 'separated' | 'columns'
+  type?: 'stack' | 'separated' | 'columns' | 'row'
   size?: 'small' | 'normal' | 'large' | 'max'
   justify?: 'start' | 'around' | 'between' | 'end'
   truncate?: boolean
@@ -22,6 +22,31 @@ const props = withDefaults(defineProps<{
 })
 </script>
 <style lang="scss" scoped>
+.row {
+  display: flex;
+  gap: $kui-space-40;
+  align-items: center;
+  width: 100%;
+
+  & > * {
+    align-self: start;
+  }
+
+  &.start {
+    justify-content: flex-start;
+  }
+  &.max,
+  &.between {
+    justify-content: space-between;
+  }
+  &.around {
+    justify-content: space-around;
+  }
+  &.end {
+    justify-content: flex-end;
+  }
+}
+
 .stack.large > * + * {
   margin-block-start: $kui-space-100;
 }

--- a/packages/kuma-gui/src/app/x/components/x-radio/XRadio.vue
+++ b/packages/kuma-gui/src/app/x/components/x-radio/XRadio.vue
@@ -1,0 +1,70 @@
+<template>
+  <KRadio
+    v-bind="attrs"
+    v-model="model"
+    :card="props.card"
+    :card-radio-visible="false"
+    :selected-value="props.value"
+    @change="change"
+  >
+    <template
+      v-for="(_, slotName) in slots"
+      :key="slotName"
+      #[slotName]="slotProps"
+    >
+      <slot
+        :name="slotName"
+        v-bind="(slotProps)"
+      />
+    </template>
+  </KRadio>
+</template>
+
+<script setup lang="ts">
+import { KRadio } from '@kong/kongponents'
+import { useAttrs, inject, ref } from 'vue'
+
+const slots = defineSlots()
+const attrs = useAttrs()
+const props = withDefaults(defineProps<{
+  card?: boolean
+  value?: string
+}>(), {
+  card: false,
+  value: '',
+})
+const model = ref()
+const select = inject<{
+  emit: (name: string, e: string) => void
+}>('x-select')
+
+const change = (e: string) => {
+  if(select) {
+    select.emit('change', e)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.k-radio:not(.checked) :deep(.card-content-wrapper) {
+  color: $kui-color-text !important;
+}
+:deep(.card-content-wrapper) {
+  & {
+    font-family: $kui-font-family-text;
+    font-size: $kui-font-size-30;
+    font-weight: $kui-font-weight-semibold;
+    line-height: $kui-line-height-30;
+  }
+  header {
+    margin-bottom: $kui-space-20;
+  }
+  p {
+    color: $kui-color-text-neutral;
+    font-family: $kui-font-family-text;
+    font-size: $kui-font-size-20;
+    font-weight: $kui-font-weight-regular;
+    line-height: $kui-line-height-20;
+  }
+}
+</style>

--- a/packages/kuma-gui/src/app/x/components/x-select/README.md
+++ b/packages/kuma-gui/src/app/x/components/x-select/README.md
@@ -12,5 +12,24 @@
       {{ value }}
     </template>
   </XSelect>
+  <br />
+  <XSelect
+    :selected="`one`"
+    :expanded="true"
+    @change="(val) => console.log(val)"
+  >
+    <template
+      v-for="{ value } in [{ value: 'one'}, {value: 'two'}]"
+      :key="value"
+      #[`${value}-option`]
+    >
+      <XRadio
+        :card="true"
+        :value="value"
+      >
+        <header>{{ value }}</header>
+      </XRadio>
+    </template>
+  </XSelect>
 </Story>
 

--- a/packages/kuma-gui/src/app/x/components/x-select/XSelect.vue
+++ b/packages/kuma-gui/src/app/x/components/x-select/XSelect.vue
@@ -1,28 +1,53 @@
 <template>
-  <KSelect
-    v-model="selected"
-    :label="props.label"
-    :items="items"
-    @selected="emit('change', String($event.value))"
+  <template
+    v-if="expanded"
   >
-    <template
-      #selected-item-template="{ item }: any"
+    <XProvider
+      name="x-select"
+      :service="{ props, emit }"
     >
-      <slot
-        v-if="slots.selected"
-        :item="item.value as any"
-        name="selected"
-      />
-      <slot
-        v-else
-        :item="item.value as any"
-        :name="`${item?.value}-option`"
-      />
-    </template>
-    <template #item-template="{ item }: any">
-      <slot :name="`${item.value}-option`" />
-    </template>
-  </KSelect>
+      <XLayout
+        type="row"
+      >
+        <template
+          v-for="item in items"
+        >
+          <slot
+            :name="`${item.value}-option`"
+            :item="item.value as any"
+          />
+        </template>
+      </XLayout>
+    </XProvider>
+  </template>
+  <template
+    v-else
+  >
+    <KSelect
+      v-model="selected"
+      :label="props.label"
+      :items="items"
+      @selected="emit('change', String($event.value))"
+    >
+      <template
+        #selected-item-template="{ item }: any"
+      >
+        <slot
+          v-if="slots.selected"
+          :item="item.value as any"
+          name="selected"
+        />
+        <slot
+          v-else
+          :item="item.value as any"
+          :name="`${item?.value}-option`"
+        />
+      </template>
+      <template #item-template="{ item }: any">
+        <slot :name="`${item.value}-option`" />
+      </template>
+    </KSelect>
+  </template>
 </template>
 <script lang="ts" setup>
 import { KSelect } from '@kong/kongponents'
@@ -34,9 +59,11 @@ const emit = defineEmits<{
 const props = withDefaults(defineProps<{
   label?: string
   selected?: string
+  expanded?: boolean
 }>(), {
   label: '',
   selected: '',
+  expanded: false,
 })
 
 const slots = defineSlots()

--- a/packages/kuma-gui/src/app/x/index.ts
+++ b/packages/kuma-gui/src/app/x/index.ts
@@ -1,4 +1,4 @@
-import { KCard, KPop, KRadio } from '@kong/kongponents'
+import { KCard, KPop, KLabel } from '@kong/kongponents'
 
 import XAboutCard from './components/x-about-card/XAboutCard.vue'
 import XAction from './components/x-action/XAction.vue'
@@ -24,6 +24,7 @@ import XNotificationHub from './components/x-notification/XNotificationHub.vue'
 import XProgress from './components/x-progress/XProgress.vue'
 import XPrompt from './components/x-prompt/XPrompt.vue'
 import XProvider from './components/x-provider/XProvider.vue'
+import XRadio from './components/x-radio/XRadio.vue'
 import XSearch from './components/x-search/XSearch.vue'
 import XSelect from './components/x-select/XSelect.vue'
 import XTabs from './components/x-tabs/XTabs.vue'
@@ -38,8 +39,8 @@ export { default as XCopyButtonDebug } from './components/x-copy-button/XCopyBut
 const components = [
   ['XAlert', XAlert],
   ['XCard', KCard],
+  ['XLabel', KLabel],
   ['XPop', KPop],
-  ['XRadio', KRadio],
   //
   ['XAction', XAction],
   ['XActionGroup', XActionGroup],
@@ -59,6 +60,7 @@ const components = [
   ['XPrompt', XPrompt],
   ['XProvider', XProvider],
   ['XProgress', XProgress],
+  ['XRadio', XRadio],
   ['XSelect', XSelect],
   ['XTabs', XTabs],
   ['XTeleportTemplate', XTeleportTemplate],
@@ -80,8 +82,8 @@ const directives = [
 declare module 'vue' {
   export interface GlobalComponents {
     XCard: typeof KCard
+    XLabel: typeof KLabel
     XPop: typeof KPop
-    XRadio: typeof KRadio
     //
     XAlert: typeof XAlert
     XAnonymous: typeof XAnonymous
@@ -102,6 +104,7 @@ declare module 'vue' {
     XPrompt: typeof XPrompt
     XProvider: typeof XProvider
     XProgress: typeof XProgress
+    XRadio: typeof XRadio
     XSelect: typeof XSelect
     XTabs: typeof XTabs
     XTeleportTemplate: typeof XTeleportTemplate

--- a/packages/kuma-gui/src/assets/styles/_components.scss
+++ b/packages/kuma-gui/src/assets/styles/_components.scss
@@ -17,17 +17,6 @@ Adapted from https://every-layout.dev/layouts/stack/.
 }
 
 /*
-.stack-with-borders
-
-Variant of .stack with a horizontal border in the center of the gap.
-*/
-.stack-with-borders > * + * {
-  margin-block-start: $kui-space-40;
-  border-block-start: $kui-border-width-10 solid $kui-color-border;
-  padding-block-start: $kui-space-40;
-}
-
-/*
 .columns
 
 For horizontally listing elements with consistent space between. Once the space defined by `--threshold` is exhausted, the elements will **start** to wrap.
@@ -48,6 +37,20 @@ Adapted from https://every-layout.dev/layouts/switcher/.
   flex-basis: calc((var(--threshold) - 100%) * 999);
   min-inline-size: 0;
 }
+/*
+.stack-with-borders
+
+Variant of .stack with a horizontal border in the center of the gap.
+*/
+.stack-with-borders > * + * {
+  margin-block-start: $kui-space-40;
+  border-block-start: $kui-border-width-10 solid $kui-color-border;
+  padding-block-start: $kui-space-40;
+}
+.stack-with-borders.large > * + * {
+  padding-block-start: $kui-space-100;
+}
+
 
 /*
 .columns-with--borders


### PR DESCRIPTION
Mostly adds a `:expanded` property to XSelect, at the moment this will simply layout any options using a new `row` XLayout. But additionally we add a new XRadio which works alongside XSelect, and when these are used within a XSelect then the change events are propagated to the XSelect itself instead of the XRadios. Meaning you can listen for changes to the XSelect in exactly the same way as if you were using the XSelect to render a "non-expanded" dropdown menu.

P.S. I also noticed that using `X` within docs was broken, so I fixed that up in order to provide a little example of the above in our docs site.
