### PR TITLE
feat(mesh): show mesh-identities

### DIFF
--- a/packages/kuma-gui/features/mesh/MeshIdentity.feature
+++ b/packages/kuma-gui/features/mesh/MeshIdentity.feature
@@ -1,0 +1,35 @@
+Feature: mesh / mesh-identity
+
+  Background:
+    Given the CSS selectors
+      | Alias                     | Selector                                  |
+      | meshidentities-collection | [data-testid="meshidentities-collection"] |
+      | summary                   | [data-testid="slideout-container"]        |
+
+  Scenario: MeshIdentities are listed in mesh about section
+    Given the URL "/meshes/default/meshidentities" responds with
+      """
+      body:
+        items:
+          - name: identity-1
+      """
+    When I visit the "/meshes/default" URL
+    Then the "$meshidentities-collection" element exists
+    And the "$meshidentities-collection" element contains "identity-1"
+
+  Scenario: Clicking on mesh identity opens summary view
+    Given the URL "/meshes/default/meshidentities" responds with
+      """
+      body:
+        items:
+          - name: identity-1
+      """
+    When I visit the "/meshes/default" URL
+    Then I click the "$meshidentities-collection a:first" element
+    Then the URL contains "/meshes/default/overview/meshidentity/identity-1"
+    And the "$summary" element exists
+    And the "$summary" element contains "identity-1"
+    And the "$summary [data-testid='k-code-block']" element exists
+    And the "$summary [data-testid='k-code-block']" element contains "type: MeshIdentity"
+    And the "$summary [data-testid='k-code-block']" element contains "mesh: default"
+    And the "$summary [data-testid='k-code-block']" element contains "name: identity-1"

--- a/packages/kuma-gui/src/app/meshes/routes.ts
+++ b/packages/kuma-gui/src/app/meshes/routes.ts
@@ -1,3 +1,4 @@
+import { meshIdentityRoutes } from '../resources/routes'
 import type { RouteRecordRaw } from 'vue-router'
 
 export type SplitRouteRecordRaw = {
@@ -39,6 +40,7 @@ export const routes = (
                   path: 'overview',
                   name: 'mesh-detail-view',
                   component: () => import('@/app/meshes/views/MeshDetailView.vue'),
+                  children: [...meshIdentityRoutes()],
                 },
                 ...services.items(),
                 ...gateways.items(),

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -18,203 +18,270 @@
       })"
       v-slot="{ data }"
     >
-      <AppView
-        :docs="t('meshes.href.docs')"
-        :notifications="true"
+      <DataSource
+        :src="uri(resourceSources, '/meshes/:mesh/meshidentities', {
+          mesh: route.params.mesh,
+        })"
+        v-slot="{ data: meshIdentities }"
       >
-        <XNotification
-          :notify="!props.mesh.mtlsBackend"
-          :uri="`meshes.notifications.mtls-warning:${props.mesh.id}`"
+        <AppView
+          :docs="t('meshes.href.docs')"
+          :notifications="true"
         >
-          <XI18n
-            path="meshes.notifications.mtls-warning"
-          />
-        </XNotification>
-        <XNotification
-          :notify="mesh.meshServices.mode === 'Disabled'"
-          :uri="`meshes.notifications.mesh-service-activation:${route.params.mesh}`"
-          variant="info"
-        >
-          <XI18n
-            path="meshes.notifications.mesh-service-activation"
-          />
-        </XNotification>
-        <XLayout
-          type="stack"
-        >
-          <XAboutCard
-            :title="t('meshes.routes.item.about.title')"
-            :created="props.mesh.creationTime"
-            :modified="props.mesh.modificationTime"
+          <DataLoader
+            :data="[meshIdentities]"
           >
-            <template
-              v-for="policy in ['MeshTrafficPermission', 'MeshMetric', 'MeshAccessLog', 'MeshTrace']"
-              :key="policy"
+            <XNotification
+              :notify="!props.mesh.mtlsBackend"
+              :uri="`meshes.notifications.mtls-warning:${props.mesh.id}`"
             >
