### PR TITLE
chore: prefer vites configLoader over experimental node var

### DIFF
--- a/packages/config/src/mk/build.mk
+++ b/packages/config/src/mk/build.mk
@@ -1,16 +1,16 @@
 .PHONY: .build
 .build: VITE ?= $(shell $(MAKE) resolve/bin BIN=vite)
 .build: $(if $(NOPRUNE),,prune) install
-	@NODE_OPTIONS=--experimental-strip-types \
-		$(VITE) \
+	@$(VITE) \
+			--configLoader runner \
 			-c ./vite.config.production.ts \
 			build
 
 .PHONY: build/preview
 build/preview: VITE ?= $(shell $(MAKE) resolve/bin BIN=vite)
 build/preview:
-	@NODE_OPTIONS=--experimental-strip-types \
-		$(VITE) \
+	@$(VITE) \
+			--configLoader runner \
 			-c ./vite.config.development.ts \
 			--mode preview \
 			build

--- a/packages/config/src/mk/run.mk
+++ b/packages/config/src/mk/run.mk
@@ -1,8 +1,8 @@
 .PHONY: .run
 .run: VITE ?= $(shell $(MAKE) resolve/bin BIN=vite)
 .run: install
-	@NODE_OPTIONS=--experimental-strip-types \
-		$(VITE) \
+	@$(VITE) \
+		--configLoader runner \
 		-c ./vite.config.development.ts
 
 .PHONY: .run/docs

--- a/packages/config/src/mk/test.mk
+++ b/packages/config/src/mk/test.mk
@@ -5,8 +5,8 @@
 .test/unit: install
 	@TZ=UTC \
 		FORCE_COLOR=1 \
-		NODE_OPTIONS=--experimental-strip-types \
 		$(VITEST) \
+			--configLoader runner \
 			-c vite.config.production.ts \
 			run
 
@@ -15,8 +15,8 @@
 .test/unit/watch: install
 	@TZ=UTC \
 		FORCE_COLOR=1 \
-		NODE_OPTIONS=--experimental-strip-types \
 		$(VITEST) \
+			--configLoader runner \
 			-c vite.config.production.ts \
 
 

--- a/packages/fake-api/src/cypress.ts
+++ b/packages/fake-api/src/cypress.ts
@@ -1,5 +1,5 @@
-import { createFetchSync } from './index.ts'
-import type { Middleware, Dependencies, FS, Mocker } from './index.ts'
+import { createFetchSync } from './index'
+import type { Middleware, Dependencies, FS, Mocker } from './index'
 
 const reEscape = /[/\-\\^$*+?.()|[\]{}]/g
 const noop: Middleware = (_req, response) => response

--- a/packages/fake-api/src/msw.ts
+++ b/packages/fake-api/src/msw.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse, passthrough } from 'msw'
 
-import { createFetch } from './index.ts'
-import type { Dependencies, FS, MockEndpoint } from './index.ts'
+import { createFetch } from './index'
+import type { Dependencies, FS, MockEndpoint } from './index'
 
 export const server = <TDependencies extends object = {}>(
   mock: MockEndpoint<TDependencies>,

--- a/packages/fake-api/src/vite.ts
+++ b/packages/fake-api/src/vite.ts
@@ -1,5 +1,5 @@
-import { createFetch } from './index.ts'
-import type { Dependencies, FS } from './index.ts'
+import { createFetch } from './index'
+import type { Dependencies, FS } from './index'
 import type { Plugin } from 'vite'
 
 type PluginOptions<TDependencies extends object = {}> = {


### PR DESCRIPTION
Uses `vite`s `configLoader` option over nodes `--experimental-strip-types`, which consequently means we don't need to use `.ts` extensions for imports.

At the time that we started this `vitest` had a little issue with using `configLoader`, which seems to have been fixed in 3.1.0.