### PR TITLE
chore: ignore escape-string-regexp

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,7 +34,8 @@
     },
     {
       "matchPackageNames": [
-        "npm"
+        "npm",
+        "escape-string-regexp"
       ],
       "enabled": false
     },


### PR DESCRIPTION
This package is a line.

https://github.com/sindresorhus/escape-string-regexp/blob/cbc42403142c96923b482604e1f3d627b1956aff/index.js#L8-L10

But its caused me more thinking about what to do here because of licensing, the fact that its coming in Node 24 anyway, and the fact we keep getting pestered to update it.

I would have just copy/pasted the line, but then theres licence to include, which is huge, so I guess let just ignore it, and hopefully node 24 will come soon.