### PR TITLE
chore: adds more information when we get a client HTTP error

### DIFF
--- a/packages/kuma-gui/src/app/application/services/data-source/index.ts
+++ b/packages/kuma-gui/src/app/application/services/data-source/index.ts
@@ -125,6 +125,11 @@ export const create: Creator = (src, router) => {
             throw e
           }
         } else {
+          // non-blocking
+          (async () => {
+            await new Promise(resolve => setTimeout(resolve, 3000))
+            console.error(`DataSourceError: ${e}`)
+          })()
           throw e
         }
       }

--- a/packages/kuma-gui/src/app/kuma/services/kuma-api/makeRequest.spec.ts
+++ b/packages/kuma-gui/src/app/kuma/services/kuma-api/makeRequest.spec.ts
@@ -89,7 +89,7 @@ describe('makeRequest', () => {
       function () {
         return Promise.reject(new Error('A most terrible error'))
       },
-      new Error('A most terrible error'),
+      /A most terrible error/,
     ],
     [
       function () {

--- a/packages/kuma-gui/src/app/kuma/services/kuma-api/makeRequest.ts
+++ b/packages/kuma-gui/src/app/kuma/services/kuma-api/makeRequest.ts
@@ -33,7 +33,7 @@ export async function makeRequest(url: string, options: RequestInit & { params?:
   try {
     response = await fetch(completeUrl, init)
   } catch (error) {
-    throw createNetworkError(error)
+    throw createNetworkError(error, completeUrl)
   }
 
   const contentType = response.headers.get('content-type')
@@ -47,8 +47,8 @@ export async function makeRequest(url: string, options: RequestInit & { params?:
   }
 }
 
-function createNetworkError(error: unknown): Error {
-  const requestErrorMessage = error instanceof Error ? error.message : 'An unknown network error occurred.'
+function createNetworkError(error: unknown, url: string): Error {
+  const requestErrorMessage = error instanceof Error ? `${error.message}: ${url}` : 'An unknown network error occurred.'
 
   return new Error(requestErrorMessage)
 }


### PR DESCRIPTION
There are a few things I would like to know when we get an unknown status type error from our HTTP client, are couple are:

1. What was the URL for the request?
2. Is the user still on our page for 3 seconds after the error occurred?

Number one is out of curiosity, and to verify exactly where the request was going.
Number two is to investigate whether its worth us trying to retry the request

I have a suspicion some of these errors happen because the user navigates to another page (via a traditional link, not a JS `pushState` i.e. a page refresh) whilst a request is in-flight. In this case it would be pointless retrying. Whereas if we can see via this console.error that the user is still on the page, it would be worth retrying.
