### PR TITLE
fix: infinite rerenders during development

### DIFF
--- a/packages/kuma-gui/features/zones/zone-cps/Warnings.feature
+++ b/packages/kuma-gui/features/zones/zone-cps/Warnings.feature
@@ -24,7 +24,8 @@ Feature: zones / warnings
           subscriptions: !!js/undefined
       """
     When I visit the "/zones/zone-cp-1/overview" URL
-    And I click the "[data-testid='zone-cp-config-view-tab'] a" element
+    Then I wait for 500 ms
+    Then I click the "[data-testid='zone-cp-config-view-tab'] a" element
     Then the "$warning-no-subscriptions" element exists
 
   Scenario: When zone store type is memory a warning is shown in listings

--- a/packages/kuma-gui/src/app/application/components/data-source/DataLoader.vue
+++ b/packages/kuma-gui/src/app/application/components/data-source/DataLoader.vue
@@ -14,10 +14,12 @@
         :error="allErrors[0]"
         :refresh="props.src !== '' ? refresh : () => {}"
       >
-        <ErrorBlock
-          v-bind="$attrs"
-          :error="allErrors[0]"
-        />
+        <XCard>
+          <ErrorBlock
+            v-bind="$attrs"
+            :error="allErrors[0]"
+          />
+        </XCard>
       </slot>
     </template>
     <template

--- a/packages/kuma-gui/src/app/connections/views/ConnectionsStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionsStatsView.vue
@@ -16,7 +16,7 @@
       :title="t('data-planes.routes.item.navigation.data-plane-stats-view')"
     />
     <AppView>
-      <XCard>
+      <XCard v-if="props.networking">
         <DataLoader
           :src="uri(sources, '/connections/stats/for/:proxyType/:name/:mesh/:socketAddress', {
             proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress'})[route.params.proxyType] ?? 'dataplane',

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailTabsView.vue
@@ -12,7 +12,7 @@
         mesh: route.params.mesh,
         name: route.params.proxy,
       })"
-      v-slot="{ data, error }"
+      v-slot="{ data, error, refresh }"
     >
       <AppView
         :breadcrumbs="[
@@ -177,37 +177,40 @@
           </XDisclosure>
         </template>
 
-        <DataLoader
-          :data="[data]"
-          :errors="[error]"
+        <template
+          v-if="error"
+          #error
         >
-          <XTabs
-            :selected="route.child()?.name"
+          <ErrorBlock :error="error" />
+        </template>
+          
+        <XTabs
+          :selected="route.child()?.name"
+        >
+          <template
+            v-for="{ name } in route.children"
+            :key="name"
+            #[`${name}-tab`]
           >
-            <template
-              v-for="{ name } in route.children"
-              :key="name"
-              #[`${name}-tab`]
+            <XAction
+              :to="{ name }"
             >
-              <XAction
-                :to="{ name }"
-              >
-                {{ t(`data-planes.routes.item.navigation.${name}`) }}
-              </XAction>
-            </template>
-          </XTabs>
+              {{ t(`data-planes.routes.item.navigation.${name}`) }}
+            </XAction>
+          </template>
+        </XTabs>
 
-          <RouterView
-            v-slot="{ Component }"
-          >
-            <component
-              :is="Component"
-              :data="data"
-              :networking="data?.dataplane.networking"
-              :mesh="props.mesh"
-            />
-          </RouterView>
-        </DataLoader>
+        <RouterView
+          v-slot="{ Component }"
+        >
+          <component
+            :is="Component"
+            :data="data"
+            :source="{ data, error, refresh }"
+            :networking="data?.dataplane.networking"
+            :mesh="props.mesh"
+          />
+        </RouterView>
       </AppView>
     </DataSource>
   </RouteView>
@@ -217,6 +220,7 @@
 import { ref } from 'vue'
 
 import { sources } from '../sources'
+import ErrorBlock from '@/app/common/ErrorBlock.vue'
 import type { Mesh } from '@/app/meshes/data'
 const props = defineProps<{
   mesh: Mesh

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -10,219 +10,102 @@
     name="data-plane-detail-view"
     v-slot="{ route, t, can, me, uri }"
   >
-    <DataSource
-      :src="uri(sources, '/connections/stats/for/:proxyType/:name/:mesh/:socketAddress', {
-        proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress' })[route.params.proxyType] ?? 'dataplane',
-        name: route.params.proxy,
-        mesh: route.params.mesh || '*',
-        socketAddress: props.data.dataplane.networking.inboundAddress,
-      })"
-      v-slot="{ data: traffic, error, refresh }"
+    <AppView
+      :notifications="true"
     >
-      <AppView
-        :notifications="true"
+      <template v-if="props.source.data">
+        <DataSource
+          :src="uri(sources, '/connections/stats/for/:proxyType/:name/:mesh/:socketAddress', {
+            proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress' })[route.params.proxyType] ?? 'dataplane',
+            name: route.params.proxy,
+            mesh: route.params.mesh || '*',
+            socketAddress: props.source.data.dataplane.networking.inboundAddress,
+          })"
+          v-slot="{ error }"
+        >
+          <template
+            v-for="{ bool, key, params, variant } in [
+              {
+                bool: props.source.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false,
+                key: 'dp-cp-incompatible',
+                params: {
+                  kumaDp: props.source.data.dataplaneInsight.version?.kumaDp.version ?? '',
+                },
+              },
+              {
+                bool: props.source.data.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                key: 'envoy-dp-incompatible',
+                params: {
+                  envoy: props.source.data.dataplaneInsight.version?.envoy.version ?? '',
+                  kumaDp: props.source.data.dataplaneInsight.version?.kumaDp.version ?? '',
+                },
+              },
+              {
+                bool: !!(can('use zones') && props.source.data.zone && props.source.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false),
+                key: 'dp-zone-cp-incompatible',
+                params: {
+                  kumaDp: props.source.data.dataplaneInsight.version?.kumaDp.version ?? '',
+                },
+              },
+              {
+                bool: props.source.data.isCertExpiresSoon,
+                key: 'certificate-expires-soon',
+              },
+              {
+                bool: props.source.data.isCertExpired,
+                key: 'certificate-expired',
+              },
+              {
+                bool: !props.source.data.dataplaneInsight.mTLS,
+                key: 'no-mtls',
+              },
+              {
+                bool: !!error,
+                key: 'stats-not-enhanced',
+                params: {
+                  error: error?.toString() ?? '',
+                },
+              },
+              {
+                bool: !can('use transparent-proxying', props.source.data),
+                key: 'networking-transparent-proxying',
+                variant: 'info' as const,
+              },
+            ]"
+            :key="key"
+          >
+            <XNotification
+              :notify="bool"
+              :data-testid="`warning-${key}`"
+              :uri="`data-planes.notifications.${key}.${props.source.data.id}`"
+              :variant="variant"
+            >
+              <XI18n
+                :path="`data-planes.notifications.${key}`"
+                :params="Object.fromEntries(Object.entries(params ?? {}))"
+              />
+            </XNotification>
+          </template>
+        </DataSource>
+      </template>
+
+      <XLayout
+        type="stack"
+        data-testid="dataplane-details"
       >
-        <template
-          v-for="{ bool, key, params, variant } in [
-            {
-              bool: props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false,
-              key: 'dp-cp-incompatible',
-              params: {
-                kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
-              },
-            },
-            {
-              bool: props.data.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
-              key: 'envoy-dp-incompatible',
-              params: {
-                envoy: props.data.dataplaneInsight.version?.envoy.version ?? '',
-                kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
-              },
-            },
-            {
-              bool: !!(can('use zones') && props.data.zone && props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false),
-              key: 'dp-zone-cp-incompatible',
-              params: {
-                kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
-              },
-            },
-            {
-              bool: props.data.isCertExpiresSoon,
-              key: 'certificate-expires-soon',
-            },
-            {
-              bool: props.data.isCertExpired,
-              key: 'certificate-expired',
-            },
-            {
-              bool: !props.data.dataplaneInsight.mTLS,
-              key: 'no-mtls',
-            },
-            {
-              bool: !!error,
-              key: 'stats-not-enhanced',
-              params: {
-                error: error?.toString() ?? '',
-              },
-            },
-            {
-              bool: !can('use transparent-proxying', props.data),
-              key: 'networking-transparent-proxying',
-              variant: 'info' as const,
-            },
-          ]"
-          :key="key"
+        <XAboutCard
+          :title="t('data-planes.routes.item.about.title')"
+          :created="props.source.data?.creationTime"
+          :modified="props.source.data?.modificationTime"
+          class="about-section"
         >
-          <XNotification
-            :notify="bool"
-            :data-testid="`warning-${key}`"
-            :uri="`data-planes.notifications.${key}.${props.data.id}`"
-            :variant="variant"
+          <DataLoader
+            :data="[props.source.data]"
           >
-            <XI18n
-              :path="`data-planes.notifications.${key}`"
-              :params="Object.fromEntries(Object.entries(params ?? {}))"
-            />
-          </XNotification>
-        </template>
-
-        <XLayout
-          type="stack"
-          data-testid="dataplane-details"
-        >
-          <XAboutCard
-            :title="t('data-planes.routes.item.about.title')"
-            :created="props.data.creationTime"
-            :modified="props.data.modificationTime"
-            class="about-section"
-          >
-            <XLayout>
-              <XLayout
-                type="separated"
-              >
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template
-                    #title
-                  >
-                    {{ t('http.api.property.status') }}
-                  </template>
-
-                  <template
-                    #body
-                  >
-                    <XLayout
-                      type="separated"
-                    >
-                      <StatusBadge :status="props.data.status" />
-                      <DataCollection
-                        v-if="props.data.dataplaneType === 'standard'"
-                        :items="props.data.dataplane.networking.inbounds"
-                        :predicate="item => item.state !== 'Ready'"
-                        :empty="false"
-                        v-slot="{ items: unhealthyInbounds }"
-                      >
-                        <XIcon name="info">
-                          <ul>
-                            <li
-                              v-for="inbound in unhealthyInbounds"
-                              :key="`${inbound.service}:${inbound.port}`"
-                            >
-                              {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
-                            </li>
-                          </ul>
-                        </XIcon>
-                      </DataCollection>
-                    </XLayout>
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
-                  v-if="can('use zones') && props.data.zone"
-                  layout="horizontal"
-                >
-                  <template
-                    #title
-                  >
-                    {{ t('http.api.property.zone') }}
-                  </template>
-                  <template
-                    #body
-                  >
-                    <XBadge appearance="decorative">
-                      <XAction
-                        :to="{
-                          name: 'zone-cp-detail-view',
-                          params: {
-                            zone: props.data.zone,
-                          },
-                        }"
-                      >
-                        {{ props.data.zone }}
-                      </XAction>
-                    </XBadge>
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard layout="horizontal">
-                  <template
-                    #title
-                  >
-                    {{ t('http.api.proptery.type') }}
-                  </template>
-
-                  <template
-                    #body
-                  >
-                    <XBadge appearance="decorative">
-                      {{ t(`data-planes.type.${props.data.dataplaneType}`) }}
-                    </XBadge>
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
-                  v-if="props.data.namespace.length > 0"
-                  layout="horizontal"
-                >
-                  <template
-                    #title
-                  >
-                    {{ t('http.api.property.namespace') }}
-                  </template>
-
-                  <template
-                    #body
-                  >
-                    <XBadge
-                      appearance="decorative"
-                    >
-                      {{ props.data.namespace }}
-                    </XBadge>
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template
-                    #title
-                  >
-                    {{ t('http.api.property.address') }}
-                  </template>
-
-                  <template
-                    #body
-                  >
-                    <XCopyButton
-                      variant="badge"
-                      format="default"
-                      :text="`${props.data.dataplane.networking.address}`"
-                    />
-                  </template>
-                </DefinitionCard>
-
-                <template
-                  v-if="props.data.dataplane.networking.gateway"
+            <template v-if="props.source.data">
+              <XLayout>
+                <XLayout
+                  type="separated"
                 >
                   <DefinitionCard
                     layout="horizontal"
@@ -230,501 +113,653 @@
                     <template
                       #title
                     >
-                      {{ t('http.api.property.tags') }}
+                      {{ t('http.api.property.status') }}
                     </template>
 
                     <template
                       #body
                     >
-                      <TagList
-                        :tags="props.data.dataplane.networking.gateway.tags"
+                      <XLayout
+                        type="separated"
+                      >
+                        <StatusBadge :status="props.source.data.status" />
+                        <DataCollection
+                          v-if="props.source.data.dataplaneType === 'standard'"
+                          :items="props.source.data.dataplane.networking.inbounds"
+                          :predicate="item => item.state !== 'Ready'"
+                          :empty="false"
+                          v-slot="{ items: unhealthyInbounds }"
+                        >
+                          <XIcon name="info">
+                            <ul>
+                              <li
+                                v-for="inbound in unhealthyInbounds"
+                                :key="`${inbound.service}:${inbound.port}`"
+                              >
+                                {{ t('data-planes.routes.item.unhealthy_inbound', { service: inbound.service, port: inbound.port }) }}
+                              </li>
+                            </ul>
+                          </XIcon>
+                        </DataCollection>
+                      </XLayout>
+                    </template>
+                  </DefinitionCard>
+
+                  <DefinitionCard
+                    v-if="can('use zones') && props.source.data.zone"
+                    layout="horizontal"
+                  >
+                    <template
+                      #title
+                    >
+                      {{ t('http.api.property.zone') }}
+                    </template>
+                    <template
+                      #body
+                    >
+                      <XBadge appearance="decorative">
+                        <XAction
+                          :to="{
+                            name: 'zone-cp-detail-view',
+                            params: {
+                              zone: props.source.data.zone,
+                            },
+                          }"
+                        >
+                          {{ props.source.data.zone }}
+                        </XAction>
+                      </XBadge>
+                    </template>
+                  </DefinitionCard>
+                  <DefinitionCard layout="horizontal">
+                    <template
+                      #title
+                    >
+                      {{ t('http.api.proptery.type') }}
+                    </template>
+
+                    <template
+                      #body
+                    >
+                      <XBadge appearance="decorative">
+                        {{ t(`data-planes.type.${props.source.data.dataplaneType}`) }}
+                      </XBadge>
+                    </template>
+                  </DefinitionCard>
+
+                  <DefinitionCard
+                    v-if="props.source.data.namespace.length > 0"
+                    layout="horizontal"
+                  >
+                    <template
+                      #title
+                    >
+                      {{ t('http.api.property.namespace') }}
+                    </template>
+
+                    <template
+                      #body
+                    >
+                      <XBadge
+                        appearance="decorative"
+                      >
+                        {{ props.source.data.namespace }}
+                      </XBadge>
+                    </template>
+                  </DefinitionCard>
+
+                  <DefinitionCard
+                    layout="horizontal"
+                  >
+                    <template
+                      #title
+                    >
+                      {{ t('http.api.property.address') }}
+                    </template>
+
+                    <template
+                      #body
+                    >
+                      <XCopyButton
+                        variant="badge"
+                        format="default"
+                        :text="`${props.source.data.dataplane.networking.address}`"
                       />
                     </template>
                   </DefinitionCard>
-                </template>
-              </XLayout>
 
-              <XLayout
-                v-if="props.data.dataplaneInsight.mTLS"
-                data-testid="dataplane-mtls"
-                class="dataplane-mtls"
-                size="small"
-              >
-                <h3>{{ t('data-planes.routes.item.mtls.title') }}</h3>
-                <XLayout size="small">
                   <template
-                    v-for="mTLS in [
-                      props.data.dataplaneInsight.mTLS,
-                    ]"
-                    :key="mTLS"
+                    v-if="props.source.data.dataplane.networking.gateway"
                   >
-                    <XLayout type="separated">
-                      <DefinitionCard layout="horizontal">
-                        <template #title>
-                          <XI18n
-                            path="data-planes.routes.item.mtls.generation_time.title"
-                          />
-                        </template>
+                    <DefinitionCard
+                      layout="horizontal"
+                    >
+                      <template
+                        #title
+                      >
+                        {{ t('http.api.property.tags') }}
+                      </template>
 
-                        <template #body>
-                          <XBadge appearance="neutral">
-                            {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
-                          </XBadge>
-                        </template>
-                      </DefinitionCard>
-                      <DefinitionCard layout="horizontal">
-                        <template #title>
-                          <XI18n
-                            path="data-planes.routes.item.mtls.expiration_time.title"
-                          />
-                        </template>
-
-                        <template #body>
-                          <XBadge appearance="neutral">
-                            {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
-                          </XBadge>
-                        </template>
-                      </DefinitionCard>
-                    </XLayout>
-                    <XLayout type="separated">
-                      <DefinitionCard layout="horizontal">
-                        <template
-                          #title
-                        >
-                          {{ t('data-planes.routes.item.mtls.regenerations.title') }}
-                        </template>
-
-                        <template
-                          #body
-                        >
-                          <XBadge appearance="info">
-                            {{ t('common.formats.integer', { value: mTLS.certificateRegenerations }) }}
-                          </XBadge>
-                        </template>
-                      </DefinitionCard>
-
-                      <DefinitionCard layout="horizontal">
-                        <template
-                          #title
-                        >
-                          {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
-                        </template>
-
-                        <template
-                          #body
-                        >
-                          <XBadge appearance="decorative">
-                            {{ mTLS.issuedBackend }}
-                          </XBadge>
-                        </template>
-                      </DefinitionCard>
-
-                      <DefinitionCard layout="horizontal">
-                        <template
-                          #title
-                        >
-                          {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
-                        </template>
-
-                        <template
-                          #body
-                        >
-                          <XLayout
-                            type="separated"
-                            truncate
-                          >
-                            <XBadge
-                              v-for="item in mTLS.supportedBackends"
-                              :key="item"
-                              :appearance="item === mTLS.issuedBackend ? 'decorative' : 'info'"
-                            >
-                              {{ item }}
-                            </XBadge>
-                          </XLayout>
-                        </template>
-                      </DefinitionCard>
-                    </XLayout>
+                      <template
+                        #body
+                      >
+                        <TagList
+                          :tags="props.source.data.dataplane.networking.gateway.tags"
+                        />
+                      </template>
+                    </DefinitionCard>
                   </template>
                 </XLayout>
-              </XLayout>
-            </XLayout>
-          </XAboutCard>
 
-          <XCard
-            class="traffic"
-            data-testid="dataplane-traffic"
-          >
-            <XLayout
-              type="columns"
-            >
-              <ConnectionTraffic>
-                <template
-                  #title
+                <XLayout
+                  v-if="props.source.data.dataplaneInsight.mTLS"
+                  data-testid="dataplane-mtls"
+                  class="dataplane-mtls"
+                  size="small"
                 >
-                  <XLayout
-                    type="separated"
-                  >
-                    <XIcon
-                      name="inbound"
-                    />
-                    <span>Inbounds</span>
-                  </XLayout>
-                </template>
-                <!-- if we are a builtin gateway proxy i.e. a 'gateway' proxy -->
-                <!-- use its first and only inbounds as a template  -->
-                <!-- and fill the inbounds out from the stats once they are loaded -->
-                <template
-                  v-for="inbounds in [props.data.dataplane.networking.type === 'gateway' ? Object.entries<any>(traffic?.inbounds ?? {}).reduce<DataplaneInbound[]>((prev, [key, value]) => {
-                    // As we are just 'finding' inbounds from stats without knowing them
-                    // from the dataplane overview API request, we will wrongly 'find'
-                    // the envoy admin inbound that is used for kumas /stats API. Ignore
-                    // the envoy admin inbound when we find it
-                    const port = key.split('_').at(-1)
-                    if (port === (props.data.dataplane.networking.admin?.port ?? '9901')) {
-                      return prev
-                    }
-                    return prev.concat([
-                      {
-                        ...props.data.dataplane.networking.inbounds[0],
-                        name: key,
-                        clusterName: key,
-                        port: Number(port),
-                        protocol: ['http', 'tcp'].find(item => typeof value[item] !== 'undefined') ?? 'tcp',
-                        addressPort: `${props.data.dataplane.networking.inbounds[0].address}:${port}`,
-                      },
-                    ])
-                  }, []) : props.data.dataplane.networking.inbounds]"
-                  :key="inbounds"
-                >
-                  <ConnectionGroup
-                    type="inbound"
-                    data-testid="dataplane-inbounds"
-                  >
-                    <!-- don't show a card for anything on port 49151 as those are service-less inbounds -->
-                    <DataCollection
-                      type="inbounds"
-                      :items="inbounds"
-                      :predicate="(item) => item.port !== 49151"
-                    >
-                      <template
-                        v-if="props.data.dataplaneType === 'delegated'"
-                        #empty
-                      >
-                        <XEmptyState>
-                          <p>
-                            This proxy is a delegated gateway therefore {{ t('common.product.name') }} does not have any
-                            visibility into inbounds for this gateway.
-                          </p>
-                        </XEmptyState>
-                      </template>
-                      <template
-                        #default="{ items: _inbounds }"
-                      >
-                        <XLayout
-                          type="stack"
-                          size="small"
-                        >
-                          <template
-                            v-for="item in _inbounds"
-                            :key="`${item.name}`"
-                          >
-                            <template
-                              v-for="stats in [
-                                traffic?.inbounds[item.clusterName],
-                              ]"
-                              :key="stats"
-                            >
-                              <ConnectionCard
-                                data-testid="dataplane-inbound"
-                                :protocol="item.protocol"
-                                :service="can('use service-insights', props.mesh) ? item.tags['kuma.io/service'] : ''"
-                                :port-name="item.portName"
-                                :traffic="typeof error === 'undefined' ?
-                                  stats :
-                                  {
-                                    name: '',
-                                    protocol: item.protocol,
-                                    port: `${item.port}`,
-                                  }
-                                "
-                              >
-                                <XAction
-                                  data-action
-                                  :to="{
-                                    name: ((name) => name.includes('bound') ? name.replace('-outbound-', '-inbound-') : 'data-plane-connection-inbound-summary-overview-view')(String(_route.name)),
-                                    params: {
-                                      connection: item.name,
-                                    },
-                                    query: {
-                                      inactive: route.params.inactive,
-                                    },
-                                  }"
-                                >
-                                  {{ item.name.replace('localhost', '').replace('_', ':') }}
-                                </XAction>
-                              </ConnectionCard>
-                            </template>
-                          </template>
-                        </XLayout>
-                      </template>
-                    </DataCollection>
-                  </ConnectionGroup>
-                </template>
-              </ConnectionTraffic>
-
-              <ConnectionTraffic>
-                <template
-                  v-if="traffic"
-                  #actions
-                >
-                  <XInputSwitch
-                    :checked="route.params.inactive"
-                    data-testid="dataplane-outbounds-inactive-toggle"
-                    @change="(value) => route.update({ inactive: value })"
-                  >
-                    <template #label>
-                      Show inactive
-                    </template>
-                  </XInputSwitch>
-
-                  <XAction
-                    action="refresh"
-                    appearance="primary"
-                    @click="refresh"
-                  >
-                    Refresh
-                  </XAction>
-                </template>
-                <template
-                  #title
-                >
-                  <XLayout type="separated">
-                    <XIcon name="outbound" />
-                    <span>Outbounds</span>
-                  </XLayout>
-                </template>
-                <!-- we don't want to show an error here -->
-                <!-- instead we show a No Data EmptyState -->
-                <template
-                  v-if="typeof error === 'undefined'"
-                >
-                  <XProgress
-                    v-if="typeof traffic === 'undefined'"
-                  />
-                  <template
-                    v-else
-                  >
-                    <ConnectionGroup
-                      type="passthrough"
-                    >
-                      <ConnectionCard
-                        :protocol="`passthrough`"
-                        :traffic="traffic.passthrough"
-                      >
-                        Non mesh traffic
-                      </ConnectionCard>
-                    </ConnectionGroup>
-                    <!-- Outbounds for gateways report actual traffic on the upstream so we switch to upstream here for non-standard-->
+                  <h3>{{ t('data-planes.routes.item.mtls.title') }}</h3>
+                  <XLayout size="small">
                     <template
-                      v-for="direction in ['upstream'] as const"
-                      :key="direction"
+                      v-for="mTLS in [
+                        props.source.data.dataplaneInsight.mTLS,
+                      ]"
+                      :key="mTLS"
                     >
-                      <XNotification
-                        :notify="!!Object.values(traffic.outbounds).find(item => (typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) ?? 0 > 0)"
-                        variant="info"
-                        :uri="`data-planes.notifications.recommend-reachable-services:${props.data.id}`"
-                      >
-                        <XI18n
-                          path="data-planes.notifications.recommend-reachable"
-                          :params="{ mode: props.mesh.meshServices.mode }"
-                        />
-                      </XNotification>
-                      <DataCollection
-                        type="outbounds"
-                        :predicate="route.params.inactive ? undefined : ([key, item]) => ((typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) ?? 0) > 0"
-                        :items="Object.entries<any>(traffic.outbounds)"
-                        v-slot="{ items: outbounds }"
-                      >
-                        <ConnectionGroup
-                          v-if="outbounds.length > 0"
-                          type="outbound"
-                          data-testid="dataplane-outbounds"
-                        >
-                          <!-- the outbound name is the service name potentially with a 16 digit hash appended -->
-                          <!-- that potential hash follows a hypen and can contain digits and a-f -->
-                          <!-- so we replace this with `` if we find it to get the service name for linking -->
+                      <XLayout type="separated">
+                        <DefinitionCard layout="horizontal">
+                          <template #title>
+                            <XI18n
+                              path="data-planes.routes.item.mtls.generation_time.title"
+                            />
+                          </template>
+
+                          <template #body>
+                            <XBadge appearance="neutral">
+                              {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
+                            </XBadge>
+                          </template>
+                        </DefinitionCard>
+                        <DefinitionCard layout="horizontal">
+                          <template #title>
+                            <XI18n
+                              path="data-planes.routes.item.mtls.expiration_time.title"
+                            />
+                          </template>
+
+                          <template #body>
+                            <XBadge appearance="neutral">
+                              {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
+                            </XBadge>
+                          </template>
+                        </DefinitionCard>
+                      </XLayout>
+                      <XLayout type="separated">
+                        <DefinitionCard layout="horizontal">
                           <template
-                            v-for="hash in [/-([a-f0-9]){16}$/]"
-                            :key="hash"
+                            #title
+                          >
+                            {{ t('data-planes.routes.item.mtls.regenerations.title') }}
+                          </template>
+
+                          <template
+                            #body
+                          >
+                            <XBadge appearance="info">
+                              {{ t('common.formats.integer', { value: mTLS.certificateRegenerations }) }}
+                            </XBadge>
+                          </template>
+                        </DefinitionCard>
+
+                        <DefinitionCard layout="horizontal">
+                          <template
+                            #title
+                          >
+                            {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
+                          </template>
+
+                          <template
+                            #body
+                          >
+                            <XBadge appearance="decorative">
+                              {{ mTLS.issuedBackend }}
+                            </XBadge>
+                          </template>
+                        </DefinitionCard>
+
+                        <DefinitionCard layout="horizontal">
+                          <template
+                            #title
+                          >
+                            {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
+                          </template>
+
+                          <template
+                            #body
+                          >
+                            <XLayout
+                              type="separated"
+                              truncate
+                            >
+                              <XBadge
+                                v-for="item in mTLS.supportedBackends"
+                                :key="item"
+                                :appearance="item === mTLS.issuedBackend ? 'decorative' : 'info'"
+                              >
+                                {{ item }}
+                              </XBadge>
+                            </XLayout>
+                          </template>
+                        </DefinitionCard>
+                      </XLayout>
+                    </template>
+                  </XLayout>
+                </XLayout>
+              </XLayout>
+            </template>
+          </DataLoader>
+        </XAboutCard>
+
+        <DataLoader
+          :data="[props.source.data]"
+        >
+          <template v-if="props.source.data">
+            <DataSource
+              :src="uri(sources, '/connections/stats/for/:proxyType/:name/:mesh/:socketAddress', {
+                proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress' })[route.params.proxyType] ?? 'dataplane',
+                name: route.params.proxy,
+                mesh: route.params.mesh || '*',
+                socketAddress: props.source.data.dataplane.networking.inboundAddress,
+              })"
+              v-slot="{ data: traffic, error, refresh }"
+            >
+              <XCard
+                class="traffic"
+                data-testid="dataplane-traffic"
+              >
+                <XLayout
+                  type="columns"
+                >
+                  <ConnectionTraffic>
+                    <template
+                      #title
+                    >
+                      <XLayout
+                        type="separated"
+                      >
+                        <XIcon
+                          name="inbound"
+                        />
+                        <span>Inbounds</span>
+                      </XLayout>
+                    </template>
+                    <!-- if we are a builtin gateway proxy i.e. a 'gateway' proxy -->
+                    <!-- use its first and only inbounds as a template  -->
+                    <!-- and fill the inbounds out from the stats once they are loaded -->
+                    <template
+                      v-for="inbounds in [props.source.data.dataplane.networking.type === 'gateway' ? Object.entries<any>(traffic?.inbounds ?? {}).reduce<DataplaneInbound[]>((prev, [key, value]) => {
+                        // As we are just 'finding' inbounds from stats without knowing them
+                        // from the dataplane overview API request, we will wrongly 'find'
+                        // the envoy admin inbound that is used for kumas /stats API. Ignore
+                        // the envoy admin inbound when we find it
+                        const port = key.split('_').at(-1)
+                        if (port === (props.source.data?.dataplane.networking.admin?.port ?? '9901')) {
+                          return prev
+                        }
+
+                        if(!props.source.data) return []
+
+                        return prev.concat([
+                          {
+                            ...props.source.data.dataplane.networking.inbounds[0],
+                            name: key,
+                            clusterName: key,
+                            port: Number(port),
+                            protocol: ['http', 'tcp'].find(item => typeof value[item] !== 'undefined') ?? 'tcp',
+                            addressPort: `${props.source.data.dataplane.networking.inbounds[0].address}:${port}`,
+                          },
+                        ])
+                      }, []) : props.source.data.dataplane.networking.inbounds]"
+                      :key="inbounds"
+                    >
+                      <ConnectionGroup
+                        type="inbound"
+                        data-testid="dataplane-inbounds"
+                      >
+                        <!-- don't show a card for anything on port 49151 as those are service-less inbounds -->
+                        <DataCollection
+                          type="inbounds"
+                          :items="inbounds"
+                          :predicate="(item) => item.port !== 49151"
+                        >
+                          <template
+                            v-if="props.source.data.dataplaneType === 'delegated'"
+                            #empty
+                          >
+                            <XEmptyState>
+                              <p>
+                                This proxy is a delegated gateway therefore {{ t('common.product.name') }} does not have any
+                                visibility into inbounds for this gateway.
+                              </p>
+                            </XEmptyState>
+                          </template>
+                          <template
+                            #default="{ items: _inbounds }"
                           >
                             <XLayout
                               type="stack"
                               size="small"
                             >
                               <template
-                                v-for="[name, outbound] in outbounds"
-                                :key="`${name}`"
+                                v-for="item in _inbounds"
+                                :key="`${item.name}`"
                               >
-                                <ConnectionCard
-                                  data-testid="dataplane-outbound"
-                                  :protocol="['grpc', 'http', 'tcp'].find(protocol => typeof outbound[protocol] !== 'undefined') ?? 'tcp'"
-                                  :traffic="outbound"
-                                  :service="outbound.$resourceMeta.type === '' ? name.replace(hash, '') : undefined"
-                                  :direction="direction"
+                                <template
+                                  v-for="stats in [
+                                    traffic?.inbounds[item.clusterName],
+                                  ]"
+                                  :key="stats"
                                 >
-                                  <XAction
-                                    data-action
-                                    :to="{
-                                      name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'data-plane-connection-outbound-summary-overview-view')(String(_route.name)),
-                                      params: {
-                                        connection: name,
-                                      },
-                                      query: {
-                                        inactive: route.params.inactive,
-                                      },
-                                    }"
+                                  <ConnectionCard
+                                    data-testid="dataplane-inbound"
+                                    :protocol="item.protocol"
+                                    :service="can('use service-insights', props.mesh) ? item.tags['kuma.io/service'] : ''"
+                                    :port-name="item.portName"
+                                    :traffic="typeof error === 'undefined' ?
+                                      stats :
+                                      {
+                                        name: '',
+                                        protocol: item.protocol,
+                                        port: `${item.port}`,
+                                      }
+                                    "
                                   >
-                                    {{ name }}
-                                  </XAction>
-                                </ConnectionCard>
+                                    <XAction
+                                      data-action
+                                      :to="{
+                                        name: ((name) => name.includes('bound') ? name.replace('-outbound-', '-inbound-') : 'data-plane-connection-inbound-summary-overview-view')(String(_route.name)),
+                                        params: {
+                                          connection: item.name,
+                                        },
+                                        query: {
+                                          inactive: route.params.inactive,
+                                        },
+                                      }"
+                                    >
+                                      {{ item.name.replace('localhost', '').replace('_', ':') }}
+                                    </XAction>
+                                  </ConnectionCard>
+                                </template>
                               </template>
                             </XLayout>
                           </template>
-                        </ConnectionGroup>
-                      </DataCollection>
+                        </DataCollection>
+                      </ConnectionGroup>
                     </template>
-                  </template>
-                </template>
-                <template
-                  v-else
+                  </ConnectionTraffic>
+
+                  <ConnectionTraffic>
+                    <template
+                      v-if="traffic"
+                      #actions
+                    >
+                      <XInputSwitch
+                        :checked="route.params.inactive"
+                        data-testid="dataplane-outbounds-inactive-toggle"
+                        @change="(value: boolean) => route.update({ inactive: value })"
+                      >
+                        <template #label>
+                          Show inactive
+                        </template>
+                      </XInputSwitch>
+
+                      <XAction
+                        action="refresh"
+                        appearance="primary"
+                        @click="refresh"
+                      >
+                        Refresh
+                      </XAction>
+                    </template>
+                    <template
+                      #title
+                    >
+                      <XLayout type="separated">
+                        <XIcon name="outbound" />
+                        <span>Outbounds</span>
+                      </XLayout>
+                    </template>
+                    <!-- we don't want to show an error here -->
+                    <!-- instead we show a No Data EmptyState -->
+                    <template
+                      v-if="typeof error === 'undefined'"
+                    >
+                      <XProgress
+                        v-if="typeof traffic === 'undefined'"
+                      />
+                      <template
+                        v-else
+                      >
+                        <ConnectionGroup
+                          type="passthrough"
+                        >
+                          <ConnectionCard
+                            :protocol="`passthrough`"
+                            :traffic="traffic.passthrough"
+                          >
+                            Non mesh traffic
+                          </ConnectionCard>
+                        </ConnectionGroup>
+                        <!-- Outbounds for gateways report actual traffic on the upstream so we switch to upstream here for non-standard-->
+                        <template
+                          v-for="direction in ['upstream'] as const"
+                          :key="direction"
+                        >
+                          <XNotification
+                            :notify="!!Object.values(traffic.outbounds).find(item => (typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) ?? 0 > 0)"
+                            variant="info"
+                            :uri="`data-planes.notifications.recommend-reachable-services:${props.source.data.id}`"
+                          >
+                            <XI18n
+                              path="data-planes.notifications.recommend-reachable"
+                              :params="{ mode: props.mesh.meshServices.mode }"
+                            />
+                          </XNotification>
+                          <DataCollection
+                            type="outbounds"
+                            :predicate="route.params.inactive ? undefined : ([key, item]) => ((typeof item.tcp !== 'undefined' ? item.tcp?.[`${direction}_cx_rx_bytes_total`] : item.http?.[`${direction}_rq_total`]) ?? 0) > 0"
+                            :items="Object.entries<any>(traffic.outbounds)"
+                            v-slot="{ items: outbounds }"
+                          >
+                            <ConnectionGroup
+                              v-if="outbounds.length > 0"
+                              type="outbound"
+                              data-testid="dataplane-outbounds"
+                            >
+                              <!-- the outbound name is the service name potentially with a 16 digit hash appended -->
+                              <!-- that potential hash follows a hypen and can contain digits and a-f -->
+                              <!-- so we replace this with `` if we find it to get the service name for linking -->
+                              <template
+                                v-for="hash in [/-([a-f0-9]){16}$/]"
+                                :key="hash"
+                              >
+                                <XLayout
+                                  type="stack"
+                                  size="small"
+                                >
+                                  <template
+                                    v-for="[name, outbound] in outbounds"
+                                    :key="`${name}`"
+                                  >
+                                    <ConnectionCard
+                                      data-testid="dataplane-outbound"
+                                      :protocol="['grpc', 'http', 'tcp'].find(protocol => typeof outbound[protocol] !== 'undefined') ?? 'tcp'"
+                                      :traffic="outbound"
+                                      :service="outbound.$resourceMeta.type === '' ? name.replace(hash, '') : undefined"
+                                      :direction="direction"
+                                    >
+                                      <XAction
+                                        data-action
+                                        :to="{
+                                          name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'data-plane-connection-outbound-summary-overview-view')(String(_route.name)),
+                                          params: {
+                                            connection: name,
+                                          },
+                                          query: {
+                                            inactive: route.params.inactive,
+                                          },
+                                        }"
+                                      >
+                                        {{ name }}
+                                      </XAction>
+                                    </ConnectionCard>
+                                  </template>
+                                </XLayout>
+                              </template>
+                            </ConnectionGroup>
+                          </DataCollection>
+                        </template>
+                      </template>
+                    </template>
+                    <template
+                      v-else
+                    >
+                      <XEmptyState />
+                    </template>
+                  </ConnectionTraffic>
+                </XLayout>
+              </XCard>
+              <template v-if="props.source.data">
+                <RouterView
+                  v-slot="child"
                 >
-                  <XEmptyState />
+                  <SummaryView
+                    v-if="child.route.name !== route.name"
+                    width="670px"
+                    @close="function () {
+                      route.replace({
+                        name: 'data-plane-detail-view',
+                        params: {
+                          mesh: route.params.mesh,
+                          proxy: route.params.proxy,
+                        },
+                        query: {
+                          inactive: route.params.inactive ? null : undefined,
+                        },
+                      })
+
+                    }"
+                  >
+                    <component
+                      :is="child.Component"
+                      :data="route.params.subscription.length > 0 ? props.source.data.dataplaneInsight.subscriptions : (child.route.name as string).includes('-inbound-') ? props.source.data.dataplane.networking.inbounds : traffic?.outbounds || {}"
+                      :networking="props.source.data.dataplane.networking"
+                    />
+                  </SummaryView>
+                </RouterView>
+              </template>
+            </DataSource>
+          </template>
+        </DataLoader>
+
+        <div
+          data-testid="dataplane-subscriptions"
+        >
+          <XCard>
+            <template
+              #title
+            >
+              <h2>{{ t('data-planes.routes.item.subscriptions.title') }}</h2>
+            </template>
+
+            <XLayout>
+              <XI18n path="data-planes.routes.item.subscriptions.description" />
+              <DataLoader
+                variant="list"
+                :data="[props.source.data]"
+              >
+                <template v-if="props.source.data">
+                  <AppCollection
+                    :headers="[
+                      { ...me.get('headers.connection'), label: '&nbsp;', key: 'connection' },
+                      { ...me.get('headers.instanceId'), label: t('http.api.property.instanceId'), key: 'instanceId' },
+                      { ...me.get('headers.version'), label: t('http.api.property.version'), key: 'version' },
+                      { ...me.get('headers.connected'), label: t('http.api.property.connected'), key: 'connected' },
+                      { ...me.get('headers.disconnected'), label: t('http.api.property.disconnected'), key: 'disconnected' },
+                      { ...me.get('headers.responses'), label: t('http.api.property.responses'), key: 'responses' },
+                    ]"
+                    :is-selected-row="item => item.id === route.params.subscription"
+                    :items="props.source.data.dataplaneInsight.subscriptions.map((_, i, arr) => arr[arr.length - (i + 1)])"
+                    @resize="me.set"
+                  >
+                    <template
+                      #connection="{ row: item }"
+                    >
+                      <template
+                        v-for="connection in [item.connectTime && !item.disconnectTime ? 'healthy' : 'unhealthy'] as const"
+                        :key="`${connection}`"
+                      >
+                        <XIcon :name="connection">
+                          {{ t(`common.connection.${connection}`) }}
+                        </XIcon>
+                      </template>
+                    </template>
+                    <template
+                      #instanceId="{ row: item }"
+                    >
+                      <XAction
+                        data-action
+                        :to="{
+                          name: 'data-plane-subscription-summary-view',
+                          params: {
+                            subscription: item.id,
+                          },
+                        }"
+                      >
+                        {{ item.controlPlaneInstanceId }}
+                      </XAction>
+                    </template>
+                    <template
+                      #version="{ row: item }"
+                    >
+                      {{ item.version?.kumaDp?.version ?? '-' }}
+                    </template>
+                    <template
+                      #connected="{ row: item }"
+                    >
+                      {{ t('common.formats.datetime', { value: Date.parse(item.connectTime ?? '') }) }}
+                    </template>
+                    <template
+                      #disconnected="{ row: item }"
+                    >
+                      <template
+                        v-if="item.disconnectTime"
+                      >
+                        {{ t('common.formats.datetime', { value: Date.parse(item.disconnectTime) }) }}
+                      </template>
+                    </template>
+                    <template
+                      #responses="{ row: item }"
+                    >
+                      <template
+                        v-for="responses in [item.status?.total ?? {}]"
+                      >
+                        {{ responses.responsesSent }}/{{ responses.responsesAcknowledged }}
+                      </template>
+                    </template>
+                  </AppCollection>
                 </template>
-              </ConnectionTraffic>
+              </DataLoader>
             </XLayout>
           </XCard>
-
-          <RouterView
-            v-slot="child"
-          >
-            <SummaryView
-              v-if="child.route.name !== route.name"
-              width="670px"
-              @close="function () {
-                route.replace({
-                  name: 'data-plane-detail-view',
-                  params: {
-                    mesh: route.params.mesh,
-                    proxy: route.params.proxy,
-                  },
-                  query: {
-                    inactive: route.params.inactive ? null : undefined,
-                  },
-                })
-
-              }"
-            >
-              <component
-                :is="child.Component"
-                :data="route.params.subscription.length > 0 ? props.data.dataplaneInsight.subscriptions : (child.route.name as string).includes('-inbound-') ? props.data.dataplane.networking.inbounds : traffic?.outbounds || {}"
-                :networking="props.data.dataplane.networking"
-              />
-            </SummaryView>
-          </RouterView>
-
-          <div
-            v-if="props.data.dataplaneInsight.subscriptions.length > 0"
-            data-testid="dataplane-subscriptions"
-          >
-            <XCard>
-              <template
-                #title
-              >
-                <h2>{{ t('data-planes.routes.item.subscriptions.title') }}</h2>
-              </template>
-
-              <XLayout>
-                <XI18n path="data-planes.routes.item.subscriptions.description" />
-                <AppCollection
-                  :headers="[
-                    { ...me.get('headers.connection'), label: '&nbsp;', key: 'connection' },
-                    { ...me.get('headers.instanceId'), label: t('http.api.property.instanceId'), key: 'instanceId' },
-                    { ...me.get('headers.version'), label: t('http.api.property.version'), key: 'version' },
-                    { ...me.get('headers.connected'), label: t('http.api.property.connected'), key: 'connected' },
-                    { ...me.get('headers.disconnected'), label: t('http.api.property.disconnected'), key: 'disconnected' },
-                    { ...me.get('headers.responses'), label: t('http.api.property.responses'), key: 'responses' },
-                  ]"
-                  :is-selected-row="item => item.id === route.params.subscription"
-                  :items="props.data.dataplaneInsight.subscriptions.map((_, i, arr) => arr[arr.length - (i + 1)])"
-                  @resize="me.set"
-                >
-                  <template
-                    #connection="{ row: item }"
-                  >
-                    <template
-                      v-for="connection in [item.connectTime && !item.disconnectTime ? 'healthy' : 'unhealthy'] as const"
-                      :key="`${connection}`"
-                    >
-                      <XIcon :name="connection">
-                        {{ t(`common.connection.${connection}`) }}
-                      </XIcon>
-                    </template>
-                  </template>
-                  <template
-                    #instanceId="{ row: item }"
-                  >
-                    <XAction
-                      data-action
-                      :to="{
-                        name: 'data-plane-subscription-summary-view',
-                        params: {
-                          subscription: item.id,
-                        },
-                      }"
-                    >
-                      {{ item.controlPlaneInstanceId }}
-                    </XAction>
-                  </template>
-                  <template
-                    #version="{ row: item }"
-                  >
-                    {{ item.version?.kumaDp?.version ?? '-' }}
-                  </template>
-                  <template
-                    #connected="{ row: item }"
-                  >
-                    {{ t('common.formats.datetime', { value: Date.parse(item.connectTime ?? '') }) }}
-                  </template>
-                  <template
-                    #disconnected="{ row: item }"
-                  >
-                    <template
-                      v-if="item.disconnectTime"
-                    >
-                      {{ t('common.formats.datetime', { value: Date.parse(item.disconnectTime) }) }}
-                    </template>
-                  </template>
-                  <template
-                    #responses="{ row: item }"
-                  >
-                    <template
-                      v-for="responses in [item.status?.total ?? {}]"
-                    >
-                      {{ responses.responsesSent }}/{{ responses.responsesAcknowledged }}
-                    </template>
-                  </template>
-                </AppCollection>
-              </XLayout>
-            </XCard>
-          </div>
-        </XLayout>
-      </AppView>
-    </DataSource>
+        </div>
+      </XLayout>
+    </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
 import type { DataplaneOverview, DataplaneInbound } from '../data'
+import { DataSourceResponse } from '@/app/application'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
@@ -740,8 +775,8 @@ import { useRoute } from '@/app/vue'
 const _route = useRoute()
 
 const props = defineProps<{
-  data: DataplaneOverview
   mesh: Mesh
+  source: DataSourceResponse<DataplaneOverview>
 }>()
 </script>
 

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePoliciesView.vue
@@ -30,6 +30,7 @@
             })"
             :data="[policyTypesData]"
             :errors="[policyTypesError]"
+            variant="list"
             v-slot="{ data: rulesData }"
           >
             <!-- show an empty state if we have no rules at all -->
@@ -101,6 +102,7 @@
                 :items="rulesData!.inboundRules"
                 :comparator="(a, b) => a.type.localeCompare(b.type)"
                 :empty="false"
+                variant="list"
                 v-slot="{ items }"
               >
                 <XCard>
@@ -134,11 +136,12 @@
           <template v-if="!can('use zones')">
             <div>
               <!-- builtin gateways have different data/visuals than other types of dataplanes -->
-              <template v-if="props.data.dataplaneType === 'builtin'">
+              <template v-if="props.source.data?.dataplaneType === 'builtin'">
                 <DataLoader
                   :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.proxy}/gateway-dataplane-policies`"
                   :data="[policyTypesData]"
                   :errors="[policyTypesError]"
+                  variant="list"
                   v-slot="{ data: gatewayDataplane }: MeshGatewayDataplaneSource"
                 >
                   <DataCollection
@@ -168,6 +171,7 @@
                   :src="`/meshes/${route.params.mesh}/dataplanes/${route.params.proxy}/sidecar-dataplane-policies`"
                   :data="[policyTypesData]"
                   :errors="[policyTypesError]"
+                  variant="list"
                   v-slot="{ data: sidecarDataplaneData }: SidecarDataplaneCollectionSource"
                 >
                   <DataCollection
@@ -221,6 +225,7 @@
 import BuiltinGatewayPolicies from '../components/BuiltinGatewayPolicies.vue'
 import type { DataplaneOverview } from '../data'
 import type { MeshGatewayDataplaneSource, SidecarDataplaneCollectionSource } from '../sources'
+import { DataSourceResponse } from '@/app/application'
 import SummaryView from '@/app/common/SummaryView.vue'
 import PolicyTypeEntryList from '@/app/policies/components/PolicyTypeEntryList.vue'
 import type { PolicyResourceType } from '@/app/policies/data'
@@ -229,6 +234,6 @@ import RuleList from '@/app/rules/components/RuleList.vue'
 import { sources } from '@/app/rules/sources'
 
 const props = defineProps<{
-  data: DataplaneOverview
+  source: DataSourceResponse<DataplaneOverview>
 }>()
 </script>

--- a/packages/kuma-gui/src/app/zones/views/ZoneConfigView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneConfigView.vue
@@ -13,97 +13,102 @@
       :render="false"
       :title="t('zone-cps.routes.item.navigation.zone-cp-config-view')"
     />
-    <DataSource
-      :src="uri(sources, '/control-plane/outdated/:version', {
-        version: props.data.zoneInsight.version?.kumaCp?.version ?? '-',
-      })"
-      v-slot="{ data: version }"
+    <AppView
+      :notifications="true"
     >
-      <AppView
-        :notifications="true"
-      >
-        <template
-          v-for="{ bool, key, params } in [
-            {
-              bool: props.data.zoneInsight.store === 'memory',
-              key: 'store-memory',
-            },
-            {
-              bool: !props.data.zoneInsight.version?.kumaCp?.kumaCpGlobalCompatible,
-              key: 'global-cp-incompatible',
-              params: {
-                zoneCpVersion: props.data.zoneInsight.version?.kumaCp?.version ?? '-',
-                globalCpVersion: version?.version ?? '',
-              },
-            },
-            {
-              bool: (props.data.zoneInsight.connectedSubscription?.status.total.responsesRejected ?? 0) > 0,
-              key: 'global-nack-response',
-            },
-          ]"
-          :key="key"
-        >
-          <XNotification
-            :notify="bool"
-            :data-testid="`warning-${key}`"
-            :uri="`zone-cps.notifications.${key}.${props.data.id}`"
+      <DataLoader :data="[props.source.data]">
+        <template v-if="props.source.data">
+          <DataSource
+            :src="uri(sources, '/control-plane/outdated/:version', {
+              version: props.source.data.zoneInsight.version?.kumaCp?.version ?? '-',
+            })"
+            v-slot="{ data: version }"
           >
-            <XI18n
-              :path="`zone-cps.notifications.${key}`"
-              :params="Object.fromEntries(Object.entries(params ?? {}))"
+            <template
+              v-for="{ bool, key, params } in [
+                {
+                  bool: props.source.data.zoneInsight.store === 'memory',
+                  key: 'store-memory',
+                },
+                {
+                  bool: !props.source.data.zoneInsight.version?.kumaCp?.kumaCpGlobalCompatible,
+                  key: 'global-cp-incompatible',
+                  params: {
+                    zoneCpVersion: props.source.data.zoneInsight.version?.kumaCp?.version ?? '-',
+                    globalCpVersion: version?.version ?? '',
+                  },
+                },
+                {
+                  bool: (props.source.data.zoneInsight.connectedSubscription?.status.total.responsesRejected ?? 0) > 0,
+                  key: 'global-nack-response',
+                },
+              ]"
+              :key="key"
             >
-              <template
-                v-if="key === 'global-nack-response'"
-                #link
+              <XNotification
+                :notify="bool"
+                :data-testid="`warning-${key}`"
+                :uri="`zone-cps.notifications.${key}.${props.source.data.id}`"
               >
-                <XAction
-                  data-action
-                  :to="{
-                    name: 'zone-cp-subscription-summary-view',
-                    params: {
-                      subscription: props.data.zoneInsight.connectedSubscription?.id,
-                    },
-                  }"
+                <XI18n
+                  :path="`zone-cps.notifications.${key}`"
+                  :params="Object.fromEntries(Object.entries(params ?? {}))"
                 >
-                  Zone Control Plane Summary
-                </XAction>
-              </template>
-            </XI18n>
-          </XNotification>
+                  <template
+                    v-if="key === 'global-nack-response'"
+                    #link
+                  >
+                    <XAction
+                      data-action
+                      :to="{
+                        name: 'zone-cp-subscription-summary-view',
+                        params: {
+                          subscription: props.source.data.zoneInsight.connectedSubscription?.id,
+                        },
+                      }"
+                    >
+                      Zone Control Plane Summary
+                    </XAction>
+                  </template>
+                </XI18n>
+              </XNotification>
+            </template>
+          </DataSource>
+
+          <XCard>
+            <XCodeBlock
+              v-if="Object.keys(props.source.data.zoneInsight.config).length > 0"
+              language="json"
+              :code="JSON.stringify(props.source.data.zoneInsight.config, null, 2)"
+              is-searchable
+              :query="route.params.codeSearch"
+              :is-filter-mode="route.params.codeFilter"
+              :is-reg-exp-mode="route.params.codeRegExp"
+              @query-change="route.update({ codeSearch: $event })"
+              @filter-mode-change="route.update({ codeFilter: $event })"
+              @reg-exp-mode-change="route.update({ codeRegExp: $event })"
+            />
+
+            <XAlert
+              v-else
+              class="mt-4"
+              data-testid="warning-no-subscriptions"
+              variant="warning"
+            >
+              {{ t('zone-cps.detail.no_subscriptions') }}
+            </XAlert>
+          </XCard>
         </template>
-
-        <XCard>
-          <XCodeBlock
-            v-if="Object.keys(props.data.zoneInsight.config).length > 0"
-            language="json"
-            :code="JSON.stringify(props.data.zoneInsight.config, null, 2)"
-            is-searchable
-            :query="route.params.codeSearch"
-            :is-filter-mode="route.params.codeFilter"
-            :is-reg-exp-mode="route.params.codeRegExp"
-            @query-change="route.update({ codeSearch: $event })"
-            @filter-mode-change="route.update({ codeFilter: $event })"
-            @reg-exp-mode-change="route.update({ codeRegExp: $event })"
-          />
-
-          <XAlert
-            v-else
-            class="mt-4"
-            data-testid="warning-no-subscriptions"
-            variant="warning"
-          >
-            {{ t('zone-cps.detail.no_subscriptions') }}
-          </XAlert>
-        </XCard>
-      </AppView>
-    </DataSource>
+      </DataLoader>
+    </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
 import type { ZoneOverview } from '../data'
+import { DataSourceResponse } from '@/app/application'
 import { sources } from '@/app/control-planes/sources'
 const props = defineProps<{
-  data: ZoneOverview
+  source: DataSourceResponse<ZoneOverview>
 }>()
 </script>

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -8,63 +8,65 @@
     v-slot="{ t, uri, route, me }"
   >
     <DataSource
-      :src="uri(sources, '/control-plane/outdated/:version', {
-        version: props.data.zoneInsight.version?.kumaCp?.version ?? '-',
-      })"
+      :src="props.source.data ? uri(sources, '/control-plane/outdated/:version', {
+        version: props.source.data.zoneInsight.version?.kumaCp?.version ?? '-',
+      }) : ''"
       v-slot="{ data: version }"
     >
       <AppView
         :docs="t('zones.href.docs.cta')"
         :notifications="true"
       >
-        <template
-          v-for="{ bool, key, params } in [
-            {
-              bool: props.data.zoneInsight.store === 'memory',
-              key: 'store-memory',
-            },
-            {
-              bool: !props.data.zoneInsight.version?.kumaCp?.kumaCpGlobalCompatible,
-              key: 'global-cp-incompatible',
-              params: {
-                zoneCpVersion: props.data.zoneInsight.version?.kumaCp?.version ?? '-',
-                globalCpVersion: version?.version ?? '',
+        <template v-if="props.source.data">
+          <template
+            v-for="{ bool, key, params } in [
+              {
+                bool: props.source.data.zoneInsight.store === 'memory',
+                key: 'store-memory',
               },
-            },
-            {
-              bool: (props.data.zoneInsight.connectedSubscription?.status.total.responsesRejected ?? 0) > 0,
-              key: 'global-nack-response',
-            },
-          ]"
-          :key="key"
-        >
-          <XNotification
-            :notify="bool"
-            :data-testid="`warning-${key}`"
-            :uri="`zone-cps.notifications.${key}.${props.data.id}`"
+              {
+                bool: !props.source.data.zoneInsight.version?.kumaCp?.kumaCpGlobalCompatible,
+                key: 'global-cp-incompatible',
+                params: {
+                  zoneCpVersion: props.source.data.zoneInsight.version?.kumaCp?.version ?? '-',
+                  globalCpVersion: version?.version ?? '',
+                },
+              },
+              {
+                bool: (props.source.data.zoneInsight.connectedSubscription?.status.total.responsesRejected ?? 0) > 0,
+                key: 'global-nack-response',
+              },
+            ]"
+            :key="key"
           >
-            <XI18n
-              :path="`zone-cps.notifications.${key}`"
-              :params="Object.fromEntries(Object.entries(params ?? {}))"
+            <XNotification
+              :notify="bool"
+              :data-testid="`warning-${key}`"
+              :uri="`zone-cps.notifications.${key}.${props.source.data.id}`"
             >
-              <template
-                v-if="key === 'global-nack-response'"
-                #link
+              <XI18n
+                :path="`zone-cps.notifications.${key}`"
+                :params="Object.fromEntries(Object.entries(params ?? {}))"
               >
-                <XAction
-                  data-action
-                  :to="{
-                    name: 'zone-cp-subscription-summary-view',
-                    params: {
-                      subscription: props.data.zoneInsight.connectedSubscription?.id,
-                    },
-                  }"
+                <template
+                  v-if="key === 'global-nack-response'"
+                  #link
                 >
-                  Zone Control Plane Summary
-                </XAction>
-              </template>
-            </XI18n>
-          </XNotification>
+                  <XAction
+                    data-action
+                    :to="{
+                      name: 'zone-cp-subscription-summary-view',
+                      params: {
+                        subscription: props.source.data.zoneInsight.connectedSubscription?.id,
+                      },
+                    }"
+                  >
+                    Zone Control Plane Summary
+                  </XAction>
+                </template>
+              </XI18n>
+            </XNotification>
+          </template>
         </template>
         <XLayout
           data-testid="detail-view-details"
@@ -72,196 +74,207 @@
         >
           <XAboutCard
             :title="t('zone-cps.detail.about.title')"
-            :created="props.data.creationTime"
-            :modified="props.data.modificationTime"
+            :created="props.source.data?.creationTime"
+            :modified="props.source.data?.modificationTime"
           >
-            <DefinitionCard layout="horizontal">
-              <template #title>
-                {{ t('http.api.property.status') }}
-              </template>
-
-              <template #body>
-                <StatusBadge :status="props.data.state" />
-              </template>
-            </DefinitionCard>
-            <DefinitionCard
-              layout="horizontal"
-              :class="{
-                version: true,
-                outdated: version?.outdated,
-              }"
-            >
-              <template #title>
-                {{ t('zone-cps.routes.item.version') }}
-              </template>
-
-              <template #body>
-                <XLayout type="separated">
-                  <XBadge
-                    :appearance="version?.outdated === true ? 'warning' : 'decorative'"
-                  >
-                    {{ props.data.zoneInsight.version?.kumaCp?.version ?? '—' }}
-                  </XBadge>
-                  <template
-                    v-if="version?.outdated === true"
-                  >
-                    <XIcon
-                      name="info"
-                    >
-                      <XI18n
-                        path="zone-cps.routes.item.version_warning"
-                      />
-                    </XIcon>
+            <template v-if="props.source.data">
+              <DataLoader :data="[props.source.data]">
+                <DefinitionCard layout="horizontal">
+                  <template #title>
+                    {{ t('http.api.property.status') }}
                   </template>
-                </XLayout>
-              </template>
-            </DefinitionCard>
-            <DefinitionCard layout="horizontal">
-              <template #title>
-                {{ t('http.api.property.type') }}
-              </template>
 
-              <template #body>
-                <XBadge appearance="decorative">
-                  {{ t(`common.product.environment.${props.data.zoneInsight.environment || 'unknown'}`) }}
-                </XBadge>
-              </template>
-            </DefinitionCard>
+                  <template #body>
+                    <StatusBadge :status="props.source.data.state" />
+                  </template>
+                </DefinitionCard>
+                <DefinitionCard
+                  layout="horizontal"
+                  :class="{
+                    version: true,
+                    outdated: version?.outdated,
+                  }"
+                >
+                  <template #title>
+                    {{ t('zone-cps.routes.item.version') }}
+                  </template>
 
-            <DefinitionCard layout="horizontal">
-              <template #title>
-                {{ t('zone-cps.routes.item.authentication_type') }}
-              </template>
+                  <template #body>
+                    <XLayout type="separated">
+                      <XBadge
+                        :appearance="version?.outdated === true ? 'warning' : 'decorative'"
+                      >
+                        {{ props.source.data.zoneInsight.version?.kumaCp?.version ?? '—' }}
+                      </XBadge>
+                      <template
+                        v-if="version?.outdated === true"
+                      >
+                        <XIcon
+                          name="info"
+                        >
+                          <XI18n
+                            path="zone-cps.routes.item.version_warning"
+                          />
+                        </XIcon>
+                      </template>
+                    </XLayout>
+                  </template>
+                </DefinitionCard>
+                <DefinitionCard layout="horizontal">
+                  <template #title>
+                    {{ t('http.api.property.type') }}
+                  </template>
 
-              <template #body>
-                <XBadge appearance="decorative">
-                  {{ props.data.zoneInsight.authenticationType || t('common.not_applicable') }}
-                </XBadge>
-              </template>
-            </DefinitionCard>
+                  <template #body>
+                    <XBadge appearance="decorative">
+                      {{ t(`common.product.environment.${props.source.data.zoneInsight.environment || 'unknown'}`) }}
+                    </XBadge>
+                  </template>
+                </DefinitionCard>
+
+                <DefinitionCard layout="horizontal">
+                  <template #title>
+                    {{ t('zone-cps.routes.item.authentication_type') }}
+                  </template>
+
+                  <template #body>
+                    <XBadge appearance="decorative">
+                      {{ props.source.data.zoneInsight.authenticationType || t('common.not_applicable') }}
+                    </XBadge>
+                  </template>
+                </DefinitionCard>
+              </DataLoader>
+            </template>
           </XAboutCard>
 
-          <XCard
-            v-if="props.data.zoneInsight.subscriptions.length > 0"
-          >
+          <XCard>
             <template #title>
               <h2>{{ t('zone-cps.detail.subscriptions.title') }}</h2>
             </template>
 
             <XLayout>
               <XI18n path="zone-cps.detail.subscriptions.description" />
-              <AppCollection
-                :headers="[
-                  { ...me.get('headers.connection'), label: '&nbsp;', key: 'connection' },
-                  { ...me.get('headers.zoneInstanceId'), label: t('zone-cps.routes.items.headers.zoneInstanceId'), key: 'zoneInstanceId' },
-                  { ...me.get('headers.version'), label: t('zone-cps.routes.items.headers.version'), key: 'version' },
-                  { ...me.get('headers.connected'), label: t('zone-cps.routes.items.headers.connected'), key: 'connected' },
-                  { ...me.get('headers.disconnected'), label: t('zone-cps.routes.items.headers.disconnected'), key: 'disconnected' },
-                  { ...me.get('headers.responses'), label: t('zone-cps.routes.items.headers.responses'), key: 'responses' },
-                ]"
-                :is-selected-row="item => item.id === route.params.subscription"
-                :items="props.data.zoneInsight.subscriptions.map((item, i, arr) => arr[arr.length - (i + 1)])"
-                @resize="me.set"
+              <DataLoader
+                variant="list"
+                :data="[props.source.data]"
               >
-                <template
-                  #connection="{ row: item }"
-                >
-                  <template
-                    v-for="connection in [item.connectTime && !item.disconnectTime ? 'healthy' : 'unhealthy'] as const"
-                    :key="`${connection}`"
+                <template v-if="props.source.data">
+                  <AppCollection
+                    :headers="[
+                      { ...me.get('headers.connection'), label: '&nbsp;', key: 'connection' },
+                      { ...me.get('headers.zoneInstanceId'), label: t('zone-cps.routes.items.headers.zoneInstanceId'), key: 'zoneInstanceId' },
+                      { ...me.get('headers.version'), label: t('zone-cps.routes.items.headers.version'), key: 'version' },
+                      { ...me.get('headers.connected'), label: t('zone-cps.routes.items.headers.connected'), key: 'connected' },
+                      { ...me.get('headers.disconnected'), label: t('zone-cps.routes.items.headers.disconnected'), key: 'disconnected' },
+                      { ...me.get('headers.responses'), label: t('zone-cps.routes.items.headers.responses'), key: 'responses' },
+                    ]"
+                    :is-selected-row="item => item.id === route.params.subscription"
+                    :items="props.source.data.zoneInsight.subscriptions.map((item, i, arr) => arr[arr.length - (i + 1)])"
+                    @resize="me.set"
                   >
-                    <XIcon :name="connection">
-                      {{ t(`common.connection.${connection}`) }}
-                    </XIcon>
-                  </template>
-                </template>
-                <template
-                  #zoneInstanceId="{ row: item }"
-                >
-                  <XAction
-                    data-action
-                    :to="{
-                      name: 'zone-cp-subscription-summary-view',
-                      params: {
-                        subscription: item.id,
-                      },
-                    }"
-                  >
-                    {{ item.zoneInstanceId }}
-                  </XAction>
-                </template>
-                <template
-                  #version="{ row: item }"
-                >
-                  {{ item.version?.kumaCp?.version ?? '-' }}
-                </template>
-                <template
-                  #connected="{ row: item }"
-                >
-                  {{ t('common.formats.datetime', { value: Date.parse(item.connectTime ?? '') }) }}
-                </template>
-                <template
-                  #disconnected="{ row: item }"
-                >
-                  <template
-                    v-if="item.disconnectTime"
-                  >
-                    {{ t('common.formats.datetime', { value: Date.parse(item.disconnectTime) }) }}
-                  </template>
-                </template>
-                <template
-                  #responses="{ row: item }"
-                >
-                  <template
-                    v-for="responses in [item.status?.total ?? {}]"
-                    :key="typeof responses"
-                  >
-                    <XLayout
-                      type="separated"
+                    <template
+                      #connection="{ row: item }"
                     >
-                      {{ responses.responsesSent }}/{{ responses.responsesAcknowledged }}
-                      <XIcon
-                        v-if="!item.disconnectTime && item.status.total.responsesRejected > 0"
-                        name="warning"
-                        data-testid="warning"
+                      <template
+                        v-for="connection in [item.connectTime && !item.disconnectTime ? 'healthy' : 'unhealthy'] as const"
+                        :key="`${connection}`"
                       >
-                        <XI18n
-                          path="zone-cps.routes.items.rows.nacked"
-                          :params="{
-                            nacked: String(item.status.total.responsesRejected),
-                          }"
-                        />
-                      </XIcon>
-                    </XLayout>
-                  </template>
+                        <XIcon :name="connection">
+                          {{ t(`common.connection.${connection}`) }}
+                        </XIcon>
+                      </template>
+                    </template>
+                    <template
+                      #zoneInstanceId="{ row: item }"
+                    >
+                      <XAction
+                        data-action
+                        :to="{
+                          name: 'zone-cp-subscription-summary-view',
+                          params: {
+                            subscription: item.id,
+                          },
+                        }"
+                      >
+                        {{ item.zoneInstanceId }}
+                      </XAction>
+                    </template>
+                    <template
+                      #version="{ row: item }"
+                    >
+                      {{ item.version?.kumaCp?.version ?? '-' }}
+                    </template>
+                    <template
+                      #connected="{ row: item }"
+                    >
+                      {{ t('common.formats.datetime', { value: Date.parse(item.connectTime ?? '') }) }}
+                    </template>
+                    <template
+                      #disconnected="{ row: item }"
+                    >
+                      <template
+                        v-if="item.disconnectTime"
+                      >
+                        {{ t('common.formats.datetime', { value: Date.parse(item.disconnectTime) }) }}
+                      </template>
+                    </template>
+                    <template
+                      #responses="{ row: item }"
+                    >
+                      <template
+                        v-for="responses in [item.status?.total ?? {}]"
+                        :key="typeof responses"
+                      >
+                        <XLayout
+                          type="separated"
+                        >
+                          {{ responses.responsesSent }}/{{ responses.responsesAcknowledged }}
+                          <XIcon
+                            v-if="!item.disconnectTime && item.status.total.responsesRejected > 0"
+                            name="warning"
+                            data-testid="warning"
+                          >
+                            <XI18n
+                              path="zone-cps.routes.items.rows.nacked"
+                              :params="{
+                                nacked: String(item.status.total.responsesRejected),
+                              }"
+                            />
+                          </XIcon>
+                        </XLayout>
+                      </template>
+                    </template>
+                  </AppCollection>
                 </template>
-              </AppCollection>
+              </DataLoader>
             </XLayout>
-            <RouterView
-              v-slot="{ Component }"
-            >
-              <SummaryView
-                v-if="route.child()"
-                width="670px"
-                @close="function () {
-                  route.replace({
-                    name: 'zone-cp-detail-view',
-                    params: {
-                      zone: route.params.zone,
-                    },
-                  })
-                }"
+            <template v-if="props.source.data">
+              <RouterView
+                v-slot="{ Component }"
               >
-                <component
-                  :is="Component"
-                  :data="props.data.zoneInsight.subscriptions"
+                <SummaryView
+                  v-if="route.child()"
+                  width="670px"
+                  @close="function () {
+                    route.replace({
+                      name: 'zone-cp-detail-view',
+                      params: {
+                        zone: route.params.zone,
+                      },
+                    })
+                  }"
                 >
-                  <XI18n
-                    path="zone-cps.routes.item.subscription_intro"
-                  />
-                </component>
-              </SummaryView>
-            </RouterView>
+                  <component
+                    :is="Component"
+                    :data="props.source.data.zoneInsight.subscriptions"
+                  >
+                    <XI18n
+                      path="zone-cps.routes.item.subscription_intro"
+                    />
+                  </component>
+                </SummaryView>
+              </RouterView>
+            </template>
           </XCard>
         </XLayout>
       </AppView>
@@ -271,6 +284,7 @@
 
 <script lang="ts" setup>
 import type { ZoneOverview } from '../data'
+import { DataSourceResponse } from '@/app/application'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
@@ -278,7 +292,7 @@ import SummaryView from '@/app/common/SummaryView.vue'
 import { sources } from '@/app/control-planes/sources'
 
 const props = defineProps<{
-  data: ZoneOverview
+  source: DataSourceResponse<ZoneOverview>
 }>()
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
I've noticed that the `ZoneDetailView` blew up in development mode due to `ApppCollection` not wrapped in `DataLoader variant="list"`
The same happened on the `DataplaneDetailView` when rendering the subscriptions listing.

Note: best to review with hidden whitespaces