### PR TITLE
chore(renovate): disable grouping attempt

### DIFF
--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -66,7 +66,7 @@
         "patch"
       ],
       "matchCurrentVersion": "!/^0/",
-      "enabled": false
+      "groupName": null
     }
   ]
 }


### PR DESCRIPTION
Setting `enabled: false` together with the matchers for the grouping of minors and patches completely disabled the upgrades for the matching package versions. From https://docs.renovatebot.com/configuration-options/#groupname I found that potentially setting the `groupName: null` could disable the grouping and causing individual upgrade PRs again.

> To enable grouping, you configure the groupName field to something non-null.