### PR TITLE
chore(deps): move node to always require separate approval

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,16 +41,11 @@
       "enabled": false
     },
     {
-      "groupName": "patch",
-      "matchUpdateTypes": [
-        "patch"
-      ]
-    },
-    {
-      "groupName": "minor",
-      "matchUpdateTypes": [
-        "minor"
-      ]
+      "groupName": "node",
+      "matchPackageNames": [
+        "node"
+      ],
+      "dependencyDashboardApproval": true
     },
     {
       "groupName": "@kong patches",
@@ -63,13 +58,16 @@
       "matchUpdateTypes": ["minor"]
     },
     {
-      "matchPackageNames": [
-        "node"
-      ],
+      "groupName": "patch",
       "matchUpdateTypes": [
-        "major"
-      ],
-      "dependencyDashboardApproval": true
+        "patch"
+      ]
+    },
+    {
+      "groupName": "minor",
+      "matchUpdateTypes": [
+        "minor"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Moves node to always require dashboardApproval, this hopefully always means its in a separate PR on its own and we choose when it gets updated.