### PR TITLE
chore: pin actions (master)

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: kumahq/.github/.github/workflows/wfc_lifecycle.yml@main
+    uses: kumahq/.github/.github/workflows/wfc_lifecycle.yml@75f72db331df298cdb92be152a3eccce93350a67
     permissions:
       issues: write # for editing issues (e.g. adding labels)
     with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: zgosalvez/github-actions-ensure-sha-pinned-actions@fc87bb5b5a97953d987372e74478de634726b3e5 # v3.0.25
-        with:
-          allowList:
-            kumahq/
 
   install-dependencies:
     timeout-minutes: 30


### PR DESCRIPTION
Actions need to be pinned on SHA version. We've put common actions sourced from kumahq on the allowList, but this seems to be colliding with https://github.com/kumahq/.github/blob/75f72db331df298cdb92be152a3eccce93350a67/.github/workflows/wfc_lifecycle.yml#L102