-              <template
-                v-for="stats in [data?.policies?.[policy] ?? { total: 0 }]"
-                :key="typeof stats"
-              >
-                <XNotification
-                  :notify="policy === 'MeshTrafficPermission' && props.mesh.mtlsBackend && stats.total === 0"
-                  :uri="`meshes.notifications.mtp-warning:${props.mesh.id}`"
-                >
-                  <XI18n
-                    path="meshes.notifications.mtp-warning"
-                  />
-                </XNotification>
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template #title>
-                    <XAction
-                      :to="{
-                        name: 'policy-list-view',
-                        params: {
-                          mesh: route.params.mesh,
-                          policyPath: `${policy.toLowerCase()}s`,
-                        },
-                      }"
-                    >
-                      {{ policy }}
-                    </XAction>
-                  </template>
-
-                  <template #body>
-                    <XBadge
-                      :appearance="stats.total > 0 ? 'success' : 'neutral'"
-                    >
-                      {{ stats.total > 0 ? t('meshes.detail.enabled') : t('meshes.detail.disabled') }}
-                    </XBadge>
-                  </template>
-                </DefinitionCard>
-              </template>
-            </template>
-
-            <DefinitionCard layout="horizontal">
-              <template #title>
-                {{ t('http.api.property.mtls') }}
-              </template>
-
-              <template #body>
-                <XBadge
-                  v-if="!props.mesh.mtlsBackend"
-                  appearance="neutral"
-                >
-                  {{ t('meshes.detail.disabled') }}
-                </XBadge>
-
-                <template v-else>
-                  <XBadge appearance="info">
-                    {{ props.mesh.mtlsBackend.type }} / {{ props.mesh.mtlsBackend.name }}
-                  </XBadge>
-                </template>
-              </template>
-            </DefinitionCard>
-          </XAboutCard>
-
-          <XCard>
+              <XI18n
+                path="meshes.notifications.mtls-warning"
+              />
+            </XNotification>
+            <XNotification
+              :notify="mesh.meshServices.mode === 'Disabled'"
+              :uri="`meshes.notifications.mesh-service-activation:${route.params.mesh}`"
+              variant="info"
+            >
+              <XI18n
+                path="meshes.notifications.mesh-service-activation"
+              />
+            </XNotification>
             <XLayout
-              type="columns"
-              class="columns-with-borders"
+              type="stack"
             >
-              <ResourceStatus
-                :total="data?.services.total ?? 0"
-                data-testid="services-status"
+              <XAboutCard
+                :title="t('meshes.routes.item.about.title')"
+                :created="props.mesh.creationTime"
+                :modified="props.mesh.modificationTime"
+                class="about-section"
               >
-                <template #title>
-                  {{ t('meshes.detail.services') }}
-                </template>
-              </ResourceStatus>
+                <XLayout>
+                  <XLayout type="separated">
+                    <template
+                      v-for="policy in ['MeshTrafficPermission', 'MeshMetric', 'MeshAccessLog', 'MeshTrace']"
+                      :key="policy"
+                    >
+                      <template
+                        v-for="stats in [data?.policies?.[policy] ?? { total: 0 }]"
+                        :key="typeof stats"
+                      >
+                        <XNotification
+                          :notify="policy === 'MeshTrafficPermission' && props.mesh.mtlsBackend && stats.total === 0"
+                          :uri="`meshes.notifications.mtp-warning:${props.mesh.id}`"
+                        >
+                          <XI18n
+                            path="meshes.notifications.mtp-warning"
+                          />
+                        </XNotification>
+                        <DefinitionCard
+                          layout="horizontal"
+                        >
+                          <template #title>
+                            <XAction
+                              :to="{
+                                name: 'policy-list-view',
+                                params: {
+                                  mesh: route.params.mesh,
+                                  policyPath: `${policy.toLowerCase()}s`,
+                                },
+                              }"
+                            >
+                              {{ policy }}
+                            </XAction>
+                          </template>
 
-              <ResourceStatus
-                :total="data?.dataplanesByType.standard.total ?? 0"
-                :online="data?.dataplanesByType.standard.online ?? 0"
-                data-testid="data-plane-proxies-status"
-              >
-                <template #title>
-                  {{ t('meshes.detail.data_plane_proxies') }}
-                </template>
-              </ResourceStatus>
+                          <template #body>
+                            <XBadge
+                              :appearance="stats.total > 0 ? 'success' : 'neutral'"
+                            >
+                              {{ stats.total > 0 ? t('meshes.detail.enabled') : t('meshes.detail.disabled') }}
+                            </XBadge>
+                          </template>
+                        </DefinitionCard>
+                      </template>
+                    </template>
 
