### PR TITLE
chore: allow DataCollection:EmptyState to be injectable

### DIFF
--- a/packages/kuma-gui/src/app/application/components/data-collection/DataCollection.vue
+++ b/packages/kuma-gui/src/app/application/components/data-collection/DataCollection.vue
@@ -16,7 +16,7 @@
         name="empty"
         :items="items"
       >
-        <XEmptyState
+        <DataEmptyState
           v-if="props.empty"
           :type="props.type"
         />
@@ -32,7 +32,7 @@
       name="empty"
       :items="items"
     >
-      <XEmptyState
+      <DataEmptyState
         v-if="props.empty"
         :type="props.type"
       />
@@ -90,6 +90,10 @@
 <script lang="ts" generic="T" setup>
 import { useThrottleFn } from '@vueuse/core'
 import { computed, useSlots } from 'vue'
+
+import { useDataEmptyState } from '../../'
+
+const DataEmptyState = useDataEmptyState()
 
 type PaginationChangeEvent = {
   page: number

--- a/packages/kuma-gui/src/app/application/index.ts
+++ b/packages/kuma-gui/src/app/application/index.ts
@@ -3,6 +3,7 @@ import { create, destroy, DataSourcePool } from '@kumahq/data'
 import Data, { DataLoader, DataSink, DataSource } from '@kumahq/data/vue'
 import can from '@kumahq/settings/can'
 import env from '@kumahq/settings/env'
+import { XEmptyState } from '@kumahq/x'
 // @ts-ignore TS comes with a Object.groupBy declaration but not a polyfill
 import groupBy from 'object.groupby'
 // @ts-ignore TS comes with a set.prototype.difference declaration but not a polyfill
@@ -79,6 +80,7 @@ const $ = {
 
   notFoundView: token<() => Promise<Component>>('application.not-found'),
   applicationComponents: token('application.components'),
+  DataEmptyState: token('application.components.data-empty-state'),
 
   sources: token('data.sources'),
   dataSourcePool: token<DataSourcePool>('data.DataSourcePool'),
@@ -160,6 +162,9 @@ export const services = (app: Record<string, Token>): ServiceDefinition[] => {
       labels: [
         app.components,
       ],
+    }],
+    [$.DataEmptyState, {
+      service: () => XEmptyState,
     }],
 
     [token('application.routes'), {
@@ -265,9 +270,11 @@ export const [
   useEnv,
   useCan,
   useI18n,
+  useDataEmptyState,
 ] = createInjections(
   $.env,
   $.can,
   $.i18n,
+  $.DataEmptyState,
 )
 export { uniqueId, YAML, get } from './utilities'

--- a/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
+++ b/packages/kuma-gui/src/app/policies/views/PolicyListView.vue
@@ -95,7 +95,9 @@
                   <template
                     #empty
                   >
-                    <XEmptyState>
+                    <DataEmptyState
+                      type="policies"
+                    >
                       <template #title>
                         <h3>
                           {{ t('policies.x-empty-state.title') }}
@@ -118,7 +120,7 @@
                           {{ t('common.documentation') }}
                         </XAction>
                       </template>
-                    </XEmptyState>
+                    </DataEmptyState>
                   </template>
                   <template
                     #default
@@ -266,11 +268,14 @@
 import { usePolicyActionGroup } from '../'
 import type { PolicyResourceType } from '../data'
 import { sources } from '../sources'
+import { useDataEmptyState } from '@/app/application'
 import AppCollection from '@/app/application/components/app-collection/AppCollection.vue'
 const props = defineProps<{
   policyTypes?: PolicyResourceType[]
 }>()
 const PolicyActionGroup = usePolicyActionGroup()
+
+const DataEmptyState = useDataEmptyState()
 </script>
 <style lang="scss" scoped>
 header {


### PR DESCRIPTION
Does some plumbing work to extract an dependency on `@kumahq/x` (XEmptyState) from `DataCollection`.

This means we can totally amend the empty state from The Outside, say if we need to add certain buttons if a list result is empty.

---

Separately from this I'd also like to do similar to our usage of `KPagination` inside of `DataCollection` thus removing its dependency on kongponents also, at which point I'll look to move DataCollection into `@kumahq/data` where it belongs.

For the moment the work I'm doing depends on adding buttons to empty states only so I only went so far in this PR.
