### PR TITLE
chore(renovate): reorder packageRules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,6 +38,18 @@
       "dependencyDashboardApproval": true
     },
     {
+      "groupName": "patch",
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "groupName": "minor",
+      "matchUpdateTypes": [
+        "minor"
+      ]
+    },
+    {
       "matchPackageNames": [
         "npm",
         "escape-string-regexp"
@@ -65,18 +77,6 @@
       "matchPackageNames": [
         "@kong**/**"
       ],
-      "matchUpdateTypes": [
-        "minor"
-      ]
-    },
-    {
-      "groupName": "patch",
-      "matchUpdateTypes": [
-        "patch"
-      ]
-    },
-    {
-      "groupName": "minor",
       "matchUpdateTypes": [
         "minor"
       ]


### PR DESCRIPTION
See title.

I think the grouping will be fixed by this reordering because

>packageRules is a collection of rules, that are all evaluated. If multiple rules match a dependency, configurations from matching rules will be merged together. **The order of rules matters, because later rules may override configuration options from earlier ones, if they both specify the same option.**

https://docs.renovatebot.com/configuration-options/#packagerules

Still not 100% sure though... 🤞 