-              <DataSource
-                :src="uri(PolicySources, '/policy-types', {})"
-                v-slot="{ data: resources }"
-              >
-                <template
-                  v-for="policyTypes in [resources?.policyTypes.map(item => item.name)]"
-                  :key="typeof policyTypes"
+                    <DefinitionCard layout="horizontal">
+                      <template #title>
+                        {{ t('http.api.property.mtls') }}
+                      </template>
+
+                      <template #body>
+                        <XBadge
+                          v-if="!props.mesh.mtlsBackend"
+                          appearance="neutral"
+                        >
+                          {{ t('meshes.detail.disabled') }}
+                        </XBadge>
+
+                        <template v-else>
+                          <XBadge appearance="info">
+                            {{ props.mesh.mtlsBackend.type }} / {{ props.mesh.mtlsBackend.name }}
+                          </XBadge>
+                        </template>
+                      </template>
+                    </DefinitionCard>
+                  </XLayout>
+
+                  <XLayout
+                    v-if="meshIdentities?.items?.length"
+                    data-testid="meshidentities-collection"
+                    class="about-subsection"
+                  >
+                    <h3>MeshIdentities</h3>
+                    <XLayout size="small">
+                      <XLayout type="separated">
+                        <template
+                          v-for="identity in meshIdentities.items"
+                          :key="identity.name"
+                        >
+                          <XAction
+                            :to="{
+                              name: 'mesh-identity-summary-view',
+                              params: {
+                                name: identity.name.toLocaleLowerCase(),
+                              },
+                            }"
+                          >
+                            <XBadge appearance="info">
+                              {{ identity.name }}
+                            </XBadge>
+                          </XAction>
+                        </template>
+                      </XLayout>
+                    </XLayout>
+                  </XLayout>
+                </XLayout>
+              </XAboutCard>
+
+              <XCard>
+                <XLayout
+                  type="columns"
+                  class="columns-with-borders"
                 >
                   <ResourceStatus
-                    :total="Object.entries(data?.resources || {}).reduce((prev, [key, { total }]) => {
-                      return (policyTypes || []).includes(key) ? prev + total : prev
-                    }, 0)"
-                    data-testid="policies-status"
+                    :total="data?.services.total ?? 0"
+                    data-testid="services-status"
                   >
                     <template #title>
-                      {{ t('meshes.detail.policies') }}
+                      {{ t('meshes.detail.services') }}
                     </template>
                   </ResourceStatus>
-                </template>
-              </DataSource>
-            </XLayout>
-          </XCard>
 
-          <XCard>
-            <XLayout>
-              <XLayout
-                type="separated"
-                justify="end"
-              >
-                <div
-                  v-for="options in [['universal', 'k8s']]"
-                  :key="typeof options"
-                >
-                  <XSelect
-                    :label="t('meshes.routes.item.format')"
-                    :selected="route.params.environment"
-                    @change="(value) => {
-                      route.update({ environment: value })
-                    }"
-                    @vue:before-mount="$event?.props?.selected && options.includes($event.props.selected) && $event.props.selected !== route.params.environment && route.update({ environment: $event.props.selected })"
+                  <ResourceStatus
+                    :total="data?.dataplanesByType.standard.total ?? 0"
+                    :online="data?.dataplanesByType.standard.online ?? 0"
+                    data-testid="data-plane-proxies-status"
+                  >
+                    <template #title>
+                      {{ t('meshes.detail.data_plane_proxies') }}
+                    </template>
+                  </ResourceStatus>
+
+                  <DataSource
+                    :src="uri(policySources, '/policy-types', {})"
+                    v-slot="{ data: resources }"
                   >
                     <template
-                      v-for="value in options"
-                      :key="value"
-                      #[`${value}-option`]
+                      v-for="policyTypes in [resources?.policyTypes.map(item => item.name)]"
+                      :key="typeof policyTypes"
                     >
-                      {{ t(`meshes.routes.item.formats.${value}`) }}
+                      <ResourceStatus
+                        :total="Object.entries(data?.resources || {}).reduce((prev, [key, { total }]) => {
+                          return (policyTypes || []).includes(key) ? prev + total : prev
+                        }, 0)"
+                        data-testid="policies-status"
+                      >
+                        <template #title>
+                          {{ t('meshes.detail.policies') }}
+                        </template>
+                      </ResourceStatus>
                     </template>
