### PR TITLE
fix(builtin-gateways/dataplanes): filter by zone

### DIFF
--- a/packages/kuma-gui/features/mesh/builtin-gateways/Item.feature
+++ b/packages/kuma-gui/features/mesh/builtin-gateways/Item.feature
@@ -142,6 +142,22 @@ Feature: mesh / builtin-gateways / item
     When I visit the "/meshes/default/gateways/builtin/gateway-1.kuma-system/dataplanes" URL
     Then the "$dataplanes" element exists
 
+  Scenario: Dataplanes are filtered by zone
+    Given the environment
+      """
+      KUMA_DATAPLANE_COUNT: 1
+      """
+    Given the URL "/meshes/default/meshgateways/gateway-1.kuma-system" responds with
+      """
+      body:
+        labels:
+          kuma.io/origin: zone
+          kuma.io/zone: foo
+      """
+    When I visit the "/meshes/default/gateways/builtin/gateway-1.kuma-system/dataplanes" URL
+    Then the "$dataplanes tbody tr" element exists 1 time
+    And the "$dataplanes tbody tr" element contains "foo"
+
   Scenario: Shows config with format based on environment
     When I visit the "/meshes/default/gateways/builtin/gateway-1.kuma-system/config" URL
     Then the "$config-universal" element exists

--- a/packages/kuma-gui/src/app/gateways/data/MeshGateway.ts
+++ b/packages/kuma-gui/src/app/gateways/data/MeshGateway.ts
@@ -17,6 +17,7 @@ export const MeshGateway = {
       labels,
       id: item.name,
       zone: labels['kuma.io/zone'] ?? '',
+      origin: labels['kuma.io/origin'] ?? '',
       name: labels['kuma.io/display-name'] ?? item.name,
       namespace: labels['k8s.kuma.io/namespace'] ?? '',
       config: item,

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewayDataplanesView.vue
@@ -37,7 +37,10 @@
             }, {
               page: route.params.page,
               size: route.params.size,
-              search: route.params.s,
+              search: [
+                route.params.s,
+                ...(props.gateway.origin === 'zone' && props.gateway.zone.length ? [ `zone:${props.gateway.zone}` ] : []),
+              ].join(' '),
             })"
             variant="list"
             v-slot="{ data: dataplanesData }"

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_overview.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_overview.ts
@@ -102,7 +102,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                     tags: fake.kuma.tags({
                       protocol: fake.kuma.protocol(),
                       service,
-                      zone: isMultizone && fake.datatype.boolean() ? zone : undefined,
+                      zone: zoneQuery || (isMultizone && fake.datatype.boolean()) ? zone : undefined,
                     }),
                     ...(fake.datatype.boolean() ? {
                       state: fake.kuma.inboundState(),
@@ -123,7 +123,7 @@ export default ({ fake, pager, env }: EndpointDependencies): MockResponder => (r
                 gateway: {
                   tags: fake.kuma.tags({
                     service,
-                    zone: isMultizone && fake.datatype.boolean() ? zone : undefined,
+                    zone: zoneQuery || (isMultizone && fake.datatype.boolean()) ? zone : undefined,
                   }),
                   type,
                 },


### PR DESCRIPTION
In case a builtin gateway is deployed to a specific zone, we have to filter the dataplanes by that zone to only show the dataplanes that are in the same zone as the gateway.

Closes #2982 