### PR TITLE
chore(renovate): schedule weekly early Mondays

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
     "renovate-bot"
   ],
   "schedule": [
-    "before 5am every weekday"
+    "before 4am on monday"
   ],
   "baseBranches": [
     "master"


### PR DESCRIPTION
To reduce the noise we want to go back to weekly schedule as we did with dependabot.