### PR TITLE
chore(ci): use Make properly to only npm install when needed

### DIFF
--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -1,5 +1,7 @@
 .PHONY: .install
-.install: check/node
+.install: check/node $(NPM_WORKSPACE_ROOT)/node_modules
+
+$(NPM_WORKSPACE_ROOT)/node_modules: $(NPM_WORKSPACE_ROOT)/package-lock.json
 	@cd $(NPM_WORKSPACE_ROOT) \
 		&& npm $(if $(CI),clean-install,install) \
 					--ignore-scripts


### PR DESCRIPTION
If `node_modules` exists and `package-lock.json` hasn't changed, then nothing will happen when calling `make install`

Whereas if you update `package-lock.json` (such as changing branch) the modification date changes, so then when you call `make install` `npm install` will be called and therefore update `node_modules`

This is particularly advantageous in CI where we use a cache at the start of all our jobs, but then end up calling `make install` again as its a dependency of lots of our targets. Generally this isn't an issue because nowadays npm is fast enough and re-installing is no big deal. But, I'm just thinking of cases where we might need to use a token or something, and we don't want to have to provide that for every single step in a workflow. With this change we'd only need to provide that token in the very first `actions/bootstrap` and from then on the resulting `node_modules` is cached for all steps in a workflow. As the package-lock.json hasn't changed between steps `npm install` won't be called again.

---

Just to note: I've done this in the past before and I can't remember why but it was slightly problematic. I think its less problematic here due to our different setup, and I'm pretty confident its fine, but wanted to note that we should just monitor this over the next few days/weeks to make sure its working as expected.
