### PR TITLE
chore: rollout XTable

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -14,75 +14,68 @@
           v-for="inbound in [props.dataPlaneOverview.dataplane.networking.inbounds.find((item) => item.portName === ContextualKri.fromString(route.params.connection).sectionName && item.port === props.data.port)]"
           :key="typeof inbound"
         >
-          <div
+          <XTable
             v-if="inbound"
-            class="stack-with-borders"
+            variant="kv"
           >
-            <DefinitionCard layout="horizontal">
-              <template #title>
+            <tr>
+              <th scope="row">
                 Tags
-              </template>
-
-              <template #body>
+              </th>
+              <td>
                 <TagList
                   :tags="inbound.tags"
                   alignment="right"
                 />
-              </template>
-            </DefinitionCard>
-            <DefinitionCard layout="horizontal">
-              <template #title>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">
                 Protocol
-              </template>
-
-              <template #body>
+              </th>
+              <td>
                 <XBadge
                   appearance="info"
                 >
                   {{ t(`http.api.value.${inbound.protocol}`) }}
                 </XBadge>
-              </template>
-            </DefinitionCard>
-            <DefinitionCard layout="horizontal">
-              <template #title>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">
                 Address
-              </template>
-
-              <template #body>
+              </th>
+              <td>
                 <XCopyButton
                   :text="`${inbound.addressPort}`"
                 />
-              </template>
-            </DefinitionCard>
-            <DefinitionCard
+              </td>
+            </tr>
+            <tr
               v-if="inbound.serviceAddressPort.length > 0"
-              layout="horizontal"
             >
-              <template #title>
+              <th scope="row">
                 Service address
-              </template>
-
-              <template #body>
+              </th>
+              <td>
                 <XCopyButton
                   :text="`${inbound.serviceAddressPort}`"
                 />
-              </template>
-            </DefinitionCard>
-            <DefinitionCard
+              </td>
+            </tr>
+            <tr
               v-if="inbound.portName.length > 0"
-              layout="horizontal"
             >
-              <template #title>
+              <th scope="row">
                 Name
-              </template>
-
-              <template #body>
+              </th>
+              <td>
                 <XCopyButton
                   :text="`${inbound.portName}`"
                 />
-              </template>
-            </DefinitionCard>
-          </div>
+              </td>
+            </tr>
+          </XTable>
         </template>
         <XLayout
           v-if="props.data"
@@ -130,70 +123,71 @@
                             </PolicyTypeTag>
                           </template>
                           <template #accordion-content>
-                            <div
-                              class="stack-with-borders"
+                            <XTable
+                              variant="kv"
                             >
                               <template
                                 v-for="item in rules"
                                 :key="item"
                               >
-                                <DefinitionCard
+                                <template
                                   v-if="origins.length > 0"
-                                  layout="horizontal"
                                 >
-                                  <template #title>
-                                    Origin policies
-                                  </template>
-
-                                  <template #body>
-                                    <ul>
-                                      <li
-                                        v-for="origin in origins"
-                                        :key="origin.kri"
-                                      >
-                                        <template
-                                          v-for="{ mesh, name } in [Kri.fromString(origin.kri)]"
-                                          :key="`${mesh}-${name}`"
+                                  <tr>
+                                    <th scope="row">
+                                      Origin policies
+                                    </th>
+                                    <td>
+                                      <ul>
+                                        <li
+                                          v-for="origin in origins"
+                                          :key="origin.kri"
                                         >
-                                          <XAction
-                                            v-if="policyTypes[kind]"
-                                            :to="{
-                                              name: 'policy-detail-view',
-                                              params: {
-                                                mesh: mesh,
-                                                policyPath: policyTypes[kind]![0].path,
-                                                policy: name,
-                                              },
-                                            }"
-                                          >
-                                            {{ origin.kri }}
-                                          </XAction>
                                           <template
-                                            v-else
+                                            v-for="{ mesh, name } in [Kri.fromString(origin.kri)]"
+                                            :key="`${mesh}-${name}`"
                                           >
-                                            {{ origin.kri }}
+                                            <XAction
+                                              v-if="policyTypes[kind]"
+                                              :to="{
+                                                name: 'policy-detail-view',
+                                                params: {
+                                                  mesh: mesh,
+                                                  policyPath: policyTypes[kind]![0].path,
+                                                  policy: name,
+                                                },
+                                              }"
+                                            >
+                                              {{ origin.kri }}
+                                            </XAction>
+                                            <template
+                                              v-else
+                                            >
+                                              {{ origin.kri }}
+                                            </template>
                                           </template>
-                                        </template>
-                                      </li>
-                                    </ul>
-                                  </template>
-                                </DefinitionCard>
-                                <div>
-                                  <dt>
-                                    Config
-                                  </dt>
-                                  <dd class="mt-2">
-                                    <div>
-                                      <XCodeBlock
-                                        :code="YAML.stringify(item.conf)"
-                                        language="yaml"
-                                        :show-copy-button="false"
-                                      />
-                                    </div>
-                                  </dd>
-                                </div>
+                                        </li>
+                                      </ul>
+                                    </td>
+                                  </tr>
+                                  <tr>
+                                    <td colspan="2">
+                                      <XLayout
+                                        type="stack"
+                                        size="small"
+                                      >
+                                        <span>Config</span>
+                                        <XCodeBlock
+                                          :code="YAML.stringify(item.conf)"
+                                          language="yaml"
+                                          :show-copy-button="false"
+                                        />
+                                      </XLayout>
+                                    </td>
+                                  </tr>
+                                </template>
                               </template>
-                            </div>
+                            </XTable>
                           </template>
                         </AccordionItem>
                       </XCard>
@@ -214,7 +208,6 @@ import { DataplaneNetworkingLayout, DataplaneOverview } from '../data'
 import { YAML } from '@/app/application'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import TagList from '@/app/common/TagList.vue'
 import { ContextualKri, Kri } from '@/app/kuma/kri'

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
@@ -10,34 +10,30 @@
   >
     <AppView>
       <XLayout type="stack">
-        <div
-          class="stack-with-borders"
+        <XTable
+          variant="kv"
         >
-          <DefinitionCard layout="horizontal">
-            <template #title>
+          <tr>
+            <th scope="row">
               Protocol
-            </template>
-
-            <template #body>
+            </th>
+            <td>
               <XBadge
                 appearance="info"
               >
                 {{ t(`http.api.value.${props.data.protocol}`) }}
               </XBadge>
-            </template>
-          </DefinitionCard>
-          <DefinitionCard
-            layout="horizontal"
-          >
-            <template #title>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">
               Port
-            </template>
-
-            <template #body>
+            </th>
+            <td>
               {{ props.data.port }}
-            </template>
-          </DefinitionCard>
-        </div>
+            </td>
+          </tr>
+        </XTable>
         <XLayout
           v-if="props.data"
           type="stack"
@@ -84,18 +80,15 @@
                             </PolicyTypeTag>
                           </template>
                           <template #accordion-content>
-                            <div
-                              class="stack-with-borders"
+                            <XTable
+                              v-if="origins.length > 0"
+                              variant="kv"
                             >
-                              <DefinitionCard
-                                v-if="origins.length > 0"
-                                layout="horizontal"
-                              >
-                                <template #title>
+                              <tr>
+                                <th scope="row">
                                   Origin policies
-                                </template>
-
-                                <template #body>
+                                </th>
+                                <td>
                                   <ul>
                                     <li
                                       v-for="origin in origins"
@@ -126,23 +119,24 @@
                                       </template>
                                     </li>
                                   </ul>
