### PR TITLE
fix(types): fixup DataplaneOverview type in DataplaneRouteGuard

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/features.ts
+++ b/packages/kuma-gui/src/app/data-planes/features.ts
@@ -10,8 +10,8 @@ export const features = (_env: Env['var']): Features => {
       return ('transparentProxying' in dataplaneOverview.dataplane.networking) ||
         new Set(dataplaneOverview.dataplaneInsight.metadata.features).intersection(new Set(['feature-transparent-proxy-in-dataplane-metadata', 'bind-outbounds'])).size > 0
     },
-    'use unified-resource-naming': (_can, { dataPlaneOverview, mesh }: { dataPlaneOverview: DataplaneOverview, mesh: Mesh }) => {
-      return mesh.meshServices.mode === 'Exclusive' && dataPlaneOverview.dataplaneType === 'standard' && dataPlaneOverview.dataplaneInsight.metadata.features.includes('feature-unified-resource-naming')
+    'use unified-resource-naming': (_can, { dataplaneOverview, mesh }: { dataplaneOverview: DataplaneOverview, mesh: Mesh }) => {
+      return mesh.meshServices.mode === 'Exclusive' && dataplaneOverview.dataplaneType === 'standard' && dataplaneOverview.dataplaneInsight.metadata.features.includes('feature-unified-resource-naming')
     },
   }
 }

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneRouteGuard.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneRouteGuard.vue
@@ -11,7 +11,7 @@ import { ref, watch } from 'vue'
 import { RouteRecordRaw, useRouter } from 'vue-router'
 
 import { useCan } from '@/app/application'
-import { DataplaneOverview } from '@/app/data-planes/data'
+import type { DataplaneOverview } from '@/app/data-planes/data'
 import { dataplaneRoutes } from '@/app/data-planes/routes'
 import { legacyDataplaneRoutes } from '@/app/legacy-data-planes/routes'
 import type { Mesh } from '@/app/meshes/data'

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneRouteGuard.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneRouteGuard.vue
@@ -11,16 +11,16 @@ import { ref, watch } from 'vue'
 import { RouteRecordRaw, useRouter } from 'vue-router'
 
 import { useCan } from '@/app/application'
+import { DataplaneOverview } from '@/app/data-planes/data'
 import { dataplaneRoutes } from '@/app/data-planes/routes'
 import { legacyDataplaneRoutes } from '@/app/legacy-data-planes/routes'
 import type { Mesh } from '@/app/meshes/data'
-import { DataPlaneOverview } from '@/types'
 
 const router = useRouter()
 const can = useCan()
 
 const props = defineProps<{
-  data: DataPlaneOverview
+  data: DataplaneOverview
   mesh: Mesh
 }>()
 
@@ -61,7 +61,7 @@ const addRouteName = (item: RouteRecordRaw) => {
 
 router.beforeResolve(async (to, _from, next) => {
   if(
-    !can('use unified-resource-naming', { dataPlaneOverview: props.data, mesh: props.mesh }) &&
+    !can('use unified-resource-naming', { dataplaneOverview: props.data, mesh: props.mesh }) &&
     ['data-plane-policy-config-summary-view'].includes(to.name as string)
   ) {
     next({ name: 'app-not-found-view' })
@@ -76,7 +76,7 @@ watch(() => router.currentRoute.value.name, async (val) => {
     router.removeRoute('data-plane-detail-tabs-view')
     const _routes = walkRoutes(
       addRouteName,
-      can('use unified-resource-naming', { dataPlaneOverview: props.data, mesh: props.mesh }) ? dataplaneRoutes() : legacyDataplaneRoutes(),
+      can('use unified-resource-naming', { dataplaneOverview: props.data, mesh: props.mesh }) ? dataplaneRoutes() : legacyDataplaneRoutes(),
     )
     router.addRoute('data-plane-root-view', _routes[0])
     await router.replace(router.currentRoute.value.fullPath)


### PR DESCRIPTION
Whilst working on https://github.com/kumahq/kuma-gui/pull/4194 I found that one side of `can` was expecting the DataplaneOverview from `@/app/data-planes/data` and the other side was using our old DataPlaneOverview from `@/types`.

This makes them the same.

https://github.com/kumahq/kuma-gui/pull/4194 goes some way to prevent this from happening, although this wasn't the reason for me working on that.

