### PR TITLE
chore(ci): fix flake-y policies redirect test

### DIFF
--- a/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyTypeListView.vue
@@ -66,8 +66,12 @@
                               policyPath: policyType.path,
                             },
                           }"
-                          :mount="route.params.policyPath.length === 0 && i === 0 ? route.replace : undefined"
                           :data-testid="`policy-type-link-${policyType.name}`"
+                          @vue:mounted="(vNode) => {
+                            if(route.params.policyPath.length === 0 && i === 0 && vNode.props?.to) {
+                              route.replace(vNode.props.to)
+                            }
+                          }"
                         >
                           {{ policyType.name }}
                         </XAction>

--- a/packages/kuma-gui/src/app/x/components/x-action/XAction.vue
+++ b/packages/kuma-gui/src/app/x/components/x-action/XAction.vue
@@ -192,7 +192,6 @@ const props = withDefaults(defineProps<{
   href?: string
   to?: RouteLocationRawWithBooleanQuery
   for?: string
-  mount?: (to: RouteLocationNamedRaw) => void
 }>(), {
   href: '',
   appearance: 'anchor',
@@ -200,7 +199,6 @@ const props = withDefaults(defineProps<{
   action: 'default',
   to: () => ({}),
   for: '',
-  mount: () => {},
 })
 
 const group = inject<{
@@ -238,14 +236,6 @@ watch(() => props.to, (val) => {
   }
 }, { immediate: true })
 
-watch(() => props.mount, (val) => {
-  if (typeof val === 'function') {
-    val({
-      ...props.to,
-      query: query.value,
-    })
-  }
-}, { immediate: true })
 </script>
 <style lang="scss" scoped>
 /* taken from styles/_base.scss `a` */


### PR DESCRIPTION
I also switched/remove XActions `:mounted` prop to use Vue's `@vue:mounted` instead now we have that.

Closes https://github.com/kumahq/kuma-gui/issues/3730