-                                </template>
-                              </DefinitionCard>
-                              <div>
-                                <dt>
-                                  Config
-                                </dt>
-                                <dd class="mt-2">
-                                  <div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td colspan="2">
+                                  <XLayout
+                                    type="stack"
+                                    size="small"
+                                  >
+                                    <span>Config</span>
                                     <XCodeBlock
                                       :code="YAML.stringify(conf)"
                                       language="yaml"
                                       :show-copy-button="false"
                                     />
-                                  </div>
-                                </dd>
-                              </div>
-                            </div>
+                                  </XLayout>
+                                </td>
+                              </tr>
+                            </XTable>
                           </template>
                         </AccordionItem>
                       </XCard>
@@ -163,7 +157,6 @@ import { DataplaneNetworkingLayout } from '../data'
 import { YAML } from '@/app/application'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import { Kri } from '@/app/kuma/kri'
 import { sources as policySources } from '@/app/policies/sources'

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneSummaryView.vue
@@ -101,46 +101,34 @@
                 size="large"
                 data-testid="structured-view"
               >
-                <div
-                  class="stack-with-borders"
+                <XTable
+                  variant="kv"
                 >
-                  <DefinitionCard
-                    layout="horizontal"
-                  >
-                    <template #title>
+                  <tr>
+                    <th scope="row">
                       Type
-                    </template>
-
-                    <template #body>
+                    </th>
+                    <td>
                       {{ t(`data-planes.type.${item.dataplaneType}`) }}
-                    </template>
-                  </DefinitionCard>
-
-                  <DefinitionCard
+                    </td>
+                  </tr>
+                  <tr
                     v-if="item.namespace.length > 0"
-                    layout="horizontal"
                   >
-                    <template #title>
+                    <th scope="row">
                       {{ t('data-planes.routes.item.namespace') }}
-                    </template>
-
-                    <template #body>
+                    </th>
+                    <td>
                       {{ item.namespace }}
-                    </template>
-                  </DefinitionCard>
-
-                  <DefinitionCard
+                    </td>
+                  </tr>
+                  <tr
                     v-if="can('use zones') && item.zone"
-                    layout="horizontal"
                   >
-                    <template
-                      #title
-                    >
+                    <th scope="row">
                       Zone
-                    </template>
-                    <template
-                      #body
-                    >
+                    </th>
+                    <td>
                       <XAction
                         :to="{
                           name: 'zone-cp-detail-view',
@@ -151,20 +139,17 @@
                       >
                         {{ item.zone }}
                       </XAction>
-                    </template>
-                  </DefinitionCard>
-                  <DefinitionCard
-                    layout="horizontal"
-                  >
-                    <template #title>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">
                       {{ t('http.api.property.modificationTime') }}
-                    </template>
-
-                    <template #body>
+                    </th>
+                    <td>
                       {{ t('common.formats.datetime', { value: Date.parse(item.modificationTime) }) }}
-                    </template>
-                  </DefinitionCard>
-                </div>
+                    </td>
+                  </tr>
+                </XTable>
 
                 <XLayout
                   v-if="item.dataplane.networking.gateway"
@@ -172,38 +157,31 @@
                 >
                   <h3>{{ t('data-planes.routes.item.gateway') }}</h3>
 
-                  <div
-                    class="stack-with-borders"
+                  <XTable
+                    variant="kv"
                   >
-                    <DefinitionCard
-                      layout="horizontal"
-                    >
-                      <template #title>
+                    <tr>
+                      <th scope="row">
                         {{ t('http.api.property.tags') }}
-                      </template>
-
-                      <template #body>
+                      </th>
+                      <td>
                         <TagList
                           alignment="right"
                           :tags="item.dataplane.networking.gateway.tags"
                         />
-                      </template>
-                    </DefinitionCard>
-
-                    <DefinitionCard
-                      layout="horizontal"
-                    >
-                      <template #title>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">
                         {{ t('http.api.property.address') }}
-                      </template>
-
-                      <template #body>
+                      </th>
+                      <td>
                         <XCopyButton
                           :text="`${item.dataplane.networking.address}`"
                         />
-                      </template>
-                    </DefinitionCard>
-                  </div>
+                      </td>
+                    </tr>
+                  </XTable>
                 </XLayout>
 
                 <DataCollection
@@ -229,18 +207,14 @@
                         </XCopyButton>
                       </h4>
 
-                      <XLayout
-                        class="stack-with-borders"
-                        size="small"
+                      <XTable
+                        variant="kv"
                       >
-                        <DefinitionCard
-                          layout="horizontal"
-                        >
-                          <template #title>
+                        <tr>
+                          <th scope="row">
                             {{ t('http.api.property.state') }}
-                          </template>
-
-                          <template #body>
+                          </th>
+                          <td>
                             <XBadge
                               v-if="inbound.state === 'Ready'"
                               appearance="success"
@@ -254,36 +228,28 @@
                             >
                               {{ t(`http.api.value.${inbound.state}`) }}
                             </XBadge>
-                          </template>
-                        </DefinitionCard>
-
-                        <DefinitionCard
-                          layout="horizontal"
-                        >
-                          <template #title>
+                          </td>
+                        </tr>
+                        <tr>
+                          <th scope="row">
                             {{ t('http.api.property.tags') }}
-                          </template>
-
-                          <template #body>
+                          </th>
+                          <td>
                             <TagList
                               alignment="right"
                               :tags="inbound.tags"
                             />
-                          </template>
-                        </DefinitionCard>
-
-                        <DefinitionCard
-                          layout="horizontal"
-                        >
-                          <template #title>
+                          </td>
+                        </tr>
+                        <tr>
+                          <th scope="row">
                             {{ t('http.api.property.address') }}
-                          </template>
-
-                          <template #body>
+                          </th>
+                          <td>
                             <XCopyButton :text="inbound.addressPort" />
-                          </template>
-                        </DefinitionCard>
-                      </XLayout>
+                          </td>
+                        </tr>
+                      </XTable>
                     </XLayout>
                   </XLayout>
                 </DataCollection>
@@ -311,38 +277,31 @@
                         </XCopyButton>
                       </h4>
 
-                      <XLayout
-                        class="stack-with-borders"
-                        size="small"
+                      <XTable
+                        variant="kv"
                       >
-                        <DefinitionCard
+                        <tr
                           v-if="Object.keys(outbound.tags).length"
-                          layout="horizontal"
                         >
-                          <template #title>
+                          <th scope="row">
                             {{ t('http.api.property.tags') }}
-                          </template>
-
-                          <template #body>
+                          </th>
+                          <td>
                             <TagList
                               alignment="right"
                               :tags="outbound.tags"
                             />
-                          </template>
-                        </DefinitionCard>
-
-                        <DefinitionCard
-                          layout="horizontal"
-                        >
-                          <template #title>
+                          </td>
+                        </tr>
+                        <tr>
+                          <th scope="row">
                             {{ t('http.api.property.address') }}
-                          </template>
-
-                          <template #body>
+                          </th>
+                          <td>
                             <XCopyButton :text="outbound.addressPort" />
-                          </template>
-                        </DefinitionCard>
-                      </XLayout>
+                          </td>
+                        </tr>
+                      </XTable>
                     </XLayout>
                   </XLayout>
                 </DataCollection>
