### PR TITLE
fix(application-shell): main content element doesnt fill up viewport

### DIFF
--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -191,6 +191,7 @@ html.no-navigation {
 
 .app-main-content {
   padding: var(--AppContentPadding);
+  min-height: calc(100vh - var(--AppHeaderHeight));
 }
 
 header {


### PR DESCRIPTION
The main content element currently doesn't fill up the viewport if there is not enough content. This leads to some UX issues when it comes to closing a summary drawer via clicking outside of the summary container element.

<img width="1674" height="1340" alt="image (2)" src="https://github.com/user-attachments/assets/47999345-f165-46f9-9898-f7c9159aa422" />
