### PR TITLE
feat(data-planes): add inbound/outbound summary stats, clusters, xds config

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Clusters.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Clusters.feature
@@ -1,0 +1,79 @@
+Feature: mesh / dataplanes / connections / clusters
+
+  Background:
+    Given the environment
+      """
+      KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      """
+
+  Scenario: The inbound clusters tab correctly filters by contextual KRI
+    Given the CSS selectors
+      | Alias | Selector                                                                                         |
+      | code  | [data-testid='data-plane-connection-inbound-summary-clusters-view'] [data-testid='k-code-block'] |
+    And the URL "/meshes/mesh-name/dataplanes/service-64cbb7b8b5-6g94n.namespace/_overview" responds with
+      """
+      body:
+        dataplane:
+          networking:
+            inbound:
+            - port: 9090
+              servicePort: !!js/undefined
+      """
+    And the URL "/meshes/mesh-name/dataplanes/service-64cbb7b8b5-6g94n.namespace/_layout" responds with
+      """
+      body:
+        inbounds:
+          - port: 9090
+            kri: kri_dp_default_default_namespace_service-64cbb7b8b5-6g94n.namespace_http
+            protocol: http
+            proxyResourceName: self_inbound_dp_http
+      """
+    And the URL "/meshes/mesh-name/dataplanes/service-64cbb7b8b5-6g94n.namespace/clusters" responds with
+      """
+      body: |
+        self_inbound_dp_9090::observability_name::self_inbound_dp_9090
+        self_inbound_dp_9090::default_priority::max_connections::1024
+        inbound:passthrough:ipv6::priority::connections::1024
+        system_envoy_admin::default_priority::max_connections::1025
+        kri_msvc_default_default_kuma-demo_demo-app-v2_5050:ipv4::added_via_api::true
+      """
+    When I visit the "/meshes/mesh-name/data-planes/service-64cbb7b8b5-6g94n.namespace/overview/inbound/self_inbound_dp_http/clusters" URL
+    And the "$code" element contains "observability_name::self_inbound_dp_9090"
+    And the "$code" element contains "default_priority::max_connections::1024"
+    And the "$code" element doesn't contain "priority::connections::1024"
+    And the "$code" element doesn't contain "default_priority::max_connections::1025"
+    And the "$code" element doesn't contain "added_via_api::true"
+
+  Scenario: The outbound clusters tab correctly filters by full KRI
+    Given the CSS selectors
+      | Alias | Selector                                                                                          |
+      | code  | [data-testid='data-plane-connection-outbound-summary-clusters-view'] [data-testid='k-code-block'] |
+    And the URL "/meshes/mesh-name/dataplanes/service-64cbb7b8b5-6g94n.kuma-demo/stats" responds with
+      """
+      body: |
+        cluster.kri_msvc_default_default_kuma-demo_demo-app_5050.assignment_stale: 0
+      """
+    And the URL "/meshes/mesh-name/dataplanes/service-64cbb7b8b5-6g94n.kuma-demo/_layout" responds with
+      """
+      body:
+        outbounds:
+          - port: 5050
+            kri: kri_msvc_default_default_kuma-demo_demo-app_5050
+            protocol: http
+            proxyResourceName: kri_msvc_default_default_kuma-demo_demo-app_5050
+      """
+    And the URL "/meshes/mesh-name/dataplanes/service-64cbb7b8b5-6g94n.kuma-demo/clusters" responds with
+      """
+      body: |
+        kri_msvc_default_default_kuma-demo_demo-app_5050::observability_name::kri_msvc_default_default_kuma-demo_demo-app_5050
+        kri_msvc_default_default_kuma-demo_demo-app_5050::default_priority::max_connections::1024
+        kri_msvc_default_default_kuma-demo_demo-app-v1_5050::priority::connections::1024
+        localhost:1111::default_priority::max_connections::1025
+        inbound:passthrough:ipv4::added_via_api::true
+      """
+    When I visit the "/meshes/mesh-name/data-planes/service-64cbb7b8b5-6g94n.kuma-demo/overview/outbound/kri_msvc_default_default_kuma-demo_demo-app_5050/clusters" URL
+    And the "$code" element contains "observability_name::kri_msvc_default_default_kuma-demo_demo-app_5050"
+    And the "$code" element contains "default_priority::max_connections::1024"
+    And the "$code" element doesn't contain "priority::connections::1024"
+    And the "$code" element doesn't contain "default_priority::max_connections::1025"
+    And the "$code" element doesn't contain "added_via_api::true"