-                  </XSelect>
-                </div>
-              </XLayout>
+                  </DataSource>
+                </XLayout>
+              </XCard>
 
-              <template v-if="route.params.environment === 'universal'">
-                <XCodeBlock
-                  data-testid="codeblock-yaml-universal"
-                  language="yaml"
-                  :code="YAML.stringify(props.mesh.config)"
-                />
-              </template>
+              <XCard>
+                <XLayout>
+                  <XLayout
+                    type="separated"
+                    justify="end"
+                  >
+                    <div
+                      v-for="options in [['universal', 'k8s']]"
+                      :key="typeof options"
+                    >
+                      <XSelect
+                        :label="t('meshes.routes.item.format')"
+                        :selected="route.params.environment"
+                        @change="(value) => {
+                          route.update({ environment: value })
+                        }"
+                        @vue:before-mount="$event?.props?.selected && options.includes($event.props.selected) && $event.props.selected !== route.params.environment && route.update({ environment: $event.props.selected })"
+                      >
+                        <template
+                          v-for="value in options"
+                          :key="value"
+                          #[`${value}-option`]
+                        >
+                          {{ t(`meshes.routes.item.formats.${value}`) }}
+                        </template>
+                      </XSelect>
+                    </div>
+                  </XLayout>
 
-              <template v-else>
-                <DataLoader
-                  :src="uri(sources, '/meshes/:name/as/kubernetes', {
-                    name: route.params.mesh,
-                  })"
-                  v-slot="{ data: k8sConfig }"
-                >
-                  <XCodeBlock
-                    data-testid="codeblock-yaml-k8s"
-                    language="yaml"
-                    :code="YAML.stringify(k8sConfig)"
-                  />
-                </DataLoader>
-              </template>
+                  <template v-if="route.params.environment === 'universal'">
+                    <XCodeBlock
+                      data-testid="codeblock-yaml-universal"
+                      language="yaml"
+                      :code="YAML.stringify(props.mesh.config)"
+                    />
+                  </template>
+
+                  <template v-else>
+                    <DataLoader
+                      :src="uri(sources, '/meshes/:name/as/kubernetes', {
+                        name: route.params.mesh,
+                      })"
+                      v-slot="{ data: k8sConfig }"
+                    >
+                      <XCodeBlock
+                        data-testid="codeblock-yaml-k8s"
+                        language="yaml"
+                        :code="YAML.stringify(k8sConfig)"
+                      />
+                    </DataLoader>
+                  </template>
+                </XLayout>
+              </XCard>
             </XLayout>
-          </XCard>
-        </XLayout>
-      </AppView>
+
+            <RouterView
+              v-slot="child"
+            >
+              <SummaryView
+                v-if="child.route.name !== route.name"
+                @close="route.replace({
+                  name: 'mesh-detail-view',
+                  params: {
+                    mesh: route.params.mesh,
+                  },
+                  query: {
+                    environment: route.params.environment,
+                  },
+                })"
+              >
+                <component
+                  :is="child.Component"
+                  :mesh-identities="meshIdentities?.items"
+                />
+              </SummaryView>
+            </RouterView>
+          </DataLoader>
+        </AppView>
+      </DataSource>
     </DataSource>
   </RouteView>
 </template>
@@ -225,9 +292,25 @@ import { sources } from '../sources'
 import { YAML } from '@/app/application'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import ResourceStatus from '@/app/common/ResourceStatus.vue'
-import { sources as PolicySources } from '@/app/policies/sources'
+import SummaryView from '@/app/common/SummaryView.vue'
+import { sources as policySources } from '@/app/policies/sources'
+import { sources as resourceSources } from '@/app/resources/sources'
 
 const props = defineProps<{
   mesh: Mesh
 }>()
 </script>
+<style lang="scss" scoped>
+.about-subsection {
+  border-top: $kui-border-width-10 solid $kui-color-border;
+  padding-top: $kui-space-70;
+}
+
+:deep(.about-section .about-section-content) {
+  display: block !important;
+
+  h3 {
+    color: $kui-color-text;
+  }
+}
+</style>

