### PR TITLE
chore(meshes): adds MeshActionGroup

### DIFF
--- a/packages/kuma-gui/src/app/meshes/components/MeshActionGroup.vue
+++ b/packages/kuma-gui/src/app/meshes/components/MeshActionGroup.vue
@@ -1,0 +1,28 @@
+<template>
+  <XActionGroup
+    v-bind="attrs"
+  >
+    <template
+      v-for="(_, slotName) in slots"
+      :key="slotName"
+      #[slotName]="slotProps"
+    >
+      <slot
+        :name="slotName"
+        v-bind="(slotProps)"
+      />
+    </template>
+  </XActionGroup>
+</template>
+<script lang="ts" generic="T extends { name: string } | undefined" setup>
+import { useAttrs } from 'vue'
+
+
+const slots = defineSlots()
+const attrs = useAttrs()
+const _props = withDefaults(defineProps<{
+  item?: T
+}>(), {
+  item: undefined,
+})
+</script>

--- a/packages/kuma-gui/src/app/meshes/index.ts
+++ b/packages/kuma-gui/src/app/meshes/index.ts
@@ -1,3 +1,4 @@
+import MeshActionGroup from './components/MeshActionGroup.vue'
 import MeshInsightsList from './components/MeshInsightsList.vue'
 import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
@@ -17,6 +18,7 @@ type Token = ReturnType<typeof token>
 
 const $ = {
   MeshInsightsList: token<typeof MeshInsightsList>('meshes.components.MeshInsightsList'),
+  MeshActionGroup: token<typeof MeshActionGroup>('meshes.components.MeshActionGroup'),
 }
 
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
@@ -29,6 +31,9 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       service: () => {
         return MeshInsightsList
       },
+    }],
+    [$.MeshActionGroup, {
+      service: () => MeshActionGroup,
     }],
     [token('meshes.sources'), {
       service: sources,
@@ -73,6 +78,8 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
 export const TOKENS = $
 export const [
   useMeshInsightsList,
+  useMeshActionGroup,
 ] = createInjections(
   $.MeshInsightsList,
+  $.MeshActionGroup,
 )

--- a/packages/kuma-gui/src/app/meshes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/meshes/locales/en-us/index.yaml
@@ -86,3 +86,5 @@ meshes:
     policies: 'Policies'
     enabled: 'Enabled'
     disabled: 'Disabled'
+  action_menu:
+    toggle_button: 'Actions'

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailTabsView.vue
@@ -18,6 +18,25 @@
           </XCopyButton>
         </h1>
       </template>
+      <template
+        #actions
+      >
+        <MeshActionGroup
+          :item="props.mesh"
+          @change="() => route.replace({ name: 'mesh-list-view' })"
+        >
+          <template
+            #control
+          >
+            <XAction
+              action="expand"
+              appearance="primary"
+            >
+              {{ t('meshes.action_menu.toggle_button') }}
+            </XAction>
+          </template>
+        </MeshActionGroup>
+      </template>
 
       <XTabs
         :selected="route.child()?.name"
@@ -49,8 +68,10 @@
 </template>
 
 <script lang="ts" setup>
+import { useMeshActionGroup } from '../'
 import type { Mesh } from '@/app/meshes/data'
 const props = defineProps<{
   mesh: Mesh
 }>()
+const MeshActionGroup = useMeshActionGroup()
 </script>

--- a/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
@@ -15,7 +15,7 @@
         size: route.params.size,
         search: route.params.s,
       })"
-      v-slot="{ data, error }"
+      v-slot="{ data, error, refresh }"
     >
       <AppView
         :docs="data?.items.length ? t('meshes.href.docs'):''"
@@ -33,6 +33,12 @@
           path="meshes.routes.items.intro"
           default-path="common.i18n.ignore-error"
         />
+        <XTeleportTemplate
+          v-if="(data?.items ?? []).length > 0"
+          :to="{ name: 'mesh-list-view-actions'}"
+        >
+          <MeshActionGroup />
+        </XTeleportTemplate>
 
         <XCard>
           <XLayout>
@@ -108,7 +114,10 @@
                     <template
                       #actions="{ row: item }"
                     >
-                      <XActionGroup>
+                      <MeshActionGroup
+                        :item="item"
+                        @change="refresh"
+                      >
                         <XAction
                           :to="{
                             name: 'mesh-detail-view',
@@ -119,7 +128,7 @@
                         >
                           {{ t('common.collection.actions.view') }}
                         </XAction>
-                      </XActionGroup>
+                      </MeshActionGroup>
                     </template>
                   </AppCollection>
                 </DataCollection>
@@ -133,8 +142,10 @@
 </template>
 
 <script lang="ts" setup>
+import { useMeshActionGroup } from '../'
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
+const MeshActionGroup = useMeshActionGroup()
 </script>
 <style lang="scss" scoped>
 .search-field {

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
@@ -4,11 +4,13 @@
     :params="{
       zone: '',
     }"
-    v-slot="{ route, t }"
+    v-slot="{ route, t, uri }"
   >
     <DataLoader
-      :src="`/zone-cps/${route.params.zone}`"
-      v-slot="{ data }: ZoneOverviewSource"
+      :src="uri(sources, `/zone-cps/:name`, {
+        name: route.params.zone,
+      })"
+      v-slot="{ data }"
     >
       <AppView
         v-if="data"
@@ -87,6 +89,6 @@
 
 <script lang="ts" setup>
 import { useZoneActionGroup } from '../'
-import type { ZoneOverviewSource } from '../sources'
+import { sources } from '../sources'
 const ZoneActionGroup = useZoneActionGroup()
 </script>


### PR DESCRIPTION
Pretty much a like for like copy of https://github.com/kumahq/kuma-gui/pull/3973.

~The only extra bit is that I hoisted a DataLoader from the Detail view into the TabDetailView and then passed the same data through back to the DetailView as a prop, hence quite a lot of green/red due to the re-nesting related to that.~ 👈 I realized I didn't need to do this in the end, so ignore this!