### PR TITLE
feat(zone-detail): add env-icon to title

### DIFF
--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
@@ -23,13 +23,25 @@
       >
         <template #title>
           <XLayout size="small">
-            <h1>
-              <XCopyButton :text="route.params.zone">
-                <RouteTitle
-                  :title="t('zone-cps.routes.item.title', { name: route.params.zone })"
-                />
-              </XCopyButton>
-            </h1>
+            <XLayout type="separated">
+              <template
+                v-for="env in [(['kubernetes', 'universal'] as const).find(env => env === data.zoneInsight.environment) ?? 'kubernetes']"
+                :key="env"
+              >
+                <XIcon
+                  :name="env"
+                >
+                  {{ t(`common.product.environment.${env}`) }}
+                </XIcon>
+              </template>
+              <h1>
+                <XCopyButton :text="route.params.zone">
+                  <RouteTitle
+                    :title="t('zone-cps.routes.item.title', { name: route.params.zone })"
+                  />
+                </XCopyButton>
+              </h1>
+            </XLayout>
             <XBadge
               :appearance="t(`common.status.appearance.${data.state}`, undefined, { defaultMessage: 'neutral' })"
             >

--- a/packages/kuma-gui/src/test-support/mocks/src/zones/_/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zones/_/_overview.ts
@@ -44,7 +44,7 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
                     kumaCpGlobalCompatible: fake.datatype.boolean(),
                   },
                 },
-                config: fake.kuma.subscriptionConfig(),
+                config: fake.kuma.subscriptionConfig({ environment: fake.helpers.arrayElement(['universal', 'kubernetes'])}),
                 ...fake.kuma.connection(item, i, arr),
                 status: (() => {
                   const xcks = fake.number.int({ min: 100, max: 500 })

--- a/packages/kuma-gui/src/test-support/mocks/src/zones/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/zones/_overview.ts
@@ -32,6 +32,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
               subscriptions: Array.from({ length: subscriptionCount }).map((item, i, arr) => {
                 return {
                   config: fake.kuma.subscriptionConfig({
+                    environment: fake.helpers.arrayElement(['universal', 'kubernetes']),
                     store: {
                       type: fake.helpers.arrayElement(['memory', 'postgres', 'kubernetes']),
                     },


### PR DESCRIPTION
In order to make it more clear to which environment the zone is deployed to, we want to show the icon of the environment in next to the name of the zone (title), which is a very prominent spot.