### PR TITLE
fix(zone-detail): preferred disconnected subscription config

### DIFF
--- a/packages/kuma-gui/features/zones/zone-cps/Item.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/Item.feature
@@ -37,7 +37,7 @@ Feature: zones / item
             - connectTime: 2020-07-28T16:18:09.743141Z
               disconnectTime: !!js/undefined
               config: |
-                { "environment": "universal", "store": {"type": "memory"}, "dpServer": { "auth": { "type": "dpToken" } } }
+                { "environment": "universal", "store": {"type": "memory"}, "dpServer": { "authn": { "type": "dpToken" } } }
               status:
                 stat:
                   CircuitBreaker:

--- a/packages/kuma-gui/src/app/zones/data/index.ts
+++ b/packages/kuma-gui/src/app/zones/data/index.ts
@@ -32,7 +32,9 @@ const KDSSubscriptionCollection = {
     // if its valid JSON and is not null, turn it into an object
     const config: Record<string, unknown> = (() => {
       // just find the first that has a config
-      const withConfig = collection.subscriptions.find(item => typeof item.config !== 'undefined')
+      const withConfig = collection.connectedSubscription?.config ? 
+        collection.connectedSubscription :
+        collection.subscriptions.find(item => typeof item.config !== 'undefined')
       const str = typeof withConfig?.config !== 'undefined' ? withConfig.config : '{}'
       try {
         return JSON.parse(str)
@@ -43,6 +45,7 @@ const KDSSubscriptionCollection = {
     })()
     return {
       ...collection,
+      connectedConfig: JSON.parse(collection.connectedSubscription?.config ?? '{}'),
       config,
     }
   },

--- a/packages/kuma-gui/src/app/zones/data/index.ts
+++ b/packages/kuma-gui/src/app/zones/data/index.ts
@@ -45,7 +45,6 @@ const KDSSubscriptionCollection = {
     })()
     return {
       ...collection,
-      connectedConfig: JSON.parse(collection.connectedSubscription?.config ?? '{}'),
       config,
     }
   },


### PR DESCRIPTION
I faced a new flake https://github.com/kumahq/kuma-gui/actions/runs/15676714259/job/44158981105?pr=4019 which got introduced most likely with https://github.com/kumahq/kuma-gui/pull/3987.

```sh
AssertionError: Timed out retrying after 4000ms: Expected to find content: 'Universal' within the element: <div.route-view> but never did.
```

We noticed that the data-layer did not consider that subscriptions can be disconnected and we always use the first subscription in the list to extract the config. We should rather prefer the `connectedSubscription` (has no `disconnectTime`) and only fall back to the first subscription that has a config in case there is no `connectedSubscription`.