### PR TITLE
feat: mute validation errors

### DIFF
--- a/packages/kuma-gui/src/app/application/services/data-source/index.ts
+++ b/packages/kuma-gui/src/app/application/services/data-source/index.ts
@@ -145,3 +145,5 @@ export const destroy: Destroyer = (_src, source) => {
     source.close()
   }
 }
+
+export class ValidationError extends Error {}

--- a/packages/kuma-gui/src/app/kuma/index.ts
+++ b/packages/kuma-gui/src/app/kuma/index.ts
@@ -1,6 +1,7 @@
 import { token, createInjections } from '@kumahq/container'
 
 import locales from './locales/en-us/index.yaml'
+import { ValidationError } from '../application/services/data-source'
 import KumaPort from '@/app/kuma/components/kuma-port/KumaPort.vue'
 import { ApiError } from '@/app/kuma/services/kuma-api/ApiError'
 import KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
@@ -57,7 +58,7 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       service: () => {
         return (e: Error | ErrorEvent) => {
           const error = 'error' in e ? e.error : e
-          if (error instanceof ApiError) {
+          if (error instanceof ApiError || error instanceof ValidationError) {
             return
           }
           console.error(error)


### PR DESCRIPTION
In some cases we want to validate user inputs. The validation happens in the data source layer, so we could potentially move the validation to the backend with few changes necessary. But this also causes errors being thrown unnecessarily. This PR mutes these errors but still let the error being displayed to the user, i.e. below an input field that is being validated.