### PR TITLE
chore(config): remove types from exports when default

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,8 +7,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "default": "./src/index.ts",
-      "types": "./src/index.ts"
+      "default": "./src/index.ts"
     },
     "./cypress/e2e": {
       "import": "./src/cypress/e2e.ts"


### PR DESCRIPTION
Addresses

```sh
Warning: G] The condition "types" here will never be used as it comes after "default" [package.json]

    ../config/package.json:11:6:
      11 │       "types": "./src/index.ts"
         ╵       ~~~~~~~

  The "default" condition comes earlier and will always be chosen:

    ../config/package.json:10:6:
      10 │       "default": "./src/index.ts",
         ╵       ~~~~~~~~~
```