### PR TITLE
chore: improve typing of can utility

### DIFF
--- a/packages/kuma-gui/src/app/application/index.ts
+++ b/packages/kuma-gui/src/app/application/index.ts
@@ -20,7 +20,6 @@ import storage from './services/storage'
 import { create, destroy, DataSourcePool } from '@/app/application/services/data-source'
 import { services as kuma } from '@/app/kuma'
 import type { ServiceDefinition } from '@kumahq/container'
-import type { Can } from '@kumahq/settings/can'
 import type { EnvVars } from '@kumahq/settings/env'
 import type { Component } from 'vue'
 import type { RouteRecordRaw } from 'vue-router'
@@ -63,6 +62,8 @@ declare module 'vue' {
     $routeName?: string
   }
 }
+export interface Abilities {}
+export type Can = Abilities['can']
 
 const $ = {
   Env: token<Env>('application.Env'),

--- a/packages/kuma-gui/src/app/control-planes/features.ts
+++ b/packages/kuma-gui/src/app/control-planes/features.ts
@@ -10,7 +10,7 @@ export const features = (env: Env['var']) => {
     },
   }
 }
-declare module '@kumahq/settings/can' {
+declare module '@/app/application' {
   export interface Abilities {
     can(...args: Features<ReturnType<typeof features>>): boolean
   }

--- a/packages/kuma-gui/src/app/control-planes/features.ts
+++ b/packages/kuma-gui/src/app/control-planes/features.ts
@@ -1,12 +1,17 @@
-import type { Can, Features } from '@kumahq/settings/can'
+import type { Features } from '@kumahq/settings/can'
 import type { Env } from '@kumahq/settings/env'
-export const features = (env: Env['var']): Features => {
+export const features = (env: Env['var']) => {
   return {
-    'use kubernetes': (_can: Can) => {
+    'use kubernetes': () => {
       return env('KUMA_ENVIRONMENT') === 'kubernetes'
     },
-    'use state': (_can: Can) => {
+    'use state': () => {
       return env('KUMA_STORE_TYPE') !== 'memory'
     },
+  }
+}
+declare module '@kumahq/settings/can' {
+  export interface Abilities {
+    can(...args: Features<ReturnType<typeof features>>): boolean
   }
 }

--- a/packages/kuma-gui/src/app/data-planes/features.ts
+++ b/packages/kuma-gui/src/app/data-planes/features.ts
@@ -15,7 +15,7 @@ export const features = (_env: Env['var']) => {
     },
   }
 }
-declare module '@kumahq/settings/can' {
+declare module '@/app/application' {
   export interface Abilities {
     can(...args: Features<ReturnType<typeof features>>): boolean
   }

--- a/packages/kuma-gui/src/app/data-planes/features.ts
+++ b/packages/kuma-gui/src/app/data-planes/features.ts
@@ -10,8 +10,8 @@ export const features = (_env: Env['var']) => {
       return ('transparentProxying' in dataplaneOverview.dataplane.networking) ||
         new Set(dataplaneOverview.dataplaneInsight.metadata.features).intersection(new Set(['feature-transparent-proxy-in-dataplane-metadata', 'bind-outbounds'])).size > 0
     },
-    'use unified-resource-naming': (_can: unknown, { dataPlaneOverview, mesh }: { dataPlaneOverview: DataplaneOverview, mesh: Mesh }) => {
-      return mesh.meshServices.mode === 'Exclusive' && dataPlaneOverview.dataplaneType === 'standard' && dataPlaneOverview.dataplaneInsight.metadata.features.includes('feature-unified-resource-naming')
+    'use unified-resource-naming': (_can: unknown, { dataplaneOverview, mesh }: { dataplaneOverview: DataplaneOverview, mesh: Mesh }) => {
+      return mesh.meshServices.mode === 'Exclusive' && dataplaneOverview.dataplaneType === 'standard' && dataplaneOverview.dataplaneInsight.metadata.features.includes('feature-unified-resource-naming')
     },
   }
 }

--- a/packages/kuma-gui/src/app/data-planes/features.ts
+++ b/packages/kuma-gui/src/app/data-planes/features.ts
@@ -2,16 +2,21 @@ import type { DataplaneOverview } from '@/app/data-planes/data'
 import type { Mesh } from '@/app/meshes/data'
 import type { Features } from '@kumahq/settings/can'
 import type { Env } from '@kumahq/settings/env'
-export const features = (_env: Env['var']): Features => {
+export const features = (_env: Env['var']) => {
   return {
-    'use transparent-proxying': (_can, dataplaneOverview: DataplaneOverview) => {
+    'use transparent-proxying': (_can: unknown, dataplaneOverview: DataplaneOverview) => {
       // TODO: the feature `bind-outbounds` is not implemented yet and the name might change, double check again when implemented
       // TODO: `dataplane.networking.transparentProxying` is deprecated and will be removed soon. Still checking for users that still use it.
       return ('transparentProxying' in dataplaneOverview.dataplane.networking) ||
         new Set(dataplaneOverview.dataplaneInsight.metadata.features).intersection(new Set(['feature-transparent-proxy-in-dataplane-metadata', 'bind-outbounds'])).size > 0
     },
-    'use unified-resource-naming': (_can, { dataplaneOverview, mesh }: { dataplaneOverview: DataplaneOverview, mesh: Mesh }) => {
-      return mesh.meshServices.mode === 'Exclusive' && dataplaneOverview.dataplaneType === 'standard' && dataplaneOverview.dataplaneInsight.metadata.features.includes('feature-unified-resource-naming')
+    'use unified-resource-naming': (_can: unknown, { dataPlaneOverview, mesh }: { dataPlaneOverview: DataplaneOverview, mesh: Mesh }) => {
+      return mesh.meshServices.mode === 'Exclusive' && dataPlaneOverview.dataplaneType === 'standard' && dataPlaneOverview.dataplaneInsight.metadata.features.includes('feature-unified-resource-naming')
     },
+  }
+}
+declare module '@kumahq/settings/can' {
+  export interface Abilities {
+    can(...args: Features<ReturnType<typeof features>>): boolean
   }
 }

--- a/packages/kuma-gui/src/app/external-services/features.ts
+++ b/packages/kuma-gui/src/app/external-services/features.ts
@@ -1,7 +1,0 @@
-import type { Features } from '@kumahq/settings/can'
-import type { Env } from '@kumahq/settings/env'
-
-export const features = (_env: Env['var']): Features => {
-  return {
-  }
-}

--- a/packages/kuma-gui/src/app/external-services/index.ts
+++ b/packages/kuma-gui/src/app/external-services/index.ts
@@ -1,6 +1,5 @@
 import { token } from '@kumahq/container'
 
-import { features } from './features'
 import locales from './locales/en-us/index.yaml'
 import { sources } from './sources'
 import type { ServiceDefinition } from '@kumahq/container'
@@ -16,15 +15,6 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       ],
       labels: [
         app.sources,
-      ],
-    }],
-    [token('external-services.features'), {
-      service: features,
-      arguments: [
-        app.env,
-      ],
-      labels: [
-        app.features,
       ],
     }],
     [token('external-services.locales'), {

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneRouteGuard.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneRouteGuard.vue
@@ -61,6 +61,7 @@ const addRouteName = (item: RouteRecordRaw) => {
 
 router.beforeResolve(async (to, _from, next) => {
   if(
+    // @ts-expect-error -- allow via TS to pass extra arguments
     !can('use unified-resource-naming', { dataplaneOverview: props.data, mesh: props.mesh }) &&
     ['data-plane-policy-config-summary-view'].includes(to.name as string)
   ) {
@@ -76,6 +77,7 @@ watch(() => router.currentRoute.value.name, async (val) => {
     router.removeRoute('data-plane-detail-tabs-view')
     const _routes = walkRoutes(
       addRouteName,
+      // @ts-expect-error -- allow via TS to pass extra arguments
       can('use unified-resource-naming', { dataplaneOverview: props.data, mesh: props.mesh }) ? dataplaneRoutes() : legacyDataplaneRoutes(),
     )
     router.addRoute('data-plane-root-view', _routes[0])

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneRouteGuard.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneRouteGuard.vue
@@ -61,7 +61,6 @@ const addRouteName = (item: RouteRecordRaw) => {
 
 router.beforeResolve(async (to, _from, next) => {
   if(
-    // @ts-expect-error -- allow via TS to pass extra arguments
     !can('use unified-resource-naming', { dataplaneOverview: props.data, mesh: props.mesh }) &&
     ['data-plane-policy-config-summary-view'].includes(to.name as string)
   ) {
@@ -77,7 +76,6 @@ watch(() => router.currentRoute.value.name, async (val) => {
     router.removeRoute('data-plane-detail-tabs-view')
     const _routes = walkRoutes(
       addRouteName,
-      // @ts-expect-error -- allow via TS to pass extra arguments
       can('use unified-resource-naming', { dataplaneOverview: props.data, mesh: props.mesh }) ? dataplaneRoutes() : legacyDataplaneRoutes(),
     )
     router.addRoute('data-plane-root-view', _routes[0])

--- a/packages/kuma-gui/src/app/services/features.ts
+++ b/packages/kuma-gui/src/app/services/features.ts
@@ -1,15 +1,14 @@
-import { runInDebug } from '@/app/application'
 import { Mesh } from '@/app/meshes/data'
 import type { Features } from '@kumahq/settings/can'
-export const features = (): Features => {
+export const features = () => {
   return {
-    'use service-insights': (_can, mesh: Mesh) => {
-      runInDebug(() => {
-        if (typeof mesh === 'undefined') {
-          throw new Error('argument `mesh` not provided for can(`use service-insights`)')
-        }
-      })
+    'use service-insights': (_can: unknown, mesh: Mesh) => {
       return mesh.meshServices.mode !== 'Exclusive'
     },
+  }
+}
+declare module '@kumahq/settings/can' {
+  export interface Abilities {
+    can(...args: Features<ReturnType<typeof features>>): boolean
   }
 }

--- a/packages/kuma-gui/src/app/services/features.ts
+++ b/packages/kuma-gui/src/app/services/features.ts
@@ -7,7 +7,7 @@ export const features = () => {
     },
   }
 }
-declare module '@kumahq/settings/can' {
+declare module '@/app/application' {
   export interface Abilities {
     can(...args: Features<ReturnType<typeof features>>): boolean
   }

--- a/packages/kuma-gui/src/app/services/index.ts
+++ b/packages/kuma-gui/src/app/services/index.ts
@@ -4,8 +4,8 @@ import { features } from './features'
 import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
 import { sources } from './sources'
+import type { Can } from '@/app/application'
 import type { ServiceDefinition } from '@kumahq/container'
-import type { Can } from '@kumahq/settings/can'
 
 type Token = ReturnType<typeof token>
 

--- a/packages/kuma-gui/src/app/services/routes.ts
+++ b/packages/kuma-gui/src/app/services/routes.ts
@@ -1,5 +1,5 @@
+import type { Can } from '@/app/application'
 import { routes as dataPlanes } from '@/app/legacy-data-planes/routes'
-import type { Can } from '@kumahq/settings/can'
 import type { RouteRecordRaw } from 'vue-router'
 
 export const routes = (can: Can) => {

--- a/packages/kuma-gui/src/app/zones/features.ts
+++ b/packages/kuma-gui/src/app/zones/features.ts
@@ -1,6 +1,6 @@
 import type { Features } from '@kumahq/settings/can'
 import type { Env } from '@kumahq/settings/env'
-export const features = (env: Env['var']): Features => {
+export const features = (env: Env['var']) => {
   return {
     'use zones': () => {
       return env('KUMA_MODE') === 'global'
@@ -10,4 +10,8 @@ export const features = (env: Env['var']): Features => {
     },
   }
 }
-    
+declare module '@kumahq/settings/can' {
+  export interface Abilities {
+    can(...args: Features<ReturnType<typeof features>>): boolean
+  }
+}

--- a/packages/kuma-gui/src/app/zones/features.ts
+++ b/packages/kuma-gui/src/app/zones/features.ts
@@ -1,3 +1,4 @@
+import type { Can } from '@/app/application'
 import type { Features } from '@kumahq/settings/can'
 import type { Env } from '@kumahq/settings/env'
 export const features = (env: Env['var']) => {
@@ -5,13 +6,13 @@ export const features = (env: Env['var']) => {
     'use zones': () => {
       return env('KUMA_MODE') === 'global'
     },
-    'create zones': () => {
+    'create zones': (can: Can) => {
       return false
     },
   }
 }
-declare module '@kumahq/settings/can' {
-  export interface Abilities {
+declare module '@/app/application' {
+  interface Abilities {
     can(...args: Features<ReturnType<typeof features>>): boolean
   }
 }

--- a/packages/kuma-gui/src/app/zones/routes.ts
+++ b/packages/kuma-gui/src/app/zones/routes.ts
@@ -1,7 +1,7 @@
+import type { Can } from '@/app/application'
 import { routes as subscriptions } from '@/app/subscriptions/routes'
 import { routes as egresses } from '@/app/zone-egresses/routes'
 import { routes as ingresses } from '@/app/zone-ingresses/routes'
-import type { Can } from '@kumahq/settings/can'
 import type { RouteRecordRaw } from 'vue-router'
 
 export const routes = (

--- a/packages/settings/src/can/index.spec.ts
+++ b/packages/settings/src/can/index.spec.ts
@@ -35,4 +35,15 @@ describe('can', () => {
     expect(can('use enabled-feature')).toBe(true)
     expect(can('use disabled-feature')).toBe(false)
   })
-})
+  test('allows multiple arguments to provide additional data as context', () => {
+    const can = features({
+      // @ts-expect-error -- need to allow in TS to pass extra arguments
+      'use enabled-feature': (_can, context: { enabled: boolean }) => context.enabled,
+      // @ts-expect-error -- need to allow in TS to pass extra arguments
+      'use disabled-feature': (can, context: { enabled: boolean }) => !can('use enabled-feature', context),
+    })
+    // @ts-expect-error -- need to allow in TS to pass extra arguments
+    expect(can('use enabled-feature', { enabled: true })).toBe(true)
+    // @ts-expect-error -- need to allow in TS to pass extra arguments
+    expect(can('use disabled-feature', { enabled: true })).toBe(false)
+  })})

--- a/packages/settings/src/can/index.spec.ts
+++ b/packages/settings/src/can/index.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest'
+
+import features from '.'
+
+describe('can', () => {
+  test('works', () => {
+    const can = features({
+      'use enabled-feature': () => true,
+      'use disabled-feature': () => false,
+    })
+    expect(can('use enabled-feature')).toBe(true)
+    expect(can('use disabled-feature')).toBe(false)
+  })
+  test('converts string returns correctly', () => {
+    const can = features({
+      'use enabled-feature': () => 'true',
+      'use disabled-feature': () => 'false',
+    })
+    expect(can('use enabled-feature')).toBe(true)
+    expect(can('use disabled-feature')).toBe(false)
+  })
+  test('converts numeric returns correctly', () => {
+    const can = features({
+      'use enabled-feature': () => 1,
+      'use disabled-feature': () => 0,
+    })
+    expect(can('use enabled-feature')).toBe(true)
+    expect(can('use disabled-feature')).toBe(false)
+  })
+  test('first argument is can which can be called correctly', () => {
+    const can = features({
+      'use enabled-feature': (can) => !can('use disabled-feature'),
+      'use disabled-feature': () => 0,
+    })
+    expect(can('use enabled-feature')).toBe(true)
+    expect(can('use disabled-feature')).toBe(false)
+  })
+})

--- a/packages/settings/src/can/index.ts
+++ b/packages/settings/src/can/index.ts
@@ -1,6 +1,6 @@
 
 type EnsureFunction<T> = T extends (...args: any[]) => any ? T : never
-type ParamsExceptFirst<T extends any[]> = T extends [any, ...infer Rest] ? Rest : []
+type ParamsExceptFirst<T extends any[]> = (T extends [any, ...infer Rest] ? Rest : []) | []
 
 export type Features<T extends Record<string, unknown>> = {
   [K in keyof T & string]: ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>> extends [] ? [K] : [K, ...ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>>]
@@ -10,7 +10,7 @@ export type FeatureSpec<T extends Record<string, unknown>> = {
   [K in keyof T & string]: (
     can: (...args: Features<T>) => boolean,
     //
-    ...rest: [] | [...ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>>]
+    ...rest: ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>>
     ///
   ) => any
 }

--- a/packages/settings/src/can/index.ts
+++ b/packages/settings/src/can/index.ts
@@ -1,13 +1,12 @@
-
 type EnsureFunction<T> = T extends (...args: any[]) => any ? T : never
 type ParamsExceptFirst<T extends any[]> = (T extends [any, ...infer Rest] ? Rest : []) | []
 
 export type Features<T extends Record<string, unknown>> = {
-  [K in keyof T & string]: ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>> extends [] ? [K] : [K, ...ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>>]
-}[keyof T & string]
+  [K in keyof T]: ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>> extends [] ? [K] : [K, ...ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>>]
+}[keyof T]
 
 export type FeatureSpec<T extends Record<string, unknown>> = {
-  [K in keyof T & string]: (
+  [K in keyof T]: (
     can: (...args: Features<T>) => boolean,
     //
     ...rest: ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>>

--- a/packages/settings/src/can/index.ts
+++ b/packages/settings/src/can/index.ts
@@ -1,24 +1,18 @@
-type EnsureFunction<T> = T extends (...args: any[]) => any ? T : never
-type ParamsExceptFirst<T extends any[]> = (T extends [any, ...infer Rest] ? Rest : []) | []
+type Fn = (...args: any[]) => any
+type RestParams<T extends Fn> = Parameters<T> extends [any, ...infer Rest] ? Rest : []
 
-export type Features<T extends Record<string, unknown>> = {
-  [K in keyof T]: ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>> extends [] ? [K] : [K, ...ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>>]
+export type Features<T extends Record<string, Fn>> = {
+  [K in keyof T]: [K, ...RestParams<T[K]>]
 }[keyof T]
 
-export type FeatureSpec<T extends Record<string, unknown>> = {
+export type FeatureSpec<T extends Record<string, Fn>> = {
   [K in keyof T]: (
     can: (...args: Features<T>) => boolean,
-    //
-    ...rest: ParamsExceptFirst<Parameters<EnsureFunction<T[K]>>>
-    ///
+    ...rest: RestParams<T[K]>
   ) => any
 }
-// export type FeatureSpec<T extends Record<string, unknown>> = {
-//   [K in keyof T & string]: EnsureFunction<T[K]>
-// }
 
-
-export default <T extends Record<string, unknown>>(features: FeatureSpec<T>) => {
+export default <T extends Record<string, Fn>>(features: FeatureSpec<T>) => {
   const can = (...args: Features<T>) => {
     const [str, ...rest] = args
     const feature = features[str]

--- a/packages/settings/src/can/index.ts
+++ b/packages/settings/src/can/index.ts
@@ -1,10 +1,19 @@
-export type Can = (str: string, obj?: any) => boolean
-export type Features = Record<string, (can: Can, obj?: any) => boolean>
-export default (features: Features) => {
-  const can: Can = (str, obj) => {
+export interface Abilities {}
+// @ts-ignore
+export type Can = Abilities['can']
+
+type ParamsExceptFirst<T extends any[]> = T extends [any, ...infer Rest] ? Rest : []
+
+export type Features<T extends Record<string, (...args: any[]) => boolean>> = {
+  [K in keyof T]: ParamsExceptFirst<Parameters<T[K]>> extends [] ? [K] : [K, ...ParamsExceptFirst<Parameters<T[K]>>]
+}[keyof T]
+
+type Feature = (can: Can, obj?: any) => boolean
+export default (features: Record<string, Feature>) => {
+  const can: Can = (str: string, obj?: unknown) => {
     const feature = features[str]
     if (typeof feature !== 'undefined') {
-      return features[str](can, obj)
+      return !!features[str](can, obj)
     }
     return false
   }

--- a/packages/settings/src/can/index.ts
+++ b/packages/settings/src/can/index.ts
@@ -12,7 +12,7 @@ export type FeatureSpec<T extends Record<string, Fn>> = {
   ) => any
 }
 
-export default <T extends Record<string, Fn>>(features: FeatureSpec<T>) => {
+const features = <T extends Record<string, Fn>>(features: FeatureSpec<T>) => {
   const can = (...args: Features<T>) => {
     const [str, ...rest] = args
     const feature = features[str]
@@ -28,3 +28,5 @@ export default <T extends Record<string, Fn>>(features: FeatureSpec<T>) => {
   }
   return can
 }
+
+export default features


### PR DESCRIPTION
`can()` has always accepted any strings (and number of arguments), if a 'feature'/'ability' didn't exist then we would return `false` i.e. non-existence meant not enabled.

This PR uses declarations to make `can` autocompletable/type-checked instead by using composable TS interfaces and `declare` to amend `can`s definition after initial declaration.

My main goals here are:

- Add typechecking etc to `can` from The Outside
- Keep our existing composable nature of `can`
- Make it as automatic as possible, I shouldn't have to repeat all the feature declarations, hence the utility type.

I eventually plan on re-building `env()` to use a similar approach, thus finally making env composable also.

### Notes

- There is a ts-ignore here https://github.com/kumahq/kuma-gui/pull/4194/files#diff-5fd72b2766aa02f5cdb96929d8cf41d9d6b8a6111e18d0e4b5f2d1cf346705c4R2. I couldn't find a better way to do this, everything else I tried wasn't as good as just using ts-ignore (form an autocomplete perspective). Happy to hear other suggestions to remove this.
- Currently I added the `declares` in the feature.ts files themselves. In the probably distant future its very likely these could be moved to be declared centrally in main.ts (or another single d.ts file sourced from main)
- This might not be the final approach, but it the approach here is unobtrusive enough that its easy to change/back out later when/if we want to change.