@@ -399,7 +358,6 @@
 import { DataplaneOverview } from '../data'
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import TagList from '@/app/common/TagList.vue'
 
 const props = defineProps<{

--- a/packages/kuma-gui/src/app/data-planes/views/DataplanePolicyConfigSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataplanePolicyConfigSummaryView.vue
@@ -34,18 +34,15 @@
             v-for="policyTypes in [Object.groupBy((policyTypesData?.policyTypes ?? []), ({ name }) => name)]"
             :key="`${typeof policyTypes}`"
           >
-            <div
-              class="stack-with-borders"
+            <XTable
+              v-if="origins.length > 0"
+              variant="kv"
             >
-              <DefinitionCard
-                v-if="origins.length > 0"
-                layout="horizontal"
-              >
-                <template #title>
+              <tr>
+                <th scope="row">
                   Origin policies
-                </template>
-
-                <template #body>
+                </th>
+                <td>
                   <ul>
                     <li
                       v-for="origin in origins"
@@ -76,23 +73,24 @@
                       </template>
                     </li>
                   </ul>
-                </template>
-              </DefinitionCard>
-              <div>
-                <dt>
-                  Config
-                </dt>
-                <dd class="mt-2">
-                  <div>
+                </td>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <XLayout
+                    type="stack"
+                    size="small"
+                  >
+                    <span>Config</span>
                     <XCodeBlock
                       :code="YAML.stringify(conf)"
                       language="yaml"
                       :show-copy-button="false"
                     />
-                  </div>
-                </dd>
-              </div>
-            </div>
+                  </XLayout>
+                </td>
+              </tr>
+            </XTable>
           </template>
         </AppView>
       </template>
@@ -102,7 +100,6 @@
 
 <script lang="ts" setup>
 import { YAML } from '@/app/application'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import { Kri } from '@/app/kuma/kri'
 import { ResourceCollection } from '@/app/policies/data'

--- a/packages/kuma-gui/src/app/gateways/views/BuiltinGatewaySummaryView.vue
+++ b/packages/kuma-gui/src/app/gateways/views/BuiltinGatewaySummaryView.vue
@@ -87,90 +87,65 @@
               </header>
 
               <template v-if="route.params.format === 'structured'">
-                <div
-                  class="stack-with-borders"
+                <XTable
                   data-testid="structured-view"
+                  variant="kv"
                 >
-                  <DefinitionCard
+                  <tr
                     v-if="item.type.length > 0"
-                    layout="horizontal"
                   >
-                    <template #title>
+                    <th scope="row">
                       {{ t('gateways.routes.item.type') }}
-                    </template>
-
-                    <template #body>
-                      {{ item.type }}
-                    </template>
-                  </DefinitionCard>
-                  <DefinitionCard
+                    </th>
+                    <td>{{ item.type }}</td>
+                  </tr>
+                  <tr
                     v-if="item.namespace.length > 0"
-                    layout="horizontal"
                   >
-                    <template #title>
+                    <th scope="row">
                       {{ t('gateways.routes.item.namespace') }}
-                    </template>
-
-                    <template #body>
-                      {{ item.namespace }}
-                    </template>
-                  </DefinitionCard>
-                  <DefinitionCard
+                    </th>
+                    <td>{{ item.namespace }}</td>
+                  </tr>
+                  <tr
                     v-if="item.mesh.length > 0"
-                    layout="horizontal"
                   >
-                    <template #title>
+                    <th scope="row">
                       {{ t('gateways.routes.item.mesh') }}
-                    </template>
-
-                    <template #body>
-                      {{ item.mesh }}
-                    </template>
-                  </DefinitionCard>
-                  <DefinitionCard
+                    </th>
+                    <td>{{ item.mesh }}</td>
+                  </tr>
+                  <tr
                     v-if="item.zone.length > 0"
-                    layout="horizontal"
                   >
-                    <template #title>
+                    <th scope="row">
                       {{ t('gateways.routes.item.zone') }}
-                    </template>
-
-                    <template #body>
-                      {{ item.zone }}
-                    </template>
-                  </DefinitionCard>
-                  <DefinitionCard
+                    </th>
+                    <td>{{ item.zone }}</td>
+                  </tr>
+                  <tr
                     v-if="item.creationTime.length > 0"
-                    layout="horizontal"
                   >
-                    <template #title>
+                    <th scope="row">
                       {{ t('gateways.routes.item.created') }}
-                    </template>
-
-                    <template #body>
-                      {{ t('common.formats.datetime', { value: Date.parse(item.creationTime) }) }}
-                    </template>
-                  </DefinitionCard>
-                  <DefinitionCard
+                    </th>
+                    <td>{{ t('common.formats.datetime', { value: Date.parse(item.creationTime) }) }}</td>
+                  </tr>
+                  <tr
                     v-if="item.modificationTime.length > 0"
-                    layout="horizontal"
                   >
-                    <template #title>
+                    <th scope="row">
                       {{ t('gateways.routes.item.modified') }}
-                    </template>
-
-                    <template #body>
-                      {{ t('common.formats.datetime', { value: Date.parse(item.modificationTime) }) }}
-                    </template>
-                  </DefinitionCard>
-                  <DefinitionCard
+                    </th>
+                    <td>{{ t('common.formats.datetime', { value: Date.parse(item.modificationTime) }) }}</td>
+                  </tr>
+                  <tr
                     v-if="Object.keys(item.labels).length > 0"
-                    layout="horizontal"
                   >
-                    <template #title>
+                    <th scope="row">
                       {{ t('gateways.routes.item.labels') }}
-                    </template>
-                    <template #body>
+                    </th>
+                    <td>
                       <XLayout
                         type="separated"
                         justify="end"
@@ -201,16 +176,15 @@
                           </XBadge>
                         </template>
                       </XLayout>
-                    </template>
-                  </DefinitionCard>
-                  <DefinitionCard
+                    </td>
+                  </tr>
+                  <tr
                     v-if="item.selectors.length > 0"
-                    layout="horizontal"
                   >
-                    <template #title>
+                    <th scope="row">
                       {{ t('gateways.routes.item.selectors') }}
-                    </template>
-                    <template #body>
+                    </th>
+                    <td>
                       <XLayout
                         type="separated"
                         justify="end"
@@ -223,10 +197,9 @@
                           {{ key }}:{{ value }}
                         </XBadge>
                       </XLayout>
-                    </template>
-                  </DefinitionCard>
-                </div>
-
+                    </td>
+                  </tr>
+                </XTable>
                 <XCodeBlock
                   data-testid="codeblock-yaml-structured-conf"
                   language="yaml"
@@ -287,7 +260,6 @@ import type { MeshGateway } from '../data'
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
 import DataCollection from '@/app/application/components/data-collection/DataCollection.vue'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 
 const props = defineProps<{
   items: MeshGateway[]

--- a/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
+++ b/packages/kuma-gui/src/app/hostname-generators/views/HostnameGeneratorSummaryView.vue
@@ -70,40 +70,27 @@
                 </div>
               </XLayout>
             </header>
-            
+
             <template v-if="route.params.format === 'structured'">
-              <div
-                class="stack-with-borders"
+              <XTable
+                variant="kv"
                 data-testid="structured-view"
               >
-                <DefinitionCard
+                <tr
                   v-if="item.namespace.length > 0"
-                  layout="horizontal"
                 >
-                  <template
-                    #title
-                  >
+                  <th scope="row">
                     {{ t('hostname-generators.common.namespace') }}
-                  </template>
-
-                  <template
-                    #body
-                  >
-                    {{ item.namespace }}
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard
+                  </th>
+                  <td>{{ item.namespace }}</td>
+                </tr>
+                <tr
                   v-if="can('use zones') && item.zone"
-                  layout="horizontal"
                 >
-                  <template
-                    #title
-                  >
+                  <th scope="row">
                     {{ t('hostname-generators.common.zone') }}
-                  </template>
-                  <template
-                    #body
-                  >
+                  </th>
+                  <td>
                     <XAction
                       :to="{
                         name: 'zone-cp-detail-view',
@@ -114,24 +101,17 @@
                     >
                       {{ item.zone }}
                     </XAction>
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard
+                  </td>
+                </tr>
+                <tr
                   v-if="item.spec.template"
-                  layout="horizontal"
                 >
-                  <template
-                    #title
-                  >
+                  <th scope="row">
                     {{ t('hostname-generators.common.template') }}
-                  </template>
-                  <template
-                    #body
-                  >
-                    {{ item.spec.template }}
-                  </template>
-                </DefinitionCard>
-              </div>
+                  </th>
+                  <td>{{ item.spec.template }}</td>
+                </tr>
+              </XTable>
             </template>
 
             <template v-else-if="route.params.format === 'universal'">
@@ -182,7 +162,6 @@
 <script lang="ts" setup>
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import type { HostnameGenerator } from '@/app/hostname-generators/data'
 const props = defineProps<{
   items: HostnameGenerator[]

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneInboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneInboundSummaryOverviewView.vue
@@ -9,208 +9,201 @@
     v-slot="{ t, route, uri }"
   >
     <AppView>
-      <div
-        class="stack-with-borders"
+      <XLayout
+        type="stack"
       >
-        <DefinitionCard layout="horizontal">
-          <template #title>
-            Tags
-          </template>
-
-          <template #body>
-            <TagList
-              :tags="props.data.tags"
-              alignment="right"
-            />
-          </template>
-        </DefinitionCard>
-        <DefinitionCard layout="horizontal">
-          <template #title>
-            Protocol
-          </template>
-
-          <template #body>
-            <XBadge
-              appearance="info"
-            >
-              {{ t(`http.api.value.${props.data.protocol}`) }}
-            </XBadge>
-          </template>
-        </DefinitionCard>
-        <DefinitionCard layout="horizontal">
-          <template #title>
-            Address
-          </template>
-
-          <template #body>
-            <XCopyButton
-              :text="`${props.data.addressPort}`"
-            />
-          </template>
-        </DefinitionCard>
-        <DefinitionCard
-          v-if="props.data.serviceAddressPort.length > 0"
-          layout="horizontal"
+        <XTable
+          variant="kv"
         >
-          <template #title>
-            Service address
-          </template>
-
-          <template #body>
-            <XCopyButton
-              :text="`${props.data.serviceAddressPort}`"
-            />
-          </template>
-        </DefinitionCard>
-        <DefinitionCard
-          v-if="props.data.portName.length > 0"
-          layout="horizontal"
-        >
-          <template #title>
-            Name
-          </template>
-
-          <template #body>
-            <XCopyButton
-              :text="`${props.data.portName}`"
-            />
-          </template>
-        </DefinitionCard>
-      </div>
-      <div
-        v-if="props.data"
-        class="mt-6"
-      >
-        <h3>Rules</h3>
-        <DataSource
-          :src="uri(policySources, '/policy-types', {})"
-          v-slot="{ data: policyTypesData, error: policyTypesError }"
-        >
-          <DataSource
-            :src="uri(sources, '/meshes/:mesh/rules/for/:dataplane', {
-              mesh: route.params.mesh,
-              dataplane: route.params.proxy,
-            })"
-            v-slot="{ data: rulesData, error: rulesError }"
-          >
-            <DataLoader
-              :data="[policyTypesData, rulesData]"
-              :errors="[policyTypesError, rulesError]"
-            >
-              <template
-                v-for="policyTypes in [Object.groupBy((policyTypesData?.policyTypes ?? []), ({ name }) => name)]"
-                :key="`${typeof policyTypes}`"
+          <tr>
+            <th scope="row">
+              Tags
+            </th>
+            <td>
+              <TagList
+                :tags="props.data.tags"
+                alignment="right"
+              />
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">
+              Protocol
+            </th>
+            <td>
+              <XBadge
+                appearance="info"
               >
-                <DataCollection
-                  :predicate="(item) => {
-                    return (item.ruleType === 'inbound' || (item.ruleType === 'from' && !Boolean(policyTypes[item.type]?.[0]?.policy.isFromAsRules))) && Number(item.inbound!.port) === Number(route.params.connection.split('_')[1])
-                  }"
-                  :items="[...rulesData!.rules, ...rulesData!.inboundRules]"
-                  v-slot="{ items }"
+                {{ t(`http.api.value.${props.data.protocol}`) }}
+              </XBadge>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">
+              Address
+            </th>
+            <td>
+              <XCopyButton
+                :text="`${props.data.addressPort}`"
+              />
+            </td>
+          </tr>
+          <tr
+            v-if="props.data.serviceAddressPort.length > 0"
+          >
+            <th scope="row">
+              Service address
+            </th>
+            <td>
+              <XCopyButton
+                :text="`${props.data.serviceAddressPort}`"
+              />
+            </td>
+          </tr>
+          <tr
+            v-if="props.data.portName.length > 0"
+          >
+            <th scope="row">
+              Name
+            </th>
+            <td>
+              <XCopyButton
+                :text="`${props.data.portName}`"
+              />
+            </td>
+          </tr>
+        </XTable>
+        <div
+          v-if="props.data"
+        >
+          <h3>Rules</h3>
+          <DataSource
+            :src="uri(policySources, '/policy-types', {})"
+            v-slot="{ data: policyTypesData, error: policyTypesError }"
+          >
+            <DataSource
+              :src="uri(sources, '/meshes/:mesh/rules/for/:dataplane', {
+                mesh: route.params.mesh,
+                dataplane: route.params.proxy,
+              })"
+              v-slot="{ data: rulesData, error: rulesError }"
+            >
+              <DataLoader
+                :data="[policyTypesData, rulesData]"
+                :errors="[policyTypesError, rulesError]"
+              >
+                <template
+                  v-for="policyTypes in [Object.groupBy((policyTypesData?.policyTypes ?? []), ({ name }) => name)]"
+                  :key="`${typeof policyTypes}`"
                 >
