### PR TITLE
fix(dataplanes): copy over entire dataplane resource to config

### DIFF
--- a/packages/kuma-gui/src/app/data-planes/data/Dataplane.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/Dataplane.ts
@@ -1,17 +1,16 @@
 import { DataplaneNetworking } from './DataplaneNetworking'
-import type {
-  DataPlane as PartialDataplane,
-} from '@/types/index.d'
-export type Dataplane = PartialDataplane & {
-  config: PartialDataplane
-  networking: DataplaneNetworking
-}
+import type { components } from '@kumahq/kuma-http-api'
+
+type KumaDataplane = NonNullable<components['schemas']['DataplaneItem']>
+type KumaDataplaneNetworking = NonNullable<components['schemas']['DataplaneItem']['networking']>
+
 export const Dataplane = {
-  fromObject(partialDataplane: PartialDataplane): Dataplane {
+  fromObject(partialDataplane: KumaDataplane) {
     return {
       ...partialDataplane,
       config: partialDataplane,
-      networking: DataplaneNetworking.fromObject(partialDataplane.networking),
+      networking: DataplaneNetworking.fromObject(partialDataplane.networking as KumaDataplaneNetworking),
     }
   },
 }
+export type Dataplane = ReturnType<typeof Dataplane['fromObject']>

--- a/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/DataplaneNetworking.ts
@@ -1,35 +1,12 @@
 import { Kri } from '@/app/kuma'
-import type {
-  DataplaneGateway as PartialDataplaneGateway,
-  DataplaneInbound as PartialDataplaneInbound,
-  DataplaneNetworking as PartialDataplaneNetworking,
-} from '@/types/index.d'
 import type { components } from '@kumahq/kuma-http-api'
 
-
-type Connection = {
-  name: string
-  service: string
-  protocol: string
-}
-export type DataplaneInbound = PartialDataplaneInbound & Connection & {
-  address: string
-  state: NonNullable<PartialDataplaneInbound['state']>
-  addressPort: string
-  serviceAddressPort: string
-  socketAddress: string
-  listenerAddress: string
-  portName: string
-  clusterName: string
-}
-type PartialDataplaneOutbound = NonNullable<NonNullable<NonNullable<components['schemas']['DataplaneOverviewWithMeta']['dataplane']>['networking']>['outbound']>[number]
-
-export type DataplaneGateway = PartialDataplaneGateway & {}
-
-type PartialDataplaneNetworkingLayout = components['schemas']['DataplaneNetworkingLayout']
+type KumaDataplaneNetworking = NonNullable<components['schemas']['DataplaneItem']['networking']>
+type KumaDataplaneOutbound = NonNullable<NonNullable<NonNullable<components['schemas']['DataplaneOverviewWithMeta']['dataplane']>['networking']>['outbound']>[number]
+type KumaDataplaneNetworkingLayout = components['schemas']['DataplaneNetworkingLayout']
 
 export const DataplaneNetworkingLayout = {
-  fromObject(dataplaneNetworkingLayout: PartialDataplaneNetworkingLayout) {
+  fromObject(dataplaneNetworkingLayout: KumaDataplaneNetworkingLayout) {
     // `stat_prefix` corresponds to the stat_prefix used in the Envoy stats.
     // proxyResourceName.sectionName can either be a portName or port, so we
     // make sure its always the port as this is what the Envoy stat_prefix
@@ -55,13 +32,12 @@ export const DataplaneNetworkingLayout = {
           portName: kri.sectionName !== String(item.port) ? kri.sectionName : undefined,
         }
       }),
-    } satisfies PartialDataplaneNetworkingLayout
+    } satisfies KumaDataplaneNetworkingLayout
   },
 }
