### PR TITLE
feat(data-planes/list): show cert info in case of SPIRE

### DIFF
--- a/packages/kuma-gui/features/mesh/dataplanes/Index.feature
+++ b/packages/kuma-gui/features/mesh/dataplanes/Index.feature
@@ -83,8 +83,7 @@ Feature: mesh / dataplanes / index
                       kuma.io/service: !!js/undefined
                     state: Ready
             dataplaneInsight:
-              mTLS:
-                certificateExpirationTime: !!js/undefined
+              mTLS: <mTLS>
               subscriptions:
                 - connectTime: 2021-02-17T07:33:36.412683Z
                   disconnectTime: 2021-02-17T07:33:36.412683Z
@@ -92,10 +91,16 @@ Feature: mesh / dataplanes / index
     When I visit the "/meshes/default/data-planes" URL
     Then the "$service-cell" element is empty
     Then the "$item:nth-child(1)" element contains
-      | Value          |
-      | dpp-2          |
-      | No certificate |
-      | Offline        |
+      | Value         |
+      | dpp-2         |
+      | <mTLSColText> |
+      | Offline       |
+
+    Examples:
+      | mTLS                                                | mTLSColText          |
+      | !!js/undefined                                      | No certificate       |
+      | { certificateExpirationTime: !!js/undefined }       | Externally managed   |
+      | { certificateExpirationTime: 2023-11-03T09:10:17Z } | Nov 3, 2023, 9:10 AM |
 
   Scenario: Searching by tag doesn't overwrite the existing service tag
     When I visit the "/meshes/default/data-planes" URL

--- a/packages/kuma-gui/features/mesh/legacy-dataplanes/Index.feature
+++ b/packages/kuma-gui/features/mesh/legacy-dataplanes/Index.feature
@@ -83,8 +83,7 @@ Feature: mesh / dataplanes / index
                       kuma.io/service: !!js/undefined
                     state: Ready
             dataplaneInsight:
-              mTLS:
-                certificateExpirationTime: !!js/undefined
+              mTLS: <mTLS>
               subscriptions:
                 - connectTime: 2021-02-17T07:33:36.412683Z
                   disconnectTime: 2021-02-17T07:33:36.412683Z
@@ -92,10 +91,16 @@ Feature: mesh / dataplanes / index
     When I visit the "/meshes/default/data-planes" URL
     Then the "$service-cell" element is empty
     Then the "$item:nth-child(1)" element contains
-      | Value          |
-      | dpp-2          |
-      | No certificate |
-      | Offline        |
+      | Value         |
+      | dpp-2         |
+      | <mTLSColText> |
+      | Offline       |
+
+    Examples:
+      | mTLS                                                | mTLSColText          |
+      | !!js/undefined                                      | No certificate       |
+      | { certificateExpirationTime: !!js/undefined }       | Externally managed   |
+      | { certificateExpirationTime: 2023-11-03T09:10:17Z } | Nov 3, 2023, 9:10 AM |
 
   Scenario: Searching by tag doesn't overwrite the existing service tag
     When I visit the "/meshes/default/data-planes" URL

--- a/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
+++ b/packages/kuma-gui/src/app/data-planes/locales/en-us/index.yaml
@@ -152,6 +152,8 @@ data-planes:
         dp-cp-incompatible: Version mismatch
         certificate-expires-soon: Certificate expires soon
         certificate-expired: Certificate expired
+      mtls:
+        managed_externally: Externally managed
   href:
     docs:
       data_plane_proxy: '{KUMA_DOCS_URL}/production/dp-config/dpp?{KUMA_UTM_QUERY_PARAMS}'

--- a/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
+++ b/packages/kuma-gui/src/app/data-planes/views/DataPlaneListView.vue
@@ -200,12 +200,21 @@
               </template>
 
               <template #certificate="{ row }">
-                <template v-if="row.dataplaneInsight.mTLS?.certificateExpirationTime">
-                  {{ t('common.formats.datetime', { value: Date.parse(row.dataplaneInsight.mTLS.certificateExpirationTime) }) }}
-                </template>
+                <template
+                  v-for="mTLS in [row.dataplaneInsight.mTLS]"
+                  :key="typeof mTLS"
+                >
+                  <template v-if="mTLS?.certificateExpirationTime">
+                    {{ t('common.formats.datetime', { value: Date.parse(mTLS.certificateExpirationTime) }) }}
+                  </template>
 
-                <template v-else>
-                  {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                  <template v-else-if="mTLS">
+                    {{ t('data-planes.routes.items.mtls.managed_externally') }}
+                  </template>
+
+                  <template v-else>
+                    {{ t('data-planes.components.data-plane-list.certificate.none') }}
+                  </template>
                 </template>
               </template>
 


### PR DESCRIPTION
In case of SPIRE the certificate is managed externally, which is indicated by existing `dataplaneInsight.mTLS` but without any expiration times (only `certificateRegenerations` and `issuedBackend` which is a KRI of a MeshIdentity). In case we can't show an `certificateExpirationTime` but `mTLS` is defined we now show `Externally managed`. Only in case `mTLS` is undefined we show `No certificate`.

Closes https://github.com/kumahq/kuma-gui/issues/4384