### PR TITLE
chore(policies): move YAML usage to data layer

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlanePolicySummaryView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlanePolicySummaryView.vue
@@ -83,7 +83,7 @@
               <XCodeBlock
                 data-testid="codeblock-yaml-universal"
                 language="yaml"
-                :code="YAML.stringify(data.config)"
+                :code="data.yaml"
                 is-searchable
                 :show-k8s-copy-button="false"
                 :query="route.params.codeSearch"
@@ -102,12 +102,12 @@
                   path: route.params.policyPath,
                   name: route.params.policy,
                 })"
-                v-slot="{ data: k8sConfig }"
+                v-slot="{ data: yaml }"
               >
                 <XCodeBlock
                   data-testid="codeblock-yaml-k8s"
                   language="yaml"
-                  :code="YAML.stringify(k8sConfig)"
+                  :code="yaml"
                   :show-k8s-copy-button="false"
                   is-searchable
                   :query="route.params.codeSearch"
@@ -127,7 +127,6 @@
 </template>
 
 <script lang="ts" setup>
-import { YAML } from '@/app/application'
 import PolicySummary from '@/app/policies/components/PolicySummary.vue'
 import type { PolicyResourceType } from '@/app/policies/data'
 import { type PolicySource , sources } from '@/app/policies/sources'

--- a/packages/kuma-gui/src/app/policies/data/index.ts
+++ b/packages/kuma-gui/src/app/policies/data/index.ts
@@ -1,4 +1,4 @@
-
+import { YAML } from '@/app/application'
 import { Resource } from '@/app/resources/data/Resource'
 import type { PaginatedApiListResponse } from '@/types/api.d'
 import type {
@@ -57,6 +57,7 @@ export const Policy = {
       zone: labels['kuma.io/origin'] === 'zone' && labels['kuma.io/zone'] ? labels['kuma.io/zone'] : '',
       role: labels['kuma.io/policy-role'] ?? 'system',
       config: item,
+      yaml: YAML.stringify(item),
     }
   },
 

--- a/packages/kuma-gui/src/app/policies/sources.ts
+++ b/packages/kuma-gui/src/app/policies/sources.ts
@@ -1,9 +1,11 @@
 import createClient from 'openapi-fetch'
 
+
 import { Policy, PolicyDataplane, PolicyResourceType } from './data'
 import { DataplanePolicies } from './data/DataplanePolicies'
 import { DataplaneInboundPolicies, DataplaneOutboundPolicies } from './data/DataplaneTrafficPolicies'
 import { defineSources } from '../application/services/data-source'
+import { YAML } from '@/app/application'
 import type { DataSourceResponse } from '@/app/application'
 import type KumaApi from '@/app/kuma/services/kuma-api/KumaApi'
 import type { PaginatedApiListResponse as CollectionResponse } from '@/types/api.d'
@@ -29,7 +31,7 @@ export const sources = (api: KumaApi) => {
 
       return PolicyResourceType.fromCollection(res.data!)
     },
