### PR TITLE
chore: integrate XDl into DataPlaneDetailView

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/Subscriptions.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Subscriptions.feature
@@ -44,6 +44,7 @@ Feature: dataplanes / subscriptions
     Then I click the "$about-dp-subscriptions a" element
     Then the URL contains "/meshes/default/data-planes/backend/subscriptions"
     And the "$dp-subscriptions" element exists
+    And I wait for 500 ms
     Then I click the "$dp-subscriptions table tbody tr a" element
     Then the URL contains "/meshes/default/data-planes/backend/subscriptions/subscription/bar"
     And the "$dp-subscription-summary" element exists

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryClustersView.vue
@@ -26,7 +26,7 @@
         v-slot="{ data: connections, refresh }"
       >
         <template
-          v-for="prefix in ['proxyResourcePortName' in props.data ? props.data.proxyResourcePortName : ('clusterName' in props.data ? props.data.clusterName : route.params.connection).replace('_', ':')]"
+          v-for="prefix in ['stat_prefix' in props.data ? props.data.stat_prefix : ('clusterName' in props.data ? props.data.clusterName : route.params.connection).replace('_', ':')]"
           :key="typeof prefix"
         >
           <DataCollection

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryStatsView.vue
@@ -88,7 +88,7 @@ const props = defineProps<{
 
 const data = computed(() => ({
   ...props.data,
-  proxyResourceName: 'proxyResourcePortName' in props.data ? props.data.proxyResourcePortName : '',
+  proxyResourceName: 'stat_prefix' in props.data ? props.data.stat_prefix : '',
   listenerAddress: 'listenerAddress' in props.data ? props.data.listenerAddress : '',
   clusterName: 'clusterName' in props.data ? props.data.clusterName : '',
   port: 'port' in props.data ? props.data.port.toString() : '',

--- a/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
+++ b/packages/kuma-gui/src/app/connections/views/ConnectionInboundSummaryXdsConfigView.vue
@@ -21,7 +21,7 @@
         :src="uri(sources, '/connections/xds/for/:proxyType/:name/:mesh/inbound/:inbound', {
           mesh: route.params.mesh || '*',
           name: route.params.proxy,
-          inbound: 'proxyResourcePortName' in props.data ? props.data.proxyResourcePortName : `${props.data.port}`,
+          inbound: 'stat_prefix' in props.data ? props.data.stat_prefix : `${props.data.port}`,
           proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress'})[route.params.proxyType] ?? 'dataplane',
         })"
         v-slot="{ data: raw, refresh }"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -25,620 +25,615 @@
         v-slot="{ data: dataplaneLayout, refresh, error }"
       >
         <DataSource
-          :src="uri(policySources, '/policy-types', {})"
-          v-slot="{ data: policyTypesData }"
+          :src="uri(connectionSources, '/connections/stats/for/:proxyType/:name/:mesh/:socketAddress', {
+            proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress' })[route.params.proxyType] ?? 'dataplane',
+            name: route.params.proxy,
+            mesh: route.params.mesh || '*',
+            // 'self_inbound' can be used as socket address to filter the stats as the contextual kri of an inbound always starts with 'self_inbound'
+            socketAddress: 'self_inbound',
+          })"
+          v-slot="{ data: traffic, error: trafficError, refresh: refreshTraffic }"
         >
-          <DataSource
-            :src="uri(connectionSources, '/connections/stats/for/:proxyType/:name/:mesh/:socketAddress', {
-              proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress' })[route.params.proxyType] ?? 'dataplane',
-              name: route.params.proxy,
-              mesh: route.params.mesh || '*',
-              // 'self_inbound' can be used as socket address to filter the stats as the contextual kri of an inbound always starts with 'self_inbound'
-              socketAddress: 'self_inbound',
-            })"
-            v-slot="{ data: traffic, error: trafficError, refresh: refreshTraffic }"
+          <DataLoader
+            :data="[dataplaneLayout, dataplanePolicies, traffic]"
           >
-            <DataLoader
-              :data="[dataplaneLayout, dataplanePolicies, policyTypesData, traffic]"
+            <AppView
+              :notifications="true"
             >
-              <AppView
-                :notifications="true"
+              <template
+                v-for="{ bool, key, params, variant } in [
+                  {
+                    bool: props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false,
+                    key: 'dp-cp-incompatible',
+                    params: {
+                      kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
+                    },
+                  },
+                  {
+                    bool: props.data.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+                    key: 'envoy-dp-incompatible',
+                    params: {
+                      envoy: props.data.dataplaneInsight.version?.envoy.version ?? '',
+                      kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
+                    },
+                  },
+                  {
+                    bool: !!(can('use zones') && props.data.zone && props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false),
+                    key: 'dp-zone-cp-incompatible',
+                    params: {
+                      kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
+                    },
+                  },
+                  {
+                    bool: props.data.isCertExpiresSoon,
+                    key: 'certificate-expires-soon',
+                  },
+                  {
+                    bool: props.data.isCertExpired,
+                    key: 'certificate-expired',
+                  },
+                  {
+                    bool: !props.data.dataplaneInsight.mTLS,
+                    key: 'no-mtls',
+                  },
+                  {
+                    bool: !can('use transparent-proxying', props.data),
+                    key: 'networking-transparent-proxying',
+                    variant: 'info' as const,
+                  },
+                ]"
+                :key="key"
               >
-                <template
-                  v-for="{ bool, key, params, variant } in [
-                    {
-                      bool: props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false,
-                      key: 'dp-cp-incompatible',
-                      params: {
-                        kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
-                      },
-                    },
-                    {
-                      bool: props.data.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
-                      key: 'envoy-dp-incompatible',
-                      params: {
-                        envoy: props.data.dataplaneInsight.version?.envoy.version ?? '',
-                        kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
-                      },
-                    },
-                    {
-                      bool: !!(can('use zones') && props.data.zone && props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false),
-                      key: 'dp-zone-cp-incompatible',
-                      params: {
-                        kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
-                      },
-                    },
-                    {
-                      bool: props.data.isCertExpiresSoon,
-                      key: 'certificate-expires-soon',
-                    },
-                    {
-                      bool: props.data.isCertExpired,
-                      key: 'certificate-expired',
-                    },
-                    {
-                      bool: !props.data.dataplaneInsight.mTLS,
-                      key: 'no-mtls',
-                    },
-                    {
-                      bool: !can('use transparent-proxying', props.data),
-                      key: 'networking-transparent-proxying',
-                      variant: 'info' as const,
-                    },
-                  ]"
-                  :key="key"
+                <XNotification
+                  :notify="bool"
+                  :data-testid="`warning-${key}`"
+                  :uri="`data-planes.notifications.${key}.${props.data.id}`"
+                  :variant="variant"
                 >
-                  <XNotification
-                    :notify="bool"
-                    :data-testid="`warning-${key}`"
-                    :uri="`data-planes.notifications.${key}.${props.data.id}`"
-                    :variant="variant"
-                  >
-                    <XI18n
-                      :path="`data-planes.notifications.${key}`"
-                      :params="Object.fromEntries(Object.entries(params ?? {}))"
-                    />
-                  </XNotification>
-                </template>
+                  <XI18n
+                    :path="`data-planes.notifications.${key}`"
+                    :params="Object.fromEntries(Object.entries(params ?? {}))"
+                  />
+                </XNotification>
+              </template>
 
-                <XLayout
-                  type="stack"
-                  data-testid="dataplane-details"
+              <XLayout
+                type="stack"
+                data-testid="dataplane-details"
+              >
+                <XAboutCard
+                  :title="t('data-planes.routes.item.about.title')"
+                  :created="props.data.creationTime"
+                  :modified="props.data.modificationTime"
+                  class="about-section"
                 >
