### PR TITLE
chore(deps): bump msw worker file

### DIFF
--- a/packages/kuma-gui/public/mockServiceWorker.js
+++ b/packages/kuma-gui/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.9.0'
+const PACKAGE_VERSION = '2.10.4'
 const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()


### PR DESCRIPTION
The worker file is outdated. Even though it's just the `PACKAGE_VERSION`, this should stay up to date.