### PR TITLE
chore(xbadge): use slot for icon (and spacing)

### DIFF
--- a/packages/x/src/components/x-badge/XBadge.vue
+++ b/packages/x/src/components/x-badge/XBadge.vue
@@ -1,12 +1,15 @@
 <template>
   <KBadge
     :max-width="props.maxWidth"
+    :icon-before="false"
   >
     <slot name="default" />
-    <XIcon
-      v-if="xAction"
-      name="link"
-    />
+    <template #icon>
+      <XIcon
+        v-if="xAction"
+        name="link"
+      />
+    </template>
   </KBadge>
 </template>
 
@@ -20,11 +23,3 @@ const props = withDefaults(defineProps<{
 })
 const xAction = inject<{} | undefined>('x-action', undefined)
 </script>
-<style scoped>
-/* ideally we wouldn't use this, but its works to centralize the icon correctly */
-/* feel free to change if you find something else*/
-:deep(.x-icon-icon) {
-  position: relative;
-  top: -1px;
-}
-</style>


### PR DESCRIPTION
We decided to use the icon slot and `:icon-before` for the link