### PR TITLE
feat(data-plane): remove link to MeshIdentity (#4204)

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/overview/Tls.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/overview/Tls.feature
@@ -24,17 +24,3 @@ Feature: mesh / dataplanes / overview / TLS
     And the "$tls-section" element contains "The certificate is managed externally"
     And the "$tls-section" element contains "kri_mid_default_east_kuma-demo_identity-1_"
     And the "$tls-section" element doesn't contain "Supported CAs"
-
-  Scenario: Clicking on issuedBackend KRI opens MeshIdentity summary
-    Given the URL "/meshes/default/dataplanes/backend/_overview" responds with
-      """
-      body:
-        dataplaneInsight:
-          mTLS:
-            issuedBackend: kri_mid_default_east_kuma-demo_identity-1_
-      """
-    When I visit the "/meshes/default/data-planes/backend/overview" URL
-    Then the "$tls-section" element exists
-    And I wait for 500 ms
-    Then I click the "$tls-section a" element
-    Then the URL contains "/meshes/default/data-planes/backend/overview/meshidentity/identity-1"

--- a/packages/kuma-gui/src/app/data-planes/routes.ts
+++ b/packages/kuma-gui/src/app/data-planes/routes.ts
@@ -1,4 +1,3 @@
-import { meshIdentityRoutes } from '../resources/routes'
 import { routes as connections, networking } from '@/app/connections/routes'
 import { routes as subscriptions } from '@/app/subscriptions/routes'
 import type { RouteRecordRaw } from 'vue-router'
@@ -61,7 +60,6 @@ export const dataplaneRoutes = (): RouteRecordRaw[] => {
               name: 'data-plane-policy-config-summary-view',
               component: () => import('@/app/data-planes/views/DataplanePolicyConfigSummaryView.vue'),
             },
-            ...meshIdentityRoutes('data-plane'),
           ],
         },
         ...networking('data-plane'),

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -341,25 +341,9 @@
                                 <template
                                   #body
                                 >
-                                  <template v-if="Kri.isKri(mTLS.issuedBackend)">
-                                    <XAction
-                                      :to="{
-                                        name: 'data-plane-mesh-identity-summary-view',
-                                        params: {
-                                          ...Kri.fromString(mTLS.issuedBackend),
-                                        },
-                                      }"
-                                    >
-                                      <XBadge appearance="decorative">
-                                        {{ mTLS.issuedBackend }}
-                                      </XBadge>
-                                    </XAction>
-                                  </template>
-                                  <template v-else>
-                                    <XBadge appearance="decorative">
-                                      {{ mTLS.issuedBackend }}
-                                    </XBadge>
-                                  </template>
+                                  <XBadge appearance="decorative">
+                                    {{ mTLS.issuedBackend }}
+                                  </XBadge>
                                 </template>
                               </DefinitionCard>
 


### PR DESCRIPTION
cherry-pick of https://github.com/kumahq/kuma-gui/commit/4badeedb3711854b265b95dc1c1a6f9f6c6de48d

>In case the issuer for mTLS is `MeshIdentity` we show the `kri` of the `MeshIdentity` in the DP's TLS section. We use to link from the `kri` to the `MeshIdentitySummaryView`, which turns out is not possible as we cannot reconstruct the correct `name` parameter for `/meshes/{mesh}/meshidentities/{name}` to fetch the config. So until we can potentially use the full `kri` as the `name` parameter we have to remove the linking and therefore just display the `kri` as is.
