### PR TITLE
chore: DataLoader amends

### DIFF
--- a/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
+++ b/packages/kuma-gui/src/app/application/components/app-view/AppView.vue
@@ -149,11 +149,14 @@ import { nextTick , provide, inject, watch, ref, onBeforeUnmount } from 'vue'
 import { ROUTE_VIEW_PARENT } from '../route-view/index'
 import type { RouteView } from '../route-view/RouteView.vue'
 import { uniqueId } from '@/app/application'
-import type { BreadcrumbItem } from '@kong/kongponents'
 type AppView = {
   addBreadcrumbs: (items: BreadcrumbItem[], sym: symbol) => void
   removeBreadcrumbs: (sym: symbol) => void
 }
+import type { XBreadcrumbs } from '@kumahq/x'
+import type { ComponentInstance } from 'vue'
+
+type BreadcrumbItem = ComponentInstance<typeof XBreadcrumbs>['$props']['items'][number]
 type Breadcrumbs = Map<symbol, BreadcrumbItem[]>
 
 

--- a/packages/kuma-gui/src/app/control-planes/components/ControlPlaneStatus.vue
+++ b/packages/kuma-gui/src/app/control-planes/components/ControlPlaneStatus.vue
@@ -5,53 +5,110 @@
         <h2>{{ t('main-overview.detail.about.title') }}</h2>
       </div>
     </div>
-
-    <XLayout
-      type="columns"
-      class="columns-with-borders"
+    <DataLoader
+      :data="[props.globalInsight]"
     >
-      <ResourceStatus
-        v-if="props.canUseZones"
-        :total="props.globalInsight.zones.controlPlanes.total"
-        data-testid="zone-control-planes-status"
-      >
-        <template #icon>
-          <img
-            class="icon"
-            src="@/assets/images/zone.svg?url"
-            alt=""
-          >
-        </template>
-
-        <template #title>
-          {{ t('main-overview.detail.about.zone_control_planes') }}
-        </template>
-      </ResourceStatus>
-
-      <ResourceStatus
-        :total="props.globalInsight.meshes.total"
-        data-testid="meshes-status"
-      >
-        <template #icon>
-          <img
-            class="icon"
-            src="@/assets/images/mesh.svg?url"
-            alt=""
-          >
-        </template>
-
-        <template #title>
-          {{ t('main-overview.detail.about.meshes') }}
-        </template>
-      </ResourceStatus>
-
-      <template
-        v-for="meshServicesGeneric in [(['MeshService', 'MeshMultiZoneService', 'MeshExternalService'] as const).reduce((acc, curr) => ({ total: acc.total + props.globalInsight.resources[curr].total }), { total: 0 })]"
-        :key="typeof meshServicesGeneric"
+      <XLayout
+        v-if="props.globalInsight && !(props.globalInsight instanceof Error)"
+        type="columns"
+        class="columns-with-borders"
       >
         <ResourceStatus
-          :total="meshServicesGeneric.total || props.globalInsight.services.internal.total"
-          data-testid="services-status"
+          v-if="props.canUseZones"
+          :total="props.globalInsight.zones.controlPlanes.total"
+          data-testid="zone-control-planes-status"
+        >
+          <template #icon>
+            <img
+              class="icon"
+              src="@/assets/images/zone.svg?url"
+              alt=""
+            >
+          </template>
+
+          <template #title>
+            {{ t('main-overview.detail.about.zone_control_planes') }}
+          </template>
+        </ResourceStatus>
+
+        <ResourceStatus
+          :total="props.globalInsight.meshes.total"
+          data-testid="meshes-status"
+        >
+          <template #icon>
+            <img
+              class="icon"
+              src="@/assets/images/mesh.svg?url"
+              alt=""
+            >
+          </template>
+
+          <template #title>
+            {{ t('main-overview.detail.about.meshes') }}
+          </template>
+        </ResourceStatus>
+        <template
+          v-for="insight in [props.globalInsight]"
+          :key="typeof insight"
+        >
+          <template
+            v-for="meshServicesGeneric in [(['MeshService', 'MeshMultiZoneService', 'MeshExternalService'] as const).reduce((acc, curr) => ({ total: acc.total + insight.resources[curr].total }), { total: 0 })]"
+            :key="typeof meshServicesGeneric"
+          >
+            <ResourceStatus
+              :total="meshServicesGeneric.total || props.globalInsight.services.internal.total"
+              data-testid="services-status"
+            >
+              <template #icon>
+                <img
+                  class="icon"
+                  src="@/assets/images/icon-wifi-tethering.svg?url"
+                  alt=""
+                >
+              </template>
+
+              <template #title>
+                <XI18n
+                  path="main-overview.detail.about.services"
+                />
+              </template>
+
+              <template
+                v-if="meshServicesGeneric.total && props.globalInsight.services.internal.total > 0"
+                #description
+              >
+                <XI18n
+                  path="main-overview.detail.about.descriptions.mesh_services"
+                />
+              </template>
+
+              <template
+                v-if="meshServicesGeneric.total && props.globalInsight.services.internal.total > 0"
+                #body
+              >
+                <ResourceStatus :total="props.globalInsight.services.internal.total">
+                  <template #description>
+                    <XI18n
+                      path="main-overview.detail.about.descriptions.internal_services"
+                    />
+
+                    <XIcon
+                      name="info"
+                    >
+                      <XI18n
+                        path="main-overview.detail.about.infos.internal_services"
+                      />
+                    </XIcon>
+                  </template>
+                </ResourceStatus>
+              </template>
+            </ResourceStatus>
+          </template>
+        </template>
+
+        <ResourceStatus
+          :total="props.globalInsight.dataplanes.standard.total"
+          data-testid="data-plane-proxies-status"
         >
           <template #icon>
             <img
