### PR TITLE
fix(dataplane/stats): consider inbound servicePort to be different than port

### DIFF
--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
@@ -23,14 +23,14 @@
           name: route.params.proxy,
           mesh: route.params.mesh || '*',
         })"
-        v-slot="{ data , refresh }"
+        v-slot="{ data: connections, refresh }"
       >
         <template
-          v-for="prefix in [route.params.connection.replace('_', ':')]"
+          v-for="prefix in [(props.data.clusterName === route.params.connection ? route.params.connection : props.data.clusterName).replace('_', ':')]"
           :key="typeof prefix"
         >
           <DataCollection
-            :items="data.split('\n')"
+            :items="connections.split('\n')"
             :predicate="item => item.startsWith(`${prefix}::`)"
             v-slot="{ items: lines }"
           >
@@ -63,7 +63,9 @@
 </template>
 <script lang="ts" setup>
 import { sources } from '../sources'
+import { DataplaneInbound } from '@/app/data-planes/data'
 const props = defineProps<{
   routeName: string
+  data: DataplaneInbound
 }>()
 </script>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
@@ -28,17 +28,20 @@
       >
         <DataCollection
           :items="stats.raw.split('\n')"
-          :predicate="item => [
-            `listener.${props.data.listenerAddress.length > 0 ? props.data.listenerAddress : route.params.connection}`,
-            `cluster.${props.data.name}.`,
-            `http.${props.data.name}.`,
-            `tcp.${props.data.name}.`,
-          ].some(prefix => item.startsWith(prefix)) && (!item.includes('.rds.') || item.includes(`_${props.data.port}`))"
+          :predicate="item => {
+            return [
+              `listener.${props.data.listenerAddress.length > 0 ? props.data.listenerAddress : route.params.connection}`,
+              `cluster.${props.data.name}.`,
+              `cluster.${props.data.clusterName}.`,
+              `http.${props.data.name}.`,
+              `http.${props.data.clusterName}.`,
+              `tcp.${props.data.name}.`,
+            ].some(prefix => item.startsWith(prefix)) && (!item.includes('.rds.') || item.includes(`_${props.data.port}`) || item.includes(`${props.data.servicePort}`))}"
           v-slot="{ items: lines }"
         >
           <XCodeBlock
             language="json"
-            :code="lines.map(item => item.replace(`${props.data.listenerAddress.length > 0 ? props.data.listenerAddress : route.params.connection}.`, '').replace(`${props.data.name}.`, '')).join('\n')"
+            :code="lines.map(item => item.replace(`${props.data.listenerAddress.length > 0 ? props.data.listenerAddress : route.params.connection}.`, '').replace(`${props.data.name}.`, '').replace(`${props.data.clusterName}.`, '')).join('\n')"
             is-searchable
             :query="route.params.codeSearch"
             :is-filter-mode="route.params.codeFilter"

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
@@ -19,6 +19,7 @@ export type DataplaneInbound = PartialDataplaneInbound & Connection & {
   socketAddress: string
   listenerAddress: string
   portName: string
+  clusterName: string
 }
 type PartialDataplaneOutbound = NonNullable<NonNullable<NonNullable<components['schemas']['DataplaneOverviewWithMeta']['dataplane']>['networking']>['outbound']>[number]
 
@@ -91,18 +92,21 @@ export const DataplaneNetworking = {
           listenerAddress: '',
           // not available for gateway
           portName: '',
+          clusterName: '',
         }]
         : inbounds.map((item) => {
           // inbound address, advertisedAddress, networkingAddress because externally accessible address
           const address = item.address ?? networking.advertisedAddress ?? networking.address
+          const name = `localhost_${item.port}`
           return {
             ...item,
             // the name can be used to lookup listener envoy stats
-            name: `localhost_${item.port}`,
+            name,
             // the portName adds another way of referencing the port, usable with MeshService
             portName: item.name?.length ? item.name : '',
             socketAddress: `${address}_${item.port}`,
             listenerAddress: `${address}_${item.port}`,
+            clusterName: item.servicePort && item.servicePort !== item.port ? `localhost_${item.servicePort}` : name,
             // If a health property is unset the inbound is considered healthy
             state: typeof item.state !== 'undefined' ? item.state : 'Ready',
             service: item.tags['kuma.io/service'],

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -429,7 +429,7 @@
                           >
                             <template
                               v-for="stats in [
-                                traffic?.inbounds[item.name],
+                                traffic?.inbounds[item.clusterName],
                               ]"
                               :key="stats"
                             >


### PR DESCRIPTION
When not using transparent proxy it's possible to set a different `servicePort` than `port`. If not set the `servicePort` internally falls back to `port`. Due to not considering the potential difference of `servicePort` we didn't show the stats because the stats refer to the `servicePort`.
In order to include the potential `servicePort` I've added another field to the inbounds in the data layer: `clusterName`, which falls back to the `name` (`localhost_<port>`) which should provide a name of the grouping between proxy and service based on the networking configuration.