### PR TITLE
chore: adds YAML.parse

### DIFF
--- a/packages/kuma-gui/src/app/application/utilities/index.ts
+++ b/packages/kuma-gui/src/app/application/utilities/index.ts
@@ -21,6 +21,10 @@ export const YAML = {
       // Removes the trailing new line js-yaml is outputting.
       .replace(/\n$/, '')
   },
+  parse: (str: string) => {
+    return jsYaml
+      .load(str)
+  },
 }
 
 export function get(obj: any, path: string, defaultValue: any = undefined): any {


### PR DESCRIPTION
I noticed we have `YAML.stringify`, but not `YAML.parse`, so I decided to complete that `JSON` like API.