### PR TITLE
chore: make `make install` also check `package.json`s

### DIFF
--- a/packages/config/src/mk/install.mk
+++ b/packages/config/src/mk/install.mk
@@ -9,7 +9,7 @@
 .PHONY: .install
 .install: check/node $(NPM_WORKSPACE_ROOT)/node_modules
 
-$(NPM_WORKSPACE_ROOT)/node_modules: $(if $(CI),,$(NPM_WORKSPACE_ROOT)/package-lock.json)
+$(NPM_WORKSPACE_ROOT)/node_modules: $(if $(CI),,$(NPM_WORKSPACE_ROOT)/package-lock.json $(shell find $(NPM_WORKSPACE_ROOT) -maxdepth 5 -path "*/node_modules/*" -prune -o -name "package.json" -print))
 	@cd $(NPM_WORKSPACE_ROOT) \
 		&& npm $(if $(CI),clean-install,install) \
 					--ignore-scripts \


### PR DESCRIPTION
Follow up of https://github.com/kumahq/kuma-gui/pull/4035

Importantly, as before, we need to not run this in CI unless `node_modules` doesn't exist at all.

The `find` command is as quick as I could get it, hence the `maxdepth` etc.