### PR TITLE
chore(deps): ask renovate not to make PRs for pending upgrades

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,7 @@
   "vulnerabilityAlerts": {
     "enabled": true
   },
+  "prCreation": "not-pending",
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
We don't want upgrade PRs with a minimumReleaseAge of less than our setting (currently renovate makes the PRs and then blocks the PR via a check)


> If you use minimumReleaseAge=3 days, prCreation="not-pending" and internalChecksFilter="strict" then Renovate only creates branches when 3 (or more days) have passed since the version was released. We recommend you set dependencyDashboard=true, so you can see these pending PRs.

https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days

We are hoping to implement the above, `internalChecksFilter="strict"` is the default, so we've changed just `prCreation` here.

In order to test this we need to merge and observe