-    
+
     '/meshes/:mesh/policy-path/:path': async (params) => {
       const { mesh, path, size } = params
       const offset = params.size * (params.page - 1)
@@ -41,8 +43,8 @@ export const sources = (api: KumaApi) => {
 
     '/meshes/:mesh/policy-path/:path/policy/:name': async (params) => {
       const { mesh, path, name } = params
-
-      return Policy.fromObject(await api.getSinglePolicyEntity({ mesh, path, name }))
+      const res = await api.getSinglePolicyEntity({ mesh, path, name })
+      return Policy.fromObject(res)
     },
 
     '/meshes/:mesh/policy-path/:path/policy/:name/dataplanes': async (params) => {
@@ -51,12 +53,12 @@ export const sources = (api: KumaApi) => {
       return PolicyDataplane.fromCollection(await api.getPolicyConnections({ mesh, path, name }, { offset, size }))
     },
 
-    '/meshes/:mesh/policy-path/:path/policy/:name/as/kubernetes': (params) => {
+    '/meshes/:mesh/policy-path/:path/policy/:name/as/kubernetes': async (params) => {
       const { mesh, path, name } = params
 
-      return api.getSinglePolicyEntity({ mesh, path, name }, { format: 'kubernetes' })
+      return YAML.stringify(await api.getSinglePolicyEntity({ mesh, path, name }, { format: 'kubernetes' }))
     },
-        
+
     '/meshes/:mesh/dataplanes/:name/policies/for/proxy': async (params) => {
       const { mesh, name } = params
       const res = await http.GET('/meshes/{mesh}/dataplanes/{name}/_policies', {
@@ -69,7 +71,7 @@ export const sources = (api: KumaApi) => {
       })
       return DataplanePolicies.fromCollection(res.data!)
     },
-        
+
     '/meshes/:mesh/dataplanes/:name/policies/for/inbound/:kri': async (params) => {
       const { mesh, name, kri } = params
       const res = await http.GET('/meshes/{mesh}/dataplanes/{name}/_inbounds/{inbound-kri}/_policies', {
@@ -83,7 +85,7 @@ export const sources = (api: KumaApi) => {
       })
       return DataplaneInboundPolicies.fromCollection(res.data!)
     },
-    
+
     '/meshes/:mesh/dataplanes/:name/policies/for/outbound/:kri': async (params) => {
       const { mesh, name, kri } = params
       const res = await http.GET('/meshes/{mesh}/dataplanes/{name}/_outbounds/{kri}/_policies', {

--- a/packages/kuma-gui/src/app/policies/views/PolicyDetailConfigView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyDetailConfigView.vue
@@ -46,7 +46,7 @@
             <XCodeBlock
               data-testid="codeblock-yaml-universal"
               language="yaml"
-              :code="YAML.stringify(props.data.config)"
+              :code="props.data.yaml"
               :show-k8s-copy-button="false"
               is-searchable
               :query="route.params.codeSearch"
@@ -65,12 +65,12 @@
                 path: route.params.policyPath,
                 name: route.params.policy,
               })"
-              v-slot="{ data: k8sConfig }"
+              v-slot="{ data: yaml }"
             >
               <XCodeBlock
                 data-testid="codeblock-yaml-k8s"
                 language="yaml"
-                :code="YAML.stringify(k8sConfig)"
+                :code="yaml"
                 :show-k8s-copy-button="false"
                 is-searchable
                 :query="route.params.codeSearch"
@@ -91,7 +91,6 @@
 <script lang="ts" setup>
 import type { Policy } from '../data'
 import { sources } from '../sources'
-import { YAML } from '@/app/application'
 const props = defineProps<{
   data: Policy
 }>()

--- a/packages/kuma-gui/src/app/policies/views/PolicySummaryView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicySummaryView.vue
@@ -99,7 +99,7 @@
                 <XCodeBlock
                   data-testid="codeblock-yaml-universal"
                   language="yaml"
-                  :code="YAML.stringify(item.config)"
+                  :code="item.yaml"
                   is-searchable
                   :show-k8s-copy-button="false"
                   :query="route.params.codeSearch"
@@ -118,12 +118,12 @@
                     path: route.params.policyPath,
                     name: route.params.policy,
                   })"
-                  v-slot="{ data: k8sConfig }"
+                  v-slot="{ data: yaml }"
                 >
                   <XCodeBlock
                     data-testid="codeblock-yaml-k8s"
                     language="yaml"
-                    :code="YAML.stringify(k8sConfig)"
+                    :code="yaml"
                     is-searchable
                     :show-k8s-copy-button="false"
                     :query="route.params.codeSearch"
@@ -147,7 +147,6 @@
 import PolicySummary from '../components/PolicySummary.vue'
 import type { Policy, PolicyResourceType } from '../data'
 import { sources } from '../sources'
-import { YAML } from '@/app/application'
 
 const props = defineProps<{
   items: Policy[]


### PR DESCRIPTION
I've thought about doing this for a while, and while I've gone back and forth a little today following offline catchups, I'm still pretty sure that we should put the YAML serialising into the data layer, and I think the word "serialising" is important when thinking about this.

Whilst you could think of this converting of JSON to YAML as making the data "look different" and therefore is a view thing, its actually "serialising" data from one format to another, and therefore I'd definitely say this belongs in the data layer.

I might add a bit more here but I wanted to get the PR up, seeing as I wasn't totally sure earlier today