### PR TITLE
feat: remove entity-empty-state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2576,37 +2576,6 @@
         "vue-router": "^4.4.5"
       }
     },
-    "node_modules/@kong-ui-public/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@kong-ui-public/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-QAuFbuprcsRWSyrgBH/wg0CM07PZes4xAFz5Szij54rECKCfHx8QrBMvk4iD5llhZOC1OwgdKcu2kuqnEcAfhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "date-fns": "^4.1.0"
-      },
-      "peerDependencies": {
-        "axios": "^1.11.0",
-        "vue": "^3.5.12"
-      }
-    },
-    "node_modules/@kong-ui-public/entities-shared": {
-      "version": "3.27.6",
-      "resolved": "https://registry.npmjs.org/@kong-ui-public/entities-shared/-/entities-shared-3.27.6.tgz",
-      "integrity": "sha512-oRjW3X0PFd2Orfu4eECIqvxwhAesQEwxPa1R+L5m6kN6Ze3ELHPAbAzy+vgx0Trsr3Ey9+K3p/aoxVD4nPp7cA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@kong-ui-public/core": "^1.11.2",
-        "compare-versions": "^6.1.1"
-      },
-      "peerDependencies": {
-        "@kong-ui-public/i18n": "^2.4.4",
-        "@kong/icons": "^1.31.0",
-        "@kong/kongponents": "^9.34.2",
-        "axios": "^1.11.0",
-        "vue": ">= 3.3.13 < 4",
-        "vue-router": "^4.4.5"
-      }
-    },
     "node_modules/@kong-ui-public/i18n": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@kong-ui-public/i18n/-/i18n-2.4.4.tgz",
@@ -6269,6 +6238,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
       "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -8041,16 +8011,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {
@@ -10120,6 +10080,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=4.0"
@@ -14984,6 +14945,7 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/psl": {
@@ -19880,7 +19842,6 @@
       "dependencies": {
         "@gera2ld/tarjs": "^0.3.1",
         "@kong-ui-public/app-layout": "^4.6.3",
-        "@kong-ui-public/entities-shared": "^3.27.6",
         "@kong-ui-public/i18n": "^2.4.4",
         "@kong/icons": "^1.33.2",
         "@kong/kongponents": "^9.38.5",

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@gera2ld/tarjs": "^0.3.1",
     "@kong-ui-public/app-layout": "^4.6.3",
-    "@kong-ui-public/entities-shared": "^3.27.6",
     "@kong-ui-public/i18n": "^2.4.4",
     "@kong/icons": "^1.33.2",
     "@kong/kongponents": "^9.38.5",

--- a/packages/kuma-gui/src/app/meshes/components/MeshInsightsList.vue
+++ b/packages/kuma-gui/src/app/meshes/components/MeshInsightsList.vue
@@ -4,6 +4,12 @@
       :items="props.items"
       type="meshes"
     >
+      <template #empty>
+        <XEmptyState
+          type="meshes"
+          icon-background
+        />
+      </template>
       <AppCollection
         :headers="[
           { ...storage.get('mesh.headers.name') ,label: t('meshes.components.mesh-insights-list.name'), key: 'name'},

--- a/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
@@ -65,6 +65,12 @@
                 :total="data?.total"
                 @change="route.update"
               >
+                <template #empty>
+                  <XEmptyState
+                    type="meshes"
+                    icon-background
+                  />
+                </template>
                 <AppCollection
                   class="mesh-collection"
                   data-testid="mesh-collection"

--- a/packages/kuma-gui/src/app/x/components/x-empty-state/XEmptyState.vue
+++ b/packages/kuma-gui/src/app/x/components/x-empty-state/XEmptyState.vue
@@ -18,12 +18,13 @@
         ]"
         :key="title"
       >
-        <EntityEmptyState
+        <KEmptyState
+          :icon-background="props.iconBackground"
           :title="title"
           appearance="secondary"
           data-testid="empty-block"
         >
-          <template #image>
+          <template #icon>
             <slot
               v-if="slots.icon"
               name="icon"
@@ -70,7 +71,7 @@
             </template>
           </template>
           <template
-            #actions
+            #action
           >
             <slot name="action">
               <XTeleportSlot
@@ -91,7 +92,7 @@
               </XAction>
             </slot>
           </template>
-        </EntityEmptyState>
+        </KEmptyState>
       </template>
     </template>
   </XI18n>
@@ -100,12 +101,13 @@
 <script lang="ts" setup>
 import { KUI_COLOR_TEXT_DECORATIVE_AQUA, KUI_ICON_SIZE_40, KUI_ICON_SIZE_50 } from '@kong/design-tokens'
 import { LocationIcon, AnalyticsIcon, MeshIcon } from '@kong/icons'
-import { EntityEmptyState } from '@kong-ui-public/entities-shared'
 
 const props = withDefaults(defineProps<{
   type?: string
+  iconBackground?: boolean
 }>(), {
   type: '',
+  iconBackground: false,
 })
 const slots = defineSlots()
 
@@ -116,13 +118,7 @@ const iconMapping: Record<string, unknown> = {
 }
 </script>
 <style lang="scss" scoped>
-.empty-state-icon {
-  background-color: $kui-method-color-background-patch;
-  border-radius: $kui-border-radius-20;
-  padding: $kui-space-40;
-}
-
-.x-empty-state-title{
+.x-empty-state-title {
   font-size: $kui-font-size-50;
 }
 </style>

--- a/packages/kuma-gui/src/app/zones/components/ZoneControlPlanesList.vue
+++ b/packages/kuma-gui/src/app/zones/components/ZoneControlPlanesList.vue
@@ -6,6 +6,12 @@
       :items="props.items"
       :type="can('create zones') ? `zones-crud` : `zone-cps`"
     >
+      <template #empty>
+        <XEmptyState
+          :type="can('create zones') ? `zones-crud` : `zone-cps`"
+          icon-background
+        />
+      </template>
       <AppCollection
         :headers="[
           { ...storage.get('zone.headers.type'), label: '&nbsp;', key: 'type' },

--- a/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
@@ -72,6 +72,12 @@
                 :total="data?.total"
                 @change="route.update"
               >
+                <template #empty>
+                  <XEmptyState
+                    type="zone-cps"
+                    icon-background
+                  />
+                </template>
                 <AppCollection
                   class="zone-cp-collection"
                   data-testid="zone-cp-collection"

--- a/packages/kuma-gui/src/assets/styles/main.scss
+++ b/packages/kuma-gui/src/assets/styles/main.scss
@@ -6,4 +6,3 @@
 
 @import "@kong/kongponents/dist/style.css";
 @import "@kong-ui-public/app-layout/dist/style.css";
-@import "@kong-ui-public/entities-shared/dist/style.css";


### PR DESCRIPTION
We are able to remove `EntityEmptyState` and replace it back with `KEmptyState`. This also allows us to remove the dependency to `@kong-ui-public/entities-shared`.
Some icons in `KEmptyState` need a background. For these exceptions I've used the `#empty`-slot in the respective `DataCollection` (zones listing and meshes listing).