### PR TITLE
chore(kuma-http-api): move MeshItem overlay to its own overlay file

### DIFF
--- a/packages/kuma-http-api/dist/components/schemas/MeshItem.yaml
+++ b/packages/kuma-http-api/dist/components/schemas/MeshItem.yaml
@@ -88,9 +88,12 @@ properties:
     type: object
     properties:
       mode:
-        oneOf:
-          - type: string
-          - type: integer
+        type: string
+        enum:
+          - Disabled
+          - Everywhere
+          - ReachableBackends
+          - Exclusive
   metrics:
     description: |-
       Configuration for metrics collected and exposed by dataplanes.
@@ -265,6 +268,10 @@ properties:
         description: Name of the default backend
         type: string
   type:
+    type: string
+  creationTime:
+    type: string
+  modificationTime:
     type: string
 required:
   - type

--- a/packages/kuma-http-api/openapi.overlay.tmpl.yaml
+++ b/packages/kuma-http-api/openapi.overlay.tmpl.yaml
@@ -42,25 +42,6 @@ actions:
       lastCertificateRegeneration:
         type: string
 
-  - target: '$.components.schemas.MeshItem.properties'
-    update:
-      creationTime:
-        type: string
-      modificationTime:
-        type: string
-
-  # numbers to string enums
-  - target: '$.components.schemas.MeshItem.properties.meshServices.properties.mode.oneOf'
-    remove: true
-  - target: '$.components.schemas.MeshItem.properties.meshServices.properties.mode'
-    update:
-      type: string
-      enum:
-        - Disabled
-        - Everywhere
-        - ReachableBackends
-        - Exclusive
-
   ### requestBodies: any schema marked with x-request is a request body
 
   # delete readOnly properties from original OpenAPI completely for request bodies

--- a/packages/kuma-http-api/src/components/schemas/MeshItem.overlay.yaml
+++ b/packages/kuma-http-api/src/components/schemas/MeshItem.overlay.yaml
@@ -1,0 +1,24 @@
+overlay: 1.0.0
+info:
+  title: Customise Mesh
+  version: 0.1.0
+extends: ../../../generated/components/schemas/MeshItem.yaml
+actions:
+  - target: '$.properties'
+    update:
+      creationTime:
+        type: string
+      modificationTime:
+        type: string
+
+  # numbers to string enums
+  - target: '$.properties.meshServices.properties.mode.oneOf'
+    remove: true
+  - target: '$.properties.meshServices.properties.mode'
+    update:
+      type: string
+      enum:
+        - Disabled
+        - Everywhere
+        - ReachableBackends
+        - Exclusive


### PR DESCRIPTION
`MeshItem` was one of the first reasons why we started using overlays, and at that point we only had 1 single overlay file.

The overlaying is now structured into a file mapping with individual overlay files per resource, and also applies the overlays to our split out individual OAS resource files before finally merging together.

This PR moves the old `MeshItem` overlay into its own overlay file like the rest, you can see:

1. That the final openapi.yaml nor the index.d.ts file change as a result of this
2. The overlay is now also applied to the individual "resource OAS" as it should be.