### PR TITLE
fix(deps): remove majority of renovate grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,26 +38,6 @@
       "dependencyDashboardApproval": true
     },
     {
-      "groupName": "patch",
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "minimumReleaseAge": "3 days"
-    },
-    {
-      "groupName": "minor",
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "minimumReleaseAge": "3 days"
-    },
-    {
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "minimumReleaseAge": "3 days"
-    },
-    {
       "matchPackageNames": [
         "npm",
         "escape-string-regexp"
@@ -70,32 +50,6 @@
         "node"
       ],
       "dependencyDashboardApproval": true
-    },
-    {
-      "groupName": "@kong patches",
-      "matchPackageNames": [
-        "@kong**/**"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "minimumReleaseAge": "0"
-    },
-    {
-      "groupName": "@kong minors",
-      "matchPackageNames": [
-        "@kong**/**"
-      ],
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "minimumReleaseAge": "0"
-    },
-    {
-      "groupName": "github-actions",
-      "matchManagers": [
-        "github-actions"
-      ]
     }
   ]
 }


### PR DESCRIPTION
Related: https://github.com/kumahq/kuma-gui/issues/4410

Our renovate groups quite often/can end up being "block-y" because if you have a group of 10 dependencies to be upgraded and for one reason 1 of those can't/shouldn't be upgraded, then the other 9 are blocked.

We've decided to remove the groups for now at least.

Note: I've also removed the `minimumReleaseAge` as this is not quite doing what we want it to do (it doesn't effect transitive dependencies) and is causing PRs titles/descs to have mismatching versions from the actual changes it is making.

In the meantime we should consider the `age` that renovate adds to the PR descriptions - PR CI will still run, but then there is a human review to get past which would spot any strange additions/amends and we don't expose any tokens anywhere in CI.

Lastly we are soon to look to move to kong's shared renovate anyway, so I guess all this will be changed.