### PR TITLE
fix(e2e/tls): flake timing issue

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/overview/Tls.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/Tls.feature
@@ -12,10 +12,6 @@ Feature: mesh / dataplanes / overview / TLS
       """
 
   Scenario: The TLS section shows expected content
-    Given the environment
-      """
-      KUMA_DATAPLANE_TLS_ISSUED_MESHIDENTITY: true
-      """
     Given the URL "/meshes/default/dataplanes/backend/_overview" responds with
       """
       body:
@@ -30,10 +26,6 @@ Feature: mesh / dataplanes / overview / TLS
     And the "$tls-section" element doesn't contain "Supported CAs"
 
   Scenario: Clicking on issuedBackend KRI opens MeshIdentity summary
-    Given the environment
-      """
-      KUMA_DATAPLANE_TLS_ISSUED_MESHIDENTITY: true
-      """
     Given the URL "/meshes/default/dataplanes/backend/_overview" responds with
       """
       body:
@@ -42,5 +34,7 @@ Feature: mesh / dataplanes / overview / TLS
             issuedBackend: kri_mid_default_east_kuma-demo_identity-1_
       """
     When I visit the "/meshes/default/data-planes/backend/overview" URL
+    Then the "$tls-section" element exists
+    And I wait for 500 ms
     Then I click the "$tls-section a" element
     Then the URL contains "/meshes/default/data-planes/backend/overview/meshidentity/identity-1"


### PR DESCRIPTION
Again one of those scenarios where the click on the link happens too fast leading to the routing not being performed and the test fails. I've added a random `wait for 500 ms` to get around this issue.
Furthermore I've deduped the env variable `KUMA_DATAPLANE_TLS_ISSUED_MESHIDENTITY` as this is already set for all scenarios.