### PR TITLE
chore(deps): ignore npm from the bot, use the version shipped with node

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,6 +33,12 @@
       "dependencyDashboardApproval": true
     },
     {
+      "matchPackageNames": [
+        "npm"
+      ],
+      "enabled": false
+    },
+    {
       "groupName": "patch",
       "matchUpdateTypes": [
         "patch"
@@ -55,21 +61,8 @@
       "matchUpdateTypes": ["minor"]
     },
     {
-      "groupName": "Node and npm",
       "matchPackageNames": [
-        "node",
-        "npm"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor",
-        "major"
-      ]
-    },
-    {
-      "matchPackageNames": [
-        "node",
-        "npm"
+        "node"
       ],
       "matchUpdateTypes": [
         "major"


### PR DESCRIPTION
Adds the npm ignore to the top of the package rules, removes the Node/Npm group that I assume we don't need anymore (?). I think this is one of those PRs that we won't know is 100% fine until merged.

note for future: I would like to move this file to `.json5` so we can add comments in it