-                  <div class="mt-4">
-                    <AccordionList
-                      :initially-open="0"
-                      multiple-open
-                      class="stack"
-                    >
-                      <template
-                        v-for="(rules, key) in Object.groupBy(items, item => item.type)"
-                        :key="key"
+                  <DataCollection
+                    :predicate="(item) => {
+                      return (item.ruleType === 'inbound' || (item.ruleType === 'from' && !Boolean(policyTypes[item.type]?.[0]?.policy.isFromAsRules))) && Number(item.inbound!.port) === Number(route.params.connection.split('_')[1])
+                    }"
+                    :items="[...rulesData!.rules, ...rulesData!.inboundRules]"
+                    v-slot="{ items }"
+                  >
+                    <div class="mt-4">
+                      <AccordionList
+                        :initially-open="0"
+                        multiple-open
+                        class="stack"
                       >
-                        <XCard>
-                          <AccordionItem>
-                            <template #accordion-header>
-                              <PolicyTypeTag
-                                :policy-type="key"
-                              >
-                                {{ key }} ({{ rules!.length }})
-                              </PolicyTypeTag>
-                            </template>
-                            <template #accordion-content>
-                              <div
-                                class="stack-with-borders"
-                              >
-                                <template
-                                  v-for="item in rules"
-                                  :key="item"
+                        <template
+                          v-for="(rules, key) in Object.groupBy(items, item => item.type)"
+                          :key="key"
+                        >
+                          <XCard>
+                            <AccordionItem>
+                              <template #accordion-header>
+                                <PolicyTypeTag
+                                  :policy-type="key"
                                 >
