### PR TITLE
feat(mesh-service): show identities listing

### DIFF
--- a/packages/kuma-gui/features/mesh/services/mesh-services/Item.feature
+++ b/packages/kuma-gui/features/mesh/services/mesh-services/Item.feature
@@ -8,6 +8,7 @@ Feature: mesh / mesh-services / item
       | config-universal   | [data-testid='codeblock-yaml-universal']       |
       | config-k8s         | [data-testid='codeblock-yaml-k8s']             |
       | select-environment | [data-testid='select-input']                   |
+      | identities         | [data-testid='mesh-service-identities']        |
 
   Scenario: The dataplane table exists
     Given the environment
@@ -48,3 +49,21 @@ Feature: mesh / mesh-services / item
     When I click the "[data-testid='select-item-k8s'] button" element
     Then the "$config-k8s" element exists
     And the URL contains "?environment=k8s"
+
+  Scenario: Shows identities in the table
+    Given the URL "/meshes/default/meshservices/firewall-1" responds with
+      """
+      body:
+        spec:
+          identities:
+            - type: ServiceTag
+              value: firewall-1-tag
+            - type: SpiffeID
+              value: spiffe://kuma.io/ns/firewall-app/sa/firewall-1
+      """
+    When I visit the "/meshes/default/services/mesh-services/firewall-1/overview" URL
+    Then the "$identities" element exists
+    And the "$identities" element contains "firewall-1-tag"
+    And the "$identities" element contains "ServiceTag"
+    And the "$identities" element contains "spiffe://kuma.io/ns/firewall-app/sa/firewall-1" 
+    And the "$identities" element contains "SpiffeID"

--- a/packages/kuma-gui/src/app/services/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/services/locales/en-us/index.yaml
@@ -62,6 +62,10 @@ services:
       title: Hostnames
       hostname: Hostname
       zone: Zone
+    identities:
+      title: Identities
+      identity: Identity
+      type: Type
   href:
     docs: '{KUMA_DOCS_URL}/introduction/architecture/?{KUMA_UTM_QUERY_PARAMS}#services-and-pods'
   internal-service:

--- a/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceDetailView.vue
@@ -193,6 +193,46 @@
           </DataLoader>
         </XCard>
 
+        <XCard
+          v-if="props.data.spec.identities?.length"
+          data-testid="mesh-service-identities"
+        >
+          <template #title>
+            {{ t('services.detail.identities.title') }}
+          </template>
+          <DataCollection
+            type="mesh-identities"
+            :items="data.spec.identities ?? []"
+          >
+            <AppCollection
+              type="mesh-identities-collection"
+              :items="data.spec.identities ?? []"
+              :headers="[
+                { ...me.get('headers.identity'), label: t('services.detail.identities.identity'), key: 'identity' },
+                { ...me.get('headers.type'), label: t('services.detail.identities.type'), key: 'type' },
+              ]"
+              @resize="me.set"
+            >
+              <template #identity="{ row: item }">
+                <b>
+                  <XCopyButton
+                    :text="item.value"
+                  />
+                </b>
+              </template>
+              <template #type="{ row: item }">
+                <XLayout type="separated">
+                  <XBadge
+                    appearance="decorative"
+                  >
+                    {{ item.type }}
+                  </XBadge>
+                </XLayout>
+              </template>
+            </AppCollection>
+          </DataCollection>
+        </XCard>
+
         <XCard>
           <template #title>
             {{ t('services.detail.dpp-status.title') }}


### PR DESCRIPTION
A `MeshService` can now include `spec.identities` which are now being shown on the `MeshService` detail view below the hostnames listing.

Requires
- https://github.com/kumahq/kuma-gui/pull/4162
- ...

Closes https://github.com/kumahq/kuma-gui/issues/4160