### PR TITLE
fix(kuma-http-api/mocks/kri): missing `source` in `invalid_parameters`

### DIFF
--- a/packages/kuma-http-api/mocks/src/_kri/_.ts
+++ b/packages/kuma-http-api/mocks/src/_kri/_.ts
@@ -21,6 +21,7 @@ export default (_dependencies: Dependencies): ResponseHandler => (request) => {
         {
           field: 'kri',
           reason: `The provided KRI includes a [shortName] ([resourceType]) that is not supported in the mock API. Given [${shortName}] is not supported yet.`,
+          source: 'path',
         },        
       ],
     } satisfies components['schemas']['Error'],


### PR DESCRIPTION
Somehow this issue slipped through, probably due to a missing rebase before merging.