### PR TITLE
chore: adds PolicyActionGroup

### DIFF
--- a/packages/kuma-gui/src/app/policies/components/PolicyActionGroup.vue
+++ b/packages/kuma-gui/src/app/policies/components/PolicyActionGroup.vue
@@ -1,0 +1,28 @@
+<template>
+  <XActionGroup
+    v-bind="attrs"
+  >
+    <template
+      v-for="(_, slotName) in slots"
+      :key="slotName"
+      #[slotName]="slotProps"
+    >
+      <slot
+        :name="slotName"
+        v-bind="(slotProps)"
+      />
+    </template>
+  </XActionGroup>
+</template>
+<script lang="ts" generic="T extends { name: string } | undefined" setup>
+import { useAttrs } from 'vue'
+const slots = defineSlots()
+const attrs = useAttrs()
+const _props = withDefaults(defineProps<{
+  item?: T
+  type?: unknown
+}>(), {
+  item: undefined,
+  type: undefined,
+})
+</script>

--- a/packages/kuma-gui/src/app/policies/index.ts
+++ b/packages/kuma-gui/src/app/policies/index.ts
@@ -1,5 +1,6 @@
-import { token } from '@kumahq/container'
+import { token, createInjections } from '@kumahq/container'
 
+import PolicyActionGroup from './components/PolicyActionGroup.vue'
 import locales from './locales/en-us/index.yaml'
 import { routes } from './routes'
 import { sources } from './sources'
@@ -7,8 +8,14 @@ import type { ServiceDefinition } from '@kumahq/container'
 
 type Token = ReturnType<typeof token>
 
+const $ = {
+  PolicyActionGroup: token<typeof PolicyActionGroup>('policies.components.PolicyActionGroup'),
+}
 export const services = (app: Record<string, Token>): ServiceDefinition[] => {
   return [
+    [$.PolicyActionGroup, {
+      service: () => PolicyActionGroup,
+    }],
     [token('policies.sources'), {
       service: sources,
       arguments: [
@@ -34,3 +41,9 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
     }],
   ]
 }
+export const TOKENS = $
+export const [
+  usePolicyActionGroup,
+] = createInjections(
+  $.PolicyActionGroup,
+)

--- a/packages/kuma-gui/src/app/policies/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/policies/locales/en-us/index.yaml
@@ -41,3 +41,5 @@ policies:
   type:
     # CircuitBreaker:
     #   description: 'About CircuitBreaker ...'
+  action_group:
+    toggle_button: 'Actions'

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailTabsView.vue
@@ -52,6 +52,34 @@
             </XCopyButton>
           </h1>
         </template>
+        <template
+          #actions
+        >
+          <PolicyActionGroup
+            :item="data"
+            :type="{ path: route.params.policyPath }"
+            @change="() => route.replace(
+              {
+                name: 'policy-list-view',
+                params: {
+                  mesh: route.params.mesh,
+                  policyPath: route.params.policyPath,
+                },
+              },
+            )"
+          >
+            <template
+              #control
+            >
+              <XAction
+                action="expand"
+                appearance="primary"
+              >
+                {{ t('policies.action_group.toggle_button') }}
+              </XAction>
+            </template>
+          </PolicyActionGroup>
+        </template>
 
         <DataLoader
           :data="[data]"
@@ -88,5 +116,7 @@
 </template>
 
 <script lang="ts" setup>
+import { usePolicyActionGroup } from '../'
 import { sources } from '../sources'
+const PolicyActionGroup = usePolicyActionGroup()
 </script>

--- a/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
@@ -85,7 +85,7 @@
                   search: route.params.s,
                 })"
                 variant="list"
-                v-slot="{ data }"
+                v-slot="{ data, refresh }"
               >
                 <DataCollection
                   :items="data.items"
@@ -216,7 +216,11 @@
                       </template>
 
                       <template #actions="{ row: item }">
-                        <XActionGroup>
+                        <PolicyActionGroup
+                          :item="item"
+                          :type="type"
+                          @change="refresh"
+                        >
                           <XAction
                             :to="{
                               name: 'policy-detail-view',
@@ -229,7 +233,7 @@
                           >
                             {{ t('common.collection.actions.view') }}
                           </XAction>
-                        </XActionGroup>
+                        </PolicyActionGroup>
                       </template>
                     </AppCollection>
                   </template>
@@ -270,6 +274,7 @@
 </template>
 
 <script lang="ts" setup>
+import { usePolicyActionGroup } from '../'
 import type { PolicyResourceType } from '../data'
 import { sources } from '../sources'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
@@ -277,6 +282,7 @@ import PolicyTypeTag from '@/app/common/PolicyTypeTag.vue'
 const props = defineProps<{
   policyTypes?: PolicyResourceType[]
 }>()
+const PolicyActionGroup = usePolicyActionGroup()
 </script>
 <style lang="scss" scoped>
 header {


### PR DESCRIPTION
A while back we decided to put all menu like "ActionGroups" into their own individual component per resource (or "resource collection" in the case of "policies")

This PR adds a PolicyActionGroup for policies