-                  <XAboutCard
-                    :title="t('data-planes.routes.item.about.title')"
-                    :created="props.data.creationTime"
-                    :modified="props.data.modificationTime"
-                    class="about-section"
-                  >
-                    <XLayout>
+                  <XLayout>
+                    <XDl
+                      variant="x-stack"
+                    >
+                      <div>
+                        <dt>
+                          {{ t('http.api.property.status') }}
+                        </dt>
+                        <dd>
+                          <XLayout
+                            type="separated"
+                          >
+                            <StatusBadge :status="props.data.status" />
+                            <DataCollection
+                              v-if="props.data.dataplaneType === 'standard'"
+                              :items="props.data.dataplane.networking.inbounds"
+                              :predicate="item => item.state !== 'Ready'"
+                              :empty="false"
+                              v-slot="{ items: unhealthyInbounds }"
+                            >
+                              <XIcon name="info">
+                                <ul>
+                                  <li
+                                    v-for="inbound in unhealthyInbounds"
+                                    :key="`${inbound.service}:${inbound.port}`"
+                                  >
+                                    {{ t('data-planes.routes.item.unhealthy_inbound', { port: inbound.port }) }}
+                                  </li>
+                                </ul>
+                              </XIcon>
+                            </DataCollection>
+                          </XLayout>
+                        </dd>
+                      </div>
+                      <div
+                        v-if="can('use zones') && props.data.zone"
+                      >
+                        <dt>
+                          {{ t('http.api.property.zone') }}
+                        </dt>
+                        <dd>
+                          <XBadge appearance="decorative">
+                            <XAction
+                              :to="{
+                                name: 'zone-cp-detail-view',
+                                params: {
+                                  zone: props.data.zone,
+                                },
+                              }"
+                            >
+                              {{ props.data.zone }}
+                            </XAction>
+                          </XBadge>
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>
+                          {{ t('http.api.property.type') }}
+                        </dt>
+                        <dd>
+                          <XBadge appearance="decorative">
+                            {{ t(`data-planes.type.${props.data.dataplaneType}`) }}
+                          </XBadge>
+                        </dd>
+                      </div>
+                      <div
+                        v-if="props.data.namespace.length > 0"
+                      >
+                        <dt>
+                          {{ t('http.api.property.namespace') }}
+                        </dt>
+                        <dd>
+                          <XBadge
+                            appearance="decorative"
+                          >
+                            {{ props.data.namespace }}
+                          </XBadge>
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>
+                          {{ t('http.api.property.address') }}
+                        </dt>
+                        <dd>
+                          <XCopyButton
+                            variant="badge"
+                            format="default"
+                            :text="`${props.data.dataplane.networking.address}`"
+                          />
+                        </dd>
+                      </div>
+                      <div
+                        v-if="props.data.dataplane.networking.gateway"
+                      >
+                        <dt>
+                          {{ t('http.api.property.tags') }}
+                        </dt>
+                        <dd>
+                          <TagList
+                            :tags="props.data.dataplane.networking.gateway.tags"
+                          />
+                        </dd>
+                      </div>
+                    </XDl>
+
+                    <XLayout
+                      v-if="props.data.dataplaneInsight.mTLS"
+                      data-testid="dataplane-mtls"
+                      class="about-subsection"
+                      size="small"
+                    >
+                      <h3>{{ t('data-planes.routes.item.mtls.title') }}</h3>
+                      <XLayout size="small">
+                        <template
+                          v-for="mTLS in [props.data.dataplaneInsight.mTLS]"
+                          :key="typeof mTLS"
+                        >
+                          <XDl
+                            v-if="typeof mTLS.lastCertificateRegeneration !== 'undefined' && typeof mTLS.certificateExpirationTime !== 'undefined' && typeof mTLS.issuedBackend !== 'undefined'"
+                            variant="x-stack"
+                          >
+                            <div>
+                              <dt>
+                                {{ t('data-planes.routes.item.mtls.generation_time.title') }}
+                              </dt>
+                              <dd>
+                                <XBadge appearance="neutral">
+                                  {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
+                                </XBadge>
+                              </dd>
+                            </div>
+                            <div>
+                              <dt>
+                                {{ t('data-planes.routes.item.mtls.expiration_time.title') }}
+                              </dt>
+                              <dd>
+                                <XBadge appearance="neutral">
+                                  {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
+                                </XBadge>
+                              </dd>
+                            </div>
+                          </XDl>
+                          <XI18n
+                            v-else
+                            path="data-planes.routes.item.mtls.managed_externally"
+                          />
+                          <XDl
+                            variant="x-stack"
+                          >
+                            <div
+                              v-if="typeof mTLS.certificateRegenerations !== 'undefined'"
+                            >
+                              <dt>
+                                {{ t('data-planes.routes.item.mtls.regenerations.title') }}
+                              </dt>
+                              <dd>
+                                <XBadge appearance="info">
+                                  {{ t('common.formats.integer', { value: mTLS.certificateRegenerations }) }}
+                                </XBadge>
+                              </dd>
+                            </div>
+                            <div
+                              v-if="typeof mTLS.issuedBackend !== 'undefined'"
+                            >
+                              <dt>
+                                {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
+                              </dt>
+                              <dd>
+                                <XBadge appearance="decorative">
+                                  {{ mTLS.issuedBackend }}
+                                </XBadge>
+                              </dd>
+                            </div>
+                            <div
+                              v-if="typeof mTLS.supportedBackends !== 'undefined'"
+                            >
+                              <dt>
+                                {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
+                              </dt>
+                              <dd>
+                                <XLayout
+                                  type="separated"
+                                  truncate
+                                >
+                                  <XBadge
+                                    v-for="item in mTLS.supportedBackends"
+                                    :key="item"
+                                    :appearance="item === mTLS.issuedBackend ? 'decorative' : 'info'"
+                                  >
+                                    {{ item }}
+                                  </XBadge>
+                                </XLayout>
+                              </dd>
+                            </div>
+                          </XDl>
+                        </template>
+                      </XLayout>
+                    </XLayout>
+
+                    <XLayout
+                      v-if="props.data.dataplaneInsight.subscriptions.length > 0"
+                      data-testid="about-dataplane-subscriptions"
+                      class="about-subsection"
+                    >
+                      <XLayout type="separated">
+                        <h3>{{ t('data-planes.routes.item.subscriptions.title') }}</h3>
+                        <XAction
+                          appearance="anchor"
+                          :to="{
+                            name: 'data-plane-subscriptions-summary-view',
+                            params: {
+                              mesh: route.params.mesh,
+                              proxy: route.params.proxy,
+                            },
+                            query: {
+                              inactive: route.params.inactive,
+                            },
+                          }"
+                        >
+                          ({{ t('data-planes.routes.item.xds.show-details') }})
+                        </XAction>
+                      </XLayout>
+
                       <XDl
+                        v-if="props.data.dataplaneInsight.connectedSubscription"
                         variant="x-stack"
                       >
                         <div>
                           <dt>
-                            {{ t('http.api.property.status') }}
+                            {{ t('data-planes.routes.item.xds.connected') }}
                           </dt>
                           <dd>
-                            <XLayout
-                              type="separated"
-                            >
-                              <StatusBadge :status="props.data.status" />
-                              <DataCollection
-                                v-if="props.data.dataplaneType === 'standard'"
-                                :items="props.data.dataplane.networking.inbounds"
-                                :predicate="item => item.state !== 'Ready'"
-                                :empty="false"
-                                v-slot="{ items: unhealthyInbounds }"
-                              >
-                                <XIcon name="info">
-                                  <ul>
-                                    <li
-                                      v-for="inbound in unhealthyInbounds"
-                                      :key="`${inbound.service}:${inbound.port}`"
-                                    >
-                                      {{ t('data-planes.routes.item.unhealthy_inbound', { port: inbound.port }) }}
-                                    </li>
-                                  </ul>
-                                </XIcon>
-                              </DataCollection>
-                            </XLayout>
-                          </dd>
-                        </div>
-                        <div
-                          v-if="can('use zones') && props.data.zone"
-                        >
-                          <dt>
-                            {{ t('http.api.property.zone') }}
-                          </dt>
-                          <dd>
-                            <XBadge appearance="decorative">
-                              <XAction
-                                :to="{
-                                  name: 'zone-cp-detail-view',
-                                  params: {
-                                    zone: props.data.zone,
-                                  },
-                                }"
-                              >
-                                {{ props.data.zone }}
-                              </XAction>
+                            <XBadge appearance="neutral">
+                              {{ t('common.formats.datetime', { value: Date.parse(props.data.dataplaneInsight.connectedSubscription.connectTime ?? '') }) }}
                             </XBadge>
                           </dd>
                         </div>
                         <div>
                           <dt>
-                            {{ t('http.api.property.type') }}
+                            {{ t('data-planes.routes.item.xds.instance') }}
                           </dt>
                           <dd>
-                            <XBadge appearance="decorative">
-                              {{ t(`data-planes.type.${props.data.dataplaneType}`) }}
-                            </XBadge>
-                          </dd>
-                        </div>
-                        <div
-                          v-if="props.data.namespace.length > 0"
-                        >
-                          <dt>
-                            {{ t('http.api.property.namespace') }}
-                          </dt>
-                          <dd>
-                            <XBadge
-                              appearance="decorative"
-                            >
-                              {{ props.data.namespace }}
+                            <XBadge>
+                              {{ props.data.dataplaneInsight.connectedSubscription.controlPlaneInstanceId }}
                             </XBadge>
                           </dd>
                         </div>
                         <div>
                           <dt>
-                            {{ t('http.api.property.address') }}
+                            {{ t('data-planes.routes.item.xds.version') }}
                           </dt>
                           <dd>
-                            <XCopyButton
-                              variant="badge"
-                              format="default"
-                              :text="`${props.data.dataplane.networking.address}`"
-                            />
-                          </dd>
-                        </div>
-                        <div
-                          v-if="props.data.dataplane.networking.gateway"
-                        >
-                          <dt>
-                            {{ t('http.api.property.tags') }}
-                          </dt>
-                          <dd>
-                            <TagList
-                              :tags="props.data.dataplane.networking.gateway.tags"
-                            />
+                            <XBadge>
+                              {{ props.data.dataplaneInsight.connectedSubscription.version?.kumaDp?.version ?? t('common.unknown') }}
+                            </XBadge>
                           </dd>
                         </div>
                       </XDl>
+                      <template v-else>
+                        <XI18n path="data-planes.routes.item.xds.disconnected" />
+                      </template>
+                    </XLayout>
+
+                    <XLayout
+                      v-if="dataplanePolicies?.policies.length"
+                      data-testid="about-dataplane-policies"
+                      class="about-subsection"
+                    >
+                      <h3>{{ t('data-planes.routes.item.policies') }}</h3>
 
                       <XLayout
-                        v-if="props.data.dataplaneInsight.mTLS"
-                        data-testid="dataplane-mtls"
-                        class="about-subsection"
-                        size="small"
+                        type="separated"
                       >
-                        <h3>{{ t('data-planes.routes.item.mtls.title') }}</h3>
-                        <XLayout size="small">
-                          <template
-                            v-for="mTLS in [props.data.dataplaneInsight.mTLS]"
-                            :key="typeof mTLS"
-                          >
-                            <XDl
-                              v-if="typeof mTLS.lastCertificateRegeneration !== 'undefined' && typeof mTLS.certificateExpirationTime !== 'undefined' && typeof mTLS.issuedBackend !== 'undefined'"
-                              variant="x-stack"
-                            >
-                              <div>
-                                <dt>
-                                  {{ t('data-planes.routes.item.mtls.generation_time.title') }}
-                                </dt>
-                                <dd>
-                                  <XBadge appearance="neutral">
-                                    {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
-                                  </XBadge>
-                                </dd>
-                              </div>
-                              <div>
-                                <dt>
-                                  {{ t('data-planes.routes.item.mtls.expiration_time.title') }}
-                                </dt>
-                                <dd>
-                                  <XBadge appearance="neutral">
-                                    {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
-                                  </XBadge>
-                                </dd>
-                              </div>
-                            </XDl>
-                            <XI18n
-                              v-else
-                              path="data-planes.routes.item.mtls.managed_externally"
-                            />
-                            <XDl
-                              variant="x-stack"
-                            >
-                              <div
-                                v-if="typeof mTLS.certificateRegenerations !== 'undefined'"
-                              >
-                                <dt>
-                                  {{ t('data-planes.routes.item.mtls.regenerations.title') }}
-                                </dt>
-                                <dd>
-                                  <XBadge appearance="info">
-                                    {{ t('common.formats.integer', { value: mTLS.certificateRegenerations }) }}
-                                  </XBadge>
-                                </dd>
-                              </div>
-                              <div
-                                v-if="typeof mTLS.issuedBackend !== 'undefined'"
-                              >
-                                <dt>
-                                  {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
-                                </dt>
-                                <dd>
-                                  <XBadge appearance="decorative">
-                                    {{ mTLS.issuedBackend }}
-                                  </XBadge>
-                                </dd>
-                              </div>
-                              <div
-                                v-if="typeof mTLS.supportedBackends !== 'undefined'"
-                              >
-                                <dt>
-                                  {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
-                                </dt>
-                                <dd>
-                                  <XLayout
-                                    type="separated"
-                                    truncate
-                                  >
-                                    <XBadge
-                                      v-for="item in mTLS.supportedBackends"
-                                      :key="item"
-                                      :appearance="item === mTLS.issuedBackend ? 'decorative' : 'info'"
-                                    >
-                                      {{ item }}
-                                    </XBadge>
-                                  </XLayout>
-                                </dd>
-                              </div>
-                            </XDl>
-                          </template>
-                        </XLayout>
-                      </XLayout>
-
-                      <XLayout
-                        v-if="props.data.dataplaneInsight.subscriptions.length > 0"
-                        data-testid="about-dataplane-subscriptions"
-                        class="about-subsection"
-                      >
-                        <XLayout type="separated">
-                          <h3>{{ t('data-planes.routes.item.subscriptions.title') }}</h3>
+                        <template
+                          v-for="policy in dataplanePolicies?.policies"
+                          :key="policy.kind"
+                        >
                           <XAction
-                            appearance="anchor"
                             :to="{
-                              name: 'data-plane-subscriptions-list-view',
+                              name: 'data-plane-policy-config-summary-view',
                               params: {
                                 mesh: route.params.mesh,
                                 proxy: route.params.proxy,
-                              },
-                              query: {
-                                inactive: route.params.inactive,
+                                policy: policy.kind.toLowerCase(),
                               },
                             }"
                           >
-                            ({{ t('data-planes.routes.item.xds.show-details') }})
+                            <XBadge>
+                              {{ policy.kind }}
+                            </XBadge>
                           </XAction>
-                        </XLayout>
-
-                        <XDl
-                          v-if="props.data.dataplaneInsight.connectedSubscription"
-                          variant="x-stack"
-                        >
-                          <div>
-                            <dt>
-                              {{ t('data-planes.routes.item.xds.connected') }}
-                            </dt>
-                            <dd>
-                              <XBadge appearance="neutral">
-                                {{ t('common.formats.datetime', { value: Date.parse(props.data.dataplaneInsight.connectedSubscription.connectTime ?? '') }) }}
-                              </XBadge>
-                            </dd>
-                          </div>
-                          <div>
-                            <dt>
-                              {{ t('data-planes.routes.item.xds.instance') }}
-                            </dt>
-                            <dd>
-                              <XBadge>
-                                {{ props.data.dataplaneInsight.connectedSubscription.controlPlaneInstanceId }}
-                              </XBadge>
-                            </dd>
-                          </div>
-                          <div>
-                            <dt>
-                              {{ t('data-planes.routes.item.xds.version') }}
-                            </dt>
-                            <dd>
-                              <XBadge>
-                                {{ props.data.dataplaneInsight.connectedSubscription.version?.kumaDp?.version ?? t('common.unknown') }}
-                              </XBadge>
-                            </dd>
-                          </div>
-                        </XDl>
-                        <template v-else>
-                          <XI18n path="data-planes.routes.item.xds.disconnected" />
                         </template>
                       </XLayout>
-
-                      <XLayout
-                        v-if="dataplanePolicies?.policies.length"
-                        data-testid="about-dataplane-policies"
-                        class="about-subsection"
-                      >
-                        <h3>{{ t('data-planes.routes.item.policies') }}</h3>
-
-                        <XLayout
-                          type="separated"
-                        >
-                          <template
-                            v-for="policy in dataplanePolicies?.policies"
-                            :key="policy.kind"
-                          >
-                            <XAction
-                              :to="{
-                                name: 'data-plane-policy-config-summary-view',
-                                params: {
-                                  mesh: route.params.mesh,
-                                  proxy: route.params.proxy,
-                                  policy: policy.kind.toLowerCase(),
-                                },
-                              }"
-                            >
-                              <XBadge>
-                                {{ policy.kind }}
-                              </XBadge>
-                            </XAction>
-                          </template>
-                        </XLayout>
-                      </XLayout>
                     </XLayout>
-                  </XAboutCard>
+                  </XLayout>
+                </XAboutCard>
 
-                  <template
-                    v-for="(inboundsByPort, port) in [Object.groupBy(props.data.dataplane.networking.inbounds, (item) => item.port)]"
-                    :key="port"
+                <template
+                  v-for="(inboundsByPort, port) in [Object.groupBy(props.data.dataplane.networking.inbounds, (item) => item.port)]"
+                  :key="port"
+                >
+                  <XCard
+                    class="traffic"
+                    data-testid="dataplane-traffic"
                   >
-                    <XCard
-                      class="traffic"
-                      data-testid="dataplane-traffic"
+                    <XLayout
+                      type="columns"
                     >
-                      <XLayout
-                        type="columns"
-                      >
-                        <ConnectionTraffic>
-                          <template
-                            #title
+                      <ConnectionTraffic>
+                        <template
+                          #title
+                        >
+                          <XLayout
+                            type="separated"
                           >
-                            <XLayout
-                              type="separated"
-                            >
-                              <XIcon
-                                name="inbound"
-                              />
-                              <span>Inbounds</span>
-                            </XLayout>
-                          </template>
-                          <template
-                            v-for="inbounds in [dataplaneLayout?.inbounds ?? []]"
-                            :key="typeof inbounds"
+                            <XIcon
+                              name="inbound"
+                            />
+                            <span>Inbounds</span>
+                          </XLayout>
+                        </template>
+                        <template
+                          v-for="inbounds in [dataplaneLayout?.inbounds ?? []]"
+                          :key="typeof inbounds"
+                        >
+                          <ConnectionGroup
+                            type="inbound"
+                            data-testid="dataplane-inbounds"
                           >
-                            <ConnectionGroup
-                              type="inbound"
-                              data-testid="dataplane-inbounds"
-                            >
-                              <!-- don't show a card for anything on port 49151 as those are service-less inbounds -->
-                              <DataCollection
-                                type="inbounds"
-                                :items="inbounds"
-                                :predicate="(item) => item.port !== 49151"
-                              >
-                                <template
-                                  v-if="props.data.dataplaneType === 'delegated'"
-                                  #empty
-                                >
-                                  <XEmptyState>
-                                    <p>
-                                      This proxy is a delegated gateway therefore {{ t('common.product.name') }} does not have any
-                                      visibility into inbounds for this gateway.
-                                    </p>
-                                  </XEmptyState>
-                                </template>
-                                <template
-                                  #default="{ items: _inbounds }"
-                                >
-                                  <XLayout
-                                    type="stack"
-                                    size="small"
-                                  >
-                                    <template
-                                      v-for="item in _inbounds"
-                                      :key="`${item.kri}`"
-                                    >
-                                      <template
-                                        v-for="inbound in [inboundsByPort[item.port]?.[0]]"
-                                        :key="inbound?.port"
-                                      >
-                                        <ConnectionCard
-                                          data-testid="dataplane-inbound"
-                                          :protocol="item.protocol"
-                                          :port-name="inbound?.portName"
-                                          :traffic="traffic?.inbounds[item.proxyResourcePortName]"
-                                          data-actionable
-                                        >
-                                          <template #state>
-                                            <XIcon
-                                              v-if="inbound?.state !== 'Ready'"
-                                              name="danger"
-                                              :size="KUI_ICON_SIZE_40"
-                                              placement="right"
-                                            >
-                                              {{ t('data-planes.routes.item.unhealthy_inbound', { port: inbound?.port }) }}
-                                            </XIcon>
-                                          </template>
-                                          <XAction
-                                            data-action
-                                            :to="{
-                                              name: ((name) => name.includes('bound') ? name.replace('-outbound-', '-inbound-') : 'data-plane-connection-inbound-summary-overview-view')(String(_route.name)),
-                                              params: {
-                                                connection: item.proxyResourceName,
-                                              },
-                                              query: {
-                                                inactive: route.params.inactive,
-                                              },
-                                            }"
-                                          >
-                                            {{ item.proxyResourceName }}
-                                          </XAction>
-                                        </ConnectionCard>
-                                      </template>
-                                    </template>
-                                  </XLayout>
-                                </template>
-                              </DataCollection>
-                            </ConnectionGroup>
-                          </template>
-                        </ConnectionTraffic>
-
-                        <ConnectionTraffic>
-                          <template
-                            #actions
-                          >
-                            <XAction
-                              action="refresh"
-                              appearance="primary"
-                              @click="() => {
-                                refresh()
-                                refreshTraffic()
-                              }"
-                            >
-                              Refresh
-                            </XAction>
-                          </template>
-                          <template
-                            #title
-                          >
-                            <XLayout type="separated">
-                              <XIcon name="outbound" />
-                              <span>Outbounds</span>
-                            </XLayout>
-                          </template>
-                          <!-- we don't want to show an error here -->
-                          <!-- instead we show a No Data EmptyState -->
-                          <template
-                            v-if="typeof error === 'undefined' && typeof trafficError === 'undefined' && dataplaneLayout?.outbounds.length"
-                          >
-                            <ConnectionGroup
-                              type="passthrough"
-                            >
-                              <ConnectionCard
-                                :protocol="`passthrough`"
-                                :traffic="traffic?.passthrough"
-                              >
-                                Non mesh traffic
-                              </ConnectionCard>
-                            </ConnectionGroup>
+                            <!-- don't show a card for anything on port 49151 as those are service-less inbounds -->
                             <DataCollection
-                              type="outbounds"
-                              :items="dataplaneLayout?.outbounds"
-                              v-slot="{ items: outbounds }"
+                              type="inbounds"
+                              :items="inbounds"
+                              :predicate="(item) => item.port !== 49151"
                             >
-                              <ConnectionGroup
-                                type="outbound"
-                                data-testid="dataplane-outbounds"
+                              <template
+                                v-if="props.data.dataplaneType === 'delegated'"
+                                #empty
+                              >
+                                <XEmptyState>
+                                  <p>
+                                    This proxy is a delegated gateway therefore {{ t('common.product.name') }} does not have any
+                                    visibility into inbounds for this gateway.
+                                  </p>
+                                </XEmptyState>
+                              </template>
+                              <template
+                                #default="{ items: _inbounds }"
                               >
                                 <XLayout
                                   type="stack"
                                   size="small"
                                 >
                                   <template
-                                    v-for="outbound in outbounds"
-                                    :key="outbound.kri"
+                                    v-for="item in _inbounds"
+                                    :key="`${item.kri}`"
                                   >
-                                    <ConnectionCard
-                                      data-testid="dataplane-outbound"
-                                      :protocol="outbound.protocol"
-                                      :port-name="Kri.fromString(outbound.proxyResourceName).sectionName"
-                                      :traffic="traffic?.outbounds[outbound.proxyResourceName]"
-                                      data-actionable
+                                    <template
+                                      v-for="inbound in [inboundsByPort[item.port]?.[0]]"
+                                      :key="inbound?.port"
                                     >
-                                      <XAction
-                                        data-action
-                                        :to="{
-                                          name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'data-plane-connection-outbound-summary-overview-view')(String(_route.name)),
-                                          params: {
-                                            connection: outbound.proxyResourceName,
-                                          },
-                                          query: {
-                                            inactive: route.params.inactive,
-                                          },
-                                        }"
+                                      <ConnectionCard
+                                        data-testid="dataplane-inbound"
+                                        :protocol="item.protocol"
+                                        :port-name="inbound?.portName"
+                                        :traffic="traffic?.inbounds[item.proxyResourcePortName]"
+                                        data-actionable
                                       >
