### PR TITLE
fix(deps/security-actions/sca): use hash of version release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - run: |
           make -C ${{ matrix.package.path }} build
 
-      - uses: Kong/public-shared-actions/security-actions/sca@ec3f7e6638900dfb56c6963b61659512fc6dbe54
+      - uses: Kong/public-shared-actions/security-actions/sca@80442c24d193f2a116f9305723ac144a297a8c6a # v4.1.3
         id: sbom
         env:
           SYFT_SOURCE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Our release workflow to the kuma repo is currently failing. It looks like there is an issue upstream. It started failing since we've used a hash that is newer than the hash of the actual release of the latest version of `Kong/public-shared-actions/security-actions/sca`. This is an attempt to make it work by using the hash of the actual release.