### PR TITLE
chore(ci): add Cypress#experimentalMemoryManagement setting

### DIFF
--- a/packages/config/src/cypress.ts
+++ b/packages/config/src/cypress.ts
@@ -1,6 +1,7 @@
 import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-preprocessor'
 import { createEsbuildPlugin } from '@badeball/cypress-cucumber-preprocessor/esbuild'
 import createBundler from '@bahmutov/cypress-esbuild-preprocessor'
+import { defineConfig } from 'cypress'
 import cypressFailFast from 'cypress-fail-fast/plugin'
 import installLogsPrinter from 'cypress-terminal-report/src/installLogsPrinter'
 import esbuild from 'esbuild'
@@ -22,9 +23,10 @@ function createVuePlugin(
 }
 
 export const cypress = (env: Record<string, string>) => {
-  return {
+  return defineConfig({
     viewportWidth: 1366,
     viewportHeight: 768,
+    experimentalMemoryManagement: true,
     e2e: {
       baseUrl: env.KUMA_BASE_URL,
       specPattern: '**/*.feature',
@@ -92,5 +94,5 @@ export const cypress = (env: Record<string, string>) => {
       },
     },
 
-  }
+  })
 }


### PR DESCRIPTION
We sometimes get a flake that looks like this:

<img width="659" height="327" alt="Screenshot 2025-09-03 at 16 05 24" src="https://github.com/user-attachments/assets/0c506270-ce0e-4699-8daa-3fb9c0494ab1" />

This PR tries using `experimentalMemoryManagement` to see if it improves matters.

I also added `defineConfig` usage which gives us better TS support, I don't think it has any other consequences.
