### PR TITLE
fix(mesh): mtls warning shows up with mesh identity

### DIFF
--- a/packages/kuma-gui/features/mesh/Item.feature
+++ b/packages/kuma-gui/features/mesh/Item.feature
@@ -2,12 +2,13 @@ Feature: mesh / item
 
   Background:
     Given the CSS selectors
-      | Alias              | Selector                                 |
-      | error              | [data-testid="error-state"]              |
-      | service-count      | [data-testid="services-status"]          |
-      | config-universal   | [data-testid='codeblock-yaml-universal'] |
-      | config-k8s         | [data-testid='codeblock-yaml-k8s']       |
-      | select-environment | [data-testid='select-input']             |
+      | Alias              | Selector                                                        |
+      | error              | [data-testid="error-state"]                                     |
+      | service-count      | [data-testid="services-status"]                                 |
+      | config-universal   | [data-testid='codeblock-yaml-universal']                        |
+      | config-k8s         | [data-testid='codeblock-yaml-k8s']                              |
+      | select-environment | [data-testid='select-input']                                    |
+      | mtls-warning       | [data-testid^='notification-meshes.notifications.mtls-warning'] |
 
   Scenario: /mesh-insights/* isn't a 404
     Given the URL "/mesh-insights/default" responds with
@@ -37,3 +38,22 @@ Feature: mesh / item
     When I click the "[data-testid='select-item-k8s'] button" element
     Then the "$config-k8s" element exists
     And the URL contains "?environment=k8s"
+
+  Scenario Outline: With <Scenario> the mTLS warning <Exists>
+    Given the environment
+      """
+      KUMA_MESHIDENTITY_COUNT: <midCount>
+      """
+    And the URL "/meshes/default" responds with
+      """
+      body:
+        mtls: <mtls>
+      """
+    When I visit the "/meshes/default/overview" URL
+    Then the "$mtls-warning" element <Exists>
+
+    Examples:
+      | Scenario                    | Exists        | midCount | mtls           |
+      | no MeshIdentity and no mtls | exists        |        0 | !!js/undefined |
+      | a MeshIdentity and no mtls  | doesn't exist |        1 | !!js/undefined |
+      | no MeshIdentity but mtls    | doesn't exist |        0 |                |

--- a/packages/kuma-gui/features/mesh/Item.feature
+++ b/packages/kuma-gui/features/mesh/Item.feature
@@ -9,6 +9,7 @@ Feature: mesh / item
       | config-k8s         | [data-testid='codeblock-yaml-k8s']                              |
       | select-environment | [data-testid='select-input']                                    |
       | mtls-warning       | [data-testid^='notification-meshes.notifications.mtls-warning'] |
+      | mtrust-section     | [data-testid='mesh-trusts-listing']                             |
 
   Scenario: /mesh-insights/* isn't a 404
     Given the URL "/mesh-insights/default" responds with
@@ -57,3 +58,16 @@ Feature: mesh / item
       | no MeshIdentity and no mtls | exists        |        0 | !!js/undefined |
       | a MeshIdentity and no mtls  | doesn't exist |        1 | !!js/undefined |
       | no MeshIdentity but mtls    | doesn't exist |        0 |                |
+
+  Scenario Outline: With <Scenario> the MeshTrust section <Exists>
+    Given the environment
+      """
+      KUMA_MESHTRUST_COUNT: <mtrustCount>
+      """
+    When I visit the "/meshes/default/overview" URL
+    Then the "$mtrust-section" element <Exists>
+
+    Examples:
+      | Scenario               | Exists        | mtrustCount |
+      | no MeshTrust           | doesn't exist |           0 |
+      | at least one MeshTrust | exists        |           1 |

--- a/packages/kuma-gui/features/mesh/MeshIdentity.feature
+++ b/packages/kuma-gui/features/mesh/MeshIdentity.feature
@@ -3,8 +3,13 @@ Feature: mesh / mesh-identity
   Background:
     Given the CSS selectors
       | Alias                     | Selector                                  |
-      | meshidentities-collection | [data-testid="meshidentities-collection"] |
+      | mesh-mtls                 | [data-testid="mesh-mtls"]                 |
       | summary                   | [data-testid="slideout-container"]        |
+    And the environment
+      """
+      KUMA_MTLS_ENABLED: false
+      KUMA_MESHIDENTITY_COUNT: 1
+      """
 
   Scenario: MeshIdentities are listed in mesh about section
     Given the URL "/meshes/default/meshidentities" responds with
@@ -14,8 +19,8 @@ Feature: mesh / mesh-identity
           - name: identity-1
       """
     When I visit the "/meshes/default" URL
-    Then the "$meshidentities-collection" element exists
-    And the "$meshidentities-collection" element contains "identity-1"
+    Then the "$mesh-mtls" element exists
+    And the "$mesh-mtls" element contains "MeshIdentity / identity-1"
 
   Scenario: Clicking on mesh identity opens summary view
     Given the URL "/meshes/default/meshidentities" responds with
@@ -25,7 +30,7 @@ Feature: mesh / mesh-identity
           - name: identity-1
       """
     When I visit the "/meshes/default" URL
-    Then I click the "$meshidentities-collection a:first" element
+    Then I click the "$mesh-mtls a:first" element
     Then the URL contains "/meshes/default/overview/meshidentity/identity-1"
     And the "$summary" element exists
     And the "$summary" element contains "identity-1"

--- a/packages/kuma-gui/features/mesh/services/mesh-services/Item.feature
+++ b/packages/kuma-gui/features/mesh/services/mesh-services/Item.feature
@@ -65,5 +65,5 @@ Feature: mesh / mesh-services / item
     Then the "$identities" element exists
     And the "$identities" element contains "firewall-1-tag"
     And the "$identities" element contains "ServiceTag"
-    And the "$identities" element contains "spiffe://kuma.io/ns/firewall-app/sa/firewall-1" 
+    And the "$identities" element contains "spiffe://kuma.io/ns/firewall-app/sa/firewall-1"
     And the "$identities" element contains "SpiffeID"

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -109,7 +109,10 @@
                         </template>
                       </template>
 
-                      <DefinitionCard layout="horizontal">
+                      <DefinitionCard
+                        layout="horizontal"
+                        data-testid="mesh-mtls"
+                      >
                         <template #title>
                           {{ t('http.api.property.mtls') }}
                         </template>

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -38,7 +38,7 @@
               :data="[meshIdentities, meshTrusts]"
             >
               <XNotification
-                :notify="!props.mesh.mtlsBackend"
+                :notify="!props.mesh.mtlsBackend && meshIdentities!.items.length === 0"
                 :uri="`meshes.notifications.mtls-warning:${props.mesh.id}`"
               >
                 <XI18n

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -115,54 +115,45 @@
                         </template>
 
                         <template #body>
-                          <XBadge
-                            v-if="!props.mesh.mtlsBackend"
-                            appearance="neutral"
-                          >
-                            {{ t('meshes.detail.disabled') }}
-                          </XBadge>
-
-                          <template v-else>
-                            <XBadge appearance="info">
+                          <XLayout type="separated">
+                            <XBadge
+                              v-if="props.mesh.mtlsBackend"
+                              appearance="info"
+                            >
                               {{ props.mesh.mtlsBackend.type }} / {{ props.mesh.mtlsBackend.name }}
                             </XBadge>
-                          </template>
+                            <template
+                              v-for="identity in meshIdentities?.items"
+                              :key="identity.name"
+                            >
+                              <XAction
+                                :to="{
+                                  name: 'mesh-identity-summary-view',
+                                  params: {
+                                    name: identity.name.toLocaleLowerCase(),
+                                  },
+                                }"
+                              >
+                                <XBadge appearance="info">
+                                  MeshIdentity / {{ identity.name }}
+                                </XBadge>
+                              </XAction>
+                            </template>
+                            <XBadge
+                              v-if="!props.mesh.mtlsBackend && !meshIdentities?.items?.length"
+                              appearance="neutral"
+                            >
+                              {{ t('meshes.detail.disabled') }}
+                            </XBadge>
+                          </XLayout>
                         </template>
                       </DefinitionCard>
-                    </XLayout>
-
-                    <XLayout
-                      v-if="meshIdentities?.items?.length"
-                      data-testid="meshidentities-collection"
-                      class="about-subsection"
-                    >
-                      <h3>MeshIdentities</h3>
-                      <XLayout size="small">
-                        <XLayout type="separated">
-                          <template
-                            v-for="identity in meshIdentities.items"
-                            :key="identity.name"
-                          >
-                            <XAction
-                              :to="{
-                                name: 'mesh-identity-summary-view',
-                                params: {
-                                  name: identity.name.toLocaleLowerCase(),
-                                },
-                              }"
-                            >
-                              <XBadge appearance="info">
-                                {{ identity.name }}
-                              </XBadge>
-                            </XAction>
-                          </template>
-                        </XLayout>
-                      </XLayout>
                     </XLayout>
                   </XLayout>
                 </XAboutCard>
 
                 <XCard
+                  v-if="meshTrusts?.items?.length"
                   data-testid="mesh-trusts-listing"
                 >
                   <template #title>
@@ -170,11 +161,11 @@
                   </template>
                   <DataCollection
                     type="mesh-trusts"
-                    :items="meshTrusts?.items ?? []"
+                    :items="meshTrusts?.items"
                   >
                     <AppCollection
                       type="mesh-trusts-collection"
-                      :items="meshTrusts?.items ?? []"
+                      :items="meshTrusts?.items"
                       :headers="[
                         { ...me.get('headers.identity'), label: t('meshes.routes.item.mesh-trusts.name'), key: 'name' },
                         { ...me.get('headers.type'), label: t('meshes.routes.item.mesh-trusts.trust-domain'), key: 'trustDomain' },

--- a/packages/kuma-gui/src/test-support/index.ts
+++ b/packages/kuma-gui/src/test-support/index.ts
@@ -74,6 +74,7 @@ export type MockEnvKeys = keyof {
   KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: string
   KUMA_DATAPLANE_TLS_ISSUED_MESHIDENTITY: string
   KUMA_MESHIDENTITY_COUNT: string
+  KUMA_MESHTRUST_COUNT: string
 }
 export type EndpointDependencies = {
   fake: FakeKuma

--- a/packages/kuma-gui/src/test-support/index.ts
+++ b/packages/kuma-gui/src/test-support/index.ts
@@ -73,6 +73,7 @@ export type MockEnvKeys = keyof {
   KUMA_ACTIVE_RESOURCE_COUNT: string
   KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: string
   KUMA_DATAPLANE_TLS_ISSUED_MESHIDENTITY: string
+  KUMA_MESHIDENTITY_COUNT: string
 }
 export type EndpointDependencies = {
   fake: FakeKuma

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshidentities/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshidentities/_.ts
@@ -2,10 +2,10 @@ import { components } from '@kumahq/kuma-http-api'
 
 import type { EndpointDependencies, MockResponder } from '@/test-support'
 
-export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
+export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
   const mesh = params.mesh as string
-  const itemsCount = fake.number.int({ min: 1, max: 3 })
+  const itemsCount = parseInt(env('KUMA_MESHIDENTITY_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
   return {
     headers: {},
     body: {

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshtrusts/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshtrusts/_.ts
@@ -6,7 +6,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
   const params = req.params
   const mesh = params.mesh as string
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
-  const itemsCount = fake.number.int({ min: 1, max: 3 })
+  const itemsCount = parseInt(env('KUMA_MESHTRUST_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
   const namespace = fake.word.noun()
   const zone = fake.word.noun()
   return {


### PR DESCRIPTION
The mtls warning in the `MeshOverview` should only show up if mtls is not configured. With `MeshIdentity` as issuer the `mtls` field in `/meshes/{mesh}` is not set, so we also have to check for `MeshIdentity`s.

<img width="2688" height="600" alt="image" src="https://github.com/user-attachments/assets/154ae3d0-ec12-429c-97b1-d2fd72b1c379" />

This also needs to go into 2.12

---

We've decided to take this a little further. We want to move the list of `MeshIdentity`s to the `mTLS` part of the about section. Also the `MeshTrust` listing will only be rendered conditionally in case there is at least one `MeshTrust` resource.
