### PR TITLE
chore(config/cypress/e2e): ignore any ResizeObserver loop related error

### DIFF
--- a/packages/config/src/cypress/e2e.ts
+++ b/packages/config/src/cypress/e2e.ts
@@ -2,8 +2,8 @@ import 'cypress-fail-fast'
 import failOnConsoleError from 'cypress-fail-on-console-error'
 import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector'
 
-// ignore ResizeObserver loop errors, they seem to be a common occurance with Cypress
-Cypress.on('uncaught:exception', e => !e.message.includes('ResizeObserver loop limit exceeded'))
+// ignore ResizeObserver loop errors, they seem to be a common occurrence with Cypress
+Cypress.on('uncaught:exception', e => !e.message.includes('ResizeObserver loop'))
 
 installLogsCollector({
   collectTypes: ['cons:warn', 'cons:debug'],


### PR DESCRIPTION
After merging https://github.com/kumahq/kuma-gui/pull/3989 we hit another flake in https://github.com/kumahq/kuma-gui/actions/runs/15558790036/job/43805766147?pr=3993 `ResizeObserver loop completed with undelivered notifications.`. So in order to prevent fails on this I've adjusted the exception handler to ignore any `ResizeObserver loop` error.