-export type DataplaneNetworkingLayout = ReturnType<typeof DataplaneNetworkingLayout.fromObject>
 
 const DataplaneOutbound = {
-  fromObject(item: PartialDataplaneOutbound) {
+  fromObject(item: KumaDataplaneOutbound) {
     const address = item.address ?? '127.0.0.1'
     const tags = item.tags ?? {}
     return {
@@ -74,21 +50,14 @@ const DataplaneOutbound = {
       addressPort: `${address}${typeof item.port === 'number' ? `:${item.port}` : ''}`,
     }
   },
-  fromCollection(items: PartialDataplaneOutbound[]) {
+  fromCollection(items: KumaDataplaneOutbound[]) {
     return Array.isArray(items) ? items.map(item => DataplaneOutbound.fromObject(item)) : []
   },
 }
-export type DataplaneOutbound = ReturnType<typeof DataplaneOutbound.fromObject>
 
-export type DataplaneNetworking = Omit<PartialDataplaneNetworking, 'inbound' | 'outbound'> & {
-  inboundAddress: string
-  inbounds: DataplaneInbound[]
-  outbounds: DataplaneOutbound[]
-  type: 'sidecar' | 'gateway'
-}
 
 export const DataplaneNetworking = {
-  fromObject(networking: PartialDataplaneNetworking): DataplaneNetworking {
+  fromObject(networking: KumaDataplaneNetworking) {
     // remove singular inbound/outbound to be replaced with plural versions
     const { inbound, outbound, ...rest } = networking
 
@@ -98,22 +67,29 @@ export const DataplaneNetworking = {
     // proxying
     const outbounds = Array.isArray(outbound) ? outbound : []
     const type = typeof networking.gateway === 'undefined' || networking.gateway?.type !== 'BUILTIN' ? 'sidecar' : 'gateway'
+
     return {
       ...rest,
-      type,
+      ...(networking.gateway ? {
+        gateway: {
+          ...networking.gateway,
+          tags: networking.gateway.tags ?? {},
+        },
+      } : {}),
+      type: type as 'sidecar' | 'gateway',
       // used for a lookup for inbounds on the result of the envoy /stats endpoint
-      inboundAddress: type === 'gateway' ? networking.address : 'localhost',
+      inboundAddress: type === 'gateway' ? networking.address ?? 'localhost' : 'localhost',
       //
       // if we are a builtin gateway fill in as much as we can for a single inbound
       // we can 'clone' this later if we find out individual information for each inbound
       // i.e. this acts as a template
       inbounds: type === 'gateway' && typeof networking.gateway !== 'undefined'
-        ? [{
-          address: networking.address,
-          tags: networking.gateway.tags,
-          name: networking.gateway.tags['kuma.io/service'],
-          service: networking.gateway.tags['kuma.io/service'],
-          protocol: networking.gateway.tags['kuma.io/protocol'] ?? 'tcp',
+        ? ((tags = {}) => [{
+          address: networking.address ?? '',
+          tags,
+          name: tags['kuma.io/service'] ?? '',
+          service: tags['kuma.io/service'] ?? '',
+          protocol: tags['kuma.io/protocol'] ?? 'tcp',
           state: 'Ready',
           // these could be filled out during 'cloning'
           // i.e. these are like template variables to be filled out
@@ -128,24 +104,27 @@ export const DataplaneNetworking = {
           // not available for gateway
           portName: '',
           clusterName: '',
-        }]
+        }])(networking.gateway.tags)
         : inbounds.map((item) => {
           // inbound address, advertisedAddress, networkingAddress because externally accessible address
-          const address = item.address ?? networking.advertisedAddress ?? networking.address
+          const address = item.address ?? networking.advertisedAddress ?? networking.address ?? ''
           const name = `localhost_${item.port}`
+          const tags = item.tags ?? {}
           return {
             ...item,
+            tags,
             // the name can be used to lookup listener envoy stats
             name,
+            port: Number(item.port),
             // the portName adds another way of referencing the port, usable with MeshService
             portName: item.name?.length ? item.name : '',
             socketAddress: `${address}_${item.port}`,
             listenerAddress: `${address}_${item.port}`,
             clusterName: item.servicePort && item.servicePort !== item.port ? `localhost_${item.servicePort}` : name,
             // If a health property is unset the inbound is considered healthy
-            state: typeof item.state !== 'undefined' ? item.state : 'Ready',
-            service: item.tags['kuma.io/service'],
-            protocol: item.tags['kuma.io/protocol'] ?? 'tcp',
+            state: (typeof item.state !== 'undefined' ? String(item.state) : 'Ready'),
+            service: tags['kuma.io/service'] ?? '',
+            protocol: tags['kuma.io/protocol'] ?? 'tcp',
             address,
             addressPort: `${address}:${item.port}`,
             // inbound serviceAddress, inbound address, networkingAddress because the internal services accessible address
@@ -156,3 +135,8 @@ export const DataplaneNetworking = {
     }
   },
 }
+export type DataplaneNetworkingLayout = ReturnType<typeof DataplaneNetworkingLayout['fromObject']>
+export type DataplaneOutbound = ReturnType<typeof DataplaneOutbound['fromObject']>
+export type DataplaneNetworking = ReturnType<typeof DataplaneNetworking['fromObject']>
+export type DataplaneInbound = DataplaneNetworking['inbounds'][number]
+

--- a/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
+++ b/packages/kuma-gui/src/app/data-planes/data/index.spec.ts
@@ -36,7 +36,7 @@ describe('Dataplane', () => {
       'absent inbound, inbounds remains defined',
       async ({ fixture }) => {
         const actual = await fixture.setup((item) => {
-          delete item.networking.inbound
+          delete item.networking?.inbound
           return item
         })
         expect(actual.networking.inbounds).toBeDefined()
@@ -61,7 +61,7 @@ describe('Dataplane', () => {
       'absent outbound, outbounds remains defined',
       async ({ fixture }) => {
         const actual = await fixture.setup((item) => {
-          delete item.networking.outbound
+          delete item.networking?.outbound
           return item
         })
         expect(actual.networking.outbounds).toBeDefined()

--- a/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
+++ b/packages/kuma-gui/src/app/legacy-data-planes/views/DataPlaneDetailView.vue
@@ -395,7 +395,7 @@
                     // the envoy admin inbound that is used for kumas /stats API. Ignore
                     // the envoy admin inbound when we find it
                     const port = key.split('_').at(-1)
-                    if (port === (props.data.dataplane.networking.admin?.port ?? '9901')) {
+                    if (port === String(props.data.dataplane.networking.admin?.port ?? 9901)) {
                       return prev
                     }
                     return prev.concat([


### PR DESCRIPTION
Closes https://github.com/kumahq/kuma-gui/issues/4383

The most important part of this is splatting down the entire `DataplaneOverview.dataplane` object instead of just `DataplaneOverview.dataplane.networking` and then copying over the labels from `DataplaneOverview`.

There is a bunch of TS work here also, which then meant I had to add some sane defaults to a few fields. There is nothing here that is removing anything though, only adding defaults (usually this is because our types for these protobuf types are mostly Partials when they shouldn't be)


### Before

<img width="1698" height="994" alt="Screenshot 2025-12-03 at 14 13 06" src="https://github.com/user-attachments/assets/70dc63a1-c2bb-47ee-bea2-9d6b58411a73" />

### After

<img width="1698" height="1135" alt="Screenshot 2025-12-03 at 14 12 05" src="https://github.com/user-attachments/assets/706aeb9e-68f3-49cc-b677-140e0cb235ba" />

