### PR TITLE
chore(eslint): properly ignore vendor and artifact folders

### DIFF
--- a/packages/config/src/eslint.cjs
+++ b/packages/config/src/eslint.cjs
@@ -208,10 +208,6 @@ function createEslintConfig(
         '**/*.vue',
         '**/*.json',
       ],
-      ignores: [
-        'dist/*',
-        'node_modules/*',
-      ],
       settings: {
         'import/resolver': {
           typescript: {
@@ -371,6 +367,12 @@ function createEslintConfig(
       rules: {
         '@typescript-eslint/no-require-imports': 'off',
       },
+    },
+    {
+      ignores: [
+        'dist/*',
+        'node_modules/*',
+      ],
     },
   ]
 }


### PR DESCRIPTION
I've noticed that whenever there is an artifact folder in `kuma-gui` (`dist`) the linter doesn't properly ignore it. I believe this is due to the configs added after the config that sets the `ignores`. The configs added after include certain `files` via glob pattern and may override the `ignores`. I've therefore moved the `ignores` to its own config and added it as a last config to override all the previous ones. This is now also more aligned with the official [documentation/ignoring-files](https://eslint.org/docs/latest/use/configure/migration-guide#ignoring-files).


>```js
>export default [
>	// ...other config
>	{
>		// Note: there should be no other properties in this object
>		ignores: ["**/temp.js", "config/*"],
>	},
>];
>```