### PR TITLE
refactor(kri): simplify parsing kri

### DIFF
--- a/packages/kuma-gui/features/mesh/services/mesh-services/Item.feature
+++ b/packages/kuma-gui/features/mesh/services/mesh-services/Item.feature
@@ -65,5 +65,5 @@ Feature: mesh / mesh-services / item
     Then the "$identities" element exists
     And the "$identities" element contains "firewall-1-tag"
     And the "$identities" element contains "ServiceTag"
-    And the "$identities" element contains "spiffe://kuma.io/ns/firewall-app/sa/firewall-1" 
+    And the "$identities" element contains "spiffe://kuma.io/ns/firewall-app/sa/firewall-1"
     And the "$identities" element contains "SpiffeID"

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
@@ -26,7 +26,7 @@
         v-slot="{ data: connections, refresh }"
       >
         <template
-          v-for="prefix in ['proxyResourceName' in props.data ? ContextualKri.toString({ ...ContextualKri.fromString(props.data.proxyResourceName), sectionName: props.data.port.toString() }) : ('clusterName' in props.data ? props.data.clusterName : route.params.connection).replace('_', ':')]"
+          v-for="prefix in ['proxyResourceName' in props.data ? Kri.toString({ ...Kri.fromString(props.data.proxyResourceName), sectionName: props.data.port.toString() }) : ('clusterName' in props.data ? props.data.clusterName : route.params.connection).replace('_', ':')]"
           :key="typeof prefix"
         >
           <DataCollection
@@ -64,7 +64,7 @@
 <script lang="ts" setup>
 import { sources } from '../sources'
 import { DataplaneNetworkingLayout } from '@/app/data-planes/data'
