### PR TITLE
refactor: remove x-growth-*, improve x-empty-state

### DIFF
--- a/packages/kuma-gui/src/app/meshes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/meshes/locales/en-us/index.yaml
@@ -1,10 +1,6 @@
 meshes:
   docs: &meshes.docs
     type: docs
-    label: Documentation
-    href: &meshes.docs.href '{KUMA_DOCS_URL}/production/mesh?{KUMA_UTM_QUERY_PARAMS}'
-  growth-docs: &meshes.growth-docs
-    type: docs
     label: Learn more
     href: &meshes.docs.href '{KUMA_DOCS_URL}/production/mesh?{KUMA_UTM_QUERY_PARAMS}'
 
@@ -34,18 +30,11 @@ meshes:
       }
 
   x-empty-state:
-    title: 'No data'
+    title: Create your first mesh
     body: !!text/markdown |
-      There are no meshes present
+      Meshes are logical groupings of services that establish traffic management and security rules. They define the scope for routing, observability, and policy enforcement within a service mesh.
     action:
       <<: *meshes.docs
-
-  x-growth-empty-state:
-      title: Create your first mesh
-      body: !!text/markdown |
-        Meshes are logical groupings of services that establish traffic management and security rules. They define the scope for routing, observability, and policy enforcement within a service mesh.
-      action:
-        <<: *meshes.growth-docs
 
   components:
     mesh-insights-list:

--- a/packages/kuma-gui/src/app/x/components/x-empty-state/XEmptyState.vue
+++ b/packages/kuma-gui/src/app/x/components/x-empty-state/XEmptyState.vue
@@ -19,7 +19,7 @@
         :key="title"
       >
         <KEmptyState
-          :icon-background="['control-planes', 'meshes', 'zone-cps', 'zone-crud'].includes(props.type)"
+          :icon-background="['control-planes', 'meshes', 'zone-cps', 'zones-crud'].includes(props.type)"
           data-testid="empty-block"
           v-bind="bindingProps"
         >
@@ -49,16 +49,17 @@
             </div>
             <AnalyticsIcon v-else />
           </template>
-          <template
-            v-if="title.length"
-            #title
-          >
+          <template #title>
             <header>
               <h2 class="x-empty-state-title">
-                <XI18n
-                  :path="`${prefix}x-growth-empty-state.title`"
-                  default-path="components.x-empty-state.title"
-                />
+                <template
+                  v-if="title.length && !slots.title"
+                >
+                  {{ title }}
+                </template>
+                <template v-else>
+                  <slot name="title" />
+                </template>
               </h2>
             </header>
           </template>
@@ -73,7 +74,7 @@
               v-else-if="body.length > 0"
             >
               <XI18n
-                :path="`${prefix}x-growth-empty-state.body`"
+                :path="`${prefix}x-empty-state.body`"
                 default-path="components.x-empty-state.body"
               />
             </template>
@@ -86,17 +87,17 @@
                 :name="`${props.type}-x-empty-state-actions`"
               />
               <XAction
-                v-if="t(`${prefix}x-growth-empty-state.action.href`, undefined, { defaultMessage: '' }).length > 0"
-                :action="(['docs', 'create'] as const).find((item) => item === t(`${prefix}x-growth-empty-state.action.type`, undefined, { defaultMessage: '' }))"
-                :href="t(`${prefix}x-growth-empty-state.action.href`, undefined, { defaultMessage: '' })"
-                :appearance="t(`${prefix}x-growth-empty-state.action.type`, undefined, { defaultMessage: '' }) === 'docs' ? 'secondary': undefined"
+                v-if="t(`${prefix}x-empty-state.action.href`, undefined, { defaultMessage: '' }).length > 0"
+                :action="(['docs', 'create'] as const).find((item) => item === t(`${prefix}x-empty-state.action.type`, undefined, { defaultMessage: '' }))"
+                :href="t(`${prefix}x-empty-state.action.href`, undefined, { defaultMessage: '' })"
+                :appearance="t(`${prefix}x-empty-state.action.type`, undefined, { defaultMessage: '' }) === 'docs' ? 'secondary': undefined"
               >
                 <XIcon
-                  v-if="t(`${prefix}x-growth-empty-state.action.type`, undefined, { defaultMessage: '' }) === 'docs'"
+                  v-if="t(`${prefix}x-empty-state.action.type`, undefined, { defaultMessage: '' }) === 'docs'"
                   name="docs"
                   :size="KUI_ICON_SIZE_40"
                 />
-                {{ t(`${prefix}x-growth-empty-state.action.label`, undefined, { defaultMessage: '' }) }}
+                {{ t(`${prefix}x-empty-state.action.label`, undefined, { defaultMessage: '' }) }}
               </XAction>
             </slot>
           </template>

--- a/packages/kuma-gui/src/app/zones/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/zones/locales/en-us/index.yaml
@@ -1,13 +1,8 @@
 zone-cps:
   docs: &zone-cps.docs
     type: docs
-    label: Documentation
-    href: &zone-cps.docs.href '{KUMA_DOCS_URL}/production/deployment/multi-zone/#multi-zone-deployment?{KUMA_UTM_QUERY_PARAMS}'
-
-  growth-docs: &zones.growth-docs
-    type: docs
     label: Learn more
-    href: &zones.docs.href '{KUMA_DOCS_URL}/production/mesh?{KUMA_UTM_QUERY_PARAMS}'
+    href: &zone-cps.docs.href '{KUMA_DOCS_URL}/production/deployment/multi-zone/#multi-zone-deployment?{KUMA_UTM_QUERY_PARAMS}'
 
   common:
     name: Name
@@ -27,18 +22,11 @@ zone-cps:
       The global control plane got NACK responses from the zone control plane. Refer to the {link} or logs for more details.
 
   x-empty-state:
-    title: No zones yet...
+    title: Create your first zone
     body: !!text/markdown |
-      There are no zones present
+      Zones define network boundaries (e.g., clusters, VPCs) and connect to a global control plane that centrally manages and distributes configurations.
     action:
       <<: *zone-cps.docs
-
-  x-growth-empty-state:
-      title: Create your first zone
-      body: !!text/markdown |
-        Zones define network boundaries (e.g., clusters, VPCs) and connect to a global control plane that centrally manages and distributes configurations.
-      action:
-        <<: *zones.growth-docs
 
   components:
     zone-control-planes-list:


### PR DESCRIPTION
The `XEmptyState` component is auto-filling some content in case the correct locales keys are present. It should only support `x-empty-state`-keys and therefore I've moved everything from `x-growth-empty-state` to `x-empty-state`.
Also there was a tiny typo of the `types`: it should be `zones-crud`, not `zone-crud`.
As next steps we also want to remove everything around crud.