### PR TITLE
chore(renovate): group node and npm, add config schema

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,8 @@
 {
+ "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": [
     "config:recommended",
-    ":semanticCommits",
-    "Kong/public-shared-renovate:github-actions"
+    ":semanticCommits"
   ],
   "dependencyDashboard": true,
   "rangeStrategy": "bump",
@@ -15,5 +15,11 @@
   ],
   "baseBranches": [
     "master"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Node and npm",
+      "matchPackageNames": ["node", "npm"]
+    }
   ]
 }


### PR DESCRIPTION
Ideally `node` and `npm` are updated at the same time, so I thought we should group them up.