@@ -62,76 +119,27 @@
           </template>
 
           <template #title>
-            <XI18n
-              path="main-overview.detail.about.services"
-            />
-          </template>
-
-          <template
-            v-if="meshServicesGeneric.total && props.globalInsight.services.internal.total > 0"
-            #description
-          >
-            <XI18n
-              path="main-overview.detail.about.descriptions.mesh_services"
-            />
-          </template>
-
-          <template
-            v-if="meshServicesGeneric.total && props.globalInsight.services.internal.total > 0"
-            #body
-          >
-            <ResourceStatus :total="props.globalInsight.services.internal.total">
-              <template #description>
-                <XI18n
-                  path="main-overview.detail.about.descriptions.internal_services"
-                />
-
-                <XIcon
-                  name="info"
-                >
-                  <XI18n
-                    path="main-overview.detail.about.infos.internal_services"
-                  />
-                </XIcon>
-              </template>
-            </ResourceStatus>
+            {{ t('main-overview.detail.about.data_plane_proxies') }}
           </template>
         </ResourceStatus>
-      </template>
+        <ResourceStatus
+          :total="policyTotal"
+          data-testid="policies-status"
+        >
+          <template #icon>
+            <img
+              class="icon"
+              src="@/assets/images/policy.svg?url"
+              alt=""
+            >
+          </template>
 
-      <ResourceStatus
-        :total="props.globalInsight.dataplanes.standard.total"
-        data-testid="data-plane-proxies-status"
-      >
-        <template #icon>
-          <img
-            class="icon"
-            src="@/assets/images/icon-wifi-tethering.svg?url"
-            alt=""
-          >
-        </template>
-
-        <template #title>
-          {{ t('main-overview.detail.about.data_plane_proxies') }}
-        </template>
-      </ResourceStatus>
-      <ResourceStatus
-        :total="policyTotal"
-        data-testid="policies-status"
-      >
-        <template #icon>
-          <img
-            class="icon"
-            src="@/assets/images/policy.svg?url"
-            alt=""
-          >
-        </template>
-
-        <template #title>
-          {{ t('main-overview.detail.about.policies') }}
-        </template>
-      </ResourceStatus>
-    </XLayout>
+          <template #title>
+            {{ t('main-overview.detail.about.policies') }}
+          </template>
+        </ResourceStatus>
+      </XLayout>
+    </DataLoader>
   </XCard>
 </template>
 
