### PR TITLE
refactor(resources/routes): use kri for routing of mid and mtrust

### DIFF
--- a/packages/kuma-gui/features/mesh/MeshIdentity.feature
+++ b/packages/kuma-gui/features/mesh/MeshIdentity.feature
@@ -28,10 +28,11 @@ Feature: mesh / mesh-identity
       body:
         items:
           - name: identity-1
+            mesh: default
       """
     When I visit the "/meshes/default" URL
     Then I click the "$mesh-mtls a:first" element
-    Then the URL contains "/meshes/default/overview/meshidentity/identity-1"
+    Then the URL contains "/meshes/default/overview/meshidentity/kri_mid_default___identity-1_"
     And the "$summary" element exists
     And the "$summary" element contains "identity-1"
     And the "$summary [data-testid='k-code-block']" element exists

--- a/packages/kuma-gui/features/mesh/MeshTrust.feature
+++ b/packages/kuma-gui/features/mesh/MeshTrust.feature
@@ -34,7 +34,7 @@ Feature: mesh / mesh-identity
       """
     When I visit the "/meshes/default" URL
     Then I click the "$meshtrusts-listing a:first" element
-    Then the URL contains "/meshes/default/overview/meshtrust/kri_mtrust_default___trust-1_
+    Then the URL contains "/meshes/default/overview/meshtrust/kri_mtrust_default___trust-1_"
     And the "$summary" element exists
     And the "$summary" element contains "trust-1"
     And the "$summary [data-testid='k-code-block']" element exists

--- a/packages/kuma-gui/features/mesh/MeshTrust.feature
+++ b/packages/kuma-gui/features/mesh/MeshTrust.feature
@@ -27,13 +27,14 @@ Feature: mesh / mesh-identity
       body:
         items:
           - name: trust-1
+            mesh: default
             spec:
               origin:
                 kri: kri_mid_default_default_foo_bar_baz
       """
     When I visit the "/meshes/default" URL
     Then I click the "$meshtrusts-listing a:first" element
-    Then the URL contains "/meshes/default/overview/meshtrust/trust-1"
+    Then the URL contains "/meshes/default/overview/meshtrust/kri_mtrust_default___trust-1_
     And the "$summary" element exists
     And the "$summary" element contains "trust-1"
     And the "$summary [data-testid='k-code-block']" element exists
@@ -59,7 +60,7 @@ Feature: mesh / mesh-identity
       """
     When I visit the "/meshes/default" URL
     Then I click the "$meshtrusts-listing tbody tr:first-child td:nth-child(3) a" element
-    Then the URL contains "/meshes/default/overview/meshidentity/bar"
+    Then the URL contains "/meshes/default/overview/meshidentity/kri_mid_default_default_foo_bar_baz"
     And the "$summary" element exists
     And the "$summary" element contains "bar"
     And the "$summary [data-testid='k-code-block']" element exists

--- a/packages/kuma-gui/features/mesh/MeshTrust.feature
+++ b/packages/kuma-gui/features/mesh/MeshTrust.feature
@@ -6,7 +6,7 @@ Feature: mesh / mesh-identity
       | meshtrusts-listing | [data-testid="mesh-trusts-listing"] |
       | summary            | [data-testid="slideout-container"]  |
 
