### PR TITLE
refactor(data-planes/traffic): use proxyResourceName for stats

### DIFF
--- a/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
+++ b/packages/kuma-gui/src/app/connections/components/connection-traffic/ConnectionCard.vue
@@ -33,20 +33,15 @@
       </div>
     </template>
 
-    <template v-if="props.port">
-      <XDl variant="x-stack">
+    <template v-if="props.portName">
+      <dl>
         <div>
-          <dt>{{ t('http.api.property.port') }}</dt>
+          <dt>Name</dt>
           <dd>
-            <KumaPort
-              :port="{
-                port: props.port,
-                name: props.portName,
-              }"
-            />
+            {{ props.portName }}
           </dd>
         </div>
-      </XDl>
+      </dl>
     </template>
 
     <template
@@ -181,13 +176,11 @@ const props = withDefaults(defineProps<{
   traffic?: Record<string, any>
   direction?: 'upstream' | 'downstream'
   portName?: string
-  port?: number
 }>(), {
   service: '',
   traffic: undefined,
   direction: 'downstream',
   portName: undefined,
-  port: undefined,
 })
 
 </script>

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -464,7 +464,6 @@
                                   data-testid="dataplane-inbound"
                                   :protocol="item.protocol"
                                   :port-name="inbound?.portName"
-                                  :port="inbound?.port"
                                   :traffic="traffic?.inbounds[item.stat_prefix]"
                                   data-actionable
                                 >
@@ -559,8 +558,6 @@
                               <ConnectionCard
                                 data-testid="dataplane-outbound"
                                 :protocol="outbound.protocol"
-                                :port-name="outbound?.portName"
-                                :port="outbound?.port"
                                 :traffic="traffic?.outbounds[outbound.kri]"
                                 data-actionable
                               >

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -452,7 +452,6 @@
                               <ConnectionCard
                                 data-testid="dataplane-inbound"
                                 :protocol="item.protocol"
-                                :port="item.port"
                                 :port-name="item.portName"
                                 :service="can('use service-insights', props.mesh) ? item.tags['kuma.io/service'] : ''"
                                 :traffic="typeof error === 'undefined' ?


### PR DESCRIPTION
As https://github.com/kumahq/kuma/issues/14469 is done, we are now able to use `proxyResourceName` as is for `stat_prefix`.

~Since I was there I took the chance to also change the representation of `port` and `name` of a port on the traffic cards. The user can now see both the `port` and if a `name` is set also the `name` of the port. All information in one `Port` description list element.~