@@ -146,12 +154,12 @@ import type { ResourceCollection } from '@/app/policies/data'
 const { t } = useI18n()
 
 const props = defineProps<{
-  globalInsight: GlobalInsight
+  globalInsight?: GlobalInsight | Error
   resources?: ResourceCollection
   canUseZones: boolean
 }>()
 const policyTotal = computed(() => {
-  if(props.resources?.policyTypes) {
+  if(props.globalInsight && !(props.globalInsight instanceof Error) && props.resources?.policyTypes) {
     const policyTypes = props.resources?.policyTypes.map(item => item.name)
     return Object.entries(props.globalInsight.resources).reduce((prev, [key, { total }]) => {
       return policyTypes.includes(key) ? prev + total : prev

--- a/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/control-planes/views/ControlPlaneDetailView.vue
@@ -22,16 +22,16 @@
           :src="uri(PolicySources, '/policy-types', {})"
           v-slot="{ data: resources }"
         >
-          <DataLoader
+          <DataSource
             :src="uri(ControlPlaneSources, '/global-insight', {})"
-            v-slot="{ data }"
+            v-slot="{ data, error }"
           >
             <ControlPlaneStatus
               :can-use-zones="can('use zones')"
-              :global-insight="data"
+              :global-insight="error ?? data"
               :resources="resources"
             />
-          </DataLoader>
+          </DataSource>
         </DataSource>
         <XLayout
           type="columns"
@@ -39,6 +39,25 @@
           <XCard
             v-if="can('use zones')"
           >
+            <div class="card-header">
+              <div class="card-title">
+                <h2>
+                  {{ t('main-overview.detail.zone_control_planes.title') }}
+                </h2>
+
+                <XAction
+                  :to="{ name: 'zone-cp-list-view' }"
+                >
+                  {{ t('main-overview.detail.about.view_all') }}
+                </XAction>
+              </div>
+              <div
+                class="card-actions"
+              >
+                <XTeleportSlot name="control-plane-detail-view-zone-actions" />
+              </div>
+            </div>
+
             <DataLoader
               :src="uri(ZoneSources, '/zone-cps', {}, {
                 page: 1,
@@ -47,25 +66,6 @@
               variant="list"
               v-slot="{ data }"
             >
-              <div class="card-header">
-                <div class="card-title">
-                  <h2>
-                    {{ t('main-overview.detail.zone_control_planes.title') }}
-                  </h2>
-
-                  <XAction
-                    :to="{ name: 'zone-cp-list-view' }"
-                  >
-                    {{ t('main-overview.detail.about.view_all') }}
-                  </XAction>
-                </div>
-                <div
-                  class="card-actions"
-                >
-                  <XTeleportSlot name="control-plane-detail-view-zone-actions" />
-                </div>
-              </div>
-
               <ZoneControlPlanesList
                 data-testid="zone-control-planes-details"
                 :items="data.items"
@@ -75,6 +75,25 @@
           </XCard>
 
           <XCard>
+            <div class="card-header">
+              <div class="card-title">
+                <h2>
+                  {{ t('main-overview.detail.meshes.title') }}
+                </h2>
+
+                <XAction
+                  :to="{ name: 'mesh-list-view' }"
+                >
+                  {{ t('main-overview.detail.about.view_all') }}
+                </XAction>
+              </div>
+              <div
+                class="card-actions"
+              >
+                <XTeleportSlot name="control-plane-detail-view-mesh-actions" />
+              </div>
+            </div>
+
             <DataLoader
               :src="uri(MeshSources, '/mesh-insights', {}, {
                 page: 1,
@@ -83,25 +102,6 @@
               variant="list"
               v-slot="{ data }"
             >
-              <div class="card-header">
-                <div class="card-title">
-                  <h2>
-                    {{ t('main-overview.detail.meshes.title') }}
-                  </h2>
-
-                  <XAction
-                    :to="{ name: 'mesh-list-view' }"
-                  >
-                    {{ t('main-overview.detail.about.view_all') }}
-                  </XAction>
-                </div>
-                <div
-                  class="card-actions"
-                >
-                  <XTeleportSlot name="control-plane-detail-view-mesh-actions" />
-                </div>
-              </div>
-
               <MeshInsightsList
                 data-testid="meshes-details"
                 :items="data.items"


### PR DESCRIPTION
This PR is part of https://github.com/kumahq/kuma-gui/issues/4106. Diff best viewed with Github's `Hide whitespace` setting.

---

This PR adds 2 things to our much used `DataLoader` component

- Allows non-blocking behaviour if you don't specify data. This allows you to specify only errors. The DataLoader will not block and show its default slot _unless_ there is an error. In which case it will show the error instead of the default slot.
- More of an ergonomic change: The `:data="[]"` prop can now contain errors. On the inside we check `:data` for errors and split them out into our internal `errors` variable. This allows us to load/error on single properties that are of type `Result | Error`. This assumes (a reasonable assumption) that data result will never actually be an `Error` its always some other actual data. Whilst we only absolutely need this is rare cases, its actually ergonomically better to not have to manual give both `:data` and `:error` properties, so just be able to give a single `:data` property may become the default way we use DataLoader in the future.

---

Using the above changes I've made some amends to the homepage to allow us to show loaders inside of our XCards (inside our grey borders)

## Before

<img width="1323" height="879" alt="Screenshot 2025-11-13 at 14 34 50" src="https://github.com/user-attachments/assets/92ee8217-de63-43cb-be20-eaa5945bdec2" />

## After

<img width="1238" height="995" alt="Screenshot 2025-11-13 at 14 38 37" src="https://github.com/user-attachments/assets/d6b9abad-b382-4557-9c9d-36f66ca6c25f" />




