### PR TITLE
chore(dataplanes): only show mTLS info on inbounds

### DIFF
--- a/packages/kuma-gui/src/app/common/data-card/DataCard.vue
+++ b/packages/kuma-gui/src/app/common/data-card/DataCard.vue
@@ -28,7 +28,7 @@
 .card,
 .body,
 .body > :deep(dl),
-.body > :deep(dl) > div {
+.body > :deep(dl) div {
   display: flex;
   flex-wrap: wrap;
   gap: $kui-space-40;
@@ -48,13 +48,13 @@
 }
 .body > :deep(dl) > div {
   column-gap: $kui-space-20;
-  > dt {
+  dt {
     color: $kui-color-text-disabled;
   }
-  > dd  {
+  dd  {
     color: $kui-color-text;
   }
-  > dt::after {
+  dt::after {
     display: inline;
     /*[lang="en"]*/
     content: ': ';

--- a/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
+++ b/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
@@ -85,21 +85,20 @@
             <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.failure }) }}</dd>
           </div>
           <template
-            v-for="mtls in [Object.values(props.traffic.http?.rbac ?? {}).reduce<number>((prev, item) => prev + (item as number), 0)]"
-            :key="typeof mtls"
+            v-if="props.direction === 'downstream'"
           >
-            <div
-              data-testid="rq-mtls"
+            <template
+              v-for="nonMtls in [(props.traffic.http?.rq_total ?? 0) - Object.values(props.traffic.http?.rbac ?? {}).reduce<number>((prev, item) => prev + (item as number), 0)]"
+              :key="typeof nonMtls"
             >
-              <dt>{{ t('data-planes.components.service_traffic_card.mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: mtls }) }}</dd>
-            </div>
-            <div
-              data-testid="rq-no-mtls"
-            >
-              <dt>{{ t('data-planes.components.service_traffic_card.no-mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: (props.traffic.http?.rq_total ?? 0) - mtls }) }}</dd>
-            </div>
+              <div
+                v-if="nonMtls !== 0"
+                class="rq-no-mtls"
+              >
+                <dt>{{ t('data-planes.components.service_traffic_card.no-mtls.title') }}</dt>
+                <dd>{{ t('common.formats.integer', { value: nonMtls}) }}</dd>
+              </div>
+            </template>
           </template>
         </template>
         <template
@@ -140,21 +139,20 @@
             <dd>{{ t('common.formats.integer', { value: props.traffic.http?.[`${props.direction}_rq_5xx`] }) }}</dd>
           </div>
           <template
-            v-for="mtls in [Object.values(props.traffic.http?.rbac ?? {}).reduce<number>((prev, item) => prev + (item as number), 0)]"
-            :key="typeof mtls"
+            v-if="props.direction === 'downstream'"
           >
-            <div
-              data-testid="rq-mtls"
+            <template
+              v-for="nonMtls in [(props.traffic.http?.rq_total ?? 0) - Object.values(props.traffic.http?.rbac ?? {}).reduce<number>((prev, item) => prev + (item as number), 0)]"
+              :key="typeof nonMtls"
             >
-              <dt>{{ t('data-planes.components.service_traffic_card.mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: mtls }) }}</dd>
-            </div>
-            <div
-              data-testid="rq-no-mtls"
-            >
-              <dt>{{ t('data-planes.components.service_traffic_card.no-mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: (props.traffic.http?.rq_total ?? 0) - mtls }) }}</dd>
-            </div>
+              <div
+                v-if="nonMtls !== 0"
+                class="rq-no-mtls"
+              >
+                <dt>{{ t('data-planes.components.service_traffic_card.no-mtls.title') }}</dt>
+                <dd>{{ t('common.formats.integer', { value: nonMtls}) }}</dd>
+              </div>
+            </template>
           </template>
         </template>
         <template
@@ -181,21 +179,20 @@
             <dd>{{ formatBytes(props.traffic.tcp?.[`${props.direction}_cx_rx_bytes_total`]) }}</dd>
           </div>
           <template
-            v-for="mtls in [Object.values(props.traffic.tcp?.rbac ?? {}).reduce<number>((prev, item) => prev + (item as number), 0)]"
-            :key="typeof mtls"
+            v-if="props.direction === 'downstream'"
           >
-            <div
-              data-testid="rq-mtls"
+            <template
+              v-for="nonMtls in [(props.traffic.tcp?.rq_total ?? 0) - Object.values(props.traffic.tcp?.rbac ?? {}).reduce<number>((prev, item) => prev + (item as number), 0)]"
+              :key="typeof nonMtls"
             >
-              <dt>{{ t('data-planes.components.service_traffic_card.mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: mtls }) }}</dd>
-            </div>
-            <div
-              data-testid="rq-no-mtls"
-            >
-              <dt>{{ t('data-planes.components.service_traffic_card.no-mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: (props.traffic.tcp?.[`${props.direction}_cx_total`] ?? 0) - mtls }) }}</dd>
-            </div>
+              <div
+                v-if="nonMtls !== 0"
+                class="rq-no-mtls"
+              >
+                <dt>{{ t('data-planes.components.service_traffic_card.no-mtls.title') }}</dt>
+                <dd>{{ t('common.formats.integer', { value: nonMtls}) }}</dd>
+              </div>
+            </template>
           </template>
         </template>
       </dl>
@@ -260,4 +257,9 @@ const click = (e: MouseEvent) => {
   text-decoration: none;
   color: inherit;
 }
+.rq-no-mtls dt,
+.rq-no-mtls dd {
+  color: $kui-color-text-warning !important
+}
+
 </style>

--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -35,8 +35,10 @@ data-planes:
       3xx: 3xx
       4xx: 4xx
       5xx: 5xx
-      mtls: mTLS enabled
-      no-mtls: mTLS disabled
+      no-mtls:
+        title: non-mTLS requests
+        tooltip: !!text/markdown |
+          When using permissive mTLS this is the number of requests received that did not have a client certificate. Before switching to strict mTLS this count should not increase otherwise some clients will fail request
       cx: Total connections
       tx: Bytes sent
       rx: Bytes received


### PR DESCRIPTION
Follow up of https://github.com/kumahq/kuma-gui/pull/4067 (which was to close https://github.com/kumahq/kuma-gui/issues/2974)

Wraps a conditional around mTLS stats to only show them on inbounds.

Also (taken from a comment on https://github.com/kumahq/kuma-gui/issues/2974)

> - [x] Only show non-mtls
> - [x] when its non-zero show in orange (well, warning color)
> - [ ] always add a tooltip: When using permissive mTLS this is the number of requests received that did not have a client certificate. Before switching to strict mTLS this count should not increase otherwise some clients will fail request

Note I haven't added the tooltip here as adding a KTooltip here looks like this:

<img width="1667" height="833" alt="Screenshot 2025-07-17 at 12 30 53" src="https://github.com/user-attachments/assets/e13c74d9-081e-45a5-a082-352844e33a12" />

i.e. its not positioned correctly.

I'm tempted to get this in first and then follow up with the tooltip. But also if there are suggestions on how to fix that I can add it here also