--- a/packages/kuma-gui/src/app/resources/data/MeshIdentity.ts
+++ b/packages/kuma-gui/src/app/resources/data/MeshIdentity.ts
@@ -1,0 +1,21 @@
+import type { components } from '@kumahq/kuma-http-api'
+
+type PartialMeshIdentityList = components['responses']['MeshIdentityList']['content']['application/json']
+type PartialMeshIdentity = components['schemas']['MeshIdentityItem']
+
+export const MeshIdentity = {
+  fromObject: (item: PartialMeshIdentity) => {
+    return {
+      ...item,
+    }
+  },
+  
+  fromCollection: (collection: PartialMeshIdentityList) => {
+    return {
+      ...collection,
+      items: collection.items?.map((item) => MeshIdentity.fromObject(item)) ?? [],
+    }
+  },
+}
+
+export type MeshIdentity = ReturnType<typeof MeshIdentity.fromObject>

--- a/packages/kuma-gui/src/app/resources/index.ts
+++ b/packages/kuma-gui/src/app/resources/index.ts
@@ -1,0 +1,21 @@
+import { token } from '@kumahq/container'
+
+import { sources } from './sources'
+import type { ServiceDefinition } from '@kumahq/container'
+
+type Token = ReturnType<typeof token>
+type ResourcesSources = ReturnType<typeof sources>
+
+export const services = (app: Record<string, Token>): ServiceDefinition[] => {
+  return [
+    [token<ResourcesSources>('resources.sources'), {
+      service: sources,
+      arguments: [
+        app.api,
+      ],
+      labels: [
+        app.sources,
+      ],
+    }],
+  ]
+}

--- a/packages/kuma-gui/src/app/resources/routes.ts
+++ b/packages/kuma-gui/src/app/resources/routes.ts
@@ -1,0 +1,11 @@
+import type { RouteRecordRaw } from 'vue-router'
+
+export const meshIdentityRoutes = (): RouteRecordRaw[] => {
+  return [
+    {
+      path: 'meshidentity/:name',
+      name: 'mesh-identity-summary-view',
+      component: () => import('@/app/resources/views/MeshIdentitySummaryView.vue'),
+    },
+  ]
+}

--- a/packages/kuma-gui/src/app/resources/sources.ts
+++ b/packages/kuma-gui/src/app/resources/sources.ts
@@ -1,0 +1,62 @@
+import createClient from 'openapi-fetch'
+
+import { MeshIdentity } from './data/MeshIdentity'
+import { defineSources } from '@/app/application'
+import type KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
+import type { paths } from '@kumahq/kuma-http-api'
+
+export const sources = (api: KumaApi) => {
+  const http = createClient<paths>({
+    baseUrl: '',
+    fetch: api.client.fetch,
+  })
+  return defineSources({
+    '/meshes/:mesh/meshidentities': async (params) => {
+      const { mesh } = params
+  
+      const res = await http.GET('/meshes/{mesh}/meshidentities', {
+        params: {
+          path: {
+            mesh,
+          },
+        },
+      })
+  
+      return MeshIdentity.fromCollection(res.data!)
+    },
+
+    '/meshes/:mesh/meshidentities/:name': async (params) => {
+      const { mesh, name } = params
+  
+      const res = await http.GET('/meshes/{mesh}/meshidentities/{name}', {
+        params: {
+          path: {
+            mesh,
+            name,
+          },
+        },
+      })
+  
+      return MeshIdentity.fromObject(res.data!)
+    },
+
+    '/meshes/:mesh/meshidentities/:name/as/kubernetes': async (params) => {
+      const { mesh, name } = params
+  
+      const res = await http.GET('/meshes/{mesh}/meshidentities/{name}', {
+        params: {
+          path: {
+            mesh,
+            name,
+          },
+          // @ts-ignore
+          query: {
+            format: 'kubernetes',
+          },
+        },
+      })
+  
+      return MeshIdentity.fromObject(res.data!)
+    },
+  })
+}

