### PR TITLE
chore(renovate): add post-upgrade-task for msw

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,12 @@
     {
       "groupName": "Node and npm",
       "matchPackageNames": ["node", "npm"]
+    },
+    {
+      "matchPackageNames": ["msw"],
+      "postUpgradeTasks": {
+        "commands": ["make ws/post-upgrade/msw"]
+      }
     }
   ]
 }

--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -17,3 +17,8 @@
 	@if $(MAKE) -s confirm ; then \
 		find $(NPM_WORKSPACE_ROOT) -name 'node_modules' -type d -prune -exec rm -rf '{}' +; \
 	fi
+
+.PHONY: .post-upgrade/msw
+.post-upgrade/msw: MSW ?= $(shell $(MAKE) resolve/bin BIN=msw)
+.post-upgrade/msw:
+	@$(MSW) init

--- a/packages/kuma-gui/Makefile
+++ b/packages/kuma-gui/Makefile
@@ -74,3 +74,5 @@ release: KUMAHQ_KUMA_GUI=$(NPM_WORKSPACE_ROOT)/$(shell cat $(NPM_WORKSPACE_ROOT)
 release: SRC?=$(KUMAHQ_KUMA_GUI)/dist
 release: .release ## CI: 'releases' a built artifact, depends on the build artifact from 'make build'
 
+.PHONY: post-upgrade/msw
+post-upgrade/msw: .post-upgrade/msw


### PR DESCRIPTION
In #3936 `msw` was updated without updating the worker script. I did this manually in #3988, but ideally this should happen automatically. Updating the worker script is part of `msw`'s post-install script, but we use `--ignore-scripts` flag in our make target for installation and I also noticed that it wouldn't trigger if we run `npm install` from the repository root. From my point of view this leaves one option, which is to add a `postUpgradeTasks` for `msw`, which I did here.

Note that in the documentation `postUpgradeTasks` is missing in `packageRules`, but I ran the config validator and it didn't complain. So 🤞 that this works and I want to try this with the next bump of `msw`.