### PR TITLE
feat(data-planes): check for mesh-services mode to use unified-naming

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsBuiltinGateway.feature
@@ -12,6 +12,7 @@ Feature: Dataplane details for built-in gateway
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       """
 
   Scenario: Overview tab has expected content

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsDelegatedGateway.feature
@@ -9,6 +9,7 @@ Feature: Dataplane details for delegated gateway
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       """
 
   Scenario: Overview tab has expected content

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsStandardProxy.feature
@@ -12,6 +12,7 @@ Feature: Dataplane details for standard Data Plane Proxy
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       """
 
   Scenario: Overview tab has expected content

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneDetailsTraffic.feature
@@ -9,6 +9,7 @@ Feature: mesh / dataplanes / DataplaneDetailsTraffic
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       """
 
   Scenario: Dataplane Details Traffic shows expected content

--- a/packages/kuma-gui/features/mesh/dataplanes/DataplaneSummary.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/DataplaneSummary.feature
@@ -14,6 +14,7 @@ Feature: Dataplane summary
       """
       KUMA_SUBSCRIPTION_COUNT: 2
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       """
     And the URL "/meshes/default/dataplanes/_overview" responds with
       """

--- a/packages/kuma-gui/features/mesh/dataplanes/Navigation.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Navigation.feature
@@ -11,6 +11,7 @@ Feature: mesh / dataplanes / navigation
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       KUMA_DATAPLANE_COUNT: 1
       """
 

--- a/packages/kuma-gui/features/mesh/dataplanes/NoSubscriptions.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/NoSubscriptions.feature
@@ -8,6 +8,7 @@ Feature: dataplanes / no-subscriptions
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       KUMA_SUBSCRIPTION_COUNT: 0
       KUMA_DATAPLANEINBOUND_COUNT: 1
       """

--- a/packages/kuma-gui/features/mesh/dataplanes/Subscriptions.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Subscriptions.feature
@@ -12,6 +12,7 @@ Feature: dataplanes / subscriptions
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       KUMA_SUBSCRIPTION_COUNT: 1
       KUMA_DATAPLANEINBOUND_COUNT: 1
       """

--- a/packages/kuma-gui/features/mesh/dataplanes/Warnings.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Warnings.feature
@@ -12,6 +12,7 @@ Feature: mesh / dataplanes / warnings
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       """
 
   Scenario: With a certificate expires soon (at least 1 week before) a cert warning is shown

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/Policies.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/Policies.feature
@@ -7,6 +7,7 @@ Feature: mesh / dataplanes / connections / Traffic
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       """
 
   Scenario: The dataplane about section contains expected content

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/Traffic.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/Traffic.feature
@@ -9,6 +9,7 @@ Feature: mesh / dataplanes / connections / Traffic
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       KUMA_DATAPLANEINBOUND_COUNT: 1
       KUMA_DATAPLANEOUTBOUND_COUNT: 1
       KUMA_DATAPLANE_TYPE: standard

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Clusters.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Clusters.feature
@@ -4,6 +4,7 @@ Feature: mesh / dataplanes / connections / clusters
     Given the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       """
 
   Scenario: The inbound clusters tab correctly filters by contextual KRI

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Inbound.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Inbound.feature
@@ -9,6 +9,7 @@ Feature: mesh / dataplanes / overview / summary / Inbound
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       KUMA_DATAPLANEINBOUND_COUNT: 1
       KUMA_DATAPLANE_TYPE: standard
       """

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Outbound.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Outbound.feature
@@ -9,6 +9,7 @@ Feature: mesh / dataplanes / overview / summary / Outbound
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       KUMA_DATAPLANE_TYPE: standard
       """
 

--- a/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Policy.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/summary/Policy.feature
@@ -8,6 +8,7 @@ Feature: mesh / dataplanes / connections / Traffic
     And the environment
       """
       KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: true