--- a/packages/kuma-gui/src/app/resources/views/MeshIdentitySummaryView.vue
+++ b/packages/kuma-gui/src/app/resources/views/MeshIdentitySummaryView.vue
@@ -1,0 +1,84 @@
+<template>
+  <RouteView
+    name="mesh-identity-summary-view"
+    :params="{
+      mesh: '',
+      name: '',
+      environment: String,
+    }"
+    v-slot="{ route, t, uri }"
+  >
+    <DataCollection
+      :items="props.meshIdentities"
+      :predicate="item => item.name.toLocaleLowerCase() === route.params.name"
+      v-slot="{ items }"
+    >
+      <AppView>
+        <template #title>
+          <h2>{{ items[0].name }}</h2>
+        </template>
+        <XLayout
+          type="separated"
+          justify="end"
+        >
+          <div
+            v-for="options in [['universal', 'k8s']]"
+            :key="typeof options"
+          >
+            <XSelect
+              :label="t('gateways.routes.item.format')"
+              :selected="route.params.environment"
+              @change="(value) => {
+                route.update({ environment: value })
+              }"
+              @vue:before-mount="$event?.props?.selected && options.includes($event.props.selected) && $event.props.selected !== route.params.environment && route.update({ environment: $event.props.selected })"
+            >
+              <template
+                v-for="value in options"
+                :key="value"
+                #[`${value}-option`]
+              >
+                {{ t(`gateways.routes.item.formats.${value}`) }}
+              </template>
+            </XSelect>
+          </div>
+        </XLayout>
+        <template v-if="route.params.environment === 'universal'">
+          <XCodeBlock
+            language="yaml"
+            :code="YAML.stringify(items[0])"
+          />
+        </template>
+        <template v-else>
+          <DataLoader
+            :src="uri(sources, '/meshes/:mesh/meshidentities/:name/as/kubernetes', {
+              mesh: route.params.mesh,
+              name: route.params.name,
+            })"
+            v-slot="{ data: k8sYaml }"
+          >
+            <XCodeBlock
+              language="yaml"
+              :code="YAML.stringify(k8sYaml)"
+            />
+          </DataLoader>
+        </template>
+      </AppView>
+    </DataCollection>
+  </RouteView>
+</template>
+
+<script lang="ts" setup>
+import type { MeshIdentity } from '../data/MeshIdentity'
+import { YAML } from '@/app/application'
+import { sources } from '@/app/resources/sources'
+
+const props = defineProps<{
+  meshIdentities: MeshIdentity[]
+}>()
+</script>
+<style scoped>
+h2::before {
+  --icon-before: url('@/assets/images/policy.svg?inline') !important;
+}
+</style>

--- a/packages/kuma-gui/src/app/service-mesh/index.ts
+++ b/packages/kuma-gui/src/app/service-mesh/index.ts
@@ -5,6 +5,7 @@ import { services as controlPlanes } from '@/app/control-planes'
 import { services as hostnameGenerators } from '@/app/hostname-generators'
 import { services as me } from '@/app/me'
 import { services as meshes } from '@/app/meshes'
+import { services as resources } from '@/app/resources'
 import X from '@/app/x'
 import { services as zones } from '@/app/zones'
 import type { ServiceDefinition, Token } from '@kumahq/container'
@@ -31,5 +32,6 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     ...zones(app),
     ...meshes(app),
     ...hostnameGenerators(app),
+    ...resources(app),
   ]
 }

--- a/packages/kuma-gui/src/test-support/FakeKuma.ts
+++ b/packages/kuma-gui/src/test-support/FakeKuma.ts
@@ -480,6 +480,16 @@ gbXR5RnEs0hDxugaIknJMKk1b0g=
   contextualKri({ context, name }: { context: string, name: string }) {
     return `self_${context}_${name}`
   }