-                                        {{ outbound.proxyResourceName }}
-                                      </XAction>
-                                    </ConnectionCard>
+                                        <template #state>
+                                          <XIcon
+                                            v-if="inbound?.state !== 'Ready'"
+                                            name="danger"
+                                            :size="KUI_ICON_SIZE_40"
+                                            placement="right"
+                                          >
+                                            {{ t('data-planes.routes.item.unhealthy_inbound', { port: inbound?.port }) }}
+                                          </XIcon>
+                                        </template>
+                                        <XAction
+                                          data-action
+                                          :to="{
+                                            name: ((name) => name.includes('bound') ? name.replace('-outbound-', '-inbound-') : 'data-plane-connection-inbound-summary-overview-view')(String(_route.name)),
+                                            params: {
+                                              connection: item.proxyResourceName,
+                                            },
+                                            query: {
+                                              inactive: route.params.inactive,
+                                            },
+                                          }"
+                                        >
+                                          {{ item.proxyResourceName }}
+                                        </XAction>
+                                      </ConnectionCard>
+                                    </template>
                                   </template>
                                 </XLayout>
-                              </ConnectionGroup>
+                              </template>
                             </DataCollection>
-                          </template>
-                          <template
-                            v-else
+                          </ConnectionGroup>
+                        </template>
+                      </ConnectionTraffic>
+
+                      <ConnectionTraffic>
+                        <template
+                          #actions
+                        >
+                          <XAction
+                            action="refresh"
+                            appearance="primary"
+                            @click="() => {
+                              refresh()
+                              refreshTraffic()
+                            }"
                           >
-                            <XEmptyState />
-                          </template>
-                        </ConnectionTraffic>
-                      </XLayout>
-                    </XCard>
-                  </template>
+                            Refresh
+                          </XAction>
+                        </template>
+                        <template
+                          #title
+                        >
+                          <XLayout type="separated">
+                            <XIcon name="outbound" />
+                            <span>Outbounds</span>
+                          </XLayout>
+                        </template>
+                        <!-- we don't want to show an error here -->
+                        <!-- instead we show a No Data EmptyState -->
+                        <template
+                          v-if="typeof error === 'undefined' && typeof trafficError === 'undefined' && dataplaneLayout?.outbounds.length"
+                        >
+                          <ConnectionGroup
+                            type="passthrough"
+                          >
+                            <ConnectionCard
+                              :protocol="`passthrough`"
+                              :traffic="traffic?.passthrough"
+                            >
+                              Non mesh traffic
+                            </ConnectionCard>
+                          </ConnectionGroup>
+                          <DataCollection
+                            type="outbounds"
+                            :items="dataplaneLayout?.outbounds"
+                            v-slot="{ items: outbounds }"
+                          >
+                            <ConnectionGroup
+                              type="outbound"
+                              data-testid="dataplane-outbounds"
+                            >
+                              <XLayout
+                                type="stack"
+                                size="small"
+                              >
+                                <template
+                                  v-for="outbound in outbounds"
+                                  :key="outbound.kri"
+                                >
+                                  <ConnectionCard
+                                    data-testid="dataplane-outbound"
+                                    :protocol="outbound.protocol"
+                                    :port-name="Kri.fromString(outbound.proxyResourceName).sectionName"
+                                    :traffic="traffic?.outbounds[outbound.proxyResourceName]"
+                                    data-actionable
+                                  >
+                                    <XAction
+                                      data-action
+                                      :to="{
+                                        name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'data-plane-connection-outbound-summary-overview-view')(String(_route.name)),
+                                        params: {
+                                          connection: outbound.proxyResourceName,
+                                        },
+                                        query: {
+                                          inactive: route.params.inactive,
+                                        },
+                                      }"
+                                    >
+                                      {{ outbound.proxyResourceName }}
+                                    </XAction>
+                                  </ConnectionCard>
+                                </template>
+                              </XLayout>
+                            </ConnectionGroup>
+                          </DataCollection>
+                        </template>
+                        <template
+                          v-else
+                        >
+                          <XEmptyState />
+                        </template>
+                      </ConnectionTraffic>
+                    </XLayout>
+                  </XCard>
+                </template>
 
-                  <RouterView
-                    v-slot="child"
+                <RouterView
+                  v-slot="child"
+                >
+                  <XDrawer
+                    v-if="child.route.name !== route.name"
+                    width="670px"
+                    @close="function () {
+                      route.replace({
+                        name: 'data-plane-detail-view',
+                        params: {
+                          mesh: route.params.mesh,
+                          proxy: route.params.proxy,
+                        },
+                        query: {
+                          inactive: route.params.inactive ? null : undefined,
+                        },
+                      })
+
+                    }"
                   >
-                    <XDrawer
-                      v-if="child.route.name !== route.name"
-                      width="670px"
-                      @close="function () {
-                        route.replace({
-                          name: 'data-plane-detail-view',
-                          params: {
-                            mesh: route.params.mesh,
-                            proxy: route.params.proxy,
-                          },
-                          query: {
-                            inactive: route.params.inactive ? null : undefined,
-                          },
-                        })
-
-                      }"
-                    >
-                      <component
-                        :is="child.Component"
-                        :data="route.params.subscription.length > 0 ? props.data.dataplaneInsight.subscriptions : (child.route.name as string).includes('-inbound-') ? dataplaneLayout?.inbounds : dataplaneLayout?.outbounds"
-                        :data-plane-overview="props.data"
-                        :networking="props.data.dataplane.networking"
-                        :policies="dataplanePolicies?.policies ?? []"
-                        :policy-types-data="policyTypesData"
-                      />
-                    </XDrawer>
-                  </RouterView>
-                </XLayout>
-              </AppView>
-            </DataLoader>
-          </DataSource>
+                    <component
+                      :is="child.Component"
+                      :data="route.params.subscription.length > 0 ? props.data.dataplaneInsight.subscriptions : (child.route.name as string).includes('-inbound-') ? dataplaneLayout?.inbounds : dataplaneLayout?.outbounds"
+                      :data-plane-overview="props.data"
+                      :networking="props.data.dataplane.networking"
+                      :subscriptions="props.data.dataplaneInsight.subscriptions"
+                      :policies="dataplanePolicies?.policies ?? []"
+                    />
+                  </XDrawer>
+                </RouterView>
+              </XLayout>
+            </AppView>
+          </DataLoader>
         </DataSource>
       </DataSource>
     </DataSource>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -606,7 +606,7 @@
               v-slot="child"
             >
               <XDrawer
-                v-if="child.route.name !== route.name"
+                v-if="child.route.name !== route.name && dataplaneLayout"
                 width="670px"
                 @close="() => {
                   route.replace({

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -365,7 +365,7 @@
                   >
                     <XAction
                       :to="{
-                        name: 'data-plane-subscriptions-list-view',
+                        name: 'data-plane-policy-config-summary-view',
                         params: {
                           mesh: route.params.mesh,
                           proxy: route.params.proxy,

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -365,7 +365,7 @@
                   >
                     <XAction
                       :to="{
-                        name: 'data-plane-policy-config-summary-view',
+                        name: 'data-plane-subscriptions-list-view',
                         params: {
                           mesh: route.params.mesh,
                           proxy: route.params.proxy,

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -5,7 +5,6 @@
       mesh: '',
       proxy: '',
       proxyType: '',
-      subscription: '',
     }"
     name="data-plane-detail-view"
     v-slot="{ route, t, can, uri }"
@@ -288,7 +287,7 @@
                 <XAction
                   appearance="anchor"
                   :to="{
-                    name: 'data-plane-subscriptions-summary-view',
+                    name: 'data-plane-subscriptions-list-view',
                     params: {
                       mesh: route.params.mesh,
                       proxy: route.params.proxy,
@@ -600,10 +599,9 @@
               >
                 <component
                   :is="child.Component"
-                  :data="route.params.subscription.length > 0 ? props.data.dataplaneInsight.subscriptions : (child.route.name as string).includes('-inbound-') ? dataplaneLayout?.inbounds : dataplaneLayout?.outbounds"
+                  :data="(child.route.name as string).includes('-inbound-') ? dataplaneLayout?.inbounds : dataplaneLayout?.outbounds"
                   :data-plane-overview="props.data"
                   :networking="props.data.dataplane.networking"
-                  :subscriptions="props.data.dataplaneInsight.subscriptions"
                   :policies="resources?.policies"
                 />
               </XDrawer>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -606,7 +606,7 @@
               v-slot="child"
             >
               <XDrawer
-                v-if="child.route.name !== route.name && dataplaneLayout"
+                v-if="child.route.name !== route.name"
                 width="670px"
                 @close="() => {
                   route.replace({
@@ -628,7 +628,7 @@
                   :data-plane-overview="props.data"
                   :networking="props.data.dataplane.networking"
                   :subscriptions="props.data.dataplaneInsight.subscriptions"
-                  :policies="resources?.policies ?? []"
+                  :policies="resources?.policies"
                 />
               </XDrawer>
             </RouterView>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -10,639 +10,638 @@
     name="data-plane-detail-view"
     v-slot="{ route, t, can, uri }"
   >
-    <DataSource
-      :src="uri(policySources, '/meshes/:mesh/dataplanes/:name/policies/for/proxy', {
-        mesh: route.params.mesh,
-        name: route.params.proxy,
-      })"
-      v-slot="{ data: dataplanePolicies }"
+    <AppView
+      :notifications="true"
     >
-      <DataSource
-        :src="uri(sources, '/meshes/:mesh/dataplanes/:name/layout', {
-          mesh: route.params.mesh,
-          name: route.params.proxy,
-        })"
-        v-slot="{ data: dataplaneLayout, refresh, error }"
+      <template
+        v-for="{ bool, key, params, variant } in [
+          {
+            bool: props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false,
+            key: 'dp-cp-incompatible',
+            params: {
+              kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
+            },
+          },
+          {
+            bool: props.data.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
+            key: 'envoy-dp-incompatible',
+            params: {
+              envoy: props.data.dataplaneInsight.version?.envoy.version ?? '',
+              kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
+            },
+          },
+          {
+            bool: !!(can('use zones') && props.data.zone && props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false),
+            key: 'dp-zone-cp-incompatible',
+            params: {
+              kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
+            },
+          },
+          {
+            bool: props.data.isCertExpiresSoon,
+            key: 'certificate-expires-soon',
+          },
+          {
+            bool: props.data.isCertExpired,
+            key: 'certificate-expired',
+          },
+          {
+            bool: !props.data.dataplaneInsight.mTLS,
+            key: 'no-mtls',
+          },
+          {
+            bool: !can('use transparent-proxying', props.data),
+            key: 'networking-transparent-proxying',
+            variant: 'info' as const,
+          },
+        ]"
+        :key="key"
       >
-        <DataSource
-          :src="uri(connectionSources, '/connections/stats/for/:proxyType/:name/:mesh/:socketAddress', {
-            proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress' })[route.params.proxyType] ?? 'dataplane',
-            name: route.params.proxy,
-            mesh: route.params.mesh || '*',
-            // 'self_inbound' can be used as socket address to filter the stats as the contextual kri of an inbound always starts with 'self_inbound'
-            socketAddress: 'self_inbound',
-          })"
-          v-slot="{ data: traffic, error: trafficError, refresh: refreshTraffic }"
+        <XNotification
+          :notify="bool"
+          :data-testid="`warning-${key}`"
+          :uri="`data-planes.notifications.${key}.${props.data.id}`"
+          :variant="variant"
         >
-          <DataLoader
-            :data="[dataplaneLayout, dataplanePolicies, traffic]"
-          >
-            <AppView
-              :notifications="true"
+          <XI18n
+            :path="`data-planes.notifications.${key}`"
+            :params="Object.fromEntries(Object.entries(params ?? {}))"
+          />
+        </XNotification>
+      </template>
+
+      <XLayout
+        type="stack"
+        data-testid="dataplane-details"
+      >
+        <XAboutCard
+          :title="t('data-planes.routes.item.about.title')"
+          :created="props.data.creationTime"
+          :modified="props.data.modificationTime"
+          class="about-section"
+        >
+          <XLayout>
+            <XDl
+              variant="x-stack"
             >
-              <template
-                v-for="{ bool, key, params, variant } in [
-                  {
-                    bool: props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false,
-                    key: 'dp-cp-incompatible',
-                    params: {
-                      kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
-                    },
-                  },
-                  {
-                    bool: props.data.dataplaneInsight.version?.envoy?.kumaDpCompatible === false,
-                    key: 'envoy-dp-incompatible',
-                    params: {
-                      envoy: props.data.dataplaneInsight.version?.envoy.version ?? '',
-                      kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
-                    },
-                  },
-                  {
-                    bool: !!(can('use zones') && props.data.zone && props.data.dataplaneInsight.version?.kumaDp?.kumaCpCompatible === false),
-                    key: 'dp-zone-cp-incompatible',
-                    params: {
-                      kumaDp: props.data.dataplaneInsight.version?.kumaDp.version ?? '',
-                    },
-                  },
-                  {
-                    bool: props.data.isCertExpiresSoon,
-                    key: 'certificate-expires-soon',
-                  },
-                  {
-                    bool: props.data.isCertExpired,
-                    key: 'certificate-expired',
-                  },
-                  {
-                    bool: !props.data.dataplaneInsight.mTLS,
-                    key: 'no-mtls',
-                  },
-                  {
-                    bool: !can('use transparent-proxying', props.data),
-                    key: 'networking-transparent-proxying',
-                    variant: 'info' as const,
-                  },
-                ]"
-                :key="key"
+              <div>
+                <dt>
+                  {{ t('http.api.property.status') }}
+                </dt>
+                <dd>
+                  <XLayout
+                    type="separated"
+                  >
+                    <StatusBadge :status="props.data.status" />
+                    <DataCollection
+                      v-if="props.data.dataplaneType === 'standard'"
+                      :items="props.data.dataplane.networking.inbounds"
+                      :predicate="item => item.state !== 'Ready'"
+                      :empty="false"
+                      v-slot="{ items: unhealthyInbounds }"
+                    >
+                      <XIcon name="info">
+                        <ul>
+                          <li
+                            v-for="inbound in unhealthyInbounds"
+                            :key="`${inbound.service}:${inbound.port}`"
+                          >
+                            {{ t('data-planes.routes.item.unhealthy_inbound', { port: inbound.port }) }}
+                          </li>
+                        </ul>
+                      </XIcon>
+                    </DataCollection>
+                  </XLayout>
+                </dd>
+              </div>
+              <div
+                v-if="can('use zones') && props.data.zone"
               >
