### PR TITLE
chore(renovate): revert post-upgrade-task for msw

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,12 +20,6 @@
     {
       "groupName": "Node and npm",
       "matchPackageNames": ["node", "npm"]
-    },
-    {
-      "matchPackageNames": ["msw"],
-      "postUpgradeTasks": {
-        "commands": ["make ws/post-upgrade/msw"]
-      }
     }
   ]
 }


### PR DESCRIPTION
In https://github.com/kumahq/kuma-gui/pull/3993 I've added a `postUpgradeTasks` for `msw`, but I've overseen the fact that this is a feature only for self-hosted renovate instances.

I've only removed the part of the renovate config, as we can still further utilize the make target.