### PR TITLE
chore(kuma-http-api): expose/export openapi.yaml

### DIFF
--- a/packages/kuma-http-api/package.json
+++ b/packages/kuma-http-api/package.json
@@ -14,7 +14,8 @@
     },
     "./mocks": {
       "import": "./mocks/index.ts"
-    }
+    },
+    "./openapi.yaml": "./openapi.yaml"
   },
   "scripts": {
     "help": "make help"


### PR DESCRIPTION
Allows us to import `openapi.yaml` which we can then use with our yaml loader.

This could be temporary, later we might want to prebuild a json/js file and export that instead. This would mean you wouldn't need a yaml loader to be able to make use of this easily. For now tho, we have a yaml loader already so this is fine for now.