+
+  spiffeId(options: Partial<{ mesh: string, namespace: string, k8sNamespace: string, sa: string }>) {
+    const {
+      mesh = this.faker.word.noun(),
+      namespace = this.faker.word.noun(),
+      k8sNamespace = this.k8s.namespace(),
+      sa = this.faker.word.noun(),
+    } = options
+    return `spiffe://${mesh}.${namespace}.mesh.local/ns/${k8sNamespace}/sa/${sa}`
+  }
 }
 
 export default class FakeKuma extends Faker {

--- a/packages/kuma-gui/src/test-support/index.ts
+++ b/packages/kuma-gui/src/test-support/index.ts
@@ -1,4 +1,4 @@
-import { en } from '@faker-js/faker'
+import { base, en } from '@faker-js/faker'
 
 import FakeKuma from './FakeKuma'
 import type { RestRequest, MockResponder, FS as FakeFS } from '@kumahq/fake-api'
@@ -79,7 +79,7 @@ export type EndpointDependencies = {
   env: (key: Parameters<Env['var']>[0] | MockEnvKeys, d: string) => string
 }
 export const dependencies = {
-  fake: new FakeKuma({ locale: en }),
+  fake: new FakeKuma({ locale: [base, en] }),
   pager,
   env: <T extends string = Parameters<Env['var']>[0] | MockEnvKeys>(_key: T, d = '') => d,
 }

--- a/packages/kuma-gui/src/test-support/mocks/fs.ts
+++ b/packages/kuma-gui/src/test-support/mocks/fs.ts
@@ -62,6 +62,8 @@ import _134 from './src/meshes/_/meshgateways/test-meshgateway/_'
 import _135 from './src/meshes/_/meshgateways/test-meshgateway/_rules'
 import _132 from './src/meshes/_/meshhttproutes'
 import _133 from './src/meshes/_/meshhttproutes/_'
+import _241 from './src/meshes/_/meshidentities/_'
+import _242 from './src/meshes/_/meshidentities/_/_.ts'
 import _140 from './src/meshes/_/meshmultizoneservices'
 import _141 from './src/meshes/_/meshmultizoneservices/_'
 import _171 from './src/meshes/_/meshmultizoneservices/_/_hostnames'
@@ -187,6 +189,8 @@ export const fs: FS = {
   '/meshes/:mesh/dataplanes/:name/_policies': _233,
   // resources
   '/_resources': _3,
+  '/meshes/:mesh/meshidentities': _241,
+  '/meshes/:mesh/meshidentities/:name': _242,
   // legacy mesh
   '/meshes/:mesh/service-insights': _25,
   '/meshes/:mesh/service-insights/:name': _26,

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshidentities/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshidentities/_.ts
@@ -1,0 +1,93 @@
+import { components } from '@kumahq/kuma-http-api'
+
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+
+export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
+  const params = req.params
+  const mesh = params.mesh as string
+  const itemsCount = fake.number.int({ min: 1, max: 3 })
+  return {
+    headers: {},
+    body: {
+      items: Array.from({ length: itemsCount }, () => ({
+        type: 'MeshIdentity',
+        mesh,
+        name: fake.word.noun(),
+        labels: {
+          'kuma.io/mesh': mesh,
+          'kuma.io/zone': fake.word.noun(),
+          'kuma.io/origin': 'zone',
+          'kuma.io/namespace': fake.word.noun(),
+        },
+        creationTime: fake.date.past().toISOString(),
+        modificationTime: fake.date.recent().toISOString(),
+        spec: {
+          provider: {
+            bundled: {
+              autogenerate: {
+                enabled: fake.datatype.boolean(),
+              },
+              ca: {
+                certificate: {
+                  envVar: {
+                    name: fake.word.noun() + '-cert',
+                  },
+                  file: {
+                    path: `${fake.system.directoryPath()}/${fake.system.commonFileName('crt')}`,
+                  },
+                  insecureInline: {
+                    value: fake.word.noun(),
+                  },
+                  secretRef: {
+                    kind: 'Secret',
+                    name: fake.word.noun(),
+                  },
+                  type: fake.helpers.arrayElement(['File', 'Secret', 'EnvVar', 'InsecureInline']),
+                },
+                privateKey: {
+                  envVar: {
+                    name: fake.word.noun(),
+                  },
+                  file: {
+                    path: `${fake.system.directoryPath()}/${fake.system.commonFileName('key')}`,
+                  },
+                  insecureInline: {
+                    value: fake.word.noun(),
+                  },
+                  secretRef: {
+                    kind: 'Secret',
+                    name: fake.word.noun(),
+                  },
+                  type: fake.helpers.arrayElement(['File', 'Secret', 'EnvVar', 'InsecureInline']),
+                },
+              },
+              certificateParameters: {
+                expiry: fake.date.soon().toISOString(),
+              },
+              insecureAllowSelfSigned: fake.datatype.boolean(),
+              meshTrustCreation: fake.helpers.arrayElement(['Enabled', 'Disabled']),
+            },
+            spire: {
+              agent: {
+                timeout: '1s',
+              },
+            },
+            type: fake.helpers.arrayElement(['Bundled', 'Spire']),
+          },
+          selector: {
+            dataplane: {
+              matchLabels: {
+                'kuma.io/mesh': mesh,
+                'kuma.io/zone': fake.word.noun(),
+              },
+            },
+          },
+          spiffeID: {
+            path: fake.kuma.spiffeId({ mesh }),
+            trustDomain: fake.word.noun(),
+          },
+        },
+      }) satisfies components['schemas']['MeshIdentityItem']),
+    },
+  }
+}

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshidentities/_/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshidentities/_/_.ts
@@ -1,0 +1,97 @@
+import { components } from '@kumahq/kuma-http-api'
+
+import type { EndpointDependencies, MockResponder } from '@/test-support'
+
+export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
+  const params = req.params
+  const mesh = params.mesh as string
+  const k8s = req.url.searchParams.get('format') === 'kubernetes'
+  return {
+    headers: {},
+    body: {
+      ...(k8s && { apiVersion: 'kuma.io/v1alpha1' }),
+      ...(k8s ? { kind: 'MeshIdentity' } : { type: 'MeshIdentity' }),
+      ...((() => {
+        const metadata = {
+          name: fake.word.noun(),
+          labels: {
+            'kuma.io/mesh': mesh,
+            'kuma.io/zone': fake.word.noun(),
+            'kuma.io/origin': 'zone',
+            'kuma.io/namespace': fake.word.noun(),
+          }}
+        return k8s ? { metadata } : metadata
+      })()),
+      ...(!k8s && {
+        creationTime: fake.date.past().toISOString(),
+        modificationTime: fake.date.recent().toISOString(),
+      }),
+      spec: {
+        provider: {
+          bundled: {
+            autogenerate: {
+              enabled: fake.datatype.boolean(),
+            },
+            ca: {
+              certificate: {
+                envVar: {
+                  name: fake.word.noun() + '-cert',
+                },
+                file: {
+                  path: `${fake.system.directoryPath()}/${fake.system.commonFileName('crt')}`,
+                },
+                insecureInline: {
+                  value: fake.word.noun(),
+                },
+                secretRef: {
+                  kind: 'Secret',
+                  name: fake.word.noun(),
+                },
+                type: fake.helpers.arrayElement(['File', 'Secret', 'EnvVar', 'InsecureInline']),
+              },
+              privateKey: {
+                envVar: {
+                  name: fake.word.noun(),
+                },
+                file: {
+                  path: `${fake.system.directoryPath()}/${fake.system.commonFileName('key')}`,
+                },
+                insecureInline: {
+                  value: fake.word.noun(),
+                },
+                secretRef: {
+                  kind: 'Secret',
+                  name: fake.word.noun(),
+                },
+                type: fake.helpers.arrayElement(['File', 'Secret', 'EnvVar', 'InsecureInline']),
+              },
+            },
+            certificateParameters: {
+              expiry: fake.date.soon().toISOString(),
+            },
+            insecureAllowSelfSigned: fake.datatype.boolean(),
+            meshTrustCreation: fake.helpers.arrayElement(['Enabled', 'Disabled']),
+          },
+          spire: {
+            agent: {
+              timeout: '1s',
+            },
+          },
+          type: fake.helpers.arrayElement(['Bundled', 'Spire']),
+        },
+        selector: {
+          dataplane: {
+            matchLabels: {
+              'kuma.io/mesh': mesh,
+              'kuma.io/zone': fake.word.noun(),
+            },
+          },
+        },
+        spiffeID: {
+          path: fake.kuma.spiffeId({ mesh }),
+          trustDomain: fake.word.noun(),
+        },
+      } satisfies components['schemas']['MeshIdentityItem']['spec'],
+    },
+  }
+}


### PR DESCRIPTION
In order to show the user `MeshIdentity` resources I've added a collection (as badges) to the mesh about section. If there are no `MeshIdentity` resource the section is hidden.
Each item of the collection is clickable and opens a summary tray which shows the config of the `MeshIdentity`.

---

Since `MeshIdentity` is a more or less decoupled resource, I've added it to the `resources` folder so it could be used in any sub-route of a mesh.

<img width="1414" height="235" alt="image" src="https://github.com/user-attachments/assets/82d26ec2-7ee5-49aa-8c83-cb76afbc1bd5" />
<img width="1658" height="1338" alt="image" src="https://github.com/user-attachments/assets/a946f2f0-430f-465c-9cc3-18c088e405c0" />

Closes https://github.com/kumahq/kuma-gui/issues/4158
