### PR TITLE
chore: reset retry count after a successful call

### DIFF
--- a/packages/kuma-gui/src/app/application/services/data-source/index.ts
+++ b/packages/kuma-gui/src/app/application/services/data-source/index.ts
@@ -108,12 +108,14 @@ export const create: Creator = (src, router) => {
         if (isAsyncGeneratorFunction(route.route)) {
           for await (const res of route.route(params, controller)) {
             yield res
+            retry = 0
             if (document && document.hidden) {
               await waitForEvent(document, 'visibilityhidden')
             }
           }
         } else {
           yield Promise.resolve(route.route(params))
+          retry = 0
         }
         break
       } catch (e) {


### PR DESCRIPTION
Resets the retry count after a successful call.

DataSources are shared and and have a longer lifetime than a one off call. If we don't reset the retry on a successful call, the same DataSource will just increase its retry count over several calls, possibly across different call sites, meaning its possible that eventually for a DataSource with a long lifetime if you have lots of errors retries will eventually not kick in.

---

FYI: There's gonna be some more refactoring around this coming up on this soon, plus probably pulling all the DataSource code out into its own module plus more 'strategies` (retry permutations, spreading, timeout-and-retry etc), and tests around here soon. Right now tho, I'd really like to get this little tweak in before I do that.