### PR TITLE
fix: copy buttons should copy name, not name.namespace/slug

### DIFF
--- a/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshExternalServiceDetailTabsView.vue
@@ -41,7 +41,7 @@
           <h1
             v-if="data"
           >
-            <XCopyButton :text="route.params.service">
+            <XCopyButton :text="data.name">
               <RouteTitle
                 :title="t('services.routes.item.title', { name: data.name })"
               />

--- a/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshMultiZoneServiceDetailTabsView.vue
@@ -41,7 +41,7 @@
           <h1
             v-if="data"
           >
-            <XCopyButton :text="route.params.service">
+            <XCopyButton :text="data.name">
               <RouteTitle
                 :title="t('services.routes.item.title', { name: data.name })"
               />

--- a/packages/kuma-gui/src/app/services/views/MeshServiceDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/services/views/MeshServiceDetailTabsView.vue
@@ -43,7 +43,7 @@
             size="small"
           >
             <h1>
-              <XCopyButton :text="route.params.service">
+              <XCopyButton :text="data.name">
                 <RouteTitle
                   :title="t('services.routes.item.title', { name: data.name })"
                 />

--- a/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
+++ b/packages/kuma-gui/src/app/zones/views/ZoneDetailTabsView.vue
@@ -38,9 +38,9 @@
                 </XIcon>
               </template>
               <h1>
-                <XCopyButton :text="route.params.zone">
+                <XCopyButton :text="data.name">
                   <RouteTitle
-                    :title="t('zone-cps.routes.item.title', { name: route.params.zone })"
+                    :title="t('zone-cps.routes.item.title', { name: data.name })"
                   />
                 </XCopyButton>
               </h1>

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_layout.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_layout.ts
@@ -11,7 +11,7 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
 
   const parts = String(name).split('.')
   const displayName = parts.slice(0, -1).join('.')
-  const nspace = parts.pop()
+  const nspace = parts.at(-1) ?? ''
 
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
   // use seed to sync the ports in stats.ts with the ports in _overview.ts

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_rules.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/_rules.ts
@@ -29,7 +29,7 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
 
   const parts = String(name).split('.')
   const displayName = parts.slice(0, -1).join('.')
-  const nspace = parts.pop()
+  const nspace = parts.at(-1) ?? ''
 
   return {
     headers: {},

--- a/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/stats.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/dataplanes/_/stats.ts
@@ -3,7 +3,7 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const { name, mesh } = req.params
   const parts = String(name).split('.')
   const displayName = parts.slice(0, -1).join('.')
-  const nspace = parts.pop()
+  const nspace = parts.at(-1) ?? ''
 
   const isUnifiedResourceNamingEnabled = env('KUMA_DATAPLANE_RUNTIME_UNIFIED_RESOURCE_NAMING_ENABLED', '') === 'true'
   // use seed to sync the ports in stats.ts with the ports in _overview.ts

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshexternalservices/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshexternalservices/_.ts
@@ -9,14 +9,14 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const [
     mesh = req.params.mesh as string,
     _zone,
-    _namespace,
+    ns,
     name = req.params.name as string,
   ] = kri?.split('_') ?? ''
 
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
   const parts = String(name).split('.')
   const displayName = parts.slice(0, -1).join('.')
-  const nspace = parts.pop() ?? ''
+  const nspace = ns ?? parts.at(-1) ?? ''
 
   return {
     headers: {},

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshfaultinjections/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshfaultinjections/_.ts
@@ -4,13 +4,14 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const [
     mesh = req.params.mesh as string,
     _zone,
-    _namespace,
+    ns,
     name = req.params.name as string,
   ] = kri?.split('_') ?? ''
+
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
   const parts = String(name).split('.')
   const displayName = parts.slice(0, -1).join('.')
-  const nspace = parts.pop()
+  const nspace = ns ?? parts.at(-1) ?? ''
 
   return {
     headers: {},

--- a/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/_.ts
+++ b/packages/kuma-http-api/mocks/src/meshes/_/meshgateways/_.ts
@@ -6,7 +6,7 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const [
     mesh = req.params.mesh as string,
     _zone,
-    _namespace,
+    ns,
     name = req.params.name as string,
   ] = kri?.split('_') ?? ''
   const listenerCount = parseInt(env('KUMA_LISTENER_COUNT', `${fake.number.int({ min: 1, max: 3 })}`))
@@ -14,7 +14,7 @@ export default ({ env, fake }: Dependencies): ResponseHandler => (req) => {
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
   const parts = String(name).split('.')
   const displayName = parts.slice(0, -1).join('.')
-  const nspace = parts.pop()
+  const nspace = ns ?? parts.at(-1) ?? ''
 
   return {
     headers: {},

--- a/packages/kuma-http-api/mocks/src/zone-ingresses/_/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/zone-ingresses/_/_overview.ts
@@ -4,13 +4,8 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
   const k8s = env('KUMA_ENVIRONMENT', 'universal') === 'kubernetes'
 
   const parts = String(name).split('.')
-  let displayName = parts.slice(0, -1).join('.')
-  let nspace = parts.pop()
-
-  if (displayName.length === 0) {
-    displayName = String(nspace)
-    nspace = ''
-  }
+  const displayName = parts.slice(0, -1).join('.')
+  const nspace = parts.at(-1) ?? ''
 
   const zoneName = fake.word.noun()
 

--- a/packages/kuma-http-api/mocks/src/zoneegresses/_/_overview.ts
+++ b/packages/kuma-http-api/mocks/src/zoneegresses/_/_overview.ts
@@ -5,7 +5,7 @@ export default ({ fake, env }: Dependencies): ResponseHandler => (req) => {
 
   const parts = String(name).split('.')
   const displayName = parts.slice(0, -1).join('.')
-  const nspace = parts.pop()
+  const nspace = parts.at(-1) ?? ''
 
   const zoneName = fake.word.noun()
 


### PR DESCRIPTION
Closes https://github.com/kumahq/kuma-gui/issues/4336

The main issue here was that there were certain areas in the GUI that were using the URL slug as the "thing to copy" rather than the name from the responses data.

While I was here I also fixed/standardised how our mocks infer name/namespace by using an immutable `.at(-1)` rather than a mutating `pop`.