-                <XNotification
-                  :notify="bool"
-                  :data-testid="`warning-${key}`"
-                  :uri="`data-planes.notifications.${key}.${props.data.id}`"
-                  :variant="variant"
-                >
-                  <XI18n
-                    :path="`data-planes.notifications.${key}`"
-                    :params="Object.fromEntries(Object.entries(params ?? {}))"
+                <dt>
+                  {{ t('http.api.property.zone') }}
+                </dt>
+                <dd>
+                  <XBadge appearance="decorative">
+                    <XAction
+                      :to="{
+                        name: 'zone-cp-detail-view',
+                        params: {
+                          zone: props.data.zone,
+                        },
+                      }"
+                    >
+                      {{ props.data.zone }}
+                    </XAction>
+                  </XBadge>
+                </dd>
+              </div>
+              <div>
+                <dt>
+                  {{ t('http.api.property.type') }}
+                </dt>
+                <dd>
+                  <XBadge appearance="decorative">
+                    {{ t(`data-planes.type.${props.data.dataplaneType}`) }}
+                  </XBadge>
+                </dd>
+              </div>
+              <div
+                v-if="props.data.namespace.length > 0"
+              >
+                <dt>
+                  {{ t('http.api.property.namespace') }}
+                </dt>
+                <dd>
+                  <XBadge
+                    appearance="decorative"
+                  >
+                    {{ props.data.namespace }}
+                  </XBadge>
+                </dd>
+              </div>
+              <div>
+                <dt>
+                  {{ t('http.api.property.address') }}
+                </dt>
+                <dd>
+                  <XCopyButton
+                    variant="badge"
+                    format="default"
+                    :text="`${props.data.dataplane.networking.address}`"
                   />
-                </XNotification>
-              </template>
-
-              <XLayout
-                type="stack"
-                data-testid="dataplane-details"
+                </dd>
+              </div>
+              <div
+                v-if="props.data.dataplane.networking.gateway"
               >
-                <XAboutCard
-                  :title="t('data-planes.routes.item.about.title')"
-                  :created="props.data.creationTime"
-                  :modified="props.data.modificationTime"
-                  class="about-section"
+                <dt>
+                  {{ t('http.api.property.tags') }}
+                </dt>
+                <dd>
+                  <TagList
+                    :tags="props.data.dataplane.networking.gateway.tags"
+                  />
+                </dd>
+              </div>
+            </XDl>
+
+            <XLayout
+              v-if="props.data.dataplaneInsight.mTLS"
+              data-testid="dataplane-mtls"
+              class="about-subsection"
+              size="small"
+            >
+              <h3>{{ t('data-planes.routes.item.mtls.title') }}</h3>
+              <XLayout size="small">
+                <template
+                  v-for="mTLS in [props.data.dataplaneInsight.mTLS]"
+                  :key="typeof mTLS"
                 >
-                  <XLayout>
-                    <XDl
-                      variant="x-stack"
+                  <XDl
+                    v-if="typeof mTLS.lastCertificateRegeneration !== 'undefined' && typeof mTLS.certificateExpirationTime !== 'undefined' && typeof mTLS.issuedBackend !== 'undefined'"
+                    variant="x-stack"
+                  >
+                    <div>
+                      <dt>
+                        {{ t('data-planes.routes.item.mtls.generation_time.title') }}
+                      </dt>
+                      <dd>
+                        <XBadge appearance="neutral">
+                          {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
+                        </XBadge>
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>
+                        {{ t('data-planes.routes.item.mtls.expiration_time.title') }}
+                      </dt>
+                      <dd>
+                        <XBadge appearance="neutral">
+                          {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
+                        </XBadge>
+                      </dd>
+                    </div>
+                  </XDl>
+                  <XI18n
+                    v-else
+                    path="data-planes.routes.item.mtls.managed_externally"
+                  />
+                  <XDl
+                    variant="x-stack"
+                  >
+                    <div
+                      v-if="typeof mTLS.certificateRegenerations !== 'undefined'"
                     >
-                      <div>
-                        <dt>
-                          {{ t('http.api.property.status') }}
-                        </dt>
-                        <dd>
-                          <XLayout
-                            type="separated"
-                          >
-                            <StatusBadge :status="props.data.status" />
-                            <DataCollection
-                              v-if="props.data.dataplaneType === 'standard'"
-                              :items="props.data.dataplane.networking.inbounds"
-                              :predicate="item => item.state !== 'Ready'"
-                              :empty="false"
-                              v-slot="{ items: unhealthyInbounds }"
-                            >
-                              <XIcon name="info">
-                                <ul>
-                                  <li
-                                    v-for="inbound in unhealthyInbounds"
-                                    :key="`${inbound.service}:${inbound.port}`"
-                                  >
-                                    {{ t('data-planes.routes.item.unhealthy_inbound', { port: inbound.port }) }}
-                                  </li>
-                                </ul>
-                              </XIcon>
-                            </DataCollection>
-                          </XLayout>
-                        </dd>
-                      </div>
-                      <div
-                        v-if="can('use zones') && props.data.zone"
-                      >
-                        <dt>
-                          {{ t('http.api.property.zone') }}
-                        </dt>
-                        <dd>
-                          <XBadge appearance="decorative">
-                            <XAction
-                              :to="{
-                                name: 'zone-cp-detail-view',
-                                params: {
-                                  zone: props.data.zone,
-                                },
-                              }"
-                            >
-                              {{ props.data.zone }}
-                            </XAction>
-                          </XBadge>
-                        </dd>
-                      </div>
-                      <div>
-                        <dt>
-                          {{ t('http.api.property.type') }}
-                        </dt>
-                        <dd>
-                          <XBadge appearance="decorative">
-                            {{ t(`data-planes.type.${props.data.dataplaneType}`) }}
-                          </XBadge>
-                        </dd>
-                      </div>
-                      <div
-                        v-if="props.data.namespace.length > 0"
-                      >
-                        <dt>
-                          {{ t('http.api.property.namespace') }}
-                        </dt>
-                        <dd>
+                      <dt>
+                        {{ t('data-planes.routes.item.mtls.regenerations.title') }}
+                      </dt>
+                      <dd>
+                        <XBadge appearance="info">
+                          {{ t('common.formats.integer', { value: mTLS.certificateRegenerations }) }}
+                        </XBadge>
+                      </dd>
+                    </div>
+                    <div
+                      v-if="typeof mTLS.issuedBackend !== 'undefined'"
+                    >
+                      <dt>
+                        {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
+                      </dt>
+                      <dd>
+                        <XBadge appearance="decorative">
+                          {{ mTLS.issuedBackend }}
+                        </XBadge>
+                      </dd>
+                    </div>
+                    <div
+                      v-if="typeof mTLS.supportedBackends !== 'undefined'"
+                    >
+                      <dt>
+                        {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
+                      </dt>
+                      <dd>
+                        <XLayout
+                          type="separated"
+                          truncate
+                        >
                           <XBadge
-                            appearance="decorative"
+                            v-for="item in mTLS.supportedBackends"
+                            :key="item"
+                            :appearance="item === mTLS.issuedBackend ? 'decorative' : 'info'"
                           >
-                            {{ props.data.namespace }}
+                            {{ item }}
                           </XBadge>
-                        </dd>
-                      </div>
-                      <div>
-                        <dt>
-                          {{ t('http.api.property.address') }}
-                        </dt>
-                        <dd>
-                          <XCopyButton
-                            variant="badge"
-                            format="default"
-                            :text="`${props.data.dataplane.networking.address}`"
-                          />
-                        </dd>
-                      </div>
-                      <div
-                        v-if="props.data.dataplane.networking.gateway"
-                      >
-                        <dt>
-                          {{ t('http.api.property.tags') }}
-                        </dt>
-                        <dd>
-                          <TagList
-                            :tags="props.data.dataplane.networking.gateway.tags"
-                          />
-                        </dd>
-                      </div>
-                    </XDl>
+                        </XLayout>
+                      </dd>
+                    </div>
+                  </XDl>
+                </template>
+              </XLayout>
+            </XLayout>
 
-                    <XLayout
-                      v-if="props.data.dataplaneInsight.mTLS"
-                      data-testid="dataplane-mtls"
-                      class="about-subsection"
-                      size="small"
+            <XLayout
+              v-if="props.data.dataplaneInsight.subscriptions.length > 0"
+              data-testid="about-dataplane-subscriptions"
+              class="about-subsection"
+            >
+              <XLayout type="separated">
+                <h3>{{ t('data-planes.routes.item.subscriptions.title') }}</h3>
+                <XAction
+                  appearance="anchor"
+                  :to="{
+                    name: 'data-plane-subscriptions-summary-view',
+                    params: {
+                      mesh: route.params.mesh,
+                      proxy: route.params.proxy,
+                    },
+                    query: {
+                      inactive: route.params.inactive,
+                    },
+                  }"
+                >
+                  ({{ t('data-planes.routes.item.xds.show-details') }})
+                </XAction>
+              </XLayout>
+
+              <XDl
+                v-if="props.data.dataplaneInsight.connectedSubscription"
+                variant="x-stack"
+              >
+                <div>
+                  <dt>
+                    {{ t('data-planes.routes.item.xds.connected') }}
+                  </dt>
+                  <dd>
+                    <XBadge appearance="neutral">
+                      {{ t('common.formats.datetime', { value: Date.parse(props.data.dataplaneInsight.connectedSubscription.connectTime ?? '') }) }}
+                    </XBadge>
+                  </dd>
+                </div>
+                <div>
+                  <dt>
+                    {{ t('data-planes.routes.item.xds.instance') }}
+                  </dt>
+                  <dd>
+                    <XBadge>
+                      {{ props.data.dataplaneInsight.connectedSubscription.controlPlaneInstanceId }}
+                    </XBadge>
+                  </dd>
+                </div>
+                <div>
+                  <dt>
+                    {{ t('data-planes.routes.item.xds.version') }}
+                  </dt>
+                  <dd>
+                    <XBadge>
+                      {{ props.data.dataplaneInsight.connectedSubscription.version?.kumaDp?.version ?? t('common.unknown') }}
+                    </XBadge>
+                  </dd>
+                </div>
+              </XDl>
+              <template v-else>
+                <XI18n path="data-planes.routes.item.xds.disconnected" />
+              </template>
+            </XLayout>
+
+            <DataSource
+              :src="uri(policySources, '/meshes/:mesh/dataplanes/:name/policies/for/proxy', {
+                mesh: route.params.mesh,
+                name: route.params.proxy,
+              })"
+              @change="(res) => resources = res"
+            >
+              <XLayout
+                v-if="resources?.policies.length"
+                data-testid="about-dataplane-policies"
+                class="about-subsection"
+              >
+                <h3>{{ t('data-planes.routes.item.policies') }}</h3>
+
+                <XLayout
+                  type="separated"
+                >
+                  <template
+                    v-for="policy in resources?.policies"
+                    :key="policy.kind"
+                  >
+                    <XAction
+                      :to="{
+                        name: 'data-plane-policy-config-summary-view',
+                        params: {
+                          mesh: route.params.mesh,
+                          proxy: route.params.proxy,
+                          policy: policy.kind.toLowerCase(),
+                        },
+                      }"
                     >
-                      <h3>{{ t('data-planes.routes.item.mtls.title') }}</h3>
-                      <XLayout size="small">
-                        <template
-                          v-for="mTLS in [props.data.dataplaneInsight.mTLS]"
-                          :key="typeof mTLS"
-                        >
-                          <XDl
-                            v-if="typeof mTLS.lastCertificateRegeneration !== 'undefined' && typeof mTLS.certificateExpirationTime !== 'undefined' && typeof mTLS.issuedBackend !== 'undefined'"
-                            variant="x-stack"
-                          >
-                            <div>
-                              <dt>
-                                {{ t('data-planes.routes.item.mtls.generation_time.title') }}
-                              </dt>
-                              <dd>
-                                <XBadge appearance="neutral">
-                                  {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
-                                </XBadge>
-                              </dd>
-                            </div>
-                            <div>
-                              <dt>
-                                {{ t('data-planes.routes.item.mtls.expiration_time.title') }}
-                              </dt>
-                              <dd>
-                                <XBadge appearance="neutral">
-                                  {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
-                                </XBadge>
-                              </dd>
-                            </div>
-                          </XDl>
-                          <XI18n
-                            v-else
-                            path="data-planes.routes.item.mtls.managed_externally"
-                          />
-                          <XDl
-                            variant="x-stack"
-                          >
-                            <div
-                              v-if="typeof mTLS.certificateRegenerations !== 'undefined'"
-                            >
-                              <dt>
-                                {{ t('data-planes.routes.item.mtls.regenerations.title') }}
-                              </dt>
-                              <dd>
-                                <XBadge appearance="info">
-                                  {{ t('common.formats.integer', { value: mTLS.certificateRegenerations }) }}
-                                </XBadge>
-                              </dd>
-                            </div>
-                            <div
-                              v-if="typeof mTLS.issuedBackend !== 'undefined'"
-                            >
-                              <dt>
-                                {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
-                              </dt>
-                              <dd>
-                                <XBadge appearance="decorative">
-                                  {{ mTLS.issuedBackend }}
-                                </XBadge>
-                              </dd>
-                            </div>
-                            <div
-                              v-if="typeof mTLS.supportedBackends !== 'undefined'"
-                            >
-                              <dt>
-                                {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
-                              </dt>
-                              <dd>
-                                <XLayout
-                                  type="separated"
-                                  truncate
-                                >
-                                  <XBadge
-                                    v-for="item in mTLS.supportedBackends"
-                                    :key="item"
-                                    :appearance="item === mTLS.issuedBackend ? 'decorative' : 'info'"
-                                  >
-                                    {{ item }}
-                                  </XBadge>
-                                </XLayout>
-                              </dd>
-                            </div>
-                          </XDl>
-                        </template>
-                      </XLayout>
-                    </XLayout>
+                      <XBadge>
+                        {{ policy.kind }}
+                      </XBadge>
+                    </XAction>
+                  </template>
+                </XLayout>
+              </XLayout>
+            </DataSource>
+          </XLayout>
+        </XAboutCard>
 
-                    <XLayout
-                      v-if="props.data.dataplaneInsight.subscriptions.length > 0"
-                      data-testid="about-dataplane-subscriptions"
-                      class="about-subsection"
+        <DataSource
+          :src="uri(sources, '/meshes/:mesh/dataplanes/:name/layout', {
+            mesh: route.params.mesh,
+            name: route.params.proxy,
+          })"
+          v-slot="{ data: dataplaneLayout, refresh, error }"
+        >
+          <DataSource
+            :src="uri(connectionSources, '/connections/stats/for/:proxyType/:name/:mesh/:socketAddress', {
+              proxyType: ({ ingresses: 'zone-ingress', egresses: 'zone-egress' })[route.params.proxyType] ?? 'dataplane',
+              name: route.params.proxy,
+              mesh: route.params.mesh || '*',
+              // 'self_inbound' can be used as socket address to filter the stats as the contextual kri of an inbound always starts with 'self_inbound'
+              socketAddress: 'self_inbound',
+            })"
+            v-slot="{ data: traffic, error: trafficError, refresh: refreshTraffic }"
+          >
+            <XCard
+              class="traffic"
+              data-testid="dataplane-traffic"
+            >
+              <DataLoader
+                :data="[dataplaneLayout, traffic]"
+              >
+                <XLayout
+                  type="columns"
+                >
+                  <ConnectionTraffic>
+                    <template
+                      #title
                     >
