### PR TITLE
chore(renovate): reduce for internals

### DIFF
--- a/packages/config/src/renovate/base.json
+++ b/packages/config/src/renovate/base.json
@@ -52,8 +52,8 @@
     },
     {
       "description": [
-        "Disable grouping of minor and patch updates for non-0.x packages",
-        "inherited from base config `Kong/public-shared-renovate//base/javascript`"
+        " Disable grouping of minor and patch updates for non-0.x packages",
+        " inherited from base config `Kong/public-shared-renovate//base/javascript`"
       ],
       "matchCategories": [
         "js"
@@ -67,6 +67,16 @@
       ],
       "matchCurrentVersion": "!/^0/",
       "groupName": null
+    },
+    {
+      "description": [
+        "Reduce `minimumReleaseAge` for internal toolings"
+      ],
+      "matchPackageNames": [
+        "@kong**/**",
+        "kumahq/**"
+      ],
+      "minimumReleaseAge": "2 hours"
     }
   ]
 }


### PR DESCRIPTION
Reduces `minimumReleaseAge` for kong related and kuma related packages and shared actions to 2 hours.