-import { ContextualKri } from '@/app/kuma/kri'
+import { Kri } from '@/app/kuma/kri'
 import type { DataplaneInbound } from '@/app/legacy-data-planes/data'
 const props = defineProps<{
   routeName: string

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
@@ -76,7 +76,7 @@ import { computed } from 'vue'
 
 import { sources } from '../sources'
 import type { DataplaneNetworkingLayout } from '@/app/data-planes/data'
-import { ContextualKri } from '@/app/kuma/kri'
+import { Kri } from '@/app/kuma/kri'
 import type { DataplaneInbound, DataplaneNetworking } from '@/app/legacy-data-planes/data/'
 import type { ZoneEgress } from '@/app/zone-egresses/data/'
 import type { ZoneIngress } from '@/app/zone-ingresses/data/'
@@ -90,7 +90,7 @@ const props = defineProps<{
 
 const data = computed(() => ({
   ...props.data,
-  proxyResourceName: 'proxyResourceName' in props.data ? ContextualKri.toString({...ContextualKri.fromString(props.data.proxyResourceName), sectionName: props.data.port.toString() }) : '',
+  proxyResourceName: 'proxyResourceName' in props.data ? Kri.toString({...Kri.fromString(props.data.proxyResourceName), sectionName: props.data.port.toString() }) : '',
   listenerAddress: 'listenerAddress' in props.data ? props.data.listenerAddress : '',
   clusterName: 'clusterName' in props.data ? props.data.clusterName : '',
   port: 'port' in props.data ? props.data.port.toString() : '',

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
@@ -21,7 +21,7 @@
         :src="uri(sources, '/connections/xds/for/:proxyType/:name/:mesh/inbound/:inbound', {
           mesh: route.params.mesh || '*',
           name: route.params.proxy,
-          inbound: 'proxyResourceName' in props.data ? ContextualKri.toString({ ...ContextualKri.fromString(props.data.proxyResourceName), sectionName: props.data.port.toString() }) : `${props.data.port}`,
+          inbound: 'proxyResourceName' in props.data ? Kri.toString({ ...Kri.fromString(props.data.proxyResourceName), sectionName: props.data.port.toString() }) : `${props.data.port}`,
           proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress'})[route.params.proxyType] ?? 'dataplane',
         })"
         v-slot="{ data: raw, refresh }"
@@ -54,7 +54,7 @@
 <script lang="ts" setup>
 import { sources } from '../sources'
 import type { DataplaneNetworkingLayout } from '@/app/data-planes/data'
-import { ContextualKri } from '@/app/kuma/kri'
+import { Kri } from '@/app/kuma/kri'
 import type { DataplaneInbound } from '@/app/legacy-data-planes/data/'
 
 const props = defineProps<{

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
@@ -1,5 +1,6 @@
 import { components } from '@kumahq/kuma-http-api'
 
+import type { ContextualKriString, FullKriString } from '@/app/kuma/kri'
 import type {
   DataplaneGateway as PartialDataplaneGateway,
   DataplaneInbound as PartialDataplaneInbound,
@@ -31,6 +32,21 @@ export const DataplaneNetworkingLayout =  {
   fromObject(dataplaneNetworkingLayout: PartialDataplaneNetworkingLayout) {
     return {
       ...dataplaneNetworkingLayout,
+      kri: dataplaneNetworkingLayout.kri as FullKriString,
+      inbounds: dataplaneNetworkingLayout.inbounds.map((item) => {
+        return {
+          ...item,
+          kri: item.kri as FullKriString,
+          proxyResourceName: item.proxyResourceName as ContextualKriString,
+        }
+      }),
+      outbounds: dataplaneNetworkingLayout.outbounds.map((item) => {
+        return {
+          ...item,
+          kri: item.kri as FullKriString,
+          proxyResourceName: item.proxyResourceName as FullKriString,
+        }
+      }),
     } satisfies PartialDataplaneNetworkingLayout
   },
 }

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -341,7 +341,7 @@
                                 <template
                                   #body
                                 >
-                                  <template v-if="Kri.isKri(mTLS.issuedBackend)">
+                                  <template v-if="Kri.isKriString(mTLS.issuedBackend)">
                                     <XAction
                                       :to="{
                                         name: 'data-plane-mesh-identity-summary-view',
@@ -572,8 +572,8 @@
                                     <ConnectionCard
                                       data-testid="dataplane-inbound"
                                       :protocol="item.protocol"
-                                      :port-name="ContextualKri.fromString(item.proxyResourceName).sectionName"
-                                      :traffic="traffic?.inbounds[ContextualKri.toString({ ...ContextualKri.fromString(item.proxyResourceName), sectionName: item.port.toString() })]"
+                                      :port-name="Kri.fromString(item.proxyResourceName).sectionName"
+                                      :traffic="traffic?.inbounds[Kri.toString({ ...Kri.fromString(item.proxyResourceName), sectionName: item.port.toString() })]"
                                     >
                                       <XAction
                                         data-action
@@ -741,7 +741,7 @@ import ConnectionCard from '@/app/connections/components/connection-traffic/Conn
 import ConnectionGroup from '@/app/connections/components/connection-traffic/ConnectionGroup.vue'
 import ConnectionTraffic from '@/app/connections/components/connection-traffic/ConnectionTraffic.vue'
 import { sources as connectionSources } from '@/app/connections/sources'
-import { ContextualKri, Kri } from '@/app/kuma/kri'
+import { Kri } from '@/app/kuma/kri'
 import type { DataplaneOverview } from '@/app/legacy-data-planes/data'
 import type { Mesh } from '@/app/meshes/data'
 import { sources as policySources } from '@/app/policies/sources'

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -11,7 +11,7 @@
     <AppView>
       <XLayout type="stack">
         <template
-          v-for="inbound in [props.dataPlaneOverview.dataplane.networking.inbounds.find((item) => item.portName === ContextualKri.fromString(route.params.connection).sectionName && item.port === props.data.port)]"
+          v-for="inbound in [props.dataPlaneOverview.dataplane.networking.inbounds.find((item) => item.portName === Kri.fromString(route.params.connection).sectionName && item.port === props.data.port)]"
           :key="typeof inbound"
         >
           <div
@@ -217,7 +217,7 @@ import AccordionList from '@/app/common/AccordionList.vue'
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import TagList from '@/app/common/TagList.vue'
-import { ContextualKri, Kri } from '@/app/kuma/kri'
+import { Kri } from '@/app/kuma/kri'
 import { sources as policySources } from '@/app/policies/sources'
 
 const props = defineProps<{

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
@@ -9,7 +9,7 @@
     v-slot="{ route, t }"
   >
     <DataCollection
-      :items="props.data"
+      :items="[...props.data]"
       :predicate="(item) => `${item.proxyResourceName}` === route.params.connection"
       :find="true"
       v-slot="{ items }"

--- a/packages/kuma-gui/src/app/kuma/kri.spec.ts
+++ b/packages/kuma-gui/src/app/kuma/kri.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { Kri, ContextualKri } from './kri'
+import { Kri } from './kri'
 
 describe('kri', () => {
   test.each([
@@ -28,6 +28,17 @@ describe('kri', () => {
       },
     ],
     [
+      Kri.fromString(''),
+      {
+        shortName: '',
+        mesh: '',
+        zone: '',
+        namespace: '',
+        name: '',
+        sectionName: '',
+      },
+    ],
+    [
       Kri.toString({
         shortName: 'policy',
         mesh: 'mesh',
@@ -47,31 +58,35 @@ describe('kri', () => {
       }),
       'kri_policy__zone__name_section',
     ],
+    [
+      Kri.toString({}),
+      'kri______',
+    ],
 
     // ContextualKri
     [
-      ContextualKri.fromString('self_inbound_httpport'),
+      Kri.fromString('self_inbound_httpport'),
       {
         context: 'inbound',
         sectionName: 'httpport',
       },
     ],
     [
-      ContextualKri.fromString('self_transparentproxy_passthrough_inbound_ipv4'),
+      Kri.fromString('self_transparentproxy_passthrough_inbound_ipv4'),
       {
         context: 'transparentproxy_passthrough_inbound',
         sectionName: 'ipv4',
       },
     ],
     [
-      ContextualKri.toString({
+      Kri.toString({
         context: 'inbound',
         sectionName: '8080',
       }),
       'self_inbound_8080',
     ],
     [
-      ContextualKri.toString({
+      Kri.toString({
         context: 'transparentproxy_passthrough_inbound',
         sectionName: 'ipv6',
       }),
@@ -80,15 +95,15 @@ describe('kri', () => {
 
     // isKri
     [
-      Kri.isKri('kri_policy_mesh_zone_namespace_name_section'),
+      Kri.isKriString('kri_policy_mesh_zone_namespace_name_section'),
       true,
     ],
     [
-      Kri.isKri('not_a_kri'),
+      Kri.isKriString('not_a_kri'),
       false,
     ],
     [
-      Kri.isKri('kri_not_a_kri'),
+      Kri.isKriString('kri_not_a_kri'),
       false,
     ],
   ])('Kri methods produce expected output', (input, output) => {

--- a/packages/kuma-gui/src/app/kuma/kri.ts
+++ b/packages/kuma-gui/src/app/kuma/kri.ts
@@ -2,31 +2,25 @@
  * Examples: https://github.com/kumahq/kuma/blob/master/docs/madr/decisions/077-migrating-to-consistent-and-well-defined-naming-for-non-system-envoy-resources-and-stats.md#examples
  */
 
-export class Kri {
-  static fromString(kri: string) {
-    const parts = kri.split('_').slice(1)
-    return {
-      shortName: parts[0],
-      mesh: parts[1],
-      zone: parts[2],
-      namespace: parts[3],
-      name: parts[4],
-      sectionName: parts[5],
-    }
-  }
-
-  static toString(kri: Partial<ReturnType<typeof Kri.fromString>> ) {
-    const { shortName = '', mesh = '', zone = '', namespace = '', name = '', sectionName = '' } = kri
-    return `kri_${shortName}_${mesh}_${zone}_${namespace}_${name}_${sectionName}`
-  }
-
-  static isKri(kri: string) {
-    return kri.startsWith('kri_') && kri.split('_').length === 7
-  }
+export type ContextualKriString = `self_${string}_${string}`
+export type FullKriString = `kri_${string}_${string}_${string}_${string}_${string}_${string}`
+export type KriString = ContextualKriString | FullKriString
+export type ContextualKriObject = {
+  context: string
+  sectionName: string
 }
+export type FullKriObject = {
+  shortName: string
+  mesh: string
+  zone: string
+  namespace: string
+  name: string
+  sectionName: string
+}
+export type KriObject = ContextualKriObject | FullKriObject
 
-export class ContextualKri {
-  static fromString(kri: string) {
+class ContextualKri {
+  static fromString(kri: ContextualKriString) {
     const parts = kri.split('_').slice(1)
     const context = parts.slice(0, -1).join('_')
     return {
@@ -35,8 +29,56 @@ export class ContextualKri {
     }
   }
 
-  static toString(kri: ReturnType<typeof ContextualKri.fromString>) {
+  static isContextualKriString(kri: string): kri is ContextualKriString {
+    return kri.startsWith('self_')
+  }
+
+  static isContextualKriObject(kri: Partial<KriObject>): kri is ReturnType<typeof ContextualKri.fromString> {
+    return 'context' in kri && 'sectionName' in kri
+  }
+
+  static toString(kri: ReturnType<typeof ContextualKri.fromString>): ContextualKriString {
     const { context, sectionName } = kri
     return `self_${context}_${sectionName}`
+  }
+}
+
+export class Kri {
+  static fromString(kri: ContextualKriString): ContextualKriObject
+  static fromString(kri: FullKriString): FullKriObject
+  static fromString(kri: string): FullKriObject | ContextualKriObject
+  static fromString(kri: KriString) {
+    if(ContextualKri.isContextualKriString(kri)) return ContextualKri.fromString(kri)
+
+    const [
+      shortName = '',
+      mesh = '',
+      zone = '',
+      namespace = '',
+      name = '',
+      sectionName = '',
+    ] = kri.split('_').slice(1)
+
+    return {
+      shortName,
+      mesh,
+      zone,
+      namespace,
+      name,
+      sectionName,
+    }
+  }
+
+  static isKriString(kri: string): kri is FullKriString {
+    return kri.startsWith('kri_') && kri.split('_').length === 7
+  }
+
+  static toString(kri: Partial<ContextualKriObject>): ContextualKriString
+  static toString(kri: Partial<FullKriObject>): FullKriString
+  static toString(kri: Partial<FullKriObject> | ContextualKriObject): KriString {
+    if(ContextualKri.isContextualKriObject(kri)) return ContextualKri.toString(kri)
+
+    const { shortName = '', mesh = '', zone = '', namespace = '', name = '', sectionName = '' } = kri
+    return `kri_${shortName}_${mesh}_${zone}_${namespace}_${name}_${sectionName}`
   }
 }

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -326,7 +326,7 @@
                         <template
                           #body
                         >
-                          <template v-if="Kri.isKri(mTLS.issuedBackend)">
+                          <template v-if="Kri.isKriString(mTLS.issuedBackend)">
                             <XAction
                               :to="{
                                 name: 'data-plane-mesh-identity-summary-view',

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -209,21 +209,26 @@
                         </XBadge>
                       </template>
                       <template #origin="{ row: item }">
-                        <XAction
-                          :to="{
-                            name: 'mesh-identity-summary-view',
-                            params: {
-                              name: Kri.fromString(item.spec.origin.kri).name,
-                            },
-                          }"
-                          data-action
-                        >
-                          <XBadge
-                            appearance="decorative"
+                        <template v-if="Kri.isKriString(item.spec.origin.kri)">
+                          <XAction
+                            :to="{
+                              name: 'mesh-identity-summary-view',
+                              params: {
+                                name: Kri.fromString(item.spec.origin.kri).name,
+                              },
+                            }"
+                            data-action
                           >
-                            {{ item.spec.origin.kri }}
-                          </XBadge>
-                        </XAction>
+                            <XBadge
+                              appearance="decorative"
+                            >
+                              {{ item.spec.origin.kri }}
+                            </XBadge>
+                          </XAction>
+                        </template>
+                        <template v-else>
+                          {{ item.spec.origin.kri }}
+                        </template>
                       </template>
                     </AppCollection>
                   </DataCollection>

--- a/packages/kuma-gui/src/app/policies/data/DataplanePolicies.ts
+++ b/packages/kuma-gui/src/app/policies/data/DataplanePolicies.ts
@@ -1,5 +1,7 @@
 import { components } from '@kumahq/kuma-http-api'
 
+import { FullKriString } from '@/app/kuma/kri'
+
 type PoliciesList = components['schemas']['PoliciesList']
 type PolicyConf = components['schemas']['PolicyConf']
 
@@ -7,6 +9,12 @@ export const DataplanePolicies = {
   fromObject: (item: PolicyConf) => {
     return {
       ...item,
+      origins: item.origins.map((origin) => {
+        return {
+          ...origin,
+          kri: origin.kri as FullKriString,
+        }
+      }),
     }
   },
 

--- a/packages/kuma-gui/src/app/policies/data/DataplaneTrafficPolicies.ts
+++ b/packages/kuma-gui/src/app/policies/data/DataplaneTrafficPolicies.ts
@@ -1,5 +1,7 @@
 import { components } from '@kumahq/kuma-http-api'
 
+import type { FullKriString } from '@/app/kuma/kri'
+
 type OutboundPoliciesList = components['schemas']['PoliciesList']
 type OutboundPolicyConf = components['schemas']['PolicyConf']
 
@@ -7,6 +9,12 @@ export const DataplaneOutboundPolicies = {
   fromObject: (item: OutboundPolicyConf) => {
     return {
       ...item,
+      origins: item.origins.map((origin) => {
+        return {
+          ...origin,
+          kri: origin.kri as FullKriString,
+        }
+      }),
     }
   },
 
@@ -27,6 +35,12 @@ export const DataplaneInboundPolicies = {
   fromObject: (item: InboundPolicyConf) => {
     return {
       ...item,
+      origins: item.origins.map((origin) => {
+        return {
+          ...origin,
+          kri: origin.kri as FullKriString,
+        }
+      }),
     }
   },
 


### PR DESCRIPTION
In order to simplify the parsing and usage of `Kri` in the views I've refactored the `Kri` class. From the outside it doesn't really matter if a `kri` is contextual or the full `kri`. The differentiation between both is now being handled in the `Kri`class methods. It's only important to tell typescript which type of `kri` is expected for an entry in the api response. From that point on all different `kri` are fully typed and can be handled via `Kri.fromString` or `Kri.toString`.