### PR TITLE
feat(docs): several docs links amends

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -153,7 +153,7 @@ data-planes:
   href:
     docs:
       data_plane_proxy: '{KUMA_DOCS_URL}/production/dp-config/dpp?{KUMA_UTM_QUERY_PARAMS}'
-      gateway: '{KUMA_DOCS_URL}/explore/gateway?{KUMA_UTM_QUERY_PARAMS}'
+      gateway: '{KUMA_DOCS_URL}/using-mesh/managing-ingress-traffic/overview/?{KUMA_UTM_QUERY_PARAMS}'
   type:
     all: 'All'
     standard: 'Proxy'

--- a/packages/kuma-gui/src/app/zones/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/zones/locales/en-us/index.yaml
@@ -2,7 +2,7 @@ zone-cps:
   docs: &zone-cps.docs
     type: docs
     label: Documentation
-    href: &zone-cps.docs.href '{KUMA_DOCS_URL}/documentation/deployments?{KUMA_UTM_QUERY_PARAMS}'
+    href: &zone-cps.docs.href '{KUMA_DOCS_URL}/production/deployment/multi-zone/#multi-zone-deployment?{KUMA_UTM_QUERY_PARAMS}'
 
   growth-docs: &zones.growth-docs
     type: docs


### PR DESCRIPTION
The following links are currently out-of-date.

For the `gateway` link I'm "almost sure" that its not even used, but felt it was easier to replace it anyway. But if anyone can confirm for me that they can't see it being used in our code also, I'd be happy to just totally remove it from the locales files. I'm pretty sure its just left over from an older version. lmk

