### PR TITLE
fix: amend positioning of main nav icons

### DIFF
--- a/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
+++ b/packages/kuma-gui/src/app/kuma/components/ApplicationShell.vue
@@ -254,8 +254,7 @@ nav :deep(.app-navigator) + .app-navigator {
 }
 nav :deep(.app-navigator) > a {
   width: 100%;
-  display: flex;
-  align-items: center;
+  display: inline-block;
   padding: $kui-space-40 $kui-space-60 $kui-space-40 $kui-space-70;
   border-radius: 5px;
   text-decoration: none;


### PR DESCRIPTION
I noticed that following https://github.com/kumahq/kuma-gui/pull/4284 our main nav icons were ever so slightly off position. This was due to some CSS that we had previously applied to the containing element to make the icons centered.

Since https://github.com/kumahq/kuma-gui/pull/4284 our icons centre themselves so this is no longer needed.

## Before

<img width="238" height="312" alt="Screenshot 2025-10-29 at 11 19 18" src="https://github.com/user-attachments/assets/1deec3a6-13e6-4e2a-b99a-e16f8b2fe4a6" />

## After

<img width="243" height="309" alt="Screenshot 2025-10-29 at 11 19 04" src="https://github.com/user-attachments/assets/95ba9798-fad2-4e12-a16d-72b422843dd0" />

Its hard to see so it might be worth looking locally on master and switching to this branch and back to see.
