### PR TITLE
fix(i18n): type augmentation may be processed too late

### DIFF
--- a/packages/kuma-gui/src/app/application/services/i18n/I18n.ts
+++ b/packages/kuma-gui/src/app/application/services/i18n/I18n.ts
@@ -3,12 +3,7 @@ import { semver } from '@kumahq/config/utils'
 
 import { get } from '@/app/application'
 import type { Env } from '@kumahq/settings/env'
-
-declare module 'intl-messageformat' {
-  interface Options {
-    defaultMessage: string
-  }
-}
+import './i18n.d'
 
 interface I18nRecord {
   [key: string]: I18nRecord | string

--- a/packages/kuma-gui/src/app/application/services/i18n/i18n.d.ts
+++ b/packages/kuma-gui/src/app/application/services/i18n/i18n.d.ts
@@ -1,0 +1,5 @@
+declare module 'intl-messageformat' {
+  interface Options {
+    defaultMessage: string
+  }
+}


### PR DESCRIPTION
It can happen that the module augmentation is not fully processed when we use it. Moving it to a declaration file ensures that it's always processed early in the compilation.
There were two options:

1. Import the declaration file
2. Reference the declaration file in the `tsconfig.json` `types` field.

I went for option 1 as we only need it in this one place. If we'd need it globally or in more files it would be better to add it to the `tsconfig` and potentially add the module augmentation to a global `index.d.ts` file that we can reference in the `types` field. With option 1 everything around `i18n` is in one place and easier to maintain.