### PR TITLE
feat(oas): adds separate PUT request specs for all policies

### DIFF
--- a/packages/kuma-http-api/dist/components/schemas/MeshAccessLogItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshAccessLogItem_Put_RequestBody.yaml
@@ -1,0 +1,741 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshAccessLog
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mal_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshAccessLog resource.
+    type: object
+    properties:
+      from:
+        description: From list makes a match between clients and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of clients referenced in
+                'targetRef'
+              type: object
+              properties:
+                backends:
+                  type: array
+                  items:
+                    properties:
+                      file:
+                        description: FileBackend defines configuration for file based access logs
+                        type: object
+                        properties:
+                          format:
+                            description: |-
+                              Format of access logs. Placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            type: object
+                            properties:
+                              json:
+                                type: array
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                    - key
+                                    - value
+                                  type: object
+                                example:
+                                  - key: start_time
+                                    value: '%START_TIME%'
+                                  - key: bytes_received
+                                    value: '%BYTES_RECEIVED%'
+                              omitEmptyValues:
+                                type: boolean
+                                default: false
+                              plain:
+                                type: string
+                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                              type:
+                                type: string
+                                enum:
+                                  - Plain
+                                  - Json
+                            required:
+                              - type
+                          path:
+                            description: Path to a file that logs will be written to
+                            type: string
+                            example: /tmp/access.log
+                            minLength: 1
+                        required:
+                          - path
+                      openTelemetry:
+                        description: Defines an OpenTelemetry logging backend.
+                        type: object
+                        properties:
+                          attributes:
+                            description: |-
+                              Attributes can contain placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            type: array
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - key
+                                - value
+                              type: object
+                            example:
+                              - key: mesh
+                                value: '%KUMA_MESH%'
+                          body:
+                            description: |-
+                              Body is a raw string or an OTLP any value as described at
+                              https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                              It can contain placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            example:
+                              kvlistValue:
+                                values:
+                                  - key: mesh
+                                    value:
+                                      stringValue: '%KUMA_MESH%'
+                            x-kubernetes-preserve-unknown-fields: true
+                          endpoint:
+                            description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                            type: string
+                            example: 'otel-collector:4317'
+                            minLength: 1
+                        required:
+                          - endpoint
+                      tcp:
+                        description: TCPBackend defines a TCP logging backend.
+                        type: object
+                        properties:
+                          address:
+                            description: Address of the TCP logging backend
+                            type: string
+                            example: '127.0.0.1:5000'
+                            minLength: 1
+                          format:
+                            description: |-
+                              Format of access logs. Placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            type: object
+                            properties:
+                              json:
+                                type: array
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                    - key
+                                    - value
+                                  type: object
+                                example:
+                                  - key: start_time
+                                    value: '%START_TIME%'
+                                  - key: bytes_received
+                                    value: '%BYTES_RECEIVED%'
+                              omitEmptyValues:
+                                type: boolean
+                                default: false
+                              plain:
+                                type: string
+                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                              type:
+                                type: string
+                                enum:
+                                  - Plain
+                                  - Json
+                            required:
+                              - type
+                        required:
+                          - address
+                      type:
+                        type: string
+                        enum:
+                          - Tcp
+                          - File
+                          - OpenTelemetry
+                    required:
+                      - type
+                    type: object
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                clients.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - default
+            - targetRef
+          type: object
+      rules:
+        description: |-
+          Rules defines inbound access log configurations. Currently limited to
+          selecting all inbound traffic, as L7 matching is not yet implemented.
+        type: array
+        items:
+          properties:
+            default:
+              description: Default contains configuration of the inbound access logging
+              type: object
+              properties:
+                backends:
+                  type: array
+                  items:
+                    properties:
+                      file:
+                        description: FileBackend defines configuration for file based access logs
+                        type: object
+                        properties:
+                          format:
+                            description: |-
+                              Format of access logs. Placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            type: object
+                            properties:
+                              json:
+                                type: array
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                    - key
+                                    - value
+                                  type: object
+                                example:
+                                  - key: start_time
+                                    value: '%START_TIME%'
+                                  - key: bytes_received
+                                    value: '%BYTES_RECEIVED%'
+                              omitEmptyValues:
+                                type: boolean
+                                default: false
+                              plain:
+                                type: string
+                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                              type:
+                                type: string
+                                enum:
+                                  - Plain
+                                  - Json
+                            required:
+                              - type
+                          path:
+                            description: Path to a file that logs will be written to
+                            type: string
+                            example: /tmp/access.log
+                            minLength: 1
+                        required:
+                          - path
+                      openTelemetry:
+                        description: Defines an OpenTelemetry logging backend.
+                        type: object
+                        properties:
+                          attributes:
+                            description: |-
+                              Attributes can contain placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            type: array
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - key
+                                - value
+                              type: object
+                            example:
+                              - key: mesh
+                                value: '%KUMA_MESH%'
+                          body:
+                            description: |-
+                              Body is a raw string or an OTLP any value as described at
+                              https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                              It can contain placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            example:
+                              kvlistValue:
+                                values:
+                                  - key: mesh
+                                    value:
+                                      stringValue: '%KUMA_MESH%'
+                            x-kubernetes-preserve-unknown-fields: true
+                          endpoint:
+                            description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                            type: string
+                            example: 'otel-collector:4317'
+                            minLength: 1
+                        required:
+                          - endpoint
+                      tcp:
+                        description: TCPBackend defines a TCP logging backend.
+                        type: object
+                        properties:
+                          address:
+                            description: Address of the TCP logging backend
+                            type: string
+                            example: '127.0.0.1:5000'
+                            minLength: 1
+                          format:
+                            description: |-
+                              Format of access logs. Placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            type: object
+                            properties:
+                              json:
+                                type: array
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                    - key
+                                    - value
+                                  type: object
+                                example:
+                                  - key: start_time
+                                    value: '%START_TIME%'
+                                  - key: bytes_received
+                                    value: '%BYTES_RECEIVED%'
+                              omitEmptyValues:
+                                type: boolean
+                                default: false
+                              plain:
+                                type: string
+                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                              type:
+                                type: string
+                                enum:
+                                  - Plain
+                                  - Json
+                            required:
+                              - type
+                        required:
+                          - address
+                      type:
+                        type: string
+                        enum:
+                          - Tcp
+                          - File
+                          - OpenTelemetry
+                    required:
+                      - type
+                    type: object
+          required:
+            - default
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              backends: []
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined in-place.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+      to:
+        description: To list makes a match between the consumed services and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of destinations referenced in
+                'targetRef'
+              type: object
+              properties:
+                backends:
+                  type: array
+                  items:
+                    properties:
+                      file:
+                        description: FileBackend defines configuration for file based access logs
+                        type: object
+                        properties:
+                          format:
+                            description: |-
+                              Format of access logs. Placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            type: object
+                            properties:
+                              json:
+                                type: array
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                    - key
+                                    - value
+                                  type: object
+                                example:
+                                  - key: start_time
+                                    value: '%START_TIME%'
+                                  - key: bytes_received
+                                    value: '%BYTES_RECEIVED%'
+                              omitEmptyValues:
+                                type: boolean
+                                default: false
+                              plain:
+                                type: string
+                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                              type:
+                                type: string
+                                enum:
+                                  - Plain
+                                  - Json
+                            required:
+                              - type
+                          path:
+                            description: Path to a file that logs will be written to
+                            type: string
+                            example: /tmp/access.log
+                            minLength: 1
+                        required:
+                          - path
+                      openTelemetry:
+                        description: Defines an OpenTelemetry logging backend.
+                        type: object
+                        properties:
+                          attributes:
+                            description: |-
+                              Attributes can contain placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            type: array
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                                - key
+                                - value
+                              type: object
+                            example:
+                              - key: mesh
+                                value: '%KUMA_MESH%'
+                          body:
+                            description: |-
+                              Body is a raw string or an OTLP any value as described at
+                              https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                              It can contain placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            example:
+                              kvlistValue:
+                                values:
+                                  - key: mesh
+                                    value:
+                                      stringValue: '%KUMA_MESH%'
+                            x-kubernetes-preserve-unknown-fields: true
+                          endpoint:
+                            description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                            type: string
+                            example: 'otel-collector:4317'
+                            minLength: 1
+                        required:
+                          - endpoint
+                      tcp:
+                        description: TCPBackend defines a TCP logging backend.
+                        type: object
+                        properties:
+                          address:
+                            description: Address of the TCP logging backend
+                            type: string
+                            example: '127.0.0.1:5000'
+                            minLength: 1
+                          format:
+                            description: |-
+                              Format of access logs. Placeholders available on
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                            type: object
+                            properties:
+                              json:
+                                type: array
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                    - key
+                                    - value
+                                  type: object
+                                example:
+                                  - key: start_time
+                                    value: '%START_TIME%'
+                                  - key: bytes_received
+                                    value: '%BYTES_RECEIVED%'
+                              omitEmptyValues:
+                                type: boolean
+                                default: false
+                              plain:
+                                type: string
+                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                              type:
+                                type: string
+                                enum:
+                                  - Plain
+                                  - Json
+                            required:
+                              - type
+                        required:
+                          - address
+                      type:
+                        type: string
+                        enum:
+                          - Tcp
+                          - File
+                          - OpenTelemetry
+                    required:
+                      - type
+                    type: object
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                destinations.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - default
+            - targetRef
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              backends: []
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshAccessLogItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshCircuitBreakerItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshCircuitBreakerItem_Put_RequestBody.yaml
@@ -1,0 +1,1026 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshCircuitBreaker
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mcb_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshCircuitBreaker resource.
+    type: object
+    properties:
+      from:
+        description: From list makes a match between clients and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of destinations
+                referenced in 'targetRef'
+              type: object
+              properties:
+                connectionLimits:
+                  description: |-
+                    ConnectionLimits contains configuration of each circuit breaking limit,
+                    which when exceeded makes the circuit breaker to become open (no traffic
+                    is allowed like no current is allowed in the circuits when physical
+                    circuit breaker ir open)
+                  type: object
+                  properties:
+                    maxConnectionPools:
+                      description: |-
+                        The maximum number of connection pools per cluster that are concurrently
+                        supported at once. Set this for clusters which create a large number of
+                        connection pools.
+                      type: integer
+                      format: int32
+                    maxConnections:
+                      description: |-
+                        The maximum number of connections allowed to be made to the upstream
+                        cluster.
+                      type: integer
+                      format: int32
+                    maxPendingRequests:
+                      description: |-
+                        The maximum number of pending requests that are allowed to the upstream
+                        cluster. This limit is applied as a connection limit for non-HTTP
+                        traffic.
+                      type: integer
+                      format: int32
+                    maxRequests:
+                      description: |-
+                        The maximum number of parallel requests that are allowed to be made
+                        to the upstream cluster. This limit does not apply to non-HTTP traffic.
+                      type: integer
+                      format: int32
+                    maxRetries:
+                      description: |-
+                        The maximum number of parallel retries that will be allowed to
+                        the upstream cluster.
+                      type: integer
+                      format: int32
+                outlierDetection:
+                  description: |-
+                    OutlierDetection contains the configuration of the process of dynamically
+                    determining whether some number of hosts in an upstream cluster are
+                    performing unlike the others and removing them from the healthy load
+                    balancing set. Performance might be along different axes such as
+                    consecutive failures, temporal success rate, temporal latency, etc.
+                    Outlier detection is a form of passive health checking.
+                  type: object
+                  properties:
+                    baseEjectionTime:
+                      description: |-
+                        The base time that a host is ejected for. The real time is equal to
+                        the base time multiplied by the number of times the host has been
+                        ejected.
+                      type: string
+                    detectors:
+                      description: Contains configuration for supported outlier detectors
+                      type: object
+                      properties:
+                        failurePercentage:
+                          description: |-
+                            Failure Percentage based outlier detection functions similarly to success
+                            rate detection, in that it relies on success rate data from each host in
+                            a cluster. However, rather than compare those values to the mean success
+                            rate of the cluster as a whole, they are compared to a flat
+                            user-configured threshold. This threshold is configured via the
+                            outlierDetection.failurePercentageThreshold field.
+                            The other configuration fields for failure percentage based detection are
+                            similar to the fields for success rate detection. As with success rate
+                            detection, detection will not be performed for a host if its request
+                            volume over the aggregation interval is less than the
+                            outlierDetection.detectors.failurePercentage.requestVolume value.
+                            Detection also will not be performed for a cluster if the number of hosts
+                            with the minimum required request volume in an interval is less than the
+                            outlierDetection.detectors.failurePercentage.minimumHosts value.
+                          type: object
+                          properties:
+                            minimumHosts:
+                              description: |-
+                                The minimum number of hosts in a cluster in order to perform failure
+                                percentage-based ejection. If the total number of hosts in the cluster is
+                                less than this value, failure percentage-based ejection will not be
+                                performed.
+                              type: integer
+                              format: int32
+                            requestVolume:
+                              description: |-
+                                The minimum number of total requests that must be collected in one
+                                interval (as defined by the interval duration above) to perform failure
+                                percentage-based ejection for this host. If the volume is lower than this
+                                setting, failure percentage-based ejection will not be performed for this
+                                host.
+                              type: integer
+                              format: int32
+                            threshold:
+                              description: |-
+                                The failure percentage to use when determining failure percentage-based
+                                outlier detection. If the failure percentage of a given host is greater
+                                than or equal to this value, it will be ejected.
+                              type: integer
+                              format: int32
+                        gatewayFailures:
+                          description: |-
+                            In the default mode (outlierDetection.splitExternalLocalOriginErrors is
+                            false) this detection type takes into account a subset of 5xx errors,
+                            called "gateway errors" (502, 503 or 504 status code) and local origin
+                            failures, such as timeout, TCP reset etc.
+                            In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                            this detection type takes into account a subset of 5xx errors, called
+                            "gateway errors" (502, 503 or 504 status code) and is supported only by
+                            the http router.
+                          type: object
+                          properties:
+                            consecutive:
+                              description: |-
+                                The number of consecutive gateway failures (502, 503, 504 status codes)
+                                before a consecutive gateway failure ejection occurs.
+                              type: integer
+                              format: int32
+                        localOriginFailures:
+                          description: |-
+                            This detection type is enabled only when
+                            outlierDetection.splitExternalLocalOriginErrors is true and takes into
+                            account only locally originated errors (timeout, reset, etc).
+                            If Envoy repeatedly cannot connect to an upstream host or communication
+                            with the upstream host is repeatedly interrupted, it will be ejected.
+                            Various locally originated problems are detected: timeout, TCP reset,
+                            ICMP errors, etc. This detection type is supported by http router and
+                            tcp proxy.
+                          type: object
+                          properties:
+                            consecutive:
+                              description: |-
+                                The number of consecutive locally originated failures before ejection
+                                occurs. Parameter takes effect only when splitExternalAndLocalErrors
+                                is set to true.
+                              type: integer
+                              format: int32
+                        successRate:
+                          description: |-
+                            Success Rate based outlier detection aggregates success rate data from
+                            every host in a cluster. Then at given intervals ejects hosts based on
+                            statistical outlier detection. Success Rate outlier detection will not be
+                            calculated for a host if its request volume over the aggregation interval
+                            is less than the outlierDetection.detectors.successRate.requestVolume
+                            value.
+                            Moreover, detection will not be performed for a cluster if the number of
+                            hosts with the minimum required request volume in an interval is less
+                            than the outlierDetection.detectors.successRate.minimumHosts value.
+                            In the default configuration mode
+                            (outlierDetection.splitExternalLocalOriginErrors is false) this detection
+                            type takes into account all types of errors: locally and externally
+                            originated.
+                            In split mode (outlierDetection.splitExternalLocalOriginErrors is true),
+                            locally originated errors and externally originated (transaction) errors
+                            are counted and treated separately.
+                          type: object
+                          properties:
+                            minimumHosts:
+                              description: |-
+                                The number of hosts in a cluster that must have enough request volume to
+                                detect success rate outliers. If the number of hosts is less than this
+                                setting, outlier detection via success rate statistics is not performed
+                                for any host in the cluster.
+                              type: integer
+                              format: int32
+                            requestVolume:
+                              description: |-
+                                The minimum number of total requests that must be collected in one
+                                interval (as defined by the interval duration configured in
+                                outlierDetection section) to include this host in success rate based
+                                outlier detection. If the volume is lower than this setting, outlier
+                                detection via success rate statistics is not performed for that host.
+                              type: integer
+                              format: int32
+                            standardDeviationFactor:
+                              description: |-
+                                This factor is used to determine the ejection threshold for success rate
+                                outlier ejection. The ejection threshold is the difference between
+                                the mean success rate, and the product of this factor and the standard
+                                deviation of the mean success rate: mean - (standard_deviation *
+                                success_rate_standard_deviation_factor).
+                                Either int or decimal represented as string.
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                        totalFailures:
+                          description: |-
+                            In the default mode (outlierDetection.splitExternalAndLocalErrors is
+                            false) this detection type takes into account all generated errors:
+                            locally originated and externally originated (transaction) errors.
+                            In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                            this detection type takes into account only externally originated
+                            (transaction) errors, ignoring locally originated errors.
+                            If an upstream host is an HTTP-server, only 5xx types of error are taken
+                            into account (see Consecutive Gateway Failure for exceptions).
+                            Properly formatted responses, even when they carry an operational error
+                            (like index not found, access denied) are not taken into account.
+                          type: object
+                          properties:
+                            consecutive:
+                              description: |-
+                                The number of consecutive server-side error responses (for HTTP traffic,
+                                5xx responses; for TCP traffic, connection failures; for Redis, failure
+                                to respond PONG; etc.) before a consecutive total failure ejection
+                                occurs.
+                              type: integer
+                              format: int32
+                    disabled:
+                      description: 'When set to true, outlierDetection configuration won''t take any effect'
+                      type: boolean
+                    healthyPanicThreshold:
+                      description: |-
+                        Allows to configure panic threshold for Envoy cluster. If not specified,
+                        the default is 50%. To disable panic mode, set to 0%.
+                        Either int or decimal represented as string.
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      x-kubernetes-int-or-string: true
+                    interval:
+                      description: |-
+                        The time interval between ejection analysis sweeps. This can result in
+                        both new ejections and hosts being returned to service.
+                      type: string
+                    maxEjectionPercent:
+                      description: |-
+                        The maximum % of an upstream cluster that can be ejected due to outlier
+                        detection. Defaults to 10% but will eject at least one host regardless of
+                        the value.
+                      type: integer
+                      format: int32
+                    splitExternalAndLocalErrors:
+                      description: |-
+                        Determines whether to distinguish local origin failures from external
+                        errors. If set to true the following configuration parameters are taken
+                        into account: detectors.localOriginFailures.consecutive
+                      type: boolean
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                destinations.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+      rules:
+        description: |-
+          Rules defines inbound circuit breaker configurations. Currently limited to
+          selecting all inbound traffic, as L7 matching is not yet implemented.
+        type: array
+        items:
+          properties:
+            default:
+              description: Default contains configuration of the inbound circuit breaker
+              type: object
+              properties:
+                connectionLimits:
+                  description: |-
+                    ConnectionLimits contains configuration of each circuit breaking limit,
+                    which when exceeded makes the circuit breaker to become open (no traffic
+                    is allowed like no current is allowed in the circuits when physical
+                    circuit breaker ir open)
+                  type: object
+                  properties:
+                    maxConnectionPools:
+                      description: |-
+                        The maximum number of connection pools per cluster that are concurrently
+                        supported at once. Set this for clusters which create a large number of
+                        connection pools.
+                      type: integer
+                      format: int32
+                    maxConnections:
+                      description: |-
+                        The maximum number of connections allowed to be made to the upstream
+                        cluster.
+                      type: integer
+                      format: int32
+                    maxPendingRequests:
+                      description: |-
+                        The maximum number of pending requests that are allowed to the upstream
+                        cluster. This limit is applied as a connection limit for non-HTTP
+                        traffic.
+                      type: integer
+                      format: int32
+                    maxRequests:
+                      description: |-
+                        The maximum number of parallel requests that are allowed to be made
+                        to the upstream cluster. This limit does not apply to non-HTTP traffic.
+                      type: integer
+                      format: int32
+                    maxRetries:
+                      description: |-
+                        The maximum number of parallel retries that will be allowed to
+                        the upstream cluster.
+                      type: integer
+                      format: int32
+                outlierDetection:
+                  description: |-
+                    OutlierDetection contains the configuration of the process of dynamically
+                    determining whether some number of hosts in an upstream cluster are
+                    performing unlike the others and removing them from the healthy load
+                    balancing set. Performance might be along different axes such as
+                    consecutive failures, temporal success rate, temporal latency, etc.
+                    Outlier detection is a form of passive health checking.
+                  type: object
+                  properties:
+                    baseEjectionTime:
+                      description: |-
+                        The base time that a host is ejected for. The real time is equal to
+                        the base time multiplied by the number of times the host has been
+                        ejected.
+                      type: string
+                    detectors:
+                      description: Contains configuration for supported outlier detectors
+                      type: object
+                      properties:
+                        failurePercentage:
+                          description: |-
+                            Failure Percentage based outlier detection functions similarly to success
+                            rate detection, in that it relies on success rate data from each host in
+                            a cluster. However, rather than compare those values to the mean success
+                            rate of the cluster as a whole, they are compared to a flat
+                            user-configured threshold. This threshold is configured via the
+                            outlierDetection.failurePercentageThreshold field.
+                            The other configuration fields for failure percentage based detection are
+                            similar to the fields for success rate detection. As with success rate
+                            detection, detection will not be performed for a host if its request
+                            volume over the aggregation interval is less than the
+                            outlierDetection.detectors.failurePercentage.requestVolume value.
+                            Detection also will not be performed for a cluster if the number of hosts
+                            with the minimum required request volume in an interval is less than the
+                            outlierDetection.detectors.failurePercentage.minimumHosts value.
+                          type: object
+                          properties:
+                            minimumHosts:
+                              description: |-
+                                The minimum number of hosts in a cluster in order to perform failure
+                                percentage-based ejection. If the total number of hosts in the cluster is
+                                less than this value, failure percentage-based ejection will not be
+                                performed.
+                              type: integer
+                              format: int32
+                            requestVolume:
+                              description: |-
+                                The minimum number of total requests that must be collected in one
+                                interval (as defined by the interval duration above) to perform failure
+                                percentage-based ejection for this host. If the volume is lower than this
+                                setting, failure percentage-based ejection will not be performed for this
+                                host.
+                              type: integer
+                              format: int32
+                            threshold:
+                              description: |-
+                                The failure percentage to use when determining failure percentage-based
+                                outlier detection. If the failure percentage of a given host is greater
+                                than or equal to this value, it will be ejected.
+                              type: integer
+                              format: int32
+                        gatewayFailures:
+                          description: |-
+                            In the default mode (outlierDetection.splitExternalLocalOriginErrors is
+                            false) this detection type takes into account a subset of 5xx errors,
+                            called "gateway errors" (502, 503 or 504 status code) and local origin
+                            failures, such as timeout, TCP reset etc.
+                            In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                            this detection type takes into account a subset of 5xx errors, called
+                            "gateway errors" (502, 503 or 504 status code) and is supported only by
+                            the http router.
+                          type: object
+                          properties:
+                            consecutive:
+                              description: |-
+                                The number of consecutive gateway failures (502, 503, 504 status codes)
+                                before a consecutive gateway failure ejection occurs.
+                              type: integer
+                              format: int32
+                        localOriginFailures:
+                          description: |-
+                            This detection type is enabled only when
+                            outlierDetection.splitExternalLocalOriginErrors is true and takes into
+                            account only locally originated errors (timeout, reset, etc).
+                            If Envoy repeatedly cannot connect to an upstream host or communication
+                            with the upstream host is repeatedly interrupted, it will be ejected.
+                            Various locally originated problems are detected: timeout, TCP reset,
+                            ICMP errors, etc. This detection type is supported by http router and
+                            tcp proxy.
+                          type: object
+                          properties:
+                            consecutive:
+                              description: |-
+                                The number of consecutive locally originated failures before ejection
+                                occurs. Parameter takes effect only when splitExternalAndLocalErrors
+                                is set to true.
+                              type: integer
+                              format: int32
+                        successRate:
+                          description: |-
+                            Success Rate based outlier detection aggregates success rate data from
+                            every host in a cluster. Then at given intervals ejects hosts based on
+                            statistical outlier detection. Success Rate outlier detection will not be
+                            calculated for a host if its request volume over the aggregation interval
+                            is less than the outlierDetection.detectors.successRate.requestVolume
+                            value.
+                            Moreover, detection will not be performed for a cluster if the number of
+                            hosts with the minimum required request volume in an interval is less
+                            than the outlierDetection.detectors.successRate.minimumHosts value.
+                            In the default configuration mode
+                            (outlierDetection.splitExternalLocalOriginErrors is false) this detection
+                            type takes into account all types of errors: locally and externally
+                            originated.
+                            In split mode (outlierDetection.splitExternalLocalOriginErrors is true),
+                            locally originated errors and externally originated (transaction) errors
+                            are counted and treated separately.
+                          type: object
+                          properties:
+                            minimumHosts:
+                              description: |-
+                                The number of hosts in a cluster that must have enough request volume to
+                                detect success rate outliers. If the number of hosts is less than this
+                                setting, outlier detection via success rate statistics is not performed
+                                for any host in the cluster.
+                              type: integer
+                              format: int32
+                            requestVolume:
+                              description: |-
+                                The minimum number of total requests that must be collected in one
+                                interval (as defined by the interval duration configured in
+                                outlierDetection section) to include this host in success rate based
+                                outlier detection. If the volume is lower than this setting, outlier
+                                detection via success rate statistics is not performed for that host.
+                              type: integer
+                              format: int32
+                            standardDeviationFactor:
+                              description: |-
+                                This factor is used to determine the ejection threshold for success rate
+                                outlier ejection. The ejection threshold is the difference between
+                                the mean success rate, and the product of this factor and the standard
+                                deviation of the mean success rate: mean - (standard_deviation *
+                                success_rate_standard_deviation_factor).
+                                Either int or decimal represented as string.
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                        totalFailures:
+                          description: |-
+                            In the default mode (outlierDetection.splitExternalAndLocalErrors is
+                            false) this detection type takes into account all generated errors:
+                            locally originated and externally originated (transaction) errors.
+                            In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                            this detection type takes into account only externally originated
+                            (transaction) errors, ignoring locally originated errors.
+                            If an upstream host is an HTTP-server, only 5xx types of error are taken
+                            into account (see Consecutive Gateway Failure for exceptions).
+                            Properly formatted responses, even when they carry an operational error
+                            (like index not found, access denied) are not taken into account.
+                          type: object
+                          properties:
+                            consecutive:
+                              description: |-
+                                The number of consecutive server-side error responses (for HTTP traffic,
+                                5xx responses; for TCP traffic, connection failures; for Redis, failure
+                                to respond PONG; etc.) before a consecutive total failure ejection
+                                occurs.
+                              type: integer
+                              format: int32
+                    disabled:
+                      description: 'When set to true, outlierDetection configuration won''t take any effect'
+                      type: boolean
+                    healthyPanicThreshold:
+                      description: |-
+                        Allows to configure panic threshold for Envoy cluster. If not specified,
+                        the default is 50%. To disable panic mode, set to 0%.
+                        Either int or decimal represented as string.
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      x-kubernetes-int-or-string: true
+                    interval:
+                      description: |-
+                        The time interval between ejection analysis sweeps. This can result in
+                        both new ejections and hosts being returned to service.
+                      type: string
+                    maxEjectionPercent:
+                      description: |-
+                        The maximum % of an upstream cluster that can be ejected due to outlier
+                        detection. Defaults to 10% but will eject at least one host regardless of
+                        the value.
+                      type: integer
+                      format: int32
+                    splitExternalAndLocalErrors:
+                      description: |-
+                        Determines whether to distinguish local origin failures from external
+                        errors. If set to true the following configuration parameters are taken
+                        into account: detectors.localOriginFailures.consecutive
+                      type: boolean
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              connectionLimits:
+                maxConnections: 2
+                maxPendingRequests: 8
+                maxRetries: 2
+                maxRequests: 2
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined in place.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+      to:
+        description: |-
+          To list makes a match between the consumed services and corresponding
+          configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of destinations
+                referenced in 'targetRef'
+              type: object
+              default:
+                connectionLimits:
+                  maxConnections: 2
+                  maxPendingRequests: 8
+                  maxRetries: 2
+                  maxRequests: 2
+              properties:
+                connectionLimits:
+                  description: |-
+                    ConnectionLimits contains configuration of each circuit breaking limit,
+                    which when exceeded makes the circuit breaker to become open (no traffic
+                    is allowed like no current is allowed in the circuits when physical
+                    circuit breaker ir open)
+                  type: object
+                  properties:
+                    maxConnectionPools:
+                      description: |-
+                        The maximum number of connection pools per cluster that are concurrently
+                        supported at once. Set this for clusters which create a large number of
+                        connection pools.
+                      type: integer
+                      format: int32
+                    maxConnections:
+                      description: |-
+                        The maximum number of connections allowed to be made to the upstream
+                        cluster.
+                      type: integer
+                      format: int32
+                    maxPendingRequests:
+                      description: |-
+                        The maximum number of pending requests that are allowed to the upstream
+                        cluster. This limit is applied as a connection limit for non-HTTP
+                        traffic.
+                      type: integer
+                      format: int32
+                    maxRequests:
+                      description: |-
+                        The maximum number of parallel requests that are allowed to be made
+                        to the upstream cluster. This limit does not apply to non-HTTP traffic.
+                      type: integer
+                      format: int32
+                    maxRetries:
+                      description: |-
+                        The maximum number of parallel retries that will be allowed to
+                        the upstream cluster.
+                      type: integer
+                      format: int32
+                outlierDetection:
+                  description: |-
+                    OutlierDetection contains the configuration of the process of dynamically
+                    determining whether some number of hosts in an upstream cluster are
+                    performing unlike the others and removing them from the healthy load
+                    balancing set. Performance might be along different axes such as
+                    consecutive failures, temporal success rate, temporal latency, etc.
+                    Outlier detection is a form of passive health checking.
+                  type: object
+                  properties:
+                    baseEjectionTime:
+                      description: |-
+                        The base time that a host is ejected for. The real time is equal to
+                        the base time multiplied by the number of times the host has been
+                        ejected.
+                      type: string
+                    detectors:
+                      description: Contains configuration for supported outlier detectors
+                      type: object
+                      properties:
+                        failurePercentage:
+                          description: |-
+                            Failure Percentage based outlier detection functions similarly to success
+                            rate detection, in that it relies on success rate data from each host in
+                            a cluster. However, rather than compare those values to the mean success
+                            rate of the cluster as a whole, they are compared to a flat
+                            user-configured threshold. This threshold is configured via the
+                            outlierDetection.failurePercentageThreshold field.
+                            The other configuration fields for failure percentage based detection are
+                            similar to the fields for success rate detection. As with success rate
+                            detection, detection will not be performed for a host if its request
+                            volume over the aggregation interval is less than the
+                            outlierDetection.detectors.failurePercentage.requestVolume value.
+                            Detection also will not be performed for a cluster if the number of hosts
+                            with the minimum required request volume in an interval is less than the
+                            outlierDetection.detectors.failurePercentage.minimumHosts value.
+                          type: object
+                          properties:
+                            minimumHosts:
+                              description: |-
+                                The minimum number of hosts in a cluster in order to perform failure
+                                percentage-based ejection. If the total number of hosts in the cluster is
+                                less than this value, failure percentage-based ejection will not be
+                                performed.
+                              type: integer
+                              format: int32
+                            requestVolume:
+                              description: |-
+                                The minimum number of total requests that must be collected in one
+                                interval (as defined by the interval duration above) to perform failure
+                                percentage-based ejection for this host. If the volume is lower than this
+                                setting, failure percentage-based ejection will not be performed for this
+                                host.
+                              type: integer
+                              format: int32
+                            threshold:
+                              description: |-
+                                The failure percentage to use when determining failure percentage-based
+                                outlier detection. If the failure percentage of a given host is greater
+                                than or equal to this value, it will be ejected.
+                              type: integer
+                              format: int32
+                        gatewayFailures:
+                          description: |-
+                            In the default mode (outlierDetection.splitExternalLocalOriginErrors is
+                            false) this detection type takes into account a subset of 5xx errors,
+                            called "gateway errors" (502, 503 or 504 status code) and local origin
+                            failures, such as timeout, TCP reset etc.
+                            In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                            this detection type takes into account a subset of 5xx errors, called
+                            "gateway errors" (502, 503 or 504 status code) and is supported only by
+                            the http router.
+                          type: object
+                          properties:
+                            consecutive:
+                              description: |-
+                                The number of consecutive gateway failures (502, 503, 504 status codes)
+                                before a consecutive gateway failure ejection occurs.
+                              type: integer
+                              format: int32
+                        localOriginFailures:
+                          description: |-
+                            This detection type is enabled only when
+                            outlierDetection.splitExternalLocalOriginErrors is true and takes into
+                            account only locally originated errors (timeout, reset, etc).
+                            If Envoy repeatedly cannot connect to an upstream host or communication
+                            with the upstream host is repeatedly interrupted, it will be ejected.
+                            Various locally originated problems are detected: timeout, TCP reset,
+                            ICMP errors, etc. This detection type is supported by http router and
+                            tcp proxy.
+                          type: object
+                          properties:
+                            consecutive:
+                              description: |-
+                                The number of consecutive locally originated failures before ejection
+                                occurs. Parameter takes effect only when splitExternalAndLocalErrors
+                                is set to true.
+                              type: integer
+                              format: int32
+                        successRate:
+                          description: |-
+                            Success Rate based outlier detection aggregates success rate data from
+                            every host in a cluster. Then at given intervals ejects hosts based on
+                            statistical outlier detection. Success Rate outlier detection will not be
+                            calculated for a host if its request volume over the aggregation interval
+                            is less than the outlierDetection.detectors.successRate.requestVolume
+                            value.
+                            Moreover, detection will not be performed for a cluster if the number of
+                            hosts with the minimum required request volume in an interval is less
+                            than the outlierDetection.detectors.successRate.minimumHosts value.
+                            In the default configuration mode
+                            (outlierDetection.splitExternalLocalOriginErrors is false) this detection
+                            type takes into account all types of errors: locally and externally
+                            originated.
+                            In split mode (outlierDetection.splitExternalLocalOriginErrors is true),
+                            locally originated errors and externally originated (transaction) errors
+                            are counted and treated separately.
+                          type: object
+                          properties:
+                            minimumHosts:
+                              description: |-
+                                The number of hosts in a cluster that must have enough request volume to
+                                detect success rate outliers. If the number of hosts is less than this
+                                setting, outlier detection via success rate statistics is not performed
+                                for any host in the cluster.
+                              type: integer
+                              format: int32
+                            requestVolume:
+                              description: |-
+                                The minimum number of total requests that must be collected in one
+                                interval (as defined by the interval duration configured in
+                                outlierDetection section) to include this host in success rate based
+                                outlier detection. If the volume is lower than this setting, outlier
+                                detection via success rate statistics is not performed for that host.
+                              type: integer
+                              format: int32
+                            standardDeviationFactor:
+                              description: |-
+                                This factor is used to determine the ejection threshold for success rate
+                                outlier ejection. The ejection threshold is the difference between
+                                the mean success rate, and the product of this factor and the standard
+                                deviation of the mean success rate: mean - (standard_deviation *
+                                success_rate_standard_deviation_factor).
+                                Either int or decimal represented as string.
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                        totalFailures:
+                          description: |-
+                            In the default mode (outlierDetection.splitExternalAndLocalErrors is
+                            false) this detection type takes into account all generated errors:
+                            locally originated and externally originated (transaction) errors.
+                            In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                            this detection type takes into account only externally originated
+                            (transaction) errors, ignoring locally originated errors.
+                            If an upstream host is an HTTP-server, only 5xx types of error are taken
+                            into account (see Consecutive Gateway Failure for exceptions).
+                            Properly formatted responses, even when they carry an operational error
+                            (like index not found, access denied) are not taken into account.
+                          type: object
+                          properties:
+                            consecutive:
+                              description: |-
+                                The number of consecutive server-side error responses (for HTTP traffic,
+                                5xx responses; for TCP traffic, connection failures; for Redis, failure
+                                to respond PONG; etc.) before a consecutive total failure ejection
+                                occurs.
+                              type: integer
+                              format: int32
+                    disabled:
+                      description: 'When set to true, outlierDetection configuration won''t take any effect'
+                      type: boolean
+                    healthyPanicThreshold:
+                      description: |-
+                        Allows to configure panic threshold for Envoy cluster. If not specified,
+                        the default is 50%. To disable panic mode, set to 0%.
+                        Either int or decimal represented as string.
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      x-kubernetes-int-or-string: true
+                    interval:
+                      description: |-
+                        The time interval between ejection analysis sweeps. This can result in
+                        both new ejections and hosts being returned to service.
+                      type: string
+                    maxEjectionPercent:
+                      description: |-
+                        The maximum % of an upstream cluster that can be ejected due to outlier
+                        detection. Defaults to 10% but will eject at least one host regardless of
+                        the value.
+                      type: integer
+                      format: int32
+                    splitExternalAndLocalErrors:
+                      description: |-
+                        Determines whether to distinguish local origin failures from external
+                        errors. If set to true the following configuration parameters are taken
+                        into account: detectors.localOriginFailures.consecutive
+                      type: boolean
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                destinations.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              connectionLimits:
+                maxConnections: 2
+                maxPendingRequests: 8
+                maxRetries: 2
+                maxRequests: 2
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshCircuitBreakerItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshFaultInjectionItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshFaultInjectionItem_Put_RequestBody.yaml
@@ -1,0 +1,519 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshFaultInjection
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mfi_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshFaultInjection resource.
+    type: object
+    properties:
+      from:
+        description: From list makes a match between clients and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of destinations referenced in
+                'targetRef'
+              type: object
+              properties:
+                http:
+                  description: Http allows to define list of Http faults between dataplanes.
+                  type: array
+                  items:
+                    description: FaultInjection defines the configuration of faults between dataplanes.
+                    properties:
+                      abort:
+                        description: |-
+                          Abort defines a configuration of not delivering requests to destination
+                          service and replacing the responses from destination dataplane by
+                          predefined status code
+                        type: object
+                        properties:
+                          httpStatus:
+                            description: HTTP status code which will be returned to source side
+                            type: integer
+                            format: int32
+                          percentage:
+                            description: |-
+                              Percentage of requests on which abort will be injected, has to be
+                              either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        required:
+                          - httpStatus
+                          - percentage
+                      delay:
+                        description: Delay defines configuration of delaying a response from a destination
+                        type: object
+                        properties:
+                          percentage:
+                            description: |-
+                              Percentage of requests on which delay will be injected, has to be
+                              either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                          value:
+                            description: The duration during which the response will be delayed
+                            type: string
+                        required:
+                          - percentage
+                          - value
+                      responseBandwidth:
+                        description: |-
+                          ResponseBandwidth defines a configuration to limit the speed of
+                          responding to the requests
+                        type: object
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
+                              10kbps
+                            type: string
+                          percentage:
+                            description: |-
+                              Percentage of requests on which response bandwidth limit will be
+                              either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        required:
+                          - limit
+                          - percentage
+                    type: object
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                destinations.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+      rules:
+        description: Rules defines inbound fault injection configuration
+        type: array
+        items:
+          properties:
+            default:
+              description: Default defines fault configuration
+              type: object
+              properties:
+                http:
+                  description: Http allows to define list of Http faults between dataplanes.
+                  type: array
+                  items:
+                    description: FaultInjection defines the configuration of faults between dataplanes.
+                    properties:
+                      abort:
+                        description: |-
+                          Abort defines a configuration of not delivering requests to destination
+                          service and replacing the responses from destination dataplane by
+                          predefined status code
+                        type: object
+                        properties:
+                          httpStatus:
+                            description: HTTP status code which will be returned to source side
+                            type: integer
+                            format: int32
+                          percentage:
+                            description: |-
+                              Percentage of requests on which abort will be injected, has to be
+                              either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        required:
+                          - httpStatus
+                          - percentage
+                      delay:
+                        description: Delay defines configuration of delaying a response from a destination
+                        type: object
+                        properties:
+                          percentage:
+                            description: |-
+                              Percentage of requests on which delay will be injected, has to be
+                              either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                          value:
+                            description: The duration during which the response will be delayed
+                            type: string
+                        required:
+                          - percentage
+                          - value
+                      responseBandwidth:
+                        description: |-
+                          ResponseBandwidth defines a configuration to limit the speed of
+                          responding to the requests
+                        type: object
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
+                              10kbps
+                            type: string
+                          percentage:
+                            description: |-
+                              Percentage of requests on which response bandwidth limit will be
+                              either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        required:
+                          - limit
+                          - percentage
+                    type: object
+            matches:
+              description: Matches defines list of matches for which fault injection will be applied
+              type: array
+              items:
+                properties:
+                  spiffeID:
+                    description: SpiffeID defines a matcher configuration for SpiffeID matching
+                    type: object
+                    properties:
+                      type:
+                        description: Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                        type: string
+                        enum:
+                          - Exact
+                          - Prefix
+                      value:
+                        description: Value is SpiffeId of a client that needs to match for the configuration to be applied
+                        type: string
+                    required:
+                      - type
+                      - value
+                type: object
+          required:
+            - default
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              http: []
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined inplace.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+      to:
+        description: To list makes a match between clients and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of destinations referenced in
+                'targetRef'
+              type: object
+              properties:
+                http:
+                  description: Http allows to define list of Http faults between dataplanes.
+                  type: array
+                  items:
+                    description: FaultInjection defines the configuration of faults between dataplanes.
+                    properties:
+                      abort:
+                        description: |-
+                          Abort defines a configuration of not delivering requests to destination
+                          service and replacing the responses from destination dataplane by
+                          predefined status code
+                        type: object
+                        properties:
+                          httpStatus:
+                            description: HTTP status code which will be returned to source side
+                            type: integer
+                            format: int32
+                          percentage:
+                            description: |-
+                              Percentage of requests on which abort will be injected, has to be
+                              either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        required:
+                          - httpStatus
+                          - percentage
+                      delay:
+                        description: Delay defines configuration of delaying a response from a destination
+                        type: object
+                        properties:
+                          percentage:
+                            description: |-
+                              Percentage of requests on which delay will be injected, has to be
+                              either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                          value:
+                            description: The duration during which the response will be delayed
+                            type: string
+                        required:
+                          - percentage
+                          - value
+                      responseBandwidth:
+                        description: |-
+                          ResponseBandwidth defines a configuration to limit the speed of
+                          responding to the requests
+                        type: object
+                        properties:
+                          limit:
+                            description: |-
+                              Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
+                              10kbps
+                            type: string
+                          percentage:
+                            description: |-
+                              Percentage of requests on which response bandwidth limit will be
+                              either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        required:
+                          - limit
+                          - percentage
+                    type: object
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                destinations.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              http: []
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshFaultInjectionItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshHTTPRouteItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshHTTPRouteItem_Put_RequestBody.yaml
@@ -1,0 +1,661 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshHTTPRoute
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mhttpr_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshHTTPRoute resource.
+    type: object
+    properties:
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined inplace.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+      to:
+        description: To matches destination services of requests and holds configuration.
+        type: array
+        items:
+          properties:
+            hostnames:
+              description: |-
+                Hostnames is only valid when targeting MeshGateway and limits the
+                effects of the rules to requests to this hostname.
+                Given hostnames must intersect with the hostname of the listeners the
+                route attaches to.
+              type: array
+              items:
+                type: string
+            rules:
+              description: |-
+                Rules contains the routing rules applies to a combination of top-level
+                targetRef and the targetRef in this entry.
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default holds routing rules that can be merged with rules from other
+                      policies.
+                    type: object
+                    properties:
+                      backendRefs:
+                        type: array
+                        items:
+                          description: BackendRef defines where to forward traffic.
+                          properties:
+                            kind:
+                              description: Kind of the referenced resource
+                              type: string
+                              enum:
+                                - Mesh
+                                - MeshSubset
+                                - MeshGateway
+                                - MeshService
+                                - MeshExternalService
+                                - MeshMultiZoneService
+                                - MeshServiceSubset
+                                - MeshHTTPRoute
+                                - Dataplane
+                            labels:
+                              description: |-
+                                Labels are used to select group of MeshServices that match labels. Either Labels or
+                                Name and Namespace can be used.
+                              type: object
+                              additionalProperties:
+                                type: string
+                            mesh:
+                              description: Mesh is reserved for future use to identify cross mesh resources.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                                `MeshServiceSubset` and `MeshGatewayRoute`
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                                will be targeted.
+                              type: string
+                            port:
+                              description: Port is only supported when this ref refers to a real MeshService object
+                              type: integer
+                              format: int32
+                            proxyTypes:
+                              description: |-
+                                ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                                all data plane types are targeted by the policy.
+                              type: array
+                              items:
+                                enum:
+                                  - Sidecar
+                                  - Gateway
+                                type: string
+                            sectionName:
+                              description: |-
+                                SectionName is used to target specific section of resource.
+                                For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                              type: string
+                            tags:
+                              description: |-
+                                Tags used to select a subset of proxies by tags. Can only be used with kinds
+                                `MeshSubset` and `MeshServiceSubset`
+                              type: object
+                              additionalProperties:
+                                type: string
+                            weight:
+                              type: integer
+                              default: 1
+                              minimum: 0
+                          required:
+                            - kind
+                          type: object
+                      filters:
+                        type: array
+                        items:
+                          properties:
+                            requestHeaderModifier:
+                              description: |-
+                                Only one action is supported per header name.
+                                Configuration to set or add multiple values for a header must use RFC 7230
+                                header value formatting, separating each value with a comma.
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                remove:
+                                  type: array
+                                  items:
+                                    type: string
+                                  maxItems: 16
+                                set:
+                                  type: array
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                            requestMirror:
+                              type: object
+                              properties:
+                                backendRef:
+                                  description: BackendRef defines where to forward traffic.
+                                  type: object
+                                  properties:
+                                    kind:
+                                      description: Kind of the referenced resource
+                                      type: string
+                                      enum:
+                                        - Mesh
+                                        - MeshSubset
+                                        - MeshGateway
+                                        - MeshService
+                                        - MeshExternalService
+                                        - MeshMultiZoneService
+                                        - MeshServiceSubset
+                                        - MeshHTTPRoute
+                                        - Dataplane
+                                    labels:
+                                      description: |-
+                                        Labels are used to select group of MeshServices that match labels. Either Labels or
+                                        Name and Namespace can be used.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    mesh:
+                                      description: Mesh is reserved for future use to identify cross mesh resources.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                                        `MeshServiceSubset` and `MeshGatewayRoute`
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                                        will be targeted.
+                                      type: string
+                                    port:
+                                      description: Port is only supported when this ref refers to a real MeshService object
+                                      type: integer
+                                      format: int32
+                                    proxyTypes:
+                                      description: |-
+                                        ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                                        all data plane types are targeted by the policy.
+                                      type: array
+                                      items:
+                                        enum:
+                                          - Sidecar
+                                          - Gateway
+                                        type: string
+                                    sectionName:
+                                      description: |-
+                                        SectionName is used to target specific section of resource.
+                                        For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                                      type: string
+                                    tags:
+                                      description: |-
+                                        Tags used to select a subset of proxies by tags. Can only be used with kinds
+                                        `MeshSubset` and `MeshServiceSubset`
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    weight:
+                                      type: integer
+                                      default: 1
+                                      minimum: 0
+                                  required:
+                                    - kind
+                                percentage:
+                                  description: |-
+                                    Percentage of requests to mirror. If not specified, all requests
+                                    to the target cluster will be mirrored.
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - backendRef
+                            requestRedirect:
+                              type: object
+                              properties:
+                                hostname:
+                                  description: |-
+                                    PreciseHostname is the fully qualified domain name of a network host. This
+                                    matches the RFC 1123 definition of a hostname with 1 notable exception that
+                                    numeric IP addresses are not allowed.
+
+                                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                                    character. No other punctuation is allowed.
+                                  type: string
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+                                path:
+                                  description: |-
+                                    Path defines parameters used to modify the path of the incoming request.
+                                    The modified path is then used to construct the location header.
+                                    When empty, the request path is used as-is.
+                                  type: object
+                                  properties:
+                                    replaceFullPath:
+                                      type: string
+                                    replacePrefixMatch:
+                                      type: string
+                                    type:
+                                      type: string
+                                      enum:
+                                        - ReplaceFullPath
+                                        - ReplacePrefixMatch
+                                  required:
+                                    - type
+                                port:
+                                  description: |-
+                                    Port is the port to be used in the value of the `Location`
+                                    header in the response.
+                                    When empty, port (if specified) of the request is used.
+                                  type: integer
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                scheme:
+                                  type: string
+                                  enum:
+                                    - http
+                                    - https
+                                statusCode:
+                                  description: StatusCode is the HTTP status code to be used in response.
+                                  type: integer
+                                  default: 302
+                                  enum:
+                                    - 301
+                                    - 302
+                                    - 303
+                                    - 307
+                                    - 308
+                            responseHeaderModifier:
+                              description: |-
+                                Only one action is supported per header name.
+                                Configuration to set or add multiple values for a header must use RFC 7230
+                                header value formatting, separating each value with a comma.
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                remove:
+                                  type: array
+                                  items:
+                                    type: string
+                                  maxItems: 16
+                                set:
+                                  type: array
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                            type:
+                              type: string
+                              enum:
+                                - RequestHeaderModifier
+                                - ResponseHeaderModifier
+                                - RequestRedirect
+                                - URLRewrite
+                                - RequestMirror
+                            urlRewrite:
+                              type: object
+                              properties:
+                                hostToBackendHostname:
+                                  description: |-
+                                    HostToBackendHostname rewrites the hostname to the hostname of the
+                                    upstream host. This option is only available when targeting MeshGateways.
+                                  type: boolean
+                                hostname:
+                                  description: Hostname is the value to be used to replace the host header value during forwarding.
+                                  type: string
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+                                path:
+                                  description: Path defines a path rewrite.
+                                  type: object
+                                  properties:
+                                    replaceFullPath:
+                                      type: string
+                                    replacePrefixMatch:
+                                      type: string
+                                    type:
+                                      type: string
+                                      enum:
+                                        - ReplaceFullPath
+                                        - ReplacePrefixMatch
+                                  required:
+                                    - type
+                          required:
+                            - type
+                          type: object
+                  matches:
+                    description: |-
+                      Matches describes how to match HTTP requests this rule should be applied
+                      to.
+                    type: array
+                    items:
+                      properties:
+                        headers:
+                          type: array
+                          items:
+                            description: |-
+                              HeaderMatch describes how to select an HTTP route by matching HTTP request
+                              headers.
+                            properties:
+                              name:
+                                description: |-
+                                  Name is the name of the HTTP Header to be matched. Name MUST be lower case
+                                  as they will be handled with case insensitivity (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                type: string
+                                maxLength: 256
+                                minLength: 1
+                                pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                              type:
+                                description: Type specifies how to match against the value of the header.
+                                type: string
+                                default: Exact
+                                enum:
+                                  - Exact
+                                  - Present
+                                  - RegularExpression
+                                  - Absent
+                                  - Prefix
+                              value:
+                                description: Value is the value of HTTP Header to be matched.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                        method:
+                          type: string
+                          enum:
+                            - CONNECT
+                            - DELETE
+                            - GET
+                            - HEAD
+                            - OPTIONS
+                            - PATCH
+                            - POST
+                            - PUT
+                            - TRACE
+                        path:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - Exact
+                                - PathPrefix
+                                - RegularExpression
+                            value:
+                              description: |-
+                                Exact or prefix matches must be an absolute path. A prefix matches only
+                                if separated by a slash or the entire path.
+                              type: string
+                              minLength: 1
+                          required:
+                            - type
+                            - value
+                        queryParams:
+                          description: |-
+                            QueryParams matches based on HTTP URL query parameters. Multiple matches
+                            are ANDed together such that all listed matches must succeed.
+                          type: array
+                          items:
+                            properties:
+                              name:
+                                type: string
+                                minLength: 1
+                              type:
+                                type: string
+                                enum:
+                                  - Exact
+                                  - RegularExpression
+                              value:
+                                type: string
+                            required:
+                              - name
+                              - type
+                              - value
+                            type: object
+                      type: object
+                    minItems: 1
+                required:
+                  - default
+                  - matches
+                type: object
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                request destinations.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - rules
+            - targetRef
+          type: object
+          default:
+            rules: []
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshHTTPRouteItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshHealthCheckItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshHealthCheckItem_Put_RequestBody.yaml
@@ -1,0 +1,392 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshHealthCheck
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mhc_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshHealthCheck resource.
+    type: object
+    properties:
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined inplace.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+      to:
+        description: To list makes a match between the consumed services and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of destinations referenced in
+                'targetRef'
+              type: object
+              properties:
+                alwaysLogHealthCheckFailures:
+                  description: |-
+                    If set to true, health check failure events will always be logged. If set
+                    to false, only the initial health check failure event will be logged. The
+                    default value is false.
+                  type: boolean
+                eventLogPath:
+                  description: |-
+                    Specifies the path to the file where Envoy can log health check events.
+                    If empty, no event log will be written.
+                  type: string
+                failTrafficOnPanic:
+                  description: |-
+                    If set to true, Envoy will not consider any hosts when the cluster is in
+                    'panic mode'. Instead, the cluster will fail all requests as if all hosts
+                    are unhealthy. This can help avoid potentially overwhelming a failing
+                    service.
+                  type: boolean
+                grpc:
+                  description: |-
+                    GrpcHealthCheck defines gRPC configuration which will instruct the service
+                    the health check will be made for is a gRPC service.
+                  type: object
+                  properties:
+                    authority:
+                      description: |-
+                        The value of the :authority header in the gRPC health check request,
+                        by default name of the cluster this health check is associated with
+                      type: string
+                    disabled:
+                      description: If true the GrpcHealthCheck is disabled
+                      type: boolean
+                    serviceName:
+                      description: Service name parameter which will be sent to gRPC service
+                      type: string
+                healthyPanicThreshold:
+                  description: |-
+                    Allows to configure panic threshold for Envoy cluster. If not specified,
+                    the default is 50%. To disable panic mode, set to 0%.
+                    Either int or decimal represented as string.
+
+                    Deprecated: the setting has been moved to MeshCircuitBreaker policy,
+                    please use MeshCircuitBreaker policy instead.
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  x-kubernetes-int-or-string: true
+                healthyThreshold:
+                  description: |-
+                    Number of consecutive healthy checks before considering a host healthy.
+                    If not specified then the default value is 1
+                  type: integer
+                  format: int32
+                http:
+                  description: |-
+                    HttpHealthCheck defines HTTP configuration which will instruct the service
+                    the health check will be made for is an HTTP service.
+                  type: object
+                  properties:
+                    disabled:
+                      description: If true the HttpHealthCheck is disabled
+                      type: boolean
+                    expectedStatuses:
+                      description: List of HTTP response statuses which are considered healthy
+                      type: array
+                      items:
+                        format: int32
+                        type: integer
+                    path:
+                      description: |-
+                        The HTTP path which will be requested during the health check
+                        (ie. /health)
+                        If not specified then the default value is "/"
+                      type: string
+                    requestHeadersToAdd:
+                      description: |-
+                        The list of HTTP headers which should be added to each health check
+                        request
+                      type: object
+                      properties:
+                        add:
+                          type: array
+                          items:
+                            properties:
+                              name:
+                                type: string
+                                maxLength: 256
+                                minLength: 1
+                                pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                              value:
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          maxItems: 16
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        set:
+                          type: array
+                          items:
+                            properties:
+                              name:
+                                type: string
+                                maxLength: 256
+                                minLength: 1
+                                pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                              value:
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          maxItems: 16
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                initialJitter:
+                  description: |-
+                    If specified, Envoy will start health checking after a random time in
+                    ms between 0 and initialJitter. This only applies to the first health
+                    check.
+                  type: string
+                interval:
+                  description: |-
+                    Interval between consecutive health checks.
+                    If not specified then the default value is 1m
+                  type: string
+                intervalJitter:
+                  description: |-
+                    If specified, during every interval Envoy will add IntervalJitter to the
+                    wait time.
+                  type: string
+                intervalJitterPercent:
+                  description: |-
+                    If specified, during every interval Envoy will add IntervalJitter *
+                    IntervalJitterPercent / 100 to the wait time. If IntervalJitter and
+                    IntervalJitterPercent are both set, both of them will be used to
+                    increase the wait time.
+                  type: integer
+                  format: int32
+                noTrafficInterval:
+                  description: |-
+                    The "no traffic interval" is a special health check interval that is used
+                    when a cluster has never had traffic routed to it. This lower interval
+                    allows cluster information to be kept up to date, without sending a
+                    potentially large amount of active health checking traffic for no reason.
+                    Once a cluster has been used for traffic routing, Envoy will shift back
+                    to using the standard health check interval that is defined. Note that
+                    this interval takes precedence over any other. The default value for "no
+                    traffic interval" is 60 seconds.
+                  type: string
+                reuseConnection:
+                  description: Reuse health check connection between health checks. Default is true.
+                  type: boolean
+                tcp:
+                  description: |-
+                    TcpHealthCheck defines configuration for specifying bytes to send and
+                    expected response during the health check
+                  type: object
+                  properties:
+                    disabled:
+                      description: If true the TcpHealthCheck is disabled
+                      type: boolean
+                    receive:
+                      description: |-
+                        List of Base64 encoded blocks of strings expected as a response. When checking the response,
+                        "fuzzy" matching is performed such that each block must be found, and
+                        in the order specified, but not necessarily contiguous.
+                        If not provided or empty, checks will be performed as "connect only" and be marked as successful when TCP connection is successfully established.
+                      type: array
+                      items:
+                        type: string
+                    send:
+                      description: Base64 encoded content of the message which will be sent during the health check to the target
+                      type: string
+                timeout:
+                  description: |-
+                    Maximum time to wait for a health check response.
+                    If not specified then the default value is 15s
+                  type: string
+                unhealthyThreshold:
+                  description: |-
+                    Number of consecutive unhealthy checks before considering a host
+                    unhealthy.
+                    If not specified then the default value is 5
+                  type: integer
+                  format: int32
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                destinations.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              interval: 10s
+              timeout: 2s
+              unhealthyThreshold: 3
+              healthyThreshold: 1
+              http:
+                path: /health
+                expectedStatuses:
+                  - 200
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshHealthCheckItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshLoadBalancingStrategyItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshLoadBalancingStrategyItem_Put_RequestBody.yaml
@@ -1,0 +1,635 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshLoadBalancingStrategy
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mlbs_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshLoadBalancingStrategy resource.
+    type: object
+    properties:
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined inplace.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+      to:
+        description: To list makes a match between the consumed services and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of destinations referenced in
+                'targetRef'
+              type: object
+              properties:
+                hashPolicies:
+                  description: |-
+                    HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                    These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                    set to true, and there is already a hash generated, the hash is returned immediately,
+                    ignoring the rest of the hash policy list.
+                  type: array
+                  items:
+                    properties:
+                      connection:
+                        type: object
+                        properties:
+                          sourceIP:
+                            description: Hash on source IP address.
+                            type: boolean
+                      cookie:
+                        type: object
+                        properties:
+                          name:
+                            description: The name of the cookie that will be used to obtain the hash key.
+                            type: string
+                            minLength: 1
+                          path:
+                            description: The name of the path for the cookie.
+                            type: string
+                          ttl:
+                            description: 'If specified, a cookie with the TTL will be generated if the cookie is not present.'
+                            type: string
+                        required:
+                          - name
+                      filterState:
+                        type: object
+                        properties:
+                          key:
+                            description: |-
+                              The name of the Object in the per-request filterState, which is
+                              an Envoy::Hashable object. If there is no data associated with the key,
+                              or the stored object is not Envoy::Hashable, no hash will be produced.
+                            type: string
+                            minLength: 1
+                        required:
+                          - key
+                      header:
+                        type: object
+                        properties:
+                          name:
+                            description: The name of the request header that will be used to obtain the hash key.
+                            type: string
+                            minLength: 1
+                        required:
+                          - name
+                      queryParameter:
+                        type: object
+                        properties:
+                          name:
+                            description: |-
+                              The name of the URL query parameter that will be used to obtain the hash key.
+                              If the parameter is not present, no hash will be produced. Query parameter names
+                              are case-sensitive.
+                            type: string
+                            minLength: 1
+                        required:
+                          - name
+                      terminal:
+                        description: |-
+                          Terminal is a flag that short-circuits the hash computing. This field provides
+                          a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                          to rest of the policy list”, it saves time when the terminal policy works.
+                          If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                        type: boolean
+                      type:
+                        type: string
+                        enum:
+                          - Header
+                          - Cookie
+                          - Connection
+                          - SourceIP
+                          - QueryParameter
+                          - FilterState
+                    required:
+                      - type
+                    type: object
+                loadBalancer:
+                  description: LoadBalancer allows to specify load balancing algorithm.
+                  type: object
+                  properties:
+                    leastRequest:
+                      description: |-
+                        LeastRequest selects N random available hosts as specified in 'choiceCount' (2 by default)
+                        and picks the host which has the fewest active requests
+                      type: object
+                      properties:
+                        activeRequestBias:
+                          description: |-
+                            ActiveRequestBias refers to dynamic weights applied when hosts have varying load
+                            balancing weights. A higher value here aggressively reduces the weight of endpoints
+                            that are currently handling active requests. In essence, the higher the ActiveRequestBias
+                            value, the more forcefully it reduces the load balancing weight of endpoints that are
+                            actively serving requests.
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          x-kubernetes-int-or-string: true
+                        choiceCount:
+                          description: |-
+                            ChoiceCount is the number of random healthy hosts from which the host with
+                            the fewest active requests will be chosen. Defaults to 2 so that Envoy performs
+                            two-choice selection if the field is not set.
+                          type: integer
+                          format: int32
+                          minimum: 2
+                    maglev:
+                      description: |-
+                        Maglev implements consistent hashing to upstream hosts. Maglev can be used as
+                        a drop in replacement for the ring hash load balancer any place in which
+                        consistent hashing is desired.
+                      type: object
+                      properties:
+                        hashPolicies:
+                          description: |-
+                            HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                            These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                            set to true, and there is already a hash generated, the hash is returned immediately,
+                            ignoring the rest of the hash policy list.
+                          type: array
+                          items:
+                            properties:
+                              connection:
+                                type: object
+                                properties:
+                                  sourceIP:
+                                    description: Hash on source IP address.
+                                    type: boolean
+                              cookie:
+                                type: object
+                                properties:
+                                  name:
+                                    description: The name of the cookie that will be used to obtain the hash key.
+                                    type: string
+                                    minLength: 1
+                                  path:
+                                    description: The name of the path for the cookie.
+                                    type: string
+                                  ttl:
+                                    description: 'If specified, a cookie with the TTL will be generated if the cookie is not present.'
+                                    type: string
+                                required:
+                                  - name
+                              filterState:
+                                type: object
+                                properties:
+                                  key:
+                                    description: |-
+                                      The name of the Object in the per-request filterState, which is
+                                      an Envoy::Hashable object. If there is no data associated with the key,
+                                      or the stored object is not Envoy::Hashable, no hash will be produced.
+                                    type: string
+                                    minLength: 1
+                                required:
+                                  - key
+                              header:
+                                type: object
+                                properties:
+                                  name:
+                                    description: The name of the request header that will be used to obtain the hash key.
+                                    type: string
+                                    minLength: 1
+                                required:
+                                  - name
+                              queryParameter:
+                                type: object
+                                properties:
+                                  name:
+                                    description: |-
+                                      The name of the URL query parameter that will be used to obtain the hash key.
+                                      If the parameter is not present, no hash will be produced. Query parameter names
+                                      are case-sensitive.
+                                    type: string
+                                    minLength: 1
+                                required:
+                                  - name
+                              terminal:
+                                description: |-
+                                  Terminal is a flag that short-circuits the hash computing. This field provides
+                                  a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                  to rest of the policy list”, it saves time when the terminal policy works.
+                                  If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                                type: boolean
+                              type:
+                                type: string
+                                enum:
+                                  - Header
+                                  - Cookie
+                                  - Connection
+                                  - SourceIP
+                                  - QueryParameter
+                                  - FilterState
+                            required:
+                              - type
+                            type: object
+                        tableSize:
+                          description: |-
+                            The table size for Maglev hashing. Maglev aims for “minimal disruption”
+                            rather than an absolute guarantee. Minimal disruption means that when
+                            the set of upstream hosts change, a connection will likely be sent
+                            to the same upstream as it was before. Increasing the table size reduces
+                            the amount of disruption. The table size must be prime number limited to 5000011.
+                            If it is not specified, the default is 65537.
+                          type: integer
+                          format: int32
+                          maximum: 5000011
+                          minimum: 1
+                    random:
+                      description: |-
+                        Random selects a random available host. The random load balancer generally
+                        performs better than round-robin if no health checking policy is configured.
+                        Random selection avoids bias towards the host in the set that comes after a failed host.
+                      type: object
+                    ringHash:
+                      description: |-
+                        RingHash  implements consistent hashing to upstream hosts. Each host is mapped
+                        onto a circle (the “ring”) by hashing its address; each request is then routed
+                        to a host by hashing some property of the request, and finding the nearest
+                        corresponding host clockwise around the ring.
+                      type: object
+                      properties:
+                        hashFunction:
+                          description: |-
+                            HashFunction is a function used to hash hosts onto the ketama ring.
+                            The value defaults to XX_HASH. Available values – XX_HASH, MURMUR_HASH_2.
+                          type: string
+                          enum:
+                            - XXHash
+                            - MurmurHash2
+                        hashPolicies:
+                          description: |-
+                            HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                            These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                            set to true, and there is already a hash generated, the hash is returned immediately,
+                            ignoring the rest of the hash policy list.
+                          type: array
+                          items:
+                            properties:
+                              connection:
+                                type: object
+                                properties:
+                                  sourceIP:
+                                    description: Hash on source IP address.
+                                    type: boolean
+                              cookie:
+                                type: object
+                                properties:
+                                  name:
+                                    description: The name of the cookie that will be used to obtain the hash key.
+                                    type: string
+                                    minLength: 1
+                                  path:
+                                    description: The name of the path for the cookie.
+                                    type: string
+                                  ttl:
+                                    description: 'If specified, a cookie with the TTL will be generated if the cookie is not present.'
+                                    type: string
+                                required:
+                                  - name
+                              filterState:
+                                type: object
+                                properties:
+                                  key:
+                                    description: |-
+                                      The name of the Object in the per-request filterState, which is
+                                      an Envoy::Hashable object. If there is no data associated with the key,
+                                      or the stored object is not Envoy::Hashable, no hash will be produced.
+                                    type: string
+                                    minLength: 1
+                                required:
+                                  - key
+                              header:
+                                type: object
+                                properties:
+                                  name:
+                                    description: The name of the request header that will be used to obtain the hash key.
+                                    type: string
+                                    minLength: 1
+                                required:
+                                  - name
+                              queryParameter:
+                                type: object
+                                properties:
+                                  name:
+                                    description: |-
+                                      The name of the URL query parameter that will be used to obtain the hash key.
+                                      If the parameter is not present, no hash will be produced. Query parameter names
+                                      are case-sensitive.
+                                    type: string
+                                    minLength: 1
+                                required:
+                                  - name
+                              terminal:
+                                description: |-
+                                  Terminal is a flag that short-circuits the hash computing. This field provides
+                                  a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                  to rest of the policy list”, it saves time when the terminal policy works.
+                                  If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                                type: boolean
+                              type:
+                                type: string
+                                enum:
+                                  - Header
+                                  - Cookie
+                                  - Connection
+                                  - SourceIP
+                                  - QueryParameter
+                                  - FilterState
+                            required:
+                              - type
+                            type: object
+                        maxRingSize:
+                          description: |-
+                            Maximum hash ring size. Defaults to 8M entries, and limited to 8M entries,
+                            but can be lowered to further constrain resource use.
+                          type: integer
+                          format: int32
+                          maximum: 8000000
+                          minimum: 1
+                        minRingSize:
+                          description: |-
+                            Minimum hash ring size. The larger the ring is (that is,
+                            the more hashes there are for each provided host) the better the request distribution
+                            will reflect the desired weights. Defaults to 1024 entries, and limited to 8M entries.
+                          type: integer
+                          format: int32
+                          maximum: 8000000
+                          minimum: 1
+                    roundRobin:
+                      description: |-
+                        RoundRobin is a load balancing algorithm that distributes requests
+                        across available upstream hosts in round-robin order.
+                      type: object
+                    type:
+                      type: string
+                      enum:
+                        - RoundRobin
+                        - LeastRequest
+                        - RingHash
+                        - Random
+                        - Maglev
+                  required:
+                    - type
+                localityAwareness:
+                  description: LocalityAwareness contains configuration for locality aware load balancing.
+                  type: object
+                  properties:
+                    crossZone:
+                      description: |-
+                        CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
+                        are unavailable
+                      type: object
+                      properties:
+                        failover:
+                          description: Failover defines list of load balancing rules in order of priority
+                          type: array
+                          items:
+                            properties:
+                              from:
+                                description: From defines the list of zones to which the rule applies
+                                type: object
+                                properties:
+                                  zones:
+                                    type: array
+                                    items:
+                                      type: string
+                                required:
+                                  - zones
+                              to:
+                                description: To defines to which zones the traffic should be load balanced
+                                type: object
+                                properties:
+                                  type:
+                                    description: Type defines how target zones will be picked from available zones
+                                    type: string
+                                    enum:
+                                      - None
+                                      - Only
+                                      - Any
+                                      - AnyExcept
+                                  zones:
+                                    type: array
+                                    items:
+                                      type: string
+                                required:
+                                  - type
+                            required:
+                              - to
+                            type: object
+                        failoverThreshold:
+                          description: |-
+                            FailoverThreshold defines the percentage of live destination dataplane proxies below which load balancing to the
+                            next priority starts.
+                            Example: If you configure failoverThreshold to 70, and you have deployed 10 destination dataplane proxies.
+                            Load balancing to next priority will start when number of live destination dataplane proxies drops below 7.
+                            Default 50
+                          type: object
+                          properties:
+                            percentage:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                          required:
+                            - percentage
+                    disabled:
+                      description: |-
+                        Disabled allows to disable locality-aware load balancing.
+                        When disabled requests are distributed across all endpoints regardless of locality.
+                      type: boolean
+                    localZone:
+                      description: LocalZone defines locality aware load balancing priorities between dataplane proxies inside a zone
+                      type: object
+                      properties:
+                        affinityTags:
+                          description: AffinityTags list of tags for local zone load balancing.
+                          type: array
+                          items:
+                            properties:
+                              key:
+                                description: Key defines tag for which affinity is configured
+                                type: string
+                              weight:
+                                description: |-
+                                  Weight of the tag used for load balancing. The bigger the weight the bigger the priority.
+                                  Percentage of local traffic load balanced to tag is computed by dividing weight by sum of weights from all tags.
+                                  For example with two affinity tags first with weight 80 and second with weight 20,
+                                  then 80% of traffic will be redirected to the first tag, and 20% of traffic will be redirected to second one.
+                                  Setting weights is not mandatory. When weights are not set control plane will compute default weight based on list order.
+                                  Default: If you do not specify weight we will adjust them so that 90% traffic goes to first tag, 9% to next, and 1% to third and so on.
+                                type: integer
+                                format: int32
+                            required:
+                              - key
+                            type: object
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                destinations.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default: {}
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshLoadBalancingStrategyItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshMetricItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshMetricItem_Put_RequestBody.yaml
@@ -1,0 +1,271 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshMetric
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mm_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshMetric resource.
+    type: object
+    default:
+      default:
+        backends: []
+    properties:
+      default:
+        description: MeshMetric configuration.
+        type: object
+        properties:
+          applications:
+            description: Applications is a list of application that Dataplane Proxy will scrape
+            type: array
+            items:
+              properties:
+                address:
+                  description: Address on which an application listens.
+                  type: string
+                name:
+                  description: Name of the application to scrape
+                  type: string
+                path:
+                  description: Path on which an application expose HTTP endpoint with metrics.
+                  type: string
+                  default: /metrics
+                port:
+                  description: Port on which an application expose HTTP endpoint with metrics.
+                  type: integer
+                  format: int32
+              required:
+                - port
+              type: object
+          backends:
+            description: Backends list that will be used to collect metrics.
+            type: array
+            items:
+              properties:
+                openTelemetry:
+                  description: OpenTelemetry backend configuration
+                  type: object
+                  properties:
+                    endpoint:
+                      description: Endpoint for OpenTelemetry collector
+                      type: string
+                    refreshInterval:
+                      description: RefreshInterval defines how frequent metrics should be pushed to collector
+                      type: string
+                  required:
+                    - endpoint
+                prometheus:
+                  description: Prometheus backend configuration.
+                  type: object
+                  properties:
+                    clientId:
+                      description: ClientId of the Prometheus backend. Needed when using MADS for DP discovery.
+                      type: string
+                    path:
+                      description: Path on which a dataplane should expose HTTP endpoint with Prometheus metrics.
+                      type: string
+                      default: /metrics
+                    port:
+                      description: Port on which a dataplane should expose HTTP endpoint with Prometheus metrics.
+                      type: integer
+                      format: int32
+                      default: 5670
+                    tls:
+                      description: Configuration of TLS for prometheus listener.
+                      type: object
+                      properties:
+                        mode:
+                          description: Configuration of TLS for Prometheus listener.
+                          type: string
+                          default: Disabled
+                          enum:
+                            - Disabled
+                            - ProvidedTLS
+                            - ActiveMTLSBackend
+                type:
+                  description: Type of the backend that will be used to collect metrics. At the moment only Prometheus backend is available.
+                  type: string
+                  enum:
+                    - Prometheus
+                    - OpenTelemetry
+              required:
+                - type
+              type: object
+          sidecar:
+            description: Sidecar metrics collection configuration
+            type: object
+            properties:
+              includeUnused:
+                description: |-
+                  IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
+                  at least once, gauges changed at least once, and histograms added to at
+                  least once). If true will scrape all metrics (even the ones with zeros).
+                  If not specified then the default value is false.
+                type: boolean
+              profiles:
+                description: Profiles allows to customize which metrics are published.
+                type: object
+                properties:
+                  appendProfiles:
+                    description: AppendProfiles allows to combine the metrics from multiple predefined profiles.
+                    type: array
+                    items:
+                      properties:
+                        name:
+                          description: 'Name of the predefined profile, one of: all, basic, none'
+                          type: string
+                          enum:
+                            - All
+                            - Basic
+                            - None
+                      required:
+                        - name
+                      type: object
+                  exclude:
+                    description: |-
+                      Exclude makes it possible to exclude groups of metrics from a resulting profile.
+                      Exclude is subordinate to Include.
+                    type: array
+                    items:
+                      properties:
+                        match:
+                          description: Match is the value used to match using particular Type
+                          type: string
+                        type:
+                          description: 'Type defined the type of selector, one of: prefix, regex, exact'
+                          type: string
+                          enum:
+                            - Prefix
+                            - Regex
+                            - Exact
+                            - Contains
+                      required:
+                        - match
+                        - type
+                      type: object
+                  include:
+                    description: |-
+                      Include makes it possible to include additional metrics in a selected profiles.
+                      Include takes precedence over Exclude.
+                    type: array
+                    items:
+                      properties:
+                        match:
+                          description: Match is the value used to match using particular Type
+                          type: string
+                        type:
+                          description: 'Type defined the type of selector, one of: prefix, regex, exact'
+                          type: string
+                          enum:
+                            - Prefix
+                            - Regex
+                            - Exact
+                            - Contains
+                      required:
+                        - match
+                        - type
+                      type: object
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined in-place.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshMetricItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshPassthroughItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshPassthroughItem_Put_RequestBody.yaml
@@ -1,0 +1,165 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshPassthrough
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mp_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshPassthrough resource.
+    type: object
+    default:
+      default:
+        passthroughMode: None
+    properties:
+      default:
+        description: MeshPassthrough configuration.
+        type: object
+        properties:
+          appendMatch:
+            description: AppendMatch is a list of destinations that should be allowed through the sidecar.
+            type: array
+            items:
+              properties:
+                port:
+                  description: Port defines the port to which a user makes a request.
+                  type: integer
+                  format: int32
+                protocol:
+                  description: 'Protocol defines the communication protocol. Possible values: `tcp`, `tls`, `grpc`, `http`, `http2`, `mysql`.'
+                  type: string
+                  default: tcp
+                  enum:
+                    - tcp
+                    - tls
+                    - grpc
+                    - http
+                    - http2
+                    - mysql
+                type:
+                  description: 'Type of the match, one of `Domain`, `IP` or `CIDR` is available.'
+                  type: string
+                  enum:
+                    - Domain
+                    - IP
+                    - CIDR
+                value:
+                  description: Value for the specified Type.
+                  type: string
+              required:
+                - type
+                - value
+              type: object
+          passthroughMode:
+            description: |-
+              Defines the passthrough behavior. Possible values: `All`, `None`, `Matched`
+              When `All` or `None` `appendMatch` has no effect.
+              If not specified then the default value is "Matched".
+            type: string
+            enum:
+              - All
+              - Matched
+              - None
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined in-place.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshPassthroughItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshProxyPatchItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshProxyPatchItem_Put_RequestBody.yaml
@@ -1,0 +1,516 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshProxyPatch
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mpp_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshProxyPatch resource.
+    type: object
+    default:
+      default:
+        appendModifications: []
+    properties:
+      default:
+        description: |-
+          Default is a configuration specific to the group of destinations
+          referenced in 'targetRef'.
+        type: object
+        properties:
+          appendModifications:
+            description: AppendModifications is a list of modifications applied on the selected proxy.
+            type: array
+            items:
+              properties:
+                cluster:
+                  description: Cluster is a modification of Envoy's Cluster resource.
+                  type: object
+                  properties:
+                    jsonPatches:
+                      description: |-
+                        JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
+                        resource
+                      type: array
+                      items:
+                        description: JsonPatchBlock is one json patch operation block.
+                        properties:
+                          from:
+                            description: 'From is a jsonpatch from string, used by move and copy operations.'
+                            type: string
+                          op:
+                            description: Op is a jsonpatch operation string.
+                            type: string
+                            enum:
+                              - add
+                              - remove
+                              - replace
+                              - move
+                              - copy
+                          path:
+                            description: Path is a jsonpatch path string.
+                            type: string
+                          value:
+                            description: Value must be a valid json value used by replace and add operations.
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                          - op
+                          - path
+                        type: object
+                    match:
+                      description: Match is a set of conditions that have to be matched for modification operation to happen.
+                      type: object
+                      properties:
+                        name:
+                          description: Name of the cluster to match.
+                          type: string
+                        origin:
+                          description: |-
+                            Origin is the name of the component or plugin that generated the resource.
+
+                            Here is the list of well-known origins:
+                            inbound - resources generated for handling incoming traffic.
+                            outbound - resources generated for handling outgoing traffic.
+                            transparent - resources generated for transparent proxy functionality.
+                            prometheus - resources generated when Prometheus metrics are enabled.
+                            direct-access - resources generated for Direct Access functionality.
+                            ingress - resources generated for Zone Ingress.
+                            egress - resources generated for Zone Egress.
+                            gateway - resources generated for MeshGateway.
+
+                            The list is not complete, because policy plugins can introduce new resources.
+                            For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                          type: string
+                    operation:
+                      description: Operation to execute on matched cluster.
+                      type: string
+                      enum:
+                        - Add
+                        - Remove
+                        - Patch
+                    value:
+                      description: Value of xDS resource in YAML format to add or patch.
+                      type: string
+                  required:
+                    - operation
+                httpFilter:
+                  description: |-
+                    HTTPFilter is a modification of Envoy HTTP Filter
+                    available in HTTP Connection Manager in a Listener resource.
+                  type: object
+                  properties:
+                    jsonPatches:
+                      description: |-
+                        JsonPatches specifies list of jsonpatches to apply to on Envoy's
+                        HTTP Filter available in HTTP Connection Manager in a Listener resource.
+                      type: array
+                      items:
+                        description: JsonPatchBlock is one json patch operation block.
+                        properties:
+                          from:
+                            description: 'From is a jsonpatch from string, used by move and copy operations.'
+                            type: string
+                          op:
+                            description: Op is a jsonpatch operation string.
+                            type: string
+                            enum:
+                              - add
+                              - remove
+                              - replace
+                              - move
+                              - copy
+                          path:
+                            description: Path is a jsonpatch path string.
+                            type: string
+                          value:
+                            description: Value must be a valid json value used by replace and add operations.
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                          - op
+                          - path
+                        type: object
+                    match:
+                      description: Match is a set of conditions that have to be matched for modification operation to happen.
+                      type: object
+                      properties:
+                        listenerName:
+                          description: Name of the listener to match.
+                          type: string
+                        listenerTags:
+                          description: 'Listener tags available in Listener#Metadata#FilterMetadata[io.kuma.tags]'
+                          type: object
+                          additionalProperties:
+                            type: string
+                        name:
+                          description: Name of the HTTP filter. For example "envoy.filters.http.local_ratelimit"
+                          type: string
+                        origin:
+                          description: |-
+                            Origin is the name of the component or plugin that generated the resource.
+
+                            Here is the list of well-known origins:
+                            inbound - resources generated for handling incoming traffic.
+                            outbound - resources generated for handling outgoing traffic.
+                            transparent - resources generated for transparent proxy functionality.
+                            prometheus - resources generated when Prometheus metrics are enabled.
+                            direct-access - resources generated for Direct Access functionality.
+                            ingress - resources generated for Zone Ingress.
+                            egress - resources generated for Zone Egress.
+                            gateway - resources generated for MeshGateway.
+
+                            The list is not complete, because policy plugins can introduce new resources.
+                            For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                          type: string
+                    operation:
+                      description: Operation to execute on matched listener.
+                      type: string
+                      enum:
+                        - Remove
+                        - Patch
+                        - AddFirst
+                        - AddBefore
+                        - AddAfter
+                        - AddLast
+                    value:
+                      description: Value of xDS resource in YAML format to add or patch.
+                      type: string
+                  required:
+                    - operation
+                listener:
+                  description: Listener is a modification of Envoy's Listener resource.
+                  type: object
+                  properties:
+                    jsonPatches:
+                      description: |-
+                        JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
+                        resource
+                      type: array
+                      items:
+                        description: JsonPatchBlock is one json patch operation block.
+                        properties:
+                          from:
+                            description: 'From is a jsonpatch from string, used by move and copy operations.'
+                            type: string
+                          op:
+                            description: Op is a jsonpatch operation string.
+                            type: string
+                            enum:
+                              - add
+                              - remove
+                              - replace
+                              - move
+                              - copy
+                          path:
+                            description: Path is a jsonpatch path string.
+                            type: string
+                          value:
+                            description: Value must be a valid json value used by replace and add operations.
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                          - op
+                          - path
+                        type: object
+                    match:
+                      description: Match is a set of conditions that have to be matched for modification operation to happen.
+                      type: object
+                      properties:
+                        name:
+                          description: Name of the listener to match.
+                          type: string
+                        origin:
+                          description: |-
+                            Origin is the name of the component or plugin that generated the resource.
+
+                            Here is the list of well-known origins:
+                            inbound - resources generated for handling incoming traffic.
+                            outbound - resources generated for handling outgoing traffic.
+                            transparent - resources generated for transparent proxy functionality.
+                            prometheus - resources generated when Prometheus metrics are enabled.
+                            direct-access - resources generated for Direct Access functionality.
+                            ingress - resources generated for Zone Ingress.
+                            egress - resources generated for Zone Egress.
+                            gateway - resources generated for MeshGateway.
+
+                            The list is not complete, because policy plugins can introduce new resources.
+                            For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                          type: string
+                        tags:
+                          description: 'Tags available in Listener#Metadata#FilterMetadata[io.kuma.tags]'
+                          type: object
+                          additionalProperties:
+                            type: string
+                    operation:
+                      description: Operation to execute on matched listener.
+                      type: string
+                      enum:
+                        - Add
+                        - Remove
+                        - Patch
+                    value:
+                      description: Value of xDS resource in YAML format to add or patch.
+                      type: string
+                  required:
+                    - operation
+                networkFilter:
+                  description: NetworkFilter is a modification of Envoy Listener's filter.
+                  type: object
+                  properties:
+                    jsonPatches:
+                      description: |-
+                        JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
+                        filter.
+                      type: array
+                      items:
+                        description: JsonPatchBlock is one json patch operation block.
+                        properties:
+                          from:
+                            description: 'From is a jsonpatch from string, used by move and copy operations.'
+                            type: string
+                          op:
+                            description: Op is a jsonpatch operation string.
+                            type: string
+                            enum:
+                              - add
+                              - remove
+                              - replace
+                              - move
+                              - copy
+                          path:
+                            description: Path is a jsonpatch path string.
+                            type: string
+                          value:
+                            description: Value must be a valid json value used by replace and add operations.
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                          - op
+                          - path
+                        type: object
+                    match:
+                      description: Match is a set of conditions that have to be matched for modification operation to happen.
+                      type: object
+                      properties:
+                        listenerName:
+                          description: Name of the listener to match.
+                          type: string
+                        listenerTags:
+                          description: 'Listener tags available in Listener#Metadata#FilterMetadata[io.kuma.tags]'
+                          type: object
+                          additionalProperties:
+                            type: string
+                        name:
+                          description: Name of the network filter. For example "envoy.filters.network.ratelimit"
+                          type: string
+                        origin:
+                          description: |-
+                            Origin is the name of the component or plugin that generated the resource.
+
+                            Here is the list of well-known origins:
+                            inbound - resources generated for handling incoming traffic.
+                            outbound - resources generated for handling outgoing traffic.
+                            transparent - resources generated for transparent proxy functionality.
+                            prometheus - resources generated when Prometheus metrics are enabled.
+                            direct-access - resources generated for Direct Access functionality.
+                            ingress - resources generated for Zone Ingress.
+                            egress - resources generated for Zone Egress.
+                            gateway - resources generated for MeshGateway.
+
+                            The list is not complete, because policy plugins can introduce new resources.
+                            For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                          type: string
+                    operation:
+                      description: Operation to execute on matched listener.
+                      type: string
+                      enum:
+                        - Remove
+                        - Patch
+                        - AddFirst
+                        - AddBefore
+                        - AddAfter
+                        - AddLast
+                    value:
+                      description: Value of xDS resource in YAML format to add or patch.
+                      type: string
+                  required:
+                    - operation
+                virtualHost:
+                  description: |-
+                    VirtualHost is a modification of Envoy's VirtualHost
+                    referenced in HTTP Connection Manager in a Listener resource.
+                  type: object
+                  properties:
+                    jsonPatches:
+                      description: |-
+                        JsonPatches specifies list of jsonpatches to apply to on Envoy's
+                        VirtualHost resource
+                      type: array
+                      items:
+                        description: JsonPatchBlock is one json patch operation block.
+                        properties:
+                          from:
+                            description: 'From is a jsonpatch from string, used by move and copy operations.'
+                            type: string
+                          op:
+                            description: Op is a jsonpatch operation string.
+                            type: string
+                            enum:
+                              - add
+                              - remove
+                              - replace
+                              - move
+                              - copy
+                          path:
+                            description: Path is a jsonpatch path string.
+                            type: string
+                          value:
+                            description: Value must be a valid json value used by replace and add operations.
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                          - op
+                          - path
+                        type: object
+                    match:
+                      description: Match is a set of conditions that have to be matched for modification operation to happen.
+                      type: object
+                      properties:
+                        name:
+                          description: Name of the VirtualHost to match.
+                          type: string
+                        origin:
+                          description: |-
+                            Origin is the name of the component or plugin that generated the resource.
+
+                            Here is the list of well-known origins:
+                            inbound - resources generated for handling incoming traffic.
+                            outbound - resources generated for handling outgoing traffic.
+                            transparent - resources generated for transparent proxy functionality.
+                            prometheus - resources generated when Prometheus metrics are enabled.
+                            direct-access - resources generated for Direct Access functionality.
+                            ingress - resources generated for Zone Ingress.
+                            egress - resources generated for Zone Egress.
+                            gateway - resources generated for MeshGateway.
+
+                            The list is not complete, because policy plugins can introduce new resources.
+                            For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                          type: string
+                        routeConfigurationName:
+                          description: Name of the RouteConfiguration resource to match.
+                          type: string
+                    operation:
+                      description: Operation to execute on matched listener.
+                      type: string
+                      enum:
+                        - Add
+                        - Remove
+                        - Patch
+                    value:
+                      description: Value of xDS resource in YAML format to add or patch.
+                      type: string
+                  required:
+                    - match
+                    - operation
+              type: object
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined inplace.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+    required:
+      - default
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshProxyPatchItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshRateLimitItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshRateLimitItem_Put_RequestBody.yaml
@@ -1,0 +1,608 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshRateLimit
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mrl_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshRateLimit resource.
+    type: object
+    properties:
+      from:
+        description: From list makes a match between clients and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of clients referenced in
+                'targetRef'
+              type: object
+              properties:
+                local:
+                  description: LocalConf defines local http or/and tcp rate limit configuration
+                  type: object
+                  properties:
+                    http:
+                      description: |-
+                        LocalHTTP defines configuration of local HTTP rate limiting
+                        https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
+                      type: object
+                      properties:
+                        disabled:
+                          description: Define if rate limiting should be disabled.
+                          type: boolean
+                        onRateLimit:
+                          description: Describes the actions to take on a rate limit event
+                          type: object
+                          properties:
+                            headers:
+                              description: The Headers to be added to the HTTP response on a rate limit event
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                set:
+                                  type: array
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                            status:
+                              description: The HTTP status code to be set on a rate limit event
+                              type: integer
+                              format: int32
+                        requestRate:
+                          description: Defines how many requests are allowed per interval.
+                          type: object
+                          properties:
+                            interval:
+                              description: The interval the number of units is accounted for.
+                              type: string
+                            num:
+                              description: |-
+                                Number of units per interval (depending on usage it can be a number of requests,
+                                or a number of connections).
+                              type: integer
+                              format: int32
+                          required:
+                            - interval
+                            - num
+                    tcp:
+                      description: |-
+                        LocalTCP defines confguration of local TCP rate limiting
+                        https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter
+                      type: object
+                      properties:
+                        connectionRate:
+                          description: Defines how many connections are allowed per interval.
+                          type: object
+                          properties:
+                            interval:
+                              description: The interval the number of units is accounted for.
+                              type: string
+                            num:
+                              description: |-
+                                Number of units per interval (depending on usage it can be a number of requests,
+                                or a number of connections).
+                              type: integer
+                              format: int32
+                          required:
+                            - interval
+                            - num
+                        disabled:
+                          description: |-
+                            Define if rate limiting should be disabled.
+                            Default: false
+                          type: boolean
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                clients.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+      rules:
+        description: |-
+          Rules defines inbound rate limiting configurations. Currently limited to
+          selecting all inbound traffic, as L7 matching is not yet implemented.
+        type: array
+        items:
+          properties:
+            default:
+              description: Default contains configuration of the inbound rate limits
+              type: object
+              properties:
+                local:
+                  description: LocalConf defines local http or/and tcp rate limit configuration
+                  type: object
+                  properties:
+                    http:
+                      description: |-
+                        LocalHTTP defines configuration of local HTTP rate limiting
+                        https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
+                      type: object
+                      properties:
+                        disabled:
+                          description: Define if rate limiting should be disabled.
+                          type: boolean
+                        onRateLimit:
+                          description: Describes the actions to take on a rate limit event
+                          type: object
+                          properties:
+                            headers:
+                              description: The Headers to be added to the HTTP response on a rate limit event
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                set:
+                                  type: array
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                            status:
+                              description: The HTTP status code to be set on a rate limit event
+                              type: integer
+                              format: int32
+                        requestRate:
+                          description: Defines how many requests are allowed per interval.
+                          type: object
+                          properties:
+                            interval:
+                              description: The interval the number of units is accounted for.
+                              type: string
+                            num:
+                              description: |-
+                                Number of units per interval (depending on usage it can be a number of requests,
+                                or a number of connections).
+                              type: integer
+                              format: int32
+                          required:
+                            - interval
+                            - num
+                    tcp:
+                      description: |-
+                        LocalTCP defines confguration of local TCP rate limiting
+                        https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter
+                      type: object
+                      properties:
+                        connectionRate:
+                          description: Defines how many connections are allowed per interval.
+                          type: object
+                          properties:
+                            interval:
+                              description: The interval the number of units is accounted for.
+                              type: string
+                            num:
+                              description: |-
+                                Number of units per interval (depending on usage it can be a number of requests,
+                                or a number of connections).
+                              type: integer
+                              format: int32
+                          required:
+                            - interval
+                            - num
+                        disabled:
+                          description: |-
+                            Define if rate limiting should be disabled.
+                            Default: false
+                          type: boolean
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              local: {}
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined inplace.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+      to:
+        description: To list makes a match between clients and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of clients referenced in
+                'targetRef'
+              type: object
+              properties:
+                local:
+                  description: LocalConf defines local http or/and tcp rate limit configuration
+                  type: object
+                  properties:
+                    http:
+                      description: |-
+                        LocalHTTP defines configuration of local HTTP rate limiting
+                        https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
+                      type: object
+                      properties:
+                        disabled:
+                          description: Define if rate limiting should be disabled.
+                          type: boolean
+                        onRateLimit:
+                          description: Describes the actions to take on a rate limit event
+                          type: object
+                          properties:
+                            headers:
+                              description: The Headers to be added to the HTTP response on a rate limit event
+                              type: object
+                              properties:
+                                add:
+                                  type: array
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                set:
+                                  type: array
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                      value:
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                            status:
+                              description: The HTTP status code to be set on a rate limit event
+                              type: integer
+                              format: int32
+                        requestRate:
+                          description: Defines how many requests are allowed per interval.
+                          type: object
+                          properties:
+                            interval:
+                              description: The interval the number of units is accounted for.
+                              type: string
+                            num:
+                              description: |-
+                                Number of units per interval (depending on usage it can be a number of requests,
+                                or a number of connections).
+                              type: integer
+                              format: int32
+                          required:
+                            - interval
+                            - num
+                    tcp:
+                      description: |-
+                        LocalTCP defines confguration of local TCP rate limiting
+                        https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter
+                      type: object
+                      properties:
+                        connectionRate:
+                          description: Defines how many connections are allowed per interval.
+                          type: object
+                          properties:
+                            interval:
+                              description: The interval the number of units is accounted for.
+                              type: string
+                            num:
+                              description: |-
+                                Number of units per interval (depending on usage it can be a number of requests,
+                                or a number of connections).
+                              type: integer
+                              format: int32
+                          required:
+                            - interval
+                            - num
+                        disabled:
+                          description: |-
+                            Define if rate limiting should be disabled.
+                            Default: false
+                          type: boolean
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                clients.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              local: {}
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshRateLimitItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshRetryItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshRetryItem_Put_RequestBody.yaml
@@ -1,0 +1,507 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshRetry
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mr_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshRetry resource.
+    type: object
+    properties:
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined inplace.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+      to:
+        description: To list makes a match between the consumed services and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of destinations referenced in
+                'targetRef'
+              type: object
+              properties:
+                grpc:
+                  description: GRPC defines a configuration of retries for GRPC traffic
+                  type: object
+                  properties:
+                    backOff:
+                      description: |-
+                        BackOff is a configuration of durations which will be used in an exponential
+                        backoff strategy between retries.
+                      type: object
+                      properties:
+                        baseInterval:
+                          description: |-
+                            BaseInterval is an amount of time which should be taken between retries.
+                            Must be greater than zero. Values less than 1 ms are rounded up to 1 ms.
+                            If not specified then the default value is "25ms".
+                          type: string
+                        maxInterval:
+                          description: |-
+                            MaxInterval is a maximal amount of time which will be taken between retries.
+                            Default is 10 times the "BaseInterval".
+                          type: string
+                    numRetries:
+                      description: |-
+                        NumRetries is the number of attempts that will be made on failed (and
+                        retriable) requests. If not set, the default value is 1.
+                      type: integer
+                      format: int32
+                    perTryTimeout:
+                      description: |-
+                        PerTryTimeout is the maximum amount of time each retry attempt can take
+                        before it times out. If not set, the global request timeout for the route
+                        will be used. Setting this value to 0 will disable the per-try timeout.
+                      type: string
+                    rateLimitedBackOff:
+                      description: |-
+                        RateLimitedBackOff is a configuration of backoff which will be used when
+                        the upstream returns one of the headers configured.
+                      type: object
+                      properties:
+                        maxInterval:
+                          description: |-
+                            MaxInterval is a maximal amount of time which will be taken between retries.
+                            If not specified then the default value is "300s".
+                          type: string
+                        resetHeaders:
+                          description: |-
+                            ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
+                            to match against the response. Headers are tried in order, and matched
+                            case-insensitive. The first header to be parsed successfully is used.
+                            If no headers match the default exponential BackOff is used instead.
+                          type: array
+                          items:
+                            properties:
+                              format:
+                                description: The format of the reset header.
+                                type: string
+                                enum:
+                                  - Seconds
+                                  - UnixTimestamp
+                              name:
+                                description: The Name of the reset header.
+                                type: string
+                                maxLength: 256
+                                minLength: 1
+                                pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                            required:
+                              - format
+                              - name
+                            type: object
+                    retryOn:
+                      description: RetryOn is a list of conditions which will cause a retry.
+                      type: array
+                      items:
+                        enum:
+                          - Canceled
+                          - DeadlineExceeded
+                          - Internal
+                          - ResourceExhausted
+                          - Unavailable
+                        type: string
+                      example:
+                        - Canceled
+                        - DeadlineExceeded
+                        - Internal
+                        - ResourceExhausted
+                        - Unavailable
+                http:
+                  description: HTTP defines a configuration of retries for HTTP traffic
+                  type: object
+                  properties:
+                    backOff:
+                      description: |-
+                        BackOff is a configuration of durations which will be used in exponential
+                        backoff strategy between retries.
+                      type: object
+                      properties:
+                        baseInterval:
+                          description: |-
+                            BaseInterval is an amount of time which should be taken between retries.
+                            Must be greater than zero. Values less than 1 ms are rounded up to 1 ms.
+                            If not specified then the default value is "25ms".
+                          type: string
+                        maxInterval:
+                          description: |-
+                            MaxInterval is a maximal amount of time which will be taken between retries.
+                            Default is 10 times the "BaseInterval".
+                          type: string
+                    hostSelection:
+                      description: |-
+                        HostSelection is a list of predicates that dictate how hosts should be selected
+                        when requests are retried.
+                      type: array
+                      items:
+                        properties:
+                          predicate:
+                            description: Type is requested predicate mode.
+                            type: string
+                            enum:
+                              - OmitPreviousHosts
+                              - OmitHostsWithTags
+                              - OmitPreviousPriorities
+                          tags:
+                            description: |-
+                              Tags is a map of metadata to match against for selecting the omitted hosts. Required if Type is
+                              OmitHostsWithTags
+                            type: object
+                            additionalProperties:
+                              type: string
+                          updateFrequency:
+                            description: |-
+                              UpdateFrequency is how often the priority load should be updated based on previously attempted priorities.
+                              Used for OmitPreviousPriorities.
+                            type: integer
+                            format: int32
+                            default: 2
+                        required:
+                          - predicate
+                        type: object
+                    hostSelectionMaxAttempts:
+                      description: |-
+                        HostSelectionMaxAttempts is the maximum number of times host selection will be
+                        reattempted before giving up, at which point the host that was last selected will
+                        be routed to. If unspecified, this will default to retrying once.
+                      type: integer
+                      format: int64
+                    numRetries:
+                      description: |-
+                        NumRetries is the number of attempts that will be made on failed (and
+                        retriable) requests.  If not set, the default value is 1.
+                      type: integer
+                      format: int32
+                    perTryTimeout:
+                      description: |-
+                        PerTryTimeout is the amount of time after which retry attempt should time out.
+                        If left unspecified, the global route timeout for the request will be used.
+                        Consequently, when using a 5xx based retry policy, a request that times out
+                        will not be retried as the total timeout budget would have been exhausted.
+                        Setting this timeout to 0 will disable it.
+                      type: string
+                    rateLimitedBackOff:
+                      description: |-
+                        RateLimitedBackOff is a configuration of backoff which will be used
+                        when the upstream returns one of the headers configured.
+                      type: object
+                      properties:
+                        maxInterval:
+                          description: |-
+                            MaxInterval is a maximal amount of time which will be taken between retries.
+                            If not specified then the default value is "300s".
+                          type: string
+                        resetHeaders:
+                          description: |-
+                            ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
+                            to match against the response. Headers are tried in order, and matched
+                            case-insensitive. The first header to be parsed successfully is used.
+                            If no headers match the default exponential BackOff is used instead.
+                          type: array
+                          items:
+                            properties:
+                              format:
+                                description: The format of the reset header.
+                                type: string
+                                enum:
+                                  - Seconds
+                                  - UnixTimestamp
+                              name:
+                                description: The Name of the reset header.
+                                type: string
+                                maxLength: 256
+                                minLength: 1
+                                pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                            required:
+                              - format
+                              - name
+                            type: object
+                    retriableRequestHeaders:
+                      description: |-
+                        RetriableRequestHeaders is an HTTP headers which must be present in the request
+                        for retries to be attempted.
+                      type: array
+                      items:
+                        description: |-
+                          HeaderMatch describes how to select an HTTP route by matching HTTP request
+                          headers.
+                        properties:
+                          name:
+                            description: |-
+                              Name is the name of the HTTP Header to be matched. Name MUST be lower case
+                              as they will be handled with case insensitivity (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                            type: string
+                            maxLength: 256
+                            minLength: 1
+                            pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                          type:
+                            description: Type specifies how to match against the value of the header.
+                            type: string
+                            default: Exact
+                            enum:
+                              - Exact
+                              - Present
+                              - RegularExpression
+                              - Absent
+                              - Prefix
+                          value:
+                            description: Value is the value of HTTP Header to be matched.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                    retriableResponseHeaders:
+                      description: |-
+                        RetriableResponseHeaders is an HTTP response headers that trigger a retry
+                        if present in the response. A retry will be triggered if any of the header
+                        matches the upstream response headers.
+                      type: array
+                      items:
+                        description: |-
+                          HeaderMatch describes how to select an HTTP route by matching HTTP request
+                          headers.
+                        properties:
+                          name:
+                            description: |-
+                              Name is the name of the HTTP Header to be matched. Name MUST be lower case
+                              as they will be handled with case insensitivity (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                            type: string
+                            maxLength: 256
+                            minLength: 1
+                            pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                          type:
+                            description: Type specifies how to match against the value of the header.
+                            type: string
+                            default: Exact
+                            enum:
+                              - Exact
+                              - Present
+                              - RegularExpression
+                              - Absent
+                              - Prefix
+                          value:
+                            description: Value is the value of HTTP Header to be matched.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                    retryOn:
+                      description: |-
+                        RetryOn is a list of conditions which will cause a retry. Available values are:
+                        [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited,
+                        RefusedStream, Http3PostConnectFailure, HttpMethodConnect, HttpMethodDelete,
+                        HttpMethodGet, HttpMethodHead, HttpMethodOptions, HttpMethodPatch,
+                        HttpMethodPost, HttpMethodPut, HttpMethodTrace].
+                        Also, any HTTP status code (500, 503, etc.).
+                      type: array
+                      items:
+                        type: string
+                      example:
+                        - 5XX
+                        - GatewayError
+                        - Reset
+                        - Retriable4xx
+                        - ConnectFailure
+                        - EnvoyRatelimited
+                        - RefusedStream
+                        - Http3PostConnectFailure
+                        - HttpMethodConnect
+                        - HttpMethodDelete
+                        - HttpMethodGet
+                        - HttpMethodHead
+                        - HttpMethodOptions
+                        - HttpMethodPatch
+                        - HttpMethodPost
+                        - HttpMethodPut
+                        - HttpMethodTrace
+                        - '500'
+                        - '503'
+                tcp:
+                  description: TCP defines a configuration of retries for TCP traffic
+                  type: object
+                  properties:
+                    maxConnectAttempt:
+                      description: |-
+                        MaxConnectAttempt is a maximal amount of TCP connection attempts
+                        which will be made before giving up
+                      type: integer
+                      format: int32
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                destinations.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              http:
+                numRetries: 10
+                backOff:
+                  baseInterval: 15s
+                  maxInterval: 20m
+                retryOn:
+                  - 5xx
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshRetryItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshTCPRouteItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshTCPRouteItem_Put_RequestBody.yaml
@@ -1,0 +1,281 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshTCPRoute
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mtcpr_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshTCPRoute resource.
+    type: object
+    properties:
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined in-place.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+      to:
+        description: |-
+          To list makes a match between the consumed services and corresponding
+          configurations
+        type: array
+        items:
+          properties:
+            rules:
+              description: |-
+                Rules contains the routing rules applies to a combination of top-level
+                targetRef and the targetRef in this entry.
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default holds routing rules that can be merged with rules from other
+                      policies.
+                    type: object
+                    properties:
+                      backendRefs:
+                        type: array
+                        items:
+                          description: BackendRef defines where to forward traffic.
+                          properties:
+                            kind:
+                              description: Kind of the referenced resource
+                              type: string
+                              enum:
+                                - Mesh
+                                - MeshSubset
+                                - MeshGateway
+                                - MeshService
+                                - MeshExternalService
+                                - MeshMultiZoneService
+                                - MeshServiceSubset
+                                - MeshHTTPRoute
+                                - Dataplane
+                            labels:
+                              description: |-
+                                Labels are used to select group of MeshServices that match labels. Either Labels or
+                                Name and Namespace can be used.
+                              type: object
+                              additionalProperties:
+                                type: string
+                            mesh:
+                              description: Mesh is reserved for future use to identify cross mesh resources.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                                `MeshServiceSubset` and `MeshGatewayRoute`
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                                will be targeted.
+                              type: string
+                            port:
+                              description: Port is only supported when this ref refers to a real MeshService object
+                              type: integer
+                              format: int32
+                            proxyTypes:
+                              description: |-
+                                ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                                all data plane types are targeted by the policy.
+                              type: array
+                              items:
+                                enum:
+                                  - Sidecar
+                                  - Gateway
+                                type: string
+                            sectionName:
+                              description: |-
+                                SectionName is used to target specific section of resource.
+                                For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                              type: string
+                            tags:
+                              description: |-
+                                Tags used to select a subset of proxies by tags. Can only be used with kinds
+                                `MeshSubset` and `MeshServiceSubset`
+                              type: object
+                              additionalProperties:
+                                type: string
+                            weight:
+                              type: integer
+                              default: 1
+                              minimum: 0
+                          required:
+                            - kind
+                          type: object
+                required:
+                  - default
+                type: object
+              maxItems: 1
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                destinations.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - rules
+            - targetRef
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            rules: []
+        minItems: 1
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshTCPRouteItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshTLSItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshTLSItem_Put_RequestBody.yaml
@@ -1,0 +1,292 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshTLS
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mtls_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshTLS resource.
+    type: object
+    properties:
+      from:
+        description: From list makes a match between clients and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of clients referenced in
+                'targetRef'
+              type: object
+              properties:
+                mode:
+                  description: Mode defines the behavior of inbound listeners with regard to traffic encryption.
+                  type: string
+                  enum:
+                    - Permissive
+                    - Strict
+                tlsCiphers:
+                  description: TlsCiphers section for providing ciphers specification.
+                  type: array
+                  items:
+                    enum:
+                      - ECDHE-ECDSA-AES128-GCM-SHA256
+                      - ECDHE-ECDSA-AES256-GCM-SHA384
+                      - ECDHE-ECDSA-CHACHA20-POLY1305
+                      - ECDHE-RSA-AES128-GCM-SHA256
+                      - ECDHE-RSA-AES256-GCM-SHA384
+                      - ECDHE-RSA-CHACHA20-POLY1305
+                    type: string
+                tlsVersion:
+                  description: Version section for providing version specification.
+                  type: object
+                  properties:
+                    max:
+                      description: 'Max defines maximum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.'
+                      type: string
+                      default: TLSAuto
+                      enum:
+                        - TLSAuto
+                        - TLS10
+                        - TLS11
+                        - TLS12
+                        - TLS13
+                    min:
+                      description: 'Min defines minimum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.'
+                      type: string
+                      default: TLSAuto
+                      enum:
+                        - TLSAuto
+                        - TLS10
+                        - TLS11
+                        - TLS12
+                        - TLS13
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                clients.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+      rules:
+        description: |-
+          Rules defines inbound tls configurations. Currently limited to
+          selecting all inbound traffic, as L7 matching is not yet implemented.
+        type: array
+        items:
+          properties:
+            default:
+              description: Default contains configuration of the inbound tls
+              type: object
+              properties:
+                mode:
+                  description: Mode defines the behavior of inbound listeners with regard to traffic encryption.
+                  type: string
+                  enum:
+                    - Permissive
+                    - Strict
+                tlsCiphers:
+                  description: TlsCiphers section for providing ciphers specification.
+                  type: array
+                  items:
+                    enum:
+                      - ECDHE-ECDSA-AES128-GCM-SHA256
+                      - ECDHE-ECDSA-AES256-GCM-SHA384
+                      - ECDHE-ECDSA-CHACHA20-POLY1305
+                      - ECDHE-RSA-AES128-GCM-SHA256
+                      - ECDHE-RSA-AES256-GCM-SHA384
+                      - ECDHE-RSA-CHACHA20-POLY1305
+                    type: string
+                tlsVersion:
+                  description: Version section for providing version specification.
+                  type: object
+                  properties:
+                    max:
+                      description: 'Max defines maximum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.'
+                      type: string
+                      default: TLSAuto
+                      enum:
+                        - TLSAuto
+                        - TLS10
+                        - TLS11
+                        - TLS12
+                        - TLS13
+                    min:
+                      description: 'Min defines minimum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.'
+                      type: string
+                      default: TLSAuto
+                      enum:
+                        - TLSAuto
+                        - TLS10
+                        - TLS11
+                        - TLS12
+                        - TLS13
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              mode: Strict
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined in-place.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshTLSItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshTimeoutItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshTimeoutItem_Put_RequestBody.yaml
@@ -1,0 +1,431 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshTimeout
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mt_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshTimeout resource.
+    type: object
+    properties:
+      from:
+        description: From list makes a match between clients and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of clients referenced in
+                'targetRef'
+              type: object
+              properties:
+                connectionTimeout:
+                  description: |-
+                    ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established.
+                    Default value is 5 seconds. Cannot be set to 0.
+                  type: string
+                http:
+                  description: Http provides configuration for HTTP specific timeouts
+                  type: object
+                  properties:
+                    maxConnectionDuration:
+                      description: |-
+                        MaxConnectionDuration is the time after which a connection will be drained and/or closed,
+                        starting from when it was first established. Setting this timeout to 0 will disable it.
+                        Disabled by default.
+                      type: string
+                    maxStreamDuration:
+                      description: |-
+                        MaxStreamDuration is the maximum time that a stream’s lifetime will span.
+                        Setting this timeout to 0 will disable it. Disabled by default.
+                      type: string
+                    requestHeadersTimeout:
+                      description: |-
+                        RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is
+                        activated when the first byte of the headers is received, and is disarmed when the last byte of
+                        the headers has been received. If not specified or set to 0, this timeout is disabled.
+                        Disabled by default.
+                      type: string
+                    requestTimeout:
+                      description: |-
+                        RequestTimeout The amount of time that proxy will wait for the entire request to be received.
+                        The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent,
+                        OR when the response is initiated. Setting this timeout to 0 will disable it.
+                        Default is 15s.
+                      type: string
+                    streamIdleTimeout:
+                      description: |-
+                        StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity.
+                        Setting this timeout to 0 will disable it. Default is 30m
+                      type: string
+                idleTimeout:
+                  description: |-
+                    IdleTimeout is defined as the period in which there are no bytes sent or received on connection
+                    Setting this timeout to 0 will disable it. Be cautious when disabling it because
+                    it can lead to connection leaking. Default value is 1h.
+                  type: string
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                clients.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+      rules:
+        description: |-
+          Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
+          default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
+        type: array
+        items:
+          properties:
+            default:
+              description: Default contains configuration of the inbound timeouts
+              type: object
+              properties:
+                connectionTimeout:
+                  description: |-
+                    ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established.
+                    Default value is 5 seconds. Cannot be set to 0.
+                  type: string
+                http:
+                  description: Http provides configuration for HTTP specific timeouts
+                  type: object
+                  properties:
+                    maxConnectionDuration:
+                      description: |-
+                        MaxConnectionDuration is the time after which a connection will be drained and/or closed,
+                        starting from when it was first established. Setting this timeout to 0 will disable it.
+                        Disabled by default.
+                      type: string
+                    maxStreamDuration:
+                      description: |-
+                        MaxStreamDuration is the maximum time that a stream’s lifetime will span.
+                        Setting this timeout to 0 will disable it. Disabled by default.
+                      type: string
+                    requestHeadersTimeout:
+                      description: |-
+                        RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is
+                        activated when the first byte of the headers is received, and is disarmed when the last byte of
+                        the headers has been received. If not specified or set to 0, this timeout is disabled.
+                        Disabled by default.
+                      type: string
+                    requestTimeout:
+                      description: |-
+                        RequestTimeout The amount of time that proxy will wait for the entire request to be received.
+                        The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent,
+                        OR when the response is initiated. Setting this timeout to 0 will disable it.
+                        Default is 15s.
+                      type: string
+                    streamIdleTimeout:
+                      description: |-
+                        StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity.
+                        Setting this timeout to 0 will disable it. Default is 30m
+                      type: string
+                idleTimeout:
+                  description: |-
+                    IdleTimeout is defined as the period in which there are no bytes sent or received on connection
+                    Setting this timeout to 0 will disable it. Be cautious when disabling it because
+                    it can lead to connection leaking. Default value is 1h.
+                  type: string
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              idleTimeout: 20s
+              connectionTimeout: 2s
+              http:
+                requestTimeout: 2s
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined inplace.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+      to:
+        description: To list makes a match between the consumed services and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of destinations referenced in
+                'targetRef'
+              type: object
+              properties:
+                connectionTimeout:
+                  description: |-
+                    ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established.
+                    Default value is 5 seconds. Cannot be set to 0.
+                  type: string
+                http:
+                  description: Http provides configuration for HTTP specific timeouts
+                  type: object
+                  properties:
+                    maxConnectionDuration:
+                      description: |-
+                        MaxConnectionDuration is the time after which a connection will be drained and/or closed,
+                        starting from when it was first established. Setting this timeout to 0 will disable it.
+                        Disabled by default.
+                      type: string
+                    maxStreamDuration:
+                      description: |-
+                        MaxStreamDuration is the maximum time that a stream’s lifetime will span.
+                        Setting this timeout to 0 will disable it. Disabled by default.
+                      type: string
+                    requestHeadersTimeout:
+                      description: |-
+                        RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is
+                        activated when the first byte of the headers is received, and is disarmed when the last byte of
+                        the headers has been received. If not specified or set to 0, this timeout is disabled.
+                        Disabled by default.
+                      type: string
+                    requestTimeout:
+                      description: |-
+                        RequestTimeout The amount of time that proxy will wait for the entire request to be received.
+                        The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent,
+                        OR when the response is initiated. Setting this timeout to 0 will disable it.
+                        Default is 15s.
+                      type: string
+                    streamIdleTimeout:
+                      description: |-
+                        StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity.
+                        Setting this timeout to 0 will disable it. Default is 30m
+                      type: string
+                idleTimeout:
+                  description: |-
+                    IdleTimeout is defined as the period in which there are no bytes sent or received on connection
+                    Setting this timeout to 0 will disable it. Be cautious when disabling it because
+                    it can lead to connection leaking. Default value is 1h.
+                  type: string
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                destinations.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              idleTimeout: 20s
+              connectionTimeout: 2s
+              http:
+                requestTimeout: 2s
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshTimeoutItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshTraceItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshTraceItem_Put_RequestBody.yaml
@@ -1,0 +1,282 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshTrace
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mtr_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshTrace resource.
+    type: object
+    default:
+      default:
+        backends: []
+    properties:
+      default:
+        description: MeshTrace configuration.
+        type: object
+        properties:
+          backends:
+            description: |-
+              A one element array of backend definition.
+              Envoy allows configuring only 1 backend, so the natural way of
+              representing that would be just one object. Unfortunately due to the
+              reasons explained in MADR 009-tracing-policy this has to be a one element
+              array for now.
+            type: array
+            items:
+              description: 'Only one of zipkin, datadog or openTelemetry can be used.'
+              properties:
+                datadog:
+                  description: Datadog backend configuration.
+                  type: object
+                  properties:
+                    splitService:
+                      description: |-
+                        Determines if datadog service name should be split based on traffic
+                        direction and destination. For example, with `splitService: true` and a
+                        `backend` service that communicates with a couple of databases, you would
+                        get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
+                        `backend_OUTBOUND_db2` in Datadog.
+                      type: boolean
+                      default: false
+                    url:
+                      description: |-
+                        Address of Datadog collector, only host and port are allowed (no paths,
+                        fragments etc.)
+                      type: string
+                  required:
+                    - url
+                openTelemetry:
+                  description: OpenTelemetry backend configuration.
+                  type: object
+                  properties:
+                    endpoint:
+                      description: Address of OpenTelemetry collector.
+                      type: string
+                      example: 'otel-collector:4317'
+                      minLength: 1
+                  required:
+                    - endpoint
+                type:
+                  type: string
+                  enum:
+                    - Zipkin
+                    - Datadog
+                    - OpenTelemetry
+                zipkin:
+                  description: Zipkin backend configuration.
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: |-
+                        Version of the API.
+                        https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
+                      type: string
+                      default: httpJson
+                      enum:
+                        - httpJson
+                        - httpProto
+                    sharedSpanContext:
+                      description: |-
+                        Determines whether client and server spans will share the same span
+                        context.
+                        https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
+                      type: boolean
+                      default: true
+                    traceId128bit:
+                      description: Generate 128bit traces.
+                      type: boolean
+                      default: false
+                    url:
+                      description: Address of Zipkin collector.
+                      type: string
+                  required:
+                    - url
+              required:
+                - type
+              type: object
+            maxItems: 1
+          sampling:
+            description: |-
+              Sampling configuration.
+              Sampling is the process by which a decision is made on whether to
+              process/export a span or not.
+            type: object
+            properties:
+              client:
+                description: |-
+                  Target percentage of requests that will be force traced if the
+                  'x-client-trace-id' header is set. Mirror of client_sampling in Envoy
+                  https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                  Either int or decimal represented as string.
+                  If not specified then the default value is 100.
+                anyOf:
+                  - type: integer
+                  - type: string
+                x-kubernetes-int-or-string: true
+              overall:
+                description: |-
+                  Target percentage of requests will be traced
+                  after all other sampling checks have been applied (client, force tracing,
+                  random sampling). This field functions as an upper limit on the total
+                  configured sampling rate. For instance, setting client to 100
+                  but overall to 1 will result in only 1% of client requests with
+                  the appropriate headers to be force traced. Mirror of
+                  overall_sampling in Envoy
+                  https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                  Either int or decimal represented as string.
+                  If not specified then the default value is 100.
+                anyOf:
+                  - type: integer
+                  - type: string
+                x-kubernetes-int-or-string: true
+              random:
+                description: |-
+                  Target percentage of requests that will be randomly selected for trace
+                  generation, if not requested by the client or not forced.
+                  Mirror of random_sampling in Envoy
+                  https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                  Either int or decimal represented as string.
+                  If not specified then the default value is 100.
+                anyOf:
+                  - type: integer
+                  - type: string
+                x-kubernetes-int-or-string: true
+          tags:
+            description: |-
+              Custom tags configuration. You can add custom tags to traces based on
+              headers or literal values.
+            type: array
+            items:
+              description: |-
+                Custom tags configuration.
+                Only one of literal or header can be used.
+              properties:
+                header:
+                  description: Tag taken from a header.
+                  type: object
+                  properties:
+                    default:
+                      description: |-
+                        Default value to use if header is missing.
+                        If the default is missing and there is no value the tag will not be
+                        included.
+                      type: string
+                    name:
+                      description: Name of the header.
+                      type: string
+                  required:
+                    - name
+                literal:
+                  description: Tag taken from literal value.
+                  type: string
+                name:
+                  description: Name of the tag.
+                  type: string
+              required:
+                - name
+              type: object
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined inplace.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshTraceItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/MeshTrafficPermissionItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshTrafficPermissionItem_Put_RequestBody.yaml
@@ -1,0 +1,282 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+    enum:
+      - MeshTrafficPermission
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mtp_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  spec:
+    description: Spec is the specification of the Kuma MeshTrafficPermission resource.
+    type: object
+    properties:
+      from:
+        description: From list makes a match between clients and corresponding configurations
+        type: array
+        items:
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of clients referenced in
+                'targetRef'
+              type: object
+              properties:
+                action:
+                  description: 'Action defines a behavior for the specified group of clients:'
+                  type: string
+                  enum:
+                    - Allow
+                    - Deny
+                    - AllowWithShadowDeny
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource that represents a group of
+                clients.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - MeshSubset
+                    - MeshGateway
+                    - MeshService
+                    - MeshExternalService
+                    - MeshMultiZoneService
+                    - MeshServiceSubset
+                    - MeshHTTPRoute
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                mesh:
+                  description: Mesh is reserved for future use to identify cross mesh resources.
+                  type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                proxyTypes:
+                  description: |-
+                    ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                    all data plane types are targeted by the policy.
+                  type: array
+                  items:
+                    enum:
+                      - Sidecar
+                      - Gateway
+                    type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+                tags:
+                  description: |-
+                    Tags used to select a subset of proxies by tags. Can only be used with kinds
+                    `MeshSubset` and `MeshServiceSubset`
+                  type: object
+                  additionalProperties:
+                    type: string
+              required:
+                - kind
+          required:
+            - targetRef
+          type: object
+      rules:
+        description: Rules defines inbound permissions configuration
+        type: array
+        items:
+          properties:
+            default:
+              type: object
+              properties:
+                allow:
+                  description: Allow definees a list of matches for which access will be allowed
+                  type: array
+                  items:
+                    properties:
+                      spiffeID:
+                        description: SpiffeID defines a matcher configuration for SpiffeID matching
+                        type: object
+                        properties:
+                          type:
+                            description: Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                            type: string
+                            enum:
+                              - Exact
+                              - Prefix
+                          value:
+                            description: Value is SpiffeId of a client that needs to match for the configuration to be applied
+                            type: string
+                        required:
+                          - type
+                          - value
+                    type: object
+                allowWithShadowDeny:
+                  description: |-
+                    AllowWithShadowDeny defines a list of matches for which access will be allowed but emits logs as if
+                    requests are denied
+                  type: array
+                  items:
+                    properties:
+                      spiffeID:
+                        description: SpiffeID defines a matcher configuration for SpiffeID matching
+                        type: object
+                        properties:
+                          type:
+                            description: Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                            type: string
+                            enum:
+                              - Exact
+                              - Prefix
+                          value:
+                            description: Value is SpiffeId of a client that needs to match for the configuration to be applied
+                            type: string
+                        required:
+                          - type
+                          - value
+                    type: object
+                deny:
+                  description: Deny defines a list of matches for which access will be denied
+                  type: array
+                  items:
+                    properties:
+                      spiffeID:
+                        description: SpiffeID defines a matcher configuration for SpiffeID matching
+                        type: object
+                        properties:
+                          type:
+                            description: Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                            type: string
+                            enum:
+                              - Exact
+                              - Prefix
+                          value:
+                            description: Value is SpiffeId of a client that needs to match for the configuration to be applied
+                            type: string
+                        required:
+                          - type
+                          - value
+                    type: object
+          required:
+            - default
+          type: object
+          default:
+            targetRef:
+              kind: MeshService
+            default:
+              action: Deny
+      targetRef:
+        description: |-
+          TargetRef is a reference to the resource the policy takes an effect on.
+          The resource could be either a real store object or virtual resource
+          defined inplace.
+        type: object
+        properties:
+          kind:
+            description: Kind of the referenced resource
+            type: string
+            enum:
+              - Mesh
+              - MeshSubset
+              - MeshGateway
+              - MeshService
+              - MeshExternalService
+              - MeshMultiZoneService
+              - MeshServiceSubset
+              - MeshHTTPRoute
+              - Dataplane
+          labels:
+            description: |-
+              Labels are used to select group of MeshServices that match labels. Either Labels or
+              Name and Namespace can be used.
+            type: object
+            additionalProperties:
+              type: string
+          mesh:
+            description: Mesh is reserved for future use to identify cross mesh resources.
+            type: string
+          name:
+            description: |-
+              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+              `MeshServiceSubset` and `MeshGatewayRoute`
+            type: string
+          namespace:
+            description: |-
+              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+              will be targeted.
+            type: string
+          proxyTypes:
+            description: |-
+              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+              all data plane types are targeted by the policy.
+            type: array
+            items:
+              enum:
+                - Sidecar
+                - Gateway
+              type: string
+          sectionName:
+            description: |-
+              SectionName is used to target specific section of resource.
+              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+            type: string
+          tags:
+            description: |-
+              Tags used to select a subset of proxies by tags. Can only be used with kinds
+              `MeshSubset` and `MeshServiceSubset`
+            type: object
+            additionalProperties:
+              type: string
+        required:
+          - kind
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+content:
+  application/json:
+    schema:
+      $ref: "MeshTrafficPermissionItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/components/schemas/TargetRefPolicy_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/TargetRefPolicy_Put_RequestBody.yaml
@@ -1,0 +1,49 @@
+description: Successful response
+type: object
+properties:
+  type:
+    description: the type of the resource
+    type: string
+  mesh:
+    description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+    type: string
+    default: default
+  kri:
+    description: A unique identifier for this resource instance used by internal tooling and integrations. Typically derived from resource attributes and may be used for cross-references or indexing
+    type: string
+    example: kri_mal_default_zone-east_kuma-demo_mypolicy1_
+    readOnly: true
+  name:
+    description: Name of the Kuma resource
+    type: string
+  labels:
+    description: The labels to help identity resources
+    type: object
+    additionalProperties:
+      type: string
+  creationTime:
+    description: Time at which the resource was created
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  modificationTime:
+    description: Time at which the resource was updated
+    type: string
+    format: date-time
+    example: '0001-01-01T00:00:00Z'
+    readOnly: true
+  spec:
+    description: Spec is the specification of the Kuma Policy resource.
+    properties:
+      targetRef:
+        $ref: "./MeshAccessLogItem.yaml#/properties/spec/properties/targetRef"
+content:
+  application/json:
+    schema:
+      $ref: "MeshAccessLogItem.yaml"
+required:
+  - type
+  - name
+  - spec
+x-request: true

--- a/packages/kuma-http-api/dist/openapi.yaml
+++ b/packages/kuma-http-api/dist/openapi.yaml
@@ -352,6 +352,40 @@ components:
       $ref: "components/schemas/LegacyPolicy.yaml"
     TargetRefPolicy:
       $ref: "components/schemas/TargetRefPolicy.yaml"
+    TargetRefPolicy_Put_RequestBody:
+      $ref: "components/schemas/TargetRefPolicy_Put_RequestBody.yaml"
+    MeshAccessLogItem_Put_RequestBody:
+      $ref: "components/schemas/MeshAccessLogItem_Put_RequestBody.yaml"
+    MeshCircuitBreakerItem_Put_RequestBody:
+      $ref: "components/schemas/MeshCircuitBreakerItem_Put_RequestBody.yaml"
+    MeshFaultInjectionItem_Put_RequestBody:
+      $ref: "components/schemas/MeshFaultInjectionItem_Put_RequestBody.yaml"
+    MeshHTTPRouteItem_Put_RequestBody:
+      $ref: "components/schemas/MeshHTTPRouteItem_Put_RequestBody.yaml"
+    MeshHealthCheckItem_Put_RequestBody:
+      $ref: "components/schemas/MeshHealthCheckItem_Put_RequestBody.yaml"
+    MeshLoadBalancingStrategyItem_Put_RequestBody:
+      $ref: "components/schemas/MeshLoadBalancingStrategyItem_Put_RequestBody.yaml"
+    MeshMetricItem_Put_RequestBody:
+      $ref: "components/schemas/MeshMetricItem_Put_RequestBody.yaml"
+    MeshPassthroughItem_Put_RequestBody:
+      $ref: "components/schemas/MeshPassthroughItem_Put_RequestBody.yaml"
+    MeshProxyPatchItem_Put_RequestBody:
+      $ref: "components/schemas/MeshProxyPatchItem_Put_RequestBody.yaml"
+    MeshRateLimitItem_Put_RequestBody:
+      $ref: "components/schemas/MeshRateLimitItem_Put_RequestBody.yaml"
+    MeshRetryItem_Put_RequestBody:
+      $ref: "components/schemas/MeshRetryItem_Put_RequestBody.yaml"
+    MeshTCPRouteItem_Put_RequestBody:
+      $ref: "components/schemas/MeshTCPRouteItem_Put_RequestBody.yaml"
+    MeshTimeoutItem_Put_RequestBody:
+      $ref: "components/schemas/MeshTimeoutItem_Put_RequestBody.yaml"
+    MeshTLSItem_Put_RequestBody:
+      $ref: "components/schemas/MeshTLSItem_Put_RequestBody.yaml"
+    MeshTraceItem_Put_RequestBody:
+      $ref: "components/schemas/MeshTraceItem_Put_RequestBody.yaml"
+    MeshTrafficPermissionItem_Put_RequestBody:
+      $ref: "components/schemas/MeshTrafficPermissionItem_Put_RequestBody.yaml"
   examples:
     GlobalInsightExample:
       $ref: "components/examples/GlobalInsightExample.yaml"

--- a/packages/kuma-http-api/index.d.ts
+++ b/packages/kuma-http-api/index.d.ts
@@ -9799,6 +9799,5205 @@ export interface components {
         PolicyCollection: components["schemas"]["PagedCollection"] & {
             items?: components["schemas"]["Policy"][];
         };
+        /** @description Successful response */
+        TargetRefPolicy_Put_RequestBody: {
+            /** @description the type of the resource */
+            readonly type: string;
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma Policy resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                targetRef?: components["schemas"]["MeshAccessLogItem"]["spec"]["targetRef"];
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshAccessLogItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshAccessLog";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshAccessLog resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @deprecated
+                 * @description From list makes a match between clients and corresponding configurations
+                 */
+                from?: {
+                    /**
+                     * @description Default is a configuration specific to the group of clients referenced in
+                     *     'targetRef'
+                     */
+                    default: {
+                        backends?: {
+                            /** @description FileBackend defines configuration for file based access logs */
+                            file?: {
+                                /**
+                                 * @description Format of access logs. Placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 */
+                                format?: {
+                                    /**
+                                     * @example [
+                                     *       {
+                                     *         "key": "start_time",
+                                     *         "value": "%START_TIME%"
+                                     *       },
+                                     *       {
+                                     *         "key": "bytes_received",
+                                     *         "value": "%BYTES_RECEIVED%"
+                                     *       }
+                                     *     ]
+                                     */
+                                    json?: {
+                                        key: string;
+                                        value: string;
+                                    }[];
+                                    /** @default false */
+                                    omitEmptyValues: boolean;
+                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
+                                    plain?: string;
+                                    /** @enum {string} */
+                                    type: "Plain" | "Json";
+                                };
+                                /**
+                                 * @description Path to a file that logs will be written to
+                                 * @example /tmp/access.log
+                                 */
+                                path: string;
+                            };
+                            /** @description Defines an OpenTelemetry logging backend. */
+                            openTelemetry?: {
+                                /**
+                                 * @description Attributes can contain placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 * @example [
+                                 *       {
+                                 *         "key": "mesh",
+                                 *         "value": "%KUMA_MESH%"
+                                 *       }
+                                 *     ]
+                                 */
+                                attributes?: {
+                                    key: string;
+                                    value: string;
+                                }[];
+                                /**
+                                 * @description Body is a raw string or an OTLP any value as described at
+                                 *     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                 *     It can contain placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 * @example {
+                                 *       "kvlistValue": {
+                                 *         "values": [
+                                 *           {
+                                 *             "key": "mesh",
+                                 *             "value": {
+                                 *               "stringValue": "%KUMA_MESH%"
+                                 *             }
+                                 *           }
+                                 *         ]
+                                 *       }
+                                 *     }
+                                 */
+                                body?: unknown;
+                                /**
+                                 * @description Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                 * @example otel-collector:4317
+                                 */
+                                endpoint: string;
+                            };
+                            /** @description TCPBackend defines a TCP logging backend. */
+                            tcp?: {
+                                /**
+                                 * @description Address of the TCP logging backend
+                                 * @example 127.0.0.1:5000
+                                 */
+                                address: string;
+                                /**
+                                 * @description Format of access logs. Placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 */
+                                format?: {
+                                    /**
+                                     * @example [
+                                     *       {
+                                     *         "key": "start_time",
+                                     *         "value": "%START_TIME%"
+                                     *       },
+                                     *       {
+                                     *         "key": "bytes_received",
+                                     *         "value": "%BYTES_RECEIVED%"
+                                     *       }
+                                     *     ]
+                                     */
+                                    json?: {
+                                        key: string;
+                                        value: string;
+                                    }[];
+                                    /** @default false */
+                                    omitEmptyValues: boolean;
+                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
+                                    plain?: string;
+                                    /** @enum {string} */
+                                    type: "Plain" | "Json";
+                                };
+                            };
+                            /** @enum {string} */
+                            type: "Tcp" | "File" | "OpenTelemetry";
+                        }[];
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     clients.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+                /**
+                 * @description Rules defines inbound access log configurations. Currently limited to
+                 *     selecting all inbound traffic, as L7 matching is not yet implemented.
+                 */
+                rules?: {
+                    /** @description Default contains configuration of the inbound access logging */
+                    default: {
+                        backends?: {
+                            /** @description FileBackend defines configuration for file based access logs */
+                            file?: {
+                                /**
+                                 * @description Format of access logs. Placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 */
+                                format?: {
+                                    /**
+                                     * @example [
+                                     *       {
+                                     *         "key": "start_time",
+                                     *         "value": "%START_TIME%"
+                                     *       },
+                                     *       {
+                                     *         "key": "bytes_received",
+                                     *         "value": "%BYTES_RECEIVED%"
+                                     *       }
+                                     *     ]
+                                     */
+                                    json?: {
+                                        key: string;
+                                        value: string;
+                                    }[];
+                                    /** @default false */
+                                    omitEmptyValues: boolean;
+                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
+                                    plain?: string;
+                                    /** @enum {string} */
+                                    type: "Plain" | "Json";
+                                };
+                                /**
+                                 * @description Path to a file that logs will be written to
+                                 * @example /tmp/access.log
+                                 */
+                                path: string;
+                            };
+                            /** @description Defines an OpenTelemetry logging backend. */
+                            openTelemetry?: {
+                                /**
+                                 * @description Attributes can contain placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 * @example [
+                                 *       {
+                                 *         "key": "mesh",
+                                 *         "value": "%KUMA_MESH%"
+                                 *       }
+                                 *     ]
+                                 */
+                                attributes?: {
+                                    key: string;
+                                    value: string;
+                                }[];
+                                /**
+                                 * @description Body is a raw string or an OTLP any value as described at
+                                 *     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                 *     It can contain placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 * @example {
+                                 *       "kvlistValue": {
+                                 *         "values": [
+                                 *           {
+                                 *             "key": "mesh",
+                                 *             "value": {
+                                 *               "stringValue": "%KUMA_MESH%"
+                                 *             }
+                                 *           }
+                                 *         ]
+                                 *       }
+                                 *     }
+                                 */
+                                body?: unknown;
+                                /**
+                                 * @description Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                 * @example otel-collector:4317
+                                 */
+                                endpoint: string;
+                            };
+                            /** @description TCPBackend defines a TCP logging backend. */
+                            tcp?: {
+                                /**
+                                 * @description Address of the TCP logging backend
+                                 * @example 127.0.0.1:5000
+                                 */
+                                address: string;
+                                /**
+                                 * @description Format of access logs. Placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 */
+                                format?: {
+                                    /**
+                                     * @example [
+                                     *       {
+                                     *         "key": "start_time",
+                                     *         "value": "%START_TIME%"
+                                     *       },
+                                     *       {
+                                     *         "key": "bytes_received",
+                                     *         "value": "%BYTES_RECEIVED%"
+                                     *       }
+                                     *     ]
+                                     */
+                                    json?: {
+                                        key: string;
+                                        value: string;
+                                    }[];
+                                    /** @default false */
+                                    omitEmptyValues: boolean;
+                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
+                                    plain?: string;
+                                    /** @enum {string} */
+                                    type: "Plain" | "Json";
+                                };
+                            };
+                            /** @enum {string} */
+                            type: "Tcp" | "File" | "OpenTelemetry";
+                        }[];
+                    };
+                }[];
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined in-place.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+                /** @description To list makes a match between the consumed services and corresponding configurations */
+                to?: {
+                    /**
+                     * @description Default is a configuration specific to the group of destinations referenced in
+                     *     'targetRef'
+                     */
+                    default: {
+                        backends?: {
+                            /** @description FileBackend defines configuration for file based access logs */
+                            file?: {
+                                /**
+                                 * @description Format of access logs. Placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 */
+                                format?: {
+                                    /**
+                                     * @example [
+                                     *       {
+                                     *         "key": "start_time",
+                                     *         "value": "%START_TIME%"
+                                     *       },
+                                     *       {
+                                     *         "key": "bytes_received",
+                                     *         "value": "%BYTES_RECEIVED%"
+                                     *       }
+                                     *     ]
+                                     */
+                                    json?: {
+                                        key: string;
+                                        value: string;
+                                    }[];
+                                    /** @default false */
+                                    omitEmptyValues: boolean;
+                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
+                                    plain?: string;
+                                    /** @enum {string} */
+                                    type: "Plain" | "Json";
+                                };
+                                /**
+                                 * @description Path to a file that logs will be written to
+                                 * @example /tmp/access.log
+                                 */
+                                path: string;
+                            };
+                            /** @description Defines an OpenTelemetry logging backend. */
+                            openTelemetry?: {
+                                /**
+                                 * @description Attributes can contain placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 * @example [
+                                 *       {
+                                 *         "key": "mesh",
+                                 *         "value": "%KUMA_MESH%"
+                                 *       }
+                                 *     ]
+                                 */
+                                attributes?: {
+                                    key: string;
+                                    value: string;
+                                }[];
+                                /**
+                                 * @description Body is a raw string or an OTLP any value as described at
+                                 *     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                 *     It can contain placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 * @example {
+                                 *       "kvlistValue": {
+                                 *         "values": [
+                                 *           {
+                                 *             "key": "mesh",
+                                 *             "value": {
+                                 *               "stringValue": "%KUMA_MESH%"
+                                 *             }
+                                 *           }
+                                 *         ]
+                                 *       }
+                                 *     }
+                                 */
+                                body?: unknown;
+                                /**
+                                 * @description Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                 * @example otel-collector:4317
+                                 */
+                                endpoint: string;
+                            };
+                            /** @description TCPBackend defines a TCP logging backend. */
+                            tcp?: {
+                                /**
+                                 * @description Address of the TCP logging backend
+                                 * @example 127.0.0.1:5000
+                                 */
+                                address: string;
+                                /**
+                                 * @description Format of access logs. Placeholders available on
+                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                 */
+                                format?: {
+                                    /**
+                                     * @example [
+                                     *       {
+                                     *         "key": "start_time",
+                                     *         "value": "%START_TIME%"
+                                     *       },
+                                     *       {
+                                     *         "key": "bytes_received",
+                                     *         "value": "%BYTES_RECEIVED%"
+                                     *       }
+                                     *     ]
+                                     */
+                                    json?: {
+                                        key: string;
+                                        value: string;
+                                    }[];
+                                    /** @default false */
+                                    omitEmptyValues: boolean;
+                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
+                                    plain?: string;
+                                    /** @enum {string} */
+                                    type: "Plain" | "Json";
+                                };
+                            };
+                            /** @enum {string} */
+                            type: "Tcp" | "File" | "OpenTelemetry";
+                        }[];
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     destinations.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshCircuitBreakerItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshCircuitBreaker";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshCircuitBreaker resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @deprecated
+                 * @description From list makes a match between clients and corresponding configurations
+                 */
+                from?: {
+                    /**
+                     * @description Default is a configuration specific to the group of destinations
+                     *     referenced in 'targetRef'
+                     */
+                    default?: {
+                        /**
+                         * @description ConnectionLimits contains configuration of each circuit breaking limit,
+                         *     which when exceeded makes the circuit breaker to become open (no traffic
+                         *     is allowed like no current is allowed in the circuits when physical
+                         *     circuit breaker ir open)
+                         */
+                        connectionLimits?: {
+                            /**
+                             * Format: int32
+                             * @description The maximum number of connection pools per cluster that are concurrently
+                             *     supported at once. Set this for clusters which create a large number of
+                             *     connection pools.
+                             */
+                            maxConnectionPools?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of connections allowed to be made to the upstream
+                             *     cluster.
+                             */
+                            maxConnections?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of pending requests that are allowed to the upstream
+                             *     cluster. This limit is applied as a connection limit for non-HTTP
+                             *     traffic.
+                             */
+                            maxPendingRequests?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of parallel requests that are allowed to be made
+                             *     to the upstream cluster. This limit does not apply to non-HTTP traffic.
+                             */
+                            maxRequests?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of parallel retries that will be allowed to
+                             *     the upstream cluster.
+                             */
+                            maxRetries?: number;
+                        };
+                        /**
+                         * @description OutlierDetection contains the configuration of the process of dynamically
+                         *     determining whether some number of hosts in an upstream cluster are
+                         *     performing unlike the others and removing them from the healthy load
+                         *     balancing set. Performance might be along different axes such as
+                         *     consecutive failures, temporal success rate, temporal latency, etc.
+                         *     Outlier detection is a form of passive health checking.
+                         */
+                        outlierDetection?: {
+                            /**
+                             * @description The base time that a host is ejected for. The real time is equal to
+                             *     the base time multiplied by the number of times the host has been
+                             *     ejected.
+                             */
+                            baseEjectionTime?: string;
+                            /** @description Contains configuration for supported outlier detectors */
+                            detectors?: {
+                                /**
+                                 * @description Failure Percentage based outlier detection functions similarly to success
+                                 *     rate detection, in that it relies on success rate data from each host in
+                                 *     a cluster. However, rather than compare those values to the mean success
+                                 *     rate of the cluster as a whole, they are compared to a flat
+                                 *     user-configured threshold. This threshold is configured via the
+                                 *     outlierDetection.failurePercentageThreshold field.
+                                 *     The other configuration fields for failure percentage based detection are
+                                 *     similar to the fields for success rate detection. As with success rate
+                                 *     detection, detection will not be performed for a host if its request
+                                 *     volume over the aggregation interval is less than the
+                                 *     outlierDetection.detectors.failurePercentage.requestVolume value.
+                                 *     Detection also will not be performed for a cluster if the number of hosts
+                                 *     with the minimum required request volume in an interval is less than the
+                                 *     outlierDetection.detectors.failurePercentage.minimumHosts value.
+                                 */
+                                failurePercentage?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The minimum number of hosts in a cluster in order to perform failure
+                                     *     percentage-based ejection. If the total number of hosts in the cluster is
+                                     *     less than this value, failure percentage-based ejection will not be
+                                     *     performed.
+                                     */
+                                    minimumHosts?: number;
+                                    /**
+                                     * Format: int32
+                                     * @description The minimum number of total requests that must be collected in one
+                                     *     interval (as defined by the interval duration above) to perform failure
+                                     *     percentage-based ejection for this host. If the volume is lower than this
+                                     *     setting, failure percentage-based ejection will not be performed for this
+                                     *     host.
+                                     */
+                                    requestVolume?: number;
+                                    /**
+                                     * Format: int32
+                                     * @description The failure percentage to use when determining failure percentage-based
+                                     *     outlier detection. If the failure percentage of a given host is greater
+                                     *     than or equal to this value, it will be ejected.
+                                     */
+                                    threshold?: number;
+                                };
+                                /**
+                                 * @description In the default mode (outlierDetection.splitExternalLocalOriginErrors is
+                                 *     false) this detection type takes into account a subset of 5xx errors,
+                                 *     called "gateway errors" (502, 503 or 504 status code) and local origin
+                                 *     failures, such as timeout, TCP reset etc.
+                                 *     In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                 *     this detection type takes into account a subset of 5xx errors, called
+                                 *     "gateway errors" (502, 503 or 504 status code) and is supported only by
+                                 *     the http router.
+                                 */
+                                gatewayFailures?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of consecutive gateway failures (502, 503, 504 status codes)
+                                     *     before a consecutive gateway failure ejection occurs.
+                                     */
+                                    consecutive?: number;
+                                };
+                                /**
+                                 * @description This detection type is enabled only when
+                                 *     outlierDetection.splitExternalLocalOriginErrors is true and takes into
+                                 *     account only locally originated errors (timeout, reset, etc).
+                                 *     If Envoy repeatedly cannot connect to an upstream host or communication
+                                 *     with the upstream host is repeatedly interrupted, it will be ejected.
+                                 *     Various locally originated problems are detected: timeout, TCP reset,
+                                 *     ICMP errors, etc. This detection type is supported by http router and
+                                 *     tcp proxy.
+                                 */
+                                localOriginFailures?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of consecutive locally originated failures before ejection
+                                     *     occurs. Parameter takes effect only when splitExternalAndLocalErrors
+                                     *     is set to true.
+                                     */
+                                    consecutive?: number;
+                                };
+                                /**
+                                 * @description Success Rate based outlier detection aggregates success rate data from
+                                 *     every host in a cluster. Then at given intervals ejects hosts based on
+                                 *     statistical outlier detection. Success Rate outlier detection will not be
+                                 *     calculated for a host if its request volume over the aggregation interval
+                                 *     is less than the outlierDetection.detectors.successRate.requestVolume
+                                 *     value.
+                                 *     Moreover, detection will not be performed for a cluster if the number of
+                                 *     hosts with the minimum required request volume in an interval is less
+                                 *     than the outlierDetection.detectors.successRate.minimumHosts value.
+                                 *     In the default configuration mode
+                                 *     (outlierDetection.splitExternalLocalOriginErrors is false) this detection
+                                 *     type takes into account all types of errors: locally and externally
+                                 *     originated.
+                                 *     In split mode (outlierDetection.splitExternalLocalOriginErrors is true),
+                                 *     locally originated errors and externally originated (transaction) errors
+                                 *     are counted and treated separately.
+                                 */
+                                successRate?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of hosts in a cluster that must have enough request volume to
+                                     *     detect success rate outliers. If the number of hosts is less than this
+                                     *     setting, outlier detection via success rate statistics is not performed
+                                     *     for any host in the cluster.
+                                     */
+                                    minimumHosts?: number;
+                                    /**
+                                     * Format: int32
+                                     * @description The minimum number of total requests that must be collected in one
+                                     *     interval (as defined by the interval duration configured in
+                                     *     outlierDetection section) to include this host in success rate based
+                                     *     outlier detection. If the volume is lower than this setting, outlier
+                                     *     detection via success rate statistics is not performed for that host.
+                                     */
+                                    requestVolume?: number;
+                                    /**
+                                     * @description This factor is used to determine the ejection threshold for success rate
+                                     *     outlier ejection. The ejection threshold is the difference between
+                                     *     the mean success rate, and the product of this factor and the standard
+                                     *     deviation of the mean success rate: mean - (standard_deviation *
+                                     *     success_rate_standard_deviation_factor).
+                                     *     Either int or decimal represented as string.
+                                     */
+                                    standardDeviationFactor?: number | string;
+                                };
+                                /**
+                                 * @description In the default mode (outlierDetection.splitExternalAndLocalErrors is
+                                 *     false) this detection type takes into account all generated errors:
+                                 *     locally originated and externally originated (transaction) errors.
+                                 *     In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                 *     this detection type takes into account only externally originated
+                                 *     (transaction) errors, ignoring locally originated errors.
+                                 *     If an upstream host is an HTTP-server, only 5xx types of error are taken
+                                 *     into account (see Consecutive Gateway Failure for exceptions).
+                                 *     Properly formatted responses, even when they carry an operational error
+                                 *     (like index not found, access denied) are not taken into account.
+                                 */
+                                totalFailures?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of consecutive server-side error responses (for HTTP traffic,
+                                     *     5xx responses; for TCP traffic, connection failures; for Redis, failure
+                                     *     to respond PONG; etc.) before a consecutive total failure ejection
+                                     *     occurs.
+                                     */
+                                    consecutive?: number;
+                                };
+                            };
+                            /** @description When set to true, outlierDetection configuration won't take any effect */
+                            disabled?: boolean;
+                            /**
+                             * @description Allows to configure panic threshold for Envoy cluster. If not specified,
+                             *     the default is 50%. To disable panic mode, set to 0%.
+                             *     Either int or decimal represented as string.
+                             */
+                            healthyPanicThreshold?: number | string;
+                            /**
+                             * @description The time interval between ejection analysis sweeps. This can result in
+                             *     both new ejections and hosts being returned to service.
+                             */
+                            interval?: string;
+                            /**
+                             * Format: int32
+                             * @description The maximum % of an upstream cluster that can be ejected due to outlier
+                             *     detection. Defaults to 10% but will eject at least one host regardless of
+                             *     the value.
+                             */
+                            maxEjectionPercent?: number;
+                            /**
+                             * @description Determines whether to distinguish local origin failures from external
+                             *     errors. If set to true the following configuration parameters are taken
+                             *     into account: detectors.localOriginFailures.consecutive
+                             */
+                            splitExternalAndLocalErrors?: boolean;
+                        };
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     destinations.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+                /**
+                 * @description Rules defines inbound circuit breaker configurations. Currently limited to
+                 *     selecting all inbound traffic, as L7 matching is not yet implemented.
+                 */
+                rules?: {
+                    /** @description Default contains configuration of the inbound circuit breaker */
+                    default?: {
+                        /**
+                         * @description ConnectionLimits contains configuration of each circuit breaking limit,
+                         *     which when exceeded makes the circuit breaker to become open (no traffic
+                         *     is allowed like no current is allowed in the circuits when physical
+                         *     circuit breaker ir open)
+                         */
+                        connectionLimits?: {
+                            /**
+                             * Format: int32
+                             * @description The maximum number of connection pools per cluster that are concurrently
+                             *     supported at once. Set this for clusters which create a large number of
+                             *     connection pools.
+                             */
+                            maxConnectionPools?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of connections allowed to be made to the upstream
+                             *     cluster.
+                             */
+                            maxConnections?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of pending requests that are allowed to the upstream
+                             *     cluster. This limit is applied as a connection limit for non-HTTP
+                             *     traffic.
+                             */
+                            maxPendingRequests?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of parallel requests that are allowed to be made
+                             *     to the upstream cluster. This limit does not apply to non-HTTP traffic.
+                             */
+                            maxRequests?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of parallel retries that will be allowed to
+                             *     the upstream cluster.
+                             */
+                            maxRetries?: number;
+                        };
+                        /**
+                         * @description OutlierDetection contains the configuration of the process of dynamically
+                         *     determining whether some number of hosts in an upstream cluster are
+                         *     performing unlike the others and removing them from the healthy load
+                         *     balancing set. Performance might be along different axes such as
+                         *     consecutive failures, temporal success rate, temporal latency, etc.
+                         *     Outlier detection is a form of passive health checking.
+                         */
+                        outlierDetection?: {
+                            /**
+                             * @description The base time that a host is ejected for. The real time is equal to
+                             *     the base time multiplied by the number of times the host has been
+                             *     ejected.
+                             */
+                            baseEjectionTime?: string;
+                            /** @description Contains configuration for supported outlier detectors */
+                            detectors?: {
+                                /**
+                                 * @description Failure Percentage based outlier detection functions similarly to success
+                                 *     rate detection, in that it relies on success rate data from each host in
+                                 *     a cluster. However, rather than compare those values to the mean success
+                                 *     rate of the cluster as a whole, they are compared to a flat
+                                 *     user-configured threshold. This threshold is configured via the
+                                 *     outlierDetection.failurePercentageThreshold field.
+                                 *     The other configuration fields for failure percentage based detection are
+                                 *     similar to the fields for success rate detection. As with success rate
+                                 *     detection, detection will not be performed for a host if its request
+                                 *     volume over the aggregation interval is less than the
+                                 *     outlierDetection.detectors.failurePercentage.requestVolume value.
+                                 *     Detection also will not be performed for a cluster if the number of hosts
+                                 *     with the minimum required request volume in an interval is less than the
+                                 *     outlierDetection.detectors.failurePercentage.minimumHosts value.
+                                 */
+                                failurePercentage?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The minimum number of hosts in a cluster in order to perform failure
+                                     *     percentage-based ejection. If the total number of hosts in the cluster is
+                                     *     less than this value, failure percentage-based ejection will not be
+                                     *     performed.
+                                     */
+                                    minimumHosts?: number;
+                                    /**
+                                     * Format: int32
+                                     * @description The minimum number of total requests that must be collected in one
+                                     *     interval (as defined by the interval duration above) to perform failure
+                                     *     percentage-based ejection for this host. If the volume is lower than this
+                                     *     setting, failure percentage-based ejection will not be performed for this
+                                     *     host.
+                                     */
+                                    requestVolume?: number;
+                                    /**
+                                     * Format: int32
+                                     * @description The failure percentage to use when determining failure percentage-based
+                                     *     outlier detection. If the failure percentage of a given host is greater
+                                     *     than or equal to this value, it will be ejected.
+                                     */
+                                    threshold?: number;
+                                };
+                                /**
+                                 * @description In the default mode (outlierDetection.splitExternalLocalOriginErrors is
+                                 *     false) this detection type takes into account a subset of 5xx errors,
+                                 *     called "gateway errors" (502, 503 or 504 status code) and local origin
+                                 *     failures, such as timeout, TCP reset etc.
+                                 *     In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                 *     this detection type takes into account a subset of 5xx errors, called
+                                 *     "gateway errors" (502, 503 or 504 status code) and is supported only by
+                                 *     the http router.
+                                 */
+                                gatewayFailures?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of consecutive gateway failures (502, 503, 504 status codes)
+                                     *     before a consecutive gateway failure ejection occurs.
+                                     */
+                                    consecutive?: number;
+                                };
+                                /**
+                                 * @description This detection type is enabled only when
+                                 *     outlierDetection.splitExternalLocalOriginErrors is true and takes into
+                                 *     account only locally originated errors (timeout, reset, etc).
+                                 *     If Envoy repeatedly cannot connect to an upstream host or communication
+                                 *     with the upstream host is repeatedly interrupted, it will be ejected.
+                                 *     Various locally originated problems are detected: timeout, TCP reset,
+                                 *     ICMP errors, etc. This detection type is supported by http router and
+                                 *     tcp proxy.
+                                 */
+                                localOriginFailures?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of consecutive locally originated failures before ejection
+                                     *     occurs. Parameter takes effect only when splitExternalAndLocalErrors
+                                     *     is set to true.
+                                     */
+                                    consecutive?: number;
+                                };
+                                /**
+                                 * @description Success Rate based outlier detection aggregates success rate data from
+                                 *     every host in a cluster. Then at given intervals ejects hosts based on
+                                 *     statistical outlier detection. Success Rate outlier detection will not be
+                                 *     calculated for a host if its request volume over the aggregation interval
+                                 *     is less than the outlierDetection.detectors.successRate.requestVolume
+                                 *     value.
+                                 *     Moreover, detection will not be performed for a cluster if the number of
+                                 *     hosts with the minimum required request volume in an interval is less
+                                 *     than the outlierDetection.detectors.successRate.minimumHosts value.
+                                 *     In the default configuration mode
+                                 *     (outlierDetection.splitExternalLocalOriginErrors is false) this detection
+                                 *     type takes into account all types of errors: locally and externally
+                                 *     originated.
+                                 *     In split mode (outlierDetection.splitExternalLocalOriginErrors is true),
+                                 *     locally originated errors and externally originated (transaction) errors
+                                 *     are counted and treated separately.
+                                 */
+                                successRate?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of hosts in a cluster that must have enough request volume to
+                                     *     detect success rate outliers. If the number of hosts is less than this
+                                     *     setting, outlier detection via success rate statistics is not performed
+                                     *     for any host in the cluster.
+                                     */
+                                    minimumHosts?: number;
+                                    /**
+                                     * Format: int32
+                                     * @description The minimum number of total requests that must be collected in one
+                                     *     interval (as defined by the interval duration configured in
+                                     *     outlierDetection section) to include this host in success rate based
+                                     *     outlier detection. If the volume is lower than this setting, outlier
+                                     *     detection via success rate statistics is not performed for that host.
+                                     */
+                                    requestVolume?: number;
+                                    /**
+                                     * @description This factor is used to determine the ejection threshold for success rate
+                                     *     outlier ejection. The ejection threshold is the difference between
+                                     *     the mean success rate, and the product of this factor and the standard
+                                     *     deviation of the mean success rate: mean - (standard_deviation *
+                                     *     success_rate_standard_deviation_factor).
+                                     *     Either int or decimal represented as string.
+                                     */
+                                    standardDeviationFactor?: number | string;
+                                };
+                                /**
+                                 * @description In the default mode (outlierDetection.splitExternalAndLocalErrors is
+                                 *     false) this detection type takes into account all generated errors:
+                                 *     locally originated and externally originated (transaction) errors.
+                                 *     In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                 *     this detection type takes into account only externally originated
+                                 *     (transaction) errors, ignoring locally originated errors.
+                                 *     If an upstream host is an HTTP-server, only 5xx types of error are taken
+                                 *     into account (see Consecutive Gateway Failure for exceptions).
+                                 *     Properly formatted responses, even when they carry an operational error
+                                 *     (like index not found, access denied) are not taken into account.
+                                 */
+                                totalFailures?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of consecutive server-side error responses (for HTTP traffic,
+                                     *     5xx responses; for TCP traffic, connection failures; for Redis, failure
+                                     *     to respond PONG; etc.) before a consecutive total failure ejection
+                                     *     occurs.
+                                     */
+                                    consecutive?: number;
+                                };
+                            };
+                            /** @description When set to true, outlierDetection configuration won't take any effect */
+                            disabled?: boolean;
+                            /**
+                             * @description Allows to configure panic threshold for Envoy cluster. If not specified,
+                             *     the default is 50%. To disable panic mode, set to 0%.
+                             *     Either int or decimal represented as string.
+                             */
+                            healthyPanicThreshold?: number | string;
+                            /**
+                             * @description The time interval between ejection analysis sweeps. This can result in
+                             *     both new ejections and hosts being returned to service.
+                             */
+                            interval?: string;
+                            /**
+                             * Format: int32
+                             * @description The maximum % of an upstream cluster that can be ejected due to outlier
+                             *     detection. Defaults to 10% but will eject at least one host regardless of
+                             *     the value.
+                             */
+                            maxEjectionPercent?: number;
+                            /**
+                             * @description Determines whether to distinguish local origin failures from external
+                             *     errors. If set to true the following configuration parameters are taken
+                             *     into account: detectors.localOriginFailures.consecutive
+                             */
+                            splitExternalAndLocalErrors?: boolean;
+                        };
+                    };
+                }[];
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined in place.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+                /**
+                 * @description To list makes a match between the consumed services and corresponding
+                 *     configurations
+                 */
+                to?: {
+                    /**
+                     * @description Default is a configuration specific to the group of destinations
+                     *     referenced in 'targetRef'
+                     * @default {
+                     *       "connectionLimits": {
+                     *         "maxConnections": 2,
+                     *         "maxPendingRequests": 8,
+                     *         "maxRetries": 2,
+                     *         "maxRequests": 2
+                     *       }
+                     *     }
+                     */
+                    default: {
+                        /**
+                         * @description ConnectionLimits contains configuration of each circuit breaking limit,
+                         *     which when exceeded makes the circuit breaker to become open (no traffic
+                         *     is allowed like no current is allowed in the circuits when physical
+                         *     circuit breaker ir open)
+                         */
+                        connectionLimits?: {
+                            /**
+                             * Format: int32
+                             * @description The maximum number of connection pools per cluster that are concurrently
+                             *     supported at once. Set this for clusters which create a large number of
+                             *     connection pools.
+                             */
+                            maxConnectionPools?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of connections allowed to be made to the upstream
+                             *     cluster.
+                             */
+                            maxConnections?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of pending requests that are allowed to the upstream
+                             *     cluster. This limit is applied as a connection limit for non-HTTP
+                             *     traffic.
+                             */
+                            maxPendingRequests?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of parallel requests that are allowed to be made
+                             *     to the upstream cluster. This limit does not apply to non-HTTP traffic.
+                             */
+                            maxRequests?: number;
+                            /**
+                             * Format: int32
+                             * @description The maximum number of parallel retries that will be allowed to
+                             *     the upstream cluster.
+                             */
+                            maxRetries?: number;
+                        };
+                        /**
+                         * @description OutlierDetection contains the configuration of the process of dynamically
+                         *     determining whether some number of hosts in an upstream cluster are
+                         *     performing unlike the others and removing them from the healthy load
+                         *     balancing set. Performance might be along different axes such as
+                         *     consecutive failures, temporal success rate, temporal latency, etc.
+                         *     Outlier detection is a form of passive health checking.
+                         */
+                        outlierDetection?: {
+                            /**
+                             * @description The base time that a host is ejected for. The real time is equal to
+                             *     the base time multiplied by the number of times the host has been
+                             *     ejected.
+                             */
+                            baseEjectionTime?: string;
+                            /** @description Contains configuration for supported outlier detectors */
+                            detectors?: {
+                                /**
+                                 * @description Failure Percentage based outlier detection functions similarly to success
+                                 *     rate detection, in that it relies on success rate data from each host in
+                                 *     a cluster. However, rather than compare those values to the mean success
+                                 *     rate of the cluster as a whole, they are compared to a flat
+                                 *     user-configured threshold. This threshold is configured via the
+                                 *     outlierDetection.failurePercentageThreshold field.
+                                 *     The other configuration fields for failure percentage based detection are
+                                 *     similar to the fields for success rate detection. As with success rate
+                                 *     detection, detection will not be performed for a host if its request
+                                 *     volume over the aggregation interval is less than the
+                                 *     outlierDetection.detectors.failurePercentage.requestVolume value.
+                                 *     Detection also will not be performed for a cluster if the number of hosts
+                                 *     with the minimum required request volume in an interval is less than the
+                                 *     outlierDetection.detectors.failurePercentage.minimumHosts value.
+                                 */
+                                failurePercentage?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The minimum number of hosts in a cluster in order to perform failure
+                                     *     percentage-based ejection. If the total number of hosts in the cluster is
+                                     *     less than this value, failure percentage-based ejection will not be
+                                     *     performed.
+                                     */
+                                    minimumHosts?: number;
+                                    /**
+                                     * Format: int32
+                                     * @description The minimum number of total requests that must be collected in one
+                                     *     interval (as defined by the interval duration above) to perform failure
+                                     *     percentage-based ejection for this host. If the volume is lower than this
+                                     *     setting, failure percentage-based ejection will not be performed for this
+                                     *     host.
+                                     */
+                                    requestVolume?: number;
+                                    /**
+                                     * Format: int32
+                                     * @description The failure percentage to use when determining failure percentage-based
+                                     *     outlier detection. If the failure percentage of a given host is greater
+                                     *     than or equal to this value, it will be ejected.
+                                     */
+                                    threshold?: number;
+                                };
+                                /**
+                                 * @description In the default mode (outlierDetection.splitExternalLocalOriginErrors is
+                                 *     false) this detection type takes into account a subset of 5xx errors,
+                                 *     called "gateway errors" (502, 503 or 504 status code) and local origin
+                                 *     failures, such as timeout, TCP reset etc.
+                                 *     In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                 *     this detection type takes into account a subset of 5xx errors, called
+                                 *     "gateway errors" (502, 503 or 504 status code) and is supported only by
+                                 *     the http router.
+                                 */
+                                gatewayFailures?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of consecutive gateway failures (502, 503, 504 status codes)
+                                     *     before a consecutive gateway failure ejection occurs.
+                                     */
+                                    consecutive?: number;
+                                };
+                                /**
+                                 * @description This detection type is enabled only when
+                                 *     outlierDetection.splitExternalLocalOriginErrors is true and takes into
+                                 *     account only locally originated errors (timeout, reset, etc).
+                                 *     If Envoy repeatedly cannot connect to an upstream host or communication
+                                 *     with the upstream host is repeatedly interrupted, it will be ejected.
+                                 *     Various locally originated problems are detected: timeout, TCP reset,
+                                 *     ICMP errors, etc. This detection type is supported by http router and
+                                 *     tcp proxy.
+                                 */
+                                localOriginFailures?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of consecutive locally originated failures before ejection
+                                     *     occurs. Parameter takes effect only when splitExternalAndLocalErrors
+                                     *     is set to true.
+                                     */
+                                    consecutive?: number;
+                                };
+                                /**
+                                 * @description Success Rate based outlier detection aggregates success rate data from
+                                 *     every host in a cluster. Then at given intervals ejects hosts based on
+                                 *     statistical outlier detection. Success Rate outlier detection will not be
+                                 *     calculated for a host if its request volume over the aggregation interval
+                                 *     is less than the outlierDetection.detectors.successRate.requestVolume
+                                 *     value.
+                                 *     Moreover, detection will not be performed for a cluster if the number of
+                                 *     hosts with the minimum required request volume in an interval is less
+                                 *     than the outlierDetection.detectors.successRate.minimumHosts value.
+                                 *     In the default configuration mode
+                                 *     (outlierDetection.splitExternalLocalOriginErrors is false) this detection
+                                 *     type takes into account all types of errors: locally and externally
+                                 *     originated.
+                                 *     In split mode (outlierDetection.splitExternalLocalOriginErrors is true),
+                                 *     locally originated errors and externally originated (transaction) errors
+                                 *     are counted and treated separately.
+                                 */
+                                successRate?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of hosts in a cluster that must have enough request volume to
+                                     *     detect success rate outliers. If the number of hosts is less than this
+                                     *     setting, outlier detection via success rate statistics is not performed
+                                     *     for any host in the cluster.
+                                     */
+                                    minimumHosts?: number;
+                                    /**
+                                     * Format: int32
+                                     * @description The minimum number of total requests that must be collected in one
+                                     *     interval (as defined by the interval duration configured in
+                                     *     outlierDetection section) to include this host in success rate based
+                                     *     outlier detection. If the volume is lower than this setting, outlier
+                                     *     detection via success rate statistics is not performed for that host.
+                                     */
+                                    requestVolume?: number;
+                                    /**
+                                     * @description This factor is used to determine the ejection threshold for success rate
+                                     *     outlier ejection. The ejection threshold is the difference between
+                                     *     the mean success rate, and the product of this factor and the standard
+                                     *     deviation of the mean success rate: mean - (standard_deviation *
+                                     *     success_rate_standard_deviation_factor).
+                                     *     Either int or decimal represented as string.
+                                     */
+                                    standardDeviationFactor?: number | string;
+                                };
+                                /**
+                                 * @description In the default mode (outlierDetection.splitExternalAndLocalErrors is
+                                 *     false) this detection type takes into account all generated errors:
+                                 *     locally originated and externally originated (transaction) errors.
+                                 *     In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                 *     this detection type takes into account only externally originated
+                                 *     (transaction) errors, ignoring locally originated errors.
+                                 *     If an upstream host is an HTTP-server, only 5xx types of error are taken
+                                 *     into account (see Consecutive Gateway Failure for exceptions).
+                                 *     Properly formatted responses, even when they carry an operational error
+                                 *     (like index not found, access denied) are not taken into account.
+                                 */
+                                totalFailures?: {
+                                    /**
+                                     * Format: int32
+                                     * @description The number of consecutive server-side error responses (for HTTP traffic,
+                                     *     5xx responses; for TCP traffic, connection failures; for Redis, failure
+                                     *     to respond PONG; etc.) before a consecutive total failure ejection
+                                     *     occurs.
+                                     */
+                                    consecutive?: number;
+                                };
+                            };
+                            /** @description When set to true, outlierDetection configuration won't take any effect */
+                            disabled?: boolean;
+                            /**
+                             * @description Allows to configure panic threshold for Envoy cluster. If not specified,
+                             *     the default is 50%. To disable panic mode, set to 0%.
+                             *     Either int or decimal represented as string.
+                             */
+                            healthyPanicThreshold?: number | string;
+                            /**
+                             * @description The time interval between ejection analysis sweeps. This can result in
+                             *     both new ejections and hosts being returned to service.
+                             */
+                            interval?: string;
+                            /**
+                             * Format: int32
+                             * @description The maximum % of an upstream cluster that can be ejected due to outlier
+                             *     detection. Defaults to 10% but will eject at least one host regardless of
+                             *     the value.
+                             */
+                            maxEjectionPercent?: number;
+                            /**
+                             * @description Determines whether to distinguish local origin failures from external
+                             *     errors. If set to true the following configuration parameters are taken
+                             *     into account: detectors.localOriginFailures.consecutive
+                             */
+                            splitExternalAndLocalErrors?: boolean;
+                        };
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     destinations.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshFaultInjectionItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshFaultInjection";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshFaultInjection resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @deprecated
+                 * @description From list makes a match between clients and corresponding configurations
+                 */
+                from?: {
+                    /**
+                     * @description Default is a configuration specific to the group of destinations referenced in
+                     *     'targetRef'
+                     */
+                    default?: {
+                        /** @description Http allows to define list of Http faults between dataplanes. */
+                        http?: {
+                            /**
+                             * @description Abort defines a configuration of not delivering requests to destination
+                             *     service and replacing the responses from destination dataplane by
+                             *     predefined status code
+                             */
+                            abort?: {
+                                /**
+                                 * Format: int32
+                                 * @description HTTP status code which will be returned to source side
+                                 */
+                                httpStatus: number;
+                                /**
+                                 * @description Percentage of requests on which abort will be injected, has to be
+                                 *     either int or decimal represented as string.
+                                 */
+                                percentage: number | string;
+                            };
+                            /** @description Delay defines configuration of delaying a response from a destination */
+                            delay?: {
+                                /**
+                                 * @description Percentage of requests on which delay will be injected, has to be
+                                 *     either int or decimal represented as string.
+                                 */
+                                percentage: number | string;
+                                /** @description The duration during which the response will be delayed */
+                                value: string;
+                            };
+                            /**
+                             * @description ResponseBandwidth defines a configuration to limit the speed of
+                             *     responding to the requests
+                             */
+                            responseBandwidth?: {
+                                /**
+                                 * @description Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
+                                 *     10kbps
+                                 */
+                                limit: string;
+                                /**
+                                 * @description Percentage of requests on which response bandwidth limit will be
+                                 *     either int or decimal represented as string.
+                                 */
+                                percentage: number | string;
+                            };
+                        }[];
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     destinations.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+                /** @description Rules defines inbound fault injection configuration */
+                rules?: {
+                    /** @description Default defines fault configuration */
+                    default: {
+                        /** @description Http allows to define list of Http faults between dataplanes. */
+                        http?: {
+                            /**
+                             * @description Abort defines a configuration of not delivering requests to destination
+                             *     service and replacing the responses from destination dataplane by
+                             *     predefined status code
+                             */
+                            abort?: {
+                                /**
+                                 * Format: int32
+                                 * @description HTTP status code which will be returned to source side
+                                 */
+                                httpStatus: number;
+                                /**
+                                 * @description Percentage of requests on which abort will be injected, has to be
+                                 *     either int or decimal represented as string.
+                                 */
+                                percentage: number | string;
+                            };
+                            /** @description Delay defines configuration of delaying a response from a destination */
+                            delay?: {
+                                /**
+                                 * @description Percentage of requests on which delay will be injected, has to be
+                                 *     either int or decimal represented as string.
+                                 */
+                                percentage: number | string;
+                                /** @description The duration during which the response will be delayed */
+                                value: string;
+                            };
+                            /**
+                             * @description ResponseBandwidth defines a configuration to limit the speed of
+                             *     responding to the requests
+                             */
+                            responseBandwidth?: {
+                                /**
+                                 * @description Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
+                                 *     10kbps
+                                 */
+                                limit: string;
+                                /**
+                                 * @description Percentage of requests on which response bandwidth limit will be
+                                 *     either int or decimal represented as string.
+                                 */
+                                percentage: number | string;
+                            };
+                        }[];
+                    };
+                    /** @description Matches defines list of matches for which fault injection will be applied */
+                    matches?: {
+                        /** @description SpiffeID defines a matcher configuration for SpiffeID matching */
+                        spiffeID?: {
+                            /**
+                             * @description Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                             * @enum {string}
+                             */
+                            type: "Exact" | "Prefix";
+                            /** @description Value is SpiffeId of a client that needs to match for the configuration to be applied */
+                            value: string;
+                        };
+                    }[];
+                }[];
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined inplace.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+                /** @description To list makes a match between clients and corresponding configurations */
+                to?: {
+                    /**
+                     * @description Default is a configuration specific to the group of destinations referenced in
+                     *     'targetRef'
+                     */
+                    default?: {
+                        /** @description Http allows to define list of Http faults between dataplanes. */
+                        http?: {
+                            /**
+                             * @description Abort defines a configuration of not delivering requests to destination
+                             *     service and replacing the responses from destination dataplane by
+                             *     predefined status code
+                             */
+                            abort?: {
+                                /**
+                                 * Format: int32
+                                 * @description HTTP status code which will be returned to source side
+                                 */
+                                httpStatus: number;
+                                /**
+                                 * @description Percentage of requests on which abort will be injected, has to be
+                                 *     either int or decimal represented as string.
+                                 */
+                                percentage: number | string;
+                            };
+                            /** @description Delay defines configuration of delaying a response from a destination */
+                            delay?: {
+                                /**
+                                 * @description Percentage of requests on which delay will be injected, has to be
+                                 *     either int or decimal represented as string.
+                                 */
+                                percentage: number | string;
+                                /** @description The duration during which the response will be delayed */
+                                value: string;
+                            };
+                            /**
+                             * @description ResponseBandwidth defines a configuration to limit the speed of
+                             *     responding to the requests
+                             */
+                            responseBandwidth?: {
+                                /**
+                                 * @description Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
+                                 *     10kbps
+                                 */
+                                limit: string;
+                                /**
+                                 * @description Percentage of requests on which response bandwidth limit will be
+                                 *     either int or decimal represented as string.
+                                 */
+                                percentage: number | string;
+                            };
+                        }[];
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     destinations.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshHTTPRouteItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshHTTPRoute";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshHTTPRoute resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined inplace.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+                /** @description To matches destination services of requests and holds configuration. */
+                to?: {
+                    /**
+                     * @description Hostnames is only valid when targeting MeshGateway and limits the
+                     *     effects of the rules to requests to this hostname.
+                     *     Given hostnames must intersect with the hostname of the listeners the
+                     *     route attaches to.
+                     */
+                    hostnames?: string[];
+                    /**
+                     * @description Rules contains the routing rules applies to a combination of top-level
+                     *     targetRef and the targetRef in this entry.
+                     */
+                    rules: {
+                        /**
+                         * @description Default holds routing rules that can be merged with rules from other
+                         *     policies.
+                         */
+                        default: {
+                            backendRefs?: {
+                                /**
+                                 * @description Kind of the referenced resource
+                                 * @enum {string}
+                                 */
+                                kind: "Mesh" | "MeshSubset" | "MeshGateway" | "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshServiceSubset" | "MeshHTTPRoute" | "Dataplane";
+                                /**
+                                 * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                                 *     Name and Namespace can be used.
+                                 */
+                                labels?: {
+                                    [key: string]: string;
+                                };
+                                /** @description Mesh is reserved for future use to identify cross mesh resources. */
+                                mesh?: string;
+                                /**
+                                 * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                                 *     `MeshServiceSubset` and `MeshGatewayRoute`
+                                 */
+                                name?: string;
+                                /**
+                                 * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                                 *     will be targeted.
+                                 */
+                                namespace?: string;
+                                /**
+                                 * Format: int32
+                                 * @description Port is only supported when this ref refers to a real MeshService object
+                                 */
+                                port?: number;
+                                /**
+                                 * @description ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                                 *     all data plane types are targeted by the policy.
+                                 */
+                                proxyTypes?: ("Sidecar" | "Gateway")[];
+                                /**
+                                 * @description SectionName is used to target specific section of resource.
+                                 *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                                 */
+                                sectionName?: string;
+                                /**
+                                 * @description Tags used to select a subset of proxies by tags. Can only be used with kinds
+                                 *     `MeshSubset` and `MeshServiceSubset`
+                                 */
+                                tags?: {
+                                    [key: string]: string;
+                                };
+                                /** @default 1 */
+                                weight: number;
+                            }[];
+                            filters?: {
+                                /**
+                                 * @description Only one action is supported per header name.
+                                 *     Configuration to set or add multiple values for a header must use RFC 7230
+                                 *     header value formatting, separating each value with a comma.
+                                 */
+                                requestHeaderModifier?: {
+                                    add?: {
+                                        name: string;
+                                        value: string;
+                                    }[];
+                                    remove?: string[];
+                                    set?: {
+                                        name: string;
+                                        value: string;
+                                    }[];
+                                };
+                                requestMirror?: {
+                                    /** @description BackendRef defines where to forward traffic. */
+                                    backendRef: {
+                                        /**
+                                         * @description Kind of the referenced resource
+                                         * @enum {string}
+                                         */
+                                        kind: "Mesh" | "MeshSubset" | "MeshGateway" | "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshServiceSubset" | "MeshHTTPRoute" | "Dataplane";
+                                        /**
+                                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                                         *     Name and Namespace can be used.
+                                         */
+                                        labels?: {
+                                            [key: string]: string;
+                                        };
+                                        /** @description Mesh is reserved for future use to identify cross mesh resources. */
+                                        mesh?: string;
+                                        /**
+                                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                                         */
+                                        name?: string;
+                                        /**
+                                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                                         *     will be targeted.
+                                         */
+                                        namespace?: string;
+                                        /**
+                                         * Format: int32
+                                         * @description Port is only supported when this ref refers to a real MeshService object
+                                         */
+                                        port?: number;
+                                        /**
+                                         * @description ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                                         *     all data plane types are targeted by the policy.
+                                         */
+                                        proxyTypes?: ("Sidecar" | "Gateway")[];
+                                        /**
+                                         * @description SectionName is used to target specific section of resource.
+                                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                                         */
+                                        sectionName?: string;
+                                        /**
+                                         * @description Tags used to select a subset of proxies by tags. Can only be used with kinds
+                                         *     `MeshSubset` and `MeshServiceSubset`
+                                         */
+                                        tags?: {
+                                            [key: string]: string;
+                                        };
+                                        /** @default 1 */
+                                        weight: number;
+                                    };
+                                    /**
+                                     * @description Percentage of requests to mirror. If not specified, all requests
+                                     *     to the target cluster will be mirrored.
+                                     */
+                                    percentage?: number | string;
+                                };
+                                requestRedirect?: {
+                                    /**
+                                     * @description PreciseHostname is the fully qualified domain name of a network host. This
+                                     *     matches the RFC 1123 definition of a hostname with 1 notable exception that
+                                     *     numeric IP addresses are not allowed.
+                                     *
+                                     *     Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                     *     alphanumeric characters or '-', and must start and end with an alphanumeric
+                                     *     character. No other punctuation is allowed.
+                                     */
+                                    hostname?: string;
+                                    /**
+                                     * @description Path defines parameters used to modify the path of the incoming request.
+                                     *     The modified path is then used to construct the location header.
+                                     *     When empty, the request path is used as-is.
+                                     */
+                                    path?: {
+                                        replaceFullPath?: string;
+                                        replacePrefixMatch?: string;
+                                        /** @enum {string} */
+                                        type: "ReplaceFullPath" | "ReplacePrefixMatch";
+                                    };
+                                    /**
+                                     * Format: int32
+                                     * @description Port is the port to be used in the value of the `Location`
+                                     *     header in the response.
+                                     *     When empty, port (if specified) of the request is used.
+                                     */
+                                    port?: number;
+                                    /** @enum {string} */
+                                    scheme?: "http" | "https";
+                                    /**
+                                     * @description StatusCode is the HTTP status code to be used in response.
+                                     * @default 302
+                                     * @enum {integer}
+                                     */
+                                    statusCode: 301 | 302 | 303 | 307 | 308;
+                                };
+                                /**
+                                 * @description Only one action is supported per header name.
+                                 *     Configuration to set or add multiple values for a header must use RFC 7230
+                                 *     header value formatting, separating each value with a comma.
+                                 */
+                                responseHeaderModifier?: {
+                                    add?: {
+                                        name: string;
+                                        value: string;
+                                    }[];
+                                    remove?: string[];
+                                    set?: {
+                                        name: string;
+                                        value: string;
+                                    }[];
+                                };
+                                /** @enum {string} */
+                                type: "RequestHeaderModifier" | "ResponseHeaderModifier" | "RequestRedirect" | "URLRewrite" | "RequestMirror";
+                                urlRewrite?: {
+                                    /**
+                                     * @description HostToBackendHostname rewrites the hostname to the hostname of the
+                                     *     upstream host. This option is only available when targeting MeshGateways.
+                                     */
+                                    hostToBackendHostname?: boolean;
+                                    /** @description Hostname is the value to be used to replace the host header value during forwarding. */
+                                    hostname?: string;
+                                    /** @description Path defines a path rewrite. */
+                                    path?: {
+                                        replaceFullPath?: string;
+                                        replacePrefixMatch?: string;
+                                        /** @enum {string} */
+                                        type: "ReplaceFullPath" | "ReplacePrefixMatch";
+                                    };
+                                };
+                            }[];
+                        };
+                        /**
+                         * @description Matches describes how to match HTTP requests this rule should be applied
+                         *     to.
+                         */
+                        matches: {
+                            headers?: {
+                                /**
+                                 * @description Name is the name of the HTTP Header to be matched. Name MUST be lower case
+                                 *     as they will be handled with case insensitivity (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                 */
+                                name: string;
+                                /**
+                                 * @description Type specifies how to match against the value of the header.
+                                 * @default Exact
+                                 * @enum {string}
+                                 */
+                                type: "Exact" | "Present" | "RegularExpression" | "Absent" | "Prefix";
+                                /** @description Value is the value of HTTP Header to be matched. */
+                                value?: string;
+                            }[];
+                            /** @enum {string} */
+                            method?: "CONNECT" | "DELETE" | "GET" | "HEAD" | "OPTIONS" | "PATCH" | "POST" | "PUT" | "TRACE";
+                            path?: {
+                                /** @enum {string} */
+                                type: "Exact" | "PathPrefix" | "RegularExpression";
+                                /**
+                                 * @description Exact or prefix matches must be an absolute path. A prefix matches only
+                                 *     if separated by a slash or the entire path.
+                                 */
+                                value: string;
+                            };
+                            /**
+                             * @description QueryParams matches based on HTTP URL query parameters. Multiple matches
+                             *     are ANDed together such that all listed matches must succeed.
+                             */
+                            queryParams?: {
+                                name: string;
+                                /** @enum {string} */
+                                type: "Exact" | "RegularExpression";
+                                value: string;
+                            }[];
+                        }[];
+                    }[];
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     request destinations.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshHealthCheckItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshHealthCheck";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshHealthCheck resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined inplace.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+                /** @description To list makes a match between the consumed services and corresponding configurations */
+                to?: {
+                    /**
+                     * @description Default is a configuration specific to the group of destinations referenced in
+                     *     'targetRef'
+                     */
+                    default?: {
+                        /**
+                         * @description If set to true, health check failure events will always be logged. If set
+                         *     to false, only the initial health check failure event will be logged. The
+                         *     default value is false.
+                         */
+                        alwaysLogHealthCheckFailures?: boolean;
+                        /**
+                         * @description Specifies the path to the file where Envoy can log health check events.
+                         *     If empty, no event log will be written.
+                         */
+                        eventLogPath?: string;
+                        /**
+                         * @description If set to true, Envoy will not consider any hosts when the cluster is in
+                         *     'panic mode'. Instead, the cluster will fail all requests as if all hosts
+                         *     are unhealthy. This can help avoid potentially overwhelming a failing
+                         *     service.
+                         */
+                        failTrafficOnPanic?: boolean;
+                        /**
+                         * @description GrpcHealthCheck defines gRPC configuration which will instruct the service
+                         *     the health check will be made for is a gRPC service.
+                         */
+                        grpc?: {
+                            /**
+                             * @description The value of the :authority header in the gRPC health check request,
+                             *     by default name of the cluster this health check is associated with
+                             */
+                            authority?: string;
+                            /** @description If true the GrpcHealthCheck is disabled */
+                            disabled?: boolean;
+                            /** @description Service name parameter which will be sent to gRPC service */
+                            serviceName?: string;
+                        };
+                        /**
+                         * @description Allows to configure panic threshold for Envoy cluster. If not specified,
+                         *     the default is 50%. To disable panic mode, set to 0%.
+                         *     Either int or decimal represented as string.
+                         *
+                         *     Deprecated: the setting has been moved to MeshCircuitBreaker policy,
+                         *     please use MeshCircuitBreaker policy instead.
+                         */
+                        healthyPanicThreshold?: number | string;
+                        /**
+                         * Format: int32
+                         * @description Number of consecutive healthy checks before considering a host healthy.
+                         *     If not specified then the default value is 1
+                         */
+                        healthyThreshold?: number;
+                        /**
+                         * @description HttpHealthCheck defines HTTP configuration which will instruct the service
+                         *     the health check will be made for is an HTTP service.
+                         */
+                        http?: {
+                            /** @description If true the HttpHealthCheck is disabled */
+                            disabled?: boolean;
+                            /** @description List of HTTP response statuses which are considered healthy */
+                            expectedStatuses?: number[];
+                            /**
+                             * @description The HTTP path which will be requested during the health check
+                             *     (ie. /health)
+                             *     If not specified then the default value is "/"
+                             */
+                            path?: string;
+                            /**
+                             * @description The list of HTTP headers which should be added to each health check
+                             *     request
+                             */
+                            requestHeadersToAdd?: {
+                                add?: {
+                                    name: string;
+                                    value: string;
+                                }[];
+                                set?: {
+                                    name: string;
+                                    value: string;
+                                }[];
+                            };
+                        };
+                        /**
+                         * @description If specified, Envoy will start health checking after a random time in
+                         *     ms between 0 and initialJitter. This only applies to the first health
+                         *     check.
+                         */
+                        initialJitter?: string;
+                        /**
+                         * @description Interval between consecutive health checks.
+                         *     If not specified then the default value is 1m
+                         */
+                        interval?: string;
+                        /**
+                         * @description If specified, during every interval Envoy will add IntervalJitter to the
+                         *     wait time.
+                         */
+                        intervalJitter?: string;
+                        /**
+                         * Format: int32
+                         * @description If specified, during every interval Envoy will add IntervalJitter *
+                         *     IntervalJitterPercent / 100 to the wait time. If IntervalJitter and
+                         *     IntervalJitterPercent are both set, both of them will be used to
+                         *     increase the wait time.
+                         */
+                        intervalJitterPercent?: number;
+                        /**
+                         * @description The "no traffic interval" is a special health check interval that is used
+                         *     when a cluster has never had traffic routed to it. This lower interval
+                         *     allows cluster information to be kept up to date, without sending a
+                         *     potentially large amount of active health checking traffic for no reason.
+                         *     Once a cluster has been used for traffic routing, Envoy will shift back
+                         *     to using the standard health check interval that is defined. Note that
+                         *     this interval takes precedence over any other. The default value for "no
+                         *     traffic interval" is 60 seconds.
+                         */
+                        noTrafficInterval?: string;
+                        /** @description Reuse health check connection between health checks. Default is true. */
+                        reuseConnection?: boolean;
+                        /**
+                         * @description TcpHealthCheck defines configuration for specifying bytes to send and
+                         *     expected response during the health check
+                         */
+                        tcp?: {
+                            /** @description If true the TcpHealthCheck is disabled */
+                            disabled?: boolean;
+                            /**
+                             * @description List of Base64 encoded blocks of strings expected as a response. When checking the response,
+                             *     "fuzzy" matching is performed such that each block must be found, and
+                             *     in the order specified, but not necessarily contiguous.
+                             *     If not provided or empty, checks will be performed as "connect only" and be marked as successful when TCP connection is successfully established.
+                             */
+                            receive?: string[];
+                            /** @description Base64 encoded content of the message which will be sent during the health check to the target */
+                            send?: string;
+                        };
+                        /**
+                         * @description Maximum time to wait for a health check response.
+                         *     If not specified then the default value is 15s
+                         */
+                        timeout?: string;
+                        /**
+                         * Format: int32
+                         * @description Number of consecutive unhealthy checks before considering a host
+                         *     unhealthy.
+                         *     If not specified then the default value is 5
+                         */
+                        unhealthyThreshold?: number;
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     destinations.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshLoadBalancingStrategyItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshLoadBalancingStrategy";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshLoadBalancingStrategy resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined inplace.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+                /** @description To list makes a match between the consumed services and corresponding configurations */
+                to?: {
+                    /**
+                     * @description Default is a configuration specific to the group of destinations referenced in
+                     *     'targetRef'
+                     */
+                    default?: {
+                        /**
+                         * @description HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                         *     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                         *     set to true, and there is already a hash generated, the hash is returned immediately,
+                         *     ignoring the rest of the hash policy list.
+                         */
+                        hashPolicies?: {
+                            connection?: {
+                                /** @description Hash on source IP address. */
+                                sourceIP?: boolean;
+                            };
+                            cookie?: {
+                                /** @description The name of the cookie that will be used to obtain the hash key. */
+                                name: string;
+                                /** @description The name of the path for the cookie. */
+                                path?: string;
+                                /** @description If specified, a cookie with the TTL will be generated if the cookie is not present. */
+                                ttl?: string;
+                            };
+                            filterState?: {
+                                /**
+                                 * @description The name of the Object in the per-request filterState, which is
+                                 *     an Envoy::Hashable object. If there is no data associated with the key,
+                                 *     or the stored object is not Envoy::Hashable, no hash will be produced.
+                                 */
+                                key: string;
+                            };
+                            header?: {
+                                /** @description The name of the request header that will be used to obtain the hash key. */
+                                name: string;
+                            };
+                            queryParameter?: {
+                                /**
+                                 * @description The name of the URL query parameter that will be used to obtain the hash key.
+                                 *     If the parameter is not present, no hash will be produced. Query parameter names
+                                 *     are case-sensitive.
+                                 */
+                                name: string;
+                            };
+                            /**
+                             * @description Terminal is a flag that short-circuits the hash computing. This field provides
+                             *     a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                             *     to rest of the policy list”, it saves time when the terminal policy works.
+                             *     If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                             */
+                            terminal?: boolean;
+                            /** @enum {string} */
+                            type: "Header" | "Cookie" | "Connection" | "SourceIP" | "QueryParameter" | "FilterState";
+                        }[];
+                        /** @description LoadBalancer allows to specify load balancing algorithm. */
+                        loadBalancer?: {
+                            /**
+                             * @description LeastRequest selects N random available hosts as specified in 'choiceCount' (2 by default)
+                             *     and picks the host which has the fewest active requests
+                             */
+                            leastRequest?: {
+                                /**
+                                 * @description ActiveRequestBias refers to dynamic weights applied when hosts have varying load
+                                 *     balancing weights. A higher value here aggressively reduces the weight of endpoints
+                                 *     that are currently handling active requests. In essence, the higher the ActiveRequestBias
+                                 *     value, the more forcefully it reduces the load balancing weight of endpoints that are
+                                 *     actively serving requests.
+                                 */
+                                activeRequestBias?: number | string;
+                                /**
+                                 * Format: int32
+                                 * @description ChoiceCount is the number of random healthy hosts from which the host with
+                                 *     the fewest active requests will be chosen. Defaults to 2 so that Envoy performs
+                                 *     two-choice selection if the field is not set.
+                                 */
+                                choiceCount?: number;
+                            };
+                            /**
+                             * @description Maglev implements consistent hashing to upstream hosts. Maglev can be used as
+                             *     a drop in replacement for the ring hash load balancer any place in which
+                             *     consistent hashing is desired.
+                             */
+                            maglev?: {
+                                /**
+                                 * @description HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                                 *     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                                 *     set to true, and there is already a hash generated, the hash is returned immediately,
+                                 *     ignoring the rest of the hash policy list.
+                                 */
+                                hashPolicies?: {
+                                    connection?: {
+                                        /** @description Hash on source IP address. */
+                                        sourceIP?: boolean;
+                                    };
+                                    cookie?: {
+                                        /** @description The name of the cookie that will be used to obtain the hash key. */
+                                        name: string;
+                                        /** @description The name of the path for the cookie. */
+                                        path?: string;
+                                        /** @description If specified, a cookie with the TTL will be generated if the cookie is not present. */
+                                        ttl?: string;
+                                    };
+                                    filterState?: {
+                                        /**
+                                         * @description The name of the Object in the per-request filterState, which is
+                                         *     an Envoy::Hashable object. If there is no data associated with the key,
+                                         *     or the stored object is not Envoy::Hashable, no hash will be produced.
+                                         */
+                                        key: string;
+                                    };
+                                    header?: {
+                                        /** @description The name of the request header that will be used to obtain the hash key. */
+                                        name: string;
+                                    };
+                                    queryParameter?: {
+                                        /**
+                                         * @description The name of the URL query parameter that will be used to obtain the hash key.
+                                         *     If the parameter is not present, no hash will be produced. Query parameter names
+                                         *     are case-sensitive.
+                                         */
+                                        name: string;
+                                    };
+                                    /**
+                                     * @description Terminal is a flag that short-circuits the hash computing. This field provides
+                                     *     a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                     *     to rest of the policy list”, it saves time when the terminal policy works.
+                                     *     If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                                     */
+                                    terminal?: boolean;
+                                    /** @enum {string} */
+                                    type: "Header" | "Cookie" | "Connection" | "SourceIP" | "QueryParameter" | "FilterState";
+                                }[];
+                                /**
+                                 * Format: int32
+                                 * @description The table size for Maglev hashing. Maglev aims for “minimal disruption”
+                                 *     rather than an absolute guarantee. Minimal disruption means that when
+                                 *     the set of upstream hosts change, a connection will likely be sent
+                                 *     to the same upstream as it was before. Increasing the table size reduces
+                                 *     the amount of disruption. The table size must be prime number limited to 5000011.
+                                 *     If it is not specified, the default is 65537.
+                                 */
+                                tableSize?: number;
+                            };
+                            /**
+                             * @description Random selects a random available host. The random load balancer generally
+                             *     performs better than round-robin if no health checking policy is configured.
+                             *     Random selection avoids bias towards the host in the set that comes after a failed host.
+                             */
+                            random?: Record<string, never>;
+                            /**
+                             * @description RingHash  implements consistent hashing to upstream hosts. Each host is mapped
+                             *     onto a circle (the “ring”) by hashing its address; each request is then routed
+                             *     to a host by hashing some property of the request, and finding the nearest
+                             *     corresponding host clockwise around the ring.
+                             */
+                            ringHash?: {
+                                /**
+                                 * @description HashFunction is a function used to hash hosts onto the ketama ring.
+                                 *     The value defaults to XX_HASH. Available values – XX_HASH, MURMUR_HASH_2.
+                                 * @enum {string}
+                                 */
+                                hashFunction?: "XXHash" | "MurmurHash2";
+                                /**
+                                 * @description HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                                 *     These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                                 *     set to true, and there is already a hash generated, the hash is returned immediately,
+                                 *     ignoring the rest of the hash policy list.
+                                 */
+                                hashPolicies?: {
+                                    connection?: {
+                                        /** @description Hash on source IP address. */
+                                        sourceIP?: boolean;
+                                    };
+                                    cookie?: {
+                                        /** @description The name of the cookie that will be used to obtain the hash key. */
+                                        name: string;
+                                        /** @description The name of the path for the cookie. */
+                                        path?: string;
+                                        /** @description If specified, a cookie with the TTL will be generated if the cookie is not present. */
+                                        ttl?: string;
+                                    };
+                                    filterState?: {
+                                        /**
+                                         * @description The name of the Object in the per-request filterState, which is
+                                         *     an Envoy::Hashable object. If there is no data associated with the key,
+                                         *     or the stored object is not Envoy::Hashable, no hash will be produced.
+                                         */
+                                        key: string;
+                                    };
+                                    header?: {
+                                        /** @description The name of the request header that will be used to obtain the hash key. */
+                                        name: string;
+                                    };
+                                    queryParameter?: {
+                                        /**
+                                         * @description The name of the URL query parameter that will be used to obtain the hash key.
+                                         *     If the parameter is not present, no hash will be produced. Query parameter names
+                                         *     are case-sensitive.
+                                         */
+                                        name: string;
+                                    };
+                                    /**
+                                     * @description Terminal is a flag that short-circuits the hash computing. This field provides
+                                     *     a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                     *     to rest of the policy list”, it saves time when the terminal policy works.
+                                     *     If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                                     */
+                                    terminal?: boolean;
+                                    /** @enum {string} */
+                                    type: "Header" | "Cookie" | "Connection" | "SourceIP" | "QueryParameter" | "FilterState";
+                                }[];
+                                /**
+                                 * Format: int32
+                                 * @description Maximum hash ring size. Defaults to 8M entries, and limited to 8M entries,
+                                 *     but can be lowered to further constrain resource use.
+                                 */
+                                maxRingSize?: number;
+                                /**
+                                 * Format: int32
+                                 * @description Minimum hash ring size. The larger the ring is (that is,
+                                 *     the more hashes there are for each provided host) the better the request distribution
+                                 *     will reflect the desired weights. Defaults to 1024 entries, and limited to 8M entries.
+                                 */
+                                minRingSize?: number;
+                            };
+                            /**
+                             * @description RoundRobin is a load balancing algorithm that distributes requests
+                             *     across available upstream hosts in round-robin order.
+                             */
+                            roundRobin?: Record<string, never>;
+                            /** @enum {string} */
+                            type: "RoundRobin" | "LeastRequest" | "RingHash" | "Random" | "Maglev";
+                        };
+                        /** @description LocalityAwareness contains configuration for locality aware load balancing. */
+                        localityAwareness?: {
+                            /**
+                             * @description CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
+                             *     are unavailable
+                             */
+                            crossZone?: {
+                                /** @description Failover defines list of load balancing rules in order of priority */
+                                failover?: {
+                                    /**
+                                     * @deprecated
+                                     * @description From defines the list of zones to which the rule applies
+                                     */
+                                    from?: {
+                                        zones: string[];
+                                    };
+                                    /** @description To defines to which zones the traffic should be load balanced */
+                                    to: {
+                                        /**
+                                         * @description Type defines how target zones will be picked from available zones
+                                         * @enum {string}
+                                         */
+                                        type: "None" | "Only" | "Any" | "AnyExcept";
+                                        zones?: string[];
+                                    };
+                                }[];
+                                /**
+                                 * @description FailoverThreshold defines the percentage of live destination dataplane proxies below which load balancing to the
+                                 *     next priority starts.
+                                 *     Example: If you configure failoverThreshold to 70, and you have deployed 10 destination dataplane proxies.
+                                 *     Load balancing to next priority will start when number of live destination dataplane proxies drops below 7.
+                                 *     Default 50
+                                 */
+                                failoverThreshold?: {
+                                    percentage: number | string;
+                                };
+                            };
+                            /**
+                             * @description Disabled allows to disable locality-aware load balancing.
+                             *     When disabled requests are distributed across all endpoints regardless of locality.
+                             */
+                            disabled?: boolean;
+                            /** @description LocalZone defines locality aware load balancing priorities between dataplane proxies inside a zone */
+                            localZone?: {
+                                /** @description AffinityTags list of tags for local zone load balancing. */
+                                affinityTags?: {
+                                    /** @description Key defines tag for which affinity is configured */
+                                    key: string;
+                                    /**
+                                     * Format: int32
+                                     * @description Weight of the tag used for load balancing. The bigger the weight the bigger the priority.
+                                     *     Percentage of local traffic load balanced to tag is computed by dividing weight by sum of weights from all tags.
+                                     *     For example with two affinity tags first with weight 80 and second with weight 20,
+                                     *     then 80% of traffic will be redirected to the first tag, and 20% of traffic will be redirected to second one.
+                                     *     Setting weights is not mandatory. When weights are not set control plane will compute default weight based on list order.
+                                     *     Default: If you do not specify weight we will adjust them so that 90% traffic goes to first tag, 9% to next, and 1% to third and so on.
+                                     */
+                                    weight?: number;
+                                }[];
+                            };
+                        };
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     destinations.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshMetricItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshMetric";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshMetric resource.
+             * @default {
+             *       "default": {
+             *         "backends": []
+             *       },
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /** @description MeshMetric configuration. */
+                default?: {
+                    /** @description Applications is a list of application that Dataplane Proxy will scrape */
+                    applications?: {
+                        /** @description Address on which an application listens. */
+                        address?: string;
+                        /** @description Name of the application to scrape */
+                        name?: string;
+                        /**
+                         * @description Path on which an application expose HTTP endpoint with metrics.
+                         * @default /metrics
+                         */
+                        path: string;
+                        /**
+                         * Format: int32
+                         * @description Port on which an application expose HTTP endpoint with metrics.
+                         */
+                        port: number;
+                    }[];
+                    /** @description Backends list that will be used to collect metrics. */
+                    backends?: {
+                        /** @description OpenTelemetry backend configuration */
+                        openTelemetry?: {
+                            /** @description Endpoint for OpenTelemetry collector */
+                            endpoint: string;
+                            /** @description RefreshInterval defines how frequent metrics should be pushed to collector */
+                            refreshInterval?: string;
+                        };
+                        /** @description Prometheus backend configuration. */
+                        prometheus?: {
+                            /** @description ClientId of the Prometheus backend. Needed when using MADS for DP discovery. */
+                            clientId?: string;
+                            /**
+                             * @description Path on which a dataplane should expose HTTP endpoint with Prometheus metrics.
+                             * @default /metrics
+                             */
+                            path: string;
+                            /**
+                             * Format: int32
+                             * @description Port on which a dataplane should expose HTTP endpoint with Prometheus metrics.
+                             * @default 5670
+                             */
+                            port: number;
+                            /** @description Configuration of TLS for prometheus listener. */
+                            tls?: {
+                                /**
+                                 * @description Configuration of TLS for Prometheus listener.
+                                 * @default Disabled
+                                 * @enum {string}
+                                 */
+                                mode: "Disabled" | "ProvidedTLS" | "ActiveMTLSBackend";
+                            };
+                        };
+                        /**
+                         * @description Type of the backend that will be used to collect metrics. At the moment only Prometheus backend is available.
+                         * @enum {string}
+                         */
+                        type: "Prometheus" | "OpenTelemetry";
+                    }[];
+                    /** @description Sidecar metrics collection configuration */
+                    sidecar?: {
+                        /**
+                         * @description IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
+                         *     at least once, gauges changed at least once, and histograms added to at
+                         *     least once). If true will scrape all metrics (even the ones with zeros).
+                         *     If not specified then the default value is false.
+                         */
+                        includeUnused?: boolean;
+                        /** @description Profiles allows to customize which metrics are published. */
+                        profiles?: {
+                            /** @description AppendProfiles allows to combine the metrics from multiple predefined profiles. */
+                            appendProfiles?: {
+                                /**
+                                 * @description Name of the predefined profile, one of: all, basic, none
+                                 * @enum {string}
+                                 */
+                                name: "All" | "Basic" | "None";
+                            }[];
+                            /**
+                             * @description Exclude makes it possible to exclude groups of metrics from a resulting profile.
+                             *     Exclude is subordinate to Include.
+                             */
+                            exclude?: {
+                                /** @description Match is the value used to match using particular Type */
+                                match: string;
+                                /**
+                                 * @description Type defined the type of selector, one of: prefix, regex, exact
+                                 * @enum {string}
+                                 */
+                                type: "Prefix" | "Regex" | "Exact" | "Contains";
+                            }[];
+                            /**
+                             * @description Include makes it possible to include additional metrics in a selected profiles.
+                             *     Include takes precedence over Exclude.
+                             */
+                            include?: {
+                                /** @description Match is the value used to match using particular Type */
+                                match: string;
+                                /**
+                                 * @description Type defined the type of selector, one of: prefix, regex, exact
+                                 * @enum {string}
+                                 */
+                                type: "Prefix" | "Regex" | "Exact" | "Contains";
+                            }[];
+                        };
+                    };
+                };
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined in-place.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshPassthroughItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshPassthrough";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshPassthrough resource.
+             * @default {
+             *       "default": {
+             *         "passthroughMode": "None"
+             *       },
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /** @description MeshPassthrough configuration. */
+                default?: {
+                    /** @description AppendMatch is a list of destinations that should be allowed through the sidecar. */
+                    appendMatch?: {
+                        /**
+                         * Format: int32
+                         * @description Port defines the port to which a user makes a request.
+                         */
+                        port?: number;
+                        /**
+                         * @description Protocol defines the communication protocol. Possible values: `tcp`, `tls`, `grpc`, `http`, `http2`, `mysql`.
+                         * @default tcp
+                         * @enum {string}
+                         */
+                        protocol: "tcp" | "tls" | "grpc" | "http" | "http2" | "mysql";
+                        /**
+                         * @description Type of the match, one of `Domain`, `IP` or `CIDR` is available.
+                         * @enum {string}
+                         */
+                        type: "Domain" | "IP" | "CIDR";
+                        /** @description Value for the specified Type. */
+                        value: string;
+                    }[];
+                    /**
+                     * @description Defines the passthrough behavior. Possible values: `All`, `None`, `Matched`
+                     *     When `All` or `None` `appendMatch` has no effect.
+                     *     If not specified then the default value is "Matched".
+                     * @enum {string}
+                     */
+                    passthroughMode?: "All" | "Matched" | "None";
+                };
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined in-place.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshProxyPatchItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshProxyPatch";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshProxyPatch resource.
+             * @default {
+             *       "default": {
+             *         "appendModifications": []
+             *       },
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @description Default is a configuration specific to the group of destinations
+                 *     referenced in 'targetRef'.
+                 */
+                default: {
+                    /** @description AppendModifications is a list of modifications applied on the selected proxy. */
+                    appendModifications?: {
+                        /** @description Cluster is a modification of Envoy's Cluster resource. */
+                        cluster?: {
+                            /**
+                             * @description JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
+                             *     resource
+                             */
+                            jsonPatches?: {
+                                /**
+                                 * @deprecated
+                                 * @description From is a jsonpatch from string, used by move and copy operations.
+                                 */
+                                from?: string;
+                                /**
+                                 * @description Op is a jsonpatch operation string.
+                                 * @enum {string}
+                                 */
+                                op: "add" | "remove" | "replace" | "move" | "copy";
+                                /** @description Path is a jsonpatch path string. */
+                                path: string;
+                                /** @description Value must be a valid json value used by replace and add operations. */
+                                value?: unknown;
+                            }[];
+                            /** @description Match is a set of conditions that have to be matched for modification operation to happen. */
+                            match?: {
+                                /** @description Name of the cluster to match. */
+                                name?: string;
+                                /**
+                                 * @description Origin is the name of the component or plugin that generated the resource.
+                                 *
+                                 *     Here is the list of well-known origins:
+                                 *     inbound - resources generated for handling incoming traffic.
+                                 *     outbound - resources generated for handling outgoing traffic.
+                                 *     transparent - resources generated for transparent proxy functionality.
+                                 *     prometheus - resources generated when Prometheus metrics are enabled.
+                                 *     direct-access - resources generated for Direct Access functionality.
+                                 *     ingress - resources generated for Zone Ingress.
+                                 *     egress - resources generated for Zone Egress.
+                                 *     gateway - resources generated for MeshGateway.
+                                 *
+                                 *     The list is not complete, because policy plugins can introduce new resources.
+                                 *     For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                                 */
+                                origin?: string;
+                            };
+                            /**
+                             * @description Operation to execute on matched cluster.
+                             * @enum {string}
+                             */
+                            operation: "Add" | "Remove" | "Patch";
+                            /** @description Value of xDS resource in YAML format to add or patch. */
+                            value?: string;
+                        };
+                        /**
+                         * @description HTTPFilter is a modification of Envoy HTTP Filter
+                         *     available in HTTP Connection Manager in a Listener resource.
+                         */
+                        httpFilter?: {
+                            /**
+                             * @description JsonPatches specifies list of jsonpatches to apply to on Envoy's
+                             *     HTTP Filter available in HTTP Connection Manager in a Listener resource.
+                             */
+                            jsonPatches?: {
+                                /**
+                                 * @deprecated
+                                 * @description From is a jsonpatch from string, used by move and copy operations.
+                                 */
+                                from?: string;
+                                /**
+                                 * @description Op is a jsonpatch operation string.
+                                 * @enum {string}
+                                 */
+                                op: "add" | "remove" | "replace" | "move" | "copy";
+                                /** @description Path is a jsonpatch path string. */
+                                path: string;
+                                /** @description Value must be a valid json value used by replace and add operations. */
+                                value?: unknown;
+                            }[];
+                            /** @description Match is a set of conditions that have to be matched for modification operation to happen. */
+                            match?: {
+                                /** @description Name of the listener to match. */
+                                listenerName?: string;
+                                /** @description Listener tags available in Listener#Metadata#FilterMetadata[io.kuma.tags] */
+                                listenerTags?: {
+                                    [key: string]: string;
+                                };
+                                /** @description Name of the HTTP filter. For example "envoy.filters.http.local_ratelimit" */
+                                name?: string;
+                                /**
+                                 * @description Origin is the name of the component or plugin that generated the resource.
+                                 *
+                                 *     Here is the list of well-known origins:
+                                 *     inbound - resources generated for handling incoming traffic.
+                                 *     outbound - resources generated for handling outgoing traffic.
+                                 *     transparent - resources generated for transparent proxy functionality.
+                                 *     prometheus - resources generated when Prometheus metrics are enabled.
+                                 *     direct-access - resources generated for Direct Access functionality.
+                                 *     ingress - resources generated for Zone Ingress.
+                                 *     egress - resources generated for Zone Egress.
+                                 *     gateway - resources generated for MeshGateway.
+                                 *
+                                 *     The list is not complete, because policy plugins can introduce new resources.
+                                 *     For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                                 */
+                                origin?: string;
+                            };
+                            /**
+                             * @description Operation to execute on matched listener.
+                             * @enum {string}
+                             */
+                            operation: "Remove" | "Patch" | "AddFirst" | "AddBefore" | "AddAfter" | "AddLast";
+                            /** @description Value of xDS resource in YAML format to add or patch. */
+                            value?: string;
+                        };
+                        /** @description Listener is a modification of Envoy's Listener resource. */
+                        listener?: {
+                            /**
+                             * @description JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
+                             *     resource
+                             */
+                            jsonPatches?: {
+                                /**
+                                 * @deprecated
+                                 * @description From is a jsonpatch from string, used by move and copy operations.
+                                 */
+                                from?: string;
+                                /**
+                                 * @description Op is a jsonpatch operation string.
+                                 * @enum {string}
+                                 */
+                                op: "add" | "remove" | "replace" | "move" | "copy";
+                                /** @description Path is a jsonpatch path string. */
+                                path: string;
+                                /** @description Value must be a valid json value used by replace and add operations. */
+                                value?: unknown;
+                            }[];
+                            /** @description Match is a set of conditions that have to be matched for modification operation to happen. */
+                            match?: {
+                                /** @description Name of the listener to match. */
+                                name?: string;
+                                /**
+                                 * @description Origin is the name of the component or plugin that generated the resource.
+                                 *
+                                 *     Here is the list of well-known origins:
+                                 *     inbound - resources generated for handling incoming traffic.
+                                 *     outbound - resources generated for handling outgoing traffic.
+                                 *     transparent - resources generated for transparent proxy functionality.
+                                 *     prometheus - resources generated when Prometheus metrics are enabled.
+                                 *     direct-access - resources generated for Direct Access functionality.
+                                 *     ingress - resources generated for Zone Ingress.
+                                 *     egress - resources generated for Zone Egress.
+                                 *     gateway - resources generated for MeshGateway.
+                                 *
+                                 *     The list is not complete, because policy plugins can introduce new resources.
+                                 *     For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                                 */
+                                origin?: string;
+                                /** @description Tags available in Listener#Metadata#FilterMetadata[io.kuma.tags] */
+                                tags?: {
+                                    [key: string]: string;
+                                };
+                            };
+                            /**
+                             * @description Operation to execute on matched listener.
+                             * @enum {string}
+                             */
+                            operation: "Add" | "Remove" | "Patch";
+                            /** @description Value of xDS resource in YAML format to add or patch. */
+                            value?: string;
+                        };
+                        /** @description NetworkFilter is a modification of Envoy Listener's filter. */
+                        networkFilter?: {
+                            /**
+                             * @description JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
+                             *     filter.
+                             */
+                            jsonPatches?: {
+                                /**
+                                 * @deprecated
+                                 * @description From is a jsonpatch from string, used by move and copy operations.
+                                 */
+                                from?: string;
+                                /**
+                                 * @description Op is a jsonpatch operation string.
+                                 * @enum {string}
+                                 */
+                                op: "add" | "remove" | "replace" | "move" | "copy";
+                                /** @description Path is a jsonpatch path string. */
+                                path: string;
+                                /** @description Value must be a valid json value used by replace and add operations. */
+                                value?: unknown;
+                            }[];
+                            /** @description Match is a set of conditions that have to be matched for modification operation to happen. */
+                            match?: {
+                                /** @description Name of the listener to match. */
+                                listenerName?: string;
+                                /** @description Listener tags available in Listener#Metadata#FilterMetadata[io.kuma.tags] */
+                                listenerTags?: {
+                                    [key: string]: string;
+                                };
+                                /** @description Name of the network filter. For example "envoy.filters.network.ratelimit" */
+                                name?: string;
+                                /**
+                                 * @description Origin is the name of the component or plugin that generated the resource.
+                                 *
+                                 *     Here is the list of well-known origins:
+                                 *     inbound - resources generated for handling incoming traffic.
+                                 *     outbound - resources generated for handling outgoing traffic.
+                                 *     transparent - resources generated for transparent proxy functionality.
+                                 *     prometheus - resources generated when Prometheus metrics are enabled.
+                                 *     direct-access - resources generated for Direct Access functionality.
+                                 *     ingress - resources generated for Zone Ingress.
+                                 *     egress - resources generated for Zone Egress.
+                                 *     gateway - resources generated for MeshGateway.
+                                 *
+                                 *     The list is not complete, because policy plugins can introduce new resources.
+                                 *     For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                                 */
+                                origin?: string;
+                            };
+                            /**
+                             * @description Operation to execute on matched listener.
+                             * @enum {string}
+                             */
+                            operation: "Remove" | "Patch" | "AddFirst" | "AddBefore" | "AddAfter" | "AddLast";
+                            /** @description Value of xDS resource in YAML format to add or patch. */
+                            value?: string;
+                        };
+                        /**
+                         * @description VirtualHost is a modification of Envoy's VirtualHost
+                         *     referenced in HTTP Connection Manager in a Listener resource.
+                         */
+                        virtualHost?: {
+                            /**
+                             * @description JsonPatches specifies list of jsonpatches to apply to on Envoy's
+                             *     VirtualHost resource
+                             */
+                            jsonPatches?: {
+                                /**
+                                 * @deprecated
+                                 * @description From is a jsonpatch from string, used by move and copy operations.
+                                 */
+                                from?: string;
+                                /**
+                                 * @description Op is a jsonpatch operation string.
+                                 * @enum {string}
+                                 */
+                                op: "add" | "remove" | "replace" | "move" | "copy";
+                                /** @description Path is a jsonpatch path string. */
+                                path: string;
+                                /** @description Value must be a valid json value used by replace and add operations. */
+                                value?: unknown;
+                            }[];
+                            /** @description Match is a set of conditions that have to be matched for modification operation to happen. */
+                            match: {
+                                /** @description Name of the VirtualHost to match. */
+                                name?: string;
+                                /**
+                                 * @description Origin is the name of the component or plugin that generated the resource.
+                                 *
+                                 *     Here is the list of well-known origins:
+                                 *     inbound - resources generated for handling incoming traffic.
+                                 *     outbound - resources generated for handling outgoing traffic.
+                                 *     transparent - resources generated for transparent proxy functionality.
+                                 *     prometheus - resources generated when Prometheus metrics are enabled.
+                                 *     direct-access - resources generated for Direct Access functionality.
+                                 *     ingress - resources generated for Zone Ingress.
+                                 *     egress - resources generated for Zone Egress.
+                                 *     gateway - resources generated for MeshGateway.
+                                 *
+                                 *     The list is not complete, because policy plugins can introduce new resources.
+                                 *     For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                                 */
+                                origin?: string;
+                                /** @description Name of the RouteConfiguration resource to match. */
+                                routeConfigurationName?: string;
+                            };
+                            /**
+                             * @description Operation to execute on matched listener.
+                             * @enum {string}
+                             */
+                            operation: "Add" | "Remove" | "Patch";
+                            /** @description Value of xDS resource in YAML format to add or patch. */
+                            value?: string;
+                        };
+                    }[];
+                };
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined inplace.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshRateLimitItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshRateLimit";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshRateLimit resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @deprecated
+                 * @description From list makes a match between clients and corresponding configurations
+                 */
+                from?: {
+                    /**
+                     * @description Default is a configuration specific to the group of clients referenced in
+                     *     'targetRef'
+                     */
+                    default?: {
+                        /** @description LocalConf defines local http or/and tcp rate limit configuration */
+                        local?: {
+                            /**
+                             * @description LocalHTTP defines configuration of local HTTP rate limiting
+                             *     https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
+                             */
+                            http?: {
+                                /** @description Define if rate limiting should be disabled. */
+                                disabled?: boolean;
+                                /** @description Describes the actions to take on a rate limit event */
+                                onRateLimit?: {
+                                    /** @description The Headers to be added to the HTTP response on a rate limit event */
+                                    headers?: {
+                                        add?: {
+                                            name: string;
+                                            value: string;
+                                        }[];
+                                        set?: {
+                                            name: string;
+                                            value: string;
+                                        }[];
+                                    };
+                                    /**
+                                     * Format: int32
+                                     * @description The HTTP status code to be set on a rate limit event
+                                     */
+                                    status?: number;
+                                };
+                                /** @description Defines how many requests are allowed per interval. */
+                                requestRate?: {
+                                    /** @description The interval the number of units is accounted for. */
+                                    interval: string;
+                                    /**
+                                     * Format: int32
+                                     * @description Number of units per interval (depending on usage it can be a number of requests,
+                                     *     or a number of connections).
+                                     */
+                                    num: number;
+                                };
+                            };
+                            /**
+                             * @description LocalTCP defines confguration of local TCP rate limiting
+                             *     https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter
+                             */
+                            tcp?: {
+                                /** @description Defines how many connections are allowed per interval. */
+                                connectionRate?: {
+                                    /** @description The interval the number of units is accounted for. */
+                                    interval: string;
+                                    /**
+                                     * Format: int32
+                                     * @description Number of units per interval (depending on usage it can be a number of requests,
+                                     *     or a number of connections).
+                                     */
+                                    num: number;
+                                };
+                                /**
+                                 * @description Define if rate limiting should be disabled.
+                                 *     Default: false
+                                 */
+                                disabled?: boolean;
+                            };
+                        };
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     clients.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+                /**
+                 * @description Rules defines inbound rate limiting configurations. Currently limited to
+                 *     selecting all inbound traffic, as L7 matching is not yet implemented.
+                 */
+                rules?: {
+                    /** @description Default contains configuration of the inbound rate limits */
+                    default?: {
+                        /** @description LocalConf defines local http or/and tcp rate limit configuration */
+                        local?: {
+                            /**
+                             * @description LocalHTTP defines configuration of local HTTP rate limiting
+                             *     https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
+                             */
+                            http?: {
+                                /** @description Define if rate limiting should be disabled. */
+                                disabled?: boolean;
+                                /** @description Describes the actions to take on a rate limit event */
+                                onRateLimit?: {
+                                    /** @description The Headers to be added to the HTTP response on a rate limit event */
+                                    headers?: {
+                                        add?: {
+                                            name: string;
+                                            value: string;
+                                        }[];
+                                        set?: {
+                                            name: string;
+                                            value: string;
+                                        }[];
+                                    };
+                                    /**
+                                     * Format: int32
+                                     * @description The HTTP status code to be set on a rate limit event
+                                     */
+                                    status?: number;
+                                };
+                                /** @description Defines how many requests are allowed per interval. */
+                                requestRate?: {
+                                    /** @description The interval the number of units is accounted for. */
+                                    interval: string;
+                                    /**
+                                     * Format: int32
+                                     * @description Number of units per interval (depending on usage it can be a number of requests,
+                                     *     or a number of connections).
+                                     */
+                                    num: number;
+                                };
+                            };
+                            /**
+                             * @description LocalTCP defines confguration of local TCP rate limiting
+                             *     https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter
+                             */
+                            tcp?: {
+                                /** @description Defines how many connections are allowed per interval. */
+                                connectionRate?: {
+                                    /** @description The interval the number of units is accounted for. */
+                                    interval: string;
+                                    /**
+                                     * Format: int32
+                                     * @description Number of units per interval (depending on usage it can be a number of requests,
+                                     *     or a number of connections).
+                                     */
+                                    num: number;
+                                };
+                                /**
+                                 * @description Define if rate limiting should be disabled.
+                                 *     Default: false
+                                 */
+                                disabled?: boolean;
+                            };
+                        };
+                    };
+                }[];
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined inplace.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+                /** @description To list makes a match between clients and corresponding configurations */
+                to?: {
+                    /**
+                     * @description Default is a configuration specific to the group of clients referenced in
+                     *     'targetRef'
+                     */
+                    default?: {
+                        /** @description LocalConf defines local http or/and tcp rate limit configuration */
+                        local?: {
+                            /**
+                             * @description LocalHTTP defines configuration of local HTTP rate limiting
+                             *     https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
+                             */
+                            http?: {
+                                /** @description Define if rate limiting should be disabled. */
+                                disabled?: boolean;
+                                /** @description Describes the actions to take on a rate limit event */
+                                onRateLimit?: {
+                                    /** @description The Headers to be added to the HTTP response on a rate limit event */
+                                    headers?: {
+                                        add?: {
+                                            name: string;
+                                            value: string;
+                                        }[];
+                                        set?: {
+                                            name: string;
+                                            value: string;
+                                        }[];
+                                    };
+                                    /**
+                                     * Format: int32
+                                     * @description The HTTP status code to be set on a rate limit event
+                                     */
+                                    status?: number;
+                                };
+                                /** @description Defines how many requests are allowed per interval. */
+                                requestRate?: {
+                                    /** @description The interval the number of units is accounted for. */
+                                    interval: string;
+                                    /**
+                                     * Format: int32
+                                     * @description Number of units per interval (depending on usage it can be a number of requests,
+                                     *     or a number of connections).
+                                     */
+                                    num: number;
+                                };
+                            };
+                            /**
+                             * @description LocalTCP defines confguration of local TCP rate limiting
+                             *     https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter
+                             */
+                            tcp?: {
+                                /** @description Defines how many connections are allowed per interval. */
+                                connectionRate?: {
+                                    /** @description The interval the number of units is accounted for. */
+                                    interval: string;
+                                    /**
+                                     * Format: int32
+                                     * @description Number of units per interval (depending on usage it can be a number of requests,
+                                     *     or a number of connections).
+                                     */
+                                    num: number;
+                                };
+                                /**
+                                 * @description Define if rate limiting should be disabled.
+                                 *     Default: false
+                                 */
+                                disabled?: boolean;
+                            };
+                        };
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     clients.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshRetryItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshRetry";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshRetry resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined inplace.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+                /** @description To list makes a match between the consumed services and corresponding configurations */
+                to?: {
+                    /**
+                     * @description Default is a configuration specific to the group of destinations referenced in
+                     *     'targetRef'
+                     */
+                    default?: {
+                        /** @description GRPC defines a configuration of retries for GRPC traffic */
+                        grpc?: {
+                            /**
+                             * @description BackOff is a configuration of durations which will be used in an exponential
+                             *     backoff strategy between retries.
+                             */
+                            backOff?: {
+                                /**
+                                 * @description BaseInterval is an amount of time which should be taken between retries.
+                                 *     Must be greater than zero. Values less than 1 ms are rounded up to 1 ms.
+                                 *     If not specified then the default value is "25ms".
+                                 */
+                                baseInterval?: string;
+                                /**
+                                 * @description MaxInterval is a maximal amount of time which will be taken between retries.
+                                 *     Default is 10 times the "BaseInterval".
+                                 */
+                                maxInterval?: string;
+                            };
+                            /**
+                             * Format: int32
+                             * @description NumRetries is the number of attempts that will be made on failed (and
+                             *     retriable) requests. If not set, the default value is 1.
+                             */
+                            numRetries?: number;
+                            /**
+                             * @description PerTryTimeout is the maximum amount of time each retry attempt can take
+                             *     before it times out. If not set, the global request timeout for the route
+                             *     will be used. Setting this value to 0 will disable the per-try timeout.
+                             */
+                            perTryTimeout?: string;
+                            /**
+                             * @description RateLimitedBackOff is a configuration of backoff which will be used when
+                             *     the upstream returns one of the headers configured.
+                             */
+                            rateLimitedBackOff?: {
+                                /**
+                                 * @description MaxInterval is a maximal amount of time which will be taken between retries.
+                                 *     If not specified then the default value is "300s".
+                                 */
+                                maxInterval?: string;
+                                /**
+                                 * @description ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
+                                 *     to match against the response. Headers are tried in order, and matched
+                                 *     case-insensitive. The first header to be parsed successfully is used.
+                                 *     If no headers match the default exponential BackOff is used instead.
+                                 */
+                                resetHeaders?: {
+                                    /**
+                                     * @description The format of the reset header.
+                                     * @enum {string}
+                                     */
+                                    format: "Seconds" | "UnixTimestamp";
+                                    /** @description The Name of the reset header. */
+                                    name: string;
+                                }[];
+                            };
+                            /**
+                             * @description RetryOn is a list of conditions which will cause a retry.
+                             * @example [
+                             *       "Canceled",
+                             *       "DeadlineExceeded",
+                             *       "Internal",
+                             *       "ResourceExhausted",
+                             *       "Unavailable"
+                             *     ]
+                             */
+                            retryOn?: ("Canceled" | "DeadlineExceeded" | "Internal" | "ResourceExhausted" | "Unavailable")[];
+                        };
+                        /** @description HTTP defines a configuration of retries for HTTP traffic */
+                        http?: {
+                            /**
+                             * @description BackOff is a configuration of durations which will be used in exponential
+                             *     backoff strategy between retries.
+                             */
+                            backOff?: {
+                                /**
+                                 * @description BaseInterval is an amount of time which should be taken between retries.
+                                 *     Must be greater than zero. Values less than 1 ms are rounded up to 1 ms.
+                                 *     If not specified then the default value is "25ms".
+                                 */
+                                baseInterval?: string;
+                                /**
+                                 * @description MaxInterval is a maximal amount of time which will be taken between retries.
+                                 *     Default is 10 times the "BaseInterval".
+                                 */
+                                maxInterval?: string;
+                            };
+                            /**
+                             * @description HostSelection is a list of predicates that dictate how hosts should be selected
+                             *     when requests are retried.
+                             */
+                            hostSelection?: {
+                                /**
+                                 * @description Type is requested predicate mode.
+                                 * @enum {string}
+                                 */
+                                predicate: "OmitPreviousHosts" | "OmitHostsWithTags" | "OmitPreviousPriorities";
+                                /**
+                                 * @description Tags is a map of metadata to match against for selecting the omitted hosts. Required if Type is
+                                 *     OmitHostsWithTags
+                                 */
+                                tags?: {
+                                    [key: string]: string;
+                                };
+                                /**
+                                 * Format: int32
+                                 * @description UpdateFrequency is how often the priority load should be updated based on previously attempted priorities.
+                                 *     Used for OmitPreviousPriorities.
+                                 * @default 2
+                                 */
+                                updateFrequency: number;
+                            }[];
+                            /**
+                             * Format: int64
+                             * @description HostSelectionMaxAttempts is the maximum number of times host selection will be
+                             *     reattempted before giving up, at which point the host that was last selected will
+                             *     be routed to. If unspecified, this will default to retrying once.
+                             */
+                            hostSelectionMaxAttempts?: number;
+                            /**
+                             * Format: int32
+                             * @description NumRetries is the number of attempts that will be made on failed (and
+                             *     retriable) requests.  If not set, the default value is 1.
+                             */
+                            numRetries?: number;
+                            /**
+                             * @description PerTryTimeout is the amount of time after which retry attempt should time out.
+                             *     If left unspecified, the global route timeout for the request will be used.
+                             *     Consequently, when using a 5xx based retry policy, a request that times out
+                             *     will not be retried as the total timeout budget would have been exhausted.
+                             *     Setting this timeout to 0 will disable it.
+                             */
+                            perTryTimeout?: string;
+                            /**
+                             * @description RateLimitedBackOff is a configuration of backoff which will be used
+                             *     when the upstream returns one of the headers configured.
+                             */
+                            rateLimitedBackOff?: {
+                                /**
+                                 * @description MaxInterval is a maximal amount of time which will be taken between retries.
+                                 *     If not specified then the default value is "300s".
+                                 */
+                                maxInterval?: string;
+                                /**
+                                 * @description ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
+                                 *     to match against the response. Headers are tried in order, and matched
+                                 *     case-insensitive. The first header to be parsed successfully is used.
+                                 *     If no headers match the default exponential BackOff is used instead.
+                                 */
+                                resetHeaders?: {
+                                    /**
+                                     * @description The format of the reset header.
+                                     * @enum {string}
+                                     */
+                                    format: "Seconds" | "UnixTimestamp";
+                                    /** @description The Name of the reset header. */
+                                    name: string;
+                                }[];
+                            };
+                            /**
+                             * @description RetriableRequestHeaders is an HTTP headers which must be present in the request
+                             *     for retries to be attempted.
+                             */
+                            retriableRequestHeaders?: {
+                                /**
+                                 * @description Name is the name of the HTTP Header to be matched. Name MUST be lower case
+                                 *     as they will be handled with case insensitivity (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                 */
+                                name: string;
+                                /**
+                                 * @description Type specifies how to match against the value of the header.
+                                 * @default Exact
+                                 * @enum {string}
+                                 */
+                                type: "Exact" | "Present" | "RegularExpression" | "Absent" | "Prefix";
+                                /** @description Value is the value of HTTP Header to be matched. */
+                                value?: string;
+                            }[];
+                            /**
+                             * @description RetriableResponseHeaders is an HTTP response headers that trigger a retry
+                             *     if present in the response. A retry will be triggered if any of the header
+                             *     matches the upstream response headers.
+                             */
+                            retriableResponseHeaders?: {
+                                /**
+                                 * @description Name is the name of the HTTP Header to be matched. Name MUST be lower case
+                                 *     as they will be handled with case insensitivity (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                 */
+                                name: string;
+                                /**
+                                 * @description Type specifies how to match against the value of the header.
+                                 * @default Exact
+                                 * @enum {string}
+                                 */
+                                type: "Exact" | "Present" | "RegularExpression" | "Absent" | "Prefix";
+                                /** @description Value is the value of HTTP Header to be matched. */
+                                value?: string;
+                            }[];
+                            /**
+                             * @description RetryOn is a list of conditions which will cause a retry. Available values are:
+                             *     [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited,
+                             *     RefusedStream, Http3PostConnectFailure, HttpMethodConnect, HttpMethodDelete,
+                             *     HttpMethodGet, HttpMethodHead, HttpMethodOptions, HttpMethodPatch,
+                             *     HttpMethodPost, HttpMethodPut, HttpMethodTrace].
+                             *     Also, any HTTP status code (500, 503, etc.).
+                             * @example [
+                             *       "5XX",
+                             *       "GatewayError",
+                             *       "Reset",
+                             *       "Retriable4xx",
+                             *       "ConnectFailure",
+                             *       "EnvoyRatelimited",
+                             *       "RefusedStream",
+                             *       "Http3PostConnectFailure",
+                             *       "HttpMethodConnect",
+                             *       "HttpMethodDelete",
+                             *       "HttpMethodGet",
+                             *       "HttpMethodHead",
+                             *       "HttpMethodOptions",
+                             *       "HttpMethodPatch",
+                             *       "HttpMethodPost",
+                             *       "HttpMethodPut",
+                             *       "HttpMethodTrace",
+                             *       "500",
+                             *       "503"
+                             *     ]
+                             */
+                            retryOn?: string[];
+                        };
+                        /** @description TCP defines a configuration of retries for TCP traffic */
+                        tcp?: {
+                            /**
+                             * Format: int32
+                             * @description MaxConnectAttempt is a maximal amount of TCP connection attempts
+                             *     which will be made before giving up
+                             */
+                            maxConnectAttempt?: number;
+                        };
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     destinations.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshTCPRouteItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshTCPRoute";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshTCPRoute resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined in-place.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+                /**
+                 * @description To list makes a match between the consumed services and corresponding
+                 *     configurations
+                 */
+                to?: {
+                    /**
+                     * @description Rules contains the routing rules applies to a combination of top-level
+                     *     targetRef and the targetRef in this entry.
+                     */
+                    rules: {
+                        /**
+                         * @description Default holds routing rules that can be merged with rules from other
+                         *     policies.
+                         */
+                        default: {
+                            backendRefs?: {
+                                /**
+                                 * @description Kind of the referenced resource
+                                 * @enum {string}
+                                 */
+                                kind: "Mesh" | "MeshSubset" | "MeshGateway" | "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshServiceSubset" | "MeshHTTPRoute" | "Dataplane";
+                                /**
+                                 * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                                 *     Name and Namespace can be used.
+                                 */
+                                labels?: {
+                                    [key: string]: string;
+                                };
+                                /** @description Mesh is reserved for future use to identify cross mesh resources. */
+                                mesh?: string;
+                                /**
+                                 * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                                 *     `MeshServiceSubset` and `MeshGatewayRoute`
+                                 */
+                                name?: string;
+                                /**
+                                 * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                                 *     will be targeted.
+                                 */
+                                namespace?: string;
+                                /**
+                                 * Format: int32
+                                 * @description Port is only supported when this ref refers to a real MeshService object
+                                 */
+                                port?: number;
+                                /**
+                                 * @description ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                                 *     all data plane types are targeted by the policy.
+                                 */
+                                proxyTypes?: ("Sidecar" | "Gateway")[];
+                                /**
+                                 * @description SectionName is used to target specific section of resource.
+                                 *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                                 */
+                                sectionName?: string;
+                                /**
+                                 * @description Tags used to select a subset of proxies by tags. Can only be used with kinds
+                                 *     `MeshSubset` and `MeshServiceSubset`
+                                 */
+                                tags?: {
+                                    [key: string]: string;
+                                };
+                                /** @default 1 */
+                                weight: number;
+                            }[];
+                        };
+                    }[];
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     destinations.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshTimeoutItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshTimeout";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshTimeout resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @deprecated
+                 * @description From list makes a match between clients and corresponding configurations
+                 */
+                from?: {
+                    /**
+                     * @description Default is a configuration specific to the group of clients referenced in
+                     *     'targetRef'
+                     */
+                    default?: {
+                        /**
+                         * @description ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established.
+                         *     Default value is 5 seconds. Cannot be set to 0.
+                         */
+                        connectionTimeout?: string;
+                        /** @description Http provides configuration for HTTP specific timeouts */
+                        http?: {
+                            /**
+                             * @description MaxConnectionDuration is the time after which a connection will be drained and/or closed,
+                             *     starting from when it was first established. Setting this timeout to 0 will disable it.
+                             *     Disabled by default.
+                             */
+                            maxConnectionDuration?: string;
+                            /**
+                             * @description MaxStreamDuration is the maximum time that a stream’s lifetime will span.
+                             *     Setting this timeout to 0 will disable it. Disabled by default.
+                             */
+                            maxStreamDuration?: string;
+                            /**
+                             * @description RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is
+                             *     activated when the first byte of the headers is received, and is disarmed when the last byte of
+                             *     the headers has been received. If not specified or set to 0, this timeout is disabled.
+                             *     Disabled by default.
+                             */
+                            requestHeadersTimeout?: string;
+                            /**
+                             * @description RequestTimeout The amount of time that proxy will wait for the entire request to be received.
+                             *     The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent,
+                             *     OR when the response is initiated. Setting this timeout to 0 will disable it.
+                             *     Default is 15s.
+                             */
+                            requestTimeout?: string;
+                            /**
+                             * @description StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity.
+                             *     Setting this timeout to 0 will disable it. Default is 30m
+                             */
+                            streamIdleTimeout?: string;
+                        };
+                        /**
+                         * @description IdleTimeout is defined as the period in which there are no bytes sent or received on connection
+                         *     Setting this timeout to 0 will disable it. Be cautious when disabling it because
+                         *     it can lead to connection leaking. Default value is 1h.
+                         */
+                        idleTimeout?: string;
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     clients.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+                /**
+                 * @description Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
+                 *     default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
+                 */
+                rules?: {
+                    /** @description Default contains configuration of the inbound timeouts */
+                    default?: {
+                        /**
+                         * @description ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established.
+                         *     Default value is 5 seconds. Cannot be set to 0.
+                         */
+                        connectionTimeout?: string;
+                        /** @description Http provides configuration for HTTP specific timeouts */
+                        http?: {
+                            /**
+                             * @description MaxConnectionDuration is the time after which a connection will be drained and/or closed,
+                             *     starting from when it was first established. Setting this timeout to 0 will disable it.
+                             *     Disabled by default.
+                             */
+                            maxConnectionDuration?: string;
+                            /**
+                             * @description MaxStreamDuration is the maximum time that a stream’s lifetime will span.
+                             *     Setting this timeout to 0 will disable it. Disabled by default.
+                             */
+                            maxStreamDuration?: string;
+                            /**
+                             * @description RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is
+                             *     activated when the first byte of the headers is received, and is disarmed when the last byte of
+                             *     the headers has been received. If not specified or set to 0, this timeout is disabled.
+                             *     Disabled by default.
+                             */
+                            requestHeadersTimeout?: string;
+                            /**
+                             * @description RequestTimeout The amount of time that proxy will wait for the entire request to be received.
+                             *     The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent,
+                             *     OR when the response is initiated. Setting this timeout to 0 will disable it.
+                             *     Default is 15s.
+                             */
+                            requestTimeout?: string;
+                            /**
+                             * @description StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity.
+                             *     Setting this timeout to 0 will disable it. Default is 30m
+                             */
+                            streamIdleTimeout?: string;
+                        };
+                        /**
+                         * @description IdleTimeout is defined as the period in which there are no bytes sent or received on connection
+                         *     Setting this timeout to 0 will disable it. Be cautious when disabling it because
+                         *     it can lead to connection leaking. Default value is 1h.
+                         */
+                        idleTimeout?: string;
+                    };
+                }[];
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined inplace.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+                /** @description To list makes a match between the consumed services and corresponding configurations */
+                to?: {
+                    /**
+                     * @description Default is a configuration specific to the group of destinations referenced in
+                     *     'targetRef'
+                     */
+                    default?: {
+                        /**
+                         * @description ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established.
+                         *     Default value is 5 seconds. Cannot be set to 0.
+                         */
+                        connectionTimeout?: string;
+                        /** @description Http provides configuration for HTTP specific timeouts */
+                        http?: {
+                            /**
+                             * @description MaxConnectionDuration is the time after which a connection will be drained and/or closed,
+                             *     starting from when it was first established. Setting this timeout to 0 will disable it.
+                             *     Disabled by default.
+                             */
+                            maxConnectionDuration?: string;
+                            /**
+                             * @description MaxStreamDuration is the maximum time that a stream’s lifetime will span.
+                             *     Setting this timeout to 0 will disable it. Disabled by default.
+                             */
+                            maxStreamDuration?: string;
+                            /**
+                             * @description RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is
+                             *     activated when the first byte of the headers is received, and is disarmed when the last byte of
+                             *     the headers has been received. If not specified or set to 0, this timeout is disabled.
+                             *     Disabled by default.
+                             */
+                            requestHeadersTimeout?: string;
+                            /**
+                             * @description RequestTimeout The amount of time that proxy will wait for the entire request to be received.
+                             *     The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent,
+                             *     OR when the response is initiated. Setting this timeout to 0 will disable it.
+                             *     Default is 15s.
+                             */
+                            requestTimeout?: string;
+                            /**
+                             * @description StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity.
+                             *     Setting this timeout to 0 will disable it. Default is 30m
+                             */
+                            streamIdleTimeout?: string;
+                        };
+                        /**
+                         * @description IdleTimeout is defined as the period in which there are no bytes sent or received on connection
+                         *     Setting this timeout to 0 will disable it. Be cautious when disabling it because
+                         *     it can lead to connection leaking. Default value is 1h.
+                         */
+                        idleTimeout?: string;
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     destinations.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshTLSItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshTLS";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshTLS resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @deprecated
+                 * @description From list makes a match between clients and corresponding configurations
+                 */
+                from?: {
+                    /**
+                     * @description Default is a configuration specific to the group of clients referenced in
+                     *     'targetRef'
+                     */
+                    default?: {
+                        /**
+                         * @description Mode defines the behavior of inbound listeners with regard to traffic encryption.
+                         * @enum {string}
+                         */
+                        mode?: "Permissive" | "Strict";
+                        /** @description TlsCiphers section for providing ciphers specification. */
+                        tlsCiphers?: ("ECDHE-ECDSA-AES128-GCM-SHA256" | "ECDHE-ECDSA-AES256-GCM-SHA384" | "ECDHE-ECDSA-CHACHA20-POLY1305" | "ECDHE-RSA-AES128-GCM-SHA256" | "ECDHE-RSA-AES256-GCM-SHA384" | "ECDHE-RSA-CHACHA20-POLY1305")[];
+                        /** @description Version section for providing version specification. */
+                        tlsVersion?: {
+                            /**
+                             * @description Max defines maximum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.
+                             * @default TLSAuto
+                             * @enum {string}
+                             */
+                            max: "TLSAuto" | "TLS10" | "TLS11" | "TLS12" | "TLS13";
+                            /**
+                             * @description Min defines minimum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.
+                             * @default TLSAuto
+                             * @enum {string}
+                             */
+                            min: "TLSAuto" | "TLS10" | "TLS11" | "TLS12" | "TLS13";
+                        };
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     clients.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+                /**
+                 * @description Rules defines inbound tls configurations. Currently limited to
+                 *     selecting all inbound traffic, as L7 matching is not yet implemented.
+                 */
+                rules?: {
+                    /** @description Default contains configuration of the inbound tls */
+                    default?: {
+                        /**
+                         * @description Mode defines the behavior of inbound listeners with regard to traffic encryption.
+                         * @enum {string}
+                         */
+                        mode?: "Permissive" | "Strict";
+                        /** @description TlsCiphers section for providing ciphers specification. */
+                        tlsCiphers?: ("ECDHE-ECDSA-AES128-GCM-SHA256" | "ECDHE-ECDSA-AES256-GCM-SHA384" | "ECDHE-ECDSA-CHACHA20-POLY1305" | "ECDHE-RSA-AES128-GCM-SHA256" | "ECDHE-RSA-AES256-GCM-SHA384" | "ECDHE-RSA-CHACHA20-POLY1305")[];
+                        /** @description Version section for providing version specification. */
+                        tlsVersion?: {
+                            /**
+                             * @description Max defines maximum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.
+                             * @default TLSAuto
+                             * @enum {string}
+                             */
+                            max: "TLSAuto" | "TLS10" | "TLS11" | "TLS12" | "TLS13";
+                            /**
+                             * @description Min defines minimum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.
+                             * @default TLSAuto
+                             * @enum {string}
+                             */
+                            min: "TLSAuto" | "TLS10" | "TLS11" | "TLS12" | "TLS13";
+                        };
+                    };
+                }[];
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined in-place.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshTraceItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshTrace";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshTrace resource.
+             * @default {
+             *       "default": {
+             *         "backends": []
+             *       },
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /** @description MeshTrace configuration. */
+                default?: {
+                    /**
+                     * @description A one element array of backend definition.
+                     *     Envoy allows configuring only 1 backend, so the natural way of
+                     *     representing that would be just one object. Unfortunately due to the
+                     *     reasons explained in MADR 009-tracing-policy this has to be a one element
+                     *     array for now.
+                     */
+                    backends?: {
+                        /** @description Datadog backend configuration. */
+                        datadog?: {
+                            /**
+                             * @description Determines if datadog service name should be split based on traffic
+                             *     direction and destination. For example, with `splitService: true` and a
+                             *     `backend` service that communicates with a couple of databases, you would
+                             *     get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
+                             *     `backend_OUTBOUND_db2` in Datadog.
+                             * @default false
+                             */
+                            splitService: boolean;
+                            /**
+                             * @description Address of Datadog collector, only host and port are allowed (no paths,
+                             *     fragments etc.)
+                             */
+                            url: string;
+                        };
+                        /** @description OpenTelemetry backend configuration. */
+                        openTelemetry?: {
+                            /**
+                             * @description Address of OpenTelemetry collector.
+                             * @example otel-collector:4317
+                             */
+                            endpoint: string;
+                        };
+                        /** @enum {string} */
+                        type: "Zipkin" | "Datadog" | "OpenTelemetry";
+                        /** @description Zipkin backend configuration. */
+                        zipkin?: {
+                            /**
+                             * @description Version of the API.
+                             *     https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
+                             * @default httpJson
+                             * @enum {string}
+                             */
+                            apiVersion: "httpJson" | "httpProto";
+                            /**
+                             * @description Determines whether client and server spans will share the same span
+                             *     context.
+                             *     https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
+                             * @default true
+                             */
+                            sharedSpanContext: boolean;
+                            /**
+                             * @description Generate 128bit traces.
+                             * @default false
+                             */
+                            traceId128bit: boolean;
+                            /** @description Address of Zipkin collector. */
+                            url: string;
+                        };
+                    }[];
+                    /**
+                     * @description Sampling configuration.
+                     *     Sampling is the process by which a decision is made on whether to
+                     *     process/export a span or not.
+                     */
+                    sampling?: {
+                        /**
+                         * @description Target percentage of requests that will be force traced if the
+                         *     'x-client-trace-id' header is set. Mirror of client_sampling in Envoy
+                         *     https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                         *     Either int or decimal represented as string.
+                         *     If not specified then the default value is 100.
+                         */
+                        client?: number | string;
+                        /**
+                         * @description Target percentage of requests will be traced
+                         *     after all other sampling checks have been applied (client, force tracing,
+                         *     random sampling). This field functions as an upper limit on the total
+                         *     configured sampling rate. For instance, setting client to 100
+                         *     but overall to 1 will result in only 1% of client requests with
+                         *     the appropriate headers to be force traced. Mirror of
+                         *     overall_sampling in Envoy
+                         *     https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                         *     Either int or decimal represented as string.
+                         *     If not specified then the default value is 100.
+                         */
+                        overall?: number | string;
+                        /**
+                         * @description Target percentage of requests that will be randomly selected for trace
+                         *     generation, if not requested by the client or not forced.
+                         *     Mirror of random_sampling in Envoy
+                         *     https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                         *     Either int or decimal represented as string.
+                         *     If not specified then the default value is 100.
+                         */
+                        random?: number | string;
+                    };
+                    /**
+                     * @description Custom tags configuration. You can add custom tags to traces based on
+                     *     headers or literal values.
+                     */
+                    tags?: {
+                        /** @description Tag taken from a header. */
+                        header?: {
+                            /**
+                             * @description Default value to use if header is missing.
+                             *     If the default is missing and there is no value the tag will not be
+                             *     included.
+                             */
+                            default?: string;
+                            /** @description Name of the header. */
+                            name: string;
+                        };
+                        /** @description Tag taken from literal value. */
+                        literal?: string;
+                        /** @description Name of the tag. */
+                        name: string;
+                    }[];
+                };
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined inplace.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+            };
+            additionalProperties?: never;
+        };
+        /** @description Successful response */
+        MeshTrafficPermissionItem_Put_RequestBody: {
+            /**
+             * @description the type of the resource
+             * @enum {string}
+             */
+            readonly type: "MeshTrafficPermission";
+            /**
+             * @description Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+             * @default default
+             */
+            readonly mesh: string;
+            /** @description Name of the Kuma resource */
+            readonly name: string;
+            /** @description The labels to help identity resources */
+            labels?: {
+                readonly "kuma.io/zone"?: string;
+                readonly "kuma.io/mesh"?: string;
+                readonly "kuma.io/display-name"?: string;
+                readonly "kuma.io/env"?: string;
+                readonly "kuma.io/origin"?: string;
+                readonly "kuma.io/policy-role"?: string;
+                readonly "kuma.io/proxy-type"?: string;
+            } & {
+                [key: string]: string;
+            };
+            /**
+             * @description Spec is the specification of the Kuma MeshTrafficPermission resource.
+             * @default {
+             *       "targetRef": {
+             *         "kind": "Mesh"
+             *       }
+             *     }
+             */
+            spec: {
+                /**
+                 * @deprecated
+                 * @description From list makes a match between clients and corresponding configurations
+                 */
+                from?: {
+                    /**
+                     * @description Default is a configuration specific to the group of clients referenced in
+                     *     'targetRef'
+                     */
+                    default?: {
+                        /**
+                         * @description Action defines a behavior for the specified group of clients:
+                         * @enum {string}
+                         */
+                        action?: "Allow" | "Deny" | "AllowWithShadowDeny";
+                    };
+                    /**
+                     * @description TargetRef is a reference to the resource that represents a group of
+                     *     clients.
+                     * @default {
+                     *       "kind": "MeshService"
+                     *     }
+                     */
+                    targetRef: {
+                        /**
+                         * @description Kind of the referenced resource
+                         * @enum {string}
+                         */
+                        kind: "MeshService" | "MeshExternalService" | "MeshMultiZoneService" | "MeshHTTPRoute";
+                        /**
+                         * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                         *     Name and Namespace can be used.
+                         */
+                        labels?: {
+                            [key: string]: string;
+                        };
+                        /**
+                         * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                         *     `MeshServiceSubset` and `MeshGatewayRoute`
+                         */
+                        name?: string;
+                        /**
+                         * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                         *     will be targeted.
+                         */
+                        namespace?: string;
+                        /**
+                         * @description SectionName is used to target specific section of resource.
+                         *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                         */
+                        sectionName?: string;
+                    };
+                }[];
+                /** @description Rules defines inbound permissions configuration */
+                rules?: {
+                    default: {
+                        /** @description Allow definees a list of matches for which access will be allowed */
+                        allow?: {
+                            /** @description SpiffeID defines a matcher configuration for SpiffeID matching */
+                            spiffeID?: {
+                                /**
+                                 * @description Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                                 * @enum {string}
+                                 */
+                                type: "Exact" | "Prefix";
+                                /** @description Value is SpiffeId of a client that needs to match for the configuration to be applied */
+                                value: string;
+                            };
+                        }[];
+                        /**
+                         * @description AllowWithShadowDeny defines a list of matches for which access will be allowed but emits logs as if
+                         *     requests are denied
+                         */
+                        allowWithShadowDeny?: {
+                            /** @description SpiffeID defines a matcher configuration for SpiffeID matching */
+                            spiffeID?: {
+                                /**
+                                 * @description Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                                 * @enum {string}
+                                 */
+                                type: "Exact" | "Prefix";
+                                /** @description Value is SpiffeId of a client that needs to match for the configuration to be applied */
+                                value: string;
+                            };
+                        }[];
+                        /** @description Deny defines a list of matches for which access will be denied */
+                        deny?: {
+                            /** @description SpiffeID defines a matcher configuration for SpiffeID matching */
+                            spiffeID?: {
+                                /**
+                                 * @description Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                                 * @enum {string}
+                                 */
+                                type: "Exact" | "Prefix";
+                                /** @description Value is SpiffeId of a client that needs to match for the configuration to be applied */
+                                value: string;
+                            };
+                        }[];
+                    };
+                }[];
+                /**
+                 * @description TargetRef is a reference to the resource the policy takes an effect on.
+                 *     The resource could be either a real store object or virtual resource
+                 *     defined inplace.
+                 */
+                targetRef?: {
+                    /**
+                     * @description Kind of the referenced resource
+                     * @enum {string}
+                     */
+                    kind: "Mesh" | "Dataplane";
+                    /**
+                     * @description Labels are used to select group of MeshServices that match labels. Either Labels or
+                     *     Name and Namespace can be used.
+                     */
+                    labels?: {
+                        [key: string]: string;
+                    };
+                    /**
+                     * @description Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                     *     `MeshServiceSubset` and `MeshGatewayRoute`
+                     */
+                    name?: string;
+                    /**
+                     * @description Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                     *     will be targeted.
+                     */
+                    namespace?: string;
+                    /**
+                     * @description SectionName is used to target specific section of resource.
+                     *     For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                     */
+                    sectionName?: string;
+                };
+            };
+            additionalProperties?: never;
+        };
     };
     responses: {
         /** @description A response for the index endpoint */

--- a/packages/kuma-http-api/openapi.overlay.tmpl.yaml
+++ b/packages/kuma-http-api/openapi.overlay.tmpl.yaml
@@ -4,9 +4,12 @@ info:
   version: 0.1.0
 extends: ./dist/openapi.yaml
 actions:
+  # versioning
   - target: "$.info"
     update:
       x-oas-source: kumahq/kuma@${GIT_SHA}
+
+  # dates to string
   - target: '$..[?(@.creationTime)]'
     update:
       creationTime:
@@ -38,12 +41,15 @@ actions:
     update:
       lastCertificateRegeneration:
         type: string
+
   - target: '$.components.schemas.MeshItem.properties'
     update:
       creationTime:
         type: string
       modificationTime:
         type: string
+
+  # numbers to string enums
   - target: '$.components.schemas.MeshItem.properties.meshServices.properties.mode.oneOf'
     remove: true
   - target: '$.components.schemas.MeshItem.properties.meshServices.properties.mode'
@@ -54,3 +60,113 @@ actions:
         - Everywhere
         - ReachableBackends
         - Exclusive
+
+  ### requestBodies: any schema marked with x-request is a request body
+
+  # delete readOnly properties from original OpenAPI completely for request bodies
+  - target: '$..[?(@["x-request"])].properties..[?(@.readOnly)]'
+    remove: true
+
+  # from in any spec/policy is deprecated
+  - target: '$..[?(@["x-request"])].properties.spec..from'
+    update:
+      deprecated: true
+
+  # don't allow other properties
+  - target: '$..[?(@["x-request"])].properties'
+    update:
+      additionalProperties: false
+
+  # readOnly properties you shouldn't set whilst editing as they essentially are a create if you change them
+  - target: '$..[?(@["x-request"])].properties.name'
+    update:
+      readOnly: true
+  - target: '$..[?(@["x-request"])].properties.type'
+    update:
+      readOnly: true
+  # readOnly properties you shouldn't set whilst editing, because in GUI you are inside a mesh
+  - target: '$..[?(@["x-request"])].properties.mesh'
+    update:
+      readOnly: true
+
+  # don't show certain labels
+  - target: '$..[?(@["x-request"])].properties.labels'
+    update:
+      patternProperties:
+        ^k8s\.kuma\.io/:
+          type: string
+          readOnly: true
+        ^kuma\.io/:
+          type: string
+          readOnly: true
+      properties:
+        kuma.io/zone:
+          type: string
+          readOnly: true
+        kuma.io/mesh:
+          type: string
+          readOnly: true
+        kuma.io/display-name:
+          type: string
+          readOnly: true
+        kuma.io/env:
+          type: string
+          readOnly: true
+        kuma.io/origin:
+          type: string
+          readOnly: true
+        kuma.io/policy-role:
+          type: string
+          readOnly: true
+        kuma.io/proxy-type:
+          type: string
+          readOnly: true
+
+  # correct top-level targetRef
+  - target: '$..[?(@["x-request"])].properties.spec.properties.targetRef.properties.kind.enum'
+    remove: true
+  - target: '$..[?(@["x-request"])].properties.spec.properties.targetRef.properties.kind'
+    update:
+      enum:
+        - Mesh
+        - Dataplane
+
+  # correct OutboundTargetRefs
+  - target: '$..[?(@["x-request"])].properties.spec..items.properties.targetRef.properties.kind.enum'
+    remove: true
+  - target: '$..[?(@["x-request"])].properties.spec...items.properties.targetRef.properties.kind'
+    update:
+      enum:
+        - MeshService
+        - MeshExternalService
+        - MeshMultiZoneService
+        - MeshHTTPRoute
+
+  # remove old targetRef props
+  - target: '$..[?(@["x-request"])].properties..targetRef.properties.mesh'
+    remove: true
+  - target: '$..[?(@["x-request"])].properties..targetRef.properties.proxyTypes'
+    remove: true
+  - target: '$..[?(@["x-request"])].properties..targetRef.properties.tags'
+    remove: true
+
+  # default all top-level targetRefs to Mesh
+  - target: '$..[?(@["x-request"])].properties.spec'
+    update:
+      default:
+        targetRef:
+          kind: Mesh
+
+  # default all OutboundTargetRefs to Mesh
+  - target: '$..[?(@["x-request"])].properties.spec..items.properties.targetRef'
+    update:
+      default:
+        kind: MeshService
+
+  # make to/rules spec.default field be required
+  - target: '$..[?(@["x-request"])].properties.spec.properties.to.items.[?(!contains("required", `default`))'
+    update:
+      - default
+  - target: '$..[?(@["x-request"])].properties.spec.properties.rules.items.[?(!contains("required", `default`))]'
+    update:
+      - default

--- a/packages/kuma-http-api/openapi.yaml
+++ b/packages/kuma-http-api/openapi.yaml
@@ -15545,6 +15545,7190 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Policy'
+    TargetRefPolicy_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma Policy resource.
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            targetRef:
+              $ref: '#/components/schemas/MeshAccessLogItem/properties/spec/properties/targetRef'
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshAccessLogItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshAccessLogItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshAccessLog
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshAccessLog resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            from:
+              description: From list makes a match between clients and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of clients referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      backends:
+                        type: array
+                        items:
+                          properties:
+                            file:
+                              description: FileBackend defines configuration for file based access logs
+                              type: object
+                              properties:
+                                format:
+                                  description: |-
+                                    Format of access logs. Placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  type: object
+                                  properties:
+                                    json:
+                                      type: array
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - key
+                                          - value
+                                        type: object
+                                      example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
+                                    omitEmptyValues:
+                                      type: boolean
+                                      default: false
+                                    plain:
+                                      type: string
+                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                    type:
+                                      type: string
+                                      enum:
+                                        - Plain
+                                        - Json
+                                  required:
+                                    - type
+                                path:
+                                  description: Path to a file that logs will be written to
+                                  type: string
+                                  example: /tmp/access.log
+                                  minLength: 1
+                              required:
+                                - path
+                            openTelemetry:
+                              description: Defines an OpenTelemetry logging backend.
+                              type: object
+                              properties:
+                                attributes:
+                                  description: |-
+                                    Attributes can contain placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  type: array
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - key
+                                      - value
+                                    type: object
+                                  example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
+                                body:
+                                  description: |-
+                                    Body is a raw string or an OTLP any value as described at
+                                    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                    It can contain placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  example:
+                                    kvlistValue:
+                                      values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
+                                  x-kubernetes-preserve-unknown-fields: true
+                                endpoint:
+                                  description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                  type: string
+                                  example: 'otel-collector:4317'
+                                  minLength: 1
+                              required:
+                                - endpoint
+                            tcp:
+                              description: TCPBackend defines a TCP logging backend.
+                              type: object
+                              properties:
+                                address:
+                                  description: Address of the TCP logging backend
+                                  type: string
+                                  example: '127.0.0.1:5000'
+                                  minLength: 1
+                                format:
+                                  description: |-
+                                    Format of access logs. Placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  type: object
+                                  properties:
+                                    json:
+                                      type: array
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - key
+                                          - value
+                                        type: object
+                                      example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
+                                    omitEmptyValues:
+                                      type: boolean
+                                      default: false
+                                    plain:
+                                      type: string
+                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                    type:
+                                      type: string
+                                      enum:
+                                        - Plain
+                                        - Json
+                                  required:
+                                    - type
+                              required:
+                                - address
+                            type:
+                              type: string
+                              enum:
+                                - Tcp
+                                - File
+                                - OpenTelemetry
+                          required:
+                            - type
+                          type: object
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      clients.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - default
+                  - targetRef
+                type: object
+              deprecated: true
+            rules:
+              description: |-
+                Rules defines inbound access log configurations. Currently limited to
+                selecting all inbound traffic, as L7 matching is not yet implemented.
+              type: array
+              items:
+                properties:
+                  default:
+                    description: Default contains configuration of the inbound access logging
+                    type: object
+                    properties:
+                      backends:
+                        type: array
+                        items:
+                          properties:
+                            file:
+                              description: FileBackend defines configuration for file based access logs
+                              type: object
+                              properties:
+                                format:
+                                  description: |-
+                                    Format of access logs. Placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  type: object
+                                  properties:
+                                    json:
+                                      type: array
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - key
+                                          - value
+                                        type: object
+                                      example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
+                                    omitEmptyValues:
+                                      type: boolean
+                                      default: false
+                                    plain:
+                                      type: string
+                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                    type:
+                                      type: string
+                                      enum:
+                                        - Plain
+                                        - Json
+                                  required:
+                                    - type
+                                path:
+                                  description: Path to a file that logs will be written to
+                                  type: string
+                                  example: /tmp/access.log
+                                  minLength: 1
+                              required:
+                                - path
+                            openTelemetry:
+                              description: Defines an OpenTelemetry logging backend.
+                              type: object
+                              properties:
+                                attributes:
+                                  description: |-
+                                    Attributes can contain placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  type: array
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - key
+                                      - value
+                                    type: object
+                                  example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
+                                body:
+                                  description: |-
+                                    Body is a raw string or an OTLP any value as described at
+                                    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                    It can contain placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  example:
+                                    kvlistValue:
+                                      values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
+                                  x-kubernetes-preserve-unknown-fields: true
+                                endpoint:
+                                  description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                  type: string
+                                  example: 'otel-collector:4317'
+                                  minLength: 1
+                              required:
+                                - endpoint
+                            tcp:
+                              description: TCPBackend defines a TCP logging backend.
+                              type: object
+                              properties:
+                                address:
+                                  description: Address of the TCP logging backend
+                                  type: string
+                                  example: '127.0.0.1:5000'
+                                  minLength: 1
+                                format:
+                                  description: |-
+                                    Format of access logs. Placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  type: object
+                                  properties:
+                                    json:
+                                      type: array
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - key
+                                          - value
+                                        type: object
+                                      example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
+                                    omitEmptyValues:
+                                      type: boolean
+                                      default: false
+                                    plain:
+                                      type: string
+                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                    type:
+                                      type: string
+                                      enum:
+                                        - Plain
+                                        - Json
+                                  required:
+                                    - type
+                              required:
+                                - address
+                            type:
+                              type: string
+                              enum:
+                                - Tcp
+                                - File
+                                - OpenTelemetry
+                          required:
+                            - type
+                          type: object
+                required:
+                  - default
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    backends: []
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined in-place.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+            to:
+              description: To list makes a match between the consumed services and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of destinations referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      backends:
+                        type: array
+                        items:
+                          properties:
+                            file:
+                              description: FileBackend defines configuration for file based access logs
+                              type: object
+                              properties:
+                                format:
+                                  description: |-
+                                    Format of access logs. Placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  type: object
+                                  properties:
+                                    json:
+                                      type: array
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - key
+                                          - value
+                                        type: object
+                                      example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
+                                    omitEmptyValues:
+                                      type: boolean
+                                      default: false
+                                    plain:
+                                      type: string
+                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                    type:
+                                      type: string
+                                      enum:
+                                        - Plain
+                                        - Json
+                                  required:
+                                    - type
+                                path:
+                                  description: Path to a file that logs will be written to
+                                  type: string
+                                  example: /tmp/access.log
+                                  minLength: 1
+                              required:
+                                - path
+                            openTelemetry:
+                              description: Defines an OpenTelemetry logging backend.
+                              type: object
+                              properties:
+                                attributes:
+                                  description: |-
+                                    Attributes can contain placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  type: array
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                      - key
+                                      - value
+                                    type: object
+                                  example:
+                                    - key: mesh
+                                      value: '%KUMA_MESH%'
+                                body:
+                                  description: |-
+                                    Body is a raw string or an OTLP any value as described at
+                                    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                    It can contain placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  example:
+                                    kvlistValue:
+                                      values:
+                                        - key: mesh
+                                          value:
+                                            stringValue: '%KUMA_MESH%'
+                                  x-kubernetes-preserve-unknown-fields: true
+                                endpoint:
+                                  description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                  type: string
+                                  example: 'otel-collector:4317'
+                                  minLength: 1
+                              required:
+                                - endpoint
+                            tcp:
+                              description: TCPBackend defines a TCP logging backend.
+                              type: object
+                              properties:
+                                address:
+                                  description: Address of the TCP logging backend
+                                  type: string
+                                  example: '127.0.0.1:5000'
+                                  minLength: 1
+                                format:
+                                  description: |-
+                                    Format of access logs. Placeholders available on
+                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                  type: object
+                                  properties:
+                                    json:
+                                      type: array
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                          - key
+                                          - value
+                                        type: object
+                                      example:
+                                        - key: start_time
+                                          value: '%START_TIME%'
+                                        - key: bytes_received
+                                          value: '%BYTES_RECEIVED%'
+                                    omitEmptyValues:
+                                      type: boolean
+                                      default: false
+                                    plain:
+                                      type: string
+                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                    type:
+                                      type: string
+                                      enum:
+                                        - Plain
+                                        - Json
+                                  required:
+                                    - type
+                              required:
+                                - address
+                            type:
+                              type: string
+                              enum:
+                                - Tcp
+                                - File
+                                - OpenTelemetry
+                          required:
+                            - type
+                          type: object
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      destinations.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - default
+                  - targetRef
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    backends: []
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshAccessLogItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshCircuitBreakerItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshCircuitBreaker
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshCircuitBreaker resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            from:
+              description: From list makes a match between clients and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of destinations
+                      referenced in 'targetRef'
+                    type: object
+                    properties:
+                      connectionLimits:
+                        description: |-
+                          ConnectionLimits contains configuration of each circuit breaking limit,
+                          which when exceeded makes the circuit breaker to become open (no traffic
+                          is allowed like no current is allowed in the circuits when physical
+                          circuit breaker ir open)
+                        type: object
+                        properties:
+                          maxConnectionPools:
+                            description: |-
+                              The maximum number of connection pools per cluster that are concurrently
+                              supported at once. Set this for clusters which create a large number of
+                              connection pools.
+                            type: integer
+                            format: int32
+                          maxConnections:
+                            description: |-
+                              The maximum number of connections allowed to be made to the upstream
+                              cluster.
+                            type: integer
+                            format: int32
+                          maxPendingRequests:
+                            description: |-
+                              The maximum number of pending requests that are allowed to the upstream
+                              cluster. This limit is applied as a connection limit for non-HTTP
+                              traffic.
+                            type: integer
+                            format: int32
+                          maxRequests:
+                            description: |-
+                              The maximum number of parallel requests that are allowed to be made
+                              to the upstream cluster. This limit does not apply to non-HTTP traffic.
+                            type: integer
+                            format: int32
+                          maxRetries:
+                            description: |-
+                              The maximum number of parallel retries that will be allowed to
+                              the upstream cluster.
+                            type: integer
+                            format: int32
+                      outlierDetection:
+                        description: |-
+                          OutlierDetection contains the configuration of the process of dynamically
+                          determining whether some number of hosts in an upstream cluster are
+                          performing unlike the others and removing them from the healthy load
+                          balancing set. Performance might be along different axes such as
+                          consecutive failures, temporal success rate, temporal latency, etc.
+                          Outlier detection is a form of passive health checking.
+                        type: object
+                        properties:
+                          baseEjectionTime:
+                            description: |-
+                              The base time that a host is ejected for. The real time is equal to
+                              the base time multiplied by the number of times the host has been
+                              ejected.
+                            type: string
+                          detectors:
+                            description: Contains configuration for supported outlier detectors
+                            type: object
+                            properties:
+                              failurePercentage:
+                                description: |-
+                                  Failure Percentage based outlier detection functions similarly to success
+                                  rate detection, in that it relies on success rate data from each host in
+                                  a cluster. However, rather than compare those values to the mean success
+                                  rate of the cluster as a whole, they are compared to a flat
+                                  user-configured threshold. This threshold is configured via the
+                                  outlierDetection.failurePercentageThreshold field.
+                                  The other configuration fields for failure percentage based detection are
+                                  similar to the fields for success rate detection. As with success rate
+                                  detection, detection will not be performed for a host if its request
+                                  volume over the aggregation interval is less than the
+                                  outlierDetection.detectors.failurePercentage.requestVolume value.
+                                  Detection also will not be performed for a cluster if the number of hosts
+                                  with the minimum required request volume in an interval is less than the
+                                  outlierDetection.detectors.failurePercentage.minimumHosts value.
+                                type: object
+                                properties:
+                                  minimumHosts:
+                                    description: |-
+                                      The minimum number of hosts in a cluster in order to perform failure
+                                      percentage-based ejection. If the total number of hosts in the cluster is
+                                      less than this value, failure percentage-based ejection will not be
+                                      performed.
+                                    type: integer
+                                    format: int32
+                                  requestVolume:
+                                    description: |-
+                                      The minimum number of total requests that must be collected in one
+                                      interval (as defined by the interval duration above) to perform failure
+                                      percentage-based ejection for this host. If the volume is lower than this
+                                      setting, failure percentage-based ejection will not be performed for this
+                                      host.
+                                    type: integer
+                                    format: int32
+                                  threshold:
+                                    description: |-
+                                      The failure percentage to use when determining failure percentage-based
+                                      outlier detection. If the failure percentage of a given host is greater
+                                      than or equal to this value, it will be ejected.
+                                    type: integer
+                                    format: int32
+                              gatewayFailures:
+                                description: |-
+                                  In the default mode (outlierDetection.splitExternalLocalOriginErrors is
+                                  false) this detection type takes into account a subset of 5xx errors,
+                                  called "gateway errors" (502, 503 or 504 status code) and local origin
+                                  failures, such as timeout, TCP reset etc.
+                                  In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                  this detection type takes into account a subset of 5xx errors, called
+                                  "gateway errors" (502, 503 or 504 status code) and is supported only by
+                                  the http router.
+                                type: object
+                                properties:
+                                  consecutive:
+                                    description: |-
+                                      The number of consecutive gateway failures (502, 503, 504 status codes)
+                                      before a consecutive gateway failure ejection occurs.
+                                    type: integer
+                                    format: int32
+                              localOriginFailures:
+                                description: |-
+                                  This detection type is enabled only when
+                                  outlierDetection.splitExternalLocalOriginErrors is true and takes into
+                                  account only locally originated errors (timeout, reset, etc).
+                                  If Envoy repeatedly cannot connect to an upstream host or communication
+                                  with the upstream host is repeatedly interrupted, it will be ejected.
+                                  Various locally originated problems are detected: timeout, TCP reset,
+                                  ICMP errors, etc. This detection type is supported by http router and
+                                  tcp proxy.
+                                type: object
+                                properties:
+                                  consecutive:
+                                    description: |-
+                                      The number of consecutive locally originated failures before ejection
+                                      occurs. Parameter takes effect only when splitExternalAndLocalErrors
+                                      is set to true.
+                                    type: integer
+                                    format: int32
+                              successRate:
+                                description: |-
+                                  Success Rate based outlier detection aggregates success rate data from
+                                  every host in a cluster. Then at given intervals ejects hosts based on
+                                  statistical outlier detection. Success Rate outlier detection will not be
+                                  calculated for a host if its request volume over the aggregation interval
+                                  is less than the outlierDetection.detectors.successRate.requestVolume
+                                  value.
+                                  Moreover, detection will not be performed for a cluster if the number of
+                                  hosts with the minimum required request volume in an interval is less
+                                  than the outlierDetection.detectors.successRate.minimumHosts value.
+                                  In the default configuration mode
+                                  (outlierDetection.splitExternalLocalOriginErrors is false) this detection
+                                  type takes into account all types of errors: locally and externally
+                                  originated.
+                                  In split mode (outlierDetection.splitExternalLocalOriginErrors is true),
+                                  locally originated errors and externally originated (transaction) errors
+                                  are counted and treated separately.
+                                type: object
+                                properties:
+                                  minimumHosts:
+                                    description: |-
+                                      The number of hosts in a cluster that must have enough request volume to
+                                      detect success rate outliers. If the number of hosts is less than this
+                                      setting, outlier detection via success rate statistics is not performed
+                                      for any host in the cluster.
+                                    type: integer
+                                    format: int32
+                                  requestVolume:
+                                    description: |-
+                                      The minimum number of total requests that must be collected in one
+                                      interval (as defined by the interval duration configured in
+                                      outlierDetection section) to include this host in success rate based
+                                      outlier detection. If the volume is lower than this setting, outlier
+                                      detection via success rate statistics is not performed for that host.
+                                    type: integer
+                                    format: int32
+                                  standardDeviationFactor:
+                                    description: |-
+                                      This factor is used to determine the ejection threshold for success rate
+                                      outlier ejection. The ejection threshold is the difference between
+                                      the mean success rate, and the product of this factor and the standard
+                                      deviation of the mean success rate: mean - (standard_deviation *
+                                      success_rate_standard_deviation_factor).
+                                      Either int or decimal represented as string.
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                              totalFailures:
+                                description: |-
+                                  In the default mode (outlierDetection.splitExternalAndLocalErrors is
+                                  false) this detection type takes into account all generated errors:
+                                  locally originated and externally originated (transaction) errors.
+                                  In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                  this detection type takes into account only externally originated
+                                  (transaction) errors, ignoring locally originated errors.
+                                  If an upstream host is an HTTP-server, only 5xx types of error are taken
+                                  into account (see Consecutive Gateway Failure for exceptions).
+                                  Properly formatted responses, even when they carry an operational error
+                                  (like index not found, access denied) are not taken into account.
+                                type: object
+                                properties:
+                                  consecutive:
+                                    description: |-
+                                      The number of consecutive server-side error responses (for HTTP traffic,
+                                      5xx responses; for TCP traffic, connection failures; for Redis, failure
+                                      to respond PONG; etc.) before a consecutive total failure ejection
+                                      occurs.
+                                    type: integer
+                                    format: int32
+                          disabled:
+                            description: 'When set to true, outlierDetection configuration won''t take any effect'
+                            type: boolean
+                          healthyPanicThreshold:
+                            description: |-
+                              Allows to configure panic threshold for Envoy cluster. If not specified,
+                              the default is 50%. To disable panic mode, set to 0%.
+                              Either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                          interval:
+                            description: |-
+                              The time interval between ejection analysis sweeps. This can result in
+                              both new ejections and hosts being returned to service.
+                            type: string
+                          maxEjectionPercent:
+                            description: |-
+                              The maximum % of an upstream cluster that can be ejected due to outlier
+                              detection. Defaults to 10% but will eject at least one host regardless of
+                              the value.
+                            type: integer
+                            format: int32
+                          splitExternalAndLocalErrors:
+                            description: |-
+                              Determines whether to distinguish local origin failures from external
+                              errors. If set to true the following configuration parameters are taken
+                              into account: detectors.localOriginFailures.consecutive
+                            type: boolean
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      destinations.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+              deprecated: true
+            rules:
+              description: |-
+                Rules defines inbound circuit breaker configurations. Currently limited to
+                selecting all inbound traffic, as L7 matching is not yet implemented.
+              type: array
+              items:
+                properties:
+                  default:
+                    description: Default contains configuration of the inbound circuit breaker
+                    type: object
+                    properties:
+                      connectionLimits:
+                        description: |-
+                          ConnectionLimits contains configuration of each circuit breaking limit,
+                          which when exceeded makes the circuit breaker to become open (no traffic
+                          is allowed like no current is allowed in the circuits when physical
+                          circuit breaker ir open)
+                        type: object
+                        properties:
+                          maxConnectionPools:
+                            description: |-
+                              The maximum number of connection pools per cluster that are concurrently
+                              supported at once. Set this for clusters which create a large number of
+                              connection pools.
+                            type: integer
+                            format: int32
+                          maxConnections:
+                            description: |-
+                              The maximum number of connections allowed to be made to the upstream
+                              cluster.
+                            type: integer
+                            format: int32
+                          maxPendingRequests:
+                            description: |-
+                              The maximum number of pending requests that are allowed to the upstream
+                              cluster. This limit is applied as a connection limit for non-HTTP
+                              traffic.
+                            type: integer
+                            format: int32
+                          maxRequests:
+                            description: |-
+                              The maximum number of parallel requests that are allowed to be made
+                              to the upstream cluster. This limit does not apply to non-HTTP traffic.
+                            type: integer
+                            format: int32
+                          maxRetries:
+                            description: |-
+                              The maximum number of parallel retries that will be allowed to
+                              the upstream cluster.
+                            type: integer
+                            format: int32
+                      outlierDetection:
+                        description: |-
+                          OutlierDetection contains the configuration of the process of dynamically
+                          determining whether some number of hosts in an upstream cluster are
+                          performing unlike the others and removing them from the healthy load
+                          balancing set. Performance might be along different axes such as
+                          consecutive failures, temporal success rate, temporal latency, etc.
+                          Outlier detection is a form of passive health checking.
+                        type: object
+                        properties:
+                          baseEjectionTime:
+                            description: |-
+                              The base time that a host is ejected for. The real time is equal to
+                              the base time multiplied by the number of times the host has been
+                              ejected.
+                            type: string
+                          detectors:
+                            description: Contains configuration for supported outlier detectors
+                            type: object
+                            properties:
+                              failurePercentage:
+                                description: |-
+                                  Failure Percentage based outlier detection functions similarly to success
+                                  rate detection, in that it relies on success rate data from each host in
+                                  a cluster. However, rather than compare those values to the mean success
+                                  rate of the cluster as a whole, they are compared to a flat
+                                  user-configured threshold. This threshold is configured via the
+                                  outlierDetection.failurePercentageThreshold field.
+                                  The other configuration fields for failure percentage based detection are
+                                  similar to the fields for success rate detection. As with success rate
+                                  detection, detection will not be performed for a host if its request
+                                  volume over the aggregation interval is less than the
+                                  outlierDetection.detectors.failurePercentage.requestVolume value.
+                                  Detection also will not be performed for a cluster if the number of hosts
+                                  with the minimum required request volume in an interval is less than the
+                                  outlierDetection.detectors.failurePercentage.minimumHosts value.
+                                type: object
+                                properties:
+                                  minimumHosts:
+                                    description: |-
+                                      The minimum number of hosts in a cluster in order to perform failure
+                                      percentage-based ejection. If the total number of hosts in the cluster is
+                                      less than this value, failure percentage-based ejection will not be
+                                      performed.
+                                    type: integer
+                                    format: int32
+                                  requestVolume:
+                                    description: |-
+                                      The minimum number of total requests that must be collected in one
+                                      interval (as defined by the interval duration above) to perform failure
+                                      percentage-based ejection for this host. If the volume is lower than this
+                                      setting, failure percentage-based ejection will not be performed for this
+                                      host.
+                                    type: integer
+                                    format: int32
+                                  threshold:
+                                    description: |-
+                                      The failure percentage to use when determining failure percentage-based
+                                      outlier detection. If the failure percentage of a given host is greater
+                                      than or equal to this value, it will be ejected.
+                                    type: integer
+                                    format: int32
+                              gatewayFailures:
+                                description: |-
+                                  In the default mode (outlierDetection.splitExternalLocalOriginErrors is
+                                  false) this detection type takes into account a subset of 5xx errors,
+                                  called "gateway errors" (502, 503 or 504 status code) and local origin
+                                  failures, such as timeout, TCP reset etc.
+                                  In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                  this detection type takes into account a subset of 5xx errors, called
+                                  "gateway errors" (502, 503 or 504 status code) and is supported only by
+                                  the http router.
+                                type: object
+                                properties:
+                                  consecutive:
+                                    description: |-
+                                      The number of consecutive gateway failures (502, 503, 504 status codes)
+                                      before a consecutive gateway failure ejection occurs.
+                                    type: integer
+                                    format: int32
+                              localOriginFailures:
+                                description: |-
+                                  This detection type is enabled only when
+                                  outlierDetection.splitExternalLocalOriginErrors is true and takes into
+                                  account only locally originated errors (timeout, reset, etc).
+                                  If Envoy repeatedly cannot connect to an upstream host or communication
+                                  with the upstream host is repeatedly interrupted, it will be ejected.
+                                  Various locally originated problems are detected: timeout, TCP reset,
+                                  ICMP errors, etc. This detection type is supported by http router and
+                                  tcp proxy.
+                                type: object
+                                properties:
+                                  consecutive:
+                                    description: |-
+                                      The number of consecutive locally originated failures before ejection
+                                      occurs. Parameter takes effect only when splitExternalAndLocalErrors
+                                      is set to true.
+                                    type: integer
+                                    format: int32
+                              successRate:
+                                description: |-
+                                  Success Rate based outlier detection aggregates success rate data from
+                                  every host in a cluster. Then at given intervals ejects hosts based on
+                                  statistical outlier detection. Success Rate outlier detection will not be
+                                  calculated for a host if its request volume over the aggregation interval
+                                  is less than the outlierDetection.detectors.successRate.requestVolume
+                                  value.
+                                  Moreover, detection will not be performed for a cluster if the number of
+                                  hosts with the minimum required request volume in an interval is less
+                                  than the outlierDetection.detectors.successRate.minimumHosts value.
+                                  In the default configuration mode
+                                  (outlierDetection.splitExternalLocalOriginErrors is false) this detection
+                                  type takes into account all types of errors: locally and externally
+                                  originated.
+                                  In split mode (outlierDetection.splitExternalLocalOriginErrors is true),
+                                  locally originated errors and externally originated (transaction) errors
+                                  are counted and treated separately.
+                                type: object
+                                properties:
+                                  minimumHosts:
+                                    description: |-
+                                      The number of hosts in a cluster that must have enough request volume to
+                                      detect success rate outliers. If the number of hosts is less than this
+                                      setting, outlier detection via success rate statistics is not performed
+                                      for any host in the cluster.
+                                    type: integer
+                                    format: int32
+                                  requestVolume:
+                                    description: |-
+                                      The minimum number of total requests that must be collected in one
+                                      interval (as defined by the interval duration configured in
+                                      outlierDetection section) to include this host in success rate based
+                                      outlier detection. If the volume is lower than this setting, outlier
+                                      detection via success rate statistics is not performed for that host.
+                                    type: integer
+                                    format: int32
+                                  standardDeviationFactor:
+                                    description: |-
+                                      This factor is used to determine the ejection threshold for success rate
+                                      outlier ejection. The ejection threshold is the difference between
+                                      the mean success rate, and the product of this factor and the standard
+                                      deviation of the mean success rate: mean - (standard_deviation *
+                                      success_rate_standard_deviation_factor).
+                                      Either int or decimal represented as string.
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                              totalFailures:
+                                description: |-
+                                  In the default mode (outlierDetection.splitExternalAndLocalErrors is
+                                  false) this detection type takes into account all generated errors:
+                                  locally originated and externally originated (transaction) errors.
+                                  In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                  this detection type takes into account only externally originated
+                                  (transaction) errors, ignoring locally originated errors.
+                                  If an upstream host is an HTTP-server, only 5xx types of error are taken
+                                  into account (see Consecutive Gateway Failure for exceptions).
+                                  Properly formatted responses, even when they carry an operational error
+                                  (like index not found, access denied) are not taken into account.
+                                type: object
+                                properties:
+                                  consecutive:
+                                    description: |-
+                                      The number of consecutive server-side error responses (for HTTP traffic,
+                                      5xx responses; for TCP traffic, connection failures; for Redis, failure
+                                      to respond PONG; etc.) before a consecutive total failure ejection
+                                      occurs.
+                                    type: integer
+                                    format: int32
+                          disabled:
+                            description: 'When set to true, outlierDetection configuration won''t take any effect'
+                            type: boolean
+                          healthyPanicThreshold:
+                            description: |-
+                              Allows to configure panic threshold for Envoy cluster. If not specified,
+                              the default is 50%. To disable panic mode, set to 0%.
+                              Either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                          interval:
+                            description: |-
+                              The time interval between ejection analysis sweeps. This can result in
+                              both new ejections and hosts being returned to service.
+                            type: string
+                          maxEjectionPercent:
+                            description: |-
+                              The maximum % of an upstream cluster that can be ejected due to outlier
+                              detection. Defaults to 10% but will eject at least one host regardless of
+                              the value.
+                            type: integer
+                            format: int32
+                          splitExternalAndLocalErrors:
+                            description: |-
+                              Determines whether to distinguish local origin failures from external
+                              errors. If set to true the following configuration parameters are taken
+                              into account: detectors.localOriginFailures.consecutive
+                            type: boolean
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    connectionLimits:
+                      maxConnections: 2
+                      maxPendingRequests: 8
+                      maxRetries: 2
+                      maxRequests: 2
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined in place.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+            to:
+              description: |-
+                To list makes a match between the consumed services and corresponding
+                configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of destinations
+                      referenced in 'targetRef'
+                    type: object
+                    default:
+                      connectionLimits:
+                        maxConnections: 2
+                        maxPendingRequests: 8
+                        maxRetries: 2
+                        maxRequests: 2
+                    properties:
+                      connectionLimits:
+                        description: |-
+                          ConnectionLimits contains configuration of each circuit breaking limit,
+                          which when exceeded makes the circuit breaker to become open (no traffic
+                          is allowed like no current is allowed in the circuits when physical
+                          circuit breaker ir open)
+                        type: object
+                        properties:
+                          maxConnectionPools:
+                            description: |-
+                              The maximum number of connection pools per cluster that are concurrently
+                              supported at once. Set this for clusters which create a large number of
+                              connection pools.
+                            type: integer
+                            format: int32
+                          maxConnections:
+                            description: |-
+                              The maximum number of connections allowed to be made to the upstream
+                              cluster.
+                            type: integer
+                            format: int32
+                          maxPendingRequests:
+                            description: |-
+                              The maximum number of pending requests that are allowed to the upstream
+                              cluster. This limit is applied as a connection limit for non-HTTP
+                              traffic.
+                            type: integer
+                            format: int32
+                          maxRequests:
+                            description: |-
+                              The maximum number of parallel requests that are allowed to be made
+                              to the upstream cluster. This limit does not apply to non-HTTP traffic.
+                            type: integer
+                            format: int32
+                          maxRetries:
+                            description: |-
+                              The maximum number of parallel retries that will be allowed to
+                              the upstream cluster.
+                            type: integer
+                            format: int32
+                      outlierDetection:
+                        description: |-
+                          OutlierDetection contains the configuration of the process of dynamically
+                          determining whether some number of hosts in an upstream cluster are
+                          performing unlike the others and removing them from the healthy load
+                          balancing set. Performance might be along different axes such as
+                          consecutive failures, temporal success rate, temporal latency, etc.
+                          Outlier detection is a form of passive health checking.
+                        type: object
+                        properties:
+                          baseEjectionTime:
+                            description: |-
+                              The base time that a host is ejected for. The real time is equal to
+                              the base time multiplied by the number of times the host has been
+                              ejected.
+                            type: string
+                          detectors:
+                            description: Contains configuration for supported outlier detectors
+                            type: object
+                            properties:
+                              failurePercentage:
+                                description: |-
+                                  Failure Percentage based outlier detection functions similarly to success
+                                  rate detection, in that it relies on success rate data from each host in
+                                  a cluster. However, rather than compare those values to the mean success
+                                  rate of the cluster as a whole, they are compared to a flat
+                                  user-configured threshold. This threshold is configured via the
+                                  outlierDetection.failurePercentageThreshold field.
+                                  The other configuration fields for failure percentage based detection are
+                                  similar to the fields for success rate detection. As with success rate
+                                  detection, detection will not be performed for a host if its request
+                                  volume over the aggregation interval is less than the
+                                  outlierDetection.detectors.failurePercentage.requestVolume value.
+                                  Detection also will not be performed for a cluster if the number of hosts
+                                  with the minimum required request volume in an interval is less than the
+                                  outlierDetection.detectors.failurePercentage.minimumHosts value.
+                                type: object
+                                properties:
+                                  minimumHosts:
+                                    description: |-
+                                      The minimum number of hosts in a cluster in order to perform failure
+                                      percentage-based ejection. If the total number of hosts in the cluster is
+                                      less than this value, failure percentage-based ejection will not be
+                                      performed.
+                                    type: integer
+                                    format: int32
+                                  requestVolume:
+                                    description: |-
+                                      The minimum number of total requests that must be collected in one
+                                      interval (as defined by the interval duration above) to perform failure
+                                      percentage-based ejection for this host. If the volume is lower than this
+                                      setting, failure percentage-based ejection will not be performed for this
+                                      host.
+                                    type: integer
+                                    format: int32
+                                  threshold:
+                                    description: |-
+                                      The failure percentage to use when determining failure percentage-based
+                                      outlier detection. If the failure percentage of a given host is greater
+                                      than or equal to this value, it will be ejected.
+                                    type: integer
+                                    format: int32
+                              gatewayFailures:
+                                description: |-
+                                  In the default mode (outlierDetection.splitExternalLocalOriginErrors is
+                                  false) this detection type takes into account a subset of 5xx errors,
+                                  called "gateway errors" (502, 503 or 504 status code) and local origin
+                                  failures, such as timeout, TCP reset etc.
+                                  In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                  this detection type takes into account a subset of 5xx errors, called
+                                  "gateway errors" (502, 503 or 504 status code) and is supported only by
+                                  the http router.
+                                type: object
+                                properties:
+                                  consecutive:
+                                    description: |-
+                                      The number of consecutive gateway failures (502, 503, 504 status codes)
+                                      before a consecutive gateway failure ejection occurs.
+                                    type: integer
+                                    format: int32
+                              localOriginFailures:
+                                description: |-
+                                  This detection type is enabled only when
+                                  outlierDetection.splitExternalLocalOriginErrors is true and takes into
+                                  account only locally originated errors (timeout, reset, etc).
+                                  If Envoy repeatedly cannot connect to an upstream host or communication
+                                  with the upstream host is repeatedly interrupted, it will be ejected.
+                                  Various locally originated problems are detected: timeout, TCP reset,
+                                  ICMP errors, etc. This detection type is supported by http router and
+                                  tcp proxy.
+                                type: object
+                                properties:
+                                  consecutive:
+                                    description: |-
+                                      The number of consecutive locally originated failures before ejection
+                                      occurs. Parameter takes effect only when splitExternalAndLocalErrors
+                                      is set to true.
+                                    type: integer
+                                    format: int32
+                              successRate:
+                                description: |-
+                                  Success Rate based outlier detection aggregates success rate data from
+                                  every host in a cluster. Then at given intervals ejects hosts based on
+                                  statistical outlier detection. Success Rate outlier detection will not be
+                                  calculated for a host if its request volume over the aggregation interval
+                                  is less than the outlierDetection.detectors.successRate.requestVolume
+                                  value.
+                                  Moreover, detection will not be performed for a cluster if the number of
+                                  hosts with the minimum required request volume in an interval is less
+                                  than the outlierDetection.detectors.successRate.minimumHosts value.
+                                  In the default configuration mode
+                                  (outlierDetection.splitExternalLocalOriginErrors is false) this detection
+                                  type takes into account all types of errors: locally and externally
+                                  originated.
+                                  In split mode (outlierDetection.splitExternalLocalOriginErrors is true),
+                                  locally originated errors and externally originated (transaction) errors
+                                  are counted and treated separately.
+                                type: object
+                                properties:
+                                  minimumHosts:
+                                    description: |-
+                                      The number of hosts in a cluster that must have enough request volume to
+                                      detect success rate outliers. If the number of hosts is less than this
+                                      setting, outlier detection via success rate statistics is not performed
+                                      for any host in the cluster.
+                                    type: integer
+                                    format: int32
+                                  requestVolume:
+                                    description: |-
+                                      The minimum number of total requests that must be collected in one
+                                      interval (as defined by the interval duration configured in
+                                      outlierDetection section) to include this host in success rate based
+                                      outlier detection. If the volume is lower than this setting, outlier
+                                      detection via success rate statistics is not performed for that host.
+                                    type: integer
+                                    format: int32
+                                  standardDeviationFactor:
+                                    description: |-
+                                      This factor is used to determine the ejection threshold for success rate
+                                      outlier ejection. The ejection threshold is the difference between
+                                      the mean success rate, and the product of this factor and the standard
+                                      deviation of the mean success rate: mean - (standard_deviation *
+                                      success_rate_standard_deviation_factor).
+                                      Either int or decimal represented as string.
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                              totalFailures:
+                                description: |-
+                                  In the default mode (outlierDetection.splitExternalAndLocalErrors is
+                                  false) this detection type takes into account all generated errors:
+                                  locally originated and externally originated (transaction) errors.
+                                  In split mode (outlierDetection.splitExternalLocalOriginErrors is true)
+                                  this detection type takes into account only externally originated
+                                  (transaction) errors, ignoring locally originated errors.
+                                  If an upstream host is an HTTP-server, only 5xx types of error are taken
+                                  into account (see Consecutive Gateway Failure for exceptions).
+                                  Properly formatted responses, even when they carry an operational error
+                                  (like index not found, access denied) are not taken into account.
+                                type: object
+                                properties:
+                                  consecutive:
+                                    description: |-
+                                      The number of consecutive server-side error responses (for HTTP traffic,
+                                      5xx responses; for TCP traffic, connection failures; for Redis, failure
+                                      to respond PONG; etc.) before a consecutive total failure ejection
+                                      occurs.
+                                    type: integer
+                                    format: int32
+                          disabled:
+                            description: 'When set to true, outlierDetection configuration won''t take any effect'
+                            type: boolean
+                          healthyPanicThreshold:
+                            description: |-
+                              Allows to configure panic threshold for Envoy cluster. If not specified,
+                              the default is 50%. To disable panic mode, set to 0%.
+                              Either int or decimal represented as string.
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                          interval:
+                            description: |-
+                              The time interval between ejection analysis sweeps. This can result in
+                              both new ejections and hosts being returned to service.
+                            type: string
+                          maxEjectionPercent:
+                            description: |-
+                              The maximum % of an upstream cluster that can be ejected due to outlier
+                              detection. Defaults to 10% but will eject at least one host regardless of
+                              the value.
+                            type: integer
+                            format: int32
+                          splitExternalAndLocalErrors:
+                            description: |-
+                              Determines whether to distinguish local origin failures from external
+                              errors. If set to true the following configuration parameters are taken
+                              into account: detectors.localOriginFailures.consecutive
+                            type: boolean
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      destinations.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    connectionLimits:
+                      maxConnections: 2
+                      maxPendingRequests: 8
+                      maxRetries: 2
+                      maxRequests: 2
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshCircuitBreakerItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshFaultInjectionItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshFaultInjection
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshFaultInjection resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            from:
+              description: From list makes a match between clients and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of destinations referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      http:
+                        description: Http allows to define list of Http faults between dataplanes.
+                        type: array
+                        items:
+                          description: FaultInjection defines the configuration of faults between dataplanes.
+                          properties:
+                            abort:
+                              description: |-
+                                Abort defines a configuration of not delivering requests to destination
+                                service and replacing the responses from destination dataplane by
+                                predefined status code
+                              type: object
+                              properties:
+                                httpStatus:
+                                  description: HTTP status code which will be returned to source side
+                                  type: integer
+                                  format: int32
+                                percentage:
+                                  description: |-
+                                    Percentage of requests on which abort will be injected, has to be
+                                    either int or decimal represented as string.
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - httpStatus
+                                - percentage
+                            delay:
+                              description: Delay defines configuration of delaying a response from a destination
+                              type: object
+                              properties:
+                                percentage:
+                                  description: |-
+                                    Percentage of requests on which delay will be injected, has to be
+                                    either int or decimal represented as string.
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                value:
+                                  description: The duration during which the response will be delayed
+                                  type: string
+                              required:
+                                - percentage
+                                - value
+                            responseBandwidth:
+                              description: |-
+                                ResponseBandwidth defines a configuration to limit the speed of
+                                responding to the requests
+                              type: object
+                              properties:
+                                limit:
+                                  description: |-
+                                    Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
+                                    10kbps
+                                  type: string
+                                percentage:
+                                  description: |-
+                                    Percentage of requests on which response bandwidth limit will be
+                                    either int or decimal represented as string.
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - limit
+                                - percentage
+                          type: object
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      destinations.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+              deprecated: true
+            rules:
+              description: Rules defines inbound fault injection configuration
+              type: array
+              items:
+                properties:
+                  default:
+                    description: Default defines fault configuration
+                    type: object
+                    properties:
+                      http:
+                        description: Http allows to define list of Http faults between dataplanes.
+                        type: array
+                        items:
+                          description: FaultInjection defines the configuration of faults between dataplanes.
+                          properties:
+                            abort:
+                              description: |-
+                                Abort defines a configuration of not delivering requests to destination
+                                service and replacing the responses from destination dataplane by
+                                predefined status code
+                              type: object
+                              properties:
+                                httpStatus:
+                                  description: HTTP status code which will be returned to source side
+                                  type: integer
+                                  format: int32
+                                percentage:
+                                  description: |-
+                                    Percentage of requests on which abort will be injected, has to be
+                                    either int or decimal represented as string.
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - httpStatus
+                                - percentage
+                            delay:
+                              description: Delay defines configuration of delaying a response from a destination
+                              type: object
+                              properties:
+                                percentage:
+                                  description: |-
+                                    Percentage of requests on which delay will be injected, has to be
+                                    either int or decimal represented as string.
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                value:
+                                  description: The duration during which the response will be delayed
+                                  type: string
+                              required:
+                                - percentage
+                                - value
+                            responseBandwidth:
+                              description: |-
+                                ResponseBandwidth defines a configuration to limit the speed of
+                                responding to the requests
+                              type: object
+                              properties:
+                                limit:
+                                  description: |-
+                                    Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
+                                    10kbps
+                                  type: string
+                                percentage:
+                                  description: |-
+                                    Percentage of requests on which response bandwidth limit will be
+                                    either int or decimal represented as string.
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - limit
+                                - percentage
+                          type: object
+                  matches:
+                    description: Matches defines list of matches for which fault injection will be applied
+                    type: array
+                    items:
+                      properties:
+                        spiffeID:
+                          description: SpiffeID defines a matcher configuration for SpiffeID matching
+                          type: object
+                          properties:
+                            type:
+                              description: Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                              type: string
+                              enum:
+                                - Exact
+                                - Prefix
+                            value:
+                              description: Value is SpiffeId of a client that needs to match for the configuration to be applied
+                              type: string
+                          required:
+                            - type
+                            - value
+                      type: object
+                required:
+                  - default
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    http: []
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined inplace.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+            to:
+              description: To list makes a match between clients and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of destinations referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      http:
+                        description: Http allows to define list of Http faults between dataplanes.
+                        type: array
+                        items:
+                          description: FaultInjection defines the configuration of faults between dataplanes.
+                          properties:
+                            abort:
+                              description: |-
+                                Abort defines a configuration of not delivering requests to destination
+                                service and replacing the responses from destination dataplane by
+                                predefined status code
+                              type: object
+                              properties:
+                                httpStatus:
+                                  description: HTTP status code which will be returned to source side
+                                  type: integer
+                                  format: int32
+                                percentage:
+                                  description: |-
+                                    Percentage of requests on which abort will be injected, has to be
+                                    either int or decimal represented as string.
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - httpStatus
+                                - percentage
+                            delay:
+                              description: Delay defines configuration of delaying a response from a destination
+                              type: object
+                              properties:
+                                percentage:
+                                  description: |-
+                                    Percentage of requests on which delay will be injected, has to be
+                                    either int or decimal represented as string.
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                value:
+                                  description: The duration during which the response will be delayed
+                                  type: string
+                              required:
+                                - percentage
+                                - value
+                            responseBandwidth:
+                              description: |-
+                                ResponseBandwidth defines a configuration to limit the speed of
+                                responding to the requests
+                              type: object
+                              properties:
+                                limit:
+                                  description: |-
+                                    Limit is represented by value measure in Gbps, Mbps, kbps, e.g.
+                                    10kbps
+                                  type: string
+                                percentage:
+                                  description: |-
+                                    Percentage of requests on which response bandwidth limit will be
+                                    either int or decimal represented as string.
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - limit
+                                - percentage
+                          type: object
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      destinations.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    http: []
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshFaultInjectionItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshHTTPRouteItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshHTTPRoute
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshHTTPRoute resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined inplace.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+            to:
+              description: To matches destination services of requests and holds configuration.
+              type: array
+              items:
+                properties:
+                  hostnames:
+                    description: |-
+                      Hostnames is only valid when targeting MeshGateway and limits the
+                      effects of the rules to requests to this hostname.
+                      Given hostnames must intersect with the hostname of the listeners the
+                      route attaches to.
+                    type: array
+                    items:
+                      type: string
+                  rules:
+                    description: |-
+                      Rules contains the routing rules applies to a combination of top-level
+                      targetRef and the targetRef in this entry.
+                    type: array
+                    items:
+                      properties:
+                        default:
+                          description: |-
+                            Default holds routing rules that can be merged with rules from other
+                            policies.
+                          type: object
+                          properties:
+                            backendRefs:
+                              type: array
+                              items:
+                                description: BackendRef defines where to forward traffic.
+                                properties:
+                                  kind:
+                                    description: Kind of the referenced resource
+                                    type: string
+                                    enum:
+                                      - Mesh
+                                      - MeshSubset
+                                      - MeshGateway
+                                      - MeshService
+                                      - MeshExternalService
+                                      - MeshMultiZoneService
+                                      - MeshServiceSubset
+                                      - MeshHTTPRoute
+                                      - Dataplane
+                                  labels:
+                                    description: |-
+                                      Labels are used to select group of MeshServices that match labels. Either Labels or
+                                      Name and Namespace can be used.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  mesh:
+                                    description: Mesh is reserved for future use to identify cross mesh resources.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                                      `MeshServiceSubset` and `MeshGatewayRoute`
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                                      will be targeted.
+                                    type: string
+                                  port:
+                                    description: Port is only supported when this ref refers to a real MeshService object
+                                    type: integer
+                                    format: int32
+                                  proxyTypes:
+                                    description: |-
+                                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                                      all data plane types are targeted by the policy.
+                                    type: array
+                                    items:
+                                      enum:
+                                        - Sidecar
+                                        - Gateway
+                                      type: string
+                                  sectionName:
+                                    description: |-
+                                      SectionName is used to target specific section of resource.
+                                      For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                                    type: string
+                                  tags:
+                                    description: |-
+                                      Tags used to select a subset of proxies by tags. Can only be used with kinds
+                                      `MeshSubset` and `MeshServiceSubset`
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  weight:
+                                    type: integer
+                                    default: 1
+                                    minimum: 0
+                                required:
+                                  - kind
+                                type: object
+                            filters:
+                              type: array
+                              items:
+                                properties:
+                                  requestHeaderModifier:
+                                    description: |-
+                                      Only one action is supported per header name.
+                                      Configuration to set or add multiple values for a header must use RFC 7230
+                                      header value formatting, separating each value with a comma.
+                                    type: object
+                                    properties:
+                                      add:
+                                        type: array
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      remove:
+                                        type: array
+                                        items:
+                                          type: string
+                                        maxItems: 16
+                                      set:
+                                        type: array
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                  requestMirror:
+                                    type: object
+                                    properties:
+                                      backendRef:
+                                        description: BackendRef defines where to forward traffic.
+                                        type: object
+                                        properties:
+                                          kind:
+                                            description: Kind of the referenced resource
+                                            type: string
+                                            enum:
+                                              - Mesh
+                                              - MeshSubset
+                                              - MeshGateway
+                                              - MeshService
+                                              - MeshExternalService
+                                              - MeshMultiZoneService
+                                              - MeshServiceSubset
+                                              - MeshHTTPRoute
+                                              - Dataplane
+                                          labels:
+                                            description: |-
+                                              Labels are used to select group of MeshServices that match labels. Either Labels or
+                                              Name and Namespace can be used.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          mesh:
+                                            description: Mesh is reserved for future use to identify cross mesh resources.
+                                            type: string
+                                          name:
+                                            description: |-
+                                              Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                                              `MeshServiceSubset` and `MeshGatewayRoute`
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                                              will be targeted.
+                                            type: string
+                                          port:
+                                            description: Port is only supported when this ref refers to a real MeshService object
+                                            type: integer
+                                            format: int32
+                                          proxyTypes:
+                                            description: |-
+                                              ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                                              all data plane types are targeted by the policy.
+                                            type: array
+                                            items:
+                                              enum:
+                                                - Sidecar
+                                                - Gateway
+                                              type: string
+                                          sectionName:
+                                            description: |-
+                                              SectionName is used to target specific section of resource.
+                                              For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                                            type: string
+                                          tags:
+                                            description: |-
+                                              Tags used to select a subset of proxies by tags. Can only be used with kinds
+                                              `MeshSubset` and `MeshServiceSubset`
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          weight:
+                                            type: integer
+                                            default: 1
+                                            minimum: 0
+                                        required:
+                                          - kind
+                                      percentage:
+                                        description: |-
+                                          Percentage of requests to mirror. If not specified, all requests
+                                          to the target cluster will be mirrored.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - backendRef
+                                  requestRedirect:
+                                    type: object
+                                    properties:
+                                      hostname:
+                                        description: |-
+                                          PreciseHostname is the fully qualified domain name of a network host. This
+                                          matches the RFC 1123 definition of a hostname with 1 notable exception that
+                                          numeric IP addresses are not allowed.
+
+                                          Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                          alphanumeric characters or '-', and must start and end with an alphanumeric
+                                          character. No other punctuation is allowed.
+                                        type: string
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+                                      path:
+                                        description: |-
+                                          Path defines parameters used to modify the path of the incoming request.
+                                          The modified path is then used to construct the location header.
+                                          When empty, the request path is used as-is.
+                                        type: object
+                                        properties:
+                                          replaceFullPath:
+                                            type: string
+                                          replacePrefixMatch:
+                                            type: string
+                                          type:
+                                            type: string
+                                            enum:
+                                              - ReplaceFullPath
+                                              - ReplacePrefixMatch
+                                        required:
+                                          - type
+                                      port:
+                                        description: |-
+                                          Port is the port to be used in the value of the `Location`
+                                          header in the response.
+                                          When empty, port (if specified) of the request is used.
+                                        type: integer
+                                        format: int32
+                                        maximum: 65535
+                                        minimum: 1
+                                      scheme:
+                                        type: string
+                                        enum:
+                                          - http
+                                          - https
+                                      statusCode:
+                                        description: StatusCode is the HTTP status code to be used in response.
+                                        type: integer
+                                        default: 302
+                                        enum:
+                                          - 301
+                                          - 302
+                                          - 303
+                                          - 307
+                                          - 308
+                                  responseHeaderModifier:
+                                    description: |-
+                                      Only one action is supported per header name.
+                                      Configuration to set or add multiple values for a header must use RFC 7230
+                                      header value formatting, separating each value with a comma.
+                                    type: object
+                                    properties:
+                                      add:
+                                        type: array
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      remove:
+                                        type: array
+                                        items:
+                                          type: string
+                                        maxItems: 16
+                                      set:
+                                        type: array
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                  type:
+                                    type: string
+                                    enum:
+                                      - RequestHeaderModifier
+                                      - ResponseHeaderModifier
+                                      - RequestRedirect
+                                      - URLRewrite
+                                      - RequestMirror
+                                  urlRewrite:
+                                    type: object
+                                    properties:
+                                      hostToBackendHostname:
+                                        description: |-
+                                          HostToBackendHostname rewrites the hostname to the hostname of the
+                                          upstream host. This option is only available when targeting MeshGateways.
+                                        type: boolean
+                                      hostname:
+                                        description: Hostname is the value to be used to replace the host header value during forwarding.
+                                        type: string
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+                                      path:
+                                        description: Path defines a path rewrite.
+                                        type: object
+                                        properties:
+                                          replaceFullPath:
+                                            type: string
+                                          replacePrefixMatch:
+                                            type: string
+                                          type:
+                                            type: string
+                                            enum:
+                                              - ReplaceFullPath
+                                              - ReplacePrefixMatch
+                                        required:
+                                          - type
+                                required:
+                                  - type
+                                type: object
+                        matches:
+                          description: |-
+                            Matches describes how to match HTTP requests this rule should be applied
+                            to.
+                          type: array
+                          items:
+                            properties:
+                              headers:
+                                type: array
+                                items:
+                                  description: |-
+                                    HeaderMatch describes how to select an HTTP route by matching HTTP request
+                                    headers.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name MUST be lower case
+                                        as they will be handled with case insensitivity (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                      type: string
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                    type:
+                                      description: Type specifies how to match against the value of the header.
+                                      type: string
+                                      default: Exact
+                                      enum:
+                                        - Exact
+                                        - Present
+                                        - RegularExpression
+                                        - Absent
+                                        - Prefix
+                                    value:
+                                      description: Value is the value of HTTP Header to be matched.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              method:
+                                type: string
+                                enum:
+                                  - CONNECT
+                                  - DELETE
+                                  - GET
+                                  - HEAD
+                                  - OPTIONS
+                                  - PATCH
+                                  - POST
+                                  - PUT
+                                  - TRACE
+                              path:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - Exact
+                                      - PathPrefix
+                                      - RegularExpression
+                                  value:
+                                    description: |-
+                                      Exact or prefix matches must be an absolute path. A prefix matches only
+                                      if separated by a slash or the entire path.
+                                    type: string
+                                    minLength: 1
+                                required:
+                                  - type
+                                  - value
+                              queryParams:
+                                description: |-
+                                  QueryParams matches based on HTTP URL query parameters. Multiple matches
+                                  are ANDed together such that all listed matches must succeed.
+                                type: array
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                      minLength: 1
+                                    type:
+                                      type: string
+                                      enum:
+                                        - Exact
+                                        - RegularExpression
+                                    value:
+                                      type: string
+                                  required:
+                                    - name
+                                    - type
+                                    - value
+                                  type: object
+                            type: object
+                          minItems: 1
+                      required:
+                        - default
+                        - matches
+                      type: object
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      request destinations.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - rules
+                  - targetRef
+                type: object
+                default:
+                  rules: []
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshHTTPRouteItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshHealthCheckItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshHealthCheck
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshHealthCheck resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined inplace.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+            to:
+              description: To list makes a match between the consumed services and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of destinations referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      alwaysLogHealthCheckFailures:
+                        description: |-
+                          If set to true, health check failure events will always be logged. If set
+                          to false, only the initial health check failure event will be logged. The
+                          default value is false.
+                        type: boolean
+                      eventLogPath:
+                        description: |-
+                          Specifies the path to the file where Envoy can log health check events.
+                          If empty, no event log will be written.
+                        type: string
+                      failTrafficOnPanic:
+                        description: |-
+                          If set to true, Envoy will not consider any hosts when the cluster is in
+                          'panic mode'. Instead, the cluster will fail all requests as if all hosts
+                          are unhealthy. This can help avoid potentially overwhelming a failing
+                          service.
+                        type: boolean
+                      grpc:
+                        description: |-
+                          GrpcHealthCheck defines gRPC configuration which will instruct the service
+                          the health check will be made for is a gRPC service.
+                        type: object
+                        properties:
+                          authority:
+                            description: |-
+                              The value of the :authority header in the gRPC health check request,
+                              by default name of the cluster this health check is associated with
+                            type: string
+                          disabled:
+                            description: If true the GrpcHealthCheck is disabled
+                            type: boolean
+                          serviceName:
+                            description: Service name parameter which will be sent to gRPC service
+                            type: string
+                      healthyPanicThreshold:
+                        description: |-
+                          Allows to configure panic threshold for Envoy cluster. If not specified,
+                          the default is 50%. To disable panic mode, set to 0%.
+                          Either int or decimal represented as string.
+
+                          Deprecated: the setting has been moved to MeshCircuitBreaker policy,
+                          please use MeshCircuitBreaker policy instead.
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                      healthyThreshold:
+                        description: |-
+                          Number of consecutive healthy checks before considering a host healthy.
+                          If not specified then the default value is 1
+                        type: integer
+                        format: int32
+                      http:
+                        description: |-
+                          HttpHealthCheck defines HTTP configuration which will instruct the service
+                          the health check will be made for is an HTTP service.
+                        type: object
+                        properties:
+                          disabled:
+                            description: If true the HttpHealthCheck is disabled
+                            type: boolean
+                          expectedStatuses:
+                            description: List of HTTP response statuses which are considered healthy
+                            type: array
+                            items:
+                              format: int32
+                              type: integer
+                          path:
+                            description: |-
+                              The HTTP path which will be requested during the health check
+                              (ie. /health)
+                              If not specified then the default value is "/"
+                            type: string
+                          requestHeadersToAdd:
+                            description: |-
+                              The list of HTTP headers which should be added to each health check
+                              request
+                            type: object
+                            properties:
+                              add:
+                                type: array
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                    value:
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                maxItems: 16
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              set:
+                                type: array
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                    value:
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                maxItems: 16
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                      initialJitter:
+                        description: |-
+                          If specified, Envoy will start health checking after a random time in
+                          ms between 0 and initialJitter. This only applies to the first health
+                          check.
+                        type: string
+                      interval:
+                        description: |-
+                          Interval between consecutive health checks.
+                          If not specified then the default value is 1m
+                        type: string
+                      intervalJitter:
+                        description: |-
+                          If specified, during every interval Envoy will add IntervalJitter to the
+                          wait time.
+                        type: string
+                      intervalJitterPercent:
+                        description: |-
+                          If specified, during every interval Envoy will add IntervalJitter *
+                          IntervalJitterPercent / 100 to the wait time. If IntervalJitter and
+                          IntervalJitterPercent are both set, both of them will be used to
+                          increase the wait time.
+                        type: integer
+                        format: int32
+                      noTrafficInterval:
+                        description: |-
+                          The "no traffic interval" is a special health check interval that is used
+                          when a cluster has never had traffic routed to it. This lower interval
+                          allows cluster information to be kept up to date, without sending a
+                          potentially large amount of active health checking traffic for no reason.
+                          Once a cluster has been used for traffic routing, Envoy will shift back
+                          to using the standard health check interval that is defined. Note that
+                          this interval takes precedence over any other. The default value for "no
+                          traffic interval" is 60 seconds.
+                        type: string
+                      reuseConnection:
+                        description: Reuse health check connection between health checks. Default is true.
+                        type: boolean
+                      tcp:
+                        description: |-
+                          TcpHealthCheck defines configuration for specifying bytes to send and
+                          expected response during the health check
+                        type: object
+                        properties:
+                          disabled:
+                            description: If true the TcpHealthCheck is disabled
+                            type: boolean
+                          receive:
+                            description: |-
+                              List of Base64 encoded blocks of strings expected as a response. When checking the response,
+                              "fuzzy" matching is performed such that each block must be found, and
+                              in the order specified, but not necessarily contiguous.
+                              If not provided or empty, checks will be performed as "connect only" and be marked as successful when TCP connection is successfully established.
+                            type: array
+                            items:
+                              type: string
+                          send:
+                            description: Base64 encoded content of the message which will be sent during the health check to the target
+                            type: string
+                      timeout:
+                        description: |-
+                          Maximum time to wait for a health check response.
+                          If not specified then the default value is 15s
+                        type: string
+                      unhealthyThreshold:
+                        description: |-
+                          Number of consecutive unhealthy checks before considering a host
+                          unhealthy.
+                          If not specified then the default value is 5
+                        type: integer
+                        format: int32
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      destinations.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    interval: 10s
+                    timeout: 2s
+                    unhealthyThreshold: 3
+                    healthyThreshold: 1
+                    http:
+                      path: /health
+                      expectedStatuses:
+                        - 200
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshHealthCheckItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshLoadBalancingStrategyItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshLoadBalancingStrategy
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshLoadBalancingStrategy resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined inplace.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+            to:
+              description: To list makes a match between the consumed services and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of destinations referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      hashPolicies:
+                        description: |-
+                          HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                          These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                          set to true, and there is already a hash generated, the hash is returned immediately,
+                          ignoring the rest of the hash policy list.
+                        type: array
+                        items:
+                          properties:
+                            connection:
+                              type: object
+                              properties:
+                                sourceIP:
+                                  description: Hash on source IP address.
+                                  type: boolean
+                            cookie:
+                              type: object
+                              properties:
+                                name:
+                                  description: The name of the cookie that will be used to obtain the hash key.
+                                  type: string
+                                  minLength: 1
+                                path:
+                                  description: The name of the path for the cookie.
+                                  type: string
+                                ttl:
+                                  description: 'If specified, a cookie with the TTL will be generated if the cookie is not present.'
+                                  type: string
+                              required:
+                                - name
+                            filterState:
+                              type: object
+                              properties:
+                                key:
+                                  description: |-
+                                    The name of the Object in the per-request filterState, which is
+                                    an Envoy::Hashable object. If there is no data associated with the key,
+                                    or the stored object is not Envoy::Hashable, no hash will be produced.
+                                  type: string
+                                  minLength: 1
+                              required:
+                                - key
+                            header:
+                              type: object
+                              properties:
+                                name:
+                                  description: The name of the request header that will be used to obtain the hash key.
+                                  type: string
+                                  minLength: 1
+                              required:
+                                - name
+                            queryParameter:
+                              type: object
+                              properties:
+                                name:
+                                  description: |-
+                                    The name of the URL query parameter that will be used to obtain the hash key.
+                                    If the parameter is not present, no hash will be produced. Query parameter names
+                                    are case-sensitive.
+                                  type: string
+                                  minLength: 1
+                              required:
+                                - name
+                            terminal:
+                              description: |-
+                                Terminal is a flag that short-circuits the hash computing. This field provides
+                                a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                to rest of the policy list”, it saves time when the terminal policy works.
+                                If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                              type: boolean
+                            type:
+                              type: string
+                              enum:
+                                - Header
+                                - Cookie
+                                - Connection
+                                - SourceIP
+                                - QueryParameter
+                                - FilterState
+                          required:
+                            - type
+                          type: object
+                      loadBalancer:
+                        description: LoadBalancer allows to specify load balancing algorithm.
+                        type: object
+                        properties:
+                          leastRequest:
+                            description: |-
+                              LeastRequest selects N random available hosts as specified in 'choiceCount' (2 by default)
+                              and picks the host which has the fewest active requests
+                            type: object
+                            properties:
+                              activeRequestBias:
+                                description: |-
+                                  ActiveRequestBias refers to dynamic weights applied when hosts have varying load
+                                  balancing weights. A higher value here aggressively reduces the weight of endpoints
+                                  that are currently handling active requests. In essence, the higher the ActiveRequestBias
+                                  value, the more forcefully it reduces the load balancing weight of endpoints that are
+                                  actively serving requests.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              choiceCount:
+                                description: |-
+                                  ChoiceCount is the number of random healthy hosts from which the host with
+                                  the fewest active requests will be chosen. Defaults to 2 so that Envoy performs
+                                  two-choice selection if the field is not set.
+                                type: integer
+                                format: int32
+                                minimum: 2
+                          maglev:
+                            description: |-
+                              Maglev implements consistent hashing to upstream hosts. Maglev can be used as
+                              a drop in replacement for the ring hash load balancer any place in which
+                              consistent hashing is desired.
+                            type: object
+                            properties:
+                              hashPolicies:
+                                description: |-
+                                  HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                                  These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                                  set to true, and there is already a hash generated, the hash is returned immediately,
+                                  ignoring the rest of the hash policy list.
+                                type: array
+                                items:
+                                  properties:
+                                    connection:
+                                      type: object
+                                      properties:
+                                        sourceIP:
+                                          description: Hash on source IP address.
+                                          type: boolean
+                                    cookie:
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: The name of the cookie that will be used to obtain the hash key.
+                                          type: string
+                                          minLength: 1
+                                        path:
+                                          description: The name of the path for the cookie.
+                                          type: string
+                                        ttl:
+                                          description: 'If specified, a cookie with the TTL will be generated if the cookie is not present.'
+                                          type: string
+                                      required:
+                                        - name
+                                    filterState:
+                                      type: object
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The name of the Object in the per-request filterState, which is
+                                            an Envoy::Hashable object. If there is no data associated with the key,
+                                            or the stored object is not Envoy::Hashable, no hash will be produced.
+                                          type: string
+                                          minLength: 1
+                                      required:
+                                        - key
+                                    header:
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: The name of the request header that will be used to obtain the hash key.
+                                          type: string
+                                          minLength: 1
+                                      required:
+                                        - name
+                                    queryParameter:
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The name of the URL query parameter that will be used to obtain the hash key.
+                                            If the parameter is not present, no hash will be produced. Query parameter names
+                                            are case-sensitive.
+                                          type: string
+                                          minLength: 1
+                                      required:
+                                        - name
+                                    terminal:
+                                      description: |-
+                                        Terminal is a flag that short-circuits the hash computing. This field provides
+                                        a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                        to rest of the policy list”, it saves time when the terminal policy works.
+                                        If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                                      type: boolean
+                                    type:
+                                      type: string
+                                      enum:
+                                        - Header
+                                        - Cookie
+                                        - Connection
+                                        - SourceIP
+                                        - QueryParameter
+                                        - FilterState
+                                  required:
+                                    - type
+                                  type: object
+                              tableSize:
+                                description: |-
+                                  The table size for Maglev hashing. Maglev aims for “minimal disruption”
+                                  rather than an absolute guarantee. Minimal disruption means that when
+                                  the set of upstream hosts change, a connection will likely be sent
+                                  to the same upstream as it was before. Increasing the table size reduces
+                                  the amount of disruption. The table size must be prime number limited to 5000011.
+                                  If it is not specified, the default is 65537.
+                                type: integer
+                                format: int32
+                                maximum: 5000011
+                                minimum: 1
+                          random:
+                            description: |-
+                              Random selects a random available host. The random load balancer generally
+                              performs better than round-robin if no health checking policy is configured.
+                              Random selection avoids bias towards the host in the set that comes after a failed host.
+                            type: object
+                          ringHash:
+                            description: |-
+                              RingHash  implements consistent hashing to upstream hosts. Each host is mapped
+                              onto a circle (the “ring”) by hashing its address; each request is then routed
+                              to a host by hashing some property of the request, and finding the nearest
+                              corresponding host clockwise around the ring.
+                            type: object
+                            properties:
+                              hashFunction:
+                                description: |-
+                                  HashFunction is a function used to hash hosts onto the ketama ring.
+                                  The value defaults to XX_HASH. Available values – XX_HASH, MURMUR_HASH_2.
+                                type: string
+                                enum:
+                                  - XXHash
+                                  - MurmurHash2
+                              hashPolicies:
+                                description: |-
+                                  HashPolicies specify a list of request/connection properties that are used to calculate a hash.
+                                  These hash policies are executed in the specified order. If a hash policy has the “terminal” attribute
+                                  set to true, and there is already a hash generated, the hash is returned immediately,
+                                  ignoring the rest of the hash policy list.
+                                type: array
+                                items:
+                                  properties:
+                                    connection:
+                                      type: object
+                                      properties:
+                                        sourceIP:
+                                          description: Hash on source IP address.
+                                          type: boolean
+                                    cookie:
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: The name of the cookie that will be used to obtain the hash key.
+                                          type: string
+                                          minLength: 1
+                                        path:
+                                          description: The name of the path for the cookie.
+                                          type: string
+                                        ttl:
+                                          description: 'If specified, a cookie with the TTL will be generated if the cookie is not present.'
+                                          type: string
+                                      required:
+                                        - name
+                                    filterState:
+                                      type: object
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The name of the Object in the per-request filterState, which is
+                                            an Envoy::Hashable object. If there is no data associated with the key,
+                                            or the stored object is not Envoy::Hashable, no hash will be produced.
+                                          type: string
+                                          minLength: 1
+                                      required:
+                                        - key
+                                    header:
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: The name of the request header that will be used to obtain the hash key.
+                                          type: string
+                                          minLength: 1
+                                      required:
+                                        - name
+                                    queryParameter:
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The name of the URL query parameter that will be used to obtain the hash key.
+                                            If the parameter is not present, no hash will be produced. Query parameter names
+                                            are case-sensitive.
+                                          type: string
+                                          minLength: 1
+                                      required:
+                                        - name
+                                    terminal:
+                                      description: |-
+                                        Terminal is a flag that short-circuits the hash computing. This field provides
+                                        a ‘fallback’ style of configuration: “if a terminal policy doesn’t work, fallback
+                                        to rest of the policy list”, it saves time when the terminal policy works.
+                                        If true, and there is already a hash computed, ignore rest of the list of hash polices.
+                                      type: boolean
+                                    type:
+                                      type: string
+                                      enum:
+                                        - Header
+                                        - Cookie
+                                        - Connection
+                                        - SourceIP
+                                        - QueryParameter
+                                        - FilterState
+                                  required:
+                                    - type
+                                  type: object
+                              maxRingSize:
+                                description: |-
+                                  Maximum hash ring size. Defaults to 8M entries, and limited to 8M entries,
+                                  but can be lowered to further constrain resource use.
+                                type: integer
+                                format: int32
+                                maximum: 8000000
+                                minimum: 1
+                              minRingSize:
+                                description: |-
+                                  Minimum hash ring size. The larger the ring is (that is,
+                                  the more hashes there are for each provided host) the better the request distribution
+                                  will reflect the desired weights. Defaults to 1024 entries, and limited to 8M entries.
+                                type: integer
+                                format: int32
+                                maximum: 8000000
+                                minimum: 1
+                          roundRobin:
+                            description: |-
+                              RoundRobin is a load balancing algorithm that distributes requests
+                              across available upstream hosts in round-robin order.
+                            type: object
+                          type:
+                            type: string
+                            enum:
+                              - RoundRobin
+                              - LeastRequest
+                              - RingHash
+                              - Random
+                              - Maglev
+                        required:
+                          - type
+                      localityAwareness:
+                        description: LocalityAwareness contains configuration for locality aware load balancing.
+                        type: object
+                        properties:
+                          crossZone:
+                            description: |-
+                              CrossZone defines locality aware load balancing priorities when dataplane proxies inside local zone
+                              are unavailable
+                            type: object
+                            properties:
+                              failover:
+                                description: Failover defines list of load balancing rules in order of priority
+                                type: array
+                                items:
+                                  properties:
+                                    from:
+                                      description: From defines the list of zones to which the rule applies
+                                      type: object
+                                      deprecated: true
+                                      properties:
+                                        zones:
+                                          type: array
+                                          items:
+                                            type: string
+                                      required:
+                                        - zones
+                                    to:
+                                      description: To defines to which zones the traffic should be load balanced
+                                      type: object
+                                      properties:
+                                        type:
+                                          description: Type defines how target zones will be picked from available zones
+                                          type: string
+                                          enum:
+                                            - None
+                                            - Only
+                                            - Any
+                                            - AnyExcept
+                                        zones:
+                                          type: array
+                                          items:
+                                            type: string
+                                      required:
+                                        - type
+                                  required:
+                                    - to
+                                  type: object
+                              failoverThreshold:
+                                description: |-
+                                  FailoverThreshold defines the percentage of live destination dataplane proxies below which load balancing to the
+                                  next priority starts.
+                                  Example: If you configure failoverThreshold to 70, and you have deployed 10 destination dataplane proxies.
+                                  Load balancing to next priority will start when number of live destination dataplane proxies drops below 7.
+                                  Default 50
+                                type: object
+                                properties:
+                                  percentage:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - percentage
+                          disabled:
+                            description: |-
+                              Disabled allows to disable locality-aware load balancing.
+                              When disabled requests are distributed across all endpoints regardless of locality.
+                            type: boolean
+                          localZone:
+                            description: LocalZone defines locality aware load balancing priorities between dataplane proxies inside a zone
+                            type: object
+                            properties:
+                              affinityTags:
+                                description: AffinityTags list of tags for local zone load balancing.
+                                type: array
+                                items:
+                                  properties:
+                                    key:
+                                      description: Key defines tag for which affinity is configured
+                                      type: string
+                                    weight:
+                                      description: |-
+                                        Weight of the tag used for load balancing. The bigger the weight the bigger the priority.
+                                        Percentage of local traffic load balanced to tag is computed by dividing weight by sum of weights from all tags.
+                                        For example with two affinity tags first with weight 80 and second with weight 20,
+                                        then 80% of traffic will be redirected to the first tag, and 20% of traffic will be redirected to second one.
+                                        Setting weights is not mandatory. When weights are not set control plane will compute default weight based on list order.
+                                        Default: If you do not specify weight we will adjust them so that 90% traffic goes to first tag, 9% to next, and 1% to third and so on.
+                                      type: integer
+                                      format: int32
+                                  required:
+                                    - key
+                                  type: object
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      destinations.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default: {}
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshLoadBalancingStrategyItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshMetricItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshMetric
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshMetric resource.
+          type: object
+          default:
+            default:
+              backends: []
+            targetRef:
+              kind: Mesh
+          properties:
+            default:
+              description: MeshMetric configuration.
+              type: object
+              properties:
+                applications:
+                  description: Applications is a list of application that Dataplane Proxy will scrape
+                  type: array
+                  items:
+                    properties:
+                      address:
+                        description: Address on which an application listens.
+                        type: string
+                      name:
+                        description: Name of the application to scrape
+                        type: string
+                      path:
+                        description: Path on which an application expose HTTP endpoint with metrics.
+                        type: string
+                        default: /metrics
+                      port:
+                        description: Port on which an application expose HTTP endpoint with metrics.
+                        type: integer
+                        format: int32
+                    required:
+                      - port
+                    type: object
+                backends:
+                  description: Backends list that will be used to collect metrics.
+                  type: array
+                  items:
+                    properties:
+                      openTelemetry:
+                        description: OpenTelemetry backend configuration
+                        type: object
+                        properties:
+                          endpoint:
+                            description: Endpoint for OpenTelemetry collector
+                            type: string
+                          refreshInterval:
+                            description: RefreshInterval defines how frequent metrics should be pushed to collector
+                            type: string
+                        required:
+                          - endpoint
+                      prometheus:
+                        description: Prometheus backend configuration.
+                        type: object
+                        properties:
+                          clientId:
+                            description: ClientId of the Prometheus backend. Needed when using MADS for DP discovery.
+                            type: string
+                          path:
+                            description: Path on which a dataplane should expose HTTP endpoint with Prometheus metrics.
+                            type: string
+                            default: /metrics
+                          port:
+                            description: Port on which a dataplane should expose HTTP endpoint with Prometheus metrics.
+                            type: integer
+                            format: int32
+                            default: 5670
+                          tls:
+                            description: Configuration of TLS for prometheus listener.
+                            type: object
+                            properties:
+                              mode:
+                                description: Configuration of TLS for Prometheus listener.
+                                type: string
+                                default: Disabled
+                                enum:
+                                  - Disabled
+                                  - ProvidedTLS
+                                  - ActiveMTLSBackend
+                      type:
+                        description: Type of the backend that will be used to collect metrics. At the moment only Prometheus backend is available.
+                        type: string
+                        enum:
+                          - Prometheus
+                          - OpenTelemetry
+                    required:
+                      - type
+                    type: object
+                sidecar:
+                  description: Sidecar metrics collection configuration
+                  type: object
+                  properties:
+                    includeUnused:
+                      description: |-
+                        IncludeUnused if false will scrape only metrics that has been by sidecar (counters incremented
+                        at least once, gauges changed at least once, and histograms added to at
+                        least once). If true will scrape all metrics (even the ones with zeros).
+                        If not specified then the default value is false.
+                      type: boolean
+                    profiles:
+                      description: Profiles allows to customize which metrics are published.
+                      type: object
+                      properties:
+                        appendProfiles:
+                          description: AppendProfiles allows to combine the metrics from multiple predefined profiles.
+                          type: array
+                          items:
+                            properties:
+                              name:
+                                description: 'Name of the predefined profile, one of: all, basic, none'
+                                type: string
+                                enum:
+                                  - All
+                                  - Basic
+                                  - None
+                            required:
+                              - name
+                            type: object
+                        exclude:
+                          description: |-
+                            Exclude makes it possible to exclude groups of metrics from a resulting profile.
+                            Exclude is subordinate to Include.
+                          type: array
+                          items:
+                            properties:
+                              match:
+                                description: Match is the value used to match using particular Type
+                                type: string
+                              type:
+                                description: 'Type defined the type of selector, one of: prefix, regex, exact'
+                                type: string
+                                enum:
+                                  - Prefix
+                                  - Regex
+                                  - Exact
+                                  - Contains
+                            required:
+                              - match
+                              - type
+                            type: object
+                        include:
+                          description: |-
+                            Include makes it possible to include additional metrics in a selected profiles.
+                            Include takes precedence over Exclude.
+                          type: array
+                          items:
+                            properties:
+                              match:
+                                description: Match is the value used to match using particular Type
+                                type: string
+                              type:
+                                description: 'Type defined the type of selector, one of: prefix, regex, exact'
+                                type: string
+                                enum:
+                                  - Prefix
+                                  - Regex
+                                  - Exact
+                                  - Contains
+                            required:
+                              - match
+                              - type
+                            type: object
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined in-place.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshMetricItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshPassthroughItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshPassthrough
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshPassthrough resource.
+          type: object
+          default:
+            default:
+              passthroughMode: None
+            targetRef:
+              kind: Mesh
+          properties:
+            default:
+              description: MeshPassthrough configuration.
+              type: object
+              properties:
+                appendMatch:
+                  description: AppendMatch is a list of destinations that should be allowed through the sidecar.
+                  type: array
+                  items:
+                    properties:
+                      port:
+                        description: Port defines the port to which a user makes a request.
+                        type: integer
+                        format: int32
+                      protocol:
+                        description: 'Protocol defines the communication protocol. Possible values: `tcp`, `tls`, `grpc`, `http`, `http2`, `mysql`.'
+                        type: string
+                        default: tcp
+                        enum:
+                          - tcp
+                          - tls
+                          - grpc
+                          - http
+                          - http2
+                          - mysql
+                      type:
+                        description: 'Type of the match, one of `Domain`, `IP` or `CIDR` is available.'
+                        type: string
+                        enum:
+                          - Domain
+                          - IP
+                          - CIDR
+                      value:
+                        description: Value for the specified Type.
+                        type: string
+                    required:
+                      - type
+                      - value
+                    type: object
+                passthroughMode:
+                  description: |-
+                    Defines the passthrough behavior. Possible values: `All`, `None`, `Matched`
+                    When `All` or `None` `appendMatch` has no effect.
+                    If not specified then the default value is "Matched".
+                  type: string
+                  enum:
+                    - All
+                    - Matched
+                    - None
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined in-place.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshPassthroughItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshProxyPatchItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshProxyPatch
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshProxyPatch resource.
+          type: object
+          default:
+            default:
+              appendModifications: []
+            targetRef:
+              kind: Mesh
+          properties:
+            default:
+              description: |-
+                Default is a configuration specific to the group of destinations
+                referenced in 'targetRef'.
+              type: object
+              properties:
+                appendModifications:
+                  description: AppendModifications is a list of modifications applied on the selected proxy.
+                  type: array
+                  items:
+                    properties:
+                      cluster:
+                        description: Cluster is a modification of Envoy's Cluster resource.
+                        type: object
+                        properties:
+                          jsonPatches:
+                            description: |-
+                              JsonPatches specifies list of jsonpatches to apply to on Envoy's Cluster
+                              resource
+                            type: array
+                            items:
+                              description: JsonPatchBlock is one json patch operation block.
+                              properties:
+                                from:
+                                  description: 'From is a jsonpatch from string, used by move and copy operations.'
+                                  type: string
+                                  deprecated: true
+                                op:
+                                  description: Op is a jsonpatch operation string.
+                                  type: string
+                                  enum:
+                                    - add
+                                    - remove
+                                    - replace
+                                    - move
+                                    - copy
+                                path:
+                                  description: Path is a jsonpatch path string.
+                                  type: string
+                                value:
+                                  description: Value must be a valid json value used by replace and add operations.
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                                - op
+                                - path
+                              type: object
+                          match:
+                            description: Match is a set of conditions that have to be matched for modification operation to happen.
+                            type: object
+                            properties:
+                              name:
+                                description: Name of the cluster to match.
+                                type: string
+                              origin:
+                                description: |-
+                                  Origin is the name of the component or plugin that generated the resource.
+
+                                  Here is the list of well-known origins:
+                                  inbound - resources generated for handling incoming traffic.
+                                  outbound - resources generated for handling outgoing traffic.
+                                  transparent - resources generated for transparent proxy functionality.
+                                  prometheus - resources generated when Prometheus metrics are enabled.
+                                  direct-access - resources generated for Direct Access functionality.
+                                  ingress - resources generated for Zone Ingress.
+                                  egress - resources generated for Zone Egress.
+                                  gateway - resources generated for MeshGateway.
+
+                                  The list is not complete, because policy plugins can introduce new resources.
+                                  For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                                type: string
+                          operation:
+                            description: Operation to execute on matched cluster.
+                            type: string
+                            enum:
+                              - Add
+                              - Remove
+                              - Patch
+                          value:
+                            description: Value of xDS resource in YAML format to add or patch.
+                            type: string
+                        required:
+                          - operation
+                      httpFilter:
+                        description: |-
+                          HTTPFilter is a modification of Envoy HTTP Filter
+                          available in HTTP Connection Manager in a Listener resource.
+                        type: object
+                        properties:
+                          jsonPatches:
+                            description: |-
+                              JsonPatches specifies list of jsonpatches to apply to on Envoy's
+                              HTTP Filter available in HTTP Connection Manager in a Listener resource.
+                            type: array
+                            items:
+                              description: JsonPatchBlock is one json patch operation block.
+                              properties:
+                                from:
+                                  description: 'From is a jsonpatch from string, used by move and copy operations.'
+                                  type: string
+                                  deprecated: true
+                                op:
+                                  description: Op is a jsonpatch operation string.
+                                  type: string
+                                  enum:
+                                    - add
+                                    - remove
+                                    - replace
+                                    - move
+                                    - copy
+                                path:
+                                  description: Path is a jsonpatch path string.
+                                  type: string
+                                value:
+                                  description: Value must be a valid json value used by replace and add operations.
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                                - op
+                                - path
+                              type: object
+                          match:
+                            description: Match is a set of conditions that have to be matched for modification operation to happen.
+                            type: object
+                            properties:
+                              listenerName:
+                                description: Name of the listener to match.
+                                type: string
+                              listenerTags:
+                                description: 'Listener tags available in Listener#Metadata#FilterMetadata[io.kuma.tags]'
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              name:
+                                description: Name of the HTTP filter. For example "envoy.filters.http.local_ratelimit"
+                                type: string
+                              origin:
+                                description: |-
+                                  Origin is the name of the component or plugin that generated the resource.
+
+                                  Here is the list of well-known origins:
+                                  inbound - resources generated for handling incoming traffic.
+                                  outbound - resources generated for handling outgoing traffic.
+                                  transparent - resources generated for transparent proxy functionality.
+                                  prometheus - resources generated when Prometheus metrics are enabled.
+                                  direct-access - resources generated for Direct Access functionality.
+                                  ingress - resources generated for Zone Ingress.
+                                  egress - resources generated for Zone Egress.
+                                  gateway - resources generated for MeshGateway.
+
+                                  The list is not complete, because policy plugins can introduce new resources.
+                                  For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                                type: string
+                          operation:
+                            description: Operation to execute on matched listener.
+                            type: string
+                            enum:
+                              - Remove
+                              - Patch
+                              - AddFirst
+                              - AddBefore
+                              - AddAfter
+                              - AddLast
+                          value:
+                            description: Value of xDS resource in YAML format to add or patch.
+                            type: string
+                        required:
+                          - operation
+                      listener:
+                        description: Listener is a modification of Envoy's Listener resource.
+                        type: object
+                        properties:
+                          jsonPatches:
+                            description: |-
+                              JsonPatches specifies list of jsonpatches to apply to on Envoy's Listener
+                              resource
+                            type: array
+                            items:
+                              description: JsonPatchBlock is one json patch operation block.
+                              properties:
+                                from:
+                                  description: 'From is a jsonpatch from string, used by move and copy operations.'
+                                  type: string
+                                  deprecated: true
+                                op:
+                                  description: Op is a jsonpatch operation string.
+                                  type: string
+                                  enum:
+                                    - add
+                                    - remove
+                                    - replace
+                                    - move
+                                    - copy
+                                path:
+                                  description: Path is a jsonpatch path string.
+                                  type: string
+                                value:
+                                  description: Value must be a valid json value used by replace and add operations.
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                                - op
+                                - path
+                              type: object
+                          match:
+                            description: Match is a set of conditions that have to be matched for modification operation to happen.
+                            type: object
+                            properties:
+                              name:
+                                description: Name of the listener to match.
+                                type: string
+                              origin:
+                                description: |-
+                                  Origin is the name of the component or plugin that generated the resource.
+
+                                  Here is the list of well-known origins:
+                                  inbound - resources generated for handling incoming traffic.
+                                  outbound - resources generated for handling outgoing traffic.
+                                  transparent - resources generated for transparent proxy functionality.
+                                  prometheus - resources generated when Prometheus metrics are enabled.
+                                  direct-access - resources generated for Direct Access functionality.
+                                  ingress - resources generated for Zone Ingress.
+                                  egress - resources generated for Zone Egress.
+                                  gateway - resources generated for MeshGateway.
+
+                                  The list is not complete, because policy plugins can introduce new resources.
+                                  For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                                type: string
+                              tags:
+                                description: 'Tags available in Listener#Metadata#FilterMetadata[io.kuma.tags]'
+                                type: object
+                                additionalProperties:
+                                  type: string
+                          operation:
+                            description: Operation to execute on matched listener.
+                            type: string
+                            enum:
+                              - Add
+                              - Remove
+                              - Patch
+                          value:
+                            description: Value of xDS resource in YAML format to add or patch.
+                            type: string
+                        required:
+                          - operation
+                      networkFilter:
+                        description: NetworkFilter is a modification of Envoy Listener's filter.
+                        type: object
+                        properties:
+                          jsonPatches:
+                            description: |-
+                              JsonPatches specifies list of jsonpatches to apply to on Envoy Listener's
+                              filter.
+                            type: array
+                            items:
+                              description: JsonPatchBlock is one json patch operation block.
+                              properties:
+                                from:
+                                  description: 'From is a jsonpatch from string, used by move and copy operations.'
+                                  type: string
+                                  deprecated: true
+                                op:
+                                  description: Op is a jsonpatch operation string.
+                                  type: string
+                                  enum:
+                                    - add
+                                    - remove
+                                    - replace
+                                    - move
+                                    - copy
+                                path:
+                                  description: Path is a jsonpatch path string.
+                                  type: string
+                                value:
+                                  description: Value must be a valid json value used by replace and add operations.
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                                - op
+                                - path
+                              type: object
+                          match:
+                            description: Match is a set of conditions that have to be matched for modification operation to happen.
+                            type: object
+                            properties:
+                              listenerName:
+                                description: Name of the listener to match.
+                                type: string
+                              listenerTags:
+                                description: 'Listener tags available in Listener#Metadata#FilterMetadata[io.kuma.tags]'
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              name:
+                                description: Name of the network filter. For example "envoy.filters.network.ratelimit"
+                                type: string
+                              origin:
+                                description: |-
+                                  Origin is the name of the component or plugin that generated the resource.
+
+                                  Here is the list of well-known origins:
+                                  inbound - resources generated for handling incoming traffic.
+                                  outbound - resources generated for handling outgoing traffic.
+                                  transparent - resources generated for transparent proxy functionality.
+                                  prometheus - resources generated when Prometheus metrics are enabled.
+                                  direct-access - resources generated for Direct Access functionality.
+                                  ingress - resources generated for Zone Ingress.
+                                  egress - resources generated for Zone Egress.
+                                  gateway - resources generated for MeshGateway.
+
+                                  The list is not complete, because policy plugins can introduce new resources.
+                                  For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                                type: string
+                          operation:
+                            description: Operation to execute on matched listener.
+                            type: string
+                            enum:
+                              - Remove
+                              - Patch
+                              - AddFirst
+                              - AddBefore
+                              - AddAfter
+                              - AddLast
+                          value:
+                            description: Value of xDS resource in YAML format to add or patch.
+                            type: string
+                        required:
+                          - operation
+                      virtualHost:
+                        description: |-
+                          VirtualHost is a modification of Envoy's VirtualHost
+                          referenced in HTTP Connection Manager in a Listener resource.
+                        type: object
+                        properties:
+                          jsonPatches:
+                            description: |-
+                              JsonPatches specifies list of jsonpatches to apply to on Envoy's
+                              VirtualHost resource
+                            type: array
+                            items:
+                              description: JsonPatchBlock is one json patch operation block.
+                              properties:
+                                from:
+                                  description: 'From is a jsonpatch from string, used by move and copy operations.'
+                                  type: string
+                                  deprecated: true
+                                op:
+                                  description: Op is a jsonpatch operation string.
+                                  type: string
+                                  enum:
+                                    - add
+                                    - remove
+                                    - replace
+                                    - move
+                                    - copy
+                                path:
+                                  description: Path is a jsonpatch path string.
+                                  type: string
+                                value:
+                                  description: Value must be a valid json value used by replace and add operations.
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                                - op
+                                - path
+                              type: object
+                          match:
+                            description: Match is a set of conditions that have to be matched for modification operation to happen.
+                            type: object
+                            properties:
+                              name:
+                                description: Name of the VirtualHost to match.
+                                type: string
+                              origin:
+                                description: |-
+                                  Origin is the name of the component or plugin that generated the resource.
+
+                                  Here is the list of well-known origins:
+                                  inbound - resources generated for handling incoming traffic.
+                                  outbound - resources generated for handling outgoing traffic.
+                                  transparent - resources generated for transparent proxy functionality.
+                                  prometheus - resources generated when Prometheus metrics are enabled.
+                                  direct-access - resources generated for Direct Access functionality.
+                                  ingress - resources generated for Zone Ingress.
+                                  egress - resources generated for Zone Egress.
+                                  gateway - resources generated for MeshGateway.
+
+                                  The list is not complete, because policy plugins can introduce new resources.
+                                  For example MeshTrace plugin can create Cluster with "mesh-trace" origin.
+                                type: string
+                              routeConfigurationName:
+                                description: Name of the RouteConfiguration resource to match.
+                                type: string
+                          operation:
+                            description: Operation to execute on matched listener.
+                            type: string
+                            enum:
+                              - Add
+                              - Remove
+                              - Patch
+                          value:
+                            description: Value of xDS resource in YAML format to add or patch.
+                            type: string
+                        required:
+                          - match
+                          - operation
+                    type: object
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined inplace.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+          required:
+            - default
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshProxyPatchItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshRateLimitItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshRateLimit
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshRateLimit resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            from:
+              description: From list makes a match between clients and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of clients referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      local:
+                        description: LocalConf defines local http or/and tcp rate limit configuration
+                        type: object
+                        properties:
+                          http:
+                            description: |-
+                              LocalHTTP defines configuration of local HTTP rate limiting
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
+                            type: object
+                            properties:
+                              disabled:
+                                description: Define if rate limiting should be disabled.
+                                type: boolean
+                              onRateLimit:
+                                description: Describes the actions to take on a rate limit event
+                                type: object
+                                properties:
+                                  headers:
+                                    description: The Headers to be added to the HTTP response on a rate limit event
+                                    type: object
+                                    properties:
+                                      add:
+                                        type: array
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      set:
+                                        type: array
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                  status:
+                                    description: The HTTP status code to be set on a rate limit event
+                                    type: integer
+                                    format: int32
+                              requestRate:
+                                description: Defines how many requests are allowed per interval.
+                                type: object
+                                properties:
+                                  interval:
+                                    description: The interval the number of units is accounted for.
+                                    type: string
+                                  num:
+                                    description: |-
+                                      Number of units per interval (depending on usage it can be a number of requests,
+                                      or a number of connections).
+                                    type: integer
+                                    format: int32
+                                required:
+                                  - interval
+                                  - num
+                          tcp:
+                            description: |-
+                              LocalTCP defines confguration of local TCP rate limiting
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter
+                            type: object
+                            properties:
+                              connectionRate:
+                                description: Defines how many connections are allowed per interval.
+                                type: object
+                                properties:
+                                  interval:
+                                    description: The interval the number of units is accounted for.
+                                    type: string
+                                  num:
+                                    description: |-
+                                      Number of units per interval (depending on usage it can be a number of requests,
+                                      or a number of connections).
+                                    type: integer
+                                    format: int32
+                                required:
+                                  - interval
+                                  - num
+                              disabled:
+                                description: |-
+                                  Define if rate limiting should be disabled.
+                                  Default: false
+                                type: boolean
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      clients.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+              deprecated: true
+            rules:
+              description: |-
+                Rules defines inbound rate limiting configurations. Currently limited to
+                selecting all inbound traffic, as L7 matching is not yet implemented.
+              type: array
+              items:
+                properties:
+                  default:
+                    description: Default contains configuration of the inbound rate limits
+                    type: object
+                    properties:
+                      local:
+                        description: LocalConf defines local http or/and tcp rate limit configuration
+                        type: object
+                        properties:
+                          http:
+                            description: |-
+                              LocalHTTP defines configuration of local HTTP rate limiting
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
+                            type: object
+                            properties:
+                              disabled:
+                                description: Define if rate limiting should be disabled.
+                                type: boolean
+                              onRateLimit:
+                                description: Describes the actions to take on a rate limit event
+                                type: object
+                                properties:
+                                  headers:
+                                    description: The Headers to be added to the HTTP response on a rate limit event
+                                    type: object
+                                    properties:
+                                      add:
+                                        type: array
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      set:
+                                        type: array
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                  status:
+                                    description: The HTTP status code to be set on a rate limit event
+                                    type: integer
+                                    format: int32
+                              requestRate:
+                                description: Defines how many requests are allowed per interval.
+                                type: object
+                                properties:
+                                  interval:
+                                    description: The interval the number of units is accounted for.
+                                    type: string
+                                  num:
+                                    description: |-
+                                      Number of units per interval (depending on usage it can be a number of requests,
+                                      or a number of connections).
+                                    type: integer
+                                    format: int32
+                                required:
+                                  - interval
+                                  - num
+                          tcp:
+                            description: |-
+                              LocalTCP defines confguration of local TCP rate limiting
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter
+                            type: object
+                            properties:
+                              connectionRate:
+                                description: Defines how many connections are allowed per interval.
+                                type: object
+                                properties:
+                                  interval:
+                                    description: The interval the number of units is accounted for.
+                                    type: string
+                                  num:
+                                    description: |-
+                                      Number of units per interval (depending on usage it can be a number of requests,
+                                      or a number of connections).
+                                    type: integer
+                                    format: int32
+                                required:
+                                  - interval
+                                  - num
+                              disabled:
+                                description: |-
+                                  Define if rate limiting should be disabled.
+                                  Default: false
+                                type: boolean
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    local: {}
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined inplace.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+            to:
+              description: To list makes a match between clients and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of clients referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      local:
+                        description: LocalConf defines local http or/and tcp rate limit configuration
+                        type: object
+                        properties:
+                          http:
+                            description: |-
+                              LocalHTTP defines configuration of local HTTP rate limiting
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/local_rate_limit_filter
+                            type: object
+                            properties:
+                              disabled:
+                                description: Define if rate limiting should be disabled.
+                                type: boolean
+                              onRateLimit:
+                                description: Describes the actions to take on a rate limit event
+                                type: object
+                                properties:
+                                  headers:
+                                    description: The Headers to be added to the HTTP response on a rate limit event
+                                    type: object
+                                    properties:
+                                      add:
+                                        type: array
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      set:
+                                        type: array
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                            value:
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                  status:
+                                    description: The HTTP status code to be set on a rate limit event
+                                    type: integer
+                                    format: int32
+                              requestRate:
+                                description: Defines how many requests are allowed per interval.
+                                type: object
+                                properties:
+                                  interval:
+                                    description: The interval the number of units is accounted for.
+                                    type: string
+                                  num:
+                                    description: |-
+                                      Number of units per interval (depending on usage it can be a number of requests,
+                                      or a number of connections).
+                                    type: integer
+                                    format: int32
+                                required:
+                                  - interval
+                                  - num
+                          tcp:
+                            description: |-
+                              LocalTCP defines confguration of local TCP rate limiting
+                              https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/local_rate_limit_filter
+                            type: object
+                            properties:
+                              connectionRate:
+                                description: Defines how many connections are allowed per interval.
+                                type: object
+                                properties:
+                                  interval:
+                                    description: The interval the number of units is accounted for.
+                                    type: string
+                                  num:
+                                    description: |-
+                                      Number of units per interval (depending on usage it can be a number of requests,
+                                      or a number of connections).
+                                    type: integer
+                                    format: int32
+                                required:
+                                  - interval
+                                  - num
+                              disabled:
+                                description: |-
+                                  Define if rate limiting should be disabled.
+                                  Default: false
+                                type: boolean
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      clients.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    local: {}
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshRateLimitItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshRetryItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshRetry
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshRetry resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined inplace.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+            to:
+              description: To list makes a match between the consumed services and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of destinations referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      grpc:
+                        description: GRPC defines a configuration of retries for GRPC traffic
+                        type: object
+                        properties:
+                          backOff:
+                            description: |-
+                              BackOff is a configuration of durations which will be used in an exponential
+                              backoff strategy between retries.
+                            type: object
+                            properties:
+                              baseInterval:
+                                description: |-
+                                  BaseInterval is an amount of time which should be taken between retries.
+                                  Must be greater than zero. Values less than 1 ms are rounded up to 1 ms.
+                                  If not specified then the default value is "25ms".
+                                type: string
+                              maxInterval:
+                                description: |-
+                                  MaxInterval is a maximal amount of time which will be taken between retries.
+                                  Default is 10 times the "BaseInterval".
+                                type: string
+                          numRetries:
+                            description: |-
+                              NumRetries is the number of attempts that will be made on failed (and
+                              retriable) requests. If not set, the default value is 1.
+                            type: integer
+                            format: int32
+                          perTryTimeout:
+                            description: |-
+                              PerTryTimeout is the maximum amount of time each retry attempt can take
+                              before it times out. If not set, the global request timeout for the route
+                              will be used. Setting this value to 0 will disable the per-try timeout.
+                            type: string
+                          rateLimitedBackOff:
+                            description: |-
+                              RateLimitedBackOff is a configuration of backoff which will be used when
+                              the upstream returns one of the headers configured.
+                            type: object
+                            properties:
+                              maxInterval:
+                                description: |-
+                                  MaxInterval is a maximal amount of time which will be taken between retries.
+                                  If not specified then the default value is "300s".
+                                type: string
+                              resetHeaders:
+                                description: |-
+                                  ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
+                                  to match against the response. Headers are tried in order, and matched
+                                  case-insensitive. The first header to be parsed successfully is used.
+                                  If no headers match the default exponential BackOff is used instead.
+                                type: array
+                                items:
+                                  properties:
+                                    format:
+                                      description: The format of the reset header.
+                                      type: string
+                                      enum:
+                                        - Seconds
+                                        - UnixTimestamp
+                                    name:
+                                      description: The Name of the reset header.
+                                      type: string
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                  required:
+                                    - format
+                                    - name
+                                  type: object
+                          retryOn:
+                            description: RetryOn is a list of conditions which will cause a retry.
+                            type: array
+                            items:
+                              enum:
+                                - Canceled
+                                - DeadlineExceeded
+                                - Internal
+                                - ResourceExhausted
+                                - Unavailable
+                              type: string
+                            example:
+                              - Canceled
+                              - DeadlineExceeded
+                              - Internal
+                              - ResourceExhausted
+                              - Unavailable
+                      http:
+                        description: HTTP defines a configuration of retries for HTTP traffic
+                        type: object
+                        properties:
+                          backOff:
+                            description: |-
+                              BackOff is a configuration of durations which will be used in exponential
+                              backoff strategy between retries.
+                            type: object
+                            properties:
+                              baseInterval:
+                                description: |-
+                                  BaseInterval is an amount of time which should be taken between retries.
+                                  Must be greater than zero. Values less than 1 ms are rounded up to 1 ms.
+                                  If not specified then the default value is "25ms".
+                                type: string
+                              maxInterval:
+                                description: |-
+                                  MaxInterval is a maximal amount of time which will be taken between retries.
+                                  Default is 10 times the "BaseInterval".
+                                type: string
+                          hostSelection:
+                            description: |-
+                              HostSelection is a list of predicates that dictate how hosts should be selected
+                              when requests are retried.
+                            type: array
+                            items:
+                              properties:
+                                predicate:
+                                  description: Type is requested predicate mode.
+                                  type: string
+                                  enum:
+                                    - OmitPreviousHosts
+                                    - OmitHostsWithTags
+                                    - OmitPreviousPriorities
+                                tags:
+                                  description: |-
+                                    Tags is a map of metadata to match against for selecting the omitted hosts. Required if Type is
+                                    OmitHostsWithTags
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                updateFrequency:
+                                  description: |-
+                                    UpdateFrequency is how often the priority load should be updated based on previously attempted priorities.
+                                    Used for OmitPreviousPriorities.
+                                  type: integer
+                                  format: int32
+                                  default: 2
+                              required:
+                                - predicate
+                              type: object
+                          hostSelectionMaxAttempts:
+                            description: |-
+                              HostSelectionMaxAttempts is the maximum number of times host selection will be
+                              reattempted before giving up, at which point the host that was last selected will
+                              be routed to. If unspecified, this will default to retrying once.
+                            type: integer
+                            format: int64
+                          numRetries:
+                            description: |-
+                              NumRetries is the number of attempts that will be made on failed (and
+                              retriable) requests.  If not set, the default value is 1.
+                            type: integer
+                            format: int32
+                          perTryTimeout:
+                            description: |-
+                              PerTryTimeout is the amount of time after which retry attempt should time out.
+                              If left unspecified, the global route timeout for the request will be used.
+                              Consequently, when using a 5xx based retry policy, a request that times out
+                              will not be retried as the total timeout budget would have been exhausted.
+                              Setting this timeout to 0 will disable it.
+                            type: string
+                          rateLimitedBackOff:
+                            description: |-
+                              RateLimitedBackOff is a configuration of backoff which will be used
+                              when the upstream returns one of the headers configured.
+                            type: object
+                            properties:
+                              maxInterval:
+                                description: |-
+                                  MaxInterval is a maximal amount of time which will be taken between retries.
+                                  If not specified then the default value is "300s".
+                                type: string
+                              resetHeaders:
+                                description: |-
+                                  ResetHeaders specifies the list of headers (like Retry-After or X-RateLimit-Reset)
+                                  to match against the response. Headers are tried in order, and matched
+                                  case-insensitive. The first header to be parsed successfully is used.
+                                  If no headers match the default exponential BackOff is used instead.
+                                type: array
+                                items:
+                                  properties:
+                                    format:
+                                      description: The format of the reset header.
+                                      type: string
+                                      enum:
+                                        - Seconds
+                                        - UnixTimestamp
+                                    name:
+                                      description: The Name of the reset header.
+                                      type: string
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                  required:
+                                    - format
+                                    - name
+                                  type: object
+                          retriableRequestHeaders:
+                            description: |-
+                              RetriableRequestHeaders is an HTTP headers which must be present in the request
+                              for retries to be attempted.
+                            type: array
+                            items:
+                              description: |-
+                                HeaderMatch describes how to select an HTTP route by matching HTTP request
+                                headers.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the HTTP Header to be matched. Name MUST be lower case
+                                    as they will be handled with case insensitivity (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                  type: string
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                type:
+                                  description: Type specifies how to match against the value of the header.
+                                  type: string
+                                  default: Exact
+                                  enum:
+                                    - Exact
+                                    - Present
+                                    - RegularExpression
+                                    - Absent
+                                    - Prefix
+                                value:
+                                  description: Value is the value of HTTP Header to be matched.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          retriableResponseHeaders:
+                            description: |-
+                              RetriableResponseHeaders is an HTTP response headers that trigger a retry
+                              if present in the response. A retry will be triggered if any of the header
+                              matches the upstream response headers.
+                            type: array
+                            items:
+                              description: |-
+                                HeaderMatch describes how to select an HTTP route by matching HTTP request
+                                headers.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the HTTP Header to be matched. Name MUST be lower case
+                                    as they will be handled with case insensitivity (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                  type: string
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: '^[a-z0-9!#$%&''*+\-.^_\x60|~]+$'
+                                type:
+                                  description: Type specifies how to match against the value of the header.
+                                  type: string
+                                  default: Exact
+                                  enum:
+                                    - Exact
+                                    - Present
+                                    - RegularExpression
+                                    - Absent
+                                    - Prefix
+                                value:
+                                  description: Value is the value of HTTP Header to be matched.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          retryOn:
+                            description: |-
+                              RetryOn is a list of conditions which will cause a retry. Available values are:
+                              [5XX, GatewayError, Reset, Retriable4xx, ConnectFailure, EnvoyRatelimited,
+                              RefusedStream, Http3PostConnectFailure, HttpMethodConnect, HttpMethodDelete,
+                              HttpMethodGet, HttpMethodHead, HttpMethodOptions, HttpMethodPatch,
+                              HttpMethodPost, HttpMethodPut, HttpMethodTrace].
+                              Also, any HTTP status code (500, 503, etc.).
+                            type: array
+                            items:
+                              type: string
+                            example:
+                              - 5XX
+                              - GatewayError
+                              - Reset
+                              - Retriable4xx
+                              - ConnectFailure
+                              - EnvoyRatelimited
+                              - RefusedStream
+                              - Http3PostConnectFailure
+                              - HttpMethodConnect
+                              - HttpMethodDelete
+                              - HttpMethodGet
+                              - HttpMethodHead
+                              - HttpMethodOptions
+                              - HttpMethodPatch
+                              - HttpMethodPost
+                              - HttpMethodPut
+                              - HttpMethodTrace
+                              - '500'
+                              - '503'
+                      tcp:
+                        description: TCP defines a configuration of retries for TCP traffic
+                        type: object
+                        properties:
+                          maxConnectAttempt:
+                            description: |-
+                              MaxConnectAttempt is a maximal amount of TCP connection attempts
+                              which will be made before giving up
+                            type: integer
+                            format: int32
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      destinations.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    http:
+                      numRetries: 10
+                      backOff:
+                        baseInterval: 15s
+                        maxInterval: 20m
+                      retryOn:
+                        - 5xx
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshRetryItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshTCPRouteItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshTCPRoute
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshTCPRoute resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined in-place.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+            to:
+              description: |-
+                To list makes a match between the consumed services and corresponding
+                configurations
+              type: array
+              items:
+                properties:
+                  rules:
+                    description: |-
+                      Rules contains the routing rules applies to a combination of top-level
+                      targetRef and the targetRef in this entry.
+                    type: array
+                    items:
+                      properties:
+                        default:
+                          description: |-
+                            Default holds routing rules that can be merged with rules from other
+                            policies.
+                          type: object
+                          properties:
+                            backendRefs:
+                              type: array
+                              items:
+                                description: BackendRef defines where to forward traffic.
+                                properties:
+                                  kind:
+                                    description: Kind of the referenced resource
+                                    type: string
+                                    enum:
+                                      - Mesh
+                                      - MeshSubset
+                                      - MeshGateway
+                                      - MeshService
+                                      - MeshExternalService
+                                      - MeshMultiZoneService
+                                      - MeshServiceSubset
+                                      - MeshHTTPRoute
+                                      - Dataplane
+                                  labels:
+                                    description: |-
+                                      Labels are used to select group of MeshServices that match labels. Either Labels or
+                                      Name and Namespace can be used.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  mesh:
+                                    description: Mesh is reserved for future use to identify cross mesh resources.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                                      `MeshServiceSubset` and `MeshGatewayRoute`
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                                      will be targeted.
+                                    type: string
+                                  port:
+                                    description: Port is only supported when this ref refers to a real MeshService object
+                                    type: integer
+                                    format: int32
+                                  proxyTypes:
+                                    description: |-
+                                      ProxyTypes specifies the data plane types that are subject to the policy. When not specified,
+                                      all data plane types are targeted by the policy.
+                                    type: array
+                                    items:
+                                      enum:
+                                        - Sidecar
+                                        - Gateway
+                                      type: string
+                                  sectionName:
+                                    description: |-
+                                      SectionName is used to target specific section of resource.
+                                      For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                                    type: string
+                                  tags:
+                                    description: |-
+                                      Tags used to select a subset of proxies by tags. Can only be used with kinds
+                                      `MeshSubset` and `MeshServiceSubset`
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  weight:
+                                    type: integer
+                                    default: 1
+                                    minimum: 0
+                                required:
+                                  - kind
+                                type: object
+                      required:
+                        - default
+                      type: object
+                    maxItems: 1
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      destinations.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - rules
+                  - targetRef
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  rules: []
+              minItems: 1
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshTCPRouteItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshTimeoutItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshTimeout
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshTimeout resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            from:
+              description: From list makes a match between clients and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of clients referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      connectionTimeout:
+                        description: |-
+                          ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established.
+                          Default value is 5 seconds. Cannot be set to 0.
+                        type: string
+                      http:
+                        description: Http provides configuration for HTTP specific timeouts
+                        type: object
+                        properties:
+                          maxConnectionDuration:
+                            description: |-
+                              MaxConnectionDuration is the time after which a connection will be drained and/or closed,
+                              starting from when it was first established. Setting this timeout to 0 will disable it.
+                              Disabled by default.
+                            type: string
+                          maxStreamDuration:
+                            description: |-
+                              MaxStreamDuration is the maximum time that a stream’s lifetime will span.
+                              Setting this timeout to 0 will disable it. Disabled by default.
+                            type: string
+                          requestHeadersTimeout:
+                            description: |-
+                              RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is
+                              activated when the first byte of the headers is received, and is disarmed when the last byte of
+                              the headers has been received. If not specified or set to 0, this timeout is disabled.
+                              Disabled by default.
+                            type: string
+                          requestTimeout:
+                            description: |-
+                              RequestTimeout The amount of time that proxy will wait for the entire request to be received.
+                              The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent,
+                              OR when the response is initiated. Setting this timeout to 0 will disable it.
+                              Default is 15s.
+                            type: string
+                          streamIdleTimeout:
+                            description: |-
+                              StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity.
+                              Setting this timeout to 0 will disable it. Default is 30m
+                            type: string
+                      idleTimeout:
+                        description: |-
+                          IdleTimeout is defined as the period in which there are no bytes sent or received on connection
+                          Setting this timeout to 0 will disable it. Be cautious when disabling it because
+                          it can lead to connection leaking. Default value is 1h.
+                        type: string
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      clients.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+              deprecated: true
+            rules:
+              description: |-
+                Rules defines inbound timeout configurations. Currently limited to exactly one rule containing
+                default timeouts that apply to all inbound traffic, as L7 matching is not yet implemented.
+              type: array
+              items:
+                properties:
+                  default:
+                    description: Default contains configuration of the inbound timeouts
+                    type: object
+                    properties:
+                      connectionTimeout:
+                        description: |-
+                          ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established.
+                          Default value is 5 seconds. Cannot be set to 0.
+                        type: string
+                      http:
+                        description: Http provides configuration for HTTP specific timeouts
+                        type: object
+                        properties:
+                          maxConnectionDuration:
+                            description: |-
+                              MaxConnectionDuration is the time after which a connection will be drained and/or closed,
+                              starting from when it was first established. Setting this timeout to 0 will disable it.
+                              Disabled by default.
+                            type: string
+                          maxStreamDuration:
+                            description: |-
+                              MaxStreamDuration is the maximum time that a stream’s lifetime will span.
+                              Setting this timeout to 0 will disable it. Disabled by default.
+                            type: string
+                          requestHeadersTimeout:
+                            description: |-
+                              RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is
+                              activated when the first byte of the headers is received, and is disarmed when the last byte of
+                              the headers has been received. If not specified or set to 0, this timeout is disabled.
+                              Disabled by default.
+                            type: string
+                          requestTimeout:
+                            description: |-
+                              RequestTimeout The amount of time that proxy will wait for the entire request to be received.
+                              The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent,
+                              OR when the response is initiated. Setting this timeout to 0 will disable it.
+                              Default is 15s.
+                            type: string
+                          streamIdleTimeout:
+                            description: |-
+                              StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity.
+                              Setting this timeout to 0 will disable it. Default is 30m
+                            type: string
+                      idleTimeout:
+                        description: |-
+                          IdleTimeout is defined as the period in which there are no bytes sent or received on connection
+                          Setting this timeout to 0 will disable it. Be cautious when disabling it because
+                          it can lead to connection leaking. Default value is 1h.
+                        type: string
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    idleTimeout: 20s
+                    connectionTimeout: 2s
+                    http:
+                      requestTimeout: 2s
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined inplace.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+            to:
+              description: To list makes a match between the consumed services and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of destinations referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      connectionTimeout:
+                        description: |-
+                          ConnectionTimeout specifies the amount of time proxy will wait for an TCP connection to be established.
+                          Default value is 5 seconds. Cannot be set to 0.
+                        type: string
+                      http:
+                        description: Http provides configuration for HTTP specific timeouts
+                        type: object
+                        properties:
+                          maxConnectionDuration:
+                            description: |-
+                              MaxConnectionDuration is the time after which a connection will be drained and/or closed,
+                              starting from when it was first established. Setting this timeout to 0 will disable it.
+                              Disabled by default.
+                            type: string
+                          maxStreamDuration:
+                            description: |-
+                              MaxStreamDuration is the maximum time that a stream’s lifetime will span.
+                              Setting this timeout to 0 will disable it. Disabled by default.
+                            type: string
+                          requestHeadersTimeout:
+                            description: |-
+                              RequestHeadersTimeout The amount of time that proxy will wait for the request headers to be received. The timer is
+                              activated when the first byte of the headers is received, and is disarmed when the last byte of
+                              the headers has been received. If not specified or set to 0, this timeout is disabled.
+                              Disabled by default.
+                            type: string
+                          requestTimeout:
+                            description: |-
+                              RequestTimeout The amount of time that proxy will wait for the entire request to be received.
+                              The timer is activated when the request is initiated, and is disarmed when the last byte of the request is sent,
+                              OR when the response is initiated. Setting this timeout to 0 will disable it.
+                              Default is 15s.
+                            type: string
+                          streamIdleTimeout:
+                            description: |-
+                              StreamIdleTimeout is the amount of time that proxy will allow a stream to exist with no activity.
+                              Setting this timeout to 0 will disable it. Default is 30m
+                            type: string
+                      idleTimeout:
+                        description: |-
+                          IdleTimeout is defined as the period in which there are no bytes sent or received on connection
+                          Setting this timeout to 0 will disable it. Be cautious when disabling it because
+                          it can lead to connection leaking. Default value is 1h.
+                        type: string
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      destinations.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    idleTimeout: 20s
+                    connectionTimeout: 2s
+                    http:
+                      requestTimeout: 2s
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshTimeoutItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshTLSItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshTLS
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshTLS resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            from:
+              description: From list makes a match between clients and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of clients referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      mode:
+                        description: Mode defines the behavior of inbound listeners with regard to traffic encryption.
+                        type: string
+                        enum:
+                          - Permissive
+                          - Strict
+                      tlsCiphers:
+                        description: TlsCiphers section for providing ciphers specification.
+                        type: array
+                        items:
+                          enum:
+                            - ECDHE-ECDSA-AES128-GCM-SHA256
+                            - ECDHE-ECDSA-AES256-GCM-SHA384
+                            - ECDHE-ECDSA-CHACHA20-POLY1305
+                            - ECDHE-RSA-AES128-GCM-SHA256
+                            - ECDHE-RSA-AES256-GCM-SHA384
+                            - ECDHE-RSA-CHACHA20-POLY1305
+                          type: string
+                      tlsVersion:
+                        description: Version section for providing version specification.
+                        type: object
+                        properties:
+                          max:
+                            description: 'Max defines maximum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.'
+                            type: string
+                            default: TLSAuto
+                            enum:
+                              - TLSAuto
+                              - TLS10
+                              - TLS11
+                              - TLS12
+                              - TLS13
+                          min:
+                            description: 'Min defines minimum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.'
+                            type: string
+                            default: TLSAuto
+                            enum:
+                              - TLSAuto
+                              - TLS10
+                              - TLS11
+                              - TLS12
+                              - TLS13
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      clients.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+              deprecated: true
+            rules:
+              description: |-
+                Rules defines inbound tls configurations. Currently limited to
+                selecting all inbound traffic, as L7 matching is not yet implemented.
+              type: array
+              items:
+                properties:
+                  default:
+                    description: Default contains configuration of the inbound tls
+                    type: object
+                    properties:
+                      mode:
+                        description: Mode defines the behavior of inbound listeners with regard to traffic encryption.
+                        type: string
+                        enum:
+                          - Permissive
+                          - Strict
+                      tlsCiphers:
+                        description: TlsCiphers section for providing ciphers specification.
+                        type: array
+                        items:
+                          enum:
+                            - ECDHE-ECDSA-AES128-GCM-SHA256
+                            - ECDHE-ECDSA-AES256-GCM-SHA384
+                            - ECDHE-ECDSA-CHACHA20-POLY1305
+                            - ECDHE-RSA-AES128-GCM-SHA256
+                            - ECDHE-RSA-AES256-GCM-SHA384
+                            - ECDHE-RSA-CHACHA20-POLY1305
+                          type: string
+                      tlsVersion:
+                        description: Version section for providing version specification.
+                        type: object
+                        properties:
+                          max:
+                            description: 'Max defines maximum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.'
+                            type: string
+                            default: TLSAuto
+                            enum:
+                              - TLSAuto
+                              - TLS10
+                              - TLS11
+                              - TLS12
+                              - TLS13
+                          min:
+                            description: 'Min defines minimum supported version. One of `TLSAuto`, `TLS10`, `TLS11`, `TLS12`, `TLS13`.'
+                            type: string
+                            default: TLSAuto
+                            enum:
+                              - TLSAuto
+                              - TLS10
+                              - TLS11
+                              - TLS12
+                              - TLS13
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    mode: Strict
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined in-place.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshTLSItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshTraceItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshTrace
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshTrace resource.
+          type: object
+          default:
+            default:
+              backends: []
+            targetRef:
+              kind: Mesh
+          properties:
+            default:
+              description: MeshTrace configuration.
+              type: object
+              properties:
+                backends:
+                  description: |-
+                    A one element array of backend definition.
+                    Envoy allows configuring only 1 backend, so the natural way of
+                    representing that would be just one object. Unfortunately due to the
+                    reasons explained in MADR 009-tracing-policy this has to be a one element
+                    array for now.
+                  type: array
+                  items:
+                    description: 'Only one of zipkin, datadog or openTelemetry can be used.'
+                    properties:
+                      datadog:
+                        description: Datadog backend configuration.
+                        type: object
+                        properties:
+                          splitService:
+                            description: |-
+                              Determines if datadog service name should be split based on traffic
+                              direction and destination. For example, with `splitService: true` and a
+                              `backend` service that communicates with a couple of databases, you would
+                              get service names like `backend_INBOUND`, `backend_OUTBOUND_db1`, and
+                              `backend_OUTBOUND_db2` in Datadog.
+                            type: boolean
+                            default: false
+                          url:
+                            description: |-
+                              Address of Datadog collector, only host and port are allowed (no paths,
+                              fragments etc.)
+                            type: string
+                        required:
+                          - url
+                      openTelemetry:
+                        description: OpenTelemetry backend configuration.
+                        type: object
+                        properties:
+                          endpoint:
+                            description: Address of OpenTelemetry collector.
+                            type: string
+                            example: 'otel-collector:4317'
+                            minLength: 1
+                        required:
+                          - endpoint
+                      type:
+                        type: string
+                        enum:
+                          - Zipkin
+                          - Datadog
+                          - OpenTelemetry
+                      zipkin:
+                        description: Zipkin backend configuration.
+                        type: object
+                        properties:
+                          apiVersion:
+                            description: |-
+                              Version of the API.
+                              https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L66
+                            type: string
+                            default: httpJson
+                            enum:
+                              - httpJson
+                              - httpProto
+                          sharedSpanContext:
+                            description: |-
+                              Determines whether client and server spans will share the same span
+                              context.
+                              https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/trace/v3/zipkin.proto#L63
+                            type: boolean
+                            default: true
+                          traceId128bit:
+                            description: Generate 128bit traces.
+                            type: boolean
+                            default: false
+                          url:
+                            description: Address of Zipkin collector.
+                            type: string
+                        required:
+                          - url
+                    required:
+                      - type
+                    type: object
+                  maxItems: 1
+                sampling:
+                  description: |-
+                    Sampling configuration.
+                    Sampling is the process by which a decision is made on whether to
+                    process/export a span or not.
+                  type: object
+                  properties:
+                    client:
+                      description: |-
+                        Target percentage of requests that will be force traced if the
+                        'x-client-trace-id' header is set. Mirror of client_sampling in Envoy
+                        https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L127-L133
+                        Either int or decimal represented as string.
+                        If not specified then the default value is 100.
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      x-kubernetes-int-or-string: true
+                    overall:
+                      description: |-
+                        Target percentage of requests will be traced
+                        after all other sampling checks have been applied (client, force tracing,
+                        random sampling). This field functions as an upper limit on the total
+                        configured sampling rate. For instance, setting client to 100
+                        but overall to 1 will result in only 1% of client requests with
+                        the appropriate headers to be force traced. Mirror of
+                        overall_sampling in Envoy
+                        https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L142-L150
+                        Either int or decimal represented as string.
+                        If not specified then the default value is 100.
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      x-kubernetes-int-or-string: true
+                    random:
+                      description: |-
+                        Target percentage of requests that will be randomly selected for trace
+                        generation, if not requested by the client or not forced.
+                        Mirror of random_sampling in Envoy
+                        https://github.com/envoyproxy/envoy/blob/v1.22.0/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto#L135-L140
+                        Either int or decimal represented as string.
+                        If not specified then the default value is 100.
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      x-kubernetes-int-or-string: true
+                tags:
+                  description: |-
+                    Custom tags configuration. You can add custom tags to traces based on
+                    headers or literal values.
+                  type: array
+                  items:
+                    description: |-
+                      Custom tags configuration.
+                      Only one of literal or header can be used.
+                    properties:
+                      header:
+                        description: Tag taken from a header.
+                        type: object
+                        properties:
+                          default:
+                            description: |-
+                              Default value to use if header is missing.
+                              If the default is missing and there is no value the tag will not be
+                              included.
+                            type: string
+                          name:
+                            description: Name of the header.
+                            type: string
+                        required:
+                          - name
+                      literal:
+                        description: Tag taken from literal value.
+                        type: string
+                      name:
+                        description: Name of the tag.
+                        type: string
+                    required:
+                      - name
+                    type: object
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined inplace.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshTraceItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
+    MeshTrafficPermissionItem_Put_RequestBody:
+      description: Successful response
+      type: object
+      properties:
+        type:
+          description: the type of the resource
+          type: string
+          enum:
+            - MeshTrafficPermission
+          readOnly: true
+        mesh:
+          description: Mesh is the name of the Kuma mesh this resource belongs to. It may be omitted for cluster-scoped resources.
+          type: string
+          default: default
+          readOnly: true
+        name:
+          description: Name of the Kuma resource
+          type: string
+          readOnly: true
+        labels:
+          description: The labels to help identity resources
+          type: object
+          additionalProperties:
+            type: string
+          patternProperties:
+            ^k8s\.kuma\.io/:
+              type: string
+              readOnly: true
+            ^kuma\.io/:
+              type: string
+              readOnly: true
+          properties:
+            kuma.io/zone:
+              type: string
+              readOnly: true
+            kuma.io/mesh:
+              type: string
+              readOnly: true
+            kuma.io/display-name:
+              type: string
+              readOnly: true
+            kuma.io/env:
+              type: string
+              readOnly: true
+            kuma.io/origin:
+              type: string
+              readOnly: true
+            kuma.io/policy-role:
+              type: string
+              readOnly: true
+            kuma.io/proxy-type:
+              type: string
+              readOnly: true
+        spec:
+          description: Spec is the specification of the Kuma MeshTrafficPermission resource.
+          type: object
+          default:
+            targetRef:
+              kind: Mesh
+          properties:
+            from:
+              description: From list makes a match between clients and corresponding configurations
+              type: array
+              items:
+                properties:
+                  default:
+                    description: |-
+                      Default is a configuration specific to the group of clients referenced in
+                      'targetRef'
+                    type: object
+                    properties:
+                      action:
+                        description: 'Action defines a behavior for the specified group of clients:'
+                        type: string
+                        enum:
+                          - Allow
+                          - Deny
+                          - AllowWithShadowDeny
+                  targetRef:
+                    description: |-
+                      TargetRef is a reference to the resource that represents a group of
+                      clients.
+                    type: object
+                    default:
+                      kind: MeshService
+                    properties:
+                      kind:
+                        description: Kind of the referenced resource
+                        type: string
+                        enum:
+                          - MeshService
+                          - MeshExternalService
+                          - MeshMultiZoneService
+                          - MeshHTTPRoute
+                      labels:
+                        description: |-
+                          Labels are used to select group of MeshServices that match labels. Either Labels or
+                          Name and Namespace can be used.
+                        type: object
+                        additionalProperties:
+                          type: string
+                      name:
+                        description: |-
+                          Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                          `MeshServiceSubset` and `MeshGatewayRoute`
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                          will be targeted.
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is used to target specific section of resource.
+                          For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                        type: string
+                    required:
+                      - kind
+                required:
+                  - targetRef
+                type: object
+              deprecated: true
+            rules:
+              description: Rules defines inbound permissions configuration
+              type: array
+              items:
+                properties:
+                  default:
+                    type: object
+                    properties:
+                      allow:
+                        description: Allow definees a list of matches for which access will be allowed
+                        type: array
+                        items:
+                          properties:
+                            spiffeID:
+                              description: SpiffeID defines a matcher configuration for SpiffeID matching
+                              type: object
+                              properties:
+                                type:
+                                  description: Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                                  type: string
+                                  enum:
+                                    - Exact
+                                    - Prefix
+                                value:
+                                  description: Value is SpiffeId of a client that needs to match for the configuration to be applied
+                                  type: string
+                              required:
+                                - type
+                                - value
+                          type: object
+                      allowWithShadowDeny:
+                        description: |-
+                          AllowWithShadowDeny defines a list of matches for which access will be allowed but emits logs as if
+                          requests are denied
+                        type: array
+                        items:
+                          properties:
+                            spiffeID:
+                              description: SpiffeID defines a matcher configuration for SpiffeID matching
+                              type: object
+                              properties:
+                                type:
+                                  description: Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                                  type: string
+                                  enum:
+                                    - Exact
+                                    - Prefix
+                                value:
+                                  description: Value is SpiffeId of a client that needs to match for the configuration to be applied
+                                  type: string
+                              required:
+                                - type
+                                - value
+                          type: object
+                      deny:
+                        description: Deny defines a list of matches for which access will be denied
+                        type: array
+                        items:
+                          properties:
+                            spiffeID:
+                              description: SpiffeID defines a matcher configuration for SpiffeID matching
+                              type: object
+                              properties:
+                                type:
+                                  description: Type defines how to match incoming traffic by SpiffeID. `Exact` or `Prefix` are allowed.
+                                  type: string
+                                  enum:
+                                    - Exact
+                                    - Prefix
+                                value:
+                                  description: Value is SpiffeId of a client that needs to match for the configuration to be applied
+                                  type: string
+                              required:
+                                - type
+                                - value
+                          type: object
+                required:
+                  - default
+                type: object
+                default:
+                  targetRef:
+                    kind: MeshService
+                  default:
+                    action: Deny
+            targetRef:
+              description: |-
+                TargetRef is a reference to the resource the policy takes an effect on.
+                The resource could be either a real store object or virtual resource
+                defined inplace.
+              type: object
+              properties:
+                kind:
+                  description: Kind of the referenced resource
+                  type: string
+                  enum:
+                    - Mesh
+                    - Dataplane
+                labels:
+                  description: |-
+                    Labels are used to select group of MeshServices that match labels. Either Labels or
+                    Name and Namespace can be used.
+                  type: object
+                  additionalProperties:
+                    type: string
+                name:
+                  description: |-
+                    Name of the referenced resource. Can only be used with kinds: `MeshService`,
+                    `MeshServiceSubset` and `MeshGatewayRoute`
+                  type: string
+                namespace:
+                  description: |-
+                    Namespace specifies the namespace of target resource. If empty only resources in policy namespace
+                    will be targeted.
+                  type: string
+                sectionName:
+                  description: |-
+                    SectionName is used to target specific section of resource.
+                    For example, you can target port from MeshService.ports[] by its name. Only traffic to this port will be affected.
+                  type: string
+              required:
+                - kind
+        additionalProperties: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MeshTrafficPermissionItem'
+      required:
+        - type
+        - name
+        - spec
+      x-request: true
   examples:
     GlobalInsightExample:
       value:

--- a/packages/kuma-http-api/src/components/schemas/MeshAccessLogItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshAccessLogItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,26 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshAccessLog
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshAccessLogItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.to.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          backends: []
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          backends: []

--- a/packages/kuma-http-api/src/components/schemas/MeshCircuitBreakerItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshCircuitBreakerItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,42 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshCircuitBreaker
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshCircuitBreakerItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.to.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          connectionLimits:
+            maxConnections: 2
+            maxPendingRequests: 8
+            maxRetries: 2
+            maxRequests: 2
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          connectionLimits:
+            maxConnections: 2
+            maxPendingRequests: 8
+            maxRetries: 2
+            maxRequests: 2
+  - target: '$.properties.spec.properties.to.items.properties.default'
+    update:
+      default:
+        connectionLimits:
+          maxConnections: 2
+          maxPendingRequests: 8
+          maxRetries: 2
+          maxRequests: 2

--- a/packages/kuma-http-api/src/components/schemas/MeshFaultInjectionItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshFaultInjectionItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,26 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshFaultInjection
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshFaultInjectionItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.to.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          http: []
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          http: []

--- a/packages/kuma-http-api/src/components/schemas/MeshHTTPRouteItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshHTTPRouteItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,20 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshHTTPRoute
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshHTTPRouteItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.to.items'
+    update:
+      default:
+        rules: []
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        rules: []

--- a/packages/kuma-http-api/src/components/schemas/MeshHealthCheckItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshHealthCheckItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,40 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshHealthCheck
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshHealthCheckItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.to.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          interval: 10s
+          timeout: 2s
+          unhealthyThreshold: 3
+          healthyThreshold: 1
+          http:
+            path: "/health"
+            expectedStatuses:
+            - 200
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          interval: 10s
+          timeout: 2s
+          unhealthyThreshold: 3
+          healthyThreshold: 1
+          http:
+            path: "/health"
+            expectedStatuses:
+            - 200

--- a/packages/kuma-http-api/src/components/schemas/MeshLoadBalancingStrategyItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshLoadBalancingStrategyItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,24 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshLoadBalancingStrategy
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshLoadBalancingStrategyItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.to.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default: {}
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default: {}

--- a/packages/kuma-http-api/src/components/schemas/MeshMetricItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshMetricItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,17 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshMetric
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshMetricItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec'
+    update:
+      default:
+        default:
+          backends: []

--- a/packages/kuma-http-api/src/components/schemas/MeshPassthroughItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshPassthroughItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,17 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshPassthrough
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshPassthroughItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec'
+    update:
+      default:
+        default:
+          passthroughMode: None

--- a/packages/kuma-http-api/src/components/schemas/MeshProxyPatchItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshProxyPatchItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,17 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshProxyPatch
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshProxyPatchItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec'
+    update:
+      default:
+        default:
+          appendModifications: []

--- a/packages/kuma-http-api/src/components/schemas/MeshRateLimitItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshRateLimitItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,26 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshRateLimit
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshRateLimitItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.to.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          local: {}
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          local: {}

--- a/packages/kuma-http-api/src/components/schemas/MeshRetryItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshRetryItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,38 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshRetry
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshRetryItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.to.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          http:
+            numRetries: 10
+            backOff:
+              baseInterval: 15s
+              maxInterval: 20m
+            retryOn:
+            - 5xx
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          http:
+            numRetries: 10
+            backOff:
+              baseInterval: 15s
+              maxInterval: 20m
+            retryOn:
+            - 5xx

--- a/packages/kuma-http-api/src/components/schemas/MeshTCPRouteItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshTCPRouteItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,24 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshTCPRoute
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshTCPRouteItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.to.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        rules: []
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        rules: []

--- a/packages/kuma-http-api/src/components/schemas/MeshTLSItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshTLSItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,19 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshTLS
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshTLSItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          mode: Strict

--- a/packages/kuma-http-api/src/components/schemas/MeshTimeoutItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshTimeoutItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,32 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshTimeout
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshTimeoutItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.to.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          idleTimeout: 20s
+          connectionTimeout: 2s
+          http:
+            requestTimeout: 2s
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          idleTimeout: 20s
+          connectionTimeout: 2s
+          http:
+            requestTimeout: 2s

--- a/packages/kuma-http-api/src/components/schemas/MeshTraceItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshTraceItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,17 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshTrace
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshTraceItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec'
+    update:
+      default:
+        default:
+          backends: []

--- a/packages/kuma-http-api/src/components/schemas/MeshTrafficPermissionItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshTrafficPermissionItem_Put_RequestBody.overlay.yaml
@@ -1,0 +1,19 @@
+overlay: 1.0.0
+info:
+  title: Customise MeshTrafficPermission
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshTrafficPermissionItem.yaml
+actions:
+  # mark as a request body so we can make amends for request bodies
+  - target: '$'
+    update:
+      x-request: true
+
+  # default specs.default just for this policy
+  - target: '$.properties.spec.properties.rules.items'
+    update:
+      default:
+        targetRef:
+          kind: MeshService
+        default:
+          action: Deny

--- a/packages/kuma-http-api/src/components/schemas/TargetRefPolicy_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/TargetRefPolicy_Put_RequestBody.overlay.yaml
@@ -1,0 +1,23 @@
+overlay: 1.0.0
+info:
+  title: Overlay to customise API for Kuma
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshAccessLogItem.yaml
+actions:
+  - target: '$'
+    update:
+      x-request: true
+
+  - target: '$.properties.spec'
+    remove: true
+  # This removes the `type: 'MeshAccessLog'`
+  - target: '$.properties.type.enum'
+    remove: true
+  - target: '$.properties'
+    update:
+      spec:
+        description: Spec is the specification of the Kuma Policy resource.
+        properties:
+          targetRef:
+            $ref: './MeshAccessLogItem.yaml#/properties/spec/properties/targetRef'
+

--- a/packages/kuma-http-api/src/openapi.overlay.yaml
+++ b/packages/kuma-http-api/src/openapi.overlay.yaml
@@ -4,6 +4,16 @@ info:
   version: 0.1.0
 extends: ../generated/openapi.yaml
 actions:
+  # Additional paths. These will include any schemas used in the <path>.yaml file
+  - target: "$.paths"
+    update:
+      /config:
+        $ref: "paths/config.yaml"
+      /mesh-insights:
+        $ref: "paths/mesh-insights.yaml"
+      /mesh-insights/{name}:
+        $ref: "paths/mesh-insights_{name}.yaml"
+
   # Additional schemas
   - target: '$.components.schemas'
     update:
@@ -16,13 +26,105 @@ actions:
       TargetRefPolicy:
         $ref: "components/schemas/TargetRefPolicy.yaml"
 
-  # Additional paths. These will include any schemas used in the <path>.yaml file
-  - target: "$.paths"
-    update:
-      /config:
-        $ref: "paths/config.yaml"
-      /mesh-insights:
-        $ref: "paths/mesh-insights.yaml"
-      /mesh-insights/{name}:
-        $ref: "paths/mesh-insights_{name}.yaml"
+  ### RequestBodies
 
+  # TargetRef
+  - target: '$.components.schemas'
+    update:
+      TargetRefPolicy_Put_RequestBody:
+        $ref: "components/schemas/TargetRefPolicy_Put_RequestBody.yaml"
+
+  # MeshAccessLog
+  - target: '$.components.schemas'
+    update:
+      MeshAccessLogItem_Put_RequestBody:
+        $ref: "components/schemas/MeshAccessLogItem_Put_RequestBody.yaml"
+  # we decided to use x-request to mark these, so overwriting put isn't necessary...yet?
+  # - target: "$.paths['/meshes/{mesh}/meshaccesslogs/{name}']"
+  #   update:
+  #     put:
+  #       requestBody:
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: '#/components/schemas/MeshAccessLogItem_Put_RequestBody'
+  # MeshCircuitBreaker
+  - target: '$.components.schemas'
+    update:
+      MeshCircuitBreakerItem_Put_RequestBody:
+        $ref: "components/schemas/MeshCircuitBreakerItem_Put_RequestBody.yaml"
+  # MeshFaultInjection
+  - target: '$.components.schemas'
+    update:
+      MeshFaultInjectionItem_Put_RequestBody:
+        $ref: "components/schemas/MeshFaultInjectionItem_Put_RequestBody.yaml"
+  # MeshHTTPRoute
+  - target: '$.components.schemas'
+    update:
+      MeshHTTPRouteItem_Put_RequestBody:
+        $ref: "components/schemas/MeshHTTPRouteItem_Put_RequestBody.yaml"
+  # MeshHealthCheck
+  - target: '$.components.schemas'
+    update:
+      MeshHealthCheckItem_Put_RequestBody:
+        $ref: "components/schemas/MeshHealthCheckItem_Put_RequestBody.yaml"
+  # MeshLoadBalancingStrategy
+  - target: '$.components.schemas'
+    update:
+      MeshLoadBalancingStrategyItem_Put_RequestBody:
+        $ref: "components/schemas/MeshLoadBalancingStrategyItem_Put_RequestBody.yaml"
+  # MeshMetric
+  - target: '$.components.schemas'
+    update:
+      MeshMetricItem_Put_RequestBody:
+        $ref: "components/schemas/MeshMetricItem_Put_RequestBody.yaml"
+  # MeshPassthrough
+  - target: '$.components.schemas'
+    update:
+      MeshPassthroughItem_Put_RequestBody:
+        $ref: "components/schemas/MeshPassthroughItem_Put_RequestBody.yaml"
+  # MeshProxyPatch
+  - target: '$.components.schemas'
+    update:
+      MeshProxyPatchItem_Put_RequestBody:
+        $ref: "components/schemas/MeshProxyPatchItem_Put_RequestBody.yaml"
+  # MeshRateLimit
+  - target: '$.components.schemas'
+    update:
+      MeshRateLimitItem_Put_RequestBody:
+        $ref: "components/schemas/MeshRateLimitItem_Put_RequestBody.yaml"
+  # MeshRetry
+  - target: '$.components.schemas'
+    update:
+      MeshRetryItem_Put_RequestBody:
+        $ref: "components/schemas/MeshRetryItem_Put_RequestBody.yaml"
+  # MeshTCPRoute
+  - target: '$.components.schemas'
+    update:
+      MeshTCPRouteItem_Put_RequestBody:
+        $ref: "components/schemas/MeshTCPRouteItem_Put_RequestBody.yaml"
+  # MeshTCPRoute
+  - target: '$.components.schemas'
+    update:
+      MeshTCPRouteItem_Put_RequestBody:
+        $ref: "components/schemas/MeshTCPRouteItem_Put_RequestBody.yaml"
+  # MeshTimeout
+  - target: '$.components.schemas'
+    update:
+      MeshTimeoutItem_Put_RequestBody:
+        $ref: "components/schemas/MeshTimeoutItem_Put_RequestBody.yaml"
+  # MeshTLS
+  - target: '$.components.schemas'
+    update:
+      MeshTLSItem_Put_RequestBody:
+        $ref: "components/schemas/MeshTLSItem_Put_RequestBody.yaml"
+  # MeshTrace
+  - target: '$.components.schemas'
+    update:
+      MeshTraceItem_Put_RequestBody:
+        $ref: "components/schemas/MeshTraceItem_Put_RequestBody.yaml"
+  # MeshTrafficPermission
+  - target: '$.components.schemas'
+    update:
+      MeshTrafficPermissionItem_Put_RequestBody:
+        $ref: "components/schemas/MeshTrafficPermissionItem_Put_RequestBody.yaml"


### PR DESCRIPTION
Adds a new `*_Put_RequestBody.yaml` for every single policy type via OpenAPI overlays. Essentially copying the response objects and applying smol changes to those.

**Important Note: All files in `dist/`, `openapi.yaml` and `index.d.ts` are artifacts autogenerated from the other changed files in this PR.**

Other important files to look at are `/src/openapi.overlay.yaml` which basically "includes" the new schemas, and `openapi.overlay.tmpl.yaml` which applies some "global" overlays to these "request bodies".


