### PR TITLE
feat(policy-list): extend policy roles icon with consumer and system

### DIFF
--- a/packages/kuma-gui/src/app/policies/data/index.ts
+++ b/packages/kuma-gui/src/app/policies/data/index.ts
@@ -55,7 +55,7 @@ export const Policy = {
       name: labels['kuma.io/display-name'] ?? item.name,
       namespace: labels['k8s.kuma.io/namespace'] ?? '',
       zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
-      role: labels['kuma.io/policy-role'] ?? '',
+      role: labels['kuma.io/policy-role'] ?? 'system',
       config: item,
     }
   },

--- a/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
@@ -142,10 +142,10 @@
                         #role="{ row: item }"
                       >
                         <template
-                          v-if="['producer', 'consumer', 'system'].includes(item.role)"
+                          v-if="['producer', 'consumer', 'system', 'workload-owner'].includes(item.role)"
                         >
                           <XIcon
-                            :name="`policy-role-${item.role as 'producer' | 'consumer' | 'system'}`"
+                            :name="`policy-role-${item.role}`"
                           >
                             Role: {{ item.role }}
                           </XIcon>

--- a/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
@@ -142,10 +142,10 @@
                         #role="{ row: item }"
                       >
                         <template
-                          v-if="item.role === 'producer'"
+                          v-if="['producer', 'consumer', 'system'].includes(item.role)"
                         >
                           <XIcon
-                            :name="`policy-role-${item.role}`"
+                            :name="`policy-role-${item.role as 'producer' | 'consumer' | 'system'}`"
                           >
                             Role: {{ item.role }}
                           </XIcon>

--- a/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
+++ b/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
@@ -66,6 +66,8 @@ const attrs = useAttrs()
 const icons = {
   standard: 'span',
   'policy-role-producer': 'span',
+  'policy-role-consumer': 'span',
+  'policy-role-system': 'span',
   inbound: ForwardIcon,
   outbound: GatewayIcon,
   builtin: PortalIcon,
@@ -131,14 +133,30 @@ const props = withDefaults(defineProps<{
     height: v-bind('props.size');
   }
 }
-.x-icon-policy-role-producer-icon {
+.x-icon-policy-role-producer-icon,
+.x-icon-policy-role-consumer-icon,
+.x-icon-policy-role-system-icon {
   &::before {
-    content: 'P';
     color: var(--icon-before-color, currentColor);
     display: inline-flex;
 
     width: v-bind('props.size');
     height: v-bind('props.size');
+  }
+  &.x-icon-policy-role-producer-icon {
+    &::before {
+      content: 'P';
+    }
+  }
+  &.x-icon-policy-role-consumer-icon {
+    &::before {
+      content: 'C';
+    }
+  }
+  &.x-icon-policy-role-system-icon {
+    &::before {
+      content: 'S';
+    }
   }
 }
 

--- a/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
+++ b/packages/kuma-gui/src/app/x/components/x-icon/XIcon.vue
@@ -68,6 +68,7 @@ const icons = {
   'policy-role-producer': 'span',
   'policy-role-consumer': 'span',
   'policy-role-system': 'span',
+  'policy-role-workload-owner': 'span',
   inbound: ForwardIcon,
   outbound: GatewayIcon,
   builtin: PortalIcon,
@@ -135,6 +136,7 @@ const props = withDefaults(defineProps<{
 }
 .x-icon-policy-role-producer-icon,
 .x-icon-policy-role-consumer-icon,
+.x-icon-policy-role-workload-owner-icon,
 .x-icon-policy-role-system-icon {
   &::before {
     color: var(--icon-before-color, currentColor);
@@ -156,6 +158,11 @@ const props = withDefaults(defineProps<{
   &.x-icon-policy-role-system-icon {
     &::before {
       content: 'S';
+    }
+  }
+  &.x-icon-policy-role-workload-owner-icon {
+    &::before {
+      content: 'W';
     }
   }
 }

--- a/packages/kuma-gui/src/types/index.d.ts
+++ b/packages/kuma-gui/src/types/index.d.ts
@@ -759,6 +759,7 @@ export interface PolicyEntity extends MeshEntity {
     'kuma.io/mesh'?: string
     'kuma.io/origin'?: 'zone'
     'kuma.io/zone'?: string
+    'kuma.io/policy-role'?: 'producer' | 'consumer' | 'system' | 'workload-owner'
     [key: string]: string | undefined
   }
   spec?: {


### PR DESCRIPTION
Extends the icon set for policy roles with `consumer, `system` and `workload-owner`.

Closes #3893 

![image](https://github.com/user-attachments/assets/239a8bea-678d-4499-a48d-1029b34e9363)
