### PR TITLE
chore(renovate): extend kong's public-shared-renovate/javascript

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,10 +3,10 @@
   "extends": [
     "config:recommended",
     ":semanticCommits",
-    "Kong/public-shared-renovate//base/github-actions"
+    "Kong/public-shared-renovate//base/github-actions",
+    "Kong/public-shared-renovate//base/javascript"
   ],
   "dependencyDashboard": true,
-  "rangeStrategy": "bump",
   "printConfig": true,
   "labels": [
     "dependencies",


### PR DESCRIPTION
To benefit from the efforts put into collecting best practices for renovate configs for the npm ecosystem, we've decided to extend Kong's [public-shared-renovate/javascript base config](https://github.com/Kong/public-shared-renovate/blob/main/base/javascript.json).

Closes https://github.com/kumahq/kuma-gui/issues/4410

After this is merged we are going to observe the new behaviour and may further extend our own config and/or propose changes to the shared config.

Note: `rangeStrategy` is already set to `bump` in the shared config, so I've removed it from here.