### PR TITLE
chore(deps): removes @types/glob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4795,17 +4795,6 @@
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "license": "MIT"
     },
-    "node_modules/@types/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -4871,13 +4860,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true,
       "license": "MIT"
     },
@@ -20312,7 +20294,6 @@
         "@kumahq/fake-api": "*",
         "@kumahq/kuma-http-api": "*",
         "@modyfi/vite-plugin-yaml": "^1.1.1",
-        "@types/glob": "^8.1.0",
         "@types/js-yaml": "^4.0.9",
         "@types/markdown-it": "^14.1.2",
         "@types/semver": "^7.7.0",

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -42,7 +42,6 @@
     "@kumahq/fake-api": "*",
     "@kumahq/kuma-http-api": "*",
     "@modyfi/vite-plugin-yaml": "^1.1.1",
-    "@types/glob": "^8.1.0",
     "@types/js-yaml": "^4.0.9",
     "@types/markdown-it": "^14.1.2",
     "@types/semver": "^7.7.0",


### PR DESCRIPTION
Instead of upgrading this here https://github.com/kumahq/kuma-gui/pull/4075, I looked to see why we need this, and I found that the `glob` package is in typescript (at least version 11 it seems), so I'm pretty sure we don't need to depend on this anymore.

I also checked in my IDE to make sure I was still getting type hints for glob after uninstalling this and I am.