-                                  <DefinitionCard
-                                    v-if="item.matchers.length > 0"
-                                    layout="horizontal"
+                                  {{ key }} ({{ rules!.length }})
+                                </PolicyTypeTag>
+                              </template>
+                              <template #accordion-content>
+                                <XTable
+                                  variant="kv"
+                                >
+                                  <template
+                                    v-for="item in rules"
+                                    :key="item"
                                   >
-                                    <template #title>
-                                      From
-                                    </template>
-
-                                    <template #body>
-                                      <p><RuleMatchers :items="item.matchers" /></p>
-                                    </template>
-                                  </DefinitionCard>
-                                  <DefinitionCard
-                                    v-if="item.origins.length > 0"
-                                    layout="horizontal"
-                                  >
-                                    <template #title>
-                                      Origin policies
-                                    </template>
-
-                                    <template #body>
-                                      <ul>
-                                        <li
-                                          v-for="origin in item.origins"
-                                          :key="`${origin.mesh}-${origin.name}`"
+                                    <tr
+                                      v-if="item.matchers.length > 0"
+                                    >
+                                      <th scope="row">
+                                        From
+                                      </th>
+                                      <td>
+                                        <p><RuleMatchers :items="item.matchers" /></p>
+                                      </td>
+                                    </tr>
+                                    <tr
+                                      v-if="item.origins.length > 0"
+                                    >
+                                      <th scope="row">
+                                        Origin policies
+                                      </th>
+                                      <td>
+                                        <ul>
+                                          <li
+                                            v-for="origin in item.origins"
+                                            :key="`${origin.mesh}-${origin.name}`"
+                                          >
+                                            <XAction
+                                              v-if="policyTypes[origin.type]"
+                                              :to="{
+                                                name: 'policy-detail-view',
+                                                params: {
+                                                  mesh: origin.mesh,
+                                                  policyPath: policyTypes[origin.type]![0].path,
+                                                  policy: origin.name,
+                                                },
+                                              }"
+                                            >
+                                              {{ origin.name }}
+                                            </XAction>
+                                            <template
+                                              v-else
+                                            >
+                                              {{ origin.name }}
+                                            </template>
+                                          </li>
+                                        </ul>
+                                      </td>
+                                    </tr>
+                                    <tr>
+                                      <td colspan="2">
+                                        <XLayout
+                                          type="stack"
+                                          size="small"
                                         >
-                                          <XAction
-                                            v-if="policyTypes[origin.type]"
-                                            :to="{
-                                              name: 'policy-detail-view',
-                                              params: {
-                                                mesh: origin.mesh,
-                                                policyPath: policyTypes[origin.type]![0].path,
-                                                policy: origin.name,
-                                              },
-                                            }"
-                                          >
-                                            {{ origin.name }}
-                                          </XAction>
-                                          <template
-                                            v-else
-                                          >
-                                            {{ origin.name }}
-                                          </template>
-                                        </li>
-                                      </ul>
-                                    </template>
-                                  </DefinitionCard>
-                                  <div>
-                                    <dt>
-                                      Config
-                                    </dt>
-                                    <dd class="mt-2">
-                                      <div>
-                                        <XCodeBlock
-                                          :code="YAML.stringify(item.raw)"
-                                          language="yaml"
-                                          :show-copy-button="false"
-                                        />
-                                      </div>
-                                    </dd>
-                                  </div>
-                                </template>
-                              </div>
-                            </template>
-                          </AccordionItem>
-                        </XCard>
-                      </template>
-                    </AccordionList>
-                  </div>
-                </DataCollection>
-              </template>
-            </DataLoader>
+                                          <span>Config</span>
+                                          <XCodeBlock
+                                            :code="YAML.stringify(item.raw)"
+                                            language="yaml"
+                                            :show-copy-button="false"
+                                          />
+                                        </XLayout>
+                                      </td>
+                                    </tr>
+                                  </template>
+                                </XTable>
+                              </template>
+                            </AccordionItem>
+                          </XCard>
+                        </template>
+                      </AccordionList>
+                    </div>
+                  </DataCollection>
+                </template>
+              </DataLoader>
+            </DataSource>
           </DataSource>
-        </DataSource>
-      </div>
+        </div>
+      </XLayout>
     </AppView>
   </RouteView>
 </template>
@@ -219,7 +212,6 @@
 import { YAML } from '@/app/application'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import TagList from '@/app/common/TagList.vue'
 import type { DataplaneInbound } from '@/app/data-planes/data'

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneOutboundSummaryOverviewView.vue
@@ -13,27 +13,27 @@
         v-for="service in [route.params.connection.replace(/-([a-f0-9]){16}$/, '')]"
         :key="service"
       >
-        <div
-          class="stack-with-borders"
+        <XLayout
+          type="stack"
         >
-          <DefinitionCard
-            layout="horizontal"
+          <XTable
+            variant="kv"
           >
-            <template #title>
-              Protocol
-            </template>
-
-            <template #body>
-              <XBadge
-                appearance="info"
-              >
-                {{ t(`http.api.value.${['grpc', 'http', 'tcp'].find(protocol => typeof props.data[protocol] !== 'undefined')}`) }}
-              </XBadge>
-            </template>
-          </DefinitionCard>
+            <tr>
+              <th scope="row">
+                Protocol
+              </th>
+              <td>
+                <XBadge
+                  appearance="info"
+                >
+                  {{ t(`http.api.value.${['grpc', 'http', 'tcp'].find(protocol => typeof props.data[protocol] !== 'undefined')}`) }}
+                </XBadge>
+              </td>
+            </tr>
+          </XTable>
           <div
             v-if="props.data"
-            class="rules"
           >
             <h3>Rules</h3>
 
@@ -75,63 +75,68 @@
                             >
                               {{ key }}
                             </PolicyTypeTag>
-                            <div
-                              class="stack-with-borders mt-4"
+                            <XTable
+                              variant="kv"
                             >
                               <template
                                 v-for="item in rules!.length > 1 ? rules!.filter(item => ruleForCluster(props.data, item)) : rules"
                                 :key="item"
                               >
-                                <div>
-                                  <DefinitionCard
-                                    v-if="item.origins.length > 0"
-                                    layout="horizontal"
-                                  >
-                                    <template #title>
-                                      Origin policies
-                                    </template>
-
-                                    <template #body>
-                                      <DataCollection
-                                        :predicate="(item) => {
-                                          return typeof item.resourceMeta !== 'undefined'
-                                        }"
-                                        :items="item.origins"
-                                        :empty="false"
-                                        v-slot="{ items: origins }"
-                                      >
-                                        <ul>
-                                          <li
-                                            v-for="origin in origins"
-                                            :key="JSON.stringify(origin)"
+                                <tr
+                                  v-if="item.origins.length > 0"
+                                >
+                                  <th scope="row">
+                                    Origin policies
+                                  </th>
+                                  <td>
+                                    <DataCollection
+                                      :predicate="(item) => {
+                                        return typeof item.resourceMeta !== 'undefined'
+                                      }"
+                                      :items="item.origins"
+                                      :empty="false"
+                                      v-slot="{ items: origins }"
+                                    >
+                                      <ul>
+                                        <li
+                                          v-for="origin in origins"
+                                          :key="JSON.stringify(origin)"
+                                        >
+                                          <XAction
+                                            v-if="Object.keys(types).length > 0"
+                                            :to="{
+                                              name: 'policy-detail-view',
+                                              params: {
+                                                policyPath: types[key]![0].path,
+                                                mesh: origin.resourceMeta!.mesh,
+                                                policy: origin.resourceMeta!.name,
+                                              },
+                                            }"
                                           >