-                      <XLayout type="separated">
-                        <h3>{{ t('data-planes.routes.item.subscriptions.title') }}</h3>
-                        <XAction
-                          appearance="anchor"
-                          :to="{
-                            name: 'data-plane-subscriptions-summary-view',
-                            params: {
-                              mesh: route.params.mesh,
-                              proxy: route.params.proxy,
-                            },
-                            query: {
-                              inactive: route.params.inactive,
-                            },
-                          }"
-                        >
-                          ({{ t('data-planes.routes.item.xds.show-details') }})
-                        </XAction>
-                      </XLayout>
-
-                      <XDl
-                        v-if="props.data.dataplaneInsight.connectedSubscription"
-                        variant="x-stack"
-                      >
-                        <div>
-                          <dt>
-                            {{ t('data-planes.routes.item.xds.connected') }}
-                          </dt>
-                          <dd>
-                            <XBadge appearance="neutral">
-                              {{ t('common.formats.datetime', { value: Date.parse(props.data.dataplaneInsight.connectedSubscription.connectTime ?? '') }) }}
-                            </XBadge>
-                          </dd>
-                        </div>
-                        <div>
-                          <dt>
-                            {{ t('data-planes.routes.item.xds.instance') }}
-                          </dt>
-                          <dd>
-                            <XBadge>
-                              {{ props.data.dataplaneInsight.connectedSubscription.controlPlaneInstanceId }}
-                            </XBadge>
-                          </dd>
-                        </div>
-                        <div>
-                          <dt>
-                            {{ t('data-planes.routes.item.xds.version') }}
-                          </dt>
-                          <dd>
-                            <XBadge>
-                              {{ props.data.dataplaneInsight.connectedSubscription.version?.kumaDp?.version ?? t('common.unknown') }}
-                            </XBadge>
-                          </dd>
-                        </div>
-                      </XDl>
-                      <template v-else>
-                        <XI18n path="data-planes.routes.item.xds.disconnected" />
-                      </template>
-                    </XLayout>
-
-                    <XLayout
-                      v-if="dataplanePolicies?.policies.length"
-                      data-testid="about-dataplane-policies"
-                      class="about-subsection"
-                    >
-                      <h3>{{ t('data-planes.routes.item.policies') }}</h3>
-
                       <XLayout
                         type="separated"
                       >
-                        <template
-                          v-for="policy in dataplanePolicies?.policies"
-                          :key="policy.kind"
-                        >
-                          <XAction
-                            :to="{
-                              name: 'data-plane-policy-config-summary-view',
-                              params: {
-                                mesh: route.params.mesh,
-                                proxy: route.params.proxy,
-                                policy: policy.kind.toLowerCase(),
-                              },
-                            }"
-                          >
-                            <XBadge>
-                              {{ policy.kind }}
-                            </XBadge>
-                          </XAction>
-                        </template>
+                        <XIcon
+                          name="inbound"
+                        />
+                        <span>Inbounds</span>
                       </XLayout>
-                    </XLayout>
-                  </XLayout>
-                </XAboutCard>
-
-                <template
-                  v-for="(inboundsByPort, port) in [Object.groupBy(props.data.dataplane.networking.inbounds, (item) => item.port)]"
-                  :key="port"
-                >
-                  <XCard
-                    class="traffic"
-                    data-testid="dataplane-traffic"
-                  >
-                    <XLayout
-                      type="columns"
+                    </template>
+                    <template
+                      v-for="(inboundsByPort, port) in [Object.groupBy(props.data.dataplane.networking.inbounds, (item) => item.port)]"
+                      :key="port"
                     >
-                      <ConnectionTraffic>
-                        <template
-                          #title
+                      <template
+                        v-for="inbounds in [dataplaneLayout?.inbounds ?? []]"
+                        :key="typeof inbounds"
+                      >
+                        <ConnectionGroup
+                          type="inbound"
+                          data-testid="dataplane-inbounds"
                         >
-                          <XLayout
-                            type="separated"
-                          >
-                            <XIcon
-                              name="inbound"
-                            />
-                            <span>Inbounds</span>
-                          </XLayout>
-                        </template>
-                        <template
-                          v-for="inbounds in [dataplaneLayout?.inbounds ?? []]"
-                          :key="typeof inbounds"
-                        >
-                          <ConnectionGroup
-                            type="inbound"
-                            data-testid="dataplane-inbounds"
-                          >
-                            <!-- don't show a card for anything on port 49151 as those are service-less inbounds -->
-                            <DataCollection
-                              type="inbounds"
-                              :items="inbounds"
-                              :predicate="(item) => item.port !== 49151"
-                            >
-                              <template
-                                v-if="props.data.dataplaneType === 'delegated'"
-                                #empty
-                              >
-                                <XEmptyState>
-                                  <p>
-                                    This proxy is a delegated gateway therefore {{ t('common.product.name') }} does not have any
-                                    visibility into inbounds for this gateway.
-                                  </p>
-                                </XEmptyState>
-                              </template>
-                              <template
-                                #default="{ items: _inbounds }"
-                              >
-                                <XLayout
-                                  type="stack"
-                                  size="small"
-                                >
-                                  <template
-                                    v-for="item in _inbounds"
-                                    :key="`${item.kri}`"
-                                  >
-                                    <template
-                                      v-for="inbound in [inboundsByPort[item.port]?.[0]]"
-                                      :key="inbound?.port"
-                                    >
-                                      <ConnectionCard
-                                        data-testid="dataplane-inbound"
-                                        :protocol="item.protocol"
-                                        :port-name="inbound?.portName"
-                                        :traffic="traffic?.inbounds[item.proxyResourcePortName]"
-                                        data-actionable
-                                      >
-                                        <template #state>
-                                          <XIcon
-                                            v-if="inbound?.state !== 'Ready'"
-                                            name="danger"
-                                            :size="KUI_ICON_SIZE_40"
-                                            placement="right"
-                                          >
-                                            {{ t('data-planes.routes.item.unhealthy_inbound', { port: inbound?.port }) }}
-                                          </XIcon>
-                                        </template>
-                                        <XAction
-                                          data-action
-                                          :to="{
-                                            name: ((name) => name.includes('bound') ? name.replace('-outbound-', '-inbound-') : 'data-plane-connection-inbound-summary-overview-view')(String(_route.name)),
-                                            params: {
-                                              connection: item.proxyResourceName,
-                                            },
-                                            query: {
-                                              inactive: route.params.inactive,
-                                            },
-                                          }"
-                                        >
-                                          {{ item.proxyResourceName }}
-                                        </XAction>
-                                      </ConnectionCard>
-                                    </template>
-                                  </template>
-                                </XLayout>
-                              </template>
-                            </DataCollection>
-                          </ConnectionGroup>
-                        </template>
-                      </ConnectionTraffic>
-
-                      <ConnectionTraffic>
-                        <template
-                          #actions
-                        >
-                          <XAction
-                            action="refresh"
-                            appearance="primary"
-                            @click="() => {
-                              refresh()
-                              refreshTraffic()
-                            }"
-                          >
-                            Refresh
-                          </XAction>
-                        </template>
-                        <template
-                          #title
-                        >
-                          <XLayout type="separated">
-                            <XIcon name="outbound" />
-                            <span>Outbounds</span>
-                          </XLayout>
-                        </template>
-                        <!-- we don't want to show an error here -->
-                        <!-- instead we show a No Data EmptyState -->
-                        <template
-                          v-if="typeof error === 'undefined' && typeof trafficError === 'undefined' && dataplaneLayout?.outbounds.length"
-                        >
-                          <ConnectionGroup
-                            type="passthrough"
-                          >
-                            <ConnectionCard
-                              :protocol="`passthrough`"
-                              :traffic="traffic?.passthrough"
-                            >
-                              Non mesh traffic
-                            </ConnectionCard>
-                          </ConnectionGroup>
+                          <!-- don't show a card for anything on port 49151 as those are service-less inbounds -->
                           <DataCollection
-                            type="outbounds"
-                            :items="dataplaneLayout?.outbounds"
-                            v-slot="{ items: outbounds }"
+                            type="inbounds"
+                            :items="inbounds"
+                            :predicate="(item) => item.port !== 49151"
                           >
-                            <ConnectionGroup
-                              type="outbound"
-                              data-testid="dataplane-outbounds"
+                            <template
+                              v-if="props.data.dataplaneType === 'delegated'"
+                              #empty
+                            >
+                              <XEmptyState>
+                                <p>
+                                  This proxy is a delegated gateway therefore {{ t('common.product.name') }} does not have any
+                                  visibility into inbounds for this gateway.
+                                </p>
+                              </XEmptyState>
+                            </template>
+                            <template
+                              #default="{ items: _inbounds }"
                             >
                               <XLayout
                                 type="stack"
                                 size="small"
                               >
                                 <template
-                                  v-for="outbound in outbounds"
-                                  :key="outbound.kri"
+                                  v-for="item in _inbounds"
+                                  :key="`${item.kri}`"
                                 >
-                                  <ConnectionCard
-                                    data-testid="dataplane-outbound"
-                                    :protocol="outbound.protocol"
-                                    :port-name="Kri.fromString(outbound.proxyResourceName).sectionName"
-                                    :traffic="traffic?.outbounds[outbound.proxyResourceName]"
-                                    data-actionable
+                                  <template
+                                    v-for="inbound in [inboundsByPort[item.port]?.[0]]"
+                                    :key="inbound?.port"
                                   >
-                                    <XAction
-                                      data-action
-                                      :to="{
-                                        name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'data-plane-connection-outbound-summary-overview-view')(String(_route.name)),
-                                        params: {
-                                          connection: outbound.proxyResourceName,
-                                        },
-                                        query: {
-                                          inactive: route.params.inactive,
-                                        },
-                                      }"
+                                    <ConnectionCard
+                                      data-testid="dataplane-inbound"
+                                      :protocol="item.protocol"
+                                      :port-name="inbound?.portName"
+                                      :traffic="traffic?.inbounds[item.proxyResourcePortName]"
+                                      data-actionable
                                     >
-                                      {{ outbound.proxyResourceName }}
-                                    </XAction>
-                                  </ConnectionCard>
+                                      <template #state>
+                                        <XIcon
+                                          v-if="inbound?.state !== 'Ready'"
+                                          name="danger"
+                                          :size="KUI_ICON_SIZE_40"
+                                          placement="right"
+                                        >
+                                          {{ t('data-planes.routes.item.unhealthy_inbound', { port: inbound?.port }) }}
+                                        </XIcon>
+                                      </template>
+                                      <XAction
+                                        data-action
+                                        :to="{
+                                          name: ((name) => name.includes('bound') ? name.replace('-outbound-', '-inbound-') : 'data-plane-connection-inbound-summary-overview-view')(String(_route.name)),
+                                          params: {
+                                            connection: item.proxyResourceName,
+                                          },
+                                          query: {
+                                            inactive: route.params.inactive,
+                                          },
+                                        }"
+                                      >
+                                        {{ item.proxyResourceName }}
+                                      </XAction>
+                                    </ConnectionCard>
+                                  </template>
                                 </template>
                               </XLayout>
-                            </ConnectionGroup>
+                            </template>
                           </DataCollection>
-                        </template>
-                        <template
-                          v-else
+                        </ConnectionGroup>
+                      </template>
+                    </template>
+                  </ConnectionTraffic>
+
+                  <ConnectionTraffic>
+                    <template
+                      #actions
+                    >
+                      <XAction
+                        action="refresh"
+                        appearance="primary"
+                        @click="() => {
+                          refresh()
+                          refreshTraffic()
+                        }"
+                      >
+                        Refresh
+                      </XAction>
+                    </template>
+                    <template
+                      #title
+                    >
+                      <XLayout type="separated">
+                        <XIcon name="outbound" />
+                        <span>Outbounds</span>
+                      </XLayout>
+                    </template>
+                    <!-- we don't want to show an error here -->
+                    <!-- instead we show a No Data EmptyState -->
+                    <template
+                      v-if="typeof error === 'undefined' && typeof trafficError === 'undefined' && dataplaneLayout?.outbounds.length"
+                    >
+                      <ConnectionGroup
+                        type="passthrough"
+                      >
+                        <ConnectionCard
+                          :protocol="`passthrough`"
+                          :traffic="traffic?.passthrough"
                         >
-                          <XEmptyState />
-                        </template>
-                      </ConnectionTraffic>
-                    </XLayout>
-                  </XCard>
-                </template>
+                          Non mesh traffic
+                        </ConnectionCard>
+                      </ConnectionGroup>
+                      <DataCollection
+                        type="outbounds"
+                        :items="dataplaneLayout?.outbounds"
+                        v-slot="{ items: outbounds }"
+                      >
+                        <ConnectionGroup
+                          type="outbound"
+                          data-testid="dataplane-outbounds"
+                        >
+                          <XLayout
+                            type="stack"
+                            size="small"
+                          >
+                            <template
+                              v-for="outbound in outbounds"
+                              :key="outbound.kri"
+                            >
+                              <ConnectionCard
+                                data-testid="dataplane-outbound"
+                                :protocol="outbound.protocol"
+                                :port-name="Kri.fromString(outbound.proxyResourceName).sectionName"
+                                :traffic="traffic?.outbounds[outbound.proxyResourceName]"
+                                data-actionable
+                              >
+                                <XAction
+                                  data-action
+                                  :to="{
+                                    name: ((name) => name.includes('bound') ? name.replace('-inbound-', '-outbound-') : 'data-plane-connection-outbound-summary-overview-view')(String(_route.name)),
+                                    params: {
+                                      connection: outbound.proxyResourceName,
+                                    },
+                                    query: {
+                                      inactive: route.params.inactive,
+                                    },
+                                  }"
+                                >
+                                  {{ outbound.proxyResourceName }}
+                                </XAction>
+                              </ConnectionCard>
+                            </template>
+                          </XLayout>
+                        </ConnectionGroup>
+                      </DataCollection>
+                    </template>
+                    <template
+                      v-else
+                    >
+                      <XEmptyState />
+                    </template>
+                  </ConnectionTraffic>
+                </XLayout>
+              </DataLoader>
+            </XCard>
+            <RouterView
+              v-slot="child"
+            >
+              <XDrawer
+                v-if="child.route.name !== route.name"
+                width="670px"
+                @close="() => {
+                  route.replace({
+                    name: 'data-plane-detail-view',
+                    params: {
+                      mesh: route.params.mesh,
+                      proxy: route.params.proxy,
+                    },
+                    query: {
+                      inactive: route.params.inactive ? null : undefined,
+                    },
+                  })
 
-                <RouterView
-                  v-slot="child"
-                >
-                  <XDrawer
-                    v-if="child.route.name !== route.name"
-                    width="670px"
-                    @close="function () {
-                      route.replace({
-                        name: 'data-plane-detail-view',
-                        params: {
-                          mesh: route.params.mesh,
-                          proxy: route.params.proxy,
-                        },
-                        query: {
-                          inactive: route.params.inactive ? null : undefined,
-                        },
-                      })
-
-                    }"
-                  >
-                    <component
-                      :is="child.Component"
-                      :data="route.params.subscription.length > 0 ? props.data.dataplaneInsight.subscriptions : (child.route.name as string).includes('-inbound-') ? dataplaneLayout?.inbounds : dataplaneLayout?.outbounds"
-                      :data-plane-overview="props.data"
-                      :networking="props.data.dataplane.networking"
-                      :subscriptions="props.data.dataplaneInsight.subscriptions"
-                      :policies="dataplanePolicies?.policies ?? []"
-                    />
-                  </XDrawer>
-                </RouterView>
-              </XLayout>
-            </AppView>
-          </DataLoader>
+                }"
+              >
+                <component
+                  :is="child.Component"
+                  :data="route.params.subscription.length > 0 ? props.data.dataplaneInsight.subscriptions : (child.route.name as string).includes('-inbound-') ? dataplaneLayout?.inbounds : dataplaneLayout?.outbounds"
+                  :data-plane-overview="props.data"
+                  :networking="props.data.dataplane.networking"
+                  :subscriptions="props.data.dataplaneInsight.subscriptions"
+                  :policies="resources?.policies ?? []"
+                />
+              </XDrawer>
+            </RouterView>
+          </DataSource>
         </DataSource>
