### PR TITLE
fix: don't pass query params from list to detail views

### DIFF
--- a/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
+++ b/packages/kuma-gui/src/app/meshes/views/MeshListView.vue
@@ -88,10 +88,6 @@
                         params: {
                           mesh: item.name,
                         },
-                        query: {
-                          page: route.params.page,
-                          size: route.params.size,
-                        },
                       }"
                     >
                       {{ item.name }}

--- a/packages/kuma-gui/src/app/services/views/ServiceListView.vue
+++ b/packages/kuma-gui/src/app/services/views/ServiceListView.vue
@@ -73,10 +73,6 @@
                           mesh: item.mesh,
                           service: item.name,
                         },
-                        query: {
-                          page: route.params.page,
-                          size: route.params.size,
-                        },
                       }"
                     >
                       {{ item.name }}

--- a/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneListView.vue
@@ -111,11 +111,6 @@
                         params: {
                           zone: item.name,
                         },
-                        query: {
-                          page: route.params.page,
-                          size: route.params.size,
-                          s: route.params.s,
-                        },
                       }"
                     >
                       {{ item.name }}


### PR DESCRIPTION
Closes https://github.com/kumahq/kuma-gui/issues/4358

See above issue for details

I noticed that the only places where we did this wrong was where we had a list view with no summary view. Summary views do need these query params passing to them, whereas if the list view links straight to a detail view, then they don't need the query parameters passing to them.

I then also check zone and mesh listings (neither have summary views) and noticed the parameters needed removing there also.

