### PR TITLE
fix(mesh): mtls warning shows up with mesh identity (#4203)

### DIFF
--- a/packages/kuma-gui/features/mesh/MeshIdentity.feature
+++ b/packages/kuma-gui/features/mesh/MeshIdentity.feature
@@ -3,8 +3,13 @@ Feature: mesh / mesh-identity
   Background:
     Given the CSS selectors
       | Alias                     | Selector                                  |
-      | meshidentities-collection | [data-testid="meshidentities-collection"] |
+      | mesh-mtls                 | [data-testid="mesh-mtls"]                 |
       | summary                   | [data-testid="slideout-container"]        |
+    And the environment
+      """
+      KUMA_MTLS_ENABLED: false
+      KUMA_MESHIDENTITY_COUNT: 1
+      """
 
   Scenario: MeshIdentities are listed in mesh about section
     Given the URL "/meshes/default/meshidentities" responds with
@@ -14,8 +19,8 @@ Feature: mesh / mesh-identity
           - name: identity-1
       """
     When I visit the "/meshes/default" URL
-    Then the "$meshidentities-collection" element exists
-    And the "$meshidentities-collection" element contains "identity-1"
+    Then the "$mesh-mtls" element exists
+    And the "$mesh-mtls" element contains "MeshIdentity / identity-1"
 
   Scenario: Clicking on mesh identity opens summary view
     Given the URL "/meshes/default/meshidentities" responds with
@@ -25,7 +30,7 @@ Feature: mesh / mesh-identity
           - name: identity-1
       """
     When I visit the "/meshes/default" URL
-    Then I click the "$meshidentities-collection a:first" element
+    Then I click the "$mesh-mtls a:first" element
     Then the URL contains "/meshes/default/overview/meshidentity/identity-1"
     And the "$summary" element exists
     And the "$summary" element contains "identity-1"

--- a/packages/kuma-gui/features/mesh/services/mesh-services/Item.feature
+++ b/packages/kuma-gui/features/mesh/services/mesh-services/Item.feature
@@ -65,5 +65,5 @@ Feature: mesh / mesh-services / item
     Then the "$identities" element exists
     And the "$identities" element contains "firewall-1-tag"
     And the "$identities" element contains "ServiceTag"
-    And the "$identities" element contains "spiffe://kuma.io/ns/firewall-app/sa/firewall-1" 
+    And the "$identities" element contains "spiffe://kuma.io/ns/firewall-app/sa/firewall-1"
     And the "$identities" element contains "SpiffeID"

--- a/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshDetailView.vue
@@ -38,7 +38,7 @@
               :data="[meshIdentities, meshTrusts]"
             >
               <XNotification
-                :notify="!props.mesh.mtlsBackend"
+                :notify="!props.mesh.mtlsBackend && meshIdentities!.items.length === 0"
                 :uri="`meshes.notifications.mtls-warning:${props.mesh.id}`"
               >
                 <XI18n
@@ -109,60 +109,54 @@
                         </template>
                       </template>
 
-                      <DefinitionCard layout="horizontal">
+                      <DefinitionCard
+                        layout="horizontal"
+                        data-testid="mesh-mtls"
+                      >
                         <template #title>
                           {{ t('http.api.property.mtls') }}
                         </template>
 
                         <template #body>
-                          <XBadge
-                            v-if="!props.mesh.mtlsBackend"
-                            appearance="neutral"
-                          >
-                            {{ t('meshes.detail.disabled') }}
-                          </XBadge>
-
-                          <template v-else>
-                            <XBadge appearance="info">
+                          <XLayout type="separated">
+                            <XBadge
+                              v-if="props.mesh.mtlsBackend"
+                              appearance="info"
+                            >
                               {{ props.mesh.mtlsBackend.type }} / {{ props.mesh.mtlsBackend.name }}
                             </XBadge>
-                          </template>
+                            <template
+                              v-for="identity in meshIdentities?.items"
+                              :key="identity.name"
+                            >
+                              <XAction
+                                :to="{
+                                  name: 'mesh-identity-summary-view',
+                                  params: {
+                                    name: identity.name.toLocaleLowerCase(),
+                                  },
+                                }"
+                              >
+                                <XBadge appearance="info">
+                                  MeshIdentity / {{ identity.name }}
+                                </XBadge>
+                              </XAction>
+                            </template>
+                            <XBadge
+                              v-if="!props.mesh.mtlsBackend && !meshIdentities?.items?.length"
+                              appearance="neutral"
+                            >
+                              {{ t('meshes.detail.disabled') }}
+                            </XBadge>
+                          </XLayout>
                         </template>
                       </DefinitionCard>
