### PR TITLE
feat(data-planes): add back passthrough to traffic outbounds

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -36,7 +36,7 @@
               // 'self_inbound' can be used as socket address to filter the stats as the contextual kri of an inbound always starts with 'self_inbound'
               socketAddress: 'self_inbound',
             })"
-            v-slot="{ data: traffic, refresh: refreshTraffic }"
+            v-slot="{ data: traffic, error: trafficError, refresh: refreshTraffic }"
           >
             <DataLoader
               :data="[dataplaneLayout, dataplanePolicies, policyTypesData, traffic]"
@@ -592,8 +592,18 @@
                         <!-- we don't want to show an error here -->
                         <!-- instead we show a No Data EmptyState -->
                         <template
-                          v-if="typeof error === 'undefined' && dataplaneLayout?.outbounds.length"
+                          v-if="typeof error === 'undefined' && typeof trafficError === 'undefined' && dataplaneLayout?.outbounds.length"
                         >
+                          <ConnectionGroup
+                            type="passthrough"
+                          >
+                            <ConnectionCard
+                              :protocol="`passthrough`"
+                              :traffic="traffic?.passthrough"
+                            >
+                              Non mesh traffic
+                            </ConnectionCard>
+                          </ConnectionGroup>
                           <DataCollection
                             type="outbounds"
                             :items="dataplaneLayout?.outbounds"


### PR DESCRIPTION
Until we've added the traffic listing back in https://github.com/kumahq/kuma-gui/pull/4139 we missed to add back the passthrough, which is what I'm doing here.

Part of https://github.com/kumahq/kuma-gui/issues/3736