### PR TITLE
fix(rest-client): limited support of request.body

### DIFF
--- a/packages/kuma-gui/src/app/kuma/services/kuma-api/RestClient.ts
+++ b/packages/kuma-gui/src/app/kuma/services/kuma-api/RestClient.ts
@@ -5,7 +5,8 @@ export const createFetch = (client: RestClient) => {
   return async (r: Request | string) => {
     const req = typeof r === 'string' ? new Request(r) : r
     const url = new URL(req.url)
-    const payload = ['GET', 'DELETE'].includes(req.method) ? undefined : req.body ? (await new Response(req.body).json()) : {}
+    const body = req.body ?? await req.blob?.()
+    const payload = ['GET', 'DELETE'].includes(req.method) ? undefined : body ? (await new Response(body).json()) : {}
     const options = {
       ...req,
       params: url.searchParams.size > 0 ? Object.fromEntries(url.searchParams.entries()) : undefined,


### PR DESCRIPTION
To send data as payload in our requests (i.e. `POST`, `PATCH`, `PUT`) we currently use [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response/Response) to extract the payload and pass it further to `fetch`. This is part of the integration of the openapi-fetch and the option to pass an own `fetch` implementation when using [`createClient`](https://openapi-ts.dev/openapi-fetch/api#createclient).
To extract the payload from the `Request` we currently use [`Request.body`](https://developer.mozilla.org/en-US/docs/Web/API/Request/body), which is not supported when using firefox. Instead we can use [`Request.blob`](https://developer.mozilla.org/en-US/docs/Web/API/Request/blob), which is what I did here now.

Note: I tested to replace `req.body` with `req.blob` entirely, but the logs showed that the blob was empty when not using firefox. It still seemed to work as the final request in the browser inspector revealed the correct payload to be part of the request. But I felt it's better to keep using `req.body` and only use `req.blob` if `req.body` isn't set. At least this makes it easier to debug.