-                                            <XAction
-                                              v-if="Object.keys(types).length > 0"
-                                              :to="{
-                                                name: 'policy-detail-view',
-                                                params: {
-                                                  policyPath: types[key]![0].path,
-                                                  mesh: origin.resourceMeta!.mesh,
-                                                  policy: origin.resourceMeta!.name,
-                                                },
-                                              }"
-                                            >
-                                              {{ origin.resourceMeta!.name }}
-                                            </XAction>
-                                          </li>
-                                        </ul>
-                                      </DataCollection>
-                                    </template>
-                                  </DefinitionCard>
-                                  <XCodeBlock
-                                    class="mt-2"
-                                    :code="YAML.stringify(item.raw)"
-                                    language="yaml"
-                                    :show-copy-button="false"
-                                  />
-                                </div>
+                                            {{ origin.resourceMeta!.name }}
+                                          </XAction>
+                                        </li>
+                                      </ul>
+                                    </DataCollection>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td colspan="2">
+                                    <XLayout
+                                      type="stack"
+                                      size="small"
+                                    >
+                                      <span>Config</span>
+                                      <XCodeBlock
+                                        :code="YAML.stringify(item.raw)"
+                                        language="yaml"
+                                        :show-copy-button="false"
+                                      />
+                                    </XLayout>
+                                  </td>
+                                </tr>
                               </template>
-                            </div>
+                            </XTable>
                           </div>
                         </template>
                       </div>
@@ -172,34 +177,30 @@
                                   </PolicyTypeTag>
                                 </template>
                                 <template #accordion-content>
-                                  <div
-                                    class="stack-with-borders"
+                                  <XTable
+                                    variant="kv"
                                   >
                                     <template
                                       v-for="item in rules"
                                       :key="item"
                                     >
-                                      <DefinitionCard
+                                      <tr
                                         v-if="item.matchers.length > 0"
-                                        layout="horizontal"
                                       >
-                                        <template #title>
+                                        <th scope="row">
                                           From
-                                        </template>
-
-                                        <template #body>
+                                        </th>
+                                        <td>
                                           <p><RuleMatchers :items="item.matchers" /></p>
-                                        </template>
-                                      </DefinitionCard>
-                                      <DefinitionCard
+                                        </td>
+                                      </tr>
+                                      <tr
                                         v-if="item.origins.length > 0"
-                                        layout="horizontal"
                                       >
-                                        <template #title>
+                                        <th scope="row">
                                           Origin policies
-                                        </template>
-
-                                        <template #body>
+                                        </th>
+                                        <td>
                                           <ul>
                                             <li
                                               v-for="origin in item.origins"
@@ -225,24 +226,25 @@
                                               </template>
                                             </li>
                                           </ul>
-                                        </template>
-                                      </DefinitionCard>
-                                      <div>
-                                        <dt>
-                                          Config
-                                        </dt>
-                                        <dd class="mt-2">
-                                          <div>
+                                        </td>
+                                      </tr>
+                                      <tr>
+                                        <td colspan="2">
+                                          <XLayout
+                                            type="stack"
+                                            size="small"
+                                          >
+                                            <span>Config</span>
                                             <XCodeBlock
                                               :code="YAML.stringify(item.raw)"
                                               language="yaml"
                                               :show-copy-button="false"
                                             />
-                                          </div>
-                                        </dd>
-                                      </div>
+                                          </XLayout>
+                                        </td>
+                                      </tr>
                                     </template>
-                                  </div>
+                                  </XTable>
                                 </template>
                               </AccordionItem>
                             </XCard>
@@ -255,7 +257,7 @@
               </template>
             </DataSource>
           </div>
-        </div>
+        </XLayout>
       </template>
     </AppView>
   </RouteView>
@@ -264,7 +266,6 @@
 import { YAML } from '@/app/application'
 import AccordionItem from '@/app/common/AccordionItem.vue'
 import AccordionList from '@/app/common/AccordionList.vue'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import { sources as policySources } from '@/app/policies/sources'
 import RuleMatchers from '@/app/rules/components/RuleMatchers.vue'
@@ -283,8 +284,3 @@ const ruleForCluster = (cluster: any, rule: ResourceRule) => {
   (rule.resourceSectionName === '' || cluster.$resourceMeta.port === rule.port)
 }
 </script>
-<style lang="scss" scoped>
-.rules {
-  padding-top: $kui-space-60;
-}
-</style>

--- a/packages/kuma-gui/src/app/policies/components/PolicySummary.vue
+++ b/packages/kuma-gui/src/app/policies/components/PolicySummary.vue
@@ -4,35 +4,30 @@
   >
     <slot name="header" />
     <template v-if="props.format === 'structured'">
-      <div
-        class="mt-4 stack-with-borders"
+      <XTable
         data-testid="structured-view"
+        variant="kv"
       >
-        <DefinitionCard
-          layout="horizontal"
-        >
-          <template #title>
+        <tr>
+          <th scope="row">
             {{ t('http.api.property.type') }}
-          </template>
-
-          <template #body>
+          </th>
+          <td>
             <XBadge
               v-if="props.policy.type"
               appearance="neutral"
             >
               {{ props.policy.type }}
             </XBadge>
-          </template>
-        </DefinitionCard>
-        <DefinitionCard
+          </td>
+        </tr>
+        <tr
           v-if="!props.legacy"
-          layout="horizontal"
         >
-          <template #title>
+          <th scope="row">
             {{ t('http.api.property.targetRef') }}
-          </template>
-
-          <template #body>
+          </th>
+          <td>
             <XBadge
               v-if="props.policy.spec?.targetRef"
               appearance="neutral"
@@ -45,32 +40,23 @@
             >
               Mesh
             </XBadge>
-          </template>
-        </DefinitionCard>
-        <DefinitionCard
+          </td>
+        </tr>
+        <tr
           v-if="props.policy.namespace.length > 0"
-          layout="horizontal"
         >
-          <template #title>
+          <th scope="row">
             {{ t('data-planes.routes.item.namespace') }}
-          </template>
-
-          <template #body>
-            {{ props.policy.namespace }}
-          </template>
-        </DefinitionCard>
-        <DefinitionCard
+          </th>
+          <td>{{ props.policy.namespace }}</td>
+        </tr>
+        <tr
           v-if="can('use zones') && props.policy.zone"
-          layout="horizontal"
         >
-          <template
-            #title
-          >
+          <th scope="row">
             Zone
-          </template>
-          <template
-            #body
-          >
+          </th>
+          <td>
             <XAction
               :to="{
                 name: 'zone-cp-detail-view',
@@ -81,10 +67,9 @@
             >
               {{ props.policy.zone }}
             </XAction>
-          </template>
-        </DefinitionCard>
-      </div>
-
+          </td>
+        </tr>
+      </XTable>
       <XCodeBlock
         language="yaml"
         :code="YAML.stringify(policy.spec ?
@@ -117,7 +102,6 @@
 
 import type { Policy } from '../data'
 import { useI18n, useCan, YAML } from '@/app/application'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 
 const { t } = useI18n()
 const can = useCan()

--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceSummaryView.vue
@@ -73,38 +73,25 @@
               </XLayout>
             </header>
             <template v-if="route.params.format === 'structured'">
-              <div
-                class="stack-with-borders"
+              <XTable
                 data-testid="structured-view"
+                variant="kv"
               >
-                <DefinitionCard
+                <tr
                   v-if="item.namespace.length > 0"
-                  layout="horizontal"
                 >
-                  <template
-                    #title
-                  >
+                  <th scope="row">
                     Namespace
-                  </template>
-
-                  <template
-                    #body
-                  >
-                    {{ item.namespace }}
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard
+                  </th>
+                  <td>{{ item.namespace }}</td>
+                </tr>
+                <tr
                   v-if="can('use zones') && item.zone"