-      </DataSource>
-    </DataSource>
+      </XLayout>
+    </AppView>
   </RouteView>
 </template>
 
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
-import { provide } from 'vue'
+import { ref } from 'vue'
 
 import { sources } from '../sources'
 import StatusBadge from '@/app/common/StatusBadge.vue'
@@ -654,6 +653,7 @@ import { sources as connectionSources } from '@/app/connections/sources'
 import type { DataplaneOverview } from '@/app/data-planes/data'
 import { Kri } from '@/app/kuma'
 import type { Mesh } from '@/app/meshes/data'
+import type { DataplanePolicies } from '@/app/policies/data/DataplanePolicies'
 import { sources as policySources } from '@/app/policies/sources'
 import { useRoute } from '@/app/vue'
 
@@ -663,7 +663,8 @@ const props = defineProps<{
   data: DataplaneOverview
   mesh: Mesh
 }>()
-provide('data-plane-overview', props.data)
+
+const resources = ref<DataplanePolicies | undefined>()
 </script>
 
 <style lang="scss" scoped>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -112,21 +112,14 @@
                     class="about-section"
                   >
                     <XLayout>
-                      <XLayout
-                        type="separated"
+                      <XDl
+                        variant="x-stack"
                       >
-                        <DefinitionCard
-                          layout="horizontal"
-                        >
-                          <template
-                            #title
-                          >
+                        <div>
+                          <dt>
                             {{ t('http.api.property.status') }}
-                          </template>
-
-                          <template
-                            #body
-                          >
+                          </dt>
+                          <dd>
                             <XLayout
                               type="separated"
                             >
@@ -150,21 +143,15 @@
                                 </XIcon>
                               </DataCollection>
                             </XLayout>
-                          </template>
-                        </DefinitionCard>
-
-                        <DefinitionCard
+                          </dd>
+                        </div>
+                        <div
                           v-if="can('use zones') && props.data.zone"
-                          layout="horizontal"
                         >
-                          <template
-                            #title
-                          >
+                          <dt>
                             {{ t('http.api.property.zone') }}
-                          </template>
-                          <template
-                            #body
-                          >
+                          </dt>
+                          <dd>
                             <XBadge appearance="decorative">
                               <XAction
                                 :to="{
@@ -177,87 +164,57 @@
                                 {{ props.data.zone }}
                               </XAction>
                             </XBadge>
-                          </template>
-                        </DefinitionCard>
-                        <DefinitionCard layout="horizontal">
-                          <template
-                            #title
-                          >
+                          </dd>
+                        </div>
+                        <div>
+                          <dt>
                             {{ t('http.api.property.type') }}
-                          </template>
-
-                          <template
-                            #body
-                          >
+                          </dt>
+                          <dd>
                             <XBadge appearance="decorative">
                               {{ t(`data-planes.type.${props.data.dataplaneType}`) }}
                             </XBadge>
-                          </template>
-                        </DefinitionCard>
-
-                        <DefinitionCard
+                          </dd>
+                        </div>
+                        <div
                           v-if="props.data.namespace.length > 0"
-                          layout="horizontal"
                         >
-                          <template
-                            #title
-                          >
+                          <dt>
                             {{ t('http.api.property.namespace') }}
-                          </template>
-
-                          <template
-                            #body
-                          >
+                          </dt>
+                          <dd>
                             <XBadge
                               appearance="decorative"
                             >
                               {{ props.data.namespace }}
                             </XBadge>
-                          </template>
-                        </DefinitionCard>
-
-                        <DefinitionCard
-                          layout="horizontal"
-                        >
-                          <template
-                            #title
-                          >
+                          </dd>
+                        </div>
+                        <div>
+                          <dt>
                             {{ t('http.api.property.address') }}
-                          </template>
-
-                          <template
-                            #body
-                          >
+                          </dt>
+                          <dd>
                             <XCopyButton
                               variant="badge"
                               format="default"
                               :text="`${props.data.dataplane.networking.address}`"
                             />
-                          </template>
-                        </DefinitionCard>
-
-                        <template
+                          </dd>
+                        </div>
+                        <div
                           v-if="props.data.dataplane.networking.gateway"
                         >
-                          <DefinitionCard
-                            layout="horizontal"
-                          >
-                            <template
-                              #title
-                            >
-                              {{ t('http.api.property.tags') }}
-                            </template>
-
-                            <template
-                              #body
-                            >
-                              <TagList
-                                :tags="props.data.dataplane.networking.gateway.tags"
-                              />
-                            </template>
-                          </DefinitionCard>
-                        </template>
-                      </XLayout>
+                          <dt>
+                            {{ t('http.api.property.tags') }}
+                          </dt>
+                          <dd>
+                            <TagList
+                              :tags="props.data.dataplane.networking.gateway.tags"
+                            />
+                          </dd>
+                        </div>
+                      </XDl>
 
                       <XLayout
                         v-if="props.data.dataplaneInsight.mTLS"
@@ -268,98 +225,72 @@
                         <h3>{{ t('data-planes.routes.item.mtls.title') }}</h3>
                         <XLayout size="small">
                           <template
-                            v-for="mTLS in [
-                              props.data.dataplaneInsight.mTLS,
-                            ]"
-                            :key="mTLS"
+                            v-for="mTLS in [props.data.dataplaneInsight.mTLS]"
+                            :key="typeof mTLS"
                           >
-                            <XLayout type="separated">
-                              <template v-if="typeof mTLS.lastCertificateRegeneration !== 'undefined' && typeof mTLS.certificateExpirationTime !== 'undefined' && typeof mTLS.issuedBackend !== 'undefined'">
-                                <DefinitionCard layout="horizontal">
-                                  <template #title>
-                                    <XI18n
-                                      path="data-planes.routes.item.mtls.generation_time.title"
-                                    />
-                                  </template>
-
-                                  <template #body>
-                                    <XBadge appearance="neutral">
-                                      {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
-                                    </XBadge>
-                                  </template>
-                                </DefinitionCard>
-                                <DefinitionCard layout="horizontal">
-                                  <template #title>
-                                    <XI18n
-                                      path="data-planes.routes.item.mtls.expiration_time.title"
-                                    />
-                                  </template>
-
-                                  <template #body>
-                                    <XBadge appearance="neutral">
-                                      {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
-                                    </XBadge>
-                                  </template>
-                                </DefinitionCard>
-                              </template>
-                              <template v-else>
-                                <XI18n
-                                  path="data-planes.routes.item.mtls.managed_externally"
-                                />
-                              </template>
-                            </XLayout>
-                            <XLayout type="separated">
-                              <DefinitionCard
+                            <XDl
+                              v-if="typeof mTLS.lastCertificateRegeneration !== 'undefined' && typeof mTLS.certificateExpirationTime !== 'undefined' && typeof mTLS.issuedBackend !== 'undefined'"
+                              variant="x-stack"
+                            >
+                              <div>
+                                <dt>
+                                  {{ t('data-planes.routes.item.mtls.generation_time.title') }}
+                                </dt>
+                                <dd>
+                                  <XBadge appearance="neutral">
+                                    {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
+                                  </XBadge>
+                                </dd>
+                              </div>
+                              <div>
+                                <dt>
+                                  {{ t('data-planes.routes.item.mtls.expiration_time.title') }}
+                                </dt>
+                                <dd>
+                                  <XBadge appearance="neutral">
+                                    {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
+                                  </XBadge>
+                                </dd>
+                              </div>
+                            </XDl>
+                            <XI18n
+                              v-else
+                              path="data-planes.routes.item.mtls.managed_externally"
+                            />
+                            <XDl
+                              variant="x-stack"
+                            >
+                              <div
                                 v-if="typeof mTLS.certificateRegenerations !== 'undefined'"
-                                layout="horizontal"
                               >
-                                <template
-                                  #title
-                                >
+                                <dt>
                                   {{ t('data-planes.routes.item.mtls.regenerations.title') }}
-                                </template>
-
-                                <template
-                                  #body
-                                >
+                                </dt>
+                                <dd>
                                   <XBadge appearance="info">
                                     {{ t('common.formats.integer', { value: mTLS.certificateRegenerations }) }}
                                   </XBadge>
-                                </template>
-                              </DefinitionCard>
-
-                              <DefinitionCard
-                                v-if="mTLS.issuedBackend"
-                                layout="horizontal"
+                                </dd>
+                              </div>
+                              <div
+                                v-if="typeof mTLS.issuedBackend !== 'undefined'"
                               >
-                                <template
-                                  #title
-                                >
+                                <dt>
                                   {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
-                                </template>
-
-                                <template
-                                  #body
-                                >
+                                </dt>
+                                <dd>
                                   <XBadge appearance="decorative">
                                     {{ mTLS.issuedBackend }}
                                   </XBadge>
-                                </template>
-                              </DefinitionCard>
-
-                              <DefinitionCard
+                                </dd>
+                              </div>
+                              <div
                                 v-if="typeof mTLS.supportedBackends !== 'undefined'"
-                                layout="horizontal"
                               >
-                                <template
-                                  #title
-                                >
+                                <dt>
                                   {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
-                                </template>
-
-                                <template
-                                  #body
-                                >
+                                </dt>
+                                <dd>
                                   <XLayout
                                     type="separated"
                                     truncate
@@ -372,9 +303,9 @@
                                       {{ item }}
                                     </XBadge>
                                   </XLayout>
-                                </template>
-                              </DefinitionCard>
-                            </XLayout>
+                                </dd>
+                              </div>
+                            </XDl>
                           </template>
                         </XLayout>
                       </XLayout>
@@ -387,7 +318,6 @@
                         <XLayout type="separated">
                           <h3>{{ t('data-planes.routes.item.subscriptions.title') }}</h3>
                           <XAction
-                            data-action
                             appearance="anchor"
                             :to="{
                               name: 'data-plane-subscriptions-list-view',
@@ -404,61 +334,44 @@
                           </XAction>
                         </XLayout>
 
-                        <XLayout
-                          v-for="subscriptions in [[...props.data.dataplaneInsight.subscriptions].reverse()]"
-                          :key="typeof subscriptions"
-                          type="separated"
+                        <XDl
+                          v-if="props.data.dataplaneInsight.connectedSubscription"
+                          variant="x-stack"
                         >
-                          <template
-                            v-for="subscription in [subscriptions.find((sub) => !sub.disconnectTime) ?? subscriptions[0]]"
-                            :key="subscription.id"
-                          >
-                            <template v-if="!subscription.disconnectTime && subscription.connectTime">
-                              <DefinitionCard layout="horizontal">
-                                <template #title>
-                                  <XI18n
-                                    path="data-planes.routes.item.xds.connected"
-                                  />
-                                </template>
-
-                                <template #body>
-                                  <XBadge appearance="neutral">
-                                    {{ t('common.formats.datetime', { value: Date.parse(subscription.connectTime) }) }}
-                                  </XBadge>
-                                </template>
-                              </DefinitionCard>
-                              <DefinitionCard layout="horizontal">
-                                <template #title>
-                                  <XI18n
-                                    path="data-planes.routes.item.xds.instance"
-                                  />
-                                </template>
-
-                                <template #body>
-                                  <XBadge appearance="info">
-                                    {{ subscription.controlPlaneInstanceId }}
-                                  </XBadge>
-                                </template>
-                              </DefinitionCard>
-                              <DefinitionCard layout="horizontal">
-                                <template #title>
-                                  <XI18n
-                                    path="data-planes.routes.item.xds.version"
-                                  />
-                                </template>
-
-                                <template #body>
-                                  <XBadge appearance="info">
-                                    {{ subscription.version?.kumaDp?.version ?? t('common.unknown') }}
-                                  </XBadge>
-                                </template>
-                              </DefinitionCard>
-                            </template>
-                            <template v-else>
-                              <XI18n path="data-planes.routes.item.xds.disconnected" />
-                            </template>
-                          </template>
-                        </XLayout>
+                          <div>
+                            <dt>
+                              {{ t('data-planes.routes.item.xds.connected') }}
+                            </dt>
+                            <dd>
+                              <XBadge appearance="neutral">
+                                {{ t('common.formats.datetime', { value: Date.parse(props.data.dataplaneInsight.connectedSubscription.connectTime ?? '') }) }}
+                              </XBadge>
+                            </dd>
+                          </div>
+                          <div>
+                            <dt>
+                              {{ t('data-planes.routes.item.xds.instance') }}
+                            </dt>
+                            <dd>
+                              <XBadge>
+                                {{ props.data.dataplaneInsight.connectedSubscription.controlPlaneInstanceId }}
+                              </XBadge>
+                            </dd>
+                          </div>
+                          <div>
+                            <dt>
+                              {{ t('data-planes.routes.item.xds.version') }}
+                            </dt>
+                            <dd>
+                              <XBadge>
+                                {{ props.data.dataplaneInsight.connectedSubscription.version?.kumaDp?.version ?? t('common.unknown') }}
+                              </XBadge>
+                            </dd>
+                          </div>
+                        </XDl>
+                        <template v-else>
+                          <XI18n path="data-planes.routes.item.xds.disconnected" />
+                        </template>
                       </XLayout>
 
                       <XLayout
@@ -476,8 +389,6 @@
                             :key="policy.kind"
                           >
                             <XAction
-                              data-action
-                              appearance="anchor"
                               :to="{
                                 name: 'data-plane-policy-config-summary-view',
                                 params: {
@@ -739,7 +650,6 @@ import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 import { provide } from 'vue'
 
 import { sources } from '../sources'
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TagList from '@/app/common/TagList.vue'
 import ConnectionCard from '@/app/connections/components/connection-traffic/ConnectionCard.vue'

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -342,6 +342,7 @@
             </XLayout>
 
             <DataSource
+              v-if="can('use unified-resource-naming', { mesh: props.mesh, dataplaneOverview: props.data })"
               :src="uri(policySources, '/meshes/:mesh/dataplanes/:name/policies/for/proxy', {
                 mesh: route.params.mesh,
                 name: route.params.proxy,
@@ -400,6 +401,18 @@
             })"
             v-slot="{ data: traffic, error: trafficError, refresh: refreshTraffic }"
           >
+            <XNotification
+              :notify="!!trafficError"
+              :data-testid="`warning-stats-not-enhanced`"
+              :uri="`data-planes.notifications.stats-not-enhanced.${props.data.id}`"
+            >
+              <XI18n
+                :path="`data-planes.notifications.stats-not-enhanced`"
+                :params="{
+                  error: trafficError?.toString() ?? '',
+                }"
+              />
+            </XNotification>
             <XCard
               class="traffic"
               data-testid="dataplane-traffic"

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
@@ -8,59 +8,63 @@
     }"
     v-slot="{ route, t }"
   >
-    <DataCollection
-      :items="props.data"
-      :predicate="(item) => `${item.proxyResourceName}` === route.params.connection"
-      :find="true"
-      v-slot="{ items }"
+    <DataLoader
+      :data="[props.data]"
     >
-      <AppView>
-        <template #title>
-          <XLayout size="small">
-            <h2>
-              {{ props.routeName.includes('inbound') ? 'Inbound' : 'Outbound' }}: {{ route.params.connection }}
-            </h2>
-            <template v-if="'state' in items[0]">
-              <XBadge
-                :appearance="t(`common.status.appearance.${items[0].state}`, undefined, { defaultMessage: 'neutral' })"
-              >
-                {{ t(`http.api.value.${items[0].state}`) }}
-              </XBadge>
-            </template>
-          </XLayout>
-        </template>
-
-        <XTabs
-          :selected="route.child()?.name"
-        >
-          <template
-            v-for="{ name } in route.children"
-            :key="name"
-            #[`${name}-tab`]
-          >
-            <XAction
-              :to="{
-                name,
-                query: {
-                  inactive: route.params.inactive,
-                },
-              }"
-            >
-              {{ t(`connections.routes.item.navigation.${name.split('-')[5]}`) }}
-            </XAction>
+      <DataCollection
+        :items="props.data!"
+        :predicate="(item) => `${item.proxyResourceName}` === route.params.connection"
+        :find="true"
+        v-slot="{ items }"
+      >
+        <AppView>
+          <template #title>
+            <XLayout size="small">
+              <h2>
+                {{ props.routeName.includes('inbound') ? 'Inbound' : 'Outbound' }}: {{ route.params.connection }}
+              </h2>
+              <template v-if="'state' in items[0]">
+                <XBadge
+                  :appearance="t(`common.status.appearance.${items[0].state}`, undefined, { defaultMessage: 'neutral' })"
+                >
+                  {{ t(`http.api.value.${items[0].state}`) }}
+                </XBadge>
+              </template>
+            </XLayout>
           </template>
-        </XTabs>
 
-        <RouterView v-slot="child">
-          <component
-            :is="child.Component"
-            :data="items[0]"
-            :networking="props.networking"
-            :data-plane-overview="props.dataPlaneOverview"
-          />
-        </RouterView>
-      </AppView>
-    </DataCollection>
+          <XTabs
+            :selected="route.child()?.name"
+          >
+            <template
+              v-for="{ name } in route.children"
+              :key="name"
+              #[`${name}-tab`]
+            >
+              <XAction
+                :to="{
+                  name,
+                  query: {
+                    inactive: route.params.inactive,
+                  },
+                }"
+              >
+                {{ t(`connections.routes.item.navigation.${name.split('-')[5]}`) }}
+              </XAction>
+            </template>
+          </XTabs>
+
+          <RouterView v-slot="child">
+            <component
+              :is="child.Component"
+              :data="items[0]"
+              :networking="props.networking"
+              :data-plane-overview="props.dataPlaneOverview"
+            />
+          </RouterView>
+        </AppView>
+      </DataCollection>
+    </DataLoader>
   </RouteView>
 </template>
 
@@ -69,7 +73,7 @@ import { DataplaneNetworkingLayout } from '../data'
 import type { DataplaneNetworking, DataplaneOverview } from '@/app/data-planes/data/'
 
 const props = defineProps<{
-  data: DataplaneNetworkingLayout['inbounds'] | DataplaneNetworkingLayout['outbounds']
+  data?: DataplaneNetworkingLayout['inbounds'] | DataplaneNetworkingLayout['outbounds']
   networking: DataplaneNetworking
   routeName: string
   dataPlaneOverview: DataplaneOverview

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneTrafficSummaryView.vue
@@ -68,12 +68,11 @@
   </RouteView>
 </template>
 
-<script lang="ts" setup>
-import { DataplaneNetworkingLayout } from '../data'
+<script lang="ts" generic="T extends { proxyResourceName: string }" setup>
 import type { DataplaneNetworking, DataplaneOverview } from '@/app/data-planes/data/'
 
 const props = defineProps<{
-  data?: DataplaneNetworkingLayout['inbounds'] | DataplaneNetworkingLayout['outbounds']
+  data?: T[]
   networking: DataplaneNetworking
   routeName: string
   dataPlaneOverview: DataplaneOverview

--- a/packages/kuma-gui/src/app/data-planes/views/DataplanePolicyConfigSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataplanePolicyConfigSummaryView.vue
@@ -7,94 +7,99 @@
       connection: '',
       policy: '',
     }"
-    v-slot="{ route }"
+    v-slot="{ route, uri }"
   >
-    <DataCollection
-      :items="props.policies"
-      :predicate="item => item.kind.toLocaleLowerCase() === route.params.policy"
-      v-slot="{ items }"
+    <DataLoader
+      :src="uri(policySources, '/policy-types', {})"
+      v-slot="{ data: policyTypesData }"
     >
-      <template
-        v-for="{ kind, conf, origins } of items"
-        :key="kind"
+      <DataCollection
+        :items="props.policies"
+        :predicate="item => item.kind.toLocaleLowerCase() === route.params.policy"
+        v-slot="{ items }"
       >
-        <AppView>
-          <template #title>
-            <XLayout size="small">
-              <h2>
-                <PolicyTypeTag
-                  :policy-type="kind"
-                >
-                  {{ kind }}
-                </PolicyTypeTag>
-              </h2>
-            </XLayout>
-          </template>
-          <template
-            v-for="policyTypes in [Object.groupBy((policyTypesData?.policyTypes ?? []), ({ name }) => name)]"
-            :key="`${typeof policyTypes}`"
-          >
-            <XTable
-              v-if="origins.length > 0"
-              variant="kv"
-            >
-              <tr>
-                <th scope="row">
-                  Origin policies
-                </th>
-                <td>
-                  <ul>
-                    <li
-                      v-for="origin in origins"
-                      :key="origin.kri"
-                    >
-                      <template
-                        v-for="kri in [Kri.fromString(origin.kri)]"
-                        :key="typeof kri"
-                      >
-                        <XAction
-                          v-if="policyTypes[kind]"
-                          :to="{
-                            name: 'policy-detail-view',
-                            params: {
-                              mesh: kri.mesh,
-                              policyPath: policyTypes[kind]![0].path,
-                              policy: kri.name,
-                            },
-                          }"
-                        >
-                          {{ origin.kri }}
-                        </XAction>
-                        <template
-                          v-else
-                        >
-                          {{ origin.kri }}
-                        </template>
-                      </template>
-                    </li>
-                  </ul>
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2">
-                  <XLayout
-                    type="stack"
-                    size="small"
+        <template
+          v-for="{ kind, conf, origins } of items"
+          :key="kind"
+        >
+          <AppView>
+            <template #title>
+              <XLayout size="small">
+                <h2>
+                  <PolicyTypeTag
+                    :policy-type="kind"
                   >
-                    <span>Config</span>
-                    <XCodeBlock
-                      :code="YAML.stringify(conf)"
-                      language="yaml"
-                      :show-copy-button="false"
-                    />
-                  </XLayout>
-                </td>
-              </tr>
-            </XTable>
-          </template>
-        </AppView>
-      </template>
-    </DataCollection>
+                    {{ kind }}
+                  </PolicyTypeTag>
+                </h2>
+              </XLayout>
+            </template>
+            <template
+              v-for="policyTypes in [Object.groupBy((policyTypesData?.policyTypes ?? []), ({ name }) => name)]"
+              :key="`${typeof policyTypes}`"
+            >
+              <XTable
+                v-if="origins.length > 0"
+                variant="kv"
+              >
+                <tr>
+                  <th scope="row">
+                    Origin policies
+                  </th>
+                  <td>
+                    <ul>
+                      <li
+                        v-for="origin in origins"
+                        :key="origin.kri"
+                      >
+                        <template
+                          v-for="kri in [Kri.fromString(origin.kri)]"
+                          :key="typeof kri"
+                        >
+                          <XAction
+                            v-if="policyTypes[kind]"
+                            :to="{
+                              name: 'policy-detail-view',
+                              params: {
+                                mesh: kri.mesh,
+                                policyPath: policyTypes[kind]![0].path,
+                                policy: kri.name,
+                              },
+                            }"
+                          >
+                            {{ origin.kri }}
+                          </XAction>
+                          <template
+                            v-else
+                          >
+                            {{ origin.kri }}
+                          </template>
+                        </template>
+                      </li>
+                    </ul>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2">
+                    <XLayout
+                      type="stack"
+                      size="small"
+                    >
+                      <span>Config</span>
+                      <XCodeBlock
+                        :code="YAML.stringify(conf)"
+                        language="yaml"
+                        :show-copy-button="false"
+                      />
+                    </XLayout>
+                  </td>
+                </tr>
+              </XTable>
+            </template>
+          </AppView>
+        </template>
+      </DataCollection>
+    </DataLoader>
   </RouteView>
 </template>
 
