### PR TITLE
chore(renovate): update preset alias

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended",
     ":semanticCommits",
-    "Kong/public-shared-renovate:github-actions"
+    "Kong/public-shared-renovate//base/github-actions"
   ],
   "dependencyDashboard": true,
   "rangeStrategy": "bump",


### PR DESCRIPTION
We need to update our renovate config to extend directly from `path/filename.ext` for the `Kong/public-shared-actions` preset. It currently aliases to `Kong/public-shared-renovate//base/github-actions`, but this alias will be removed in January 2026. Also refer to https://docs.renovatebot.com/config-presets/#github

> 
>name | example use | preset | resolves as | filename | Git tag
>| -- | -- | -- | -- | -- | -- |
>GitHub with preset name and path | github>abc/foo//path/xyz | xyz | https://github.com/abc/foo | path/xyz.json | Default branch

We extend from [`Kong/public-shared-renovate/base/github-actions.json`](https://github.com/Kong/public-shared-renovate/blob/main/base/github-actions.json)