--- a/packages/kuma-gui/src/app/connections/sources.ts
+++ b/packages/kuma-gui/src/app/connections/sources.ts
@@ -192,7 +192,7 @@ export const sources = (api: KumaApi) => {
             // this one won't work yet see
             // https://github.com/kumahq/kuma/issues/12093
             // dynamic_listeners[].name === 'outbound:<outbound>'
-            return arr.filter(item => prop(item, 'name') && item.name === `outbound:${outbound}`)
+            return arr.filter(item => prop(item, 'name') && (item.name === `outbound:${outbound}` || item.name === outbound))
           case 'dynamic_active_clusters':
             // dynamic_active_clusters[].cluster.name === outbound
             return arr.filter(item => prop(item, 'cluster') && prop(item.cluster, 'name') && item.cluster?.name === outbound)
@@ -237,10 +237,10 @@ export const sources = (api: KumaApi) => {
         switch (key) {
           case 'dynamic_listeners':
             // dynamic_listeners[].name === 'inbound:<ignored>:0000'
-            return arr.filter((item = {}) => prop(item, 'name') && typeof item.name === 'string' && item.name.startsWith('inbound:') && item.name?.endsWith(`:${inbound}`))
+            return arr.filter((item = {}) => prop(item, 'name') && typeof item.name === 'string' && ((item.name.startsWith('inbound:') && item.name?.endsWith(`:${inbound}`) || item.name === inbound )))
           case 'dynamic_active_clusters':
             // dynamic_active_clusters[].cluster.name === '<ignored>:0000'
-            return arr.filter(item => prop(item, 'cluster') && prop(item.cluster, 'name') && typeof item.cluster.name === 'string' && item.cluster?.name?.endsWith(`:${inbound}`))
+            return arr.filter(item => prop(item, 'cluster') && prop(item.cluster, 'name') && ((typeof item.cluster.name === 'string' && item.cluster?.name?.endsWith(`:${inbound}`) || item.cluster.name === inbound)))
         }
         return []
       })

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
@@ -26,12 +26,12 @@
         v-slot="{ data: connections, refresh }"
       >
         <template
-          v-for="prefix in [(!props.data.clusterName ? route.params.connection : props.data.clusterName).replace('_', ':')]"
+          v-for="prefix in ['proxyResourceName' in props.data ? ContextualKri.toString({ ...ContextualKri.fromString(props.data.proxyResourceName), sectionName: props.data.port.toString() }) : ('clusterName' in props.data ? props.data.clusterName : route.params.connection).replace('_', ':')]"
           :key="typeof prefix"
         >
           <DataCollection
             :items="connections.split('\n')"
-            :predicate="item => item.startsWith(`${prefix}::`)"
+            :predicate="item => item.startsWith(`${prefix}`)"
             v-slot="{ items: lines }"
           >
             <XCodeBlock
@@ -63,9 +63,11 @@
 </template>
 <script lang="ts" setup>
 import { sources } from '../sources'
-import { DataplaneInbound } from '@/app/legacy-data-planes/data'
+import { DataplaneNetworkingLayout } from '@/app/data-planes/data'
+import { ContextualKri } from '@/app/kuma/kri'
+import type { DataplaneInbound } from '@/app/legacy-data-planes/data'
 const props = defineProps<{
   routeName: string
-  data: DataplaneInbound
+  data: DataplaneInbound | DataplaneNetworkingLayout['inbounds'][number]
 }>()
 </script>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
@@ -21,7 +21,7 @@
         :src="uri(sources, '/connections/xds/for/:proxyType/:name/:mesh/inbound/:inbound', {
           mesh: route.params.mesh || '*',
           name: route.params.proxy,
-          inbound: `${props.data.port}`,
+          inbound: 'proxyResourceName' in props.data ? ContextualKri.toString({ ...ContextualKri.fromString(props.data.proxyResourceName), sectionName: props.data.port.toString() }) : `${props.data.port}`,
           proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress'})[route.params.proxyType] ?? 'dataplane',
         })"
         v-slot="{ data: raw, refresh }"
@@ -53,10 +53,12 @@
 </template>
 <script lang="ts" setup>
 import { sources } from '../sources'
+import type { DataplaneNetworkingLayout } from '@/app/data-planes/data'
+import { ContextualKri } from '@/app/kuma/kri'
 import type { DataplaneInbound } from '@/app/legacy-data-planes/data/'
 
 const props = defineProps<{
-  data: DataplaneInbound
+  data: DataplaneInbound | DataplaneNetworkingLayout['inbounds'][number]
   routeName: string
 }>()
 </script>

