### PR TITLE
feat(data-planes): add back traffic listing

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
@@ -1,0 +1,39 @@
+Feature: mesh / dataplanes / DataplaneDetailsTraffic
+
+  Background:
+    Given the CSS selectors
+      | Alias           | Selector                                                                   |
+      | traffic         | [data-testid='dataplane-traffic']                                          |
+      | inbounds        | [data-testid='dataplane-inbounds']                                         |
+      | outbounds       | [data-testid='dataplane-outbounds']                                        |
+    And the environment
+      """
+      KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      """
+
+  Scenario: Dataplane Details Traffic shows expected content
+    Given the environment
+      """
+      KUMA_DATAPLANEINBOUND_COUNT: 1
+      KUMA_DATAPLANEOUTBOUND_COUNT: 1
+      """
+    And the URL "/meshes/default/dataplanes/dpp-1-name-of-dataplane/_layout" responds with
+      """
+      body:
+        inbounds:
+          - kri: kri_dp_default_representation_kuma-system_chow-standard-4-345c47d02-ccrqz.kuma-system_httpport
+            port: 8080
+            protocol: tcp
+            proxyResourceName: self_inbound_httpport
+        outbounds:
+          - kri: kri_dp_default_parsnip_kuma-system_chow-standard-4-345c47d02-ccrqz.kuma-system_8081
+            port: 8081
+            protocol: grpc
+            proxyResourceName: kri_dp_default_parsnip_kuma-system_chow-standard-4-345c47d02-ccrqz.kuma-system_8081
+      """
+    When I visit the "/meshes/default/data-planes/dpp-1-name-of-dataplane/overview" URL
+    Then the "$traffic" element exists
+    And the "$inbounds" element contains "TCP"
+    And the "$inbounds" element contains "self_inbound_httpport"
+    And the "$outbounds" element contains "gRPC"
+    And the "$outbounds" element contains "kri_dp_default_parsnip_kuma-system_chow-standard-4-345c47d02-ccrqz.kuma-system_8081"

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
@@ -25,6 +25,17 @@ type PartialDataplaneOutbound = NonNullable<NonNullable<NonNullable<components['
 
 export type DataplaneGateway = PartialDataplaneGateway & {}
 
+type PartialDataplaneNetworkingLayout = components['schemas']['DataplaneNetworkingLayout']
+
+export const DataplaneNetworkingLayout =  {
+  fromObject(dataplaneNetworkingLayout: PartialDataplaneNetworkingLayout) {
+    return {
+      ...dataplaneNetworkingLayout,
+    } satisfies PartialDataplaneNetworkingLayout
+  },
+}
+export type DataplaneNetworkingLayout = ReturnType<typeof DataplaneNetworkingLayout.fromObject>
+
 const DataplaneOutbound = {
   fromObject(item: PartialDataplaneOutbound) {
     const address = item.address ?? '127.0.0.1'

--- a/packages/kuma-gui/src/app/data-planes/sources.ts
+++ b/packages/kuma-gui/src/app/data-planes/sources.ts
@@ -6,6 +6,7 @@ import {
   DataplaneOverview,
   MeshGatewayDataplane,
   SidecarDataplane,
+  DataplaneNetworkingLayout,
 } from './data'
 import type { DataSourceResponse } from '@/app/application'
 import { YAML } from '@/app/application'
@@ -199,6 +200,19 @@ export const sources = (api: KumaApi) => {
         offset,
         size,
       }))
+    },
+
+    '/meshes/:mesh/dataplanes/:name/layout': async (params) => {
+      const { mesh, name } = params
+      const res = await http.GET('/meshes/{mesh}/dataplanes/{name}/_layout', {
+        params: {
+          path: {
+            mesh,
+            name,
+          },
+        },
+      })
+      return DataplaneNetworkingLayout.fromObject(res.data!)
     },
   })
 }

--- a/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/kuma/locales/en-us/index.yaml
@@ -164,3 +164,4 @@ http:
       http2: HTTP2
       http: HTTP
       tcp: TCP
+      tls: TLS

--- a/packages/kuma-gui/src/test-support/FakeKuma.ts
+++ b/packages/kuma-gui/src/test-support/FakeKuma.ts
@@ -472,6 +472,14 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
 
     return this.faker.helpers.arrayElements(items, minmax({ min: 0, max: items.length }, count))
   }
