### PR TITLE
chore: remove old scoped app-collection related CSS

### DIFF
--- a/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
+++ b/packages/kuma-gui/src/app/application/components/app-collection/AppCollection.vue
@@ -137,7 +137,7 @@ onMounted(rewrite)
 .app-collection {
   isolation: isolate;
 }
-.app-collection :deep(td:first-child a) {
+.app-collection :deep(td a[data-action]) {
   color: inherit;
   font-weight: $kui-font-weight-semibold;
   text-decoration: none;

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -436,7 +436,7 @@
                                     path="data-planes.routes.item.xds.connected"
                                   />
                                 </template>
-    
+
                                 <template #body>
                                   <XBadge appearance="neutral">
                                     {{ t('common.formats.datetime', { value: Date.parse(subscription.connectTime) }) }}
@@ -449,7 +449,7 @@
                                     path="data-planes.routes.item.xds.instance"
                                   />
                                 </template>
-    
+
                                 <template #body>
                                   <XBadge appearance="info">
                                     {{ subscription.controlPlaneInstanceId }}
@@ -462,7 +462,7 @@
                                     path="data-planes.routes.item.xds.version"
                                   />
                                 </template>
-    
+
                                 <template #body>
                                   <XBadge appearance="info">
                                     {{ subscription.version?.kumaDp?.version ?? t('common.unknown') }}
@@ -597,7 +597,7 @@
                           </ConnectionGroup>
                         </template>
                       </ConnectionTraffic>
-              
+
                       <ConnectionTraffic>
                         <template
                           #actions
@@ -779,11 +779,6 @@ provide('data-plane-overview', props.data)
   margin-left: auto;
 }
 
-:deep(td:nth-child(2) a) {
-  color: inherit;
-  font-weight: $kui-font-weight-semibold;
-  text-decoration: none;
-}
 
 @container traffic (max-width: 40.95rem) {
   .traffic .columns {

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -320,11 +320,6 @@ const props = defineProps<{
   padding-right: 0 !important;
   width: 16px !important;
 }
-.app-collection :deep(td:nth-child(2) a) {
-  color: inherit;
-  font-weight: $kui-font-weight-semibold;
-  text-decoration: none;
-}
 
 search {
   width: 100%;

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -421,7 +421,7 @@
                             path="data-planes.routes.item.xds.connected"
                           />
                         </template>
-    
+
                         <template #body>
                           <XBadge appearance="neutral">
                             {{ t('common.formats.datetime', { value: Date.parse(subscription.connectTime) }) }}
@@ -434,7 +434,7 @@
                             path="data-planes.routes.item.xds.instance"
                           />
                         </template>
-    
+
                         <template #body>
                           <XBadge appearance="info">
                             {{ subscription.controlPlaneInstanceId }}
@@ -447,7 +447,7 @@
                             path="data-planes.routes.item.xds.version"
                           />
                         </template>
-    
+
                         <template #body>
                           <XBadge appearance="info">
                             {{ subscription.version?.kumaDp?.version ?? t('common.unknown') }}
@@ -795,12 +795,6 @@ const props = defineProps<{
 
 .traffic .tag-list {
   margin-left: auto;
-}
-
-:deep(td:nth-child(2) a) {
-  color: inherit;
-  font-weight: $kui-font-weight-semibold;
-  text-decoration: none;
 }
 
 @container traffic (max-width: 40.95rem) {

--- a/packages/kuma-gui/src/app/meshes/components/MeshInsightsList.vue
+++ b/packages/kuma-gui/src/app/meshes/components/MeshInsightsList.vue
@@ -21,6 +21,7 @@
           #name="{ row: item }"
         >
           <XAction
+            data-action
             :to="{
               name: 'mesh-detail-view',
               params: {

--- a/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
@@ -309,11 +309,6 @@ search form {
   padding-right: 0 !important;
   width: 16px !important;
 }
-.app-collection :deep(td:nth-child(2) a) {
-  color: inherit;
-  font-weight: $kui-font-weight-semibold;
-  text-decoration: none;
-}
 .search-field {
   flex: 1;
 }

--- a/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-egresses/views/ZoneEgressDetailView.vue
@@ -229,7 +229,7 @@
           <template #title>
             <h2>{{ t('zone-egresses.routes.item.subscriptions.title') }}</h2>
           </template>
-          
+
           <XLayout>
             <XI18n path="zone-egresses.routes.item.subscriptions.description" />
             <AppCollection
@@ -328,11 +328,5 @@ const _route = useRoute()
 <style lang="scss" scoped>
 .service-traffic-card {
   cursor: pointer;
-}
-
-:deep(td:nth-child(2) a) {
-  color: inherit;
-  font-weight: $kui-font-weight-semibold;
-  text-decoration: none;
 }
 </style>

--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressDetailView.vue
@@ -260,7 +260,7 @@
         <template #title>
           <h2>{{ t('zone-ingresses.routes.item.subscriptions.title') }}</h2>
         </template>
-        
+
         <XLayout>
           <XI18n path="zone-ingresses.routes.item.subscriptions.description" />
           <AppCollection
@@ -358,11 +358,5 @@ const _route = useRoute()
 <style lang="scss" scoped>
 .service-traffic-card {
   cursor: pointer;
-}
-
-:deep(td:nth-child(2) a) {
-  color: inherit;
-  font-weight: $kui-font-weight-semibold;
-  text-decoration: none;
 }
 </style>

--- a/packages/kuma-gui/src/app/zones/components/ZoneControlPlanesList.vue
+++ b/packages/kuma-gui/src/app/zones/components/ZoneControlPlanesList.vue
@@ -85,9 +85,4 @@ const props = withDefaults(defineProps<{
   padding-right: 0 !important;
   width: 16px !important;
 }
-.app-collection :deep(td:nth-child(2) a) {
-  color: inherit;
-  font-weight: $kui-font-weight-semibold;
-  text-decoration: none;
-}
 </style>

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailView.vue
@@ -281,10 +281,3 @@ const props = defineProps<{
   data: ZoneOverview
 }>()
 </script>
-<style lang="scss" scoped>
-:deep(td:nth-child(2) a) {
-  color: inherit;
-  font-weight: $kui-font-weight-semibold;
-  text-decoration: none;
-}
-</style>


### PR DESCRIPTION
A long time ago we used to just say "the first cell in a table is the link to _the thing_", but then we needed to have links in non-first cells, so we added a `data-action` "tag" that you could use on the links to _the thing_.

The old CSS is still in the app in several places, but its no longer needed (unless there are places where we don't use `data-action`), so I've removed it all.

The removed CSS was also causing issues in relation to https://github.com/kumahq/kuma-gui/pull/4200