### PR TITLE
Revert "chore(renovate): add post-upgrade-task for msw"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,12 +20,6 @@
     {
       "groupName": "Node and npm",
       "matchPackageNames": ["node", "npm"]
-    },
-    {
-      "matchPackageNames": ["msw"],
-      "postUpgradeTasks": {
-        "commands": ["make ws/post-upgrade/msw"]
-      }
     }
   ]
 }

--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -17,8 +17,3 @@
 	@if $(MAKE) -s confirm ; then \
 		find $(NPM_WORKSPACE_ROOT) -name 'node_modules' -type d -prune -exec rm -rf '{}' +; \
 	fi
-
-.PHONY: .post-upgrade/msw
-.post-upgrade/msw: MSW ?= $(shell $(MAKE) resolve/bin BIN=msw)
-.post-upgrade/msw:
-	@$(MSW) init

--- a/packages/kuma-gui/Makefile
+++ b/packages/kuma-gui/Makefile
@@ -74,5 +74,3 @@ release: KUMAHQ_KUMA_GUI=$(NPM_WORKSPACE_ROOT)/$(shell cat $(NPM_WORKSPACE_ROOT)
 release: SRC?=$(KUMAHQ_KUMA_GUI)/dist
 release: .release ## CI: 'releases' a built artifact, depends on the build artifact from 'make build'
 
-.PHONY: post-upgrade/msw
-post-upgrade/msw: .post-upgrade/msw


### PR DESCRIPTION
Reverts kumahq/kuma-gui#3993

I've overseen the fact that `postUpgradeTasks` can only be used with self-hosted renovate instances.