### PR TITLE
chore(renovate): print resolved config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
   ],
   "dependencyDashboard": true,
   "rangeStrategy": "bump",
+  "printConfig": true,
   "labels": [
     "dependencies",
     "renovate-bot"


### PR DESCRIPTION
In order to make it easier understand what renovate is doing and because we are already extending some base configs and presets I've added `printConfig: true` which should print the entire resolved config in the logs.

See https://docs.renovatebot.com/configuration-options/#printconfig