### PR TITLE
fix(zones): re-add zone HTTP API methods

### DIFF
--- a/packages/kuma-gui/src/app/kuma/services/kuma-api/KumaApi.ts
+++ b/packages/kuma-gui/src/app/kuma/services/kuma-api/KumaApi.ts
@@ -50,6 +50,14 @@ export default class KumaApi extends Api {
     return this.client.get('/global-insight')
   }
 
+  createZone(zone: { name: string }): Promise<{ token: string }> {
+    return this.client.post('/provision-zone', zone)
+  }
+
+  deleteZone({ name }: { name: string }): Promise<void> {
+    return this.client.delete(`/zones/${name}`)
+  }
+
   getZones(params?: PaginationParameters): Promise<PaginatedApiListResponse<Zone>> {
     return this.client.get('/zones', { params })
   }


### PR DESCRIPTION
We no longer use these, but for "reasons" need them, so its easier to leave them in the code for the moment. I prematurely removed them in https://github.com/kumahq/kuma-gui/pull/4017

Once we get full OpenAPI specs for zones we can come back and remove these again.