### PR TITLE
feat(oas): add oneOf implementation to MeshAccessLog

### DIFF
--- a/packages/kuma-http-api/dist/components/schemas/MeshAccessLogItem_Put_RequestBody.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshAccessLogItem_Put_RequestBody.yaml
@@ -41,152 +41,183 @@ properties:
                 backends:
                   type: array
                   items:
-                    properties:
+                    required:
+                      - type
+                    type: object
+                    default:
+                      type: File
                       file:
-                        description: FileBackend defines configuration for file based access logs
-                        type: object
-                        properties:
-                          format:
-                            description: |-
-                              Format of access logs. Placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            type: object
-                            properties:
-                              json:
-                                type: array
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                    - key
-                                    - value
-                                  type: object
-                                example:
-                                  - key: start_time
-                                    value: '%START_TIME%'
-                                  - key: bytes_received
-                                    value: '%BYTES_RECEIVED%'
-                              omitEmptyValues:
-                                type: boolean
-                                default: false
-                              plain:
-                                type: string
-                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                              type:
-                                type: string
-                                enum:
-                                  - Plain
-                                  - Json
-                            required:
-                              - type
-                          path:
-                            description: Path to a file that logs will be written to
-                            type: string
-                            example: /tmp/access.log
-                            minLength: 1
-                        required:
-                          - path
-                      openTelemetry:
-                        description: Defines an OpenTelemetry logging backend.
-                        type: object
-                        properties:
-                          attributes:
-                            description: |-
-                              Attributes can contain placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            type: array
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                value:
-                                  type: string
-                              required:
-                                - key
-                                - value
-                              type: object
-                            example:
-                              - key: mesh
-                                value: '%KUMA_MESH%'
-                          body:
-                            description: |-
-                              Body is a raw string or an OTLP any value as described at
-                              https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                              It can contain placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            example:
-                              kvlistValue:
-                                values:
-                                  - key: mesh
-                                    value:
-                                      stringValue: '%KUMA_MESH%'
-                            x-kubernetes-preserve-unknown-fields: true
-                          endpoint:
-                            description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                            type: string
-                            example: 'otel-collector:4317'
-                            minLength: 1
-                        required:
-                          - endpoint
-                      tcp:
-                        description: TCPBackend defines a TCP logging backend.
-                        type: object
-                        properties:
-                          address:
-                            description: Address of the TCP logging backend
-                            type: string
-                            example: '127.0.0.1:5000'
-                            minLength: 1
-                          format:
-                            description: |-
-                              Format of access logs. Placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            type: object
-                            properties:
-                              json:
-                                type: array
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                    - key
-                                    - value
-                                  type: object
-                                example:
-                                  - key: start_time
-                                    value: '%START_TIME%'
-                                  - key: bytes_received
-                                    value: '%BYTES_RECEIVED%'
-                              omitEmptyValues:
-                                type: boolean
-                                default: false
-                              plain:
-                                type: string
-                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                              type:
-                                type: string
-                                enum:
-                                  - Plain
-                                  - Json
-                            required:
-                              - type
-                        required:
-                          - address
+                        path: ''
+                    properties:
                       type:
                         type: string
                         enum:
                           - Tcp
                           - File
                           - OpenTelemetry
-                    required:
-                      - type
-                    type: object
+                    oneOf:
+                      - title: TCP
+                        type: object
+                        default:
+                          type: Tcp
+                          tcp:
+                            address: ''
+                        properties:
+                          type:
+                            const: Tcp
+                          tcp:
+                            properties:
+                              address:
+                                description: Address of the TCP logging backend
+                                type: string
+                                example: '127.0.0.1:5000'
+                                minLength: 1
+                              format:
+                                description: |-
+                                  Format of access logs. Placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                type: object
+                                properties:
+                                  json:
+                                    type: array
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - key
+                                        - value
+                                      type: object
+                                    example:
+                                      - key: start_time
+                                        value: '%START_TIME%'
+                                      - key: bytes_received
+                                        value: '%BYTES_RECEIVED%'
+                                  omitEmptyValues:
+                                    type: boolean
+                                    default: false
+                                  plain:
+                                    type: string
+                                    example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                  type:
+                                    type: string
+                                    enum:
+                                      - Plain
+                                      - Json
+                                readOnly: true
+                                required:
+                                  - type
+                            required:
+                              - address
+                      - title: File
+                        type: object
+                        default:
+                          type: File
+                          file:
+                            path: ''
+                        properties:
+                          type:
+                            const: File
+                          file:
+                            description: FileBackend defines configuration for file based access logs
+                            type: object
+                            properties:
+                              format:
+                                description: |-
+                                  Format of access logs. Placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                type: object
+                                properties:
+                                  json:
+                                    type: array
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - key
+                                        - value
+                                      type: object
+                                    example:
+                                      - key: start_time
+                                        value: '%START_TIME%'
+                                      - key: bytes_received
+                                        value: '%BYTES_RECEIVED%'
+                                  omitEmptyValues:
+                                    type: boolean
+                                    default: false
+                                  plain:
+                                    type: string
+                                    example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                  type:
+                                    type: string
+                                    enum:
+                                      - Plain
+                                      - Json
+                                readOnly: true
+                                required:
+                                  - type
+                              path:
+                                description: Path to a file that logs will be written to
+                                type: string
+                                example: /tmp/access.log
+                                minLength: 1
+                            required:
+                              - path
+                      - title: OpenTelemetry
+                        type: object
+                        default:
+                          type: OpenTelemetry
+                          openTelemetry:
+                            endpoint: ''
+                        properties:
+                          type:
+                            const: OpenTelemetry
+                          openTelemetry:
+                            properties:
+                              attributes:
+                                description: |-
+                                  Attributes can contain placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                type: array
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                    - key
+                                    - value
+                                  type: object
+                                example:
+                                  - key: mesh
+                                    value: '%KUMA_MESH%'
+                                readOnly: true
+                              body:
+                                description: |-
+                                  Body is a raw string or an OTLP any value as described at
+                                  https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                  It can contain placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                example:
+                                  kvlistValue:
+                                    values:
+                                      - key: mesh
+                                        value:
+                                          stringValue: '%KUMA_MESH%'
+                                x-kubernetes-preserve-unknown-fields: true
+                              endpoint:
+                                description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                type: string
+                                example: 'otel-collector:4317'
+                                minLength: 1
+                            required:
+                              - endpoint
             targetRef:
               description: |-
                 TargetRef is a reference to the resource that represents a group of
@@ -268,152 +299,183 @@ properties:
                 backends:
                   type: array
                   items:
-                    properties:
+                    required:
+                      - type
+                    type: object
+                    default:
+                      type: File
                       file:
