### PR TITLE
feat(control-plane): allow nesting summary route

### DIFF
--- a/packages/kuma-gui/src/app/control-planes/components/ControlPlaneActionGroup.vue
+++ b/packages/kuma-gui/src/app/control-planes/components/ControlPlaneActionGroup.vue
@@ -1,19 +1,25 @@
 <template>
-  <XActionGroup>
-    <template #control>
-      <XAction
-        action="expand"
-        appearance="primary"
-      >
-        {{ t("main-overview.action_menu.toggle_button") }}
+  <XLayout
+    type="separated"
+    justify="end"
+  >
+    <slot />
+    <XActionGroup>
+      <template #control>
+        <XAction
+          action="expand"
+          appearance="primary"
+        >
+          {{ t("main-overview.action_menu.toggle_button") }}
+        </XAction>
+      </template>
+      <XAction :to="{ name: 'hostname-generator-root-view' }">
+        {{ t("main-overview.action_menu.items.hostname_generators") }}
       </XAction>
-    </template>
-    <XAction :to="{ name: 'hostname-generator-root-view' }">
-      {{ t("main-overview.action_menu.items.hostname_generators") }}
-    </XAction>
 
-    <slot name="actions" />
-  </XActionGroup>
+      <slot name="actions" />
+    </XActionGroup>
+  </XLayout>
 </template>
 
 <script setup lang="ts">

--- a/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -1,7 +1,7 @@
 <template>
   <RouteView
-    name="control-plane-detail-view"
-    v-slot="{ can, t, uri, me }"
+    :name="props.routeName"
+    v-slot="{ can, t, uri, me, route }"
   >
     <AppView>
       <template #title>
@@ -116,18 +116,37 @@
         </XLayout>
       </XLayout>
     </AppView>
+
+    <RouterView
+      v-slot="{ Component }"
+    >
+      <SummaryView
+        v-if="route.child()"
+        @close="route.replace({
+          name: route.name,
+        })"
+      >
+        <component
+          :is="Component"
+        />
+      </SummaryView>
+    </RouterView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
+import { defineProps } from 'vue'
 
 import { sources as ControlPlaneSources } from '../sources'
+import SummaryView from '@/app/common/SummaryView.vue'
 import { useControlPlaneStatus, useControlPlaneActionGroup } from '@/app/control-planes'
 import { useMeshInsightsList } from '@/app/meshes'
 import { sources as MeshSources } from '@/app/meshes/sources'
 import { sources as PolicySources } from '@/app/policies/sources'
 import { useZoneControlPlanesList } from '@/app/zones'
 import { sources as ZoneSources } from '@/app/zones/sources'
+
+const props = defineProps<{ routeName: string }>()
 
 const ControlPlaneStatus = useControlPlaneStatus()
 const ControlPlaneActionGroup = useControlPlaneActionGroup()


### PR DESCRIPTION
In order to have nested routes in the control-plane detail view for action routes, I've added a default slot to the action group and made the routeName dynamic based on the props provided by the router.