-                    </XLayout>
-
-                    <XLayout
-                      v-if="meshIdentities?.items?.length"
-                      data-testid="meshidentities-collection"
-                      class="about-subsection"
-                    >
-                      <h3>MeshIdentities</h3>
-                      <XLayout size="small">
-                        <XLayout type="separated">
-                          <template
-                            v-for="identity in meshIdentities.items"
-                            :key="identity.name"
-                          >
-                            <XAction
-                              :to="{
-                                name: 'mesh-identity-summary-view',
-                                params: {
-                                  name: identity.name.toLocaleLowerCase(),
-                                },
-                              }"
-                            >
-                              <XBadge appearance="info">
-                                {{ identity.name }}
-                              </XBadge>
-                            </XAction>
-                          </template>
-                        </XLayout>
-                      </XLayout>
                     </XLayout>
                   </XLayout>
                 </XAboutCard>
 
                 <XCard
+                  v-if="meshTrusts?.items?.length"
                   data-testid="mesh-trusts-listing"
                 >
                   <template #title>
@@ -170,11 +164,11 @@
                   </template>
                   <DataCollection
                     type="mesh-trusts"
-                    :items="meshTrusts?.items ?? []"
+                    :items="meshTrusts?.items"
                   >
                     <AppCollection
                       type="mesh-trusts-collection"
-                      :items="meshTrusts?.items ?? []"
+                      :items="meshTrusts?.items"
                       :headers="[
                         { ...me.get('headers.identity'), label: t('meshes.routes.item.mesh-trusts.name'), key: 'name' },
                         { ...me.get('headers.type'), label: t('meshes.routes.item.mesh-trusts.trust-domain'), key: 'trustDomain' },

--- a/packages/kuma-gui/src/test-support/index.ts
+++ b/packages/kuma-gui/src/test-support/index.ts
@@ -73,6 +73,8 @@ export type MockEnvKeys = keyof {
   KUMA_ACTIVE_RESOURCE_COUNT: string
   KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED: string
   KUMA_DATAPLANE_TLS_ISSUED_MESHIDENTITY: string
+  KUMA_MESHIDENTITY_COUNT: string
+  KUMA_MESHTRUST_COUNT: string
 }
 export type EndpointDependencies = {
   fake: FakeKuma

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshidentities/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshidentities/_.ts
@@ -2,10 +2,10 @@ import { components } from '@kumahq/kuma-http-api'
 
 import type { EndpointDependencies, MockResponder } from '@/test-support'
 
-export default ({ fake }: EndpointDependencies): MockResponder => (req) => {
+export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => {
   const params = req.params
   const mesh = params.mesh as string
-  const itemsCount = fake.number.int({ min: 1, max: 3 })
+  const itemsCount = parseInt(env('KUMA_MESHIDENTITY_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
   return {
     headers: {},
     body: {

--- a/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshtrusts/_.ts
+++ b/packages/kuma-gui/src/test-support/mocks/src/meshes/_/meshtrusts/_.ts
@@ -6,7 +6,7 @@ export default ({ fake, env }: EndpointDependencies): MockResponder => (req) => 
   const params = req.params
   const mesh = params.mesh as string
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
-  const itemsCount = fake.number.int({ min: 1, max: 3 })
+  const itemsCount = parseInt(env('KUMA_MESHTRUST_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
   const namespace = fake.word.noun()
   const zone = fake.word.noun()
   return {


### PR DESCRIPTION
Cherry-pick of https://github.com/kumahq/kuma-gui/commit/3bc1ff4cc3406071b1dad69f39cdcb249a13ab94

>The mtls warning in the `MeshOverview` should only show up if mtls is not configured. With `MeshIdentity` as issuer the >`mtls` field in `/meshes/{mesh}` is not set, so we also have to check for `MeshIdentity`s.
>
><img width="2688" height="600" alt="image"
>src="https://github.com/user-attachments/assets/154ae3d0-ec12-429c-97b1-d2fd72b1c379" />
>
>---
>
>We've decided to take this a little further. We want to move the list of `MeshIdentity`s to the `mTLS` part of the about >section. Also the `MeshTrust` listing will only be rendered conditionally in case there is at least one `MeshTrust` resource.