### PR TITLE
feat(dataplanes): show a danger icon when cert is expired

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -235,7 +235,7 @@
                 >
                   <XIcon
                     v-if="warnings.length > 0"
-                    name="warning"
+                    :name="item.isCertExpired ? 'danger': 'warning'"
                     data-testid="warning"
                   >
                     <ul>


### PR DESCRIPTION
If a warning includes a cert expired warning icon/tooltips now show as a red danger icon rather than yellow warning

<img width="1519" height="872" alt="Screenshot 2025-12-02 at 15 02 41" src="https://github.com/user-attachments/assets/ec37243e-0da9-4e82-bcd6-b895befaf643" />

Closes https://github.com/kumahq/kuma-gui/issues/4376