+
+  kri({ shortName, mesh, zone, namespace, name, sectionName }: Partial<{ shortName: string, mesh: string, zone: string, namespace: string, name: string, sectionName: string }> = {}) {
+    return `kri_${shortName ?? this.faker.word.noun()}_${mesh ?? this.faker.word.noun()}_${zone ?? this.faker.word.noun()}_${namespace ?? this.k8s.namespace()}_${name ?? this.faker.word.noun()}_${sectionName ?? this.faker.word.noun()}`
+  }
+
+  contextualKri({ context, name }: { context: string, name: string }) {
+    return `self_${context}_${name}`
+  }
 }
 
 export default class FakeKuma extends Faker {

--- a/packages/kuma-gui/src/test-support/mocks/fs.ts
+++ b/packages/kuma-gui/src/test-support/mocks/fs.ts
@@ -13,6 +13,7 @@ import _17 from './src/meshes/_/circuit-breakers'
 import _18 from './src/meshes/_/circuit-breakers/_'
 import _125 from './src/meshes/_/circuit-breakers/_/_resources/dataplanes'
 import _19 from './src/meshes/_/dataplanes/_'
+import _123 from './src/meshes/_/dataplanes/_/_layout'
 import _22 from './src/meshes/_/dataplanes/_/_overview'
 import _128 from './src/meshes/_/dataplanes/_/_rules'
 import _122 from './src/meshes/_/dataplanes/_/clusters'
@@ -151,6 +152,7 @@ export const fs: FS = {
   '/meshes/:mesh/dataplanes/_overview': _21,
   '/meshes/:mesh/dataplanes/:name': _19,
   '/meshes/:mesh/dataplanes/:name/_overview': _22,
+  '/meshes/:mesh/dataplanes/:name/_layout': _123,
   '/meshes/:mesh/dataplanes/:name/_rules': _128,
   '/meshes/:mesh/dataplanes/:name/policies': _20,
   '/meshes/:mesh/dataplanes/:name/xds': _120,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/_layout.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/dataplanes/_/_layout.ts
@@ -1,0 +1,76 @@
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+import type { components } from '@kumahq/kuma-http-api'
+
+type DataplaneNetworkingLayout = components['schemas']['DataplaneNetworkingLayout']
+type DataplaneInbound = components['schemas']['DataplaneInbound']
+type DataplaneOutbound = components['schemas']['DataplaneOutbound']
+
+export default ({ env, fake }: EndpointDependencies): MockResponder => (req) => {
+  const mesh = req.params.mesh as string
+  const name = req.params.name as string
+  const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
+  const inboundCount = parseInt(env('KUMA_DATAPLANEINBOUND_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
+  const outboundCount = parseInt(env('KUMA_DATAPLANEOUTBOUND_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
+
+  const parts = String(name).split('.')
+  const displayName = parts.slice(0, -1).join('.')
+  const nspace = parts.pop()
+
+  return {
+    headers: {},
+    body: {
+      kri: fake.kuma.kri({
+        shortName: 'dp',
+        mesh,
+        namespace: nspace,
+        name,
+        sectionName: 'default',
+      }),
+      labels: {
+        'kuma.io/display-name': displayName,
+        'kuma.io/origin': fake.kuma.origin(),
+        'kuma.io/mesh': mesh || fake.word.noun(),
+        'kuma.io/zone': fake.word.noun(),
+        ...(k8s
+          ? {
+            'k8s.kuma.io/namespace': nspace,
+          }
+          : {}),
+      },
+      inbounds: Array.from({ length: inboundCount }).map((_, i) => {
+        const port = fake.number.int({ min: 1, max: 65535 })
+        const context = fake.helpers.arrayElement(['inbound', 'transparentproxy_passthrough_inbound'])
+        const sectionName = fake.helpers.arrayElement(['default', 'httpport', port.toString(), 'ipv4', 'ipv6' ])
+        return {
+          kri: fake.kuma.kri({
+            shortName: 'dp',
+            mesh,
+            namespace: nspace,
+            name,
+            sectionName,
+          }),
+          port,
+          protocol: fake.helpers.arrayElement(['http', 'tcp', 'tls', 'grpc']),
+          proxyResourceName: fake.kuma.contextualKri({ context, name: sectionName }),
+        } satisfies DataplaneInbound
+      }),
+      outbounds: Array.from({ length: outboundCount }).map((_, i) => {
+        const port = fake.number.int({ min: 1, max: 65535 })
+        const sectionName = fake.helpers.arrayElement(['default', 'httpport', port.toString(), 'ipv4', 'ipv6' ])
+        const kri = fake.kuma.kri({
+          shortName: 'dp',
+          mesh,
+          namespace: nspace,
+          name,
+          sectionName,
+        })
+        return {
+          kri,
+          port,
+          protocol: fake.helpers.arrayElement(['http', 'tcp', 'tls', 'grpc']),
+          proxyResourceName: kri,
+        } satisfies DataplaneOutbound
+      }),
+    } satisfies DataplaneNetworkingLayout,
+  }
+}


### PR DESCRIPTION
Adds back the traffic listing that uses the data returned by the new `_layout`-endpoint:

- the traffic listing is shown at the same place as before, but for now only displays the `inbounds` and `outbounds` data returned by `/_layout` (no summary view and no passthrough yet)
- tests ensure that inbounds show the contextual kri and outbounds the full kri. Everything else is as before and it uses the same components under the hood (`ConnectionGroup`, `ConnectionCard`, ...)
- adds a the new `_layout` endpoint to the mocks and new fake methods `kri` and `conextualKri` to generate kri

Example
<img width="1398" height="898" alt="image" src="https://github.com/user-attachments/assets/94cfaa56-95b2-4fba-adb2-ec7b056ab3c0" />

Closes #4119