-                        description: FileBackend defines configuration for file based access logs
-                        type: object
-                        properties:
-                          format:
-                            description: |-
-                              Format of access logs. Placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            type: object
-                            properties:
-                              json:
-                                type: array
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                    - key
-                                    - value
-                                  type: object
-                                example:
-                                  - key: start_time
-                                    value: '%START_TIME%'
-                                  - key: bytes_received
-                                    value: '%BYTES_RECEIVED%'
-                              omitEmptyValues:
-                                type: boolean
-                                default: false
-                              plain:
-                                type: string
-                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                              type:
-                                type: string
-                                enum:
-                                  - Plain
-                                  - Json
-                            required:
-                              - type
-                          path:
-                            description: Path to a file that logs will be written to
-                            type: string
-                            example: /tmp/access.log
-                            minLength: 1
-                        required:
-                          - path
-                      openTelemetry:
-                        description: Defines an OpenTelemetry logging backend.
-                        type: object
-                        properties:
-                          attributes:
-                            description: |-
-                              Attributes can contain placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            type: array
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                value:
-                                  type: string
-                              required:
-                                - key
-                                - value
-                              type: object
-                            example:
-                              - key: mesh
-                                value: '%KUMA_MESH%'
-                          body:
-                            description: |-
-                              Body is a raw string or an OTLP any value as described at
-                              https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                              It can contain placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            example:
-                              kvlistValue:
-                                values:
-                                  - key: mesh
-                                    value:
-                                      stringValue: '%KUMA_MESH%'
-                            x-kubernetes-preserve-unknown-fields: true
-                          endpoint:
-                            description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                            type: string
-                            example: 'otel-collector:4317'
-                            minLength: 1
-                        required:
-                          - endpoint
-                      tcp:
-                        description: TCPBackend defines a TCP logging backend.
-                        type: object
-                        properties:
-                          address:
-                            description: Address of the TCP logging backend
-                            type: string
-                            example: '127.0.0.1:5000'
-                            minLength: 1
-                          format:
-                            description: |-
-                              Format of access logs. Placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            type: object
-                            properties:
-                              json:
-                                type: array
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                    - key
-                                    - value
-                                  type: object
-                                example:
-                                  - key: start_time
-                                    value: '%START_TIME%'
-                                  - key: bytes_received
-                                    value: '%BYTES_RECEIVED%'
-                              omitEmptyValues:
-                                type: boolean
-                                default: false
-                              plain:
-                                type: string
-                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                              type:
-                                type: string
-                                enum:
-                                  - Plain
-                                  - Json
-                            required:
-                              - type
-                        required:
-                          - address
+                        path: ''
+                    properties:
                       type:
                         type: string
                         enum:
                           - Tcp
                           - File
                           - OpenTelemetry
-                    required:
-                      - type
-                    type: object
+                    oneOf:
+                      - title: TCP
+                        type: object
+                        default:
+                          type: Tcp
+                          tcp:
+                            address: ''
+                        properties:
+                          type:
+                            const: Tcp
+                          tcp:
+                            properties:
+                              address:
+                                description: Address of the TCP logging backend
+                                type: string
+                                example: '127.0.0.1:5000'
+                                minLength: 1
+                              format:
+                                description: |-
+                                  Format of access logs. Placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                type: object
+                                properties:
+                                  json:
+                                    type: array
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - key
+                                        - value
+                                      type: object
+                                    example:
+                                      - key: start_time
+                                        value: '%START_TIME%'
+                                      - key: bytes_received
+                                        value: '%BYTES_RECEIVED%'
+                                  omitEmptyValues:
+                                    type: boolean
+                                    default: false
+                                  plain:
+                                    type: string
+                                    example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                  type:
+                                    type: string
+                                    enum:
+                                      - Plain
+                                      - Json
+                                readOnly: true
+                                required:
+                                  - type
+                            required:
+                              - address
+                      - title: File
+                        type: object
+                        default:
+                          type: File
+                          file:
+                            path: ''
+                        properties:
+                          type:
+                            const: File
+                          file:
+                            description: FileBackend defines configuration for file based access logs
+                            type: object
+                            properties:
+                              format:
+                                description: |-
+                                  Format of access logs. Placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                type: object
+                                properties:
+                                  json:
+                                    type: array
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - key
+                                        - value
+                                      type: object
+                                    example:
+                                      - key: start_time
+                                        value: '%START_TIME%'
+                                      - key: bytes_received
+                                        value: '%BYTES_RECEIVED%'
+                                  omitEmptyValues:
+                                    type: boolean
+                                    default: false
+                                  plain:
+                                    type: string
+                                    example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                  type:
+                                    type: string
+                                    enum:
+                                      - Plain
+                                      - Json
+                                readOnly: true
+                                required:
+                                  - type
+                              path:
+                                description: Path to a file that logs will be written to
+                                type: string
+                                example: /tmp/access.log
+                                minLength: 1
+                            required:
+                              - path
+                      - title: OpenTelemetry
+                        type: object
+                        default:
+                          type: OpenTelemetry
+                          openTelemetry:
+                            endpoint: ''
+                        properties:
+                          type:
+                            const: OpenTelemetry
+                          openTelemetry:
+                            properties:
+                              attributes:
+                                description: |-
+                                  Attributes can contain placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                type: array
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                    - key
+                                    - value
+                                  type: object
+                                example:
+                                  - key: mesh
+                                    value: '%KUMA_MESH%'
+                                readOnly: true
+                              body:
+                                description: |-
+                                  Body is a raw string or an OTLP any value as described at
+                                  https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                  It can contain placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                example:
+                                  kvlistValue:
+                                    values:
+                                      - key: mesh
+                                        value:
+                                          stringValue: '%KUMA_MESH%'
+                                x-kubernetes-preserve-unknown-fields: true
+                              endpoint:
+                                description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                type: string
+                                example: 'otel-collector:4317'
+                                minLength: 1
+                            required:
+                              - endpoint
           required:
             - default
           type: object
@@ -500,152 +562,183 @@ properties:
                 backends:
                   type: array
                   items:
-                    properties:
+                    required:
+                      - type
+                    type: object
+                    default:
+                      type: File
                       file:
