### PR TITLE
fix(zones): add data-action to Zone>Services rows

### DIFF
--- a/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
+++ b/packages/kuma-gui/src/app/zone-ingresses/views/ZoneIngressServicesView.vue
@@ -27,6 +27,7 @@
           >
             <template #name="{ row: item }">
               <XAction
+                data-action
                 :to="{
                   name: 'service-detail-view',
                   params: {


### PR DESCRIPTION
Adds a `[data-action]` to to Zone>Services rows so that the first cells link is rendered in bold not blue.