### PR TITLE
chore(x-modal): export XModal's cancel action

### DIFF
--- a/packages/kuma-gui/src/app/x/components/x-modal/XModal.vue
+++ b/packages/kuma-gui/src/app/x/components/x-modal/XModal.vue
@@ -1,17 +1,31 @@
 <template>
   <KModal
     :visible="true"
+    @cancel="() => emit('cancel')"
   >
     <template
       v-for="(_, key) in slots"
       :key="key"
       #[`${key}`]
     >
-      <slot :name="key" />
+      <slot
+        :close="() => emit('cancel')"
+        :name="key"
+      />
     </template>
   </KModal>
 </template>
 <script lang="ts" setup>
 import { KModal } from '@kong/kongponents'
-const slots = defineSlots()
+const slots = defineSlots<{
+  default(props: {
+    close: () => void
+  }): any
+  ['footer-actions'](props: {
+    close: () => void
+  }): any
+}>()
+const emit = defineEmits<{
+  (event: 'cancel'): void
+}>()
 </script>


### PR DESCRIPTION
Quite often when using XModal you use its `cancel` event to control what happens when the user clicks the `X` button in the top right of the modal. If you are adding an additional `[Cancel]` button into the `footer-actions`, you probably want it to call the same function that you added to the `cancel` event.

This PR re-exports from XModal's slots whatever you define in `@cancel` event, so you can just use something like:


```vue
<XModal
  @cancel="() => route.replace({...})"
>
  <template
    #footer-actions="{ close }"
  >
    <XAction @click="close">Cancel</XAction>
    <XAction @click="() => {}">Submit</XAction>
  </template>
</XModal>
```

which means clicking the `X` or the `[Cancel]` button calls the same `route.replace({})`, and if you do configure the modal to "cancel" when you click the backdrop, it will also call the same function.