@@ -102,12 +107,11 @@
 import { YAML } from '@/app/application'
 import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 import { Kri } from '@/app/kuma'
-import type { ResourceCollection } from '@/app/policies/data'
 import type { DataplanePolicies } from '@/app/policies/data/DataplanePolicies'
+import { sources as policySources } from '@/app/policies/sources'
 
 const props = defineProps<{
   policies: DataplanePolicies['policies']
-  policyTypesData: ResourceCollection
 }>()
 </script>
 <style scoped>

--- a/packages/kuma-gui/src/app/data-planes/views/DataplanePolicyConfigSummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataplanePolicyConfigSummaryView.vue
@@ -9,97 +9,101 @@
     }"
     v-slot="{ route, uri }"
   >
-    <DataLoader
+    <DataSource
       :src="uri(policySources, '/policy-types', {})"
       v-slot="{ data: policyTypesData }"
     >
-      <DataCollection
-        :items="props.policies"
-        :predicate="item => item.kind.toLocaleLowerCase() === route.params.policy"
-        v-slot="{ items }"
+      <DataLoader
+        :data="[props.policies, policyTypesData]"
       >
-        <template
-          v-for="{ kind, conf, origins } of items"
-          :key="kind"
+        <DataCollection
+          :items="props.policies!"
+          :predicate="item => item.kind.toLocaleLowerCase() === route.params.policy"
+          v-slot="{ items }"
         >
-          <AppView>
-            <template #title>
-              <XLayout size="small">
-                <h2>
-                  <PolicyTypeTag
-                    :policy-type="kind"
-                  >
-                    {{ kind }}
-                  </PolicyTypeTag>
-                </h2>
-              </XLayout>
-            </template>
-            <template
-              v-for="policyTypes in [Object.groupBy((policyTypesData?.policyTypes ?? []), ({ name }) => name)]"
-              :key="`${typeof policyTypes}`"
-            >
-              <XTable
-                v-if="origins.length > 0"
-                variant="kv"
-              >
-                <tr>
-                  <th scope="row">
-                    Origin policies
-                  </th>
-                  <td>
-                    <ul>
-                      <li
-                        v-for="origin in origins"
-                        :key="origin.kri"
-                      >
-                        <template
-                          v-for="kri in [Kri.fromString(origin.kri)]"
-                          :key="typeof kri"
-                        >
-                          <XAction
-                            v-if="policyTypes[kind]"
-                            :to="{
-                              name: 'policy-detail-view',
-                              params: {
-                                mesh: kri.mesh,
-                                policyPath: policyTypes[kind]![0].path,
-                                policy: kri.name,
-                              },
-                            }"
-                          >
-                            {{ origin.kri }}
-                          </XAction>
-                          <template
-                            v-else
-                          >
-                            {{ origin.kri }}
-                          </template>
-                        </template>
-                      </li>
-                    </ul>
-                  </td>
-                </tr>
-                <tr>
-                  <td colspan="2">
-                    <XLayout
-                      type="stack"
-                      size="small"
+          <template
+            v-for="{ kind, conf, origins } of items"
+            :key="kind"
+          >
+            <AppView>
+              <template #title>
+                <XLayout size="small">
+                  <h2>
+                    <PolicyTypeTag
+                      :policy-type="kind"
                     >
-                      <span>Config</span>
-                      <XCodeBlock
-                        :code="YAML.stringify(conf)"
-                        language="yaml"
-                        :show-copy-button="false"
-                      />
-                    </XLayout>
-                  </td>
-                </tr>
-              </XTable>
-            </template>
-          </AppView>
-        </template>
-      </DataCollection>
-    </DataLoader>
+                      {{ kind }}
+                    </PolicyTypeTag>
+                  </h2>
+                </XLayout>
+              </template>
+              <template
+                v-for="policyTypes in [Object.groupBy((policyTypesData?.policyTypes ?? []), ({ name }) => name)]"
+                :key="`${typeof policyTypes}`"
+              >
+                <XTable
+                  v-if="origins.length > 0"
+                  variant="kv"
+                >
+                  <tr>
+                    <th scope="row">
+                      Origin policies
+                    </th>
+                    <td>
+                      <ul>
+                        <li
+                          v-for="origin in origins"
+                          :key="origin.kri"
+                        >
+                          <template
+                            v-for="kri in [Kri.fromString(origin.kri)]"
+                            :key="typeof kri"
+                          >
+                            <XAction
+                              v-if="policyTypes[kind]"
+                              :to="{
+                                name: 'policy-detail-view',
+                                params: {
+                                  mesh: kri.mesh,
+                                  policyPath: policyTypes[kind]![0].path,
+                                  policy: kri.name,
+                                },
+                              }"
+                            >
+                              {{ origin.kri }}
+                            </XAction>
+                            <template
+                              v-else
+                            >
+                              {{ origin.kri }}
+                            </template>
+                          </template>
+                        </li>
+                      </ul>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td colspan="2">
+                      <XLayout
+                        type="stack"
+                        size="small"
+                      >
+                        <span>Config</span>
+                        <XCodeBlock
+                          :code="YAML.stringify(conf)"
+                          language="yaml"
+                          :show-copy-button="false"
+                        />
+                      </XLayout>
+                    </td>
+                  </tr>
+                </XTable>
+              </template>
+            </AppView>
+          </template>
+        </DataCollection>
+      </DataLoader>
+    </DataSource>
   </RouteView>
 </template>
 
@@ -111,7 +115,7 @@ import type { DataplanePolicies } from '@/app/policies/data/DataplanePolicies'
 import { sources as policySources } from '@/app/policies/sources'
 
 const props = defineProps<{
-  policies: DataplanePolicies['policies']
+  policies?: DataplanePolicies['policies']
 }>()
 </script>
 <style scoped>

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -22,6 +22,18 @@
       <AppView
         :notifications="true"
       >
