### PR TITLE
chore(renovate): reorder package-rules, only group patch and minor

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,15 +25,6 @@
   "postUpdateOptions": ["npmDedupe"],
   "packageRules": [
     {
-      "groupName": "Node and npm",
-      "matchPackageNames": ["node", "npm"]
-    },
-    {
-      "matchPackageNames": ["node", "npm"],
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true
-    },
-    {
       "matchUpdateTypes": [
         "lockFileMaintenance"
       ],
@@ -48,8 +39,14 @@
       "matchUpdateTypes": ["minor"]
     },
     {
-      "groupName": "major",
-      "matchUpdateTypes": ["major"]
+      "groupName": "Node and npm",
+      "matchPackageNames": ["node", "npm"],
+      "matchUpdateTypes": ["patch", "minor", "major"]
+    },
+    {
+      "matchPackageNames": ["node", "npm"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
Some more minor tweaks:

- Removing the grouping for major updates as I think I was too eager trying to reduce the noise but I actually think it'd be better to address them separately and the potential breaking changes
- Reordering the package rules to make sure that `npm` and `node` are grouped separately and not with the other dependencies. Order matters as last one wins and overrides previous that have the same matchers.