-                  layout="horizontal"
                 >
-                  <template
-                    #title
-                  >
+                  <th scope="row">
                     Zone
-                  </template>
-                  <template
-                    #body
-                  >
+                  </th>
+                  <td>
                     <XAction
                       :to="{
                         name: 'zone-cp-detail-view',
@@ -115,38 +102,33 @@
                     >
                       {{ item.zone }}
                     </XAction>
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard
+                  </td>
+                </tr>
+                <tr
                   v-if="item.spec.match"
-                  layout="horizontal"
                 >
-                  <template #title>
+                  <th scope="row">
                     Port
-                  </template>
-                  <template #body>
+                  </th>
+                  <td>
                     <KumaPort
                       :port="item.spec.match"
                     />
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard layout="horizontal">
-                  <template
-                    #title
-                  >
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">
                     TLS
-                  </template>
-                  <template
-                    #body
-                  >
+                  </th>
+                  <td>
                     <XBadge
                       appearance="neutral"
                     >
                       {{ item.spec.tls?.enabled ? 'Enabled' : 'Disabled' }}
                     </XBadge>
-                  </template>
-                </DefinitionCard>
-              </div>
+                  </td>
+                </tr>
+              </XTable>
             </template>
 
             <template v-else-if="route.params.format === 'universal'">
@@ -198,7 +180,6 @@
 <script lang="ts" setup>
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import type { MeshExternalService } from '@/app/services/data'
 const props = defineProps<{
   items: MeshExternalService[]

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceSummaryView.vue
@@ -73,21 +73,15 @@
               </XLayout>
             </header>
             <template v-if="route.params.format === 'structured'">
-              <div
-                class="stack-with-borders"
+              <XTable
                 data-testid="structured-view"
+                variant="kv"
               >
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template
-                    #title
-                  >
+                <tr>
+                  <th scope="row">
                     Ports
-                  </template>
-                  <template
-                    #body
-                  >
+                  </th>
+                  <td>
                     <XLayout
                       type="separated"
                       truncate
@@ -101,19 +95,13 @@
                         }"
                       />
                     </XLayout>
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template
-                    #title
-                  >
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">
                     Selector
-                  </template>
-                  <template
-                    #body
-                  >
+                  </th>
+                  <td>
                     <XLayout
                       type="separated"
                       truncate
@@ -126,9 +114,9 @@
                         {{ key }}:{{ value }}
                       </XBadge>
                     </XLayout>
-                  </template>
-                </DefinitionCard>
-              </div>
+                  </td>
+                </tr>
+              </XTable>
             </template>
 
             <template v-else-if="route.params.format === 'universal'">
@@ -180,7 +168,6 @@
 <script lang="ts" setup>
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import type { MeshMultiZoneService } from '@/app/services/data'
 const props = defineProps<{
   items: MeshMultiZoneService[]

--- a/packages/kuma-gui/src/app/services/views/MeshServiceSummaryView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceSummaryView.vue
@@ -82,51 +82,33 @@
               </XLayout>
             </header>
             <template v-if="route.params.format === 'structured'">
-              <div
-                class="stack-with-borders"
+              <XTable
                 data-testid="structured-view"
+                variant="kv"
               >
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template
-                    #title
-                  >
+                <tr>
+                  <th scope="row">
                     Data plane proxies
-                  </template>
-                  <template
-                    #body
-                  >
+                  </th>
+                  <td>
                     {{ item.status.dataplaneProxies?.connected }} connected, {{ item.status.dataplaneProxies?.healthy }} healthy ({{ item.status.dataplaneProxies?.total }} total)
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard
+                  </td>
+                </tr>
+                <tr
                   v-if="item.namespace"
-                  layout="horizontal"
                 >
-                  <template
-                    #title
-                  >
+                  <th scope="row">
                     Namespace
-                  </template>
-                  <template
-                    #body
-                  >
-                    {{ item.namespace }}
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard
+                  </th>
+                  <td>{{ item.namespace }}</td>
+                </tr>
+                <tr
                   v-if="can('use zones') && item.zone"
-                  layout="horizontal"
                 >
-                  <template
-                    #title
-                  >
+                  <th scope="row">
                     Zone
-                  </template>
-                  <template
-                    #body
-                  >
+                  </th>
+                  <td>
                     <XAction
                       :to="{
                         name: 'zone-cp-detail-view',
@@ -137,19 +119,13 @@
                     >
                       {{ item.zone }}
                     </XAction>
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template
-                    #title
-                  >
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">
                     Ports
-                  </template>
-                  <template
-                    #body
-                  >
+                  </th>
+                  <td>
                     <XLayout
                       type="separated"
                       truncate
@@ -163,17 +139,13 @@
                         }"
                       />
                     </XLayout>
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard layout="horizontal">
-                  <template
-                    #title
-                  >
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row">
                     Selector
-                  </template>
-                  <template
-                    #body
-                  >
+                  </th>
+                  <td>
                     <XLayout
                       type="separated"
                       truncate
@@ -186,11 +158,11 @@
                         {{ key }}:{{ value }}
                       </XBadge>
                     </XLayout>
-                  </template>
-                </DefinitionCard>
-              </div>
+                  </td>
+                </tr>
+              </XTable>
             </template>
-            
+
             <template v-else-if="route.params.format === 'universal'">
               <XCodeBlock
                 data-testid="codeblock-yaml-universal"
@@ -240,7 +212,6 @@
 <script lang="ts" setup>
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import type { MeshService } from '@/app/services/data'
 const props = defineProps<{
   items: MeshService[]

--- a/packages/kuma-gui/src/app/subscriptions/views/SubscriptionSummaryView.vue
+++ b/packages/kuma-gui/src/app/subscriptions/views/SubscriptionSummaryView.vue
@@ -58,33 +58,31 @@
                 <XTable
                   variant="kv"
                 >
-                  <tbody>
-                    <tr
-                      v-for="[key, value] in [
-                        [t('http.api.property.version'), item.version?.kumaCp?.version ?? '-'],
-                        [t('http.api.property.connectTime'), t('common.formats.datetime', { value: Date.parse(item.connectTime ?? '') })],
-                        ...(item.disconnectTime ? [[t('http.api.property.disconnectTime'), t('common.formats.datetime', { value: Date.parse(item.disconnectTime) })]] : []),
-                        [t('subscriptions.routes.item.headers.responses'), `${item.status.total.responsesSent}/${item.status.total.responsesAcknowledged}`],
-                        ...(['zoneInstanceId', 'globalInstanceId', 'controlPlaneInstanceId'] as const).reduce((prev, prop) => {
-                          if(item[prop]) {
-                            prev.push([t(`http.api.property.${prop}`), item[prop]])
-                          }
-                          return prev
-                        }, ([] as [string, string][])),
-                        [t('http.api.property.id'), item.id],
-                      ]"
-                      :key="key"
+                  <tr
+                    v-for="[key, value] in [
+                      [t('http.api.property.version'), item.version?.kumaCp?.version ?? '-'],
+                      [t('http.api.property.connectTime'), t('common.formats.datetime', { value: Date.parse(item.connectTime ?? '') })],
+                      ...(item.disconnectTime ? [[t('http.api.property.disconnectTime'), t('common.formats.datetime', { value: Date.parse(item.disconnectTime) })]] : []),
+                      [t('subscriptions.routes.item.headers.responses'), `${item.status.total.responsesSent}/${item.status.total.responsesAcknowledged}`],
+                      ...(['zoneInstanceId', 'globalInstanceId', 'controlPlaneInstanceId'] as const).reduce((prev, prop) => {
+                        if(item[prop]) {
+                          prev.push([t(`http.api.property.${prop}`), item[prop]])
+                        }
+                        return prev
+                      }, ([] as [string, string][])),
+                      [t('http.api.property.id'), item.id],
+                    ]"
+                    :key="key"
+                  >
+                    <th
+                      scope="row"
                     >
