### PR TITLE
chore: bump versions for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17788,7 +17788,7 @@
     },
     "packages/kuma-gui": {
       "name": "@kumahq/kuma-gui",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "dependencies": {
         "@gera2ld/tarjs": "^0.3.1",
         "@kong-ui-public/i18n": "^2.4.4",
@@ -17838,7 +17838,7 @@
     },
     "packages/kuma-http-api": {
       "name": "@kumahq/kuma-http-api",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "devDependencies": {
         "@kumahq/config": "*"
       },

--- a/packages/kuma-gui/package.json
+++ b/packages/kuma-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kumahq/kuma-gui",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "private": true,
   "description": "Kuma Manager",
   "author": "Kong",

--- a/packages/kuma-http-api/package.json
+++ b/packages/kuma-http-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kumahq/kuma-http-api",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "private": true,
   "description": "Kuma OpenAPI to typescript converter, generated typescript types and mocks",
   "type": "module",


### PR DESCRIPTION
Seems we missed to bump the version after last release (2.12). For this release (2.13) we want the versions to be bumped.