### PR TITLE
fix(ci): adds an ignore for ResizeObserver errors in Cypress

### DIFF
--- a/packages/config/src/cypress/e2e.ts
+++ b/packages/config/src/cypress/e2e.ts
@@ -2,7 +2,11 @@ import 'cypress-fail-fast'
 import failOnConsoleError from 'cypress-fail-on-console-error'
 import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector'
 
+// ignore ResizeObserver loop errors, they seem to be a common occurance with Cypress
+Cypress.on('uncaught:exception', e => !e.message.includes('ResizeObserver loop limit exceeded'))
+
 installLogsCollector({
   collectTypes: ['cons:warn', 'cons:debug'],
 })
 failOnConsoleError()
+


### PR DESCRIPTION
Sounds like this is a common thing with Cypress, I guess it can happen also real-life. We have seen it in real-life and added a fix and not seen it in real-life since then, but we keep getting flakes with it quite often.

Not super keen on this PR myself, so this might be a temporary thing, but if we want to remove this ignore we should find a way to stop it causing flakes first.