### PR TITLE
chore(http): adds configurable retries

### DIFF
--- a/packages/kuma-gui/src/app/application/components/data-source/DataSink.vue
+++ b/packages/kuma-gui/src/app/application/components/data-source/DataSink.vue
@@ -4,7 +4,7 @@
   >
     <DataSource
       v-if="expanded"
-      :src="`${props.src}/${encodeURIComponent(JSON.stringify(payload))}?cacheControl=no-cache`"
+      :src="`${props.src}/${encodeURIComponent(JSON.stringify(payload))}?cacheControl=no-cache&retry=none`"
       @change="(d: TypeOf<T>) => {
         writing = false
         data = d;

--- a/packages/kuma-gui/src/app/kuma/services/kuma-api/makeRequest.spec.ts
+++ b/packages/kuma-gui/src/app/kuma/services/kuma-api/makeRequest.spec.ts
@@ -86,27 +86,6 @@ describe('makeRequest', () => {
 
   test.each([
     [
-      function () {
-        return Promise.reject(new Error('A most terrible error'))
-      },
-      /A most terrible error/,
-    ],
-    [
-      function () {
-        // We specifically want to test this edge case.
-        // eslint-disable-next-line prefer-promise-reject-errors
-        return Promise.reject('Now that’s just great')
-      },
-      new Error('An unknown network error occurred.'),
-    ],
-  ])('works for requests that fail with a network error', async (fetchMock, expectedError) => {
-    vi.spyOn(global, 'fetch').mockImplementation(fetchMock)
-
-    await expect(() => makeRequest('/')).rejects.toThrow(expectedError)
-  })
-
-  test.each([
-    [
       'minimal error response format',
       function () {
         const response = new Response('{"type":"great_misfortune","detail":"A most terrible error"}', {

--- a/packages/kuma-gui/src/app/kuma/services/kuma-api/makeRequest.ts
+++ b/packages/kuma-gui/src/app/kuma/services/kuma-api/makeRequest.ts
@@ -33,7 +33,10 @@ export async function makeRequest(url: string, options: RequestInit & { params?:
   try {
     response = await fetch(completeUrl, init)
   } catch (error) {
-    throw createNetworkError(error, completeUrl)
+    if(error instanceof Error) {
+      error.message = `${error.message} (${completeUrl})`
+    }
+    throw error
   }
 
   const contentType = response.headers.get('content-type')
@@ -45,12 +48,6 @@ export async function makeRequest(url: string, options: RequestInit & { params?:
   } else {
     throw createApiError(response, data)
   }
-}
-
-function createNetworkError(error: unknown, url: string): Error {
-  const requestErrorMessage = error instanceof Error ? `${error.message}: ${url}` : 'An unknown network error occurred.'
-
-  return new Error(requestErrorMessage)
 }
 
 function createApiError(response: Response, data: unknown): ApiError {


### PR DESCRIPTION
Turns out HTTP zero errors seem to be TypeErrors, not normal Errors, but since forever have turned them into Errors.

This PR stops overwriting the TypeError with a normal Error so we can then detect it, and removes the tests that proved we were overwriting the native TypeError.

I've then added HTTP retries on TypeErrors, but I've added super safe additional guards (specifically only `failed to fetch` TypeErrors), plus plenty of logging so we know what's happening (I will probably reduce this at some point)

I also turned off retries for any requests made via DataSink, which are our writing HTTP requests, we don't want to ever retry these just yet (if ever)

You can see this working by making sure you have no local kuma running and then turning off the mocks entirely. You will see the GUI retry its HTTP requests twice until finally erroring out, instead of erroring out straight away.

Note:

The `retry=none` etc is probably temporary, I would like in the future to allow engineers to be able to configure their DataSource via a selection of retry policies. For the moment, I just want to make sure they are turned off for anything using a DataSink.