--- a/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionOutboundSummaryClustersView.vue
@@ -23,14 +23,14 @@
           name: route.params.proxy,
           mesh: route.params.mesh || '*',
         })"
-        v-slot="{ data, refresh }"
+        v-slot="{ data: clusters, refresh }"
       >
         <template
           v-for="prefix in [route.params.connection]"
           :key="typeof prefix"
         >
           <DataCollection
-            :items="data.split('\n')"
+            :items="clusters.split('\n')"
             :predicate="item => item.startsWith(`${prefix}::`)"
             v-slot="{ items: lines }"
           >

--- a/packages/kuma-gui/src/app/data-planes/routes.ts
+++ b/packages/kuma-gui/src/app/data-planes/routes.ts
@@ -18,34 +18,34 @@ export const dataplaneRoutes = (): RouteRecordRaw[] => {
               if (item.name === 'data-plane-connection-inbound-summary-view' && item.children) {
                 item.component = () => import('@/app/data-planes/views/DataPlaneTrafficSummaryView.vue')
                 // temporarily exclude all children but overview
-                item.children = [{
-                  path: 'overview',
-                  name: 'data-plane-connection-inbound-summary-overview-view',
-                  component: () => import('@/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue'),
-                }]
-                // item.children.unshift(
-                //   {
-                //     path: 'overview',
-                //     name: 'data-plane-connection-inbound-summary-overview-view',
-                //     component: () => import('@/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue'),
-                //   },
-                // )
+                // item.children = [{
+                //   path: 'overview',
+                //   name: 'data-plane-connection-inbound-summary-overview-view',
+                //   component: () => import('@/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue'),
+                // }]
+                item.children.unshift(
+                  {
+                    path: 'overview',
+                    name: 'data-plane-connection-inbound-summary-overview-view',
+                    component: () => import('@/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue'),
+                  },
+                )
               }
               if (item.name === 'data-plane-connection-outbound-summary-view' && item.children) {
                 item.component = () => import('@/app/data-planes/views/DataPlaneTrafficSummaryView.vue')
                 // temporarily exclude all children but overview
-                item.children = [{
-                  path: 'overview',
-                  name: 'data-plane-connection-outbound-summary-overview-view',
-                  component: () => import('@/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue'),
-                }]
-                // item.children.unshift(
-                //   {
-                //     path: 'overview',
-                //     name: 'data-plane-connection-outbound-summary-overview-view',
-                //     component: () => import('@/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue'),
-                //   },
-                // )
+                // item.children = [{
+                //   path: 'overview',
+                //   name: 'data-plane-connection-outbound-summary-overview-view',
+                //   component: () => import('@/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue'),
+                // }]
+                item.children.unshift(
+                  {
+                    path: 'overview',
+                    name: 'data-plane-connection-outbound-summary-overview-view',
+                    component: () => import('@/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue'),
+                  },
+                )
               }
               return item
             }),

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -10,23 +10,80 @@
   >
     <AppView>
       <XLayout type="stack">
-        <div
-          class="stack-with-borders"
+        <template
+          v-for="inbound in [props.dataPlaneOverview.dataplane.networking.inbounds.find((item) => item.portName === ContextualKri.fromString(route.params.connection).sectionName && item.port === props.data.port)]"
+          :key="typeof inbound"
         >
-          <DefinitionCard layout="horizontal">
-            <template #title>
-              Protocol
-            </template>
+          <div
+            v-if="inbound"
+            class="stack-with-borders"
+          >
+            <DefinitionCard layout="horizontal">
+              <template #title>
+                Tags
+              </template>
 