-                      <th
-                        scope="row"
-                      >
-                        {{ key }}
-                      </th>
-                      <td>
-                        {{ value }}
-                      </td>
-                    </tr>
-                  </tbody>
+                      {{ key }}
+                    </th>
+                    <td>
+                      {{ value }}
+                    </td>
+                  </tr>
                 </XTable>
 
                 <DataCollection

--- a/packages/kuma-gui/src/app/x/components/x-table/XTable.vue
+++ b/packages/kuma-gui/src/app/x/components/x-table/XTable.vue
@@ -20,6 +20,7 @@ table {
 }
 :deep(th) {
   text-align: left;
+  vertical-align: top;
 }
 :deep(thead tr) {
   th {
@@ -28,15 +29,16 @@ table {
 }
 :deep(tr) {
   th, td {
-    margin-block-start: $kui-space-40;
     padding-block-start: $kui-space-40;
     padding-block-end: $kui-space-40;
   }
 }
-:deep(tbody tr) {
-  &:not(:first-child) {
-    th, td {
-      border-block-start: $kui-border-width-10 solid $kui-color-border;
+table:not(.variant-kv) {
+  :deep(tbody tr), table :deep(> tr) {
+    &:not(:first-child) {
+      th, td {
+        border-block-start: $kui-border-width-10 solid $kui-color-border;
+      }
     }
   }
 }
@@ -48,14 +50,21 @@ table.variant-kv {
       text-align: right;
     }
   }
-  :deep(tbody tr) {
+  :deep(tbody tr), :deep(> tr) {
+    display: flex;
+    justify-content: space-between;
+    &:not(:first-child) {
+      border-block-start: $kui-border-width-10 solid $kui-color-border;
+    }
+    td:only-child {
+      width: 100%;
+    }
     th[scope="row"] {
       & {
         font-weight: $kui-font-weight-regular;
       }
       + td {
         font-weight: $kui-font-weight-bold;
-        text-align: right;
       }
     }
   }

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressSummaryView.vue
@@ -98,32 +98,23 @@
               </header>
 
               <template v-if="route.params.format === 'structured'">
-                <XLayout
-                  type="stack"
-                  class="stack-with-borders"
+                <XTable
                   data-testid="structured-view"
+                  variant="kv"
                 >
-                  <DefinitionCard
+                  <tr
                     v-if="item.namespace.length > 0"
-                    layout="horizontal"
                   >
-                    <template #title>
+                    <th scope="row">
                       {{ t('data-planes.routes.item.namespace') }}
-                    </template>
-
-                    <template #body>
-                      {{ item.namespace }}
-                    </template>
-                  </DefinitionCard>
-
-                  <DefinitionCard
-                    layout="horizontal"
-                  >
-                    <template #title>
+                    </th>
+                    <td>{{ item.namespace }}</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">
                       {{ t('http.api.property.address') }}
-                    </template>
-
-                    <template #body>
+                    </th>
+                    <td>
                       <template
                         v-if="item.zoneEgress.socketAddress.length > 0"
                       >
@@ -135,9 +126,9 @@
                       <template v-else>
                         {{ t('common.detail.none') }}
                       </template>
-                    </template>
-                  </DefinitionCard>
-                </XLayout>
+                    </td>
+                  </tr>
+                </XTable>
               </template>
 
               <template v-else-if="route.params.format === 'universal'">
@@ -190,7 +181,6 @@
 import type { ZoneEgressOverview } from '../data'
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 
 const props = defineProps<{
   items: ZoneEgressOverview[]

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressSummaryView.vue
@@ -100,62 +100,54 @@
                   class="stack-with-borders"
                   data-testid="structured-view"
                 >
-                  <DefinitionCard
-                    v-if="item.namespace.length > 0"
-                    layout="horizontal"
+                  <XTable
+                    variant="kv"
                   >
-                    <template #title>
-                      {{ t('data-planes.routes.item.namespace') }}
-                    </template>
+                    <tr
+                      v-if="item.namespace.length > 0"
+                    >
+                      <th scope="row">
+                        {{ t('data-planes.routes.item.namespace') }}
+                      </th>
+                      <td>{{ item.namespace }}</td>
+                    </tr>
+                    <tr>
+                      <th scope="row">
+                        {{ t('http.api.property.address') }}
+                      </th>
+                      <td>
+                        <template
+                          v-if="item.zoneIngress.socketAddress.length > 0"
+                        >
+                          <XCopyButton
+                            :text="item.zoneIngress.socketAddress"
+                          />
+                        </template>
 
-                    <template #body>
-                      {{ item.namespace }}
-                    </template>
-                  </DefinitionCard>
+                        <template v-else>
+                          {{ t('common.detail.none') }}
+                        </template>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="row">
+                        {{ t('http.api.property.advertisedAddress') }}
+                      </th>
+                      <td>
+                        <template
+                          v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
+                        >
+                          <XCopyButton
+                            :text="item.zoneIngress.advertisedSocketAddress"
+                          />
+                        </template>
 
-                  <DefinitionCard
-                    layout="horizontal"
-                  >
-                    <template #title>
-                      {{ t('http.api.property.address') }}
-                    </template>
-
-                    <template #body>
-                      <template
-                        v-if="item.zoneIngress.socketAddress.length > 0"
-                      >
-                        <XCopyButton
-                          :text="item.zoneIngress.socketAddress"
-                        />
-                      </template>
-
-                      <template v-else>
-                        {{ t('common.detail.none') }}
-                      </template>
-                    </template>
-                  </DefinitionCard>
-
-                  <DefinitionCard
-                    layout="horizontal"
-                  >
-                    <template #title>
-                      {{ t('http.api.property.advertisedAddress') }}
-                    </template>
-
-                    <template #body>
-                      <template
-                        v-if="item.zoneIngress.advertisedSocketAddress.length > 0"
-                      >
-                        <XCopyButton
-                          :text="item.zoneIngress.advertisedSocketAddress"
-                        />
-                      </template>
-
-                      <template v-else>
-                        {{ t('common.detail.none') }}
-                      </template>
-                    </template>
-                  </DefinitionCard>
+                        <template v-else>
+                          {{ t('common.detail.none') }}
+                        </template>
+                      </td>
+                    </tr>
+                  </XTable>
                 </div>
               </template>
 
@@ -209,7 +201,6 @@
 import type { ZoneIngressOverview } from '../data'
 import { sources } from '../sources'
 import { YAML } from '@/app/application'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 
 const props = defineProps<{
   items: ZoneIngressOverview[]


### PR DESCRIPTION
Follow up of https://github.com/kumahq/kuma-gui/pull/4191

Closes https://github.com/kumahq/kuma-gui/issues/4193

Replaces DefinitionCard in all SummaryViews with XTable. DefinitionCard should no longer be being used for summary view, border separated tables anywhere.

Note: I made some further changes to XTable CSS here to get the layout exactly the same as previously.

I also noticed that following this change these links are no longer blue, I plan to resolve this in a follow up PR (I already have the change here) (edit: see https://github.com/kumahq/kuma-gui/pull/4207)

<img width="636" height="245" alt="Screenshot 2025-09-03 at 15 04 33" src="https://github.com/user-attachments/assets/acf38539-151d-4938-b983-ccc8aa69edfb" />