-                        description: FileBackend defines configuration for file based access logs
-                        type: object
-                        properties:
-                          format:
-                            description: |-
-                              Format of access logs. Placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            type: object
-                            properties:
-                              json:
-                                type: array
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                    - key
-                                    - value
-                                  type: object
-                                example:
-                                  - key: start_time
-                                    value: '%START_TIME%'
-                                  - key: bytes_received
-                                    value: '%BYTES_RECEIVED%'
-                              omitEmptyValues:
-                                type: boolean
-                                default: false
-                              plain:
-                                type: string
-                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                              type:
-                                type: string
-                                enum:
-                                  - Plain
-                                  - Json
-                            required:
-                              - type
-                          path:
-                            description: Path to a file that logs will be written to
-                            type: string
-                            example: /tmp/access.log
-                            minLength: 1
-                        required:
-                          - path
-                      openTelemetry:
-                        description: Defines an OpenTelemetry logging backend.
-                        type: object
-                        properties:
-                          attributes:
-                            description: |-
-                              Attributes can contain placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            type: array
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                value:
-                                  type: string
-                              required:
-                                - key
-                                - value
-                              type: object
-                            example:
-                              - key: mesh
-                                value: '%KUMA_MESH%'
-                          body:
-                            description: |-
-                              Body is a raw string or an OTLP any value as described at
-                              https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                              It can contain placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            example:
-                              kvlistValue:
-                                values:
-                                  - key: mesh
-                                    value:
-                                      stringValue: '%KUMA_MESH%'
-                            x-kubernetes-preserve-unknown-fields: true
-                          endpoint:
-                            description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                            type: string
-                            example: 'otel-collector:4317'
-                            minLength: 1
-                        required:
-                          - endpoint
-                      tcp:
-                        description: TCPBackend defines a TCP logging backend.
-                        type: object
-                        properties:
-                          address:
-                            description: Address of the TCP logging backend
-                            type: string
-                            example: '127.0.0.1:5000'
-                            minLength: 1
-                          format:
-                            description: |-
-                              Format of access logs. Placeholders available on
-                              https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                            type: object
-                            properties:
-                              json:
-                                type: array
-                                items:
-                                  properties:
-                                    key:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                    - key
-                                    - value
-                                  type: object
-                                example:
-                                  - key: start_time
-                                    value: '%START_TIME%'
-                                  - key: bytes_received
-                                    value: '%BYTES_RECEIVED%'
-                              omitEmptyValues:
-                                type: boolean
-                                default: false
-                              plain:
-                                type: string
-                                example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                              type:
-                                type: string
-                                enum:
-                                  - Plain
-                                  - Json
-                            required:
-                              - type
-                        required:
-                          - address
+                        path: ''
+                    properties:
                       type:
                         type: string
                         enum:
                           - Tcp
                           - File
                           - OpenTelemetry
-                    required:
-                      - type
-                    type: object
+                    oneOf:
+                      - title: TCP
+                        type: object
+                        default:
+                          type: Tcp
+                          tcp:
+                            address: ''
+                        properties:
+                          type:
+                            const: Tcp
+                          tcp:
+                            properties:
+                              address:
+                                description: Address of the TCP logging backend
+                                type: string
+                                example: '127.0.0.1:5000'
+                                minLength: 1
+                              format:
+                                description: |-
+                                  Format of access logs. Placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                type: object
+                                properties:
+                                  json:
+                                    type: array
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - key
+                                        - value
+                                      type: object
+                                    example:
+                                      - key: start_time
+                                        value: '%START_TIME%'
+                                      - key: bytes_received
+                                        value: '%BYTES_RECEIVED%'
+                                  omitEmptyValues:
+                                    type: boolean
+                                    default: false
+                                  plain:
+                                    type: string
+                                    example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                  type:
+                                    type: string
+                                    enum:
+                                      - Plain
+                                      - Json
+                                readOnly: true
+                                required:
+                                  - type
+                            required:
+                              - address
+                      - title: File
+                        type: object
+                        default:
+                          type: File
+                          file:
+                            path: ''
+                        properties:
+                          type:
+                            const: File
+                          file:
+                            description: FileBackend defines configuration for file based access logs
+                            type: object
+                            properties:
+                              format:
+                                description: |-
+                                  Format of access logs. Placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                type: object
+                                properties:
+                                  json:
+                                    type: array
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - key
+                                        - value
+                                      type: object
+                                    example:
+                                      - key: start_time
+                                        value: '%START_TIME%'
+                                      - key: bytes_received
+                                        value: '%BYTES_RECEIVED%'
+                                  omitEmptyValues:
+                                    type: boolean
+                                    default: false
+                                  plain:
+                                    type: string
+                                    example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                                  type:
+                                    type: string
+                                    enum:
+                                      - Plain
+                                      - Json
+                                readOnly: true
+                                required:
+                                  - type
+                              path:
+                                description: Path to a file that logs will be written to
+                                type: string
+                                example: /tmp/access.log
+                                minLength: 1
+                            required:
+                              - path
+                      - title: OpenTelemetry
+                        type: object
+                        default:
+                          type: OpenTelemetry
+                          openTelemetry:
+                            endpoint: ''
+                        properties:
+                          type:
+                            const: OpenTelemetry
+                          openTelemetry:
+                            properties:
+                              attributes:
+                                description: |-
+                                  Attributes can contain placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                type: array
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                    - key
+                                    - value
+                                  type: object
+                                example:
+                                  - key: mesh
+                                    value: '%KUMA_MESH%'
+                                readOnly: true
+                              body:
+                                description: |-
+                                  Body is a raw string or an OTLP any value as described at
+                                  https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                  It can contain placeholders available on
+                                  https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                example:
+                                  kvlistValue:
+                                    values:
+                                      - key: mesh
+                                        value:
+                                          stringValue: '%KUMA_MESH%'
+                                x-kubernetes-preserve-unknown-fields: true
+                              endpoint:
+                                description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                type: string
+                                example: 'otel-collector:4317'
+                                minLength: 1
+                            required:
+                              - endpoint
             targetRef:
               description: |-
                 TargetRef is a reference to the resource that represents a group of