+        <XNotification
+          :notify="!!error"
+          :data-testid="`warning-stats-not-enhanced`"
+          :uri="`data-planes.notifications.stats-not-enhanced.${props.data.id}`"
+        >
+          <XI18n
+            :path="`data-planes.notifications.stats-not-enhanced`"
+            :params="{
+              error: error?.toString() ?? '',
+            }"
+          />
+        </XNotification>
         <template
           v-for="{ bool, key, params, variant } in [
             {
@@ -59,13 +71,6 @@
               key: 'no-mtls',
             },
             {
-              bool: !!error,
-              key: 'stats-not-enhanced',
-              params: {
-                error: error?.toString() ?? '',
-              },
-            },
-            {
               bool: !can('use transparent-proxying', props.data),
               key: 'networking-transparent-proxying',
               variant: 'info' as const,
@@ -97,27 +102,19 @@
             class="about-section"
           >
             <XLayout>
-              <XLayout
-                type="separated"
+              <XDl
+                variant="x-stack"
               >
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template
-                    #title
-                  >
+                <div>
+                  <dt>
                     {{ t('http.api.property.status') }}
-                  </template>
-
-                  <template
-                    #body
-                  >
+                  </dt>
+                  <dd>
                     <XLayout
                       type="separated"
                     >
                       <StatusBadge :status="props.data.status" />
                       <DataCollection
-                        v-if="props.data.dataplaneType === 'standard'"
                         :items="props.data.dataplane.networking.inbounds"
                         :predicate="item => item.state !== 'Ready'"
                         :empty="false"
@@ -135,21 +132,15 @@
                         </XIcon>
                       </DataCollection>
                     </XLayout>
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
+                  </dd>
+                </div>
+                <div
                   v-if="can('use zones') && props.data.zone"
-                  layout="horizontal"
                 >
-                  <template
-                    #title
-                  >
+                  <dt>
                     {{ t('http.api.property.zone') }}
-                  </template>
-                  <template
-                    #body
-                  >
+                  </dt>
+                  <dd>
                     <XBadge appearance="decorative">
                       <XAction
                         :to="{
@@ -162,87 +153,57 @@
                         {{ props.data.zone }}
                       </XAction>
                     </XBadge>
-                  </template>
-                </DefinitionCard>
-                <DefinitionCard layout="horizontal">
-                  <template
-                    #title
-                  >
+                  </dd>
+                </div>
+                <div>
+                  <dt>
                     {{ t('http.api.property.type') }}
-                  </template>
-
-                  <template
-                    #body
-                  >
+                  </dt>
+                  <dd>
                     <XBadge appearance="decorative">
                       {{ t(`data-planes.type.${props.data.dataplaneType}`) }}
                     </XBadge>
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
+                  </dd>
+                </div>
+                <div
                   v-if="props.data.namespace.length > 0"
-                  layout="horizontal"
                 >
-                  <template
-                    #title
-                  >
+                  <dt>
                     {{ t('http.api.property.namespace') }}
-                  </template>
-
-                  <template
-                    #body
-                  >
+                  </dt>
+                  <dd>
                     <XBadge
                       appearance="decorative"
                     >
                       {{ props.data.namespace }}
                     </XBadge>
-                  </template>
-                </DefinitionCard>
-
-                <DefinitionCard
-                  layout="horizontal"
-                >
-                  <template
-                    #title
-                  >
+                  </dd>
+                </div>
+                <div>
+                  <dt>
                     {{ t('http.api.property.address') }}
-                  </template>
-
-                  <template
-                    #body
-                  >
+                  </dt>
+                  <dd>
                     <XCopyButton
                       variant="badge"
                       format="default"
                       :text="`${props.data.dataplane.networking.address}`"
                     />
-                  </template>
-                </DefinitionCard>
-
-                <template
+                  </dd>
+                </div>
+                <div
                   v-if="props.data.dataplane.networking.gateway"
                 >
-                  <DefinitionCard
-                    layout="horizontal"
-                  >
-                    <template
-                      #title
-                    >
-                      {{ t('http.api.property.tags') }}
-                    </template>
-
-                    <template
-                      #body
-                    >
-                      <TagList
-                        :tags="props.data.dataplane.networking.gateway.tags"
-                      />
-                    </template>
-                  </DefinitionCard>
-                </template>
-              </XLayout>
+                  <dt>
+                    {{ t('http.api.property.tags') }}
+                  </dt>
+                  <dd>
+                    <TagList
+                      :tags="props.data.dataplane.networking.gateway.tags"
+                    />
+                  </dd>
+                </div>
+              </XDl>
 
               <XLayout
                 v-if="props.data.dataplaneInsight.mTLS"
@@ -253,114 +214,72 @@
                 <h3>{{ t('data-planes.routes.item.mtls.title') }}</h3>
                 <XLayout size="small">
                   <template
-                    v-for="mTLS in [
-                      props.data.dataplaneInsight.mTLS,
-                    ]"
-                    :key="mTLS"
+                    v-for="mTLS in [props.data.dataplaneInsight.mTLS]"
+                    :key="typeof mTLS"
                   >
-                    <XLayout type="separated">
-                      <template v-if="typeof mTLS.lastCertificateRegeneration !== 'undefined' && typeof mTLS.certificateExpirationTime !== 'undefined' && typeof mTLS.issuedBackend !== 'undefined'">
-                        <DefinitionCard layout="horizontal">
-                          <template #title>
-                            <XI18n
-                              path="data-planes.routes.item.mtls.generation_time.title"
-                            />
-                          </template>
-
-                          <template #body>
-                            <XBadge appearance="neutral">
-                              {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
-                            </XBadge>
-                          </template>
-                        </DefinitionCard>
-                        <DefinitionCard layout="horizontal">
-                          <template #title>
-                            <XI18n
-                              path="data-planes.routes.item.mtls.expiration_time.title"
-                            />
-                          </template>
-
-                          <template #body>
-                            <XBadge appearance="neutral">
-                              {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
-                            </XBadge>
-                          </template>
-                        </DefinitionCard>
-                      </template>
-                      <template v-else>
-                        <XI18n
-                          path="data-planes.routes.item.mtls.managed_externally"
-                        />
-                      </template>
-                    </XLayout>
-                    <XLayout type="separated">
-                      <DefinitionCard
+                    <XDl
+                      v-if="typeof mTLS.lastCertificateRegeneration !== 'undefined' && typeof mTLS.certificateExpirationTime !== 'undefined' && typeof mTLS.issuedBackend !== 'undefined'"
+                      variant="x-stack"
+                    >
+                      <div>
+                        <dt>
+                          {{ t('data-planes.routes.item.mtls.generation_time.title') }}
+                        </dt>
+                        <dd>
+                          <XBadge appearance="neutral">
+                            {{ t('common.formats.datetime', { value: Date.parse(mTLS.lastCertificateRegeneration) }) }}
+                          </XBadge>
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>
+                          {{ t('data-planes.routes.item.mtls.expiration_time.title') }}
+                        </dt>
+                        <dd>
+                          <XBadge appearance="neutral">
+                            {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
+                          </XBadge>
+                        </dd>
+                      </div>
+                    </XDl>
+                    <XI18n
+                      v-else
+                      path="data-planes.routes.item.mtls.managed_externally"
+                    />
+                    <XDl
+                      variant="x-stack"
+                    >
+                      <div
                         v-if="typeof mTLS.certificateRegenerations !== 'undefined'"
-                        layout="horizontal"
                       >
-                        <template
-                          #title
-                        >
+                        <dt>
                           {{ t('data-planes.routes.item.mtls.regenerations.title') }}
-                        </template>
-
-                        <template
-                          #body
-                        >
+                        </dt>
+                        <dd>
                           <XBadge appearance="info">
                             {{ t('common.formats.integer', { value: mTLS.certificateRegenerations }) }}
                           </XBadge>
-                        </template>
-                      </DefinitionCard>
-
-                      <DefinitionCard
-                        v-if="mTLS.issuedBackend"
-                        layout="horizontal"
+                        </dd>
+                      </div>
+                      <div
+                        v-if="typeof mTLS.issuedBackend !== 'undefined'"
                       >
-                        <template
-                          #title
-                        >
+                        <dt>
                           {{ t('data-planes.routes.item.mtls.issued_backend.title') }}
-                        </template>
-
-                        <template
-                          #body
-                        >
-                          <template v-if="Kri.isKriString(mTLS.issuedBackend)">
-                            <XAction
-                              :to="{
-                                name: 'data-plane-mesh-identity-summary-view',
-                                params: {
-                                  mid: mTLS.issuedBackend,
-                                },
-                              }"
-                            >
-                              <XBadge appearance="decorative">
-                                {{ mTLS.issuedBackend }}
-                              </XBadge>
-                            </XAction>
-                          </template>
-                          <template v-else>
-                            <XBadge appearance="decorative">
-                              {{ mTLS.issuedBackend }}
-                            </XBadge>
-                          </template>
-                        </template>
-                      </DefinitionCard>
-
-                      <DefinitionCard
+                        </dt>
+                        <dd>
+                          <XBadge appearance="decorative">
+                            {{ mTLS.issuedBackend }}
+                          </XBadge>
+                        </dd>
+                      </div>
+                      <div
                         v-if="typeof mTLS.supportedBackends !== 'undefined'"
-                        layout="horizontal"
                       >
-                        <template
-                          #title
-                        >
+                        <dt>
                           {{ t('data-planes.routes.item.mtls.supported_backends.title') }}
-                        </template>
-
-                        <template
-                          #body
-                        >
+                        </dt>
+                        <dd>
                           <XLayout
                             type="separated"
                             truncate
@@ -373,9 +292,9 @@
                               {{ item }}
                             </XBadge>
                           </XLayout>
-                        </template>
-                      </DefinitionCard>
-                    </XLayout>
+                        </dd>
+                      </div>
+                    </XDl>
                   </template>
                 </XLayout>
               </XLayout>
@@ -388,7 +307,6 @@
                 <XLayout type="separated">
                   <h3>{{ t('data-planes.routes.item.subscriptions.title') }}</h3>
                   <XAction
-                    data-action
                     appearance="anchor"
                     :to="{
                       name: 'data-plane-subscriptions-list-view',
@@ -405,61 +323,44 @@
                   </XAction>
                 </XLayout>
 
-                <XLayout
-                  v-for="subscriptions in [[...props.data.dataplaneInsight.subscriptions].reverse()]"
-                  :key="typeof subscriptions"
-                  type="separated"
+                <XDl
+                  v-if="props.data.dataplaneInsight.connectedSubscription"
+                  variant="x-stack"
                 >
-                  <template
-                    v-for="subscription in [subscriptions.find((sub) => !sub.disconnectTime) ?? subscriptions[0]]"
-                    :key="subscription.id"
-                  >
-                    <template v-if="!subscription.disconnectTime && subscription.connectTime">
-                      <DefinitionCard layout="horizontal">
-                        <template #title>
-                          <XI18n
-                            path="data-planes.routes.item.xds.connected"
-                          />
-                        </template>
-
-                        <template #body>
-                          <XBadge appearance="neutral">
-                            {{ t('common.formats.datetime', { value: Date.parse(subscription.connectTime) }) }}
-                          </XBadge>
-                        </template>
-                      </DefinitionCard>
-                      <DefinitionCard layout="horizontal">
-                        <template #title>
-                          <XI18n
-                            path="data-planes.routes.item.xds.instance"
-                          />
-                        </template>
-
-                        <template #body>
-                          <XBadge appearance="info">
-                            {{ subscription.controlPlaneInstanceId }}
-                          </XBadge>
-                        </template>
-                      </DefinitionCard>
-                      <DefinitionCard layout="horizontal">
-                        <template #title>
-                          <XI18n
-                            path="data-planes.routes.item.xds.version"
-                          />
-                        </template>
-
-                        <template #body>
-                          <XBadge appearance="info">
-                            {{ subscription.version?.kumaDp?.version ?? t('common.unknown') }}
-                          </XBadge>
-                        </template>
-                      </DefinitionCard>
-                    </template>
-                    <template v-else>
-                      <XI18n path="data-planes.routes.item.xds.disconnected" />
-                    </template>
-                  </template>
-                </XLayout>
+                  <div>
+                    <dt>
+                      {{ t('data-planes.routes.item.xds.connected') }}
+                    </dt>
+                    <dd>
+                      <XBadge appearance="neutral">
+                        {{ t('common.formats.datetime', { value: Date.parse(props.data.dataplaneInsight.connectedSubscription.connectTime ?? '') }) }}
+                      </XBadge>
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>
+                      {{ t('data-planes.routes.item.xds.instance') }}
+                    </dt>
+                    <dd>
+                      <XBadge>
+                        {{ props.data.dataplaneInsight.connectedSubscription.controlPlaneInstanceId }}
+                      </XBadge>
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>
+                      {{ t('data-planes.routes.item.xds.version') }}
+                    </dt>
+                    <dd>
+                      <XBadge>
+                        {{ props.data.dataplaneInsight.connectedSubscription.version?.kumaDp?.version ?? t('common.unknown') }}
+                      </XBadge>
+                    </dd>
+                  </div>
+                </XDl>
+                <template v-else>
+                  <XI18n path="data-planes.routes.item.xds.disconnected" />
+                </template>
               </XLayout>
             </XLayout>
           </XAboutCard>
@@ -766,7 +667,6 @@
 <script lang="ts" setup>
 import { KUI_ICON_SIZE_40 } from '@kong/design-tokens'
 
-import DefinitionCard from '@/app/common/DefinitionCard.vue'
 import StatusBadge from '@/app/common/StatusBadge.vue'
 import TagList from '@/app/common/TagList.vue'
 import ConnectionCard from '@/app/connections/components/connection-traffic/ConnectionCard.vue'
@@ -774,7 +674,6 @@ import ConnectionGroup from '@/app/connections/components/connection-traffic/Con
 import ConnectionTraffic from '@/app/connections/components/connection-traffic/ConnectionTraffic.vue'
 import { sources } from '@/app/connections/sources'
 import type { DataplaneOverview, DataplaneInbound } from '@/app/data-planes/data'
-import { Kri } from '@/app/kuma/kri'
 import type { Mesh } from '@/app/meshes/data'
 import { useRoute } from '@/app/vue'
 

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_layout.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_layout.ts
@@ -22,17 +22,20 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
     protocol: fake.kuma.protocol(),
   }))
   const outboundCount = parseInt(env('KUMA_SERVICE_COUNT', `${fake.number.int({ min: 1, max: 10 })}`))
-  const outbounds = Array.from({ length: outboundCount }).map(() => ({
-    port: fake.number.int({ min: 1, max: 65535 }),
-    protocol: fake.kuma.protocol(),
-    kri: fake.kuma.kri({
-      shortName: fake.helpers.arrayElement(['msvc', 'mzsvc', 'extsvc']),
-      mesh,
-      namespace: nspace,
-      name: displayName,
-      sectionName: fake.number.int({ min: 1, max: 65535 }).toString(),
-    }),
-  }))
+  const outbounds = Array.from({ length: outboundCount }).map(() => {
+    const port = fake.number.int({ min: 1, max: 65535 })
+    return {
+      port,
+      protocol: fake.kuma.protocol(),
+      kri: fake.kuma.kri({
+        shortName: fake.helpers.arrayElement(['msvc', 'mzsvc', 'extsvc']),
+        mesh,
+        namespace: nspace,
+        name: displayName,
+        sectionName: fake.helpers.arrayElement([String(port), undefined]),
+      }),
+    }
+  })
 
   return {
     headers: {},
@@ -56,7 +59,7 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
           : {}),
       },
       inbounds: inbounds.map(({ port, protocol }, i) => {
-        const sectionName = fake.helpers.arrayElement(['default', 'httpport', port.toString(), 'ipv4', 'ipv6' ])
+        const sectionName = fake.helpers.arrayElement(['default', 'httpport', port.toString(), 'ipv4', 'ipv6'])
         return {
           kri: fake.kuma.kri({
             shortName: 'dp',

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_overview.ts
@@ -117,7 +117,7 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
         }
         : {}),
       dataplaneInsight: {
-        ...(isMtlsEnabled ? { 
+        ...(isMtlsEnabled ? {
           mTLS: isTlsIssuedMeshIdentity ? {
             issuedBackend: fake.kuma.kri({ shortName: 'mid', mesh: mesh as string, sectionName: '' }),
           } : fake.kuma.dataplaneMtls(),


### PR DESCRIPTION
https://github.com/kumahq/kuma-gui/pull/4228 added a new XDl component, one of the reasons for having this was to have a simpler/more-grokkable way to author `dl` type lists.

One area of code where I thought it might prove helpful was our new DataPlaneDetailView.vue, so I figured I'd do an initial rollout here to get a feel for it. Once I'd done this I kinda went a bit further after realizing a few things, and because of this I've split this PR up into commits so its easier to see the other refactors/reorgs.

All in all we've discussed this page a little in regards to it being a little more grokkable and I wanted to see if it could be improved without resorting to splitting things up into a number of smaller single-use somponents.

Rough list of changes:

- Move DefinitionCard usage to XDl 61a6f6412886027bcaa185facb53440b74277faa
- Moved some data loading our of this view and into the drawer where its used ee092b489fc299a20768c0782656ed19e568d93c
- Reorg/refactor the data interactions in this page using our composable DataSource/DataLoader to move the data and loaders closer to where its needed bf330813198b75257988f8638e58b3cdedf8b2d7 77cef1f95dd397055010693fab3ca9879a83a383

Its easier to do these sorts of reorgs when you aren't trying to build a new feature i.e. hindsight is everything, plus I might have totally missed something that I'm not aware of here. If necessary we can pull it back to just the DefinitionCard > XDl migration. Although I really do think all of this combined is a big improvement, and in doing this there are some other things I spotted we could do.

---

## Questions

1. Are Gateway detail pages even supported in KRI mode? i.e. do we just use the old view?
