### PR TITLE
fix(dataplanes): don't show tp info for builtin gateway

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/features.ts
+++ b/packages/kuma-gui/src/app/data-planes/features.ts
@@ -4,9 +4,15 @@ import type { Features } from '@kumahq/settings/can'
 export const features = () => {
   return {
     'use transparent-proxying': (_can: unknown, dataplaneOverview: DataplaneOverview) => {
-      // TODO: `dataplane.networking.transparentProxying` is deprecated and will be removed soon. Still checking for users that still use it.
-      return ('transparentProxying' in dataplaneOverview.dataplane.networking) ||
-        new Set(dataplaneOverview.dataplaneInsight.metadata.features).intersection(new Set(['feature-transparent-proxy-in-dataplane-metadata', 'feature-bind-outbounds'])).size > 0
+      switch(true) {
+        case dataplaneOverview.dataplane.networking.gateway?.type === 'BUILTIN':
+          return false
+        // TODO: `dataplane.networking.transparentProxying` is deprecated and will be removed soon. Still checking for users that still use it.
+        case 'transparentProxying' in dataplaneOverview.dataplane.networking:
+          return true
+        case new Set(dataplaneOverview.dataplaneInsight.metadata.features).intersection(new Set(['feature-transparent-proxy-in-dataplane-metadata', 'feature-bind-outbounds'])).size > 0:
+          return true
+      }
     },
     'use unified-resource-naming': (_can: unknown, { dataplaneOverview, mesh }: { dataplaneOverview: DataplaneOverview, mesh: Mesh }) => {
       return mesh.meshServices.mode === 'Exclusive' && dataplaneOverview.dataplaneType === 'standard' && dataplaneOverview.dataplaneInsight.metadata.features.includes('feature-unified-resource-naming')

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneDetailView.vue
@@ -49,7 +49,7 @@
             key: 'no-mtls',
           },
           {
-            bool: !can('use transparent-proxying', props.data),
+            bool: props.data.dataplane.networking.gateway?.type !== 'BUILTIN' && !can('use transparent-proxying', props.data),
             key: 'networking-transparent-proxying',
             variant: 'info' as const,
           },


### PR DESCRIPTION
Closes https://github.com/kumahq/kuma-gui/issues/4356

Disables message for builtin gateways only.

The conditional change here is a bit weird as I wanted to ge the wording/functionality right.

Built in gateways can't use transparent proxy so I added that to the feature conditional i.e. `can('use transparent-proxy') === false`, but in this case we don't want to show a message for built-in gateways, so I added the conditional in two places to reflect the intention here.