### PR TITLE
Revert "chore: add mTLS related stats to ConnectionCards (#4067)"

### DIFF
--- a/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
+++ b/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
@@ -84,23 +84,6 @@
             <dt>{{ t('data-planes.components.service_traffic_card.grpc_failure') }}</dt>
             <dd>{{ t('common.formats.integer', { value: props.traffic.grpc?.failure }) }}</dd>
           </div>
-          <template
-            v-for="mtls in [Object.values(props.traffic.http?.rbac ?? {}).reduce<number>((prev, item) => prev + (item as number), 0)]"
-            :key="typeof mtls"
-          >
-            <div
-              data-testid="rq-mtls"
-            >
-              <dt>{{ t('data-planes.components.service_traffic_card.mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: mtls }) }}</dd>
-            </div>
-            <div
-              data-testid="rq-no-mtls"
-            >
-              <dt>{{ t('data-planes.components.service_traffic_card.no-mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: (props.traffic.http?.rq_total ?? 0) - mtls }) }}</dd>
-            </div>
-          </template>
         </template>
         <template
           v-else-if="props.protocol.startsWith('http')"
@@ -139,23 +122,6 @@
             <dt>{{ t('data-planes.components.service_traffic_card.5xx') }}</dt>
             <dd>{{ t('common.formats.integer', { value: props.traffic.http?.[`${props.direction}_rq_5xx`] }) }}</dd>
           </div>
-          <template
-            v-for="mtls in [Object.values(props.traffic.http?.rbac ?? {}).reduce<number>((prev, item) => prev + (item as number), 0)]"
-            :key="typeof mtls"
-          >
-            <div
-              data-testid="rq-mtls"
-            >
-              <dt>{{ t('data-planes.components.service_traffic_card.mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: mtls }) }}</dd>
-            </div>
-            <div
-              data-testid="rq-no-mtls"
-            >
-              <dt>{{ t('data-planes.components.service_traffic_card.no-mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: (props.traffic.http?.rq_total ?? 0) - mtls }) }}</dd>
-            </div>
-          </template>
         </template>
         <template
           v-else
@@ -180,23 +146,6 @@
             <dt>{{ t('data-planes.components.service_traffic_card.tx') }}</dt>
             <dd>{{ formatBytes(props.traffic.tcp?.[`${props.direction}_cx_rx_bytes_total`]) }}</dd>
           </div>
-          <template
-            v-for="mtls in [Object.values(props.traffic.tcp?.rbac ?? {}).reduce<number>((prev, item) => prev + (item as number), 0)]"
-            :key="typeof mtls"
-          >
-            <div
-              data-testid="rq-mtls"
-            >
-              <dt>{{ t('data-planes.components.service_traffic_card.mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: mtls }) }}</dd>
-            </div>
-            <div
-              data-testid="rq-no-mtls"
-            >
-              <dt>{{ t('data-planes.components.service_traffic_card.no-mtls') }}</dt>
-              <dd>{{ t('common.formats.integer', { value: (props.traffic.tcp?.[`${props.direction}_cx_total`] ?? 0) - mtls }) }}</dd>
-            </div>
-          </template>
         </template>
       </dl>
     </template>

--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -35,8 +35,6 @@ data-planes:
       3xx: 3xx
       4xx: 4xx
       5xx: 5xx
-      mtls: mTLS enabled
-      no-mtls: mTLS disabled
       cx: Total connections
       tx: Bytes sent
       rx: Bytes received


### PR DESCRIPTION
We decided this isn't something that is feasible to do correctly from the frontend.

See original issue https://github.com/kumahq/kuma-gui/issues/2974