### PR TITLE
chore: allow unused arguments with any naming pattern

### DIFF
--- a/packages/config/src/eslint.cjs
+++ b/packages/config/src/eslint.cjs
@@ -329,7 +329,7 @@ function createEslintConfig(
 
         'no-unused-vars': 'off',
         '@typescript-eslint/no-unused-vars': ['error', {
-          argsIgnorePattern: '^_',
+          args: 'none',
           varsIgnorePattern: '^_',
           ignoreRestSiblings: true,
         }],


### PR DESCRIPTION
Closes https://github.com/kumahq/kuma-gui/issues/3602

---

A while back we had an instance where we have used something like:

```javascript
(_env:Env) => {
...
}
```

using the `_` in `_env` to "ignore" an unused argument whilst keeping it in the code for documentation purposes, its often handy at a glance to see what arguments you have.

What happened was somebody then used the arguments without removing the `_` leading to:

```javascript
(_env:Env) => {
  return _env('')
}
```

This on one part is great as they could easily see what they had available to them, but on the other part bad becuase we use `_` sometimes to denote unused variables, this variable is clearly being used. All in all its very confusing.

Note there is a comment on the above issue that this will close:

> So it's about disallowing using variables that start with _

I personally think this is not what we are asking for. Its not about disallowing using variables starting with a `_`, as noted we use these all the time to make throw away variables such as `const { _, keepMe } = {...}`.

I also disagree with added yet another linting rule to counteract another linting rule, its feels a bit counterproductive. To me it makes more sense to just disable the rule which bugs us when we leave an unused argument in.

If this continues to be controversial I would rather leave the existing config as is than add more linting to counteract the existing linting and then just close this PR and the original issue.