-            <template #body>
-              <XBadge
-                appearance="info"
-              >
-                {{ t(`http.api.value.${props.data.protocol}`) }}
-              </XBadge>
-            </template>
-          </DefinitionCard>
-        </div>
+              <template #body>
+                <TagList
+                  :tags="inbound.tags"
+                  alignment="right"
+                />
+              </template>
+            </DefinitionCard>
+            <DefinitionCard layout="horizontal">
+              <template #title>
+                Protocol
+              </template>
+
+              <template #body>
+                <XBadge
+                  appearance="info"
+                >
+                  {{ t(`http.api.value.${inbound.protocol}`) }}
+                </XBadge>
+              </template>
+            </DefinitionCard>
+            <DefinitionCard layout="horizontal">
+              <template #title>
+                Address
+              </template>
+
+              <template #body>
+                <XCopyButton
+                  :text="`${inbound.addressPort}`"
+                />
+              </template>
+            </DefinitionCard>
+            <DefinitionCard
+              v-if="inbound.serviceAddressPort.length > 0"
+              layout="horizontal"
+            >
+              <template #title>
+                Service address
+              </template>
+
+              <template #body>
+                <XCopyButton
+                  :text="`${inbound.serviceAddressPort}`"
+                />
+              </template>
+            </DefinitionCard>
+            <DefinitionCard
+              v-if="inbound.portName.length > 0"
+              layout="horizontal"
+            >
+              <template #title>
+                Name
+              </template>
+
+              <template #body>
+                <XCopyButton
+                  :text="`${inbound.portName}`"
+                />
+              </template>
+            </DefinitionCard>
+          </div>
+        </template>
         <XLayout
           v-if="props.data"
           type="stack"
@@ -153,17 +210,19 @@
 </template>
 
 <script lang="ts" setup>
-import { DataplaneNetworkingLayout } from '../data'
+import { DataplaneNetworkingLayout, DataplaneOverview } from '../data'
 import { YAML } from '@/app/application'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
-import { Kri } from '@/app/kuma/kri'
+import TagList from '@/app/common/TagList.vue'
+import { ContextualKri, Kri } from '@/app/kuma/kri'
 import { sources as policySources } from '@/app/policies/sources'
 
 const props = defineProps<{
   data: DataplaneNetworkingLayout['inbounds'][number]
+  dataPlaneOverview: DataplaneOverview
   routeName: string
 }>()
 </script>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
@@ -26,6 +26,17 @@
               </XBadge>
             </template>
           </DefinitionCard>
+          <DefinitionCard
+            layout="horizontal"
+          >
+            <template #title>
+              Port
+            </template>
+
+            <template #body>
+              {{ props.data.port }}
+            </template>
+          </DefinitionCard>
         </div>
         <XLayout
           v-if="props.data"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
@@ -56,6 +56,7 @@
             :is="child.Component"
             :data="items[0]"
             :networking="props.networking"
+            :data-plane-overview="props.dataPlaneOverview"
           />
         </RouterView>
       </AppView>
@@ -65,11 +66,12 @@
 
 <script lang="ts" setup>
 import { DataplaneNetworkingLayout } from '../data'
-import type { DataplaneNetworking } from '@/app/data-planes/data/'
+import type { DataplaneNetworking, DataplaneOverview } from '@/app/data-planes/data/'
 
 const props = defineProps<{
   data: DataplaneNetworkingLayout['inbounds'] | DataplaneNetworkingLayout['outbounds']
   networking: DataplaneNetworking
   routeName: string
+  dataPlaneOverview: DataplaneOverview
 }>()
 </script>


### PR DESCRIPTION
This generally adds back `stats` to the new dataplanes that have `feature-unified-resource-naming` enabled. This allows to add back the traffic summary tabs `<inbound,outbound>/<kri>/stats`, `<inbound,outbound>/<kri>/clusters` and `<inbound,outbound>/<kri>/xds`.
Furthermore I've enriched the traffic summary overview tab with more information about the inbound/outbound using the data from the `_overview`-endpoint.

In a separate PR I'm aiming to improve the mocks such that we can review and test better without a local deployment.

<img width="1401" height="563" alt="Screenshot 2025-08-18 at 17 01 36" src="https://github.com/user-attachments/assets/6c700507-bf9d-49b7-a192-1aa299b18e3c" />
<img width="661" height="436" alt="Screenshot 2025-08-18 at 17 01 46" src="https://github.com/user-attachments/assets/8bd78765-fd2d-4f9a-984c-20a0a172401a" />
<img width="669" height="1276" alt="Screenshot 2025-08-18 at 17 01 52" src="https://github.com/user-attachments/assets/589590a7-d502-4dab-a985-9148e77d8814" />
<img width="662" height="866" alt="Screenshot 2025-08-18 at 17 01 58" src="https://github.com/user-attachments/assets/5f2c8d3b-2d7e-47c4-9fbd-921211f35248" />
<img width="665" height="1279" alt="Screenshot 2025-08-18 at 17 02 04" src="https://github.com/user-attachments/assets/63e7eaa4-0a26-4868-bc96-3506d921e4dd" />

Closes #4122 
Closes #4123 