### PR TITLE
refactor(fake-kuma, mocks): remove deprecated fakes and types

### DIFF
--- a/packages/kuma-gui/src/test-support/mocks/src/dataplanes/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/dataplanes/_overview.ts
@@ -61,7 +61,64 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
           creationTime: '2021-02-17T08:33:36.442044+01:00',
           modificationTime: '2021-02-17T08:33:36.442044+01:00',
           dataplane: {
-            networking: fake.kuma.dataplaneNetworking({ type, inbounds, isMultizone, service }),
+            networking: (() => {
+              const address = fake.internet.ipv4()
+              const advertisedAddress = fake.datatype.boolean({ probability: 0.25 }) ? fake.internet.ipv4() : undefined
+              const dataplaneType = type === 'gateway_builtin' ? 'BUILTIN' : type === 'gateway_delegated' ? 'DELEGATED' : undefined
+
+              return {
+                address,
+                ...(advertisedAddress && { advertisedAddress }),
+                ...(type !== 'proxy'
+                  ? {
+                    gateway: {
+                      tags: fake.kuma.tags({
+                        service: service ?? fake.kuma.serviceName(type),
+                        zone: isMultizone && fake.datatype.boolean() ? fake.word.noun() : undefined,
+                      }),
+                      ...(dataplaneType && { type: dataplaneType }),
+                    },
+                  }
+                  : {}),
+                ...(type === 'proxy'
+                  ? {
+                    inbound: Array.from({ length: inbounds }).map(() => {
+                      const address = fake.datatype.boolean({ probability: 0.25 }) ? fake.internet.ipv4() : undefined
+                      const port = fake.internet.port()
+                      const hasServiceAddress = fake.datatype.boolean({ probability: 0.25 })
+                      const serviceAddress = hasServiceAddress ? fake.internet.ipv4() : undefined
+                      const servicePort = hasServiceAddress ? fake.internet.port() : undefined
+                      const tags = fake.kuma.tags({
+                        protocol: fake.kuma.protocol(),
+                        service: service ?? fake.kuma.serviceName(),
+                        zone: isMultizone && fake.datatype.boolean() ? fake.word.noun() : undefined,
+                      })
+
+                      return {
+                        port,
+                        tags,
+                        ...(fake.datatype.boolean()
+                          ? {
+                            health: {
+                              ready: fake.datatype.boolean(),
+                            },
+                          }
+                          : {}),
+                        ...(address && { address }),
+                        ...(serviceAddress && { serviceAddress }),
+                        ...(servicePort && { servicePort }),
+                      }
+                    }),
+                  }
+                  : {}),
+                outbound: [
+                  {
+                    port: fake.internet.port(),
+                    tags: fake.kuma.tags({ service: service ?? fake.kuma.serviceName() }),
+                  },
+                ],
+              }
+            })(),
           },
           ...(k8s
             ? {

--- a/packages/kuma-gui/src/test-support/mocks/src/mesh-insights/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/mesh-insights/_.ts
@@ -4,23 +4,29 @@ export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => 
 
   const resourceCount = parseInt(env('KUMA_ACTIVE_RESOURCE_COUNT', `${Number.MAX_SAFE_INTEGER}`))
   const serviceTotal = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 1, max: 30 })}`))
+  const max = env('KUMA_DATAPLANE_COUNT', '30') === '0' ? 0 : 30
 
-  const standard = fake.kuma.healthStatus()
-  const gatewayBuiltin = fake.kuma.healthStatus()
-  const gatewayDelegated = fake.kuma.healthStatus()
+  const { standard, gatewayBuiltin, gatewayDelegated } = fake.kuma.partitionInto({
+    standard: Number,
+    gatewayBuiltin: Number,
+    gatewayDelegated: Number,
+  }, max)
 
-  const gateway = {
-    total: (gatewayBuiltin.total ?? 0) + (gatewayDelegated.total ?? 0),
-    online: (gatewayBuiltin.online ?? 0) + (gatewayDelegated.online ?? 0),
-    partiallyDegraded: (gatewayBuiltin.partiallyDegraded ?? 0) + (gatewayDelegated.partiallyDegraded ?? 0),
-    offline: (gatewayBuiltin.offline ?? 0) + (gatewayDelegated.offline ?? 0),
-  }
-  const dataplanes = {
-    total: (standard.total ?? 0) + (gateway.total ?? 0),
-    online: (standard.online ?? 0) + (gateway.online ?? 0),
-    partiallyDegraded: (standard.partiallyDegraded ?? 0) + (gateway.partiallyDegraded ?? 0),
-    offline: (standard.offline ?? 0) + (gateway.offline ?? 0),
-  }
+  const gatewaysTotal = gatewayBuiltin + gatewayDelegated
+  const gateway = fake.kuma.partitionInto({
+    total: gatewaysTotal,
+    online: Number,
+    partiallyDegraded: Number,
+    offline: Number,
+  }, gatewaysTotal)
+
+  const dataplanesTotal = standard + gateway.total
+  const dataplanes = fake.kuma.partitionInto({
+    total: dataplanesTotal,
+    online: Number,
+    partiallyDegraded: Number,
+    offline: Number,
+  }, dataplanesTotal)
 
   const dpTotal = dataplanes.online + dataplanes.partiallyDegraded
   const totalVersions = fake.kuma.partition(1, dpTotal, 5, dpTotal)

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_.ts
@@ -24,7 +24,64 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
       name,
       creationTime: '2021-02-17T08:33:36.442044+01:00',
       modificationTime: '2021-02-17T08:33:36.442044+01:00',
-      networking: fake.kuma.dataplaneNetworking({ type, inbounds, isMultizone }),
+      networking: (() => {
+        const address = fake.internet.ipv4()
+        const advertisedAddress = fake.datatype.boolean({ probability: 0.25 }) ? fake.internet.ipv4() : undefined
+        const dataplaneType = type === 'gateway_builtin' ? 'BUILTIN' : type === 'gateway_delegated' ? 'DELEGATED' : undefined
+
+        return {
+          address,
+          ...(advertisedAddress && { advertisedAddress }),
+          ...(type !== 'proxy'
+            ? {
+              gateway: {
+                tags: fake.kuma.tags({
+                  service: fake.kuma.serviceName(type),
+                  zone: isMultizone && fake.datatype.boolean() ? fake.word.noun() : undefined,
+                }),
+                ...(dataplaneType && { type: dataplaneType }),
+              },
+            }
+            : {}),
+          ...(type === 'proxy'
+            ? {
+              inbound: Array.from({ length: inbounds }).map(() => {
+                const address = fake.datatype.boolean({ probability: 0.25 }) ? fake.internet.ipv4() : undefined
+                const port = fake.internet.port()
+                const hasServiceAddress = fake.datatype.boolean({ probability: 0.25 })
+                const serviceAddress = hasServiceAddress ? fake.internet.ipv4() : undefined
+                const servicePort = hasServiceAddress ? fake.internet.port() : undefined
+                const tags = fake.kuma.tags({
+                  protocol: fake.kuma.protocol(),
+                  service: fake.kuma.serviceName(),
+                  zone: isMultizone && fake.datatype.boolean() ? fake.word.noun() : undefined,
+                })
+
+                return {
+                  port,
+                  tags,
+                  ...(fake.datatype.boolean()
+                    ? {
+                      health: {
+                        ready: fake.datatype.boolean(),
+                      },
+                    }
+                    : {}),
+                  ...(address && { address }),
+                  ...(serviceAddress && { serviceAddress }),
+                  ...(servicePort && { servicePort }),
+                }
+              }),
+            }
+            : {}),
+          outbound: [
+            {
+              port: fake.internet.port(),
+              tags: fake.kuma.tags({ service: fake.kuma.serviceName() }),
+            },
+          ],
+        }
+      })(),
     },
   }
 }

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/service-insights.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/service-insights.ts
@@ -24,7 +24,6 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
         const name = `${serviceName ? `${serviceName}-` : ''}${fake.word.noun()}-${id}-${serviceType}`
         const addressPort = serviceType !== 'external' ? `${name}.mesh:${fake.internet.port()}` : undefined
         const status = serviceType !== 'external' ? fake.kuma.serviceStatusKeyword() : undefined
-        const dataplanes = serviceType !== 'external' ? fake.kuma.healthStatus() : undefined
 
         return {
           type: 'ServiceInsight',
@@ -35,7 +34,15 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
           ...(serviceType && { serviceType }),
           ...(addressPort && { addressPort }),
           ...(status && { status }),
-          ...(dataplanes && { dataplanes }),
+          ...(serviceType !== 'external' && { dataplanes: (() => {
+            const total = fake.number.int({ min: 1, max: 10 })
+            return fake.kuma.partitionInto({
+              total,
+              online: Number,
+              partiallyDegraded: Number,
+              offline: Number,
+            }, total)
+          })()}),
         } satisfies ServiceInsight
       }),
     },

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/service-insights/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/service-insights/_.ts
@@ -9,7 +9,6 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const serviceType = paramType ?? (fake.datatype.boolean() ? fake.kuma.serviceType() : undefined)
   const addressPort = serviceType !== 'external' ? `${name}.mesh:${fake.internet.port()}` : undefined
   const status = serviceType !== 'external' ? fake.kuma.serviceStatusKeyword() : undefined
-  const dataplanes = serviceType !== 'external' ? fake.kuma.healthStatus() : undefined
 
   return {
     headers: {},
@@ -22,7 +21,15 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
       ...(serviceType && { serviceType }),
       ...(addressPort && { addressPort }),
       ...(status && { status }),
-      ...(dataplanes && { dataplanes }),
+      ...(serviceType !== 'external' && { dataplanes: (() => {
+        const total = fake.number.int({ min: 1, max: 10 })
+        return fake.kuma.partitionInto({
+          total,
+          online: Number,
+          partiallyDegraded: Number,
+          offline: Number,
+        }, total)
+      })()}),
     } satisfies ServiceInsight,
   }
 }


### PR DESCRIPTION
First of all this removes the `@deprecated` fake utilities and inlines the results into the fs mocks. But this also removes the dependency to `@/types/index.d`, which is a preparation to be able to move the mocks and `FakeKuma` out of `kuma-gui`.

Closes #3126