--- a/packages/kuma-http-api/index.d.ts
+++ b/packages/kuma-http-api/index.d.ts
@@ -2041,123 +2041,22 @@ export interface components {
                      *     'targetRef'
                      */
                     default: {
-                        backends?: {
-                            /** @description FileBackend defines configuration for file based access logs */
-                            file?: {
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
-                                /**
-                                 * @description Path to a file that logs will be written to
-                                 * @example /tmp/access.log
-                                 */
-                                path: string;
-                            };
-                            /** @description Defines an OpenTelemetry logging backend. */
-                            openTelemetry?: {
-                                /**
-                                 * @description Attributes can contain placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 * @example [
-                                 *       {
-                                 *         "key": "mesh",
-                                 *         "value": "%KUMA_MESH%"
-                                 *       }
-                                 *     ]
-                                 */
-                                attributes?: {
-                                    key: string;
-                                    value: string;
-                                }[];
-                                /**
-                                 * @description Body is a raw string or an OTLP any value as described at
-                                 *     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                                 *     It can contain placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 * @example {
-                                 *       "kvlistValue": {
-                                 *         "values": [
-                                 *           {
-                                 *             "key": "mesh",
-                                 *             "value": {
-                                 *               "stringValue": "%KUMA_MESH%"
-                                 *             }
-                                 *           }
-                                 *         ]
-                                 *       }
-                                 *     }
-                                 */
-                                body?: unknown;
-                                /**
-                                 * @description Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                                 * @example otel-collector:4317
-                                 */
-                                endpoint: string;
-                            };
-                            /** @description TCPBackend defines a TCP logging backend. */
-                            tcp?: {
-                                /**
-                                 * @description Address of the TCP logging backend
-                                 * @example 127.0.0.1:5000
-                                 */
-                                address: string;
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
-                            };
+                        backends?: ({
                             /** @enum {string} */
                             type: "Tcp" | "File" | "OpenTelemetry";
-                        }[];
+                        } & ({
+                            /** @constant */
+                            type?: "Tcp";
+                            address: string;
+                        } | {
+                            /** @constant */
+                            type?: "File";
+                            path: string;
+                        } | {
+                            /** @constant */
+                            type?: "OpenTelemetry";
+                            endpoint: string;
+                        }))[];
                     };
                     /**
                      * @description TargetRef is a reference to the resource that represents a group of
@@ -2214,123 +2113,22 @@ export interface components {
                 rules?: {
                     /** @description Default contains configuration of the inbound access logging */
                     default: {
-                        backends?: {
-                            /** @description FileBackend defines configuration for file based access logs */
-                            file?: {
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
-                                /**
-                                 * @description Path to a file that logs will be written to
-                                 * @example /tmp/access.log
-                                 */
-                                path: string;
-                            };
-                            /** @description Defines an OpenTelemetry logging backend. */
-                            openTelemetry?: {
-                                /**
-                                 * @description Attributes can contain placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 * @example [
-                                 *       {
-                                 *         "key": "mesh",
-                                 *         "value": "%KUMA_MESH%"
-                                 *       }
-                                 *     ]
-                                 */
-                                attributes?: {
-                                    key: string;
-                                    value: string;
-                                }[];
-                                /**
-                                 * @description Body is a raw string or an OTLP any value as described at
-                                 *     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                                 *     It can contain placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 * @example {
-                                 *       "kvlistValue": {
-                                 *         "values": [
-                                 *           {
-                                 *             "key": "mesh",
-                                 *             "value": {
-                                 *               "stringValue": "%KUMA_MESH%"
-                                 *             }
-                                 *           }
-                                 *         ]
-                                 *       }
-                                 *     }
-                                 */
-                                body?: unknown;
-                                /**
-                                 * @description Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                                 * @example otel-collector:4317
-                                 */
-                                endpoint: string;
-                            };
-                            /** @description TCPBackend defines a TCP logging backend. */
-                            tcp?: {
-                                /**
-                                 * @description Address of the TCP logging backend
-                                 * @example 127.0.0.1:5000
-                                 */
-                                address: string;
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
-                            };
+                        backends?: ({
                             /** @enum {string} */
                             type: "Tcp" | "File" | "OpenTelemetry";
-                        }[];
+                        } & ({
+                            /** @constant */
+                            type?: "Tcp";
+                            address: string;
+                        } | {
+                            /** @constant */
+                            type?: "File";
+                            path: string;
+                        } | {
+                            /** @constant */
+                            type?: "OpenTelemetry";
+                            endpoint: string;
+                        }))[];
                     };
                 }[];
                 /**
@@ -2388,123 +2186,22 @@ export interface components {
                      *     'targetRef'
                      */
                     default: {
-                        backends?: {
-                            /** @description FileBackend defines configuration for file based access logs */
-                            file?: {
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
-                                /**
-                                 * @description Path to a file that logs will be written to
-                                 * @example /tmp/access.log
-                                 */
-                                path: string;
-                            };
-                            /** @description Defines an OpenTelemetry logging backend. */
-                            openTelemetry?: {
-                                /**
-                                 * @description Attributes can contain placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 * @example [
-                                 *       {
-                                 *         "key": "mesh",
-                                 *         "value": "%KUMA_MESH%"
-                                 *       }
-                                 *     ]
-                                 */
-                                attributes?: {
-                                    key: string;
-                                    value: string;
-                                }[];
-                                /**
-                                 * @description Body is a raw string or an OTLP any value as described at
-                                 *     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                                 *     It can contain placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 * @example {
-                                 *       "kvlistValue": {
-                                 *         "values": [
-                                 *           {
-                                 *             "key": "mesh",
-                                 *             "value": {
-                                 *               "stringValue": "%KUMA_MESH%"
-                                 *             }
-                                 *           }
-                                 *         ]
-                                 *       }
-                                 *     }
-                                 */
-                                body?: unknown;
-                                /**
-                                 * @description Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                                 * @example otel-collector:4317
-                                 */
-                                endpoint: string;
-                            };
-                            /** @description TCPBackend defines a TCP logging backend. */
-                            tcp?: {
-                                /**
-                                 * @description Address of the TCP logging backend
-                                 * @example 127.0.0.1:5000
-                                 */
-                                address: string;
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
-                            };
+                        backends?: ({
                             /** @enum {string} */
                             type: "Tcp" | "File" | "OpenTelemetry";
-                        }[];
+                        } & ({
+                            /** @constant */
+                            type?: "Tcp";
+                            address: string;
+                        } | {
+                            /** @constant */
+                            type?: "File";
+                            path: string;
+                        } | {
+                            /** @constant */
+                            type?: "OpenTelemetry";
+                            endpoint: string;
+                        }))[];
                     };
                     /**
                      * @description TargetRef is a reference to the resource that represents a group of
@@ -9880,59 +9577,34 @@ export interface components {
                      *     'targetRef'
                      */
                     default: {
-                        backends?: {
+                        backends?: ({
+                            /** @enum {string} */
+                            type: "Tcp" | "File" | "OpenTelemetry";
+                        } & ({
+                            /** @constant */
+                            type?: "Tcp";
+                            tcp?: {
+                                /**
+                                 * @description Address of the TCP logging backend
+                                 * @example 127.0.0.1:5000
+                                 */
+                                address: string;
+                            };
+                        } | {
+                            /** @constant */
+                            type?: "File";
                             /** @description FileBackend defines configuration for file based access logs */
                             file?: {
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
                                 /**
                                  * @description Path to a file that logs will be written to
                                  * @example /tmp/access.log
                                  */
                                 path: string;
                             };
-                            /** @description Defines an OpenTelemetry logging backend. */
+                        } | {
+                            /** @constant */
+                            type?: "OpenTelemetry";
                             openTelemetry?: {
-                                /**
-                                 * @description Attributes can contain placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 * @example [
-                                 *       {
-                                 *         "key": "mesh",
-                                 *         "value": "%KUMA_MESH%"
-                                 *       }
-                                 *     ]
-                                 */
-                                attributes?: {
-                                    key: string;
-                                    value: string;
-                                }[];
                                 /**
                                  * @description Body is a raw string or an OTLP any value as described at
                                  *     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
@@ -9958,45 +9630,7 @@ export interface components {
                                  */
                                 endpoint: string;
                             };
-                            /** @description TCPBackend defines a TCP logging backend. */
-                            tcp?: {
-                                /**
-                                 * @description Address of the TCP logging backend
-                                 * @example 127.0.0.1:5000
-                                 */
-                                address: string;
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
-                            };
-                            /** @enum {string} */
-                            type: "Tcp" | "File" | "OpenTelemetry";
-                        }[];
+                        }))[];
                     };
                     /**
                      * @description TargetRef is a reference to the resource that represents a group of
@@ -10042,59 +9676,34 @@ export interface components {
                 rules?: {
                     /** @description Default contains configuration of the inbound access logging */
                     default: {
-                        backends?: {
+                        backends?: ({
+                            /** @enum {string} */
+                            type: "Tcp" | "File" | "OpenTelemetry";
+                        } & ({
+                            /** @constant */
+                            type?: "Tcp";
+                            tcp?: {
+                                /**
+                                 * @description Address of the TCP logging backend
+                                 * @example 127.0.0.1:5000
+                                 */
+                                address: string;
+                            };
+                        } | {
+                            /** @constant */
+                            type?: "File";
                             /** @description FileBackend defines configuration for file based access logs */
                             file?: {
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
                                 /**
                                  * @description Path to a file that logs will be written to
                                  * @example /tmp/access.log
                                  */
                                 path: string;
                             };
-                            /** @description Defines an OpenTelemetry logging backend. */
+                        } | {
+                            /** @constant */
+                            type?: "OpenTelemetry";
                             openTelemetry?: {
-                                /**
-                                 * @description Attributes can contain placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 * @example [
-                                 *       {
-                                 *         "key": "mesh",
-                                 *         "value": "%KUMA_MESH%"
-                                 *       }
-                                 *     ]
-                                 */
-                                attributes?: {
-                                    key: string;
-                                    value: string;
-                                }[];
                                 /**
                                  * @description Body is a raw string or an OTLP any value as described at
                                  *     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
@@ -10120,45 +9729,7 @@ export interface components {
                                  */
                                 endpoint: string;
                             };
-                            /** @description TCPBackend defines a TCP logging backend. */
-                            tcp?: {
-                                /**
-                                 * @description Address of the TCP logging backend
-                                 * @example 127.0.0.1:5000
-                                 */
-                                address: string;
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
-                            };
-                            /** @enum {string} */
-                            type: "Tcp" | "File" | "OpenTelemetry";
-                        }[];
+                        }))[];
                     };
                 }[];
                 /**
@@ -10202,59 +9773,34 @@ export interface components {
                      *     'targetRef'
                      */
                     default: {
-                        backends?: {
+                        backends?: ({
+                            /** @enum {string} */
+                            type: "Tcp" | "File" | "OpenTelemetry";
+                        } & ({
+                            /** @constant */
+                            type?: "Tcp";
+                            tcp?: {
+                                /**
+                                 * @description Address of the TCP logging backend
+                                 * @example 127.0.0.1:5000
+                                 */
+                                address: string;
+                            };
+                        } | {
+                            /** @constant */
+                            type?: "File";
                             /** @description FileBackend defines configuration for file based access logs */
                             file?: {
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
                                 /**
                                  * @description Path to a file that logs will be written to
                                  * @example /tmp/access.log
                                  */
                                 path: string;
                             };
-                            /** @description Defines an OpenTelemetry logging backend. */
+                        } | {
+                            /** @constant */
+                            type?: "OpenTelemetry";
                             openTelemetry?: {
-                                /**
-                                 * @description Attributes can contain placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 * @example [
-                                 *       {
-                                 *         "key": "mesh",
-                                 *         "value": "%KUMA_MESH%"
-                                 *       }
-                                 *     ]
-                                 */
-                                attributes?: {
-                                    key: string;
-                                    value: string;
-                                }[];
                                 /**
                                  * @description Body is a raw string or an OTLP any value as described at
                                  *     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
@@ -10280,45 +9826,7 @@ export interface components {
                                  */
                                 endpoint: string;
                             };
-                            /** @description TCPBackend defines a TCP logging backend. */
-                            tcp?: {
-                                /**
-                                 * @description Address of the TCP logging backend
-                                 * @example 127.0.0.1:5000
-                                 */
-                                address: string;
-                                /**
-                                 * @description Format of access logs. Placeholders available on
-                                 *     https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                 */
-                                format?: {
-                                    /**
-                                     * @example [
-                                     *       {
-                                     *         "key": "start_time",
-                                     *         "value": "%START_TIME%"
-                                     *       },
-                                     *       {
-                                     *         "key": "bytes_received",
-                                     *         "value": "%BYTES_RECEIVED%"
-                                     *       }
-                                     *     ]
-                                     */
-                                    json?: {
-                                        key: string;
-                                        value: string;
-                                    }[];
-                                    /** @default false */
-                                    omitEmptyValues: boolean;
-                                    /** @example [%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST% */
-                                    plain?: string;
-                                    /** @enum {string} */
-                                    type: "Plain" | "Json";
-                                };
-                            };
-                            /** @enum {string} */
-                            type: "Tcp" | "File" | "OpenTelemetry";
-                        }[];
+                        }))[];
                     };
                     /**
                      * @description TargetRef is a reference to the resource that represents a group of

--- a/packages/kuma-http-api/openapi.yaml
+++ b/packages/kuma-http-api/openapi.yaml
@@ -4978,152 +4978,38 @@ components:
                       backends:
                         type: array
                         items:
+                          required:
+                            - type
+                          type: object
                           properties:
-                            file:
-                              description: FileBackend defines configuration for file based access logs
-                              type: object
-                              properties:
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                                path:
-                                  description: Path to a file that logs will be written to
-                                  type: string
-                                  example: /tmp/access.log
-                                  minLength: 1
-                              required:
-                                - path
-                            openTelemetry:
-                              description: Defines an OpenTelemetry logging backend.
-                              type: object
-                              properties:
-                                attributes:
-                                  description: |-
-                                    Attributes can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: array
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - key
-                                      - value
-                                    type: object
-                                  example:
-                                    - key: mesh
-                                      value: '%KUMA_MESH%'
-                                body:
-                                  description: |-
-                                    Body is a raw string or an OTLP any value as described at
-                                    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                                    It can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  example:
-                                    kvlistValue:
-                                      values:
-                                        - key: mesh
-                                          value:
-                                            stringValue: '%KUMA_MESH%'
-                                  x-kubernetes-preserve-unknown-fields: true
-                                endpoint:
-                                  description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                                  type: string
-                                  example: 'otel-collector:4317'
-                                  minLength: 1
-                              required:
-                                - endpoint
-                            tcp:
-                              description: TCPBackend defines a TCP logging backend.
-                              type: object
-                              properties:
-                                address:
-                                  description: Address of the TCP logging backend
-                                  type: string
-                                  example: '127.0.0.1:5000'
-                                  minLength: 1
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                              required:
-                                - address
                             type:
                               type: string
                               enum:
                                 - Tcp
                                 - File
                                 - OpenTelemetry
-                          required:
-                            - type
-                          type: object
+                          oneOf:
+                            - properties:
+                                type:
+                                  const: Tcp
+                                address:
+                                  type: string
+                              required:
+                                - address
+                            - properties:
+                                type:
+                                  const: File
+                                path:
+                                  type: string
+                              required:
+                                - path
+                            - properties:
+                                type:
+                                  const: OpenTelemetry
+                                endpoint:
+                                  type: string
+                              required:
+                                - endpoint
                   targetRef:
                     description: |-
                       TargetRef is a reference to the resource that represents a group of
@@ -5205,152 +5091,38 @@ components:
                       backends:
                         type: array
                         items:
+                          required:
+                            - type
+                          type: object
                           properties:
-                            file:
-                              description: FileBackend defines configuration for file based access logs
-                              type: object
-                              properties:
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                                path:
-                                  description: Path to a file that logs will be written to
-                                  type: string
-                                  example: /tmp/access.log
-                                  minLength: 1
-                              required:
-                                - path
-                            openTelemetry:
-                              description: Defines an OpenTelemetry logging backend.
-                              type: object
-                              properties:
-                                attributes:
-                                  description: |-
-                                    Attributes can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: array
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - key
-                                      - value
-                                    type: object
-                                  example:
-                                    - key: mesh
-                                      value: '%KUMA_MESH%'
-                                body:
-                                  description: |-
-                                    Body is a raw string or an OTLP any value as described at
-                                    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                                    It can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  example:
-                                    kvlistValue:
-                                      values:
-                                        - key: mesh
-                                          value:
-                                            stringValue: '%KUMA_MESH%'
-                                  x-kubernetes-preserve-unknown-fields: true
-                                endpoint:
-                                  description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                                  type: string
-                                  example: 'otel-collector:4317'
-                                  minLength: 1
-                              required:
-                                - endpoint
-                            tcp:
-                              description: TCPBackend defines a TCP logging backend.
-                              type: object
-                              properties:
-                                address:
-                                  description: Address of the TCP logging backend
-                                  type: string
-                                  example: '127.0.0.1:5000'
-                                  minLength: 1
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                              required:
-                                - address
                             type:
                               type: string
                               enum:
                                 - Tcp
                                 - File
                                 - OpenTelemetry
-                          required:
-                            - type
-                          type: object
+                          oneOf:
+                            - properties:
+                                type:
+                                  const: Tcp
+                                address:
+                                  type: string
+                              required:
+                                - address
+                            - properties:
+                                type:
+                                  const: File
+                                path:
+                                  type: string
+                              required:
+                                - path
+                            - properties:
+                                type:
+                                  const: OpenTelemetry
+                                endpoint:
+                                  type: string
+                              required:
+                                - endpoint
                 required:
                   - default
                 type: object
@@ -5432,152 +5204,38 @@ components:
                       backends:
                         type: array
                         items:
+                          required:
+                            - type
+                          type: object
                           properties:
-                            file:
-                              description: FileBackend defines configuration for file based access logs
-                              type: object
-                              properties:
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                                path:
-                                  description: Path to a file that logs will be written to
-                                  type: string
-                                  example: /tmp/access.log
-                                  minLength: 1
-                              required:
-                                - path
-                            openTelemetry:
-                              description: Defines an OpenTelemetry logging backend.
-                              type: object
-                              properties:
-                                attributes:
-                                  description: |-
-                                    Attributes can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: array
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - key
-                                      - value
-                                    type: object
-                                  example:
-                                    - key: mesh
-                                      value: '%KUMA_MESH%'
-                                body:
-                                  description: |-
-                                    Body is a raw string or an OTLP any value as described at
-                                    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                                    It can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  example:
-                                    kvlistValue:
-                                      values:
-                                        - key: mesh
-                                          value:
-                                            stringValue: '%KUMA_MESH%'
-                                  x-kubernetes-preserve-unknown-fields: true
-                                endpoint:
-                                  description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                                  type: string
-                                  example: 'otel-collector:4317'
-                                  minLength: 1
-                              required:
-                                - endpoint
-                            tcp:
-                              description: TCPBackend defines a TCP logging backend.
-                              type: object
-                              properties:
-                                address:
-                                  description: Address of the TCP logging backend
-                                  type: string
-                                  example: '127.0.0.1:5000'
-                                  minLength: 1
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                              required:
-                                - address
                             type:
                               type: string
                               enum:
                                 - Tcp
                                 - File
                                 - OpenTelemetry
-                          required:
-                            - type
-                          type: object
+                          oneOf:
+                            - properties:
+                                type:
+                                  const: Tcp
+                                address:
+                                  type: string
+                              required:
+                                - address
+                            - properties:
+                                type:
+                                  const: File
+                                path:
+                                  type: string
+                              required:
+                                - path
+                            - properties:
+                                type:
+                                  const: OpenTelemetry
+                                endpoint:
+                                  type: string
+                              required:
+                                - endpoint
                   targetRef:
                     description: |-
                       TargetRef is a reference to the resource that represents a group of
@@ -15688,152 +15346,90 @@ components:
                       backends:
                         type: array
                         items:
-                          properties:
+                          required:
+                            - type
+                          type: object
+                          default:
+                            type: File
                             file:
-                              description: FileBackend defines configuration for file based access logs
-                              type: object
-                              properties:
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                                path:
-                                  description: Path to a file that logs will be written to
-                                  type: string
-                                  example: /tmp/access.log
-                                  minLength: 1
-                              required:
-                                - path
-                            openTelemetry:
-                              description: Defines an OpenTelemetry logging backend.
-                              type: object
-                              properties:
-                                attributes:
-                                  description: |-
-                                    Attributes can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: array
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - key
-                                      - value
-                                    type: object
-                                  example:
-                                    - key: mesh
-                                      value: '%KUMA_MESH%'
-                                body:
-                                  description: |-
-                                    Body is a raw string or an OTLP any value as described at
-                                    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                                    It can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  example:
-                                    kvlistValue:
-                                      values:
-                                        - key: mesh
-                                          value:
-                                            stringValue: '%KUMA_MESH%'
-                                  x-kubernetes-preserve-unknown-fields: true
-                                endpoint:
-                                  description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                                  type: string
-                                  example: 'otel-collector:4317'
-                                  minLength: 1
-                              required:
-                                - endpoint
-                            tcp:
-                              description: TCPBackend defines a TCP logging backend.
-                              type: object
-                              properties:
-                                address:
-                                  description: Address of the TCP logging backend
-                                  type: string
-                                  example: '127.0.0.1:5000'
-                                  minLength: 1
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                              required:
-                                - address
+                              path: ''
+                          properties:
                             type:
                               type: string
                               enum:
                                 - Tcp
                                 - File
                                 - OpenTelemetry
-                          required:
-                            - type
-                          type: object
+                          oneOf:
+                            - title: TCP
+                              type: object
+                              default:
+                                type: Tcp
+                                tcp:
+                                  address: ''
+                              properties:
+                                type:
+                                  const: Tcp
+                                tcp:
+                                  properties:
+                                    address:
+                                      description: Address of the TCP logging backend
+                                      type: string
+                                      example: '127.0.0.1:5000'
+                                      minLength: 1
+                                  required:
+                                    - address
+                            - title: File
+                              type: object
+                              default:
+                                type: File
+                                file:
+                                  path: ''
+                              properties:
+                                type:
+                                  const: File
+                                file:
+                                  description: FileBackend defines configuration for file based access logs
+                                  type: object
+                                  properties:
+                                    path:
+                                      description: Path to a file that logs will be written to
+                                      type: string
+                                      example: /tmp/access.log
+                                      minLength: 1
+                                  required:
+                                    - path
+                            - title: OpenTelemetry
+                              type: object
+                              default:
+                                type: OpenTelemetry
+                                openTelemetry:
+                                  endpoint: ''
+                              properties:
+                                type:
+                                  const: OpenTelemetry
+                                openTelemetry:
+                                  properties:
+                                    body:
+                                      description: |-
+                                        Body is a raw string or an OTLP any value as described at
+                                        https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                        It can contain placeholders available on
+                                        https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                      example:
+                                        kvlistValue:
+                                          values:
+                                            - key: mesh
+                                              value:
+                                                stringValue: '%KUMA_MESH%'
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    endpoint:
+                                      description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                      type: string
+                                      example: 'otel-collector:4317'
+                                      minLength: 1
+                                  required:
+                                    - endpoint
                   targetRef:
                     description: |-
                       TargetRef is a reference to the resource that represents a group of
@@ -15893,152 +15489,90 @@ components:
                       backends:
                         type: array
                         items:
-                          properties:
+                          required:
+                            - type
+                          type: object
+                          default:
+                            type: File
                             file:
-                              description: FileBackend defines configuration for file based access logs
-                              type: object
-                              properties:
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                                path:
-                                  description: Path to a file that logs will be written to
-                                  type: string
-                                  example: /tmp/access.log
-                                  minLength: 1
-                              required:
-                                - path
-                            openTelemetry:
-                              description: Defines an OpenTelemetry logging backend.
-                              type: object
-                              properties:
-                                attributes:
-                                  description: |-
-                                    Attributes can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: array
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - key
-                                      - value
-                                    type: object
-                                  example:
-                                    - key: mesh
-                                      value: '%KUMA_MESH%'
-                                body:
-                                  description: |-
-                                    Body is a raw string or an OTLP any value as described at
-                                    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                                    It can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  example:
-                                    kvlistValue:
-                                      values:
-                                        - key: mesh
-                                          value:
-                                            stringValue: '%KUMA_MESH%'
-                                  x-kubernetes-preserve-unknown-fields: true
-                                endpoint:
-                                  description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                                  type: string
-                                  example: 'otel-collector:4317'
-                                  minLength: 1
-                              required:
-                                - endpoint
-                            tcp:
-                              description: TCPBackend defines a TCP logging backend.
-                              type: object
-                              properties:
-                                address:
-                                  description: Address of the TCP logging backend
-                                  type: string
-                                  example: '127.0.0.1:5000'
-                                  minLength: 1
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                              required:
-                                - address
+                              path: ''
+                          properties:
                             type:
                               type: string
                               enum:
                                 - Tcp
                                 - File
                                 - OpenTelemetry
-                          required:
-                            - type
-                          type: object
+                          oneOf:
+                            - title: TCP
+                              type: object
+                              default:
+                                type: Tcp
+                                tcp:
+                                  address: ''
+                              properties:
+                                type:
+                                  const: Tcp
+                                tcp:
+                                  properties:
+                                    address:
+                                      description: Address of the TCP logging backend
+                                      type: string
+                                      example: '127.0.0.1:5000'
+                                      minLength: 1
+                                  required:
+                                    - address
+                            - title: File
+                              type: object
+                              default:
+                                type: File
+                                file:
+                                  path: ''
+                              properties:
+                                type:
+                                  const: File
+                                file:
+                                  description: FileBackend defines configuration for file based access logs
+                                  type: object
+                                  properties:
+                                    path:
+                                      description: Path to a file that logs will be written to
+                                      type: string
+                                      example: /tmp/access.log
+                                      minLength: 1
+                                  required:
+                                    - path
+                            - title: OpenTelemetry
+                              type: object
+                              default:
+                                type: OpenTelemetry
+                                openTelemetry:
+                                  endpoint: ''
+                              properties:
+                                type:
+                                  const: OpenTelemetry
+                                openTelemetry:
+                                  properties:
+                                    body:
+                                      description: |-
+                                        Body is a raw string or an OTLP any value as described at
+                                        https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                        It can contain placeholders available on
+                                        https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                      example:
+                                        kvlistValue:
+                                          values:
+                                            - key: mesh
+                                              value:
+                                                stringValue: '%KUMA_MESH%'
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    endpoint:
+                                      description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                      type: string
+                                      example: 'otel-collector:4317'
+                                      minLength: 1
+                                  required:
+                                    - endpoint
                 required:
                   - default
                 type: object
@@ -16098,152 +15632,90 @@ components:
                       backends:
                         type: array
                         items:
-                          properties:
+                          required:
+                            - type
+                          type: object
+                          default:
+                            type: File
                             file:
-                              description: FileBackend defines configuration for file based access logs
-                              type: object
-                              properties:
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                                path:
-                                  description: Path to a file that logs will be written to
-                                  type: string
-                                  example: /tmp/access.log
-                                  minLength: 1
-                              required:
-                                - path
-                            openTelemetry:
-                              description: Defines an OpenTelemetry logging backend.
-                              type: object
-                              properties:
-                                attributes:
-                                  description: |-
-                                    Attributes can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: array
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - key
-                                      - value
-                                    type: object
-                                  example:
-                                    - key: mesh
-                                      value: '%KUMA_MESH%'
-                                body:
-                                  description: |-
-                                    Body is a raw string or an OTLP any value as described at
-                                    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
-                                    It can contain placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  example:
-                                    kvlistValue:
-                                      values:
-                                        - key: mesh
-                                          value:
-                                            stringValue: '%KUMA_MESH%'
-                                  x-kubernetes-preserve-unknown-fields: true
-                                endpoint:
-                                  description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
-                                  type: string
-                                  example: 'otel-collector:4317'
-                                  minLength: 1
-                              required:
-                                - endpoint
-                            tcp:
-                              description: TCPBackend defines a TCP logging backend.
-                              type: object
-                              properties:
-                                address:
-                                  description: Address of the TCP logging backend
-                                  type: string
-                                  example: '127.0.0.1:5000'
-                                  minLength: 1
-                                format:
-                                  description: |-
-                                    Format of access logs. Placeholders available on
-                                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
-                                  type: object
-                                  properties:
-                                    json:
-                                      type: array
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - key
-                                          - value
-                                        type: object
-                                      example:
-                                        - key: start_time
-                                          value: '%START_TIME%'
-                                        - key: bytes_received
-                                          value: '%BYTES_RECEIVED%'
-                                    omitEmptyValues:
-                                      type: boolean
-                                      default: false
-                                    plain:
-                                      type: string
-                                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
-                                    type:
-                                      type: string
-                                      enum:
-                                        - Plain
-                                        - Json
-                                  required:
-                                    - type
-                              required:
-                                - address
+                              path: ''
+                          properties:
                             type:
                               type: string
                               enum:
                                 - Tcp
                                 - File
                                 - OpenTelemetry
-                          required:
-                            - type
-                          type: object
+                          oneOf:
+                            - title: TCP
+                              type: object
+                              default:
+                                type: Tcp
+                                tcp:
+                                  address: ''
+                              properties:
+                                type:
+                                  const: Tcp
+                                tcp:
+                                  properties:
+                                    address:
+                                      description: Address of the TCP logging backend
+                                      type: string
+                                      example: '127.0.0.1:5000'
+                                      minLength: 1
+                                  required:
+                                    - address
+                            - title: File
+                              type: object
+                              default:
+                                type: File
+                                file:
+                                  path: ''
+                              properties:
+                                type:
+                                  const: File
+                                file:
+                                  description: FileBackend defines configuration for file based access logs
+                                  type: object
+                                  properties:
+                                    path:
+                                      description: Path to a file that logs will be written to
+                                      type: string
+                                      example: /tmp/access.log
+                                      minLength: 1
+                                  required:
+                                    - path
+                            - title: OpenTelemetry
+                              type: object
+                              default:
+                                type: OpenTelemetry
+                                openTelemetry:
+                                  endpoint: ''
+                              properties:
+                                type:
+                                  const: OpenTelemetry
+                                openTelemetry:
+                                  properties:
+                                    body:
+                                      description: |-
+                                        Body is a raw string or an OTLP any value as described at
+                                        https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                                        It can contain placeholders available on
+                                        https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                                      example:
+                                        kvlistValue:
+                                          values:
+                                            - key: mesh
+                                              value:
+                                                stringValue: '%KUMA_MESH%'
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    endpoint:
+                                      description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                                      type: string
+                                      example: 'otel-collector:4317'
+                                      minLength: 1
+                                  required:
+                                    - endpoint
                   targetRef:
                     description: |-
                       TargetRef is a reference to the resource that represents a group of

--- a/packages/kuma-http-api/src/components/schemas/MeshAccessLogItem_Put_RequestBody.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshAccessLogItem_Put_RequestBody.overlay.yaml
@@ -24,3 +24,180 @@ actions:
           kind: MeshService
         default:
           backends: []
+
+  - target: '$..backends.items.properties'
+    remove: true
+  # Update all backends.items locations using recursive descent
+  - target: '$..backends.items'
+    update:
+      default:
+        type: File
+        file:
+          path: ''
+  - target: '$..backends.items'
+    update:
+      properties:
+        type:
+          type: string
+          enum: [Tcp, File, OpenTelemetry]
+      oneOf:
+        - title: TCP
+          type: object
+          default:
+            type: Tcp
+            tcp:
+              address: ''
+          properties:
+            type: { const: Tcp }
+            tcp:
+              properties:
+                address:
+                  description: Address of the TCP logging backend
+                  type: string
+                  example: '127.0.0.1:5000'
+                  minLength: 1
+                format:
+                  readOnly: true # temporary to hide this property form the form
+                  description: |-
+                    Format of access logs. Placeholders available on
+                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                  type: object
+                  properties:
+                    json:
+                      type: array
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                          - key
+                          - value
+                        type: object
+                      example:
+                        - key: start_time
+                          value: '%START_TIME%'
+                        - key: bytes_received
+                          value: '%BYTES_RECEIVED%'
+                    omitEmptyValues:
+                      type: boolean
+                      default: false
+                    plain:
+                      type: string
+                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                    type:
+                      type: string
+                      enum:
+                        - Plain
+                        - Json
+                  required:
+                    - type
+              required:
+                - address
+        - title: File
+          type: object
+          default:
+            type: File
+            file:
+              path: ''
+          properties:
+            type: { const: File }
+            file:
+              description: FileBackend defines configuration for file based access logs
+              type: object
+              properties:
+                format:
+                  readOnly: true # temporary to hide this property form the form
+                  description: |-
+                    Format of access logs. Placeholders available on
+                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                  type: object
+                  properties:
+                    json:
+                      type: array
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                          - key
+                          - value
+                        type: object
+                      example:
+                        - key: start_time
+                          value: '%START_TIME%'
+                        - key: bytes_received
+                          value: '%BYTES_RECEIVED%'
+                    omitEmptyValues:
+                      type: boolean
+                      default: false
+                    plain:
+                      type: string
+                      example: '[%START_TIME%] %KUMA_MESH% %UPSTREAM_HOST%'
+                    type:
+                      type: string
+                      enum:
+                        - Plain
+                        - Json
+                  required:
+                    - type
+                path:
+                  description: Path to a file that logs will be written to
+                  type: string
+                  example: /tmp/access.log
+                  minLength: 1
+              required:
+                - path
+        - title: OpenTelemetry
+          type: object
+          default:
+            type: OpenTelemetry
+            openTelemetry:
+              endpoint: ''
+          properties:
+            type: { const: OpenTelemetry }
+            openTelemetry:
+              properties:
+                attributes:
+                  readOnly: true # temporary to hide this property form the form
+                  description: |-
+                    Attributes can contain placeholders available on
+                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                  type: array
+                  items:
+                    properties:
+                      key:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                      - key
+                      - value
+                    type: object
+                  example:
+                    - key: mesh
+                      value: '%KUMA_MESH%'
+                body:
+                  description: |-
+                    Body is a raw string or an OTLP any value as described at
+                    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body
+                    It can contain placeholders available on
+                    https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
+                  example:
+                    kvlistValue:
+                      values:
+                        - key: mesh
+                          value:
+                            stringValue: '%KUMA_MESH%'
+                  x-kubernetes-preserve-unknown-fields: true
+                endpoint:
+                  description: Endpoint of OpenTelemetry collector. An empty port defaults to 4317.
+                  type: string
+                  example: 'otel-collector:4317'
+                  minLength: 1
+              required:
+                - endpoint
+


### PR DESCRIPTION
This is a bit of a strange PR in that we can't move to "owning" the entire schema for our policies, but I do what one policy here for experimentation and illustration of what sort of thing we need.

This PR specifically adds a `oneOf` schema to `MeshAccessLog.backends`

Additional I've marked some fields as `readOnly`.

---

Just to underline again, this config is temporary, please ping me offline if there are questions/concerns around this