### PR TITLE
feat(dataplanes): add link icon to linked badges

### DIFF
--- a/packages/kuma-gui/src/app/common/TagList.vue
+++ b/packages/kuma-gui/src/app/common/TagList.vue
@@ -7,20 +7,23 @@
       'tag-list--align-right': props.alignment === 'right',
     }"
   >
-    <XBadge
+    <template
       v-for="(tag, index) in tagList"
       :key="index"
-      class="tag kv"
-      :data-kv-key="tag.label"
-      :data-kv-owner="tag.label.split('/')[0]"
     >
       <component
         :is="tag.route ? 'XAction' : 'span'"
         :to="tag.route"
       >
-        <span class="label">{{ tag.label }}</span>:<span class="value">{{ tag.value }}</span>
+        <XBadge
+          class="tag kv"
+          :data-kv-key="tag.label"
+          :data-kv-owner="tag.label.split('/')[0]"
+        >
+          <span class="label">{{ tag.label }}</span>:<span class="value">{{ tag.value }}</span>
+        </XBadge>
       </component>
-    </XBadge>
+    </template>
   </component>
 </template>
 
@@ -96,7 +99,6 @@ function getRoute(tag: LabelValue): RouteLocationNamedRaw | undefined {
 }
 </script>
 <style lang="scss" scoped>
-
 .kv:not(:where(
   [data-kv-owner$='.kuma.io'],
   [data-kv-owner^='kuma.io']

--- a/packages/x/src/components/x-action/XAction.vue
+++ b/packages/x/src/components/x-action/XAction.vue
@@ -172,7 +172,7 @@
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 import { KDropdownItem, KButton } from '@kong/kongponents'
-import { computed, watch, inject } from 'vue'
+import { computed, watch, inject, provide } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 
 import type { ButtonAppearance } from '@kong/kongponents'
@@ -201,6 +201,7 @@ const props = withDefaults(defineProps<{
   for: '',
 })
 
+provide('x-action', {})
 const group = inject<{
   expanded: boolean
 } | undefined>('x-action-group', undefined)

--- a/packages/x/src/components/x-badge/XBadge.vue
+++ b/packages/x/src/components/x-badge/XBadge.vue
@@ -3,14 +3,28 @@
     :max-width="props.maxWidth"
   >
     <slot name="default" />
+    <XIcon
+      v-if="xAction"
+      name="link"
+    />
   </KBadge>
 </template>
 
 <script lang="ts" setup>
 import { KBadge } from '@kong/kongponents'
+import { inject } from 'vue'
 const props = withDefaults(defineProps<{
   maxWidth?: string
 }>(), {
   maxWidth: 'auto',
 })
+const xAction = inject<{} | undefined>('x-action', undefined)
 </script>
+<style scoped>
+/* ideally we wouldn't use this, but its works to centralize the icon correctly */
+/* feel free to change if you find something else*/
+:deep(.x-icon-icon) {
+  position: relative;
+  top: -1px;
+}
+</style>

--- a/packages/x/src/components/x-icon/XIcon.vue
+++ b/packages/x/src/components/x-icon/XIcon.vue
@@ -51,6 +51,7 @@ import {
   PlugIcon,
   VitalsIcon,
   RemoveIcon,
+  LinkIcon,
   KeyboardReturnIcon,
 } from '@kong/icons'
 import { useSlots, useAttrs, useId } from 'vue'
@@ -92,6 +93,7 @@ const icons = {
   healthy: VitalsIcon,
   unhealthy: RemoveIcon,
   submit: KeyboardReturnIcon,
+  link: LinkIcon,
 } as const
 const id = `-x-icon-tooltip-${useId()}`
 const slots = useSlots()


### PR DESCRIPTION
Closes https://github.com/kumahq/kuma-gui/issues/3313

Unfortunately, I had to add a little `-1px` hack to get the icon to look lined up to my eye. I'm totally happy with this approach, but I don't mind if someone prefers a different approach, as long as it looks aligned correctly.