### PR TITLE
chore(ci): mock individual URLs with Cypress instead of a catch all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20265,6 +20265,7 @@
       "dependencies": {
         "deepmerge": "^4.3.1",
         "msw": "^2.10.3",
+        "path-to-regexp": "^8.2.0",
         "urlpattern-polyfill": "^10.1.0"
       },
       "devDependencies": {

--- a/packages/fake-api/package.json
+++ b/packages/fake-api/package.json
@@ -24,6 +24,7 @@
     }
   },
   "dependencies": {
+    "path-to-regexp": "^8.2.0",
     "urlpattern-polyfill": "^10.1.0",
     "deepmerge": "^4.3.1",
     "msw": "^2.10.3"

--- a/packages/fake-api/src/cypress.ts
+++ b/packages/fake-api/src/cypress.ts
@@ -1,78 +1,86 @@
+import { pathToRegexp } from 'path-to-regexp'
+
 import { createFetchSync } from './index'
 import type { Middleware, Dependencies, FS, Mocker } from './index'
 
-const reEscape = /[/\-\\^$*+?.()|[\]{}]/g
 const noop: Middleware = (_req, response) => response
 
+const routeToRegexp = (route: string) => {
+  const url = new URL(route, !route.includes('://') ? 'http://localhost' : undefined)
+  // escape `:`s for pathToRegexp's named segments (/:segment/)
+  const origin = url.origin.replaceAll(':', '\\:')
+  const { regexp } = pathToRegexp(`${route.includes('://') ? origin : ''}${url.pathname}`)
+  // remove the end of pathToRegexps regexp
+  // and replace it with optional `/` and optional `?<optional chars>`
+  const re = new RegExp(
+    regexp.toString().replace('(?:\\/$)?$/i', '(?:\\/)?(\\?.*)?$').substring(1), 'i',
+  )
+  return re
+}
 export const mocker = <T extends object = {}>(
   dependencies: Dependencies<T>,
   fs: FS,
 ): Mocker => {
-
-
   return (path, opts = {}, middleware = noop) => {
     const env = dependencies.env
     dependencies.env = <T extends Parameters<typeof env>[0]>(key: T, d = '') => {
       return env(key, opts[key] ?? d)
     }
-    const baseUrl = dependencies.env('KUMA_API_URL')
-    const _fs = Object.fromEntries(Object.entries(fs).map(([route, response]) => {
-      return [route.includes('://') ? route : `${baseUrl}${route}`, response]
-    }))
     const fetch = createFetchSync({
       dependencies,
-      fs: _fs,
+      fs,
     })
     // if path is `*` then that means mock everything, which currently means
     // changing to `/`
-    path = path === '*' ? '/' : path
-    return cy.intercept(
-      {
-        url: new RegExp(`${baseUrl}${path.replace(reEscape, '\\$&')}`),
-      },
-      (req) => {
-        try {
-          // headers can be string | string[], not string
-          const headers = Object.entries(req.headers).reduce((prev, [key, item]) => {
-            if (typeof item !== 'undefined') {
-              prev[key] = Array.isArray(item) ? item[0] : item
+    return Object.keys(path === '*' ? fs : { [path]: '' }).map(route => {
+      return cy.intercept(
+        {
+          url: routeToRegexp(route),
+        },
+        (req) => {
+          try {
+            // headers can be string | string[], not string
+            const headers = Object.entries(req.headers).reduce((prev, [key, item]) => {
+              if (typeof item !== 'undefined') {
+                prev[key] = Array.isArray(item) ? item[0] : item
+              }
+              return prev
+            }, {} as Record<string, string>)
+
+            const resp = fetch(req.url, {
+              method: req.method,
+              headers,
+              body: req.body,
+            })
+            const type = resp.headers.get('Content-Type') ?? 'application/json'
+
+            const response = middleware({
+              url: new URL(req.url),
+              method: req.method,
+              body: req.body,
+              params: {},
+            }, {
+              headers: Object.fromEntries(resp.headers.entries()),
+              body: type.endsWith('/json') ? resp.json() : resp.text(),
+            })
+
+            if (typeof response === 'undefined') {
+              req.continue()
+              return
             }
-            return prev
-          }, {} as Record<string, string>)
 
-          const resp = fetch(req.url, {
-            method: req.method,
-            headers,
-            body: req.body,
-          })
-          const type = resp.headers.get('Content-Type') ?? 'application/json'
-
-          const response = middleware({
-            url: new URL(req.url),
-            method: req.method,
-            body: req.body,
-            params: {},
-          }, {
-            headers: Object.fromEntries(resp.headers.entries()),
-            body: type.endsWith('/json') ? resp.json() : resp.text(),
-          })
-
-          if (typeof response === 'undefined') {
+            req.reply({
+              contentType: type,
+              statusCode: parseInt(response.headers?.['Status-Code'] ?? '200'),
+              delay: parseInt(dependencies.env('KUMA_LATENCY', opts['KUMA_LATENCY'] ?? '0')),
+              body: response.body,
+            })
+          } catch (e) {
+            console.error(e)
             req.continue()
-            return
           }
-
-          req.reply({
-            contentType: type,
-            statusCode: parseInt(response.headers?.['Status-Code'] ?? '200'),
-            delay: parseInt(dependencies.env('KUMA_LATENCY', opts['KUMA_LATENCY'] ?? '0')),
-            body: response.body,
-          })
-        } catch (e) {
-          console.error(e)
-          req.continue()
-        }
-      },
-    )
+        },
+      )
+    })
   }
 }

--- a/packages/fake-api/src/msw.ts
+++ b/packages/fake-api/src/msw.ts
@@ -36,12 +36,12 @@ export const server = <TDependencies extends object = {}>(
   }
 }
 
-export const handler = <TDependencies extends object = {}>(fs: FS, dependencies: Dependencies<TDependencies>) => {
+export const mswHandlers = <TDependencies extends object = {}>(fs: FS, dependencies: Dependencies<TDependencies>) => {
   const fetch = createFetch({
     dependencies,
     fs,
   })
-  return (route: string) => {
+  return Object.keys(fs).map(route => {
     return http.all(`${route}`, async ({ request: req }) => {
       // headers can be string | string[] | undefined, not string
       const headers = Object.entries(req.headers).reduce((prev, [key, item]) => {
@@ -66,16 +66,5 @@ export const handler = <TDependencies extends object = {}>(fs: FS, dependencies:
         status: parseInt(response.headers?.get('Status-Code') ?? '200'),
       })
     })
-  }
-}
-
-export const mswHandlers = <TDependencies extends object = {}>(fs: FS, dependencies: Dependencies<TDependencies>) => {
-  const baseUrl = dependencies.env('KUMA_API_URL')
-  const _fs = Object.fromEntries(Object.entries(fs).map(([route, response]) => {
-    return [route.includes('://') ? route : `${baseUrl}${route}`, response]
-  }))
-  const handlerFor = handler(_fs, dependencies)
-  return Object.keys(_fs).map(route => {
-    return handlerFor(route)
   })
 }

--- a/packages/kuma-gui/features/mesh/policies/Index.feature
+++ b/packages/kuma-gui/features/mesh/policies/Index.feature
@@ -5,7 +5,7 @@ Feature: mesh / policies / index
       | Alias            | Selector                                                                                 |
       | policy-type-list | [data-testid='policy-type-list']                                                         |
       | items            | [data-testid='app-collection']                                                           |
-      | detail-view      | [data-testid='policy-detail-view']                                                       |
+      | detail-view      | [data-testid='policy-detail-tabs-view']                                                  |
       | items-header     | $items th                                                                                |
       | item             | $items tbody tr                                                                          |
       | action-group     | $item:first-child [data-testid='x-action-group-control']                                 |

--- a/packages/kuma-gui/src/app/kuma/debug.ts
+++ b/packages/kuma-gui/src/app/kuma/debug.ts
@@ -1,7 +1,9 @@
 import { token } from '@kumahq/container'
 
+import type Env from '@/app/application/services/env/Env'
 import { fs } from '@/test-support/mocks/fs'
 import type { ServiceDefinition, Token } from '@kumahq/container'
+
 
 const $ = {
   kumaFS: token<typeof fs>('fake.fs.kuma'),
@@ -9,7 +11,16 @@ const $ = {
 
 export const services = (app: Record<string, Token>): ServiceDefinition[] => [
   [$.kumaFS, {
-    constant: fs,
+    service: (env: Env['var']) => {
+      // return fs
+      const baseURL = env('KUMA_API_URL')
+      return Object.fromEntries(Object.entries(fs).map(([route, response]) => {
+        return [route.includes('://') ? route : `${baseURL}${route}`, response]
+      }))
+    },
+    arguments: [
+      app.env,
+    ],
     labels: [
       app.fakeFS,
     ],


### PR DESCRIPTION
At the beginning of our Cypress tests we used to mock our entire "fake FS" with a intercept/catchall, essentially:

```javascript
new RegExp(`${baseUrl}/`)
```

This PR instead translates all our "fake FS" paths (which use `/path/:segment` notation) into individual RegExps, which can then be used individually by Cypress intercept. Following this we loop through each URL and set up a separate intercept, which is more correct.

This also adds the intercepts more exactly, so instead of saying mock anything that is _prefixed_ using this URL we say only mock this exact URL (or ending with a single `/` or some query parameters). This fact actually found a bug in our e2e mocking in one test, where this mock:

https://github.com/kumahq/kuma-gui/blob/50109cba3eef169c7bd49d32a1719f1882f83cef/packages/kuma-gui/features/mesh/policies/Index.feature#L23-L29

was also mocking requests to `/meshes/default/circuit-breakers/fake-cb-1/_resources/dataplanes`

...meaning we would end up with some dataplanes called `fake-cb-1`/`fake-cb-2` also, which makes the DOM assertion for the text `fake-cb-1` in the detail content pass (because we mistaken called a dataplane `fake-cb-1`)

There are no major consequence with this, just a very slight incorrect test, which I've also fixed up here.


Additionally I moved any reference to KUMA_API_URL out of fake-api entirely.
