### PR TITLE
chore(fix): soften DataLoader dev-time error

### DIFF
--- a/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
+++ b/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
@@ -65,7 +65,8 @@ const dataLoader = inject<{ props: { variant: string } } | undefined>('data-load
 if (typeof dataLoader !== 'undefined') {
   if (dataLoader.props.variant !== 'list') {
     runInDebug(() => {
-      throw new Error('Please use <DataLoader variant="list" />')
+      console.error('Please use <DataLoader variant="list" />')
+      // throw new Error('Please use <DataLoader variant="list" />')
     })
   }
 }


### PR DESCRIPTION
Back in https://github.com/kumahq/kuma-gui/pull/4036 I enabled the dev-time only runtime error to help me to find DataLoaders that are being used for lists but not using a list skeleton.

There are still a few tho that are more complicated to sort out and involve more complex DataSource/DataLoader interactions that aren't done yet (work is currently in progress).

Considering this, I think I uncommented this a tad early (sorry!), and I wanted to soften it so that there was less DX urgency (its only a devtime error) to figure out the more complex interactions.

I've changed this to a `console.error` so its an even softer error, still only dev-time, but still apparent where things need improving, so we can resolve as we go.