### PR TITLE
feat(RouteView): adds route.go functionality

### DIFF
--- a/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
+++ b/packages/kuma-gui/src/app/application/components/route-view/RouteView.vue
@@ -47,6 +47,7 @@
           replace: routeReplace,
           params: routeParams,
           back: routerBack,
+          go: routerGo,
           children,
           child,
           from: getFrom,
@@ -71,7 +72,7 @@ import {
 } from '../../utilities'
 import { sources } from '@/app/me/sources'
 import type { Ref } from 'vue'
-import type { RouteRecordRaw, RouteLocationNormalizedLoaded } from 'vue-router'
+import type { RouteRecordRaw, RouteLocationNormalizedLoaded, RouteLocationAsRelativeGeneric } from 'vue-router'
 
 
 export type RouteView = {
@@ -111,7 +112,6 @@ type Params = {
       T[P] extends BooleanConstructor ? boolean :
         T[P]
 }
-type RouteReplaceParams = Parameters<typeof router['push']>
 
 const setTitle = createTitleSetter(document)
 const setAttrs = createAttrsSetter(document.documentElement)
@@ -264,20 +264,27 @@ const routerPush = (params: Partial<PrimitiveParams>) => {
   newParams = {}
 }
 
-const routeReplace = (...args: RouteReplaceParams) => {
-  router.push(...args)
+const routeReplace = (to: RouteLocationAsRelativeGeneric) => {
+  router.push(to)
 }
 
-const routerBack = (...args: RouteReplaceParams) => {
+const routerBack = (to: RouteLocationAsRelativeGeneric) => {
+  routerGo({
+    ...to,
+    delta: -1,
+  })
+}
+const routerGo = (to: RouteLocationAsRelativeGeneric & { delta: number }) => {
+  const { delta, ...args } = to
   try {
     if (win.history.state.back !== null) {
-      router.back()
+      router.go(delta)
       return
     }
   } catch {
     // passthrough
   }
-  routeReplace(...args)
+  routeReplace(args)
 }
 
 const hasRoot: RouteView | undefined = inject(ROUTE_VIEW_ROOT, undefined)


### PR DESCRIPTION
Previously we only had `router.back()` which would always go one step back in the Vue routing history (if no history existed we also provide a default route name to go to instead)

This PR adds `router.go()` with an extra `delta` property on the `to` object.

This allows us to go several steps back in the Vue routing history with:

```
go({ delta: -2, name: 'mesh'})
```

...which would take us back two steps, defaulting to `mesh` if enough steps don't exist.