-  Scenario: MeshIdentities are listed in mesh about section
+  Scenario: MeshTrusts are listed in mesh overview
     Given the URL "/meshes/default/meshtrusts" responds with
       """
       body:

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -331,7 +331,7 @@
                               :to="{
                                 name: 'data-plane-mesh-identity-summary-view',
                                 params: {
-                                  ...Kri.fromString(mTLS.issuedBackend),
+                                  mid: mTLS.issuedBackend,
                                 },
                               }"
                             >

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -133,7 +133,7 @@
                                 :to="{
                                   name: 'mesh-identity-summary-view',
                                   params: {
-                                    name: identity.name.toLocaleLowerCase(),
+                                    mid: identity.kri,
                                   },
                                 }"
                               >

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -184,7 +184,7 @@
                           :to="{
                             name: 'mesh-trust-summary-view',
                             params: {
-                              name: item.name.toLocaleLowerCase(),
+                              mtrust: item.kri,
                             },
                             query: {
                               environment: route.params.environment,
@@ -207,7 +207,7 @@
                           :to="{
                             name: 'mesh-identity-summary-view',
                             params: {
-                              name: Kri.fromString(item.spec.origin.kri).name,
+                              mid: item.spec.origin.kri,
                             },
                           }"
                           data-action
@@ -363,7 +363,6 @@ import AppCollection from '@/app/application/components/app-collection/AppCollec
 import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import ResourceStatus from '@/app/common/ResourceStatus.vue'
 import SummaryView from '@/app/common/SummaryView.vue'
-import { Kri } from '@/app/kuma/kri'
 import { sources as policySources } from '@/app/policies/sources'
 import { sources as resourceSources } from '@/app/resources/sources'
 

--- a/packages/kuma-gui/src/app/resources/data/MeshIdentity.ts
+++ b/packages/kuma-gui/src/app/resources/data/MeshIdentity.ts
@@ -1,3 +1,4 @@
+import { Kri } from '@/app/kuma/kri'
 import type { components } from '@kumahq/kuma-http-api'
 
 type PartialMeshIdentityList = components['responses']['MeshIdentityList']['content']['application/json']
@@ -7,6 +8,8 @@ export const MeshIdentity = {
   fromObject: (item: PartialMeshIdentity) => {
     return {
       ...item,
+      kri: Kri.toString({ shortName: 'mid', mesh: item.mesh, name: item.name}),
+      raw: item,
     }
   },
   

--- a/packages/kuma-gui/src/app/resources/data/MeshTrust.ts
+++ b/packages/kuma-gui/src/app/resources/data/MeshTrust.ts
@@ -1,3 +1,4 @@
+import { Kri } from '@/app/kuma/kri'
 import type { components } from '@kumahq/kuma-http-api'
 
 type PartialMeshTrustList = components['responses']['MeshTrustList']['content']['application/json']
@@ -7,6 +8,7 @@ export const MeshTrust = {
   fromObject: (item: PartialMeshTrust) => {
     return {
       ...item,
+      kri: Kri.toString({ shortName: 'mtrust', mesh: item.mesh, name: item.name }),
       spec: {
         ...item.spec,
         origin: {
@@ -14,6 +16,7 @@ export const MeshTrust = {
           kri: item.spec?.origin?.kri ?? '',
         },
       },
+      raw: item,
     }
   },
   

--- a/packages/kuma-gui/src/app/resources/routes.ts
+++ b/packages/kuma-gui/src/app/resources/routes.ts
@@ -3,7 +3,7 @@ import type { RouteRecordRaw } from 'vue-router'
 export const meshIdentityRoutes = (prefix?: string): RouteRecordRaw[] => {
   return [
     {
-      path: 'meshidentity/:name',
+      path: 'meshidentity/:mid',
       name: `${prefix ? `${prefix}-` : ''}mesh-identity-summary-view`,
       component: () => import('@/app/resources/views/MeshIdentitySummaryView.vue'),
     },
@@ -13,7 +13,7 @@ export const meshIdentityRoutes = (prefix?: string): RouteRecordRaw[] => {
 export const meshTrustRoutes = (): RouteRecordRaw[] => {
   return [
     {
-      path: 'meshtrust/:name',
+      path: 'meshtrust/:mtrust',
       name: 'mesh-trust-summary-view',
       component: () => import('@/app/resources/views/MeshTrustSummaryView.vue'),
     },

--- a/packages/kuma-gui/src/app/resources/sources.ts
+++ b/packages/kuma-gui/src/app/resources/sources.ts
@@ -3,6 +3,7 @@ import createClient from 'openapi-fetch'
 import { MeshIdentity } from './data/MeshIdentity'
 import { MeshTrust } from './data/MeshTrust'
 import { defineSources } from '@/app/application'
+import { Kri } from '@/app/kuma/kri'
 import type KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
 import type { paths } from '@kumahq/kuma-http-api'
 
@@ -26,8 +27,9 @@ export const sources = (api: KumaApi) => {
       return MeshIdentity.fromCollection(res.data!)
     },
 
-    '/meshes/:mesh/meshidentities/:name': async (params) => {
-      const { mesh, name } = params
+    '/meshidentities/:mid': async (params) => {
+      const { mid } = params
+      const { mesh, name } = Kri.fromString(mid)
   
       const res = await http.GET('/meshes/{mesh}/meshidentities/{name}', {
         params: {
@@ -41,8 +43,9 @@ export const sources = (api: KumaApi) => {
       return MeshIdentity.fromObject(res.data!)
     },
 
-    '/meshes/:mesh/meshidentities/:name/as/kubernetes': async (params) => {
-      const { mesh, name } = params
+    '/meshidentities/:mid/as/kubernetes': async (params) => {
+      const { mid } = params
+      const { mesh, name } = Kri.fromString(mid)
   
       const res = await http.GET('/meshes/{mesh}/meshidentities/{name}', {
         params: {
@@ -57,7 +60,7 @@ export const sources = (api: KumaApi) => {
         },
       })
   
-      return MeshIdentity.fromObject(res.data!)
+      return res.data
     },
 
     '/meshes/:mesh/meshtrusts': async (params) => {
@@ -74,8 +77,9 @@ export const sources = (api: KumaApi) => {
       return MeshTrust.fromCollection(res.data!)
     },
 
-    '/meshes/:mesh/meshtrusts/:name': async (params) => {
-      const { mesh, name } = params
+    '/meshtrusts/:mtrust': async (params) => {
+      const { mtrust } = params
+      const { mesh, name } = Kri.fromString(mtrust)
   
       const res = await http.GET('/meshes/{mesh}/meshtrusts/{name}', {
         params: {
@@ -89,8 +93,9 @@ export const sources = (api: KumaApi) => {
       return MeshTrust.fromObject(res.data!)
     },
 
-    '/meshes/:mesh/meshtrusts/:name/as/kubernetes': async (params) => {
-      const { mesh, name } = params
+    '/meshtrusts/:mtrust/as/kubernetes': async (params) => {
+      const { mtrust } = params
+      const { mesh, name } = Kri.fromString(mtrust)
   
       const res = await http.GET('/meshes/{mesh}/meshtrusts/{name}', {
         params: {
@@ -105,7 +110,7 @@ export const sources = (api: KumaApi) => {
         },
       })
   
-      return MeshTrust.fromObject(res.data!)
+      return res.data
     },
   })
 }

--- a/packages/kuma-gui/src/app/resources/views/MeshIdentitySummaryView.vue
+++ b/packages/kuma-gui/src/app/resources/views/MeshIdentitySummaryView.vue
@@ -3,22 +3,21 @@
     :name="props.routeName"
     :params="{
       mesh: '',
-      name: '',
+      mid: '',
       environment: String,
     }"
     v-slot="{ route, t, uri }"
   >
-    <AppView>
-      <template #title>
-        <h2>{{ route.params.name }}</h2>
-      </template>
-      <DataLoader
-        :src="uri(sources, '/meshes/:mesh/meshidentities/:name', {
-          mesh: route.params.mesh,
-          name: route.params.name,
-        })"
-        v-slot="{ data }"
-      >
+    <DataLoader
+      :src="uri(sources, '/meshidentities/:mid', {
+        mid: route.params.mid,
+      })"
+      v-slot="{ data }"
+    >
+      <AppView>
+        <template #title>
+          <h2>{{ data.name }}</h2>
+        </template>
         <XLayout
           type="separated"
           justify="end"
@@ -48,14 +47,13 @@
         <template v-if="route.params.environment === 'universal'">
           <XCodeBlock
             language="yaml"
-            :code="YAML.stringify(data)"
+            :code="YAML.stringify(data.raw)"
           />
         </template>
         <template v-else>
           <DataLoader
-            :src="uri(sources, '/meshes/:mesh/meshidentities/:name/as/kubernetes', {
-              mesh: route.params.mesh,
-              name: route.params.name,
+            :src="uri(sources, '/meshidentities/:mid/as/kubernetes', {
+              mid: route.params.mid,
             })"
             v-slot="{ data: k8sYaml }"
           >
@@ -65,8 +63,8 @@
             />
           </DataLoader>
         </template>
-      </DataLoader>
-    </AppView>
+      </AppView>
+    </DataLoader>
   </RouteView>
 </template>
 

--- a/packages/kuma-gui/src/app/resources/views/MeshTrustSummaryView.vue
+++ b/packages/kuma-gui/src/app/resources/views/MeshTrustSummaryView.vue
@@ -1,21 +1,22 @@
 <template>
   <RouteView
-    name="mesh-identity-summary-view"
+    name="mesh-trust-summary-view"
     :params="{
       mesh: '',
-      name: '',
+      mtrust: '',
       environment: String,
     }"
     v-slot="{ route, t, uri }"
   >
-    <DataCollection
-      :items="props.meshTrusts"
-      :predicate="item => item.name.toLocaleLowerCase() === route.params.name"
-      v-slot="{ items }"
+    <DataLoader
+      :src="uri(sources, '/meshtrusts/:mtrust', {
+        mtrust: route.params.mtrust,
+      })"
+      v-slot="{ data }"
     >
       <AppView>
         <template #title>
-          <h2>{{ items[0].name }}</h2>
+          <h2>{{ data.name }}</h2>
         </template>
         <XLayout
           type="separated"
@@ -46,14 +47,13 @@
         <template v-if="route.params.environment === 'universal'">
           <XCodeBlock
             language="yaml"
-            :code="YAML.stringify(items[0])"
+            :code="YAML.stringify(data.raw)"
           />
         </template>
         <template v-else>
           <DataLoader
-            :src="uri(sources, '/meshes/:mesh/meshtrusts/:name/as/kubernetes', {
-              mesh: route.params.mesh,
-              name: route.params.name,
+            :src="uri(sources, '/meshtrusts/:mtrust/as/kubernetes', {
+              mtrust: route.params.mtrust,
             })"
             v-slot="{ data: k8sYaml }"
           >
@@ -64,18 +64,13 @@
           </DataLoader>
         </template>
       </AppView>
-    </DataCollection>
+    </DataLoader>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
-import type { MeshTrust } from '../data/MeshTrust'
 import { YAML } from '@/app/application'
 import { sources } from '@/app/resources/sources'
-
-const props = defineProps<{
-  meshTrusts: MeshTrust[]
-}>()
 </script>
 <style scoped>
 h2::before {

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshtrusts/_/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshtrusts/_/_.ts
@@ -5,6 +5,7 @@ import type { EndpointDependencies, MockResponder } from '@/test-support'
 export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
   const mesh = params.mesh as string
+  const name = params.name as string
   const k8s = req.url.searchParams.get('format') === 'kubernetes'
   const namespace = fake.word.noun()
   const zone = fake.word.noun()
@@ -16,7 +17,7 @@ export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
       ...((() => {
         const metadata = {
           mesh,
-          name: fake.word.noun(),
+          name,
           labels: {
             'k8s.kuma.io/namespace': fake.word.noun(),
             'kuma.io/env': k8s ? 'kubernetes' : 'universal',


### PR DESCRIPTION
We decided to use `kri`s as is whenever possible. The first and probably easiest places where we can do this is the new resources `MeshIdentity` and `MeshTrust` which have been lately being added within the context of `kri`s.
There are still some places that require the `name` instead of the `kri`, but at the very least we are trying to remove the parsing of `kri`s from the views and only keep it in the data-layer and sources.

The following routes now expect a `kri`:
- `mesh-identity-summary-view`: `/meshes/:mesh/meshidentities/:mid` - `:mid` is expected to be a `kri`
- `mesh-trust-summary-view`: `/meshes/:mesh/meshtrusts/:mtrust` - `:mtrust` is expected to be a `kri`

For both `MeshTrust` and `MeshIdentity` I've added to build a `kri` from the provided data and add it to the returned data in the data-layer. For now this is just a minimal `kri`, i.e. `kri_mid_default___identity-1_` with only `shortName`, `mesh` and the `name` of the resource.

---

Furthermore I've fixed some minor things
- the route name of `MeshTrustSummaryView` was set to `mesh-identity-summary-view`
- now that we add more data to the response of `MeshTrust` and `MeshIdentity`, I've added another entry `raw` to preserve the returned data as config.