+      KUMA_MESHSERVICE_MODE: Exclusive
       """
 
   Scenario: The dataplane about section contains expected content

--- a/packages/kuma-gui/src/app/data-planes/features.ts
+++ b/packages/kuma-gui/src/app/data-planes/features.ts
@@ -9,8 +9,5 @@ export const features = (_env: Env['var']): Features => {
       return ('transparentProxying' in dataplaneOverview.dataplane.networking) ||
         new Set(dataplaneOverview.dataplaneInsight.metadata.features).intersection(new Set(['feature-transparent-proxy-in-dataplane-metadata', 'bind-outbounds'])).size > 0
     },
-    'use unified-resource-naming': (_can, dataplaneOverview: DataplaneOverview) => {
-      return dataplaneOverview.dataplaneInsight.metadata.features.includes('feature-unified-resource-naming')
-    },
   }
 }

--- a/packages/kuma-gui/src/app/legacy-data-planes/features.ts
+++ b/packages/kuma-gui/src/app/legacy-data-planes/features.ts
@@ -1,4 +1,5 @@
 import type { DataplaneOverview } from '@/app/legacy-data-planes/data'
+import type { Mesh } from '@/app/meshes/data'
 import type { Features } from '@kumahq/settings/can'
 import type { Env } from '@kumahq/settings/env'
 export const features = (_env: Env['var']): Features => {
@@ -9,8 +10,8 @@ export const features = (_env: Env['var']): Features => {
       return ('transparentProxying' in dataplaneOverview.dataplane.networking) ||
         new Set(dataplaneOverview.dataplaneInsight.metadata.features).intersection(new Set(['feature-transparent-proxy-in-dataplane-metadata', 'bind-outbounds'])).size > 0
     },
-    'use unified-resource-naming': (_can, dataplaneOverview: DataplaneOverview) => {
-      return dataplaneOverview.dataplaneType === 'standard' && dataplaneOverview.dataplaneInsight.metadata.features.includes('feature-unified-resource-naming')
+    'use unified-resource-naming': (_can, { dataPlaneOverview, mesh }: { dataPlaneOverview: DataplaneOverview, mesh: Mesh }) => {
+      return mesh.meshServices.mode === 'Exclusive' && dataPlaneOverview.dataplaneType === 'standard' && dataPlaneOverview.dataplaneInsight.metadata.features.includes('feature-unified-resource-naming')
     },
   }
 }

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneRouteGuard.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneRouteGuard.vue
@@ -13,6 +13,7 @@ import { RouteRecordRaw, useRouter } from 'vue-router'
 import { useCan } from '@/app/application'
 import { dataplaneRoutes } from '@/app/data-planes/routes'
 import { legacyDataplaneRoutes } from '@/app/legacy-data-planes/routes'
+import type { Mesh } from '@/app/meshes/data'
 import { DataPlaneOverview } from '@/types'
 
 const router = useRouter()
@@ -20,6 +21,7 @@ const can = useCan()
 
 const props = defineProps<{
   data: DataPlaneOverview
+  mesh: Mesh
 }>()
 
 const isRouteLoaded = ref<boolean | undefined>(undefined)
@@ -59,7 +61,7 @@ const addRouteName = (item: RouteRecordRaw) => {
 
 router.beforeResolve(async (to, _from, next) => {
   if(
-    !can('use unified-resource-naming', props.data) &&
+    !can('use unified-resource-naming', { dataPlaneOverview: props.data, mesh: props.mesh }) &&
     ['data-plane-policy-config-summary-view'].includes(to.name as string)
   ) {
     next({ name: 'app-not-found-view' })
@@ -74,7 +76,7 @@ watch(() => router.currentRoute.value.name, async (val) => {
     router.removeRoute('data-plane-detail-tabs-view')
     const _routes = walkRoutes(
       addRouteName,
-      can('use unified-resource-naming', props.data) ? dataplaneRoutes() : legacyDataplaneRoutes(),
+      can('use unified-resource-naming', { dataPlaneOverview: props.data, mesh: props.mesh }) ? dataplaneRoutes() : legacyDataplaneRoutes(),
     )
     router.addRoute('data-plane-root-view', _routes[0])
     await router.replace(router.currentRoute.value.fullPath)

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/RootView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/RootView.vue
@@ -16,6 +16,7 @@
     >
       <DataPlaneRouteGuard
         :data="data"
+        :mesh="props.mesh"
       >
         <RouterView v-slot="{ Component }">
           <component


### PR DESCRIPTION
We've noticed that when `meshServices.mode` is disabled on the mesh, we can't use `feature-unified-resource-naming`. Until this condition is fully considered on the backend, we are going to check for the `meshServices.mode` being set to `Exclusive`. The backend will work on exposing a new field `dataplaneInsights.features` which will either include the feature